### PR TITLE
Add user form

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
     "classnames": "2.2.6",
     "connected-react-router": "6.5.2",
     "cross-env": "5.2.0",
-    "formik": "^1.5.8",
+    "formik": "1.5.8",
     "immer": "3.1.3",
     "prop-types": "15.7.2",
     "react": "16.8.6",
@@ -21,7 +21,7 @@
     "redux-saga": "1.0.5",
     "reselect": "4.0.0",
     "vanilla-framework": "2.1.0",
-    "yup": "^0.27.0"
+    "yup": "0.27.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
     "classnames": "2.2.6",
     "connected-react-router": "6.5.2",
     "cross-env": "5.2.0",
+    "formik": "^1.5.8",
     "immer": "3.1.3",
     "prop-types": "15.7.2",
     "react": "16.8.6",
@@ -19,7 +20,8 @@
     "redux-devtools-extension": "2.13.8",
     "redux-saga": "1.0.5",
     "reselect": "4.0.0",
-    "vanilla-framework": "2.1.0"
+    "vanilla-framework": "2.1.0",
+    "yup": "^0.27.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/ui/src/app/base/components/Button/Button.js
+++ b/ui/src/app/base/components/Button/Button.js
@@ -1,0 +1,49 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const Button = ({
+  appearance,
+  children,
+  className,
+  disabled,
+  element,
+  hasIcon,
+  inline,
+  ...props
+}) => {
+  const classes = classNames(className, `p-button--${appearance}`, {
+    "has-icon": hasIcon,
+    "is-disabled": (element === "a") & disabled,
+    "is-inline": inline
+  });
+  if (element === "button") {
+    return (
+      <button className={classes} disabled={disabled} {...props}>
+        {children}
+      </button>
+    );
+  }
+  return (
+    <a className={classes} aria-disabled={disabled} {...props}>
+      {children}
+    </a>
+  );
+};
+
+Button.propTypes = {
+  appearance: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  element: PropTypes.oneOf(["button", "a"]),
+  hasIcon: PropTypes.bool,
+  inline: PropTypes.bool
+};
+
+Button.defaultProps = {
+  appearance: "neutral",
+  element: "button"
+};
+
+export default Button;

