### PR TITLE
Create settings configuration commissioning form

### DIFF
--- a/ui/src/app/settings/components/Nav/Nav.js
+++ b/ui/src/app/settings/components/Nav/Nav.js
@@ -51,13 +51,12 @@ const _generateSection = (section, location) => {
 export const Nav = props => {
   const nav = [
     {
-      path: "/configuration",
       label: "Configuration",
       subNav: [
-        { path: "general", label: "General" },
-        { path: "commissioning", label: "Commissioning" },
-        { path: "deploy", label: "Deploy" },
-        { path: "kernel-parameters", label: "Kernel parameters" }
+        { path: "/configuration/general", label: "General" },
+        { path: "/configuration/commissioning", label: "Commissioning" },
+        { path: "/configuration/deploy", label: "Deploy" },
+        { path: "/configuration/kernel-parameters", label: "Kernel parameters" }
       ]
     },
     {

--- a/ui/src/app/settings/components/Nav/__snapshots__/Nav.test.js.snap
+++ b/ui/src/app/settings/components/Nav/__snapshots__/Nav.test.js.snap
@@ -9,61 +9,54 @@ exports[`Nav renders 1`] = `
   >
     <li
       className="settings-nav__item"
-      key="/configuration"
+      key="Configuration"
     >
-      <strong
-        className=""
-      >
-        <Link
-          className="p-link--soft"
-          to="/configuration"
-        >
-          Configuration
-        </Link>
+      <strong>
+        Configuration
       </strong>
       <ul
         className="settings-nav__list"
       >
         <li
           className="settings-nav__item"
-          key="general"
+          key="/configuration/general"
         >
           <Link
             className="p-link--soft"
-            to="general"
+            to="/configuration/general"
           >
             General
           </Link>
         </li>
         <li
           className="settings-nav__item"
-          key="commissioning"
+          key="/configuration/commissioning"
         >
           <Link
             className="p-link--soft"
-            to="commissioning"
+            to="/configuration/commissioning"
           >
             Commissioning
           </Link>
         </li>
         <li
           className="settings-nav__item"
-          key="deploy"
+          key="/configuration/deploy"
         >
           <Link
             className="p-link--soft"
-            to="deploy"
+            to="/configuration/deploy"
           >
             Deploy
           </Link>
         </li>
         <li
           className="settings-nav__item"
-          key="kernel-parameters"
+          key="/configuration/kernel-parameters"
         >
           <Link
             className="p-link--soft"
-            to="kernel-parameters"
+            to="/configuration/kernel-parameters"
           >
             Kernel parameters
           </Link>

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -1,9 +1,10 @@
 import React from "react";
 import { Route, Redirect, Switch } from "react-router-dom";
 
-import Configuration from "app/settings/containers/Configuration";
+import Commissioning from "app/settings/containers/Configuration/Commissioning";
 import Dhcp from "app/settings/containers/Dhcp";
 import DnsForm from "app/settings/containers/Network/DnsForm";
+import General from "app/settings/containers/Configuration/General";
 import Images from "app/settings/containers/Images";
 import NetworkDiscoveryForm from "app/settings/containers/Network/NetworkDiscoveryForm";
 import NtpForm from "app/settings/containers/Network/NtpForm";
@@ -18,7 +19,13 @@ import Users from "app/settings/containers/Users";
 
 const Routes = () => (
   <Switch>
-    <Route exact path="/configuration" component={Configuration} />
+    <Route exact path="/configuration/general" component={General} />
+    <Route
+      exact
+      path="/configuration/commissioning"
+      component={Commissioning}
+    />
+    <Redirect from="/configuration" to="/configuration/general" />
     <Route exact path="/users" component={Users} />
     <Route exact path="/users/add" component={UserAdd} />
     <Route exact path="/users/:id/edit" component={UserEdit} />
@@ -37,7 +44,6 @@ const Routes = () => (
     <Route exact path="/scripts" component={Scripts} />
     <Route exact path="/dhcp" component={Dhcp} />
     <Route exact path="/repositories" component={Repositories} />
-    <Redirect from="/" to="/configuration" />
   </Switch>
 );
 

--- a/ui/src/app/settings/containers/Configuration/Commissioning/Commissioning.js
+++ b/ui/src/app/settings/containers/Configuration/Commissioning/Commissioning.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { useSelector } from "react-redux";
+
+import selectors from "app/settings/selectors";
+import Col from "app/base/components/Col";
+import Loader from "app/base/components/Loader";
+import Row from "app/base/components/Row";
+import CommissioningForm from "app/settings/containers/Configuration/CommissioningForm";
+
+const Commissioning = () => {
+  const loaded = useSelector(selectors.config.loaded);
+  const loading = useSelector(selectors.config.loading);
+
+  return (
+    <Row>
+      <Col size={6}>
+        {loading && <Loader text="Loading..." />}
+        {loaded && <CommissioningForm />}
+      </Col>
+    </Row>
+  );
+};
+
+export default Commissioning;

--- a/ui/src/app/settings/containers/Configuration/Commissioning/Commissioning.test.js
+++ b/ui/src/app/settings/containers/Configuration/Commissioning/Commissioning.test.js
@@ -1,0 +1,60 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import Commissioning from "./Commissioning";
+
+const mockStore = configureStore();
+
+describe("Commissioning", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      config: {
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "default_distro_series",
+            value: "bionic",
+            choices: []
+          },
+          {
+            name: "default_min_hwe_kernel",
+            value: "ga-16.04-lowlatency",
+            choices: []
+          }
+        ]
+      }
+    };
+  });
+
+  it("displays a spinner if config is loading", () => {
+    const state = { ...initialState };
+    state.config.loading = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Commissioning />
+      </Provider>
+    );
+
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("displays the Commissioning form if config is loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Commissioning />
+      </Provider>
+    );
+
+    expect(wrapper.find("CommissioningForm").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/settings/containers/Configuration/Commissioning/index.js
+++ b/ui/src/app/settings/containers/Configuration/Commissioning/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Commissioning";

--- a/ui/src/app/settings/containers/Configuration/CommissioningForm/CommissioningForm.js
+++ b/ui/src/app/settings/containers/Configuration/CommissioningForm/CommissioningForm.js
@@ -1,0 +1,62 @@
+import { Formik } from "formik";
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import actions from "app/settings/actions";
+import config from "app/settings/selectors/config";
+import { formikFormDisabled } from "app/settings/utils";
+import { useSettingsSave } from "app/base/hooks";
+import ActionButton from "app/base/components/ActionButton";
+import Form from "app/base/components/Form";
+import CommissioningFormFields from "app/settings/containers/Configuration/CommissioningFormFields";
+
+const CommissioningSchema = Yup.object().shape({
+  default_distro_series: Yup.string(),
+  default_min_hwe_kernel: Yup.string()
+});
+
+const CommissioningForm = () => {
+  const dispatch = useDispatch();
+  const updateConfig = actions.config.update;
+
+  const defaultDistroSeries = useSelector(config.defaultDistroSeries);
+  const defaultMinKernelVersion = useSelector(config.defaultMinKernelVersion);
+
+  const saving = useSelector(config.saving);
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  useSettingsSave(saving, setLoading, setSuccess);
+
+  return (
+    <Formik
+      initialValues={{
+        default_distro_series: defaultDistroSeries,
+        default_min_hwe_kernel: defaultMinKernelVersion
+      }}
+      onSubmit={(values, { resetForm }) => {
+        dispatch(updateConfig(values));
+        resetForm(values);
+      }}
+      validationSchema={CommissioningSchema}
+      render={formikProps => (
+        <Form onSubmit={formikProps.handleSubmit}>
+          <CommissioningFormFields formikProps={formikProps} />
+          <ActionButton
+            appearance="positive"
+            className="u-no-margin--bottom"
+            type="submit"
+            disabled={formikFormDisabled(formikProps, success)}
+            loading={loading}
+            success={success}
+            width="60px"
+          >
+            Save
+          </ActionButton>
+        </Form>
+      )}
+    />
+  );
+};
+
+export default CommissioningForm;

--- a/ui/src/app/settings/containers/Configuration/CommissioningForm/CommissioningForm.test.js
+++ b/ui/src/app/settings/containers/Configuration/CommissioningForm/CommissioningForm.test.js
@@ -1,0 +1,79 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CommissioningForm from "./CommissioningForm";
+
+const mockStore = configureStore();
+
+describe("CommissioningForm", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      config: {
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "default_distro_series",
+            value: "bionic",
+            choices: [
+              ["precise", 'Ubuntu 12.04 LTS "Precise Pangolin"'],
+              ["trusty", 'Ubuntu 14.04 LTS "Trusty Tahr"'],
+              ["xenial", 'Ubuntu 16.04 LTS "Xenial Xerus"'],
+              ["bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"']
+            ]
+          },
+          {
+            name: "default_min_hwe_kernel",
+            value: "ga-16.04-lowlatency",
+            choices: [
+              ["", "--- No minimum kernel ---"],
+              ["ga-16.04-lowlatency", "xenial (ga-16.04-lowlatency)"],
+              ["ga-16.04", "xenial (ga-16.04)"],
+              ["hwe-16.04-lowlatency", "xenial (hwe-16.04-lowlatency)"],
+              ["hwe-16.04", "xenial (hwe-16.04)"],
+              ["hwe-16.04-edge", "xenial (hwe-16.04-edge)"],
+              [
+                "hwe-16.04-lowlatency-edge",
+                "xenial (hwe-16.04-lowlatency-edge)"
+              ]
+            ]
+          }
+        ]
+      }
+    };
+  });
+
+  it("dispatched an action to update config on save button click", done => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CommissioningForm />
+      </Provider>
+    );
+    wrapper.find("form").simulate("submit");
+
+    // since Formik handler is evaluated asynchronously we have to delay checking the assertion
+    window.setTimeout(() => {
+      expect(store.getActions()).toEqual([
+        {
+          type: "UPDATE_CONFIG",
+          payload: {
+            params: [
+              { name: "default_distro_series", value: "bionic" },
+              { name: "default_min_hwe_kernel", value: "ga-16.04-lowlatency" }
+            ]
+          },
+          meta: {
+            method: "config.update",
+            type: 0
+          }
+        }
+      ]);
+      done();
+    }, 0);
+  });
+});

--- a/ui/src/app/settings/containers/Configuration/CommissioningForm/index.js
+++ b/ui/src/app/settings/containers/Configuration/CommissioningForm/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CommissioningForm";

--- a/ui/src/app/settings/containers/Configuration/CommissioningFormFields/CommissioningFormFields.js
+++ b/ui/src/app/settings/containers/Configuration/CommissioningFormFields/CommissioningFormFields.js
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useSelector } from "react-redux";
+
+import { extendFormikShape } from "app/settings/proptypes";
+import config from "app/settings/selectors/config";
+import FormikField from "app/base/components/FormikField";
+import Select from "app/base/components/Select";
+
+const CommissioningFormFields = ({ formikProps }) => {
+  const distroSeriesOptions = useSelector(config.distroSeriesOptions);
+  const minKernelVersionOptions = useSelector(config.minKernelVersionOptions);
+
+  return (
+    <>
+      <FormikField
+        label="Default Ubuntu release used for commissioning"
+        component={Select}
+        options={distroSeriesOptions}
+        fieldKey="default_distro_series"
+        formikProps={formikProps}
+      />
+      <FormikField
+        label="Default minimum kernel version"
+        component={Select}
+        options={minKernelVersionOptions}
+        help="The default minimum kernel version used on all new and commissioned nodes"
+        fieldKey="default_min_hwe_kernel"
+        formikProps={formikProps}
+      />
+    </>
+  );
+};
+
+CommissioningFormFields.propTypes = extendFormikShape({
+  default_distro_series: PropTypes.string,
+  default_min_hwe_kernel: PropTypes.string
+});
+
+export default CommissioningFormFields;

--- a/ui/src/app/settings/containers/Configuration/CommissioningFormFields/CommissioningFormFields.test.js
+++ b/ui/src/app/settings/containers/Configuration/CommissioningFormFields/CommissioningFormFields.test.js
@@ -1,0 +1,103 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CommissioningFormFields from "./CommissioningFormFields";
+
+const mockStore = configureStore();
+
+describe("CommissioningFormFields", () => {
+  let baseFormikProps;
+  let initialState;
+  let baseValues = {
+    default_distro_series: "bionic",
+    default_min_hwe_kernel: "ga-16.04-lowlatency"
+  };
+
+  beforeEach(() => {
+    baseFormikProps = {
+      errors: {},
+      handleBlur: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      initialValues: { ...baseValues },
+      touched: {},
+      values: { ...baseValues }
+    };
+    initialState = {
+      config: {
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "default_distro_series",
+            value: "bionic",
+            choices: [
+              ["precise", 'Ubuntu 12.04 LTS "Precise Pangolin"'],
+              ["trusty", 'Ubuntu 14.04 LTS "Trusty Tahr"'],
+              ["xenial", 'Ubuntu 16.04 LTS "Xenial Xerus"'],
+              ["bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"']
+            ]
+          },
+          {
+            name: "default_min_hwe_kernel",
+            value: "ga-16.04-lowlatency",
+            choices: [
+              ["", "--- No minimum kernel ---"],
+              ["ga-16.04-lowlatency", "xenial (ga-16.04-lowlatency)"],
+              ["ga-16.04", "xenial (ga-16.04)"],
+              ["hwe-16.04-lowlatency", "xenial (hwe-16.04-lowlatency)"],
+              ["hwe-16.04", "xenial (hwe-16.04)"],
+              ["hwe-16.04-edge", "xenial (hwe-16.04-edge)"],
+              [
+                "hwe-16.04-lowlatency-edge",
+                "xenial (hwe-16.04-lowlatency-edge)"
+              ]
+            ]
+          }
+        ]
+      }
+    };
+  });
+
+  it("updates value for default distro series", () => {
+    const state = { ...initialState };
+    const formikProps = { ...baseFormikProps };
+    formikProps.values.default_distro_series = "trusty";
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <CommissioningFormFields formikProps={formikProps} />
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find("[name='default_distro_series']")
+        .first()
+        .props().value
+    ).toBe("trusty");
+  });
+
+  it("updates value for default min kernel", () => {
+    const state = { ...initialState };
+    const formikProps = { ...baseFormikProps };
+    formikProps.values.default_min_hwe_kernel = "hwe-16.04-edge";
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <CommissioningFormFields formikProps={formikProps} />
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find("[name='default_min_hwe_kernel']")
+        .first()
+        .props().value
+    ).toBe("hwe-16.04-edge");
+  });
+});

--- a/ui/src/app/settings/containers/Configuration/CommissioningFormFields/index.js
+++ b/ui/src/app/settings/containers/Configuration/CommissioningFormFields/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CommissioningFormFields";

--- a/ui/src/app/settings/containers/Configuration/General/General.js
+++ b/ui/src/app/settings/containers/Configuration/General/General.js
@@ -4,10 +4,10 @@ import { useSelector } from "react-redux";
 import selectors from "app/settings/selectors";
 import GeneralForm from "app/settings/components/GeneralForm";
 
-const Configuration = () => {
+const General = () => {
   const loaded = useSelector(selectors.config.loaded);
 
   return <>{loaded && <GeneralForm />}</>;
 };
 
-export default Configuration;
+export default General;

--- a/ui/src/app/settings/containers/Configuration/General/General.test.js
+++ b/ui/src/app/settings/containers/Configuration/General/General.test.js
@@ -3,11 +3,11 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import Configuration from "./Configuration";
+import General from "./General";
 
 const mockStore = configureStore();
 
-describe("Configuration", () => {
+describe("General", () => {
   let initialState;
   beforeEach(() => {
     initialState = {
@@ -25,7 +25,7 @@ describe("Configuration", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <Configuration />
+        <General />
       </Provider>
     );
 

--- a/ui/src/app/settings/containers/Configuration/General/index.js
+++ b/ui/src/app/settings/containers/Configuration/General/index.js
@@ -1,0 +1,1 @@
+export { default } from "./General";

--- a/ui/src/app/settings/containers/Configuration/index.js
+++ b/ui/src/app/settings/containers/Configuration/index.js
@@ -1,1 +1,0 @@
-export { default } from "./Configuration";

--- a/ui/src/app/settings/selectors/config.js
+++ b/ui/src/app/settings/selectors/config.js
@@ -178,4 +178,66 @@ config.analyticsEnabled = createSelector(
   configs => getValueFromName(configs, "enable_analytics")
 );
 
+/**
+ * Returns the MAAS config for default distro series.
+ * @param {Object} state - The redux state.
+ * @returns {String} Default distro series.
+ */
+config.defaultDistroSeries = createSelector(
+  [config.all],
+  configs => getValueFromName(configs, "default_distro_series")
+);
+
+/**
+ * Returns the possible distro series options reformatted as objects.
+ * @param {Object} state - The redux state.
+ * @returns {Array} Distro series options.
+ */
+config.distroSeriesOptions = createSelector(
+  [config.all],
+  configs => {
+    const configObj = configs.find(
+      config => config.name === "default_distro_series"
+    );
+    if (configObj) {
+      return configObj.choices.map(choice => ({
+        value: choice[0],
+        label: choice[1]
+      }));
+    }
+    return;
+  }
+);
+
+/**
+ * Returns the MAAS config for default min kernel version.
+ * @param {object} state - The redux state.
+ * @returns {String} Default min kernal version.
+ */
+config.defaultMinKernelVersion = createSelector(
+  [config.all],
+  configs => getValueFromName(configs, "default_min_hwe_kernel")
+);
+
+/**
+ * Returns the possible min kernel version options reformatted as objects.
+ * @param {Object} state - The redux state.
+ * @returns {Array} Min kernel version options.
+ */
+config.minKernelVersionOptions = createSelector(
+  [config.all],
+  configs => {
+    const configObj = configs.find(
+      config => config.name === "default_min_hwe_kernel"
+    );
+    if (configObj) {
+      return configObj.choices.map(choice => ({
+        value: choice[0],
+        label: choice[1]
+      }));
+    }
+    return;
+  }
+);
+
 export default config;

--- a/ui/src/app/settings/selectors/config.test.js
+++ b/ui/src/app/settings/selectors/config.test.js
@@ -233,4 +233,90 @@ describe("config selectors", () => {
       expect(config.analyticsEnabled(state)).toBe(true);
     });
   });
+
+  describe("defaultDistroSeries", () => {
+    it("returns MAAS config for default distro series", () => {
+      const state = {
+        config: {
+          loading: false,
+          loaded: true,
+          items: [{ name: "default_distro_series", value: "bionic" }]
+        }
+      };
+      expect(config.defaultDistroSeries(state)).toBe("bionic");
+    });
+  });
+
+  describe("distroSeriesOptions", () => {
+    it("returns array of distro series options, formatted as objects", () => {
+      const state = {
+        config: {
+          loading: false,
+          loaded: true,
+          items: [
+            {
+              name: "default_distro_series",
+              value: "bionic",
+              choices: [["bionic", "Ubuntu 18.04 LTS 'Bionic-Beaver'"]]
+            }
+          ]
+        }
+      };
+      expect(config.distroSeriesOptions(state)).toStrictEqual([
+        {
+          value: "bionic",
+          label: "Ubuntu 18.04 LTS 'Bionic-Beaver'"
+        }
+      ]);
+    });
+  });
+
+  describe("defaultMinKernelVersion", () => {
+    it("returns MAAS config for default kernel version", () => {
+      const state = {
+        config: {
+          loading: false,
+          loaded: true,
+          items: [{ name: "default_min_hwe_kernel", value: "" }]
+        }
+      };
+      expect(config.defaultMinKernelVersion(state)).toBe("");
+    });
+  });
+
+  describe("minKernelVersionOptions", () => {
+    it("returns array of min kernel version options, formatted as objects", () => {
+      const state = {
+        config: {
+          loading: false,
+          loaded: true,
+          items: [
+            {
+              name: "default_min_hwe_kernel",
+              value: "",
+              choices: [
+                ["", "--- No minimum kernel ---"],
+                ["ga-18.04-lowlatency", "bionic (ga-18.04-lowlatency)"],
+                ["ga-18.04", "bionic (ga-18.04)"]
+              ]
+            }
+          ]
+        }
+      };
+      expect(config.minKernelVersionOptions(state)).toStrictEqual([
+        {
+          value: "",
+          label: "--- No minimum kernel ---"
+        },
+        {
+          value: "ga-18.04-lowlatency",
+          label: "bionic (ga-18.04-lowlatency)"
+        },
+        {
+          value: "ga-18.04",
+          label: "bionic (ga-18.04)"
+        }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Done
Create the commissioning form in the configuration section of settings. Fixes [#1385](https://github.com/canonical-web-and-design/MAAS-squad/issues/1385) and [#1409](https://github.com/canonical-web-and-design/MAAS-squad/issues/1409).

## QA
- go to `/settings/configuration/commissioning`
- See the commissioning form
- See the save button is disabled
- See if you change the values of either field the save button is enabled
- See if you change the values and save that they persist when you reload the page

## Screenshots
![2019-08-13_15-15](https://user-images.githubusercontent.com/501889/62949459-1e48fd00-bdde-11e9-88ea-77f0265ce2bd.png)

![active](https://user-images.githubusercontent.com/501889/62949464-21dc8400-bdde-11e9-98e6-5dd3b34f65b7.png)
