### PR TITLE
Add save functionality to Storage form + build ActionButton

### DIFF
--- a/ui/src/app/base/components/ActionButton/ActionButton.js
+++ b/ui/src/app/base/components/ActionButton/ActionButton.js
@@ -1,0 +1,60 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+import Button from "../Button";
+import "./ActionButton.scss";
+
+const generateButtonChildren = (children, appearance, loading, success) => {
+  const iconClass = classNames({
+    "p-icon--spinner u-animation--spin": loading,
+    "is-light": appearance === "positive" || appearance === "negative",
+    "p-icon--success":
+      success && (appearance !== "positive" && appearance !== "negative"),
+    "p-icon--success-positive": success && appearance === "positive",
+    "p-icon--success-negative": success && appearance === "negative"
+  });
+
+  return loading || success ? <i className={iconClass} /> : children;
+};
+
+const ActionButton = ({
+  appearance = "neutral",
+  children,
+  className,
+  loading,
+  success,
+  width,
+  ...props
+}) => {
+  const classes = classNames(className, `p-action-button`, {
+    "is-loading": loading,
+    "is-success": success
+  });
+  const buttonChildren = generateButtonChildren(
+    children,
+    appearance,
+    loading,
+    success
+  );
+  const style = width ? { width } : {};
+
+  return (
+    <Button
+      appearance={appearance}
+      className={classes}
+      style={style}
+      {...props}
+    >
+      {buttonChildren}
+    </Button>
+  );
+};
+
+ActionButton.propTypes = {
+  className: PropTypes.string,
+  loading: PropTypes.bool,
+  success: PropTypes.bool
+};
+
+export default ActionButton;

