### PR TITLE
Handle type 2 sync messages and update config state

### DIFF
--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -4,6 +4,7 @@ import { expectSaga } from "redux-saga-test-plan";
 import {
   createConnection,
   handleMessage,
+  handleSyncMessage,
   sendMessage,
   watchMessages,
   watchWebSockets
@@ -166,7 +167,7 @@ describe("websocket sagas", () => {
     );
   });
 
-  it("can receive a successful WebSocket message", () => {
+  it("can handle a WebSocket response message", () => {
     const saga = handleMessage(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(
@@ -177,7 +178,7 @@ describe("websocket sagas", () => {
     );
   });
 
-  it("can receive a WebSocket error message", () => {
+  it("can handle a WebSocket error message", () => {
     const saga = handleMessage(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(
@@ -192,5 +193,21 @@ describe("websocket sagas", () => {
         error: { Message: "catastrophic failure" }
       })
     );
+  });
+
+  it("can handle a WebSocket sync message", () => {
+    const saga = handleMessage(socketChannel, socketClient);
+    const response = {
+      type: 2,
+      name: "config",
+      action: "update",
+      data: { name: "foo", value: "bar" }
+    };
+    expect(saga.next().value).toEqual(take(socketChannel));
+    expect(saga.next(response).value).toEqual(
+      call(handleSyncMessage, response)
+    );
+    // yield no further, take a new message
+    expect(saga.next().value).toEqual(take(socketChannel));
   });
 });

--- a/ui/src/app/settings/reducers/config.js
+++ b/ui/src/app/settings/reducers/config.js
@@ -5,24 +5,27 @@ const config = produce(
     switch (action.type) {
       case "FETCH_CONFIG_START":
         draft.loading = true;
-        return;
+        break;
       case "FETCH_CONFIG_SUCCESS":
         draft.loading = false;
         draft.loaded = true;
         draft.items = action.payload;
-        return;
+        break;
       case "UPDATE_CONFIG_START":
         draft.saving = true;
-        return;
+        break;
       case "UPDATE_CONFIG_SUCCESS":
         draft.saving = false;
+        draft.saved = true;
+        break;
+      case "UPDATE_CONFIG_SYNC":
         draft.items = draft.items.map(item => {
           if (item.name === action.payload.name) {
             return action.payload;
           }
           return item;
         });
-        return;
+        break;
       default:
         return draft;
     }

--- a/ui/src/app/settings/reducers/config.test.js
+++ b/ui/src/app/settings/reducers/config.test.js
@@ -72,13 +72,14 @@ describe("config reducer", () => {
     });
   });
 
-  it("should correctly reduce UPDATE_CONFIG_SUCCESS", () => {
+  it("should correctly reduce UPDATE_CONFIG_SUCCESS, without a store update", () => {
     expect(
       config(
         {
           loading: false,
           loaded: false,
           saving: true,
+          saved: false,
           items: [{ name: "default_storage_layout", value: "bcache" }]
         },
         {
@@ -90,7 +91,38 @@ describe("config reducer", () => {
       loading: false,
       loaded: false,
       saving: false,
-      items: [{ name: "default_storage_layout", value: "flat" }]
+      saved: true,
+      items: [{ name: "default_storage_layout", value: "bcache" }]
+    });
+  });
+
+  it("should correctly reduce UPDATE_CONFIG_SYNC, updating the store", () => {
+    expect(
+      config(
+        {
+          loading: false,
+          loaded: false,
+          saving: false,
+          saved: true,
+          items: [
+            { name: "maas_name", value: "my-maas" },
+            { name: "default_storage_layout", value: "bcache" }
+          ]
+        },
+        {
+          type: "UPDATE_CONFIG_SYNC",
+          payload: { name: "default_storage_layout", value: "flat" }
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: false,
+      saving: false,
+      saved: true,
+      items: [
+        { name: "maas_name", value: "my-maas" },
+        { name: "default_storage_layout", value: "flat" }
+      ]
     });
   });
 });


### PR DESCRIPTION
## Done
* Handle incoming 'sync' websocket messages. (messages with `type: 2` and an `action`)
* No longer update config state on receiving a `type: 1` response.
* Update config state upon receiving a sync message.
* `UPDATE_SUCCESS` now results in setting `saved` in state. The UI should rely on this state, and we'll just assume that the state becomes eventually consistent reliably and quickly. Sync messages tend to follow response messages within milliseconds, so practically this should be fine I think.

## QA
* Save a form.
* Check the diff for SUCCESS actions in redux dev tools, ensure item state is not touched.
* Check the diff for SYNC actions, ensure the changed fields value is updated in state.