### PR TITLE
Separate circle ci jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,48 @@ jobs:
             - yarn-{{ checksum "yarn.lock" }}
       - run: yarn install
       - run: cd ui && yarn run build
+      - save_cache:
+          key: yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+            - ui/node_modules
+
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - yarn-{{ checksum "yarn.lock" }}
+      - run: yarn install
       - run: cd ui && yarn run lint
+      - save_cache:
+          key: yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+            - ui/node_modules
+
+  test:
+    <<: *defaults
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - yarn-{{ checksum "yarn.lock" }}
+      - run: yarn install
       - run: cd ui && yarn run test
       - save_cache:
           key: yarn-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
             - ui/node_modules
+
+workflows:
+  version: 2
+  build_lint_and_test:
+    jobs:
+      - build
+      - lint
+      - test


### PR DESCRIPTION
## Done
Split us circle jobs into separate build steps.

## QA 
None, CI should pass with distinct steps for `build`, `lint` and `test`.