--- a/ui/src/app/base/components/Button/Button.js
+++ b/ui/src/app/base/components/Button/Button.js
@@ -3,11 +3,11 @@ import PropTypes from "prop-types";
 import React from "react";
 
 const Button = ({
-  appearance,
+  appearance = "neutral",
   children,
   className,
   disabled,
-  element,
+  element = "button",
   hasIcon,
   inline,
   ...props
@@ -39,11 +39,6 @@ Button.propTypes = {
   element: PropTypes.oneOf(["button", "a"]),
   hasIcon: PropTypes.bool,
   inline: PropTypes.bool
-};
-
-Button.defaultProps = {
-  appearance: "neutral",
-  element: "button"
 };
 
 export default Button;

--- a/ui/src/app/base/components/Button/Button.test.js
+++ b/ui/src/app/base/components/Button/Button.test.js
@@ -1,0 +1,46 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Button from "./Button";
+
+describe("Button ", () => {
+  it("renders", () => {
+    const wrapper = shallow(<Button>Test content</Button>);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it("renders as a link", () => {
+    const wrapper = shallow(<Button element="a">Test content</Button>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("correctly disables a button", () => {
+    const wrapper = shallow(<Button disabled={true} />);
+    expect(wrapper.prop("disabled")).toBe(true);
+    expect(wrapper.prop("className").includes("is-disabled")).toBe(false);
+    expect(wrapper.prop("aria-disabled")).toBe(undefined);
+  });
+
+  it("correctly disables a link", () => {
+    const wrapper = shallow(<Button element="a" disabled={true} />);
+    expect(wrapper.prop("className").includes("is-disabled")).toBe(true);
+    expect(wrapper.prop("aria-disabled")).toBe(true);
+    expect(wrapper.prop("disabled")).toBe(undefined);
+  });
+
+  it("correctly handle icons", () => {
+    const wrapper = shallow(<Button hasIcon={true} />);
+    expect(wrapper.prop("className").includes("has-icon")).toBe(true);
+  });
+
+  it("can be inline", () => {
+    const wrapper = shallow(<Button inline={true} />);
+    expect(wrapper.prop("className").includes("is-inline")).toBe(true);
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Button className="extra-class" />);
+    const className = wrapper.prop("className");
+    expect(className.includes("p-button--neutral")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Button/__snapshots__/Button.test.js.snap
+++ b/ui/src/app/base/components/Button/__snapshots__/Button.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button  renders 1`] = `
+<button
+  className="p-button--neutral"
+>
+  Test content
+</button>
+`;
+
+exports[`Button  renders as a link 1`] = `
+<a
+  className="p-button--neutral"
+>
+  Test content
+</a>
+`;

--- a/ui/src/app/base/components/Button/index.js
+++ b/ui/src/app/base/components/Button/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Button";

--- a/ui/src/app/base/components/Card/Card.js
+++ b/ui/src/app/base/components/Card/Card.js
@@ -1,0 +1,42 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const Card = ({
+  children,
+  className,
+  highlighted,
+  overlay,
+  title,
+  thumbnail,
+  ...props
+}) => (
+  <div
+    className={classNames(className, {
+      "p-card": !highlighted && !overlay,
+      "p-card--highlighted": highlighted,
+      "p-card--overlay": overlay
+    })}
+    {...props}
+  >
+    {thumbnail && (
+      <>
+        <img className="p-card__thumbnail" src={thumbnail} alt="" />
+        <hr className="u-sv1" />
+      </>
+    )}
+    <h3 className="p-card__title">{title}</h3>
+    <div className="p-card__content">{children}</div>
+  </div>
+);
+
+Card.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  highlighted: PropTypes.bool,
+  overlay: PropTypes.bool,
+  title: PropTypes.node,
+  thumbnail: PropTypes.string
+};
+
+export default Card;

--- a/ui/src/app/base/components/Card/Card.js
+++ b/ui/src/app/base/components/Card/Card.js
@@ -25,7 +25,7 @@ const Card = ({
         <hr className="u-sv1" />
       </>
     )}
-    <h3 className="p-card__title">{title}</h3>
+    {title && <h3 className="p-card__title">{title}</h3>}
     <div className="p-card__content">{children}</div>
   </div>
 );

--- a/ui/src/app/base/components/Card/Card.test.js
+++ b/ui/src/app/base/components/Card/Card.test.js
@@ -1,0 +1,37 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Card from "./Card";
+
+describe("Card ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <Card title="This is the title">Test content</Card>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can display a header", () => {
+    const wrapper = shallow(<Card thumbnail="test.png" />);
+    expect(wrapper.find(".p-card__thumbnail").prop("src")).toEqual("test.png");
+  });
+
+  it("can be highlighted", () => {
+    const wrapper = shallow(<Card highlighted={true} />);
+    expect(wrapper.prop("className").includes("p-card--highlighted")).toBe(
+      true
+    );
+  });
+
+  it("can be an overlay", () => {
+    const wrapper = shallow(<Card overlay={true} />);
+    expect(wrapper.prop("className").includes("p-card--overlay")).toBe(true);
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Card className="extra-class" />);
+    const className = wrapper.prop("className");
+    expect(className.includes("p-card")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Card/__snapshots__/Card.test.js.snap
+++ b/ui/src/app/base/components/Card/__snapshots__/Card.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card  renders 1`] = `
+<div
+  className="p-card"
+>
+  <h3
+    className="p-card__title"
+  >
+    This is the title
+  </h3>
+  <div
+    className="p-card__content"
+  >
+    Test content
+  </div>
+</div>
+`;

--- a/ui/src/app/base/components/Card/index.js
+++ b/ui/src/app/base/components/Card/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Card";

--- a/ui/src/app/base/components/Field/Field.js
+++ b/ui/src/app/base/components/Field/Field.js
@@ -76,7 +76,7 @@ const Field = ({
   const content = generateContent(
     isSelect,
     children,
-    labelFirst,
+    (labelFirst = true),
     labelNode,
     help,
     error,
@@ -111,10 +111,6 @@ Field.propTypes = {
   required: PropTypes.bool,
   stacked: PropTypes.bool,
   success: PropTypes.string
-};
-
-Field.defaultProps = {
-  labelFirst: true
 };
 
 export default Field;

--- a/ui/src/app/base/components/Field/Field.js
+++ b/ui/src/app/base/components/Field/Field.js
@@ -1,0 +1,120 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+import Label from "../Label";
+
+const generateHelp = help => help && <p className="p-form-help-text">{help}</p>;
+
+const generateError = (error, caution, success) => {
+  if (!error && !caution && !success) {
+    return;
+  }
+  let messageType =
+    (error && "Error") || (caution && "Caution") || (success && "Success");
+  return (
+    <p className="p-form-validation__message">
+      <strong>{messageType}:</strong> {error || caution || success}
+    </p>
+  );
+};
+
+const generateLabel = (forId, required, label, stacked) => {
+  if (!label) {
+    return;
+  }
+  const labelNode = (
+    <Label forId={forId} required={required}>
+      {label}
+    </Label>
+  );
+  if (stacked) {
+    return <div className="col-4">{labelNode}</div>;
+  }
+  return labelNode;
+};
+
+const generateContent = (
+  isSelect,
+  children,
+  labelFirst,
+  labelNode,
+  help,
+  error,
+  caution,
+  success
+) => (
+  <div className="p-form__control u-clearfix">
+    {isSelect ? (
+      <div className="p-form-validation__select-wrapper">{children}</div>
+    ) : (
+      children
+    )}
+    {!labelFirst && labelNode}
+    {generateHelp(help)}
+    {generateError(error, caution, success)}
+  </div>
+);
+
+const Field = ({
+  caution,
+  children,
+  className,
+  error,
+  forId,
+  help,
+  isSelect,
+  label,
+  labelFirst,
+  required,
+  stacked,
+  success,
+  type,
+  ...props
+}) => {
+  const labelNode = generateLabel(forId, required, label, stacked);
+  const content = generateContent(
+    isSelect,
+    children,
+    labelFirst,
+    labelNode,
+    help,
+    error,
+    caution,
+    success
+  );
+  return (
+    <div
+      className={classNames("p-form__group", "p-form-validation", className, {
+        "is-error": error,
+        "is-caution": caution,
+        "is-success": success,
+        row: stacked
+      })}
+    >
+      {labelFirst && labelNode}
+      {stacked ? <div className="col-8">{content}</div> : content}
+    </div>
+  );
+};
+
+Field.propTypes = {
+  caution: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  error: PropTypes.string,
+  forId: PropTypes.string,
+  help: PropTypes.string,
+  isSelect: PropTypes.bool,
+  label: PropTypes.string,
+  labelFirst: PropTypes.bool,
+  required: PropTypes.bool,
+  stacked: PropTypes.bool,
+  success: PropTypes.string
+};
+
+Field.defaultProps = {
+  labelFirst: true
+};
+
+export default Field;

--- a/ui/src/app/base/components/Field/Field.js
+++ b/ui/src/app/base/components/Field/Field.js
@@ -65,7 +65,7 @@ const Field = ({
   help,
   isSelect,
   label,
-  labelFirst,
+  labelFirst = true,
   required,
   stacked,
   success,
@@ -76,7 +76,7 @@ const Field = ({
   const content = generateContent(
     isSelect,
     children,
-    (labelFirst = true),
+    labelFirst,
     labelNode,
     help,
     error,

--- a/ui/src/app/base/components/Field/Field.test.js
+++ b/ui/src/app/base/components/Field/Field.test.js
@@ -1,0 +1,89 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import { compareJSX } from "testing/utils";
+import Field from "./Field";
+
+describe("Field ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <Field forId="test-id" label="Test label">
+        Test content
+      </Field>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Field className="extra-class" />);
+    const className = wrapper.prop("className");
+    expect(className.includes("p-form__group")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+
+  it("can display a caution message", () => {
+    const wrapper = shallow(<Field caution="Are you sure?" />);
+    compareJSX(
+      wrapper.find(".p-form-validation__message"),
+      <p className="p-form-validation__message">
+        <strong>{"Caution"}:</strong> {"Are you sure?"}
+      </p>
+    );
+    expect(wrapper.prop("className").includes("is-caution")).toBe(true);
+  });
+
+  it("can display an error message", () => {
+    const wrapper = shallow(<Field error="You can't do that" />);
+    compareJSX(
+      wrapper.find(".p-form-validation__message"),
+      <p className="p-form-validation__message">
+        <strong>{"Error"}:</strong> {"You can't do that"}
+      </p>
+    );
+    expect(wrapper.prop("className").includes("is-error")).toBe(true);
+  });
+
+  it("can display a success message", () => {
+    const wrapper = shallow(<Field success="You did it!" />);
+    compareJSX(
+      wrapper.find(".p-form-validation__message"),
+      <p className="p-form-validation__message">
+        <strong>{"Success"}:</strong> {"You did it!"}
+      </p>
+    );
+    expect(wrapper.prop("className").includes("is-success")).toBe(true);
+  });
+
+  it("can display a help message", () => {
+    const wrapper = shallow(<Field help="This is how you do it" />);
+    expect(wrapper.find(".p-form-help-text").text()).toEqual(
+      "This is how you do it"
+    );
+  });
+
+  it("can display the label before the input", () => {
+    const wrapper = shallow(<Field labelFirst={true} label="Test label" />);
+    // The label should not be inside the control.
+    expect(wrapper.find(".p-form__control Label").length).toBe(0);
+  });
+
+  it("can display the label after the input", () => {
+    const wrapper = shallow(<Field labelFirst={false} label="Test label" />);
+    // The label should be inside the control.
+    expect(wrapper.find(".p-form__control Label").length).toBe(1);
+  });
+
+  it("can be required", () => {
+    const wrapper = shallow(<Field required={true} label="Test label" />);
+    expect(wrapper.find("Label").prop("required")).toBe(true);
+  });
+
+  it("can be stacked", () => {
+    const wrapper = shallow(<Field stacked={true} label="Test label" />);
+    // The Label should be inside a col-4.
+    expect(wrapper.find(".col-4 Label").length).toBe(1);
+    // The control should be inside a col-8.
+    expect(wrapper.find(".col-8 .p-form__control").length).toBe(1);
+    expect(wrapper.prop("className").includes("row")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Field/__snapshots__/Field.test.js.snap
+++ b/ui/src/app/base/components/Field/__snapshots__/Field.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Field  renders 1`] = `
+<div
+  className="p-form__group p-form-validation"
+>
+  <Label
+    forId="test-id"
+  >
+    Test label
+  </Label>
+  <div
+    className="p-form__control u-clearfix"
+  >
+    Test content
+  </div>
+</div>
+`;

--- a/ui/src/app/base/components/Field/index.js
+++ b/ui/src/app/base/components/Field/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Field";

--- a/ui/src/app/base/components/Form/Form.js
+++ b/ui/src/app/base/components/Form/Form.js
@@ -1,0 +1,25 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const Form = ({ children, className, inline, stacked, ...props }) => (
+  <form
+    className={classNames(className, {
+      "p-form": inline || stacked,
+      "p-form--inline": inline,
+      "p-form--stacked": stacked
+    })}
+    {...props}
+  >
+    {children}
+  </form>
+);
+
+Form.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  inline: PropTypes.bool,
+  stacked: PropTypes.bool
+};
+
+export default Form;

--- a/ui/src/app/base/components/Form/Form.test.js
+++ b/ui/src/app/base/components/Form/Form.test.js
@@ -1,0 +1,28 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Form from "./Form";
+
+describe("Form ", () => {
+  it("renders", () => {
+    const wrapper = shallow(<Form>Test content</Form>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can be inline", () => {
+    const wrapper = shallow(<Form inline={true} />);
+    expect(wrapper.prop("className").includes("p-form--inline")).toBe(true);
+  });
+
+  it("can be stacked", () => {
+    const wrapper = shallow(<Form stacked={true} />);
+    expect(wrapper.prop("className").includes("p-form--stacked")).toBe(true);
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Form stacked={true} className="extra-class" />);
+    const className = wrapper.prop("className");
+    expect(className.includes("p-form")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Form/__snapshots__/Form.test.js.snap
+++ b/ui/src/app/base/components/Form/__snapshots__/Form.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Form  renders 1`] = `
+<form
+  className=""
+>
+  Test content
+</form>
+`;

--- a/ui/src/app/base/components/Form/index.js
+++ b/ui/src/app/base/components/Form/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Form";

--- a/ui/src/app/base/components/Input/Input.js
+++ b/ui/src/app/base/components/Input/Input.js
@@ -1,0 +1,56 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+import Field from "../Field";
+
+const Input = ({
+  caution,
+  className,
+  error,
+  help,
+  id,
+  label,
+  required,
+  stacked,
+  success,
+  type,
+  ...props
+}) => {
+  const labelFirst = !["checkbox", "radio"].includes(type);
+  return (
+    <Field
+      caution={caution}
+      error={error}
+      forId={id}
+      help={help}
+      label={label}
+      labelFirst={labelFirst}
+      required={required}
+      stacked={stacked}
+      success={success}
+    >
+      <input
+        className={classNames("p-form-validation__input", className)}
+        id={id}
+        type={type}
+        {...props}
+      />
+    </Field>
+  );
+};
+
+Input.propTypes = {
+  caution: PropTypes.string,
+  className: PropTypes.string,
+  error: PropTypes.string,
+  help: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+  stacked: PropTypes.bool,
+  success: PropTypes.string,
+  type: PropTypes.string
+};
+
+export default Input;

--- a/ui/src/app/base/components/Input/Input.test.js
+++ b/ui/src/app/base/components/Input/Input.test.js
@@ -1,0 +1,28 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Input from "./Input";
+
+describe("Input ", () => {
+  it("renders", () => {
+    const wrapper = shallow(<Input type="text" id="test-id" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Input type="text" className="extra-class" />);
+    const className = wrapper.find("input").prop("className");
+    expect(className.includes("p-form-validation__input")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+
+  it("moves the label for radio buttons", () => {
+    const wrapper = shallow(<Input type="radio" />);
+    expect(wrapper.prop("labelFirst")).toBe(false);
+  });
+
+  it("moves the label for checkboxes", () => {
+    const wrapper = shallow(<Input type="checkbox" />);
+    expect(wrapper.prop("labelFirst")).toBe(false);
+  });
+});

--- a/ui/src/app/base/components/Input/__snapshots__/Input.test.js.snap
+++ b/ui/src/app/base/components/Input/__snapshots__/Input.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Input  renders 1`] = `
+<Field
+  forId="test-id"
+  labelFirst={true}
+>
+  <input
+    className="p-form-validation__input"
+    id="test-id"
+    type="text"
+  />
+</Field>
+`;

--- a/ui/src/app/base/components/Input/index.js
+++ b/ui/src/app/base/components/Input/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Input";

--- a/ui/src/app/base/components/Label/Label.js
+++ b/ui/src/app/base/components/Label/Label.js
@@ -1,0 +1,24 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const Label = ({ children, className, forId, required, ...props }) => (
+  <label
+    className={classNames(className, "p-form__label", {
+      "is-required": required
+    })}
+    htmlFor={forId}
+    {...props}
+  >
+    {children}
+  </label>
+);
+
+Label.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+  forId: PropTypes.string,
+  required: PropTypes.bool
+};
+
+export default Label;

--- a/ui/src/app/base/components/Label/Label.test.js
+++ b/ui/src/app/base/components/Label/Label.test.js
@@ -1,0 +1,23 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Label from "./Label";
+
+describe("Label ", () => {
+  it("renders", () => {
+    const wrapper = shallow(<Label forId="test-id">Test content</Label>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can be required", () => {
+    const wrapper = shallow(<Label required={true} />);
+    expect(wrapper.prop("className").includes("is-required")).toBe(true);
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Label className="extra-class" />);
+    const className = wrapper.prop("className");
+    expect(className.includes("p-form__label")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Label/__snapshots__/Label.test.js.snap
+++ b/ui/src/app/base/components/Label/__snapshots__/Label.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Label  renders 1`] = `
+<label
+  className="p-form__label"
+  htmlFor="test-id"
+>
+  Test content
+</label>
+`;

--- a/ui/src/app/base/components/Label/index.js
+++ b/ui/src/app/base/components/Label/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Label";

--- a/ui/src/app/base/components/MainTable/__snapshots__/MainTable.test.js.snap
+++ b/ui/src/app/base/components/MainTable/__snapshots__/MainTable.test.js.snap
@@ -42,21 +42,18 @@ exports[`MainTable renders 1`] = `
       <TableCell
         className="u-align--right"
         key="1"
-        role="gridcell"
       >
         1
       </TableCell>
       <TableCell
         className="u-align--right"
         key="2"
-        role="gridcell"
       >
         1 GiB
       </TableCell>
       <TableCell
         className="u-align--right"
         key="3"
-        role="gridcell"
       >
         2
       </TableCell>
@@ -73,21 +70,18 @@ exports[`MainTable renders 1`] = `
       <TableCell
         className="u-align--right"
         key="1"
-        role="gridcell"
       >
         1
       </TableCell>
       <TableCell
         className="u-align--right"
         key="2"
-        role="gridcell"
       >
         1 GiB
       </TableCell>
       <TableCell
         className="u-align--right"
         key="3"
-        role="gridcell"
       >
         2
       </TableCell>
@@ -104,21 +98,18 @@ exports[`MainTable renders 1`] = `
       <TableCell
         className="u-align--right"
         key="1"
-        role="gridcell"
       >
         8
       </TableCell>
       <TableCell
         className="u-align--right"
         key="2"
-        role="gridcell"
       >
         3.9 GiB
       </TableCell>
       <TableCell
         className="u-align--right"
         key="3"
-        role="gridcell"
       >
         3
       </TableCell>

--- a/ui/src/app/base/components/Section/Section.scss
+++ b/ui/src/app/base/components/Section/Section.scss
@@ -26,7 +26,6 @@
 }
 
 .section__sidebar {
-  border-right: 1px solid $color-mid-x-light;
   height: 100%;
 }
 

--- a/ui/src/app/base/components/Select/Select.js
+++ b/ui/src/app/base/components/Select/Select.js
@@ -1,0 +1,68 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+import Field from "../Field";
+
+const generateOptions = options =>
+  options.map(({ label, value, ...props }) => (
+    <option value={value} key={value || label} {...props}>
+      {label}
+    </option>
+  ));
+
+const Select = ({
+  caution,
+  className,
+  error,
+  help,
+  id,
+  label,
+  options,
+  required,
+  stacked,
+  success,
+  ...props
+}) => {
+  return (
+    <Field
+      caution={caution}
+      error={error}
+      forId={id}
+      help={help}
+      isSelect={true}
+      label={label}
+      required={required}
+      stacked={stacked}
+      success={success}
+    >
+      <select
+        className={classNames("p-form-validation__input", className)}
+        id={id}
+        {...props}
+      >
+        {generateOptions(options)}
+      </select>
+    </Field>
+  );
+};
+
+Select.propTypes = {
+  caution: PropTypes.string,
+  className: PropTypes.string,
+  error: PropTypes.string,
+  help: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string
+    })
+  ).isRequired,
+  required: PropTypes.bool,
+  stacked: PropTypes.bool,
+  success: PropTypes.string
+};
+
+export default Select;

--- a/ui/src/app/base/components/Select/Select.test.js
+++ b/ui/src/app/base/components/Select/Select.test.js
@@ -1,0 +1,28 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Select from "./Select";
+
+describe("Select ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <Select
+        id="test-id"
+        options={[
+          { value: "", disabled: "disabled", label: "Select an option" },
+          { value: "1", label: "Cosmic Cuttlefish" },
+          { value: "2", label: "Bionic Beaver" },
+          { value: "3", label: "Xenial Xerus" }
+        ]}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Select className="extra-class" options={[]} />);
+    const className = wrapper.find("select").prop("className");
+    expect(className.includes("p-form-validation__input")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Select/__snapshots__/Select.test.js.snap
+++ b/ui/src/app/base/components/Select/__snapshots__/Select.test.js.snap
@@ -4,7 +4,6 @@ exports[`Select  renders 1`] = `
 <Field
   forId="test-id"
   isSelect={true}
-  labelFirst={true}
 >
   <select
     className="p-form-validation__input"

--- a/ui/src/app/base/components/Select/__snapshots__/Select.test.js.snap
+++ b/ui/src/app/base/components/Select/__snapshots__/Select.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select  renders 1`] = `
+<Field
+  forId="test-id"
+  isSelect={true}
+  labelFirst={true}
+>
+  <select
+    className="p-form-validation__input"
+    id="test-id"
+  >
+    <option
+      disabled="disabled"
+      key="Select an option"
+      value=""
+    >
+      Select an option
+    </option>
+    <option
+      key="1"
+      value="1"
+    >
+      Cosmic Cuttlefish
+    </option>
+    <option
+      key="2"
+      value="2"
+    >
+      Bionic Beaver
+    </option>
+    <option
+      key="3"
+      value="3"
+    >
+      Xenial Xerus
+    </option>
+  </select>
+</Field>
+`;

--- a/ui/src/app/base/components/Select/index.js
+++ b/ui/src/app/base/components/Select/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Select";

--- a/ui/src/app/base/components/TableCell/TableCell.js
+++ b/ui/src/app/base/components/TableCell/TableCell.js
@@ -7,7 +7,7 @@ const TableCell = ({
   className,
   expanding,
   hidden,
-  role,
+  role = "gridcell",
   ...props
 }) => (
   <td
@@ -28,10 +28,6 @@ TableCell.propTypes = {
   expanding: PropTypes.bool,
   hidden: PropTypes.bool,
   role: PropTypes.string
-};
-
-TableCell.defaultProps = {
-  role: "gridcell"
 };
 
 export default TableCell;

--- a/ui/src/app/base/components/Textarea/Textarea.js
+++ b/ui/src/app/base/components/Textarea/Textarea.js
@@ -1,0 +1,51 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+import Field from "../Field";
+
+const Textarea = ({
+  caution,
+  className,
+  error,
+  help,
+  id,
+  label,
+  required,
+  stacked,
+  success,
+  ...props
+}) => {
+  return (
+    <Field
+      caution={caution}
+      error={error}
+      forId={id}
+      help={help}
+      label={label}
+      required={required}
+      stacked={stacked}
+      success={success}
+    >
+      <textarea
+        className={classNames("p-form-validation__input", className)}
+        id={id}
+        {...props}
+      />
+    </Field>
+  );
+};
+
+Textarea.propTypes = {
+  caution: PropTypes.string,
+  className: PropTypes.string,
+  error: PropTypes.string,
+  help: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+  stacked: PropTypes.bool,
+  success: PropTypes.string
+};
+
+export default Textarea;

--- a/ui/src/app/base/components/Textarea/Textarea.test.js
+++ b/ui/src/app/base/components/Textarea/Textarea.test.js
@@ -1,0 +1,18 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Textarea from "./Textarea";
+
+describe("Textarea ", () => {
+  it("renders", () => {
+    const wrapper = shallow(<Textarea id="test-id" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(<Textarea className="extra-class" />);
+    const className = wrapper.find("textarea").prop("className");
+    expect(className.includes("p-form-validation__input")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Textarea/__snapshots__/Textarea.test.js.snap
+++ b/ui/src/app/base/components/Textarea/__snapshots__/Textarea.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Textarea  renders 1`] = `
+<Field
+  forId="test-id"
+  labelFirst={true}
+>
+  <textarea
+    className="p-form-validation__input"
+    id="test-id"
+  />
+</Field>
+`;

--- a/ui/src/app/base/components/Textarea/__snapshots__/Textarea.test.js.snap
+++ b/ui/src/app/base/components/Textarea/__snapshots__/Textarea.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Textarea  renders 1`] = `
 <Field
   forId="test-id"
-  labelFirst={true}
 >
   <textarea
     className="p-form-validation__input"

--- a/ui/src/app/base/components/Textarea/index.js
+++ b/ui/src/app/base/components/Textarea/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Textarea";

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -8,12 +8,16 @@ import Network from "app/settings/containers/Network";
 import Repositories from "app/settings/containers/Repositories";
 import Scripts from "app/settings/containers/Scripts";
 import Storage from "app/settings/containers/Storage";
+import UserAdd from "app/settings/containers/UserAdd";
+import UserEdit from "app/settings/containers/UserEdit";
 import Users from "app/settings/containers/Users";
 
 const Routes = () => (
   <Switch>
     <Route exact path="/configuration" component={Configuration} />
     <Route exact path="/users" component={Users} />
+    <Route exact path="/users/:id/edit" component={UserEdit} />
+    <Route exact path="/users/add" component={UserAdd} />
     <Route exact path="/images" component={Images} />
     <Route exact path="/storage" component={Storage} />
     <Route exact path="/network" component={Network} />

--- a/ui/src/app/settings/components/UserForm/UserForm.js
+++ b/ui/src/app/settings/components/UserForm/UserForm.js
@@ -1,0 +1,162 @@
+import { Formik } from "formik";
+import PropTypes from "prop-types";
+import React from "react";
+import * as Yup from "yup";
+
+import "./UserForm.scss";
+import { UserShape } from "app/base/proptypes";
+import Button from "app/base/components/Button";
+import Card from "app/base/components/Card";
+import Form from "app/base/components/Form";
+import Input from "app/base/components/Input";
+
+const UserSchema = Yup.object().shape({
+  email: Yup.string()
+    .email("Must be a valid email address")
+    .required(),
+  fullName: Yup.string(),
+  is_superuser: Yup.boolean(),
+  password: Yup.string().required("Password is required"),
+  passwordConfirm: Yup.string().oneOf(
+    [Yup.ref("password")],
+    "Passwords must be the same"
+  ),
+  username: Yup.string()
+    .max(150, "Username must be 150 characters or less")
+    .matches(
+      /^[a-zA-Z 0-9@.+-_]*$/,
+      "Usernames must contain letters, digits and @/./+/-/_ only"
+    )
+    .required("Username is required")
+});
+
+export const UserForm = ({ title, user }) => {
+  return (
+    <Card highlighted={true} className="user-form">
+      <div className="row">
+        <div className="col-3">
+          <h4>{title}</h4>
+        </div>
+        <div className="col-9">
+          <Formik
+            initialValues={{
+              isSuperuser: user ? user.is_superuser : false,
+              email: user ? user.email : "",
+              fullName: user ? `${user.first_name} ${user.last_name}` : "",
+              password: "",
+              passwordConfirm: "",
+              username: user ? user.username : ""
+            }}
+            validationSchema={UserSchema}
+            onSubmit={(values, { setSubmitting }) => {
+              setTimeout(() => {
+                alert(JSON.stringify(values, null, 2));
+                setSubmitting(false);
+              }, 400);
+            }}
+          >
+            {({
+              errors,
+              isSubmitting,
+              touched,
+              handleSubmit,
+              handleChange,
+              handleBlur,
+              values
+            }) => (
+              <Form onSubmit={handleSubmit}>
+                <div className="row">
+                  <div className="col-8">
+                    <Input
+                      error={touched.username && errors.username}
+                      help="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."
+                      id="username"
+                      label="Username"
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      required={true}
+                      type="text"
+                      value={values.username}
+                    />
+                    <Input
+                      error={touched.fullName && errors.fullName}
+                      id="fullName"
+                      label="Full name (optional)"
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      type="text"
+                      value={values.fullName}
+                    />
+                    <Input
+                      error={touched.email && errors.email}
+                      id="email"
+                      label="Email address"
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      type="email"
+                      value={values.email}
+                    />
+                    <Input
+                      error={touched.isSuperuser && errors.isSuperuser}
+                      id="isSuperuser"
+                      label="MAAS administrator"
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      type="checkbox"
+                      value={values.isSuperuser}
+                    />
+                    <Input
+                      error={touched.password && errors.password}
+                      id="password"
+                      label="Password"
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      required={true}
+                      type="password"
+                      value={values.password}
+                    />
+                    <Input
+                      error={touched.passwordConfirm && errors.passwordConfirm}
+                      help="Enter the same password as before, for verification"
+                      id="passwordConfirm"
+                      label="Password (again)"
+                      onBlur={handleBlur}
+                      onChange={handleChange}
+                      required={true}
+                      type="password"
+                      value={values.passwordConfirm}
+                    />
+                  </div>
+                </div>
+                <div className="user-form__buttons">
+                  <Button
+                    appearance="base"
+                    className="u-no-margin--bottom"
+                    type="button"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    appearance="positive"
+                    className="u-no-margin--bottom"
+                    type="submit"
+                    disabled={isSubmitting}
+                  >
+                    Save user
+                  </Button>
+                </div>
+              </Form>
+            )}
+          </Formik>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+UserForm.propTypes = {
+  title: PropTypes.string.isRequired,
+  user: UserShape
+};
+
+export default UserForm;

--- a/ui/src/app/settings/components/UserForm/UserForm.scss
+++ b/ui/src/app/settings/components/UserForm/UserForm.scss
@@ -1,0 +1,12 @@
+@import "src/scss/vanilla";
+
+.user-form {
+  margin-top: 0.5rem;
+}
+
+.user-form__buttons {
+  border-top: 1px solid $color-mid-light;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  text-align: right;
+}

--- a/ui/src/app/settings/components/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/components/UserForm/UserForm.test.js
@@ -1,0 +1,10 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { UserForm } from "./UserForm";
+
+describe("UserForm", () => {
+  it("can render", () => {
+    const wrapper = shallow(<UserForm title="Add user" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/settings/components/UserForm/__snapshots__/UserForm.test.js.snap
+++ b/ui/src/app/settings/components/UserForm/__snapshots__/UserForm.test.js.snap
@@ -1,0 +1,254 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserForm can render 1`] = `
+<Card
+  className="user-form"
+  highlighted={true}
+>
+  <div
+    className="row"
+  >
+    <div
+      className="col-3"
+    >
+      <h4>
+        Add user
+      </h4>
+    </div>
+    <div
+      className="col-9"
+    >
+      <Formik
+        enableReinitialize={false}
+        initialValues={
+          Object {
+            "email": "",
+            "fullName": "",
+            "isSuperuser": false,
+            "password": "",
+            "passwordConfirm": "",
+            "username": "",
+          }
+        }
+        isInitialValid={false}
+        onSubmit={[Function]}
+        validateOnBlur={true}
+        validateOnChange={true}
+        validationSchema={
+          ObjectSchema {
+            "_blacklist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "_conditions": Array [],
+            "_defaultDefault": [Function],
+            "_deps": Array [],
+            "_excludedEdges": Array [],
+            "_exclusive": Object {},
+            "_mutate": undefined,
+            "_nodes": Array [
+              "username",
+              "passwordConfirm",
+              "password",
+              "is_superuser",
+              "fullName",
+              "email",
+            ],
+            "_options": Object {
+              "abortEarly": true,
+              "recursive": true,
+            },
+            "_type": "object",
+            "_typeError": [Function],
+            "_whitelist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "fields": Object {
+              "email": StringSchema {
+                "_blacklist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "_conditions": Array [],
+                "_deps": Array [],
+                "_exclusive": Object {
+                  "required": true,
+                  "undefined": false,
+                },
+                "_mutate": undefined,
+                "_options": Object {
+                  "abortEarly": true,
+                  "recursive": true,
+                },
+                "_type": "string",
+                "_typeError": [Function],
+                "_whitelist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "tests": Array [
+                  [Function],
+                  [Function],
+                ],
+                "transforms": Array [
+                  [Function],
+                ],
+              },
+              "fullName": StringSchema {
+                "_blacklist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "_conditions": Array [],
+                "_deps": Array [],
+                "_exclusive": Object {},
+                "_mutate": undefined,
+                "_options": Object {
+                  "abortEarly": true,
+                  "recursive": true,
+                },
+                "_type": "string",
+                "_typeError": [Function],
+                "_whitelist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "tests": Array [],
+                "transforms": Array [
+                  [Function],
+                ],
+              },
+              "is_superuser": BooleanSchema {
+                "_blacklist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "_conditions": Array [],
+                "_deps": Array [],
+                "_exclusive": Object {},
+                "_mutate": undefined,
+                "_options": Object {
+                  "abortEarly": true,
+                  "recursive": true,
+                },
+                "_type": "boolean",
+                "_typeError": [Function],
+                "_whitelist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "tests": Array [],
+                "transforms": Array [
+                  [Function],
+                ],
+              },
+              "password": StringSchema {
+                "_blacklist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "_conditions": Array [],
+                "_deps": Array [],
+                "_exclusive": Object {
+                  "required": true,
+                },
+                "_mutate": undefined,
+                "_options": Object {
+                  "abortEarly": true,
+                  "recursive": true,
+                },
+                "_type": "string",
+                "_typeError": [Function],
+                "_whitelist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "tests": Array [
+                  [Function],
+                ],
+                "transforms": Array [
+                  [Function],
+                ],
+              },
+              "passwordConfirm": StringSchema {
+                "_blacklist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "_conditions": Array [],
+                "_deps": Array [],
+                "_exclusive": Object {},
+                "_mutate": undefined,
+                "_options": Object {
+                  "abortEarly": true,
+                  "recursive": true,
+                },
+                "_type": "string",
+                "_typeError": [Function],
+                "_whitelist": RefSet {
+                  "list": Set {},
+                  "refs": Map {
+                    "password" => Reference {
+                      "getter": [Function],
+                      "isContext": false,
+                      "isSibling": true,
+                      "isValue": false,
+                      "key": "password",
+                      "map": undefined,
+                      "path": "password",
+                    },
+                  },
+                },
+                "_whitelistError": [Function],
+                "tests": Array [],
+                "transforms": Array [
+                  [Function],
+                ],
+              },
+              "username": StringSchema {
+                "_blacklist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "_conditions": Array [],
+                "_deps": Array [],
+                "_exclusive": Object {
+                  "max": true,
+                  "required": true,
+                  "undefined": false,
+                },
+                "_mutate": undefined,
+                "_options": Object {
+                  "abortEarly": true,
+                  "recursive": true,
+                },
+                "_type": "string",
+                "_typeError": [Function],
+                "_whitelist": RefSet {
+                  "list": Set {},
+                  "refs": Map {},
+                },
+                "tests": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+                "transforms": Array [
+                  [Function],
+                ],
+              },
+            },
+            "tests": Array [],
+            "transforms": Array [
+              [Function],
+            ],
+          }
+        }
+      >
+        <Component />
+      </Formik>
+    </div>
+  </div>
+</Card>
+`;

--- a/ui/src/app/settings/components/UserForm/index.js
+++ b/ui/src/app/settings/components/UserForm/index.js
@@ -1,0 +1,1 @@
+export { default } from "./UserForm";

--- a/ui/src/app/settings/containers/UserAdd/UserAdd.js
+++ b/ui/src/app/settings/containers/UserAdd/UserAdd.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+import UserForm from "app/settings/components/UserForm";
+
+export const UserAdd = () => {
+  return <UserForm title="Add user" />;
+};
+
+export default UserAdd;

--- a/ui/src/app/settings/containers/UserAdd/UserAdd.test.js
+++ b/ui/src/app/settings/containers/UserAdd/UserAdd.test.js
@@ -1,0 +1,10 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { UserAdd } from "./UserAdd";
+
+describe("UserAdd", () => {
+  it("can render", () => {
+    const wrapper = shallow(<UserAdd />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/settings/containers/UserAdd/__snapshots__/UserAdd.test.js.snap
+++ b/ui/src/app/settings/containers/UserAdd/__snapshots__/UserAdd.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserAdd can render 1`] = `
+<UserForm
+  title="Add user"
+/>
+`;

--- a/ui/src/app/settings/containers/UserAdd/index.js
+++ b/ui/src/app/settings/containers/UserAdd/index.js
@@ -1,0 +1,1 @@
+export { default } from "./UserAdd";

--- a/ui/src/app/settings/containers/UserEdit/UserEdit.js
+++ b/ui/src/app/settings/containers/UserEdit/UserEdit.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+import UserForm from "app/settings/components/UserForm";
+
+export const UserEdit = () => {
+  return <UserForm title="Edit user" />;
+};
+
+export default UserEdit;

--- a/ui/src/app/settings/containers/UserEdit/UserEdit.test.js
+++ b/ui/src/app/settings/containers/UserEdit/UserEdit.test.js
@@ -1,0 +1,10 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { UserEdit } from "./UserEdit";
+
+describe("UserEdit", () => {
+  it("can render", () => {
+    const wrapper = shallow(<UserEdit />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/settings/containers/UserEdit/__snapshots__/UserEdit.test.js.snap
+++ b/ui/src/app/settings/containers/UserEdit/__snapshots__/UserEdit.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserEdit can render 1`] = `
+<UserForm
+  title="Edit user"
+/>
+`;

--- a/ui/src/app/settings/containers/UserEdit/index.js
+++ b/ui/src/app/settings/containers/UserEdit/index.js
@@ -1,0 +1,1 @@
+export { default } from "./UserEdit";


### PR DESCRIPTION
Done:
- Add user add and edit pages and form. Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1353.
- Added form, input, select, textarea, button and card components.

QA:
- open the users list
- click the edit pencil icon on a user
- you should see a user form like this: https://app.zeplin.io/project/5ce5423a25863c1e0d7abb27/screen/5d38490dfcd3ff77608afba4