### PR TITLE
Sequence calls for array params to prevent races for dependant config.

### DIFF
--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -1,5 +1,5 @@
 import { eventChannel } from "redux-saga";
-import { all, call, delay, put, select, take, race } from "redux-saga/effects";
+import { all, call, put, select, take, race } from "redux-saga/effects";
 
 import getCookie from "./utils";
 import WebSocketClient from "../../../websocket-client";

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -1,5 +1,5 @@
 import { eventChannel } from "redux-saga";
-import { all, call, put, select, take, race } from "redux-saga/effects";
+import { all, call, delay, put, select, take, race } from "redux-saga/effects";
 
 import getCookie from "./utils";
 import WebSocketClient from "../../../websocket-client";
@@ -158,15 +158,22 @@ export function* sendMessage(socketClient) {
     yield put({ type: `${type}_START` });
     try {
       if (params && Array.isArray(params)) {
-        yield all(
-          params.map(param =>
-            call(
-              [socketClient, socketClient.send],
-              type,
-              buildMessage(meta, param)
-            )
-          )
-        );
+        // We deliberately do not yield in parallel here with 'all'
+        // to avoid races for dependant config.
+        for (let param of params) {
+          yield call(
+            [socketClient, socketClient.send],
+            type,
+            buildMessage(meta, param)
+          );
+          // Ensure server has synced before sending next message,
+          // important for dependant config like commissioning_distro_series
+          // and default_min_hwe_kernel.
+          // There is an edge case where a different CLI or server event could
+          // dispatch a SYNC of the same type which is received before our expected SYNC,
+          // but this _probably_ does not matter in practice.
+          yield take(`${type}_SYNC`);
+        }
       } else {
         yield call(
           [socketClient, socketClient.send],

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -133,7 +133,7 @@ describe("websocket sagas", () => {
     expect(saga.next(true).value.type).toEqual("TAKE");
   });
 
-  it("can handle params as an array", () => {
+  it.only("can handle params as an array", () => {
     const saga = sendMessage(socketClient);
     saga.next();
     expect(
@@ -149,21 +149,24 @@ describe("websocket sagas", () => {
         }
       }).value
     ).toEqual(put({ type: "TEST_ACTION_START" }));
-    const effect = saga.next().value;
-    expect(effect).toEqual(
-      all([
-        call([socketClient, socketClient.send], "TEST_ACTION", {
-          method: "test.method",
-          type: 0,
-          params: { name: "foo", value: "bar" }
-        }),
-        call([socketClient, socketClient.send], "TEST_ACTION", {
-          method: "test.method",
-          type: 0,
-          params: { name: "baz", value: "qux" }
-        })
-      ])
+
+    expect(saga.next().value).toEqual(
+      call([socketClient, socketClient.send], "TEST_ACTION", {
+        method: "test.method",
+        type: 0,
+        params: { name: "foo", value: "bar" }
+      })
     );
+    expect(saga.next().value).toEqual(take("TEST_ACTION_SYNC"));
+
+    expect(saga.next().value).toEqual(
+      call([socketClient, socketClient.send], "TEST_ACTION", {
+        method: "test.method",
+        type: 0,
+        params: { name: "baz", value: "qux" }
+      })
+    );
+    expect(saga.next().value).toEqual(take("TEST_ACTION_SYNC"));
   });
 
   it("can handle errors when sending a WebSocket message", () => {

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -1,4 +1,4 @@
-import { call, put, take, all } from "redux-saga/effects";
+import { call, put, take } from "redux-saga/effects";
 import { expectSaga } from "redux-saga-test-plan";
 
 import {
@@ -133,7 +133,7 @@ describe("websocket sagas", () => {
     expect(saga.next(true).value.type).toEqual("TAKE");
   });
 
-  it.only("can handle params as an array", () => {
+  it("can handle params as an array", () => {
     const saga = sendMessage(socketClient);
     saga.next();
     expect(


### PR DESCRIPTION
## Done
For payloads with params as an array, ensure each websocket request is committed and blocks on an incoming SYNC message before dispatching the next. This is important for updating dependant config such as `commissioning_distro_series` and `default_min_hwe_kernel` (e.g. changing distro from "Xenial -> Bionic" must be committed before kernel can change from 16.04 -> 18.04).

## QA
Unfortunately a bit hard to QA as the only form with dependant config is currently in review, but I would recommend checking out steve's commissioning form branch
```
git checkout -b steverydz-fix-commissioning-form master
git pull https://github.com/steverydz/maas-ui.git fix-commissioning-form
```
and rebasing this on top. Change some config on the commissioning form and ensure you see two UPDATE_CONFIG_SYNCS and no ERROR actions.


