### PR TITLE
Enable react strict mode.

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -27,7 +27,9 @@ sagaMiddleware.run(rootSaga);
 ReactDOM.render(
   <Provider store={store}>
     <ConnectedRouter history={history}>
-      <App />
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
     </ConnectedRouter>
   </Provider>,
   document.getElementById("root")


### PR DESCRIPTION
## Done 
Turned on react strict mode. You may notice components with `useState` rendering twice now, but that is [by design](https://github.com/facebook/react/issues/15074). 

## QA
* Run the app, we shouldn't have any console warnings.
* Do something that makes Dan Abramov sad e.g. render a component using a deprecated lifecycle method like `componentWillUpdate()`, the app should complain in the console.