### PR TITLE
Fix commissioning form

### DIFF
--- a/ui/src/app/settings/actions/general/general.js
+++ b/ui/src/app/settings/actions/general/general.js
@@ -1,0 +1,14 @@
+const general = {};
+
+general.fetchOsInfo = () => {
+  return {
+    type: "FETCH_GENERAL_OSINFO",
+    meta: {
+      model: "general",
+      method: "osinfo",
+      type: 0
+    }
+  };
+};
+
+export default general;

--- a/ui/src/app/settings/actions/general/general.test.js
+++ b/ui/src/app/settings/actions/general/general.test.js
@@ -1,0 +1,14 @@
+import general from "./general";
+
+describe("general actions", () => {
+  it("should handle fetching osinfo", () => {
+    expect(general.fetchOsInfo()).toEqual({
+      type: "FETCH_GENERAL_OSINFO",
+      meta: {
+        model: "general",
+        method: "osinfo",
+        type: 0
+      }
+    });
+  });
+});

--- a/ui/src/app/settings/actions/general/index.js
+++ b/ui/src/app/settings/actions/general/index.js
@@ -1,0 +1,3 @@
+import general from "./general";
+
+export default general;

--- a/ui/src/app/settings/actions/index.js
+++ b/ui/src/app/settings/actions/index.js
@@ -1,9 +1,11 @@
 import config from "./config";
+import general from "./general";
 import repositories from "./repositories";
 import users from "./users";
 
 export default {
   config,
+  general,
   repositories,
   users
 };

--- a/ui/src/app/settings/reducers/general/general.js
+++ b/ui/src/app/settings/reducers/general/general.js
@@ -1,0 +1,25 @@
+import produce from "immer";
+
+const general = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case "FETCH_GENERAL_OSINFO_START":
+        draft.loading = true;
+        break;
+      case "FETCH_GENERAL_OSINFO_SUCCESS":
+        draft.loading = false;
+        draft.loaded = true;
+        draft.osInfo = action.payload;
+        break;
+      default:
+        return draft;
+    }
+  },
+  {
+    loading: false,
+    loaded: false,
+    osInfo: {}
+  }
+);
+
+export default general;

