### PR TITLE
Set max-workers to 2 for CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           keys:
             - yarn-{{ checksum "yarn.lock" }}
       - run: yarn install
-      - run: cd ui && yarn run test
+      - run: cd ui && yarn run test --max-workers=2
       - save_cache:
           key: yarn-{{ checksum "yarn.lock" }}
           paths:


### PR DESCRIPTION
## Done
Circle provides 2 vCPUs, so set jest max-workers to 2 to [resolve OOM issues](https://discuss.circleci.com/t/babel-7-jest-results-in-timeout/25383/3).

## QA
None, CI should pass without errors.