### PR TITLE
Remove scrollbar if section content smaller than viewport height

### DIFF
--- a/ui/src/app/base/components/Section/Section.scss
+++ b/ui/src/app/base/components/Section/Section.scss
@@ -5,7 +5,7 @@
   background-color: $color-light;
   display: grid;
   grid-template-rows: auto 1fr;
-  min-height: 100%;
+  min-height: calc(100% - 3rem);
 }
 
 .section__header {


### PR DESCRIPTION
## Done
- Remove height of header nav from section height so there isn't a 3rem overflow

## QA
- Load a short page and check there is no scrollbar
- Load users page and check that there is a scrollbar