--- a/ui/src/app/base/components/ActionButton/ActionButton.scss
+++ b/ui/src/app/base/components/ActionButton/ActionButton.scss
@@ -1,0 +1,25 @@
+@import "src/scss/vanilla";
+
+// Identical to Vanilla success icon, but possible to alter tick color
+@mixin maas-icon-success($bg-color, $tick-color: $color-x-light) {
+  background-image: url("data:image/svg+xml,%3Csvg width='17' height='17' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform='translate%281 1%29' fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='#{vf-url-friendly-color($bg-color)}' stroke-width='1.5' fill='#{vf-url-friendly-color($bg-color)}' cx='7.25' cy='7.25' r='7.25'/%3E%3Cpath fill='#{vf-url-friendly-color($tick-color)}' d='M11.05 4.173l-.066.058L6.25 8.378l-2.776-2.38-.839.948L6.25 10.75l5.5-5.787-.7-.79z'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+.p-icon--success-positive {
+  @extend %icon;
+  @include maas-icon-success($color-x-light, $color-positive);
+}
+
+.p-icon--success-negative {
+  @extend %icon;
+  @include maas-icon-success($color-x-light, $color-negative);
+}
+
+.p-action-button {
+  @include vf-animation($property: (background-color, border, opacity), $duration: snap);
+
+  &.is-loading,
+  &.is-success {
+    opacity: 1 !important; // Override Vanilla disabled opacity - too much colour changing otherwise
+  }
+}

--- a/ui/src/app/base/components/ActionButton/ActionButton.test.js
+++ b/ui/src/app/base/components/ActionButton/ActionButton.test.js
@@ -1,0 +1,25 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import ActionButton from "./ActionButton";
+
+describe("ActionButton", () => {
+  it("matches loading snapshot", () => {
+    const wrapper = shallow(<ActionButton loading>Click me</ActionButton>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("matches success snapshot", () => {
+    const wrapper = shallow(<ActionButton success>Click me</ActionButton>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("correctly shows a positive tick if appearance is positive and successful", () => {
+    const wrapper = shallow(
+      <ActionButton appearance="positive" success>
+        Click me
+      </ActionButton>
+    );
+    expect(wrapper.find(".p-icon--success-positive").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/ui/src/app/base/components/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionButton matches loading snapshot 1`] = `
+<Button
+  appearance="neutral"
+  className="p-action-button is-loading"
+  style={Object {}}
+>
+  <i
+    className="p-icon--spinner u-animation--spin"
+  />
+</Button>
+`;
+
+exports[`ActionButton matches success snapshot 1`] = `
+<Button
+  appearance="neutral"
+  className="p-action-button is-success"
+  style={Object {}}
+>
+  <i
+    className="p-icon--success"
+  />
+</Button>
+`;

--- a/ui/src/app/base/components/ActionButton/index.js
+++ b/ui/src/app/base/components/ActionButton/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ActionButton";

--- a/ui/src/app/base/components/Loader/Loader.js
+++ b/ui/src/app/base/components/Loader/Loader.js
@@ -3,9 +3,9 @@ import classNames from "classnames";
 
 import "./Loader.scss";
 
-const Loader = ({ text, isLight, inline }) => (
+const Loader = ({ className, text, isLight, inline }) => (
   <div
-    className={classNames("p-loader", "p-text--default", {
+    className={classNames(className, "p-loader", "p-text--default", {
       "p-loader--inline": inline
     })}
   >

--- a/ui/src/app/base/components/Loader/Loader.scss
+++ b/ui/src/app/base/components/Loader/Loader.scss
@@ -2,7 +2,6 @@
 
 .p-icon__text {
   margin-left: $sph-inner--small;
-  font-size: 1rem;
 }
 
 .p-loader {

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -53,7 +53,7 @@ export const useSettingsSave = (saving, setLoading, setSuccess) => {
   const prevSaving = usePrevious(saving);
 
   // Temporarily set success to true if saving changes from true to false
-  // TODO: Add a check for errors too
+  // TODO: Add a check for errors too: https://github.com/canonical-web-and-design/maas-ui/issues/39
   useEffect(() => {
     if (!prevSaving && saving) {
       setLoading(true);

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -1,7 +1,10 @@
 import { useDispatch, useSelector } from "react-redux";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useContext } from "react";
 import { __RouterContext as RouterContext } from "react-router";
+
+const DELAY_TIMER = 400; // minimium duration (ms) saving spinner displays
+const SUCCESS_TIMER = 2000; // duration (ms) success tick is displayed
 
 export const useFetchOnce = (fetchAction, loadedSelector) => {
   const dispatch = useDispatch();
@@ -34,4 +37,41 @@ export const useLocation = () => {
     location,
     navigate
   };
+};
+
+export const usePrevious = value => {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export const useSettingsSave = (saving, setLoading, setSuccess) => {
+  const delayTimer = useRef();
+  const saveTimer = useRef();
+  const prevSaving = usePrevious(saving);
+
+  // Temporarily set success to true if saving changes from true to false
+  // TODO: Add a check for errors too
+  useEffect(() => {
+    if (!prevSaving && saving) {
+      setLoading(true);
+      // resetForm(values);
+      delayTimer.current = setTimeout(() => {
+        setLoading(false);
+        setSuccess(true);
+        saveTimer.current = setTimeout(() => {
+          setSuccess(false);
+        }, SUCCESS_TIMER);
+      }, DELAY_TIMER);
+    }
+  }, [prevSaving, saving, setLoading, setSuccess]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(delayTimer.current);
+      clearTimeout(saveTimer.current);
+    };
+  }, []);
 };

--- a/ui/src/app/settings/actions/config.js
+++ b/ui/src/app/settings/actions/config.js
@@ -10,7 +10,12 @@ config.fetch = () => {
   };
 };
 
-config.update = params => {
+config.update = values => {
+  const params = Object.keys(values).map(key => ({
+    name: key,
+    value: values[key]
+  }));
+
   return {
     type: "UPDATE_CONFIG",
     payload: {

--- a/ui/src/app/settings/actions/config.test.js
+++ b/ui/src/app/settings/actions/config.test.js
@@ -12,15 +12,18 @@ describe("config actions", () => {
   });
 
   it("should handle saving config", () => {
-    const params = [
-      { name: "maas_name", value: "bionic-maas" },
-      { name: "enable_analytics", value: true }
-    ];
+    const values = {
+      maas_name: "bionic-maas",
+      enable_analytics: true
+    };
 
-    expect(config.update(params)).toEqual({
+    expect(config.update(values)).toEqual({
       type: "UPDATE_CONFIG",
       payload: {
-        params
+        params: [
+          { name: "maas_name", value: "bionic-maas" },
+          { name: "enable_analytics", value: true }
+        ]
       },
       meta: {
         method: "config.update",

--- a/ui/src/app/settings/components/GeneralForm/GeneralForm.js
+++ b/ui/src/app/settings/components/GeneralForm/GeneralForm.js
@@ -35,13 +35,7 @@ const GeneralForm = () => {
           validationSchema={GeneralSchema}
           onSubmit={(values, { setSubmitting }) => {
             setTimeout(() => {
-              const params = Object.keys(values).map(key => {
-                return {
-                  name: key,
-                  value: values[key]
-                };
-              });
-              dispatch(updateConfig(params));
+              dispatch(updateConfig(values));
               setSubmitting(false);
             }, 500);
           }}

--- a/ui/src/app/settings/containers/Storage/Storage.js
+++ b/ui/src/app/settings/containers/Storage/Storage.js
@@ -1,125 +1,23 @@
-import { Formik, Form } from "formik";
 import React from "react";
 import { useSelector } from "react-redux";
 
 import selectors from "app/settings/selectors";
-import Button from "app/base/components/Button";
-import Input from "app/base/components/Input";
+import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
-import Select from "app/base/components/Select";
-
-const getStorageLayoutWarning = layout => {
-  switch (layout) {
-    case "blank":
-      return "You will not be able to deploy machines with this storage layout. Manual configuration is required.";
-    case "vmfs6":
-      return "The VMFS6 storage layout only allows for the deployment of VMware (ESXi).";
-    default:
-      return;
-  }
-};
+import Row from "app/base/components/Row";
+import StorageForm from "app/settings/containers/StorageForm";
 
 const Storage = () => {
   const loaded = useSelector(selectors.config.loaded);
   const loading = useSelector(selectors.config.loading);
 
-  const defaultStorageLayout = useSelector(
-    selectors.config.defaultStorageLayout
-  );
-  const storageLayoutOptions = useSelector(
-    selectors.config.storageLayoutOptions
-  );
-  const enableDiskErasing = useSelector(selectors.config.enableDiskErasing);
-  const diskEraseWithSecure = useSelector(selectors.config.diskEraseWithSecure);
-  const diskEraseWithQuick = useSelector(selectors.config.diskEraseWithQuick);
-
   return (
-    <>
-      <h4>
-        Storage
-        {loading && <Loader text="Loading..." inline />}
-      </h4>
-      {loaded && (
-        <Formik
-          initialValues={{
-            defaultStorageLayout,
-            enableDiskErasing,
-            diskEraseWithQuick,
-            diskEraseWithSecure
-          }}
-          onChange
-          onSubmit={(values, { setSubmitting }) => {
-            setTimeout(() => {
-              alert(JSON.stringify(values, null, 2));
-              setSubmitting(false);
-            }, 400);
-          }}
-        >
-          {({
-            handleBlur,
-            handleChange,
-            handleSubmit,
-            isSubmitting,
-            values
-          }) => (
-            <Form onSubmit={handleSubmit}>
-              <div className="row">
-                <div className="col-8">
-                  <Select
-                    id="defaultStorageLayout"
-                    label="Default storage layout"
-                    help="Storage layout that is applied to a node when it is commissioned."
-                    options={storageLayoutOptions}
-                    caution={getStorageLayoutWarning(
-                      values.defaultStorageLayout
-                    )}
-                    value={values.defaultStorageLayout}
-                    onChange={handleChange}
-                  />
-                  <Input
-                    id="enableDiskErasing"
-                    type="checkbox"
-                    label="Erase nodes' disks prior to releasing"
-                    help="Forces users to always erase disks when releasing."
-                    onBlur={handleBlur}
-                    onChange={handleChange}
-                    checked={values.enableDiskErasing}
-                  />
-                  <Input
-                    id="diskEraseWithSecure"
-                    type="checkbox"
-                    label="Use secure erase by default when erasing disks"
-                    help="Will only be used on devices that support secure erase. Other devices will fall back to full wipe or quick erase depending on the selected options."
-                    onBlur={handleBlur}
-                    onChange={handleChange}
-                    checked={values.diskEraseWithSecure}
-                  />
-                  <Input
-                    id="diskEraseWithQuick"
-                    type="checkbox"
-                    label="Use quick erase by default when erasing disks"
-                    help="This is not a secure erase; it wipes only the beginning and end of each disk."
-                    onBlur={handleBlur}
-                    onChange={handleChange}
-                    checked={values.diskEraseWithQuick}
-                  />
-                  <div className="user-form__buttons">
-                    <Button
-                      appearance="positive"
-                      className="u-no-margin--bottom"
-                      type="submit"
-                      disabled={isSubmitting}
-                    >
-                      Save
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </Form>
-          )}
-        </Formik>
-      )}
-    </>
+    <Row>
+      <Col size={8}>
+        {loading && <Loader text="Loading..." />}
+        {loaded && <StorageForm />}
+      </Col>
+    </Row>
   );
 };
 

--- a/ui/src/app/settings/containers/Storage/Storage.js
+++ b/ui/src/app/settings/containers/Storage/Storage.js
@@ -13,7 +13,7 @@ const Storage = () => {
 
   return (
     <Row>
-      <Col size={8}>
+      <Col size={6}>
         {loading && <Loader text="Loading..." />}
         {loaded && <StorageForm />}
       </Col>

--- a/ui/src/app/settings/containers/Storage/Storage.test.js
+++ b/ui/src/app/settings/containers/Storage/Storage.test.js
@@ -2,9 +2,7 @@ import { mount } from "enzyme";
 import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { MemoryRouter } from "react-router-dom";
 
-import { reduceInitialState } from "testing/utils";
 import Storage from "./Storage";
 
 const mockStore = configureStore();
@@ -20,13 +18,7 @@ describe("Storage", () => {
           {
             name: "default_storage_layout",
             value: "bcache",
-            choices: [
-              ["bcache", "Bcache layout"],
-              ["blank", "No storage (blank) layout"],
-              ["flat", "Flat layout"],
-              ["lvm", "LVM layout"],
-              ["vmfs6", "VMFS6 layout"]
-            ]
+            choices: []
           },
           {
             name: "enable_disk_erasing_on_release",
@@ -45,147 +37,31 @@ describe("Storage", () => {
     };
   });
 
-  it("displays a loading component if loading", () => {
+  it("displays a spinner if config is loading", () => {
     const state = { ...initialState };
     state.config.loading = true;
     const store = mockStore(state);
 
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/settings/storage", key: "testKey" }]}
-        >
-          <Storage />
-        </MemoryRouter>
+        <Storage />
       </Provider>
     );
 
     expect(wrapper.find("Loader").exists()).toBe(true);
   });
 
-  it("displays a warning if blank storage layout chosen", () => {
+  it("displays the StorageForm if config is loaded", () => {
     const state = { ...initialState };
-    const items = reduceInitialState(
-      state.config.items,
-      "name",
-      "default_storage_layout",
-      { value: "blank" }
-    );
-    state.config.items = items;
+    state.config.loaded = true;
     const store = mockStore(state);
 
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/settings/storage", key: "testKey" }]}
-        >
-          <Storage />
-        </MemoryRouter>
+        <Storage />
       </Provider>
     );
 
-    expect(wrapper.find(".p-form-validation__message").text()).toBe(
-      "Caution: You will not be able to deploy machines with this storage layout. Manual configuration is required."
-    );
-  });
-
-  it("displays a warning if vmfs6 storage layout chosen", () => {
-    const state = { ...initialState };
-    const items = reduceInitialState(
-      state.config.items,
-      "name",
-      "default_storage_layout",
-      { value: "vmfs6" }
-    );
-    state.config.items = items;
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/settings/storage", key: "testKey" }]}
-        >
-          <Storage />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find(".p-form-validation__message").text()).toBe(
-      "Caution: The VMFS6 storage layout only allows for the deployment of VMware (ESXi)."
-    );
-  });
-
-  it("correctly reflects enableDiskErasing state", () => {
-    const state = { ...initialState };
-    const items = reduceInitialState(
-      state.config.items,
-      "name",
-      "enable_disk_erasing_on_release",
-      { value: true }
-    );
-    state.config.items = items;
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/settings/storage", key: "testKey" }]}
-        >
-          <Storage />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("Input#enableDiskErasing").props().checked).toBe(true);
-  });
-
-  it("correctly reflects diskEraseWithSecure state", () => {
-    const state = { ...initialState };
-    const items = reduceInitialState(
-      state.config.items,
-      "name",
-      "disk_erase_with_secure_erase",
-      { value: true }
-    );
-    state.config.items = items;
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/settings/storage", key: "testKey" }]}
-        >
-          <Storage />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("Input#diskEraseWithSecure").props().checked).toBe(
-      true
-    );
-  });
-
-  it("correctly reflects diskEraseWithQuick state", () => {
-    const state = { ...initialState };
-    const items = reduceInitialState(
-      state.config.items,
-      "name",
-      "disk_erase_with_quick_erase",
-      { value: true }
-    );
-    state.config.items = items;
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/settings/storage", key: "testKey" }]}
-        >
-          <Storage />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("Input#diskEraseWithQuick").props().checked).toBe(true);
+    expect(wrapper.find("StorageForm").exists()).toBe(true);
   });
 });

--- a/ui/src/app/settings/containers/StorageForm/StorageForm.js
+++ b/ui/src/app/settings/containers/StorageForm/StorageForm.js
@@ -1,0 +1,72 @@
+import { Formik } from "formik";
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import actions from "app/settings/actions";
+import config from "app/settings/selectors/config";
+import { formikFormDisabled } from "app/settings/utils";
+import { useSettingsSave } from "app/base/hooks";
+import ActionButton from "app/base/components/ActionButton";
+import Form from "app/base/components/Form";
+import StorageFormFields from "app/settings/containers/StorageFormFields";
+
+const StorageSchema = Yup.object().shape({
+  default_storage_layout: Yup.string().required(),
+  disk_erase_with_quick_erase: Yup.boolean().required(),
+  disk_erase_with_secure_erase: Yup.boolean().required(),
+  enable_disk_erasing_on_release: Yup.boolean().required()
+});
+
+const StorageForm = () => {
+  const dispatch = useDispatch();
+  const saveConfig = actions.config.update;
+
+  const defaultStorageLayout = useSelector(config.defaultStorageLayout);
+  const diskEraseWithQuick = useSelector(config.diskEraseWithQuick);
+  const diskEraseWithSecure = useSelector(config.diskEraseWithSecure);
+  const enableDiskErasing = useSelector(config.enableDiskErasing);
+
+  const saving = useSelector(config.saving);
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  useSettingsSave(saving, setLoading, setSuccess);
+
+  return (
+    <Formik
+      initialValues={{
+        default_storage_layout: defaultStorageLayout,
+        disk_erase_with_quick_erase: diskEraseWithQuick,
+        disk_erase_with_secure_erase: diskEraseWithSecure,
+        enable_disk_erasing_on_release: enableDiskErasing
+      }}
+      onSubmit={(values, { resetForm }) => {
+        const payload = Object.keys(values).map(key => ({
+          name: key,
+          value: values[key]
+        }));
+        dispatch(saveConfig(payload));
+        resetForm(values);
+      }}
+      validationSchema={StorageSchema}
+      render={formikProps => (
+        <Form onSubmit={formikProps.handleSubmit}>
+          <StorageFormFields formikProps={formikProps} />
+          <ActionButton
+            appearance="positive"
+            className="u-no-margin--bottom"
+            type="submit"
+            disabled={formikFormDisabled(formikProps, success)}
+            loading={loading}
+            success={success}
+            width="60px"
+          >
+            Save
+          </ActionButton>
+        </Form>
+      )}
+    />
+  );
+};
+
+export default StorageForm;

--- a/ui/src/app/settings/containers/StorageForm/StorageForm.js
+++ b/ui/src/app/settings/containers/StorageForm/StorageForm.js
@@ -20,7 +20,7 @@ const StorageSchema = Yup.object().shape({
 
 const StorageForm = () => {
   const dispatch = useDispatch();
-  const saveConfig = actions.config.update;
+  const updateConfig = actions.config.update;
 
   const defaultStorageLayout = useSelector(config.defaultStorageLayout);
   const diskEraseWithQuick = useSelector(config.diskEraseWithQuick);
@@ -41,11 +41,7 @@ const StorageForm = () => {
         enable_disk_erasing_on_release: enableDiskErasing
       }}
       onSubmit={(values, { resetForm }) => {
-        const payload = Object.keys(values).map(key => ({
-          name: key,
-          value: values[key]
-        }));
-        dispatch(saveConfig(payload));
+        dispatch(updateConfig(values));
         resetForm(values);
       }}
       validationSchema={StorageSchema}

--- a/ui/src/app/settings/containers/StorageForm/StorageForm.test.js
+++ b/ui/src/app/settings/containers/StorageForm/StorageForm.test.js
@@ -1,0 +1,78 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import StorageForm from "./StorageForm";
+
+const mockStore = configureStore();
+
+describe("StorageForm", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      config: {
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "default_storage_layout",
+            value: "bcache",
+            choices: [
+              ["bcache", "Bcache layout"],
+              ["blank", "No storage (blank) layout"],
+              ["flat", "Flat layout"],
+              ["lvm", "LVM layout"],
+              ["vmfs6", "VMFS6 layout"]
+            ]
+          },
+          {
+            name: "enable_disk_erasing_on_release",
+            value: false
+          },
+          {
+            name: "disk_erase_with_secure_erase",
+            value: false
+          },
+          {
+            name: "disk_erase_with_quick_erase",
+            value: false
+          }
+        ]
+      }
+    };
+  });
+
+  it("dispatches an action to update config on save button click", done => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageForm />
+      </Provider>
+    );
+    wrapper.find("form").simulate("submit");
+
+    // since Formik handler is evaluated asynchronously we have to delay checking the assertion
+    window.setTimeout(() => {
+      expect(store.getActions()).toEqual([
+        {
+          type: "UPDATE_CONFIG",
+          payload: {
+            params: [
+              { name: "default_storage_layout", value: "bcache" },
+              { name: "disk_erase_with_quick_erase", value: false },
+              { name: "disk_erase_with_secure_erase", value: false },
+              { name: "enable_disk_erasing_on_release", value: false }
+            ]
+          },
+          meta: {
+            method: "config.update",
+            type: 0
+          }
+        }
+      ]);
+      done();
+    }, 0);
+  });
+});

--- a/ui/src/app/settings/containers/StorageForm/index.js
+++ b/ui/src/app/settings/containers/StorageForm/index.js
@@ -1,0 +1,1 @@
+export { default } from "./StorageForm";

--- a/ui/src/app/settings/containers/StorageFormFields/StorageFormFields.js
+++ b/ui/src/app/settings/containers/StorageFormFields/StorageFormFields.js
@@ -7,17 +7,6 @@ import config from "app/settings/selectors/config";
 import FormikField from "app/base/components/FormikField";
 import Select from "app/base/components/Select";
 
-const getStorageLayoutWarning = layout => {
-  switch (layout) {
-    case "blank":
-      return "You will not be able to deploy machines with this storage layout. Manual configuration is required.";
-    case "vmfs6":
-      return "The VMFS6 storage layout only allows for the deployment of VMware (ESXi).";
-    default:
-      return;
-  }
-};
-
 const StorageFormFields = ({ formikProps }) => {
   const { values } = formikProps;
   const storageLayoutOptions = useSelector(config.storageLayoutOptions);
@@ -29,10 +18,25 @@ const StorageFormFields = ({ formikProps }) => {
         component={Select}
         options={storageLayoutOptions}
         help="Storage layout that is applied to a node when it is commissioned."
-        caution={getStorageLayoutWarning(values.default_storage_layout)}
         fieldKey="default_storage_layout"
         formikProps={formikProps}
       />
+      {values.default_storage_layout === "blank" && (
+        <p className="p-form-validation__message">
+          <i className="p-icon--warning" />
+          <strong className="p-icon__text">Caution:</strong> You will not be
+          able to deploy machines with this storage layout. Manual configuration
+          is required.
+        </p>
+      )}
+      {values.default_storage_layout === "vmfs6" && (
+        <p className="p-form-validation__message">
+          <i className="p-icon--warning" />
+          <strong className="p-icon__text">Caution:</strong> The VMFS6 storage
+          layout only allows for the deployment of{" "}
+          <strong>VMware (ESXi)</strong>.
+        </p>
+      )}
       <FormikField
         label="Erase nodes' disks prior to releasing"
         type="checkbox"

--- a/ui/src/app/settings/containers/StorageFormFields/StorageFormFields.js
+++ b/ui/src/app/settings/containers/StorageFormFields/StorageFormFields.js
@@ -1,0 +1,71 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useSelector } from "react-redux";
+
+import { extendFormikShape } from "app/settings/proptypes";
+import config from "app/settings/selectors/config";
+import FormikField from "app/base/components/FormikField";
+import Select from "app/base/components/Select";
+
+const getStorageLayoutWarning = layout => {
+  switch (layout) {
+    case "blank":
+      return "You will not be able to deploy machines with this storage layout. Manual configuration is required.";
+    case "vmfs6":
+      return "The VMFS6 storage layout only allows for the deployment of VMware (ESXi).";
+    default:
+      return;
+  }
+};
+
+const StorageFormFields = ({ formikProps }) => {
+  const { values } = formikProps;
+  const storageLayoutOptions = useSelector(config.storageLayoutOptions);
+
+  return (
+    <>
+      <FormikField
+        label="Default storage layout"
+        component={Select}
+        options={storageLayoutOptions}
+        help="Storage layout that is applied to a node when it is commissioned."
+        caution={getStorageLayoutWarning(values.default_storage_layout)}
+        fieldKey="default_storage_layout"
+        formikProps={formikProps}
+      />
+      <FormikField
+        label="Erase nodes' disks prior to releasing"
+        type="checkbox"
+        checked={values.enable_disk_erasing_on_release}
+        help="Forces users to always erase disks when releasing."
+        fieldKey="enable_disk_erasing_on_release"
+        formikProps={formikProps}
+      />
+      <FormikField
+        label="Use secure erase by default when erasing disks"
+        type="checkbox"
+        checked={values.disk_erase_with_secure_erase}
+        help="Will only be used on devices that support secure erase. Other devices will fall back to full wipe or quick erase depending on the selected options."
+        fieldKey="disk_erase_with_secure_erase"
+        formikProps={formikProps}
+      />
+      <FormikField
+        label="Use quick erase by default when erasing disks"
+        type="checkbox"
+        checked={values.disk_erase_with_quick_erase}
+        help="This is not a secure erase; it wipes only the beginning and end of each disk."
+        fieldKey="disk_erase_with_quick_erase"
+        formikProps={formikProps}
+      />
+    </>
+  );
+};
+
+StorageFormFields.propTypes = extendFormikShape({
+  default_storage_layout: PropTypes.string,
+  disk_erase_with_quick_erase: PropTypes.bool,
+  disk_erase_with_secure_erase: PropTypes.bool,
+  enable_disk_erasing_on_release: PropTypes.bool
+});
+
+export default StorageFormFields;

--- a/ui/src/app/settings/containers/StorageFormFields/StorageFormFields.test.js
+++ b/ui/src/app/settings/containers/StorageFormFields/StorageFormFields.test.js
@@ -1,0 +1,136 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import StorageFormFields from "./StorageFormFields";
+
+const mockStore = configureStore();
+
+describe("StorageFormFields", () => {
+  let baseFormikProps;
+  let initialState;
+  let baseValues = {
+    default_storage_layout: "bcache",
+    enable_disk_erasing_on_release: false,
+    disk_erase_with_secure_erase: false,
+    disk_erase_with_quick_erase: false
+  };
+
+  beforeEach(() => {
+    baseFormikProps = {
+      errors: {},
+      handleBlur: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      initialValues: { ...baseValues },
+      touched: {},
+      values: { ...baseValues }
+    };
+    initialState = {
+      config: {
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "default_storage_layout",
+            value: "bcache",
+            choices: [
+              ["bcache", "Bcache layout"],
+              ["blank", "No storage (blank) layout"],
+              ["flat", "Flat layout"],
+              ["lvm", "LVM layout"],
+              ["vmfs6", "VMFS6 layout"]
+            ]
+          }
+        ]
+      }
+    };
+  });
+
+  it("displays a warning if blank storage layout chosen", () => {
+    const state = { ...initialState };
+    const formikProps = { ...baseFormikProps };
+    formikProps.values.default_storage_layout = "blank";
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageFormFields formikProps={formikProps} />
+      </Provider>
+    );
+
+    expect(wrapper.find(".p-form-validation__message").text()).toBe(
+      "Caution: You will not be able to deploy machines with this storage layout. Manual configuration is required."
+    );
+  });
+
+  it("displays a warning if vmfs6 storage layout chosen", () => {
+    const state = { ...initialState };
+    const formikProps = { ...baseFormikProps };
+    formikProps.values.default_storage_layout = "vmfs6";
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageFormFields formikProps={formikProps} />
+      </Provider>
+    );
+
+    expect(wrapper.find(".p-form-validation__message").text()).toBe(
+      "Caution: The VMFS6 storage layout only allows for the deployment of VMware (ESXi)."
+    );
+  });
+
+  it("correctly reflects enableDiskErasing state", () => {
+    const state = { ...initialState };
+    const formikProps = { ...baseFormikProps };
+    formikProps.values.enable_disk_erasing_on_release = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageFormFields formikProps={formikProps} />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("Input[name='enable_disk_erasing_on_release']").props()
+        .checked
+    ).toBe(true);
+  });
+
+  it("correctly reflects diskEraseWithSecure state", () => {
+    const state = { ...initialState };
+    const formikProps = { ...baseFormikProps };
+    formikProps.values.disk_erase_with_secure_erase = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageFormFields formikProps={formikProps} />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("Input[name='disk_erase_with_secure_erase']").props().checked
+    ).toBe(true);
+  });
+
+  it("correctly reflects diskEraseWithQuick state", () => {
+    const state = { ...initialState };
+    const formikProps = { ...baseFormikProps };
+    formikProps.values.disk_erase_with_quick_erase = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageFormFields formikProps={formikProps} />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("Input[name='disk_erase_with_quick_erase']").props().checked
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/settings/containers/StorageFormFields/index.js
+++ b/ui/src/app/settings/containers/StorageFormFields/index.js
@@ -1,0 +1,1 @@
+export { default } from "./StorageFormFields";

--- a/ui/src/app/settings/proptypes.js
+++ b/ui/src/app/settings/proptypes.js
@@ -16,3 +16,21 @@ export const RepositoryShape = PropTypes.shape({
   updated: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired
 });
+
+export const extendFormikShape = values => {
+  let touchedShape = {};
+  Object.keys(values).forEach(key => {
+    touchedShape[key] = PropTypes.bool;
+  });
+  return {
+    formikProps: PropTypes.shape({
+      errors: PropTypes.shape(values).isRequired,
+      handleBlur: PropTypes.func.isRequired,
+      handleChange: PropTypes.func.isRequired,
+      handleSubmit: PropTypes.func.isRequired,
+      isSubmitting: PropTypes.bool,
+      touched: PropTypes.shape(touchedShape).isRequired,
+      values: PropTypes.shape(values).isRequired
+    })
+  };
+};

--- a/ui/src/app/settings/reducers/config.js
+++ b/ui/src/app/settings/reducers/config.js
@@ -11,6 +11,18 @@ const config = produce(
         draft.loaded = true;
         draft.items = action.payload;
         return;
+      case "UPDATE_CONFIG_START":
+        draft.saving = true;
+        return;
+      case "UPDATE_CONFIG_SUCCESS":
+        draft.saving = false;
+        draft.items = draft.items.map(item => {
+          if (item.name === action.payload.name) {
+            return action.payload;
+          }
+          return item;
+        });
+        return;
       default:
         return draft;
     }
@@ -18,6 +30,7 @@ const config = produce(
   {
     loading: false,
     loaded: false,
+    saving: false,
     items: []
   }
 );

--- a/ui/src/app/settings/reducers/config.test.js
+++ b/ui/src/app/settings/reducers/config.test.js
@@ -5,6 +5,7 @@ describe("config reducer", () => {
     expect(config(undefined, {})).toEqual({
       loading: false,
       loaded: false,
+      saving: false,
       items: []
     });
   });
@@ -17,6 +18,7 @@ describe("config reducer", () => {
     ).toEqual({
       loading: true,
       loaded: false,
+      saving: false,
       items: []
     });
   });
@@ -27,6 +29,7 @@ describe("config reducer", () => {
         {
           loading: true,
           loaded: false,
+          saving: false,
           items: []
         },
         {
@@ -40,10 +43,54 @@ describe("config reducer", () => {
     ).toEqual({
       loading: false,
       loaded: true,
+      saving: false,
       items: [
         { name: "default_storage_layout", value: "bcache" },
         { name: "enable_disk_erasing_on_release", value: "foo" }
       ]
+    });
+  });
+
+  it("should correctly reduce UPDATE_CONFIG_START", () => {
+    expect(
+      config(
+        {
+          loading: false,
+          loaded: false,
+          saving: false,
+          items: []
+        },
+        {
+          type: "UPDATE_CONFIG_START"
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: false,
+      saving: true,
+      items: []
+    });
+  });
+
+  it("should correctly reduce UPDATE_CONFIG_SUCCESS", () => {
+    expect(
+      config(
+        {
+          loading: false,
+          loaded: false,
+          saving: true,
+          items: [{ name: "default_storage_layout", value: "bcache" }]
+        },
+        {
+          type: "UPDATE_CONFIG_SUCCESS",
+          payload: { name: "default_storage_layout", value: "flat" }
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: false,
+      saving: false,
+      items: [{ name: "default_storage_layout", value: "flat" }]
     });
   });
 });

--- a/ui/src/app/settings/selectors/config.js
+++ b/ui/src/app/settings/selectors/config.js
@@ -24,18 +24,25 @@ const getValueFromName = (arr, name) => {
 config.all = state => state.config.items;
 
 /**
- * Returns true if users are loading.
+ * Returns true if config is loading.
  * @param {Object} state - The redux state.
- * @returns {Boolean} User is loading.
+ * @returns {Boolean} Config is loading.
  */
 config.loading = state => state.config.loading;
 
 /**
- * Returns true if users have been loaded.
+ * Returns true if config has been loaded.
  * @param {Object} state - The redux state.
- * @returns {Boolean} User has loaded.
+ * @returns {Boolean} Config has loaded.
  */
 config.loaded = state => state.config.loaded;
+
+/**
+ * Returns true if config is saving.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Config is saving.
+ */
+config.saving = state => state.config.saving;
 
 /**
  * Returns the MAAS config for default storage layout.
@@ -98,21 +105,41 @@ config.diskEraseWithQuick = createSelector(
   configs => getValueFromName(configs, "disk_erase_with_quick_erase")
 );
 
+/**
+ * Returns the MAAS config for http proxy url.
+ * @param {Object} state - The redux state.
+ * @returns {String} HTTP proxy.
+ */
 config.httpProxy = createSelector(
   [config.all],
   configs => getValueFromName(configs, "http_proxy")
 );
 
+/**
+ * Returns the MAAS config for enabling http proxy.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Enable HTTP proxy.
+ */
 config.enableHttpProxy = createSelector(
   [config.all],
   configs => getValueFromName(configs, "enable_http_proxy")
 );
 
+/**
+ * Returns the MAAS config for using peer proxy.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Use peer proxy.
+ */
 config.usePeerProxy = createSelector(
   [config.all],
   configs => getValueFromName(configs, "use_peer_proxy")
 );
 
+/**
+ * Returns the proxy type, given other proxy config.
+ * @param {Object} state - The redux state.
+ * @returns {String} Proxy type.
+ */
 config.proxyType = createSelector(
   [config.httpProxy, config.enableHttpProxy, config.usePeerProxy],
   (httpProxy, enableHttpProxy, usePeerProxy) => {

--- a/ui/src/app/settings/utils.js
+++ b/ui/src/app/settings/utils.js
@@ -1,0 +1,27 @@
+/**
+ * Returns whether two objects are equal when JSON.stringified. Note this
+ * requires identical order of keys, and is only suitable for small objects.
+ * @param {Object} obj1 - First object.
+ * @param {Object} obj2 - Second object.
+ * @returns {Boolean} Objects are equal when stringified.
+ */
+const simpleObjectEquality = (obj1, obj2) => {
+  if (typeof obj1 === "object" && typeof obj2 === "object") {
+    return JSON.stringify(obj1) === JSON.stringify(obj2);
+  }
+  return false;
+};
+
+/**
+ * Returns whether a formik form should be disabled, given the current state
+ * of the form.
+ * @param {Object} formikProps - Props required for formik forms.
+ * @param {Boolean} success - Form is in success state.
+ * @returns {Boolean} Form is disabled.
+ */
+const formikFormDisabled = formikProps => {
+  const { initialValues, isSubmitting, values } = formikProps;
+  return isSubmitting || simpleObjectEquality(initialValues, values);
+};
+
+export { formikFormDisabled, simpleObjectEquality };

--- a/ui/src/app/settings/utils.test.js
+++ b/ui/src/app/settings/utils.test.js
@@ -1,0 +1,40 @@
+import { formikFormDisabled, simpleObjectEquality } from "./utils";
+
+describe("settings utils", () => {
+  describe("simpleObjectEquality", () => {
+    it("returns true if two objects have the same key value pairs in the same order", () => {
+      const obj1 = { key1: "value1", key2: "value2" };
+      const obj2 = { key1: "value1", key2: "value2" };
+      expect(simpleObjectEquality(obj1, obj2)).toBe(true);
+    });
+  });
+
+  describe("formikFormDisabled", () => {
+    it("returns true if form is submitting", () => {
+      const formikProps = {
+        initialValues: { key: "value" },
+        values: { key: "value" },
+        isSubmitting: true
+      };
+      expect(formikFormDisabled(formikProps)).toBe(true);
+    });
+
+    it("returns true if the form values have not changed", () => {
+      const formikProps = {
+        initialValues: { key: "value" },
+        values: { key: "value" },
+        isSubmitting: false
+      };
+      expect(formikFormDisabled(formikProps)).toBe(true);
+    });
+
+    it("returns false if the form is not submitting and form values have changed", () => {
+      const formikProps = {
+        initialValues: { key: "value1" },
+        values: { key: "value2" },
+        isSubmitting: false
+      };
+      expect(formikFormDisabled(formikProps)).toBe(false);
+    });
+  });
+});

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -33,6 +33,11 @@ body {
   @include maas-icon-edit($color-mid-dark);
 }
 
+.p-form-validation__message [class*="p-icon--"] {
+  @extend %icon;
+  @include vf-icon-size(.875rem);
+}
+
 .u-text--light {
   color: $color-mid-dark;
 }


### PR DESCRIPTION
## Done
- Added save functionality to Storage form
- Reworked Storage form to use FormikField component
- Updated Storage form styling (no title, left-aligned button)
- Added ActionButton component which wraps Button. It takes props to determine whether it's in a loading or success state. It takes an explicit width prop which is a bit crap but I couldn't figure out how to store button width in the hooks world and figured this works fine for now :man_shrugging: 
- Added some hooks that essentially "fake" a delay after clicking Save, even though saving happens almost instantly and therefore saving state is `false`. Success state is simply determined as "saving state moved from true => false" so will probs need some handling for when that happens due to an error.

## QA
- Go to Storage and check that the button is disabled
- Change some values and check that button is no longer disabled
- Change values back to original (without saving) and check that button becomes disabled again
- Save some changes and check that the button text is replaced by a spinner, and then after a short time it changes to a tick
- Refresh the page and check that state has persisted

## Screenshots
### No values changed
![Screen Shot 2019-08-12 at 18 51 44-fullpage](https://user-images.githubusercontent.com/25733845/62882580-8510dc80-bd32-11e9-8e1e-a691d99c6d04.png)


### Values changed
![Screen Shot 2019-08-12 at 18 51 54-fullpage](https://user-images.githubusercontent.com/25733845/62882589-880bcd00-bd32-11e9-8622-f0153f8657bd.png)


### Saving
![Screen Shot 2019-08-12 at 18 52 00-fullpage](https://user-images.githubusercontent.com/25733845/62882596-8b06bd80-bd32-11e9-8ea4-ba81fc733220.png)


### Saved
![Screen Shot 2019-08-12 at 18 52 01-fullpage](https://user-images.githubusercontent.com/25733845/62882600-8e01ae00-bd32-11e9-97d5-e3176af7c88c.png)

