### PR TITLE
Rewrite ActionButton to control own timeouts + calculate width dynamically

### DIFF
--- a/ui/src/app/base/components/ActionButton/ActionButton.js
+++ b/ui/src/app/base/components/ActionButton/ActionButton.js
@@ -1,58 +1,108 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 
-import Button from "../Button";
 import "./ActionButton.scss";
 
-const generateButtonChildren = (children, appearance, loading, success) => {
-  const iconClass = classNames({
-    "p-icon--spinner u-animation--spin": loading,
-    "is-light": appearance === "positive" || appearance === "negative",
-    "p-icon--success":
-      success && (appearance !== "positive" && appearance !== "negative"),
-    "p-icon--success-positive": success && appearance === "positive",
-    "p-icon--success-negative": success && appearance === "negative"
-  });
-
-  return loading || success ? <i className={iconClass} /> : children;
-};
+export const LOADER_MIN_DURATION = 400; // minimium duration (ms) loader displays
+export const SUCCESS_DURATION = 2000; // duration (ms) success tick is displayed
 
 const ActionButton = ({
   appearance = "neutral",
   children,
   className,
+  disabled,
+  inline,
   loading,
   success,
-  width,
   ...props
 }) => {
-  const classes = classNames(className, `p-action-button`, {
-    "is-loading": loading,
-    "is-success": success
-  });
-  const buttonChildren = generateButtonChildren(
-    children,
-    appearance,
-    loading,
-    success
+  const [width, setWidth] = useState(0);
+  const [showLoader, setShowLoader] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const ref = useRef(null);
+
+  // Store default button width
+  useEffect(() => {
+    if (ref.current && ref.current.getBoundingClientRect().width) {
+      setWidth(ref.current.getBoundingClientRect().width);
+    }
+  }, [children]);
+
+  // Set up loader timer
+  useEffect(() => {
+    let loaderTimeout;
+
+    if (loading) {
+      setShowLoader(true);
+    }
+
+    if (!loading && showLoader) {
+      loaderTimeout = setTimeout(() => {
+        setShowLoader(false);
+
+        if (success) {
+          setShowSuccess(true);
+        }
+      }, LOADER_MIN_DURATION);
+    }
+
+    return () => clearTimeout(loaderTimeout);
+  }, [loading, showLoader, success]);
+
+  // Set up success timer
+  useEffect(() => {
+    let successTimeout;
+
+    if (showSuccess) {
+      successTimeout = setTimeout(() => {
+        setShowSuccess(false);
+      }, SUCCESS_DURATION);
+    }
+
+    return () => clearTimeout(successTimeout);
+  }, [showSuccess]);
+
+  const buttonClasses = classNames(
+    classNames,
+    "p-action-button",
+    `p-button--${appearance}`,
+    {
+      "is-loading": showLoader,
+      "is-success": showSuccess,
+      "is-disabled": disabled,
+      "is-inline": inline
+    }
   );
-  const style = width ? { width } : {};
+
+  const iconClasses = classNames({
+    "p-icon--spinner u-animation--spin": showLoader,
+    "is-light": appearance === "positive" || appearance === "negative",
+    "p-icon--success":
+      showSuccess && (appearance !== "positive" && appearance !== "negative"),
+    "p-icon--success-positive": showSuccess && appearance === "positive",
+    "p-icon--success-negative": showSuccess && appearance === "negative"
+  });
 
   return (
-    <Button
-      appearance={appearance}
-      className={classes}
-      style={style}
+    <button
+      className={buttonClasses}
+      disabled={disabled}
+      ref={ref}
+      style={width ? { width: `${width}px` } : undefined}
       {...props}
     >
-      {buttonChildren}
-    </Button>
+      {showLoader || showSuccess ? <i className={iconClasses} /> : children}
+    </button>
   );
 };
 
 ActionButton.propTypes = {
+  appearance: PropTypes.string,
+  children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
+  inline: PropTypes.bool,
   loading: PropTypes.bool,
   success: PropTypes.bool
 };

--- a/ui/src/app/base/components/ActionButton/ActionButton.test.js
+++ b/ui/src/app/base/components/ActionButton/ActionButton.test.js
@@ -1,25 +1,95 @@
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import React from "react";
+import { act } from "react-dom/test-utils";
 
-import ActionButton from "./ActionButton";
+import ActionButton, {
+  LOADER_MIN_DURATION,
+  SUCCESS_DURATION
+} from "./ActionButton";
 
 describe("ActionButton", () => {
+  jest.useFakeTimers();
+
   it("matches loading snapshot", () => {
-    const wrapper = shallow(<ActionButton loading>Click me</ActionButton>);
+    const wrapper = mount(<ActionButton loading>Click me</ActionButton>);
     expect(wrapper).toMatchSnapshot();
   });
 
   it("matches success snapshot", () => {
-    const wrapper = shallow(<ActionButton success>Click me</ActionButton>);
+    const wrapper = mount(<ActionButton loading>Click me</ActionButton>);
+    act(() => {
+      wrapper.setProps({ loading: false, success: true });
+      jest.advanceTimersByTime(LOADER_MIN_DURATION);
+      wrapper.update();
+    });
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("correctly shows a positive tick if appearance is positive and successful", () => {
-    const wrapper = shallow(
-      <ActionButton appearance="positive" success>
+  it("shows a loader icon for the correct amount of time", () => {
+    const wrapper = mount(<ActionButton loading>Click me</ActionButton>);
+
+    act(() => {
+      wrapper.setProps({ loading: false, success: true });
+      jest.advanceTimersByTime(LOADER_MIN_DURATION - 1);
+      wrapper.update();
+    });
+    expect(wrapper.find(".p-icon--spinner").exists()).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+      wrapper.update();
+    });
+    expect(wrapper.find(".p-icon--spinner").exists()).toBe(false);
+  });
+
+  it("shows a loader icon for the correct amount of time", () => {
+    const wrapper = mount(<ActionButton loading>Click me</ActionButton>);
+
+    act(() => {
+      wrapper.setProps({ loading: false, success: true });
+      jest.advanceTimersByTime(LOADER_MIN_DURATION);
+      wrapper.update();
+    });
+    expect(wrapper.find(".p-icon--success").exists()).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(SUCCESS_DURATION);
+      wrapper.update();
+    });
+    expect(wrapper.find(".p-icon--success").exists()).toBe(false);
+  });
+
+  it("shows the positive success icon if appearance is positive", () => {
+    const wrapper = mount(
+      <ActionButton appearance="positive" loading>
         Click me
       </ActionButton>
     );
+
+    act(() => {
+      wrapper.setProps({ loading: false, success: true });
+      jest.advanceTimersByTime(LOADER_MIN_DURATION);
+      wrapper.update();
+    });
     expect(wrapper.find(".p-icon--success-positive").exists()).toBe(true);
+    expect(wrapper.find(".p-icon--success-negative").exists()).toBe(false);
+    expect(wrapper.find(".p-icon--success").exists()).toBe(false);
+  });
+
+  it("shows the negative success icon if appearance is negative", () => {
+    const wrapper = mount(
+      <ActionButton appearance="negative" loading>
+        Click me
+      </ActionButton>
+    );
+
+    act(() => {
+      wrapper.setProps({ loading: false, success: true });
+      jest.advanceTimersByTime(LOADER_MIN_DURATION);
+      wrapper.update();
+    });
+    expect(wrapper.find(".p-icon--success-negative").exists()).toBe(true);
+    expect(wrapper.find(".p-icon--success-positive").exists()).toBe(false);
+    expect(wrapper.find(".p-icon--success").exists()).toBe(false);
   });
 });

--- a/ui/src/app/base/components/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/ui/src/app/base/components/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -1,25 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActionButton matches loading snapshot 1`] = `
-<Button
-  appearance="neutral"
-  className="p-action-button is-loading"
-  style={Object {}}
+<ActionButton
+  loading={true}
 >
-  <i
-    className="p-icon--spinner u-animation--spin"
-  />
-</Button>
+  <button
+    className="p-action-button p-button--neutral is-loading"
+  >
+    <i
+      className="p-icon--spinner u-animation--spin"
+    />
+  </button>
+</ActionButton>
 `;
 
 exports[`ActionButton matches success snapshot 1`] = `
-<Button
-  appearance="neutral"
-  className="p-action-button is-success"
-  style={Object {}}
+<ActionButton
+  loading={false}
+  success={true}
 >
-  <i
-    className="p-icon--success"
-  />
-</Button>
+  <button
+    className="p-action-button p-button--neutral is-success"
+  >
+    <i
+      className="p-icon--success"
+    />
+  </button>
+</ActionButton>
 `;

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -2,9 +2,6 @@ import { useEffect, useRef } from "react";
 import { useContext } from "react";
 import { __RouterContext as RouterContext } from "react-router";
 
-const DELAY_TIMER = 400; // minimium duration (ms) saving spinner displays
-const SUCCESS_TIMER = 2000; // duration (ms) success tick is displayed
-
 // Router hooks inspired by: https://github.com/ReactTraining/react-router/issues/6430#issuecomment-510266079
 // These should be replaced with official hooks if/when they become available.
 
@@ -33,33 +30,4 @@ export const usePrevious = value => {
     ref.current = value;
   });
   return ref.current;
-};
-
-export const useSettingsSave = (saving, setLoading, setSuccess) => {
-  const delayTimer = useRef();
-  const saveTimer = useRef();
-  const prevSaving = usePrevious(saving);
-
-  // Temporarily set success to true if saving changes from true to false
-  // TODO: Add a check for errors too: https://github.com/canonical-web-and-design/maas-ui/issues/39
-  useEffect(() => {
-    if (!prevSaving && saving) {
-      setLoading(true);
-      // resetForm(values);
-      delayTimer.current = setTimeout(() => {
-        setLoading(false);
-        setSuccess(true);
-        saveTimer.current = setTimeout(() => {
-          setSuccess(false);
-        }, SUCCESS_TIMER);
-      }, DELAY_TIMER);
-    }
-  }, [prevSaving, saving, setLoading, setSuccess]);
-
-  useEffect(() => {
-    return () => {
-      clearTimeout(delayTimer.current);
-      clearTimeout(saveTimer.current);
-    };
-  }, []);
 };

--- a/ui/src/app/settings/containers/Configuration/CommissioningForm/CommissioningForm.js
+++ b/ui/src/app/settings/containers/Configuration/CommissioningForm/CommissioningForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Form from "app/base/components/Form";
 import CommissioningFormFields from "app/settings/containers/Configuration/CommissioningFormFields";
@@ -20,13 +19,11 @@ const CommissioningForm = () => {
   const dispatch = useDispatch();
   const updateConfig = actions.config.update;
 
+  const saved = useSelector(config.saved);
+  const saving = useSelector(config.saving);
+
   const defaultDistroSeries = useSelector(config.defaultDistroSeries);
   const defaultMinKernelVersion = useSelector(config.defaultMinKernelVersion);
-
-  const saving = useSelector(config.saving);
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setLoading, setSuccess);
 
   return (
     <Formik
@@ -47,9 +44,8 @@ const CommissioningForm = () => {
             className="u-no-margin--bottom"
             type="submit"
             disabled={formikFormDisabled(formikProps)}
-            loading={loading}
-            success={success}
-            width="60px"
+            loading={saving}
+            success={saved}
           >
             Save
           </ActionButton>

--- a/ui/src/app/settings/containers/Configuration/GeneralForm/GeneralForm.js
+++ b/ui/src/app/settings/containers/Configuration/GeneralForm/GeneralForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Form from "app/base/components/Form";
 import GeneralFormFields from "app/settings/containers/Configuration/GeneralFormFields";
@@ -20,13 +19,11 @@ const GeneralForm = () => {
   const dispatch = useDispatch();
   const updateConfig = actions.config.update;
 
+  const saved = useSelector(config.saved);
+  const saving = useSelector(config.saving);
+
   const maasName = useSelector(config.maasName);
   const analyticsEnabled = useSelector(config.analyticsEnabled);
-
-  const saving = useSelector(config.saving);
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setLoading, setSuccess);
 
   return (
     <Formik
@@ -47,9 +44,8 @@ const GeneralForm = () => {
             className="u-no-margin--bottom"
             type="submit"
             disabled={formikFormDisabled(formikProps)}
-            loading={loading}
-            success={success}
-            width="60px"
+            loading={saving}
+            success={saved}
           >
             Save
           </ActionButton>

--- a/ui/src/app/settings/containers/Configuration/KernelParametersForm/KernelParametersForm.js
+++ b/ui/src/app/settings/containers/Configuration/KernelParametersForm/KernelParametersForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Form from "app/base/components/Form";
 import KernelParametersFormFields from "app/settings/containers/Configuration/KernelParametersFormFields";
@@ -19,12 +18,10 @@ const KernelParametersForm = () => {
   const dispatch = useDispatch();
   const updateConfig = actions.config.update;
 
-  const kernelParams = useSelector(config.kernelParams);
-
+  const saved = useSelector(config.saved);
   const saving = useSelector(config.saving);
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setLoading, setSuccess);
+
+  const kernelParams = useSelector(config.kernelParams);
 
   return (
     <Formik
@@ -44,9 +41,8 @@ const KernelParametersForm = () => {
             className="u-no-margin--bottom"
             type="submit"
             disabled={formikFormDisabled(formikProps)}
-            loading={loading}
-            success={success}
-            width="60px"
+            loading={saving}
+            success={saved}
           >
             Save
           </ActionButton>

--- a/ui/src/app/settings/containers/Network/DnsForm/DnsForm.js
+++ b/ui/src/app/settings/containers/Network/DnsForm/DnsForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Col from "app/base/components/Col";
 import Form from "app/base/components/Form";
@@ -28,14 +27,12 @@ const DnsForm = () => {
 
   const loaded = useSelector(config.loaded);
   const loading = useSelector(config.loading);
+  const saved = useSelector(config.saved);
+  const saving = useSelector(config.saving);
+
   const dnssecValidation = useSelector(config.dnssecValidation);
   const dnsTrustedAcl = useSelector(config.dnsTrustedAcl);
   const upstreamDns = useSelector(config.upstreamDns);
-
-  const saving = useSelector(config.saving);
-  const [savingUI, setSavingUI] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setSavingUI, setSuccess);
 
   return (
     <Row>
@@ -61,9 +58,8 @@ const DnsForm = () => {
                   className="u-no-margin--bottom"
                   type="submit"
                   disabled={formikFormDisabled(formikProps)}
-                  loading={savingUI}
-                  success={success}
-                  width="60px"
+                  loading={saving}
+                  success={saved}
                 >
                   Save
                 </ActionButton>

--- a/ui/src/app/settings/containers/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.js
+++ b/ui/src/app/settings/containers/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Col from "app/base/components/Col";
 import Form from "app/base/components/Form";
@@ -25,13 +24,11 @@ const NetworkDiscoveryForm = () => {
 
   const loaded = useSelector(config.loaded);
   const loading = useSelector(config.loading);
+  const saved = useSelector(config.saved);
+  const saving = useSelector(config.saving);
+
   const activeDiscoveryInterval = useSelector(config.activeDiscoveryInterval);
   const networkDiscovery = useSelector(config.networkDiscovery);
-
-  const saving = useSelector(config.saving);
-  const [savingUI, setSavingUI] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setSavingUI, setSuccess);
 
   return (
     <Row>
@@ -56,9 +53,8 @@ const NetworkDiscoveryForm = () => {
                   className="u-no-margin--bottom"
                   type="submit"
                   disabled={formikFormDisabled(formikProps)}
-                  loading={savingUI}
-                  success={success}
-                  width="60px"
+                  loading={saving}
+                  success={saved}
                 >
                   Save
                 </ActionButton>

--- a/ui/src/app/settings/containers/Network/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.js
+++ b/ui/src/app/settings/containers/Network/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.js
@@ -11,7 +11,7 @@ describe("NetworkDiscoveryFormFields", () => {
   let baseFormikProps;
   let initialState;
   let baseValues = {
-    active_discovery_interval: 0,
+    active_discovery_interval: "0",
     network_discovery: "disabled"
   };
 
@@ -58,7 +58,7 @@ describe("NetworkDiscoveryFormFields", () => {
   it("correctly reflects active_discovery_interval state", () => {
     const state = { ...initialState };
     const formikProps = { ...baseFormikProps };
-    formikProps.values.active_discovery_interval = 600;
+    formikProps.values.active_discovery_interval = "600";
     const store = mockStore(state);
 
     const wrapper = mount(
@@ -69,7 +69,7 @@ describe("NetworkDiscoveryFormFields", () => {
 
     expect(
       wrapper.find("select[name='active_discovery_interval']").props().value
-    ).toBe(600);
+    ).toBe("600");
   });
 
   it("correctly reflects network_discovery state", () => {

--- a/ui/src/app/settings/containers/Network/NtpForm/NtpForm.js
+++ b/ui/src/app/settings/containers/Network/NtpForm/NtpForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Col from "app/base/components/Col";
 import Form from "app/base/components/Form";
@@ -25,13 +24,11 @@ const NtpForm = () => {
 
   const loaded = useSelector(config.loaded);
   const loading = useSelector(config.loading);
+  const saved = useSelector(config.saved);
+  const saving = useSelector(config.saving);
+
   const ntpExternalOnly = useSelector(config.ntpExternalOnly);
   const ntpServers = useSelector(config.ntpServers);
-
-  const saving = useSelector(config.saving);
-  const [savingUI, setSavingUI] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setSavingUI, setSuccess);
 
   return (
     <Row>
@@ -56,9 +53,8 @@ const NtpForm = () => {
                   className="u-no-margin--bottom"
                   type="submit"
                   disabled={formikFormDisabled(formikProps)}
-                  loading={savingUI}
-                  success={success}
-                  width="60px"
+                  loading={saving}
+                  success={saved}
                 >
                   Save
                 </ActionButton>

--- a/ui/src/app/settings/containers/Network/ProxyForm/ProxyForm.js
+++ b/ui/src/app/settings/containers/Network/ProxyForm/ProxyForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Col from "app/base/components/Col";
 import Form from "app/base/components/Form";
@@ -30,13 +29,11 @@ const ProxyForm = () => {
 
   const loaded = useSelector(config.loaded);
   const loading = useSelector(config.loading);
+  const saved = useSelector(config.saved);
+  const saving = useSelector(config.saving);
+
   const httpProxy = useSelector(config.httpProxy);
   const proxyType = useSelector(config.proxyType);
-
-  const saving = useSelector(config.saving);
-  const [savingUI, setSavingUI] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setSavingUI, setSuccess);
 
   return (
     <Row>
@@ -96,9 +93,8 @@ const ProxyForm = () => {
                   className="u-no-margin--bottom"
                   type="submit"
                   disabled={formikFormDisabled(formikProps)}
-                  loading={savingUI}
-                  success={success}
-                  width="60px"
+                  loading={saving}
+                  success={saved}
                 >
                   Save
                 </ActionButton>

--- a/ui/src/app/settings/containers/Network/SyslogForm/SyslogForm.js
+++ b/ui/src/app/settings/containers/Network/SyslogForm/SyslogForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Col from "app/base/components/Col";
 import Form from "app/base/components/Form";
@@ -24,12 +23,10 @@ const SyslogForm = () => {
 
   const loaded = useSelector(config.loaded);
   const loading = useSelector(config.loading);
-  const remoteSyslog = useSelector(config.remoteSyslog);
-
+  const saved = useSelector(config.saved);
   const saving = useSelector(config.saving);
-  const [savingUI, setSavingUI] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setSavingUI, setSuccess);
+
+  const remoteSyslog = useSelector(config.remoteSyslog);
 
   return (
     <Row>
@@ -53,9 +50,8 @@ const SyslogForm = () => {
                   className="u-no-margin--bottom"
                   type="submit"
                   disabled={formikFormDisabled(formikProps)}
-                  loading={savingUI}
-                  success={success}
-                  width="60px"
+                  loading={saving}
+                  success={saved}
                 >
                   Save
                 </ActionButton>

--- a/ui/src/app/settings/containers/Storage/StorageForm/StorageForm.js
+++ b/ui/src/app/settings/containers/Storage/StorageForm/StorageForm.js
@@ -1,12 +1,11 @@
 import { Formik } from "formik";
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import actions from "app/settings/actions";
 import config from "app/settings/selectors/config";
 import { formikFormDisabled } from "app/settings/utils";
-import { useSettingsSave } from "app/base/hooks";
 import ActionButton from "app/base/components/ActionButton";
 import Col from "app/base/components/Col";
 import Form from "app/base/components/Form";
@@ -27,15 +26,13 @@ const StorageForm = () => {
 
   const loaded = useSelector(config.loaded);
   const loading = useSelector(config.loading);
+  const saved = useSelector(config.saved);
+  const saving = useSelector(config.saving);
+
   const defaultStorageLayout = useSelector(config.defaultStorageLayout);
   const diskEraseWithQuick = useSelector(config.diskEraseWithQuick);
   const diskEraseWithSecure = useSelector(config.diskEraseWithSecure);
   const enableDiskErasing = useSelector(config.enableDiskErasing);
-
-  const saving = useSelector(config.saving);
-  const [savingUI, setSavingUI] = useState(false);
-  const [success, setSuccess] = useState(false);
-  useSettingsSave(saving, setSavingUI, setSuccess);
 
   return (
     <Row>
@@ -62,9 +59,8 @@ const StorageForm = () => {
                   className="u-no-margin--bottom"
                   type="submit"
                   disabled={formikFormDisabled(formikProps)}
-                  loading={savingUI}
-                  success={success}
-                  width="60px"
+                  loading={saving}
+                  success={saved}
                 >
                   Save
                 </ActionButton>

--- a/ui/src/app/settings/reducers/config.js
+++ b/ui/src/app/settings/reducers/config.js
@@ -13,6 +13,7 @@ const config = produce(
         break;
       case "UPDATE_CONFIG_START":
         draft.saving = true;
+        draft.saved = false;
         break;
       case "UPDATE_CONFIG_SUCCESS":
         draft.saving = false;
@@ -34,6 +35,7 @@ const config = produce(
     loading: false,
     loaded: false,
     saving: false,
+    saved: false,
     items: []
   }
 );

--- a/ui/src/app/settings/reducers/config.test.js
+++ b/ui/src/app/settings/reducers/config.test.js
@@ -6,6 +6,7 @@ describe("config reducer", () => {
       loading: false,
       loaded: false,
       saving: false,
+      saved: false,
       items: []
     });
   });
@@ -19,6 +20,7 @@ describe("config reducer", () => {
       loading: true,
       loaded: false,
       saving: false,
+      saved: false,
       items: []
     });
   });
@@ -58,6 +60,7 @@ describe("config reducer", () => {
           loading: false,
           loaded: false,
           saving: false,
+          saved: false,
           items: []
         },
         {
@@ -68,6 +71,7 @@ describe("config reducer", () => {
       loading: false,
       loaded: false,
       saving: true,
+      saved: false,
       items: []
     });
   });

--- a/ui/src/app/settings/selectors/config.js
+++ b/ui/src/app/settings/selectors/config.js
@@ -62,6 +62,13 @@ config.loaded = state => state.config.loaded;
 config.saving = state => state.config.saving;
 
 /**
+ * Returns true if config has saved.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Config has saved.
+ */
+config.saved = state => state.config.saved;
+
+/**
  * Returns the MAAS config for default storage layout.
  * @param {Object} state - The redux state.
  * @returns {String} Default storage layout.

--- a/ui/src/app/settings/selectors/config.test.js
+++ b/ui/src/app/settings/selectors/config.test.js
@@ -44,6 +44,19 @@ describe("config selectors", () => {
     });
   });
 
+  describe("saved", () => {
+    it("returns config saved state", () => {
+      const state = {
+        config: {
+          saving: false,
+          saved: true,
+          items: []
+        }
+      };
+      expect(config.saved(state)).toStrictEqual(true);
+    });
+  });
+
   describe("defaultStorageLayout", () => {
     it("returns MAAS config for default storage layout", () => {
       const state = {


### PR DESCRIPTION
## Done
- ActionButton width is now determined by the text, rather than hardcoded.
- Updated instances of ActionButton to remove width prop.
- Timer functions have been moved out of useSettingsSave in hooks.js and in to the ActionButton component itself.
- Removed useSettingsSave hook and replaced with config.saved state.
- Update config reducer so UPDATE_SETTINGS_START sets saved to false.

## QA
- Check all the ActionButtons behave as before
- Change one of the ActionButtons to different text
- Check that the button width remains constant from saving to success