### PR TITLE
Change Vanilla $multi to 1 + add Vanilla overrides file

### DIFF
--- a/ui/src/scss/_patterns_table.scss
+++ b/ui/src/scss/_patterns_table.scss
@@ -7,16 +7,3 @@
 .p-table-expanding--light .p-table__row.is-active {
   background-color: $color-x-light;
 }
-
-// Stop the icons from adding extra height to the row:
-td:not(.p-table-expanding__panel) [class*="p-button"] {
-  margin-top: -0.25rem;
-  margin-bottom: -0.25rem;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-}
-
-.u-align-icons--top {
-  align-items: flex-start;
-  display: flex;
-}

--- a/ui/src/scss/_settings.scss
+++ b/ui/src/scss/_settings.scss
@@ -6,3 +6,5 @@ $color-navigation-background--hover: darken($color-navigation-background, 3%);
 
 $breakpoint-navigation-threshold: 870px;
 $increase-font-size-on-larger-screens: false;
+
+$multi: 1;

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -1,0 +1,37 @@
+/**
+ * Vanilla overrides.
+ * {Date} {Person}: {Description of issue}
+ * {Link to relevant GitHub issue}
+ */
+
+// 19-08-2019 Caleb: Form help text too close to input when $multi = 1
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2488
+input:not([type="checkbox"]) ~ .p-form-help-text,
+.p-form-validation__select-wrapper + .p-form-help-text {
+  padding-top: $spv-inner--small;
+  line-height: 1.25;
+}
+
+
+// 19-08-2019 Caleb: Form submit button too close to input when $multi = 1
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2497
+.p-form__control:last-of-type {
+  margin-bottom: $spv-outer--small;
+}
+.p-form__group:last-of-type {
+  margin-bottom: $spv-outer--medium;
+}
+
+// 20-08-2019 Caleb: Dense tables aren't spaced properly
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2504
+td:not(.p-table-expanding__panel) [class*="p-button"] {
+  margin-top: -0.25rem;
+  margin-bottom: -0.25rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+.u-align-icons--top {
+  align-items: flex-start;
+  display: flex;
+  padding-top: 0.3125rem;
+}

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -1,5 +1,6 @@
 // Vanilla settings:
 @import "vanilla";
+@import "vanilla-overrides";
 @import "./patterns_navigation";
 @import "./patterns_table";
 @import "./patterns_table-actions";


### PR DESCRIPTION
## Done
- Updated Vanilla settings to increase density (`$multi = 1`)
- Added a Vanilla overrides file **which we should definitely use**. If we can keep overrides in the same place and to a minimum we should get far less surprising regressions whenever we update Vanilla.

## QA
- Go to the users table and check that the density has increased.
- Click around the forms and check that everything looks okay.

## Screenshots
### Users table
![Screen Shot 2019-08-19 at 15 23 22-fullpage](https://user-images.githubusercontent.com/25733845/63269195-04a02d80-c296-11e9-913a-bc327dfc6a38.png)


### Form
![Screen Shot 2019-08-19 at 15 23 34-fullpage](https://user-images.githubusercontent.com/25733845/63269200-0833b480-c296-11e9-8875-cffd9401b548.png)
