### PR TITLE
Fix CircleCI badge url and format markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-MAAS Frontend
-=============
+# MAAS Frontend
 
 This is a mono repo for MAAS frontend projects.
 
@@ -8,10 +7,12 @@ This is a mono repo for MAAS frontend projects.
 # Projects
 
 ## UI
+
 This is a React frontend. New work should be done here where possible.
 To run this project execute `cd ui` then `./run`.
 
 # Adding a new project
+
 To add a new project, edit `package.json` and add the project's directory name to the `workspaces` array.
 
 To import modules from existing projects in your new project, add the dependant projects to your projects dependencies in `package.json`. See [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) for details.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a mono repo for MAAS frontend projects.
 
-[![CircleCI](https://circleci.com/gh/canonical-web-and-design/maas-fe/tree/master.svg?style=svg)](https://circleci.com/gh/canonical-web-and-design/maas-fe/tree/master)
+[![CircleCI](https://circleci.com/gh/canonical-web-and-design/maas-ui/tree/master.svg?style=svg)](https://circleci.com/gh/canonical-web-and-design/maas-ui/tree/master)
 
 # Projects
 


### PR DESCRIPTION
Done:
- Update the badge URLs.
- Format the markdown with prettier.

QA: 
- Visit the URLs for the CircleCI badge, they should resolve.

Fixes: #https://github.com/canonical-web-and-design/MAAS-squad/issues/1239.