### PR TITLE
Open websocket connection with csrftoken from cookie.

### DIFF
--- a/ui/src/app/base/sagas/utils.js
+++ b/ui/src/app/base/sagas/utils.js
@@ -1,0 +1,11 @@
+/**
+ * Get cookie value by name.
+ *
+ * @param {string} n - cookie name.
+ */
+export const getCookie = n => {
+  const cookie = `; ${document.cookie}`.match(`;\\s*${n}=([^;]+)`);
+  return cookie ? cookie[1] : undefined;
+};
+
+export default getCookie;

--- a/ui/src/app/base/sagas/utils.test.js
+++ b/ui/src/app/base/sagas/utils.test.js
@@ -1,0 +1,17 @@
+import getCookie from "./utils";
+
+describe("saga utils", () => {
+  it("returns undefined if a cookie is not found", () => {
+    expect(getCookie("foo")).toEqual(undefined);
+  });
+
+  it("returns the value of a cookie by name", () => {
+    Object.defineProperty(document, "cookie", {
+      get: jest.fn().mockImplementation(() => {
+        return "a=foo; b=bar; c=baz";
+      })
+    });
+
+    expect(getCookie("b")).toEqual("bar");
+  });
+});


### PR DESCRIPTION
## Done
* Provide csrftoken in querystring when opening websocket connection. (No need to hack `protocol.py` now!)

## QA
* Revert hacks to `protocol.py`, login and opening the websocket connection should work.