--- a/ui/src/app/settings/reducers/general/general.test.js
+++ b/ui/src/app/settings/reducers/general/general.test.js
@@ -1,0 +1,55 @@
+import general from "./general";
+
+describe("general reducer", () => {
+  it("should return the initial state", () => {
+    expect(general(undefined, {})).toEqual({
+      loading: false,
+      loaded: false,
+      osInfo: {}
+    });
+  });
+
+  it("should correctly reduce FETCH_GENERAL_OSINFO_START", () => {
+    expect(
+      general(undefined, {
+        type: "FETCH_GENERAL_OSINFO_START"
+      })
+    ).toEqual({
+      loading: true,
+      loaded: false,
+      osInfo: {}
+    });
+  });
+
+  it("should correctly reduce FETCH_GENERAL_OSINFO_SUCCESS", () => {
+    expect(
+      general(
+        {
+          loading: true,
+          loaded: false,
+          osInfo: {}
+        },
+        {
+          type: "FETCH_GENERAL_OSINFO_SUCCESS",
+          payload: {
+            osystems: [],
+            releases: [],
+            kernels: {},
+            default_osystem: "",
+            default_release: ""
+          }
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: true,
+      osInfo: {
+        osystems: [],
+        releases: [],
+        kernels: {},
+        default_osystem: "",
+        default_release: ""
+      }
+    });
+  });
+});

--- a/ui/src/app/settings/reducers/general/index.js
+++ b/ui/src/app/settings/reducers/general/index.js
@@ -1,0 +1,3 @@
+import general from "./general";
+
+export default general;

--- a/ui/src/app/settings/reducers/index.js
+++ b/ui/src/app/settings/reducers/index.js
@@ -1,5 +1,6 @@
 import config from "./config";
+import general from "./general";
 import packagerepository from "./packagerepository";
 import user from "./user";
 
-export default { config, packagerepository, user };
+export default { config, general, packagerepository, user };

--- a/ui/src/app/settings/selectors/config.js
+++ b/ui/src/app/settings/selectors/config.js
@@ -221,16 +221,6 @@ config.defaultMinKernelVersion = createSelector(
   configs => getValueFromName(configs, "default_min_hwe_kernel")
 );
 
-/**
- * Returns the possible min kernel version options reformatted as objects.
- * @param {Object} state - The redux state.
- * @returns {Array} Min kernel version options.
- */
-config.minKernelVersionOptions = createSelector(
-  [config.all],
-  configs => getOptionsFromName(configs, "default_min_hwe_kernel")
-);
-
 /* Returns the MAAS config for enabling DNSSEC validation of upstream zones.
  * @param {Object} state - The redux state.
  * @returns {String} DNSSEC validation type.

--- a/ui/src/app/settings/selectors/config.test.js
+++ b/ui/src/app/settings/selectors/config.test.js
@@ -297,42 +297,6 @@ describe("config selectors", () => {
     });
   });
 
-  describe("minKernelVersionOptions", () => {
-    it("returns array of min kernel version options, formatted as objects", () => {
-      const state = {
-        config: {
-          loading: false,
-          loaded: true,
-          items: [
-            {
-              name: "default_min_hwe_kernel",
-              value: "",
-              choices: [
-                ["", "--- No minimum kernel ---"],
-                ["ga-18.04-lowlatency", "bionic (ga-18.04-lowlatency)"],
-                ["ga-18.04", "bionic (ga-18.04)"]
-              ]
-            }
-          ]
-        }
-      };
-      expect(config.minKernelVersionOptions(state)).toStrictEqual([
-        {
-          value: "",
-          label: "--- No minimum kernel ---"
-        },
-        {
-          value: "ga-18.04-lowlatency",
-          label: "bionic (ga-18.04-lowlatency)"
-        },
-        {
-          value: "ga-18.04",
-          label: "bionic (ga-18.04)"
-        }
-      ]);
-    });
-  });
-
   describe("kernelParams", () => {
     it("returns MAAS config for kernel parameters", () => {
       const state = {

--- a/ui/src/app/settings/selectors/general/general.js
+++ b/ui/src/app/settings/selectors/general/general.js
@@ -1,0 +1,45 @@
+const general = {};
+
+/**
+ * Returns object with osinfo data
+ * @param {Object} state - the redux state
+ * @returns {Object} The osinfo data
+ */
+general.osinfo = state => state.general.osInfo;
+
+/**
+ * Returns true if general is loading
+ * @param {Object} state - the redux state
+ * @returns {Boolean} - general is loading
+ */
+general.loading = state => state.general.loading;
+
+/**
+ * Returns true if general is loaded
+ * @param {Object} state - the redux state
+ * @returns {Boolean} - general is loading
+ */
+general.loaded = state => state.general.loaded;
+
+/**
+ * Returns kernels data
+ * @param {Object} state - the redux state
+ * @param {String} os - the OS to get kernel options for
+ * @returns {Array} the available kernel options
+ */
+general.getUbuntuKernelOptions = (state, os) => {
+  let kernelOptions = [];
+
+  if (state.general.osInfo.kernels && state.general.osInfo.kernels.ubuntu) {
+    kernelOptions = state.general.osInfo.kernels.ubuntu[os];
+  }
+
+  kernelOptions = [["", "No minimum kernel"]].concat(kernelOptions);
+
+  return kernelOptions.map(option => ({
+    value: option[0],
+    label: option[1]
+  }));
+};
+
+export default general;

--- a/ui/src/app/settings/selectors/general/general.test.js
+++ b/ui/src/app/settings/selectors/general/general.test.js
@@ -1,0 +1,79 @@
+import general from "./general";
+
+describe("general selectors", () => {
+  describe("osinfo", () => {
+    it("returns osinfo", () => {
+      const osinfo = {
+        osystems: [],
+        releases: [],
+        kernels: {},
+        default_osystem: "",
+        default_release: ""
+      };
+      const state = {
+        general: {
+          loading: false,
+          loaded: true,
+          osInfo: osinfo
+        }
+      };
+      expect(general.osinfo(state)).toStrictEqual(osinfo);
+    });
+  });
+
+  describe("loading", () => {
+    it("returns general loading state", () => {
+      const state = {
+        general: {
+          loading: false,
+          loaded: true,
+          osInfo: {}
+        }
+      };
+      expect(general.loading(state)).toStrictEqual(false);
+    });
+  });
+
+  describe("loaded", () => {
+    it("returns general loaded state", () => {
+      const state = {
+        general: {
+          loading: false,
+          loaded: true,
+          osInfo: {}
+        }
+      };
+      expect(general.loaded(state)).toStrictEqual(true);
+    });
+  });
+
+  describe("getUbuntuKernelOptions", () => {
+    it("returns options for supplied key", () => {
+      const state = {
+        general: {
+          loading: false,
+          loaded: true,
+          osInfo: {
+            kernels: {
+              ubuntu: {
+                precise: [
+                  ["hwe-p", "precise (hwe-p)"],
+                  ["hwe-q", "precise (hwe-q)"]
+                ],
+                trusty: [
+                  ["hwe-t", "trusty (hwe-t)"],
+                  ["hwe-u", "trusty (hwe-u)"]
+                ]
+              }
+            }
+          }
+        }
+      };
+      expect(general.getUbuntuKernelOptions(state, "precise")).toEqual([
+        { value: "", label: "No minimum kernel" },
+        { value: "hwe-p", label: "precise (hwe-p)" },
+        { value: "hwe-q", label: "precise (hwe-q)" }
+      ]);
+    });
+  });
+});

--- a/ui/src/app/settings/selectors/general/index.js
+++ b/ui/src/app/settings/selectors/general/index.js
@@ -1,0 +1,3 @@
+import general from "./general";
+
+export default general;

--- a/ui/src/app/settings/selectors/index.js
+++ b/ui/src/app/settings/selectors/index.js
@@ -1,9 +1,11 @@
 import config from "./config";
+import general from "./general";
 import repositories from "./repositories";
 import users from "./users";
 
 export default {
   config,
+  general,
   repositories,
   users
 };

--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
@@ -26,6 +26,11 @@ describe("Commissioning", () => {
             choices: []
           }
         ]
+      },
+      general: {
+        loading: false,
+        loaded: true,
+        osInfo: {}
       }
     };
   });

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.js
@@ -1,5 +1,5 @@
 import { Formik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -21,6 +21,10 @@ const CommissioningForm = () => {
 
   const saved = useSelector(config.saved);
   const saving = useSelector(config.saving);
+
+  useEffect(() => {
+    dispatch(actions.general.fetchOsInfo());
+  }, [dispatch]);
 
   const commissioningDistroSeries = useSelector(
     config.commissioningDistroSeries

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
@@ -42,6 +42,11 @@ describe("CommissioningForm", () => {
             ]
           }
         ]
+      },
+      general: {
+        loading: false,
+        loaded: true,
+        osInfo: {}
       }
     };
   });
