### PR TITLE
Convert http_proxy value to empty string if fetched as null

### DIFF
--- a/ui/src/app/settings/containers/Network/ProxyForm/ProxyForm.js
+++ b/ui/src/app/settings/containers/Network/ProxyForm/ProxyForm.js
@@ -45,7 +45,7 @@ const ProxyForm = () => {
         {loaded && (
           <Formik
             initialValues={{
-              httpProxy,
+              httpProxy: httpProxy || "",
               proxyType
             }}
             onSubmit={(values, { resetForm }) => {


### PR DESCRIPTION
## QA
- Go to /MAAS/settings/network/proxy
- Click External or Peer
- Check that there are no type errors in the console