### PR TITLE
Allow params to be passed as array.

### DIFF
--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -82,11 +82,7 @@ export function* sendMessage(socketClient) {
     const { actionType, message } = data.payload;
     yield put({ type: `${actionType}_START` });
     try {
-      if (
-        actionType.startsWith("CREATE") ||
-        actionType.startsWith("UPDATE") ||
-        actionType.startsWith("DELETE")
-      ) {
+      if (actionType.startsWith("UPDATE")) {
         yield all(
           message.params.map(param =>
             call([socketClient, socketClient.send], actionType, {

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -88,13 +88,13 @@ export function* sendMessage(socketClient) {
         actionType.startsWith("DELETE")
       ) {
         yield all(
-          message.params.map(item =>
+          message.params.map(param =>
             call([socketClient, socketClient.send], actionType, {
               method: message.method,
               type: message.type,
               params: {
-                name: Object.keys(item)[0],
-                value: Object.values()[0]
+                name: Object.keys(param)[0],
+                value: Object.values(param)[0]
               }
             })
           )

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -82,7 +82,7 @@ export function* sendMessage(socketClient) {
     const { actionType, message } = data.payload;
     yield put({ type: `${actionType}_START` });
     try {
-      if (actionType.startsWith("UPDATE")) {
+      if (message.params && Array.isArray(message.params)) {
         yield all(
           message.params.map(param =>
             call([socketClient, socketClient.send], actionType, {

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -81,27 +81,30 @@ export function* sendMessage(socketClient) {
     const data = yield take("WEBSOCKET_SEND");
     const { actionType, message } = data.payload;
     yield put({ type: `${actionType}_START` });
-    if (
-      actionType.startsWith("CREATE") ||
-      actionType.startsWith("UPDATE") ||
-      actionType.startsWith("DELETE")
-    ) {
-      yield all(
-        message.params.map(param =>
-          call([socketClient, socketClient.send], actionType, {
-            method: message.method,
-            type: message.type,
-            params: {
-              name: Object.keys(param)[0],
-              value: Object.values(param)[0]
-            }
-          })
-        )
-      );
-    } else {
-      yield call([socketClient, socketClient.send], actionType, message);
+    try {
+      if (
+        actionType.startsWith("CREATE") ||
+        actionType.startsWith("UPDATE") ||
+        actionType.startsWith("DELETE")
+      ) {
+        yield all(
+          message.params.map(item =>
+            call([socketClient, socketClient.send], actionType, {
+              method: message.method,
+              type: message.type,
+              params: {
+                name: Object.keys(item)[0],
+                value: Object.values()[0]
+              }
+            })
+          )
+        );
+      } else {
+        yield call([socketClient, socketClient.send], actionType, message);
+      }
+    } catch (error) {
+      yield put({ type: `${data.payload.actionType}_ERROR`, error });
     }
-    // TODO: API provides no error responses
   }
 }
 

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -88,10 +88,7 @@ export function* sendMessage(socketClient) {
             call([socketClient, socketClient.send], actionType, {
               method: message.method,
               type: message.type,
-              params: {
-                name: Object.keys(param)[0],
-                value: Object.values(param)[0]
-              }
+              params: param
             })
           )
         );

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -110,6 +110,22 @@ describe("websocket sagas", () => {
     );
   });
 
+  it("can handle errors when sending a WebSocket message", () => {
+    const saga = sendMessage(socketClient);
+    saga.next();
+    saga.next({
+      type: "WEBSOCKET_SEND",
+      payload: {
+        actionType: "TEST_ACTION",
+        message: { payload: "here" }
+      }
+    });
+    saga.next();
+    expect(saga.throw("error!").value).toEqual(
+      put({ type: "TEST_ACTION_ERROR", error: "error!" })
+    );
+  });
+
   it("can receive a successful WebSocket message", () => {
     const saga = handleMessage(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -110,29 +110,7 @@ describe("websocket sagas", () => {
     );
   });
 
-  it("can handle errors when sending a WebSocket message", () => {
-    const saga = sendMessage(socketClient);
-    expect(saga.next().value).toEqual(take("WEBSOCKET_SEND"));
-    expect(
-      saga.next({
-        type: "WEBSOCKET_SEND",
-        payload: {
-          actionType: "TEST_ACTION",
-          message: { payload: "here" }
-        }
-      }).value
-    ).toEqual(put({ type: "TEST_ACTION_START" }));
-    expect(saga.next().value).toEqual(
-      call([socketClient, socketClient.send], "TEST_ACTION", {
-        payload: "here"
-      })
-    );
-    expect(saga.next("ERROR!").value).toEqual(
-      put({ type: "TEST_ACTION_ERROR", error: "ERROR!" })
-    );
-  });
-
-  it("can receive a succesful WebSocket message", () => {
+  it("can receive a successful WebSocket message", () => {
     const saga = handleMessage(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(

--- a/ui/src/websocket-client.js
+++ b/ui/src/websocket-client.js
@@ -46,11 +46,7 @@ class WebSocketClient {
       ...message,
       request_id: id
     };
-    try {
-      this.socket.send(JSON.stringify(payload));
-    } catch (error) {
-      return error;
-    }
+    this.socket.send(JSON.stringify(payload));
   }
 }
 

--- a/ui/src/websocket-client.test.js
+++ b/ui/src/websocket-client.test.js
@@ -31,14 +31,6 @@ describe("websocket client", () => {
     });
   });
 
-  it("can handle exceptions when sending a message", () => {
-    let recursiveObject = {};
-    recursiveObject.bad = { recursive: recursiveObject };
-    const error = client.send("TEST_ACTION", recursiveObject);
-    expect(client.socket.send.mock.calls.length).toBe(0);
-    expect(error.message).toEqual("Converting circular structure to JSON");
-  });
-
   it("increments the id", () => {
     expect(client._nextId).toBe(0);
     client.send("TEST_ACTION", {});


### PR DESCRIPTION
## DONE
* Handle `params` passed as an array, unblocking implementation of a config update action.
* Removed error handling code from the client, instead have the caller catch errors.

## QA
* In the redux devtools, dispatch an update action with params as an array (note that we don't use `{"name": foo, "value": bar}`). 


e.g.

```
{
  type: "WEBSOCKET_SEND",
  payload: {
    actionType: "UPDATE_CONFIG",
    message: {
      method: "config.update",
      type: 0,
      params: [
        { name: "maas_name", value: "foobar" },
        { name: "enable_disk_erasing_on_release", value: false }
      ]
    }
  }
}
```

## Note
This is an interim branch to unblock others, refactoring to come. The fact that `params` is an overloaded term (it can be a payload, it can be actual params for changing a response e.g. limit), is a detail we should hide in our action implementation.