### PR TITLE
Update brand colour

### DIFF
--- a/ui/src/scss/_settings.scss
+++ b/ui/src/scss/_settings.scss
@@ -4,8 +4,5 @@ $grid-max-width: 1440 / 16 * 1rem; // express in rems for easier calculations
 $color-navigation-background: #333;
 $color-navigation-background--hover: darken($color-navigation-background, 3%);
 
-$color-brand: #e95420;
-$color-navigation-active-bar: $color-brand;
-
 $breakpoint-navigation-threshold: 870px;
 $increase-font-size-on-larger-screens: false;


### PR DESCRIPTION
Done:
- Update the brand color to #333 (the default). Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/1405.

QA:
- Load the settings.
- Check that the nav indicator on the left is #333.