@@ -58,23 +63,48 @@ describe("CommissioningForm", () => {
 
     // since Formik handler is evaluated asynchronously we have to delay checking the assertion
     window.setTimeout(() => {
-      expect(store.getActions()).toEqual([
-        {
-          type: "UPDATE_CONFIG",
-          payload: {
-            params: [
-              { name: "commissioning_distro_series", value: "bionic" },
-              { name: "default_min_hwe_kernel", value: "ga-16.04-lowlatency" }
-            ]
-          },
-          meta: {
-            model: "config",
-            method: "update",
-            type: 0
-          }
+      const updateConfigAction = store
+        .getActions()
+        .find(action => action.type === "UPDATE_CONFIG");
+      expect(updateConfigAction).toEqual({
+        type: "UPDATE_CONFIG",
+        payload: {
+          params: [
+            { name: "commissioning_distro_series", value: "bionic" },
+            { name: "default_min_hwe_kernel", value: "ga-16.04-lowlatency" }
+          ]
+        },
+        meta: {
+          model: "config",
+          method: "update",
+          type: 0
         }
-      ]);
+      });
       done();
     }, 0);
+  });
+
+  it("dispatches action to fetch general on load", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <CommissioningForm />
+      </Provider>
+    );
+
+    const fetchGeneralOsinfoAction = store
+      .getActions()
+      .find(action => action.type === "FETCH_GENERAL_OSINFO");
+
+    expect(fetchGeneralOsinfoAction).toEqual({
+      type: "FETCH_GENERAL_OSINFO",
+      meta: {
+        model: "general",
+        method: "osinfo",
+        type: 0
+      }
+    });
   });
 });

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.js
@@ -3,13 +3,19 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import { extendFormikShape } from "app/settings/proptypes";
-import config from "app/settings/selectors/config";
+import selectors from "app/settings/selectors";
 import FormikField from "app/base/components/FormikField";
 import Select from "app/base/components/Select";
 
 const CommissioningFormFields = ({ formikProps }) => {
-  const distroSeriesOptions = useSelector(config.distroSeriesOptions);
-  const minKernelVersionOptions = useSelector(config.minKernelVersionOptions);
+  const distroSeriesOptions = useSelector(selectors.config.distroSeriesOptions);
+
+  const ubuntuKernelOptions = useSelector(state =>
+    selectors.general.getUbuntuKernelOptions(
+      state,
+      formikProps.values.commissioning_distro_series
+    )
+  );
 
   return (
     <>
@@ -23,7 +29,7 @@ const CommissioningFormFields = ({ formikProps }) => {
       <FormikField
         label="Default minimum kernel version"
         component={Select}
-        options={minKernelVersionOptions}
+        options={ubuntuKernelOptions}
         help="The default minimum kernel version used on all new and commissioned nodes"
         fieldKey="default_min_hwe_kernel"
         formikProps={formikProps}

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.js
@@ -42,19 +42,21 @@ describe("CommissioningFormFields", () => {
           },
           {
             name: "default_min_hwe_kernel",
-            value: "ga-16.04-lowlatency",
-            choices: [
-              ["", "--- No minimum kernel ---"],
-              ["ga-16.04-lowlatency", "xenial (ga-16.04-lowlatency)"],
-              ["ga-16.04", "xenial (ga-16.04)"],
-              ["hwe-16.04-lowlatency", "xenial (hwe-16.04-lowlatency)"],
-              ["hwe-16.04", "xenial (hwe-16.04)"],
-              ["hwe-16.04-edge", "xenial (hwe-16.04-edge)"],
-              [
-                "hwe-16.04-lowlatency-edge",
-                "xenial (hwe-16.04-lowlatency-edge)"
-              ]
-            ]
+            value: "ga-16.04-lowlatency"
+          }
+        ]
+      },
+      general: {
+        osInfo: [
+          {
+            kernels: {
+              ubuntu: {
+                xenial: [
+                  ["hwe-16.04-edge", "xenial (hwe-16.04-edge)"],
+                  ["hwe-16.04", "xenial (hwe-16.04)"]
+                ]
+              }
+            }
           }
         ]
       }

--- a/ui/src/app/settings/views/Settings.test.js
+++ b/ui/src/app/settings/views/Settings.test.js
@@ -27,15 +27,17 @@ describe("Settings", () => {
       </Provider>
     );
 
-    expect(store.getActions()).toEqual([
-      {
-        type: "FETCH_CONFIG",
-        meta: {
-          model: "config",
-          method: "list",
-          type: 0
-        }
+    const fetchConfigAction = store
+      .getActions()
+      .find(action => action.type === "FETCH_CONFIG");
+
+    expect(fetchConfigAction).toEqual({
+      type: "FETCH_CONFIG",
+      meta: {
+        model: "config",
+        method: "list",
+        type: 0
       }
-    ]);
+    });
   });
 });

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -8,6 +8,7 @@ import baseReducers from "./app/base/reducers";
 export default history =>
   combineReducers({
     config: settingsReducers.config,
+    general: settingsReducers.general,
     packagerepository: settingsReducers.packagerepository,
     user: reduceReducers(settingsReducers.user, baseReducers.auth),
     router: connectRouter(history),


### PR DESCRIPTION
This is carried over from https://github.com/canonical-web-and-design/maas-ui/pull/116

I had some git issues and ended up just making a new PR.

There was some discussion on the previous PR which is worth reviewing.

## Done
Updated the settings commissioning form so that the second fields options update when the first option changes. Fixes [#1414](https://github.com/canonical-web-and-design/MAAS-squad/issues/1414)

## QA
- Go to `/settings/configuration/commissioning`
- See that the field labelled `Default minimum kernel version` options are related to the above field (i.e. same version number 18.04 etc.)
- Change the field labelled `Default Ubuntu release used for commissioning` and see that the options in the field beneath are updated to reflect the new value
