### PR TITLE
Use standard redux actions.

### DIFF
--- a/ui/src/app/base/actions.js
+++ b/ui/src/app/base/actions.js
@@ -7,11 +7,9 @@ export const connectWebSocket = () => {
 export const fetchAuthUser = () => {
   return {
     type: "FETCH_AUTH_USER",
-    payload: {
-      message: {
-        method: "user.auth_user",
-        type: 0
-      }
+    meta: {
+      method: "user.auth_user",
+      type: 0
     }
   };
 };

--- a/ui/src/app/base/actions.js
+++ b/ui/src/app/base/actions.js
@@ -6,9 +6,8 @@ export const connectWebSocket = () => {
 
 export const fetchAuthUser = () => {
   return {
-    type: "WEBSOCKET_SEND",
+    type: "FETCH_AUTH_USER",
     payload: {
-      actionType: "FETCH_AUTH_USER",
       message: {
         method: "user.auth_user",
         type: 0

--- a/ui/src/app/base/actions.test.js
+++ b/ui/src/app/base/actions.test.js
@@ -9,9 +9,8 @@ describe("base actions", () => {
 
   it("should handle fetching the current user", () => {
     expect(fetchAuthUser()).toEqual({
-      type: "WEBSOCKET_SEND",
+      type: "FETCH_AUTH_USER",
       payload: {
-        actionType: "FETCH_AUTH_USER",
         message: {
           method: "user.auth_user",
           type: 0

--- a/ui/src/app/base/actions.test.js
+++ b/ui/src/app/base/actions.test.js
@@ -10,11 +10,9 @@ describe("base actions", () => {
   it("should handle fetching the current user", () => {
     expect(fetchAuthUser()).toEqual({
       type: "FETCH_AUTH_USER",
-      payload: {
-        message: {
-          method: "user.auth_user",
-          type: 0
-        }
+      meta: {
+        method: "user.auth_user",
+        type: 0
       }
     });
   });

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -93,12 +93,11 @@ describe("websocket sagas", () => {
 
   it("can send a WebSocket message", () => {
     const saga = sendMessage(socketClient);
-    expect(saga.next().value).toEqual(take("WEBSOCKET_SEND"));
+    saga.next();
     expect(
       saga.next({
-        type: "WEBSOCKET_SEND",
+        type: "TEST_ACTION",
         payload: {
-          actionType: "TEST_ACTION",
           message: { payload: "here" }
         }
       }).value
@@ -115,9 +114,8 @@ describe("websocket sagas", () => {
     saga.next();
     expect(
       saga.next({
-        type: "WEBSOCKET_SEND",
+        type: "TEST_ACTION",
         payload: {
-          actionType: "TEST_ACTION",
           message: {
             method: "test.method",
             type: 0,
@@ -150,9 +148,8 @@ describe("websocket sagas", () => {
     const saga = sendMessage(socketClient);
     saga.next();
     saga.next({
-      type: "WEBSOCKET_SEND",
+      type: "TEST_ACTION",
       payload: {
-        actionType: "TEST_ACTION",
         message: { payload: "here" }
       }
     });

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -97,14 +97,20 @@ describe("websocket sagas", () => {
     expect(
       saga.next({
         type: "TEST_ACTION",
+        meta: {
+          method: "test.method",
+          type: 0
+        },
         payload: {
-          message: { payload: "here" }
+          params: { foo: "bar" }
         }
       }).value
     ).toEqual(put({ type: "TEST_ACTION_START" }));
     expect(saga.next().value).toEqual(
       call([socketClient, socketClient.send], "TEST_ACTION", {
-        payload: "here"
+        method: "test.method",
+        type: 0,
+        params: { foo: "bar" }
       })
     );
   });
@@ -115,15 +121,12 @@ describe("websocket sagas", () => {
     expect(
       saga.next({
         type: "TEST_ACTION",
+        meta: {
+          method: "test.method",
+          type: 0
+        },
         payload: {
-          message: {
-            method: "test.method",
-            type: 0,
-            params: [
-              { name: "foo", value: "bar" },
-              { name: "baz", value: "qux" }
-            ]
-          }
+          params: [{ name: "foo", value: "bar" }, { name: "baz", value: "qux" }]
         }
       }).value
     ).toEqual(put({ type: "TEST_ACTION_START" }));
@@ -149,8 +152,12 @@ describe("websocket sagas", () => {
     saga.next();
     saga.next({
       type: "TEST_ACTION",
+      meta: {
+        method: "test.method",
+        type: 0
+      },
       payload: {
-        message: { payload: "here" }
+        params: { foo: "bar" }
       }
     });
     saga.next();

--- a/ui/src/app/settings/actions/config.js
+++ b/ui/src/app/settings/actions/config.js
@@ -3,11 +3,9 @@ const config = {};
 config.fetch = () => {
   return {
     type: "FETCH_CONFIG",
-    payload: {
-      message: {
-        method: "config.list",
-        type: 0
-      }
+    meta: {
+      method: "config.list",
+      type: 0
     }
   };
 };
@@ -16,11 +14,11 @@ config.update = params => {
   return {
     type: "UPDATE_CONFIG",
     payload: {
-      message: {
-        method: "config.update",
-        type: 0,
-        params
-      }
+      params
+    },
+    meta: {
+      method: "config.update",
+      type: 0
     }
   };
 };

--- a/ui/src/app/settings/actions/config.js
+++ b/ui/src/app/settings/actions/config.js
@@ -2,9 +2,8 @@ const config = {};
 
 config.fetch = () => {
   return {
-    type: "WEBSOCKET_SEND",
+    type: "FETCH_CONFIG",
     payload: {
-      actionType: "FETCH_CONFIG",
       message: {
         method: "config.list",
         type: 0
@@ -15,9 +14,8 @@ config.fetch = () => {
 
 config.update = params => {
   return {
-    type: "WEBSOCKET_SEND",
+    type: "UPDATE_CONFIG",
     payload: {
-      actionType: "UPDATE_CONFIG",
       message: {
         method: "config.update",
         type: 0,

--- a/ui/src/app/settings/actions/config.test.js
+++ b/ui/src/app/settings/actions/config.test.js
@@ -4,11 +4,9 @@ describe("config actions", () => {
   it("should handle fetching config", () => {
     expect(config.fetch()).toEqual({
       type: "FETCH_CONFIG",
-      payload: {
-        message: {
-          method: "config.list",
-          type: 0
-        }
+      meta: {
+        method: "config.list",
+        type: 0
       }
     });
   });
@@ -22,11 +20,11 @@ describe("config actions", () => {
     expect(config.update(params)).toEqual({
       type: "UPDATE_CONFIG",
       payload: {
-        message: {
-          method: "config.update",
-          type: 0,
-          params
-        }
+        params
+      },
+      meta: {
+        method: "config.update",
+        type: 0
       }
     });
   });

--- a/ui/src/app/settings/actions/config.test.js
+++ b/ui/src/app/settings/actions/config.test.js
@@ -3,9 +3,8 @@ import config from "./config";
 describe("config actions", () => {
   it("should handle fetching config", () => {
     expect(config.fetch()).toEqual({
-      type: "WEBSOCKET_SEND",
+      type: "FETCH_CONFIG",
       payload: {
-        actionType: "FETCH_CONFIG",
         message: {
           method: "config.list",
           type: 0
@@ -21,9 +20,8 @@ describe("config actions", () => {
     ];
 
     expect(config.update(params)).toEqual({
-      type: "WEBSOCKET_SEND",
+      type: "UPDATE_CONFIG",
       payload: {
-        actionType: "UPDATE_CONFIG",
         message: {
           method: "config.update",
           type: 0,

--- a/ui/src/app/settings/actions/repositories.js
+++ b/ui/src/app/settings/actions/repositories.js
@@ -2,9 +2,8 @@ const repositories = {};
 
 repositories.fetch = () => {
   return {
-    type: "WEBSOCKET_SEND",
+    type: "FETCH_REPOSITORIES",
     payload: {
-      actionType: "FETCH_REPOSITORIES",
       message: {
         method: "packagerepository.list",
         params: { limit: 50 },

--- a/ui/src/app/settings/actions/repositories.js
+++ b/ui/src/app/settings/actions/repositories.js
@@ -4,11 +4,11 @@ repositories.fetch = () => {
   return {
     type: "FETCH_REPOSITORIES",
     payload: {
-      message: {
-        method: "packagerepository.list",
-        params: { limit: 50 },
-        type: 0
-      }
+      params: { limit: 50 }
+    },
+    meta: {
+      method: "packagerepository.list",
+      type: 0
     }
   };
 };

--- a/ui/src/app/settings/actions/repositories.test.js
+++ b/ui/src/app/settings/actions/repositories.test.js
@@ -3,9 +3,8 @@ import repositories from "./repositories";
 describe("repository actions", () => {
   it("should handle fetching repositories", () => {
     expect(repositories.fetch()).toEqual({
-      type: "WEBSOCKET_SEND",
+      type: "FETCH_REPOSITORIES",
       payload: {
-        actionType: "FETCH_REPOSITORIES",
         message: {
           method: "packagerepository.list",
           params: { limit: 50 },

--- a/ui/src/app/settings/actions/repositories.test.js
+++ b/ui/src/app/settings/actions/repositories.test.js
@@ -5,11 +5,11 @@ describe("repository actions", () => {
     expect(repositories.fetch()).toEqual({
       type: "FETCH_REPOSITORIES",
       payload: {
-        message: {
-          method: "packagerepository.list",
-          params: { limit: 50 },
-          type: 0
-        }
+        params: { limit: 50 }
+      },
+      meta: {
+        method: "packagerepository.list",
+        type: 0
       }
     });
   });

--- a/ui/src/app/settings/actions/users.js
+++ b/ui/src/app/settings/actions/users.js
@@ -2,9 +2,8 @@ const users = {};
 
 users.fetch = () => {
   return {
-    type: "WEBSOCKET_SEND",
+    type: "FETCH_USERS",
     payload: {
-      actionType: "FETCH_USERS",
       message: {
         method: "user.list",
         type: 0

--- a/ui/src/app/settings/actions/users.js
+++ b/ui/src/app/settings/actions/users.js
@@ -3,11 +3,9 @@ const users = {};
 users.fetch = () => {
   return {
     type: "FETCH_USERS",
-    payload: {
-      message: {
-        method: "user.list",
-        type: 0
-      }
+    meta: {
+      method: "user.list",
+      type: 0
     }
   };
 };

--- a/ui/src/app/settings/actions/users.test.js
+++ b/ui/src/app/settings/actions/users.test.js
@@ -4,11 +4,9 @@ describe("user actions", () => {
   it("should handle fetching users", () => {
     expect(users.fetch()).toEqual({
       type: "FETCH_USERS",
-      payload: {
-        message: {
-          method: "user.list",
-          type: 0
-        }
+      meta: {
+        method: "user.list",
+        type: 0
       }
     });
   });

--- a/ui/src/app/settings/actions/users.test.js
+++ b/ui/src/app/settings/actions/users.test.js
@@ -3,9 +3,8 @@ import users from "./users";
 describe("user actions", () => {
   it("should handle fetching users", () => {
     expect(users.fetch()).toEqual({
-      type: "WEBSOCKET_SEND",
+      type: "FETCH_USERS",
       payload: {
-        actionType: "FETCH_USERS",
         message: {
           method: "user.list",
           type: 0

--- a/ui/src/app/settings/containers/Settings/Settings.test.js
+++ b/ui/src/app/settings/containers/Settings/Settings.test.js
@@ -30,11 +30,9 @@ describe("Settings", () => {
     expect(store.getActions()).toEqual([
       {
         type: "FETCH_CONFIG",
-        payload: {
-          message: {
-            method: "config.list",
-            type: 0
-          }
+        meta: {
+          method: "config.list",
+          type: 0
         }
       }
     ]);

--- a/ui/src/app/settings/containers/Settings/Settings.test.js
+++ b/ui/src/app/settings/containers/Settings/Settings.test.js
@@ -29,14 +29,13 @@ describe("Settings", () => {
 
     expect(store.getActions()).toEqual([
       {
+        type: "FETCH_CONFIG",
         payload: {
-          actionType: "FETCH_CONFIG",
           message: {
             method: "config.list",
             type: 0
           }
-        },
-        type: "WEBSOCKET_SEND"
+        }
       }
     ]);
   });


### PR DESCRIPTION
## Done
* The generic `WEBSOCKET_SEND` action type has been removed in favour of flux standard actions (we can now easily see which actions are being dispatched in redux devtools).
* websocket `sendMessage` now listens for any actions which have an RPC method in their payload.
* Move `method` and `type` to the `meta` object in redux actions. See [flux standard actions](https://github.com/redux-utilities/flux-standard-action#meta).

I considered moving knowledge of the RPC methods/metadata into the sagas, but on reflection I think this is okay in the action creators. 

## QA
* Load the app, you should see specific redux action types in redux dev tools.