### PR TITLE
Limit settings views to admins

### DIFF
--- a/ui/src/app/base/components/Main/Main.js
+++ b/ui/src/app/base/components/Main/Main.js
@@ -25,7 +25,11 @@ export function Main({ authUser, authLoading, fetchAuthUser }) {
   return (
     <>
       <Header authUser={authUser} />
-      <Routes />
+      {authUser.is_superuser ? (
+        <Routes />
+      ) : (
+        <Section title="You do not have permission to view this page." />
+      )}
     </>
   );
 }

--- a/ui/src/app/base/components/Main/Main.test.js
+++ b/ui/src/app/base/components/Main/Main.test.js
@@ -47,4 +47,26 @@ describe("Main", () => {
     );
     expect(fetchAuthUser.mock.calls.length).toBe(1);
   });
+
+  it("displays a message if not an admin", () => {
+    const wrapper = shallow(
+      <Main
+        authLoading={false}
+        authUser={{
+          email: "test@example.com",
+          first_name: "",
+          global_permissions: ["machine_create"],
+          id: 1,
+          is_superuser: false,
+          last_name: "",
+          sshkeys_count: 0,
+          username: "admin"
+        }}
+        fetchAuthUser={jest.fn()}
+      />
+    );
+    expect(wrapper.find("Section").prop("title")).toEqual(
+      "You do not have permission to view this page."
+    );
+  });
 });


### PR DESCRIPTION
Done:
- Disable the settings views if the user is not an admin. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/52.

QA:
- Log into maas as a non admin.
- Load maas-ui. You should get a message about no permissions.
- Log in again as admin.
- Reload the UI. You should now see the views.