### PR TITLE
Fix user server errors

### DIFF
--- a/ui/src/app/base/components/FormikField/FormikField.js
+++ b/ui/src/app/base/components/FormikField/FormikField.js
@@ -22,13 +22,13 @@ const FormikField = ({
   } = formikProps;
   const { serverErrors = {}, invalidValues = {} } = status;
   const isTouched = touched[fieldKey];
-  const valueChanged = value === invalidValues[fieldKey];
+  const valueUnchanged = value === invalidValues[fieldKey];
   const validationError = errors[fieldKey];
   const serverError = serverErrors[fieldKey];
   return (
     <Component
       error={
-        (isTouched && (validationError || (!valueChanged && serverError))) ||
+        (isTouched && (validationError || (valueUnchanged && serverError))) ||
         undefined
       }
       id={id.current}

--- a/ui/src/app/base/components/FormikField/FormikField.test.js
+++ b/ui/src/app/base/components/FormikField/FormikField.test.js
@@ -79,7 +79,7 @@ describe("FormikField", () => {
         value="admin"
       />
     );
-    expect(wrapper.type()).toEqual(Textarea);
+    expect(wrapper.prop("error")).toEqual("Username already exists");
   });
 
   it("does not show server errors if the value has changed", () => {
@@ -100,6 +100,6 @@ describe("FormikField", () => {
         value="koala"
       />
     );
-    expect(wrapper.type()).toEqual(Textarea);
+    expect(wrapper.prop("error")).toBe(undefined);
   });
 });


### PR DESCRIPTION
Done:
- Correctly display the server errors in the user form.

QA:
- Try and add a user with an existing username and click Save
- You should get an error message for the username field.