### PR TITLE
Use correct option for commissioning distro series

### DIFF
--- a/ui/src/app/settings/selectors/config.js
+++ b/ui/src/app/settings/selectors/config.js
@@ -196,9 +196,9 @@ config.analyticsEnabled = createSelector(
  * @param {Object} state - The redux state.
  * @returns {String} Default distro series.
  */
-config.defaultDistroSeries = createSelector(
+config.commissioningDistroSeries = createSelector(
   [config.all],
-  configs => getValueFromName(configs, "default_distro_series")
+  configs => getValueFromName(configs, "commissioning_distro_series")
 );
 
 /**
@@ -208,7 +208,7 @@ config.defaultDistroSeries = createSelector(
  */
 config.distroSeriesOptions = createSelector(
   [config.all],
-  configs => getOptionsFromName(configs, "default_distro_series")
+  configs => getOptionsFromName(configs, "commissioning_distro_series")
 );
 
 /**

--- a/ui/src/app/settings/selectors/config.test.js
+++ b/ui/src/app/settings/selectors/config.test.js
@@ -247,16 +247,16 @@ describe("config selectors", () => {
     });
   });
 
-  describe("defaultDistroSeries", () => {
+  describe("commissioningDistroSeries", () => {
     it("returns MAAS config for default distro series", () => {
       const state = {
         config: {
           loading: false,
           loaded: true,
-          items: [{ name: "default_distro_series", value: "bionic" }]
+          items: [{ name: "commissioning_distro_series", value: "bionic" }]
         }
       };
-      expect(config.defaultDistroSeries(state)).toBe("bionic");
+      expect(config.commissioningDistroSeries(state)).toBe("bionic");
     });
   });
 
@@ -268,7 +268,7 @@ describe("config selectors", () => {
           loaded: true,
           items: [
             {
-              name: "default_distro_series",
+              name: "commissioning_distro_series",
               value: "bionic",
               choices: [["bionic", "Ubuntu 18.04 LTS 'Bionic-Beaver'"]]
             }

--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
@@ -16,7 +16,7 @@ describe("Commissioning", () => {
         loaded: true,
         items: [
           {
-            name: "default_distro_series",
+            name: "commissioning_distro_series",
             value: "bionic",
             choices: []
           },

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.js
@@ -11,7 +11,7 @@ import Form from "app/base/components/Form";
 import CommissioningFormFields from "../CommissioningFormFields";
 
 const CommissioningSchema = Yup.object().shape({
-  default_distro_series: Yup.string(),
+  commissioning_distro_series: Yup.string(),
   default_min_hwe_kernel: Yup.string()
 });
 
@@ -22,13 +22,15 @@ const CommissioningForm = () => {
   const saved = useSelector(config.saved);
   const saving = useSelector(config.saving);
 
-  const defaultDistroSeries = useSelector(config.defaultDistroSeries);
+  const commissioningDistroSeries = useSelector(
+    config.commissioningDistroSeries
+  );
   const defaultMinKernelVersion = useSelector(config.defaultMinKernelVersion);
 
   return (
     <Formik
       initialValues={{
-        default_distro_series: defaultDistroSeries,
+        commissioning_distro_series: commissioningDistroSeries,
         default_min_hwe_kernel: defaultMinKernelVersion
       }}
       onSubmit={(values, { resetForm }) => {

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
@@ -16,7 +16,7 @@ describe("CommissioningForm", () => {
         loaded: true,
         items: [
           {
-            name: "default_distro_series",
+            name: "commissioning_distro_series",
             value: "bionic",
             choices: [
               ["precise", 'Ubuntu 12.04 LTS "Precise Pangolin"'],
@@ -63,7 +63,7 @@ describe("CommissioningForm", () => {
           type: "UPDATE_CONFIG",
           payload: {
             params: [
-              { name: "default_distro_series", value: "bionic" },
+              { name: "commissioning_distro_series", value: "bionic" },
               { name: "default_min_hwe_kernel", value: "ga-16.04-lowlatency" }
             ]
           },

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.js
@@ -17,7 +17,7 @@ const CommissioningFormFields = ({ formikProps }) => {
         label="Default Ubuntu release used for commissioning"
         component={Select}
         options={distroSeriesOptions}
-        fieldKey="default_distro_series"
+        fieldKey="commissioning_distro_series"
         formikProps={formikProps}
       />
       <FormikField
@@ -33,7 +33,7 @@ const CommissioningFormFields = ({ formikProps }) => {
 };
 
 CommissioningFormFields.propTypes = extendFormikShape({
-  default_distro_series: PropTypes.string,
+  commissioning_distro_series: PropTypes.string,
   default_min_hwe_kernel: PropTypes.string
 });
 

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.js
@@ -11,7 +11,7 @@ describe("CommissioningFormFields", () => {
   let baseFormikProps;
   let initialState;
   let baseValues = {
-    default_distro_series: "bionic",
+    commissioning_distro_series: "bionic",
     default_min_hwe_kernel: "ga-16.04-lowlatency"
   };
 
@@ -31,7 +31,7 @@ describe("CommissioningFormFields", () => {
         loaded: true,
         items: [
           {
-            name: "default_distro_series",
+            name: "commissioning_distro_series",
             value: "bionic",
             choices: [
               ["precise", 'Ubuntu 12.04 LTS "Precise Pangolin"'],
@@ -64,7 +64,7 @@ describe("CommissioningFormFields", () => {
   it("updates value for default distro series", () => {
     const state = { ...initialState };
     const formikProps = { ...baseFormikProps };
-    formikProps.values.default_distro_series = "trusty";
+    formikProps.values.commissioning_distro_series = "trusty";
     const store = mockStore(state);
 
     const wrapper = mount(
@@ -75,7 +75,7 @@ describe("CommissioningFormFields", () => {
 
     expect(
       wrapper
-        .find("[name='default_distro_series']")
+        .find("[name='commissioning_distro_series']")
         .first()
         .props().value
     ).toBe("trusty");


### PR DESCRIPTION
## Done
Changed the config option from `default_distro_series` to `commissioning_distro_series` for the commissioning form as it was using the incorrect option.

## QA
- See that the `default_distro_series` has been changed to `commissioning_distro_series` in the code
- See that the top form field labelled "Default Ubuntu release used for commissioning" still updates when you change it and save.

**Note**: There is a known bug where the second options field doesn't update when the top field changes. This will be fixed in a separate PR.