### PR TITLE
Implement deleting repositories over the API

### DIFF
--- a/ui/src/app/settings/actions/repositories.js
+++ b/ui/src/app/settings/actions/repositories.js
@@ -2,7 +2,7 @@ const repositories = {};
 
 repositories.fetch = () => {
   return {
-    type: "FETCH_REPOSITORIES",
+    type: "FETCH_PACKAGEREPOSITORY",
     payload: {
       params: { limit: 50 }
     },
@@ -10,6 +10,22 @@ repositories.fetch = () => {
       model: "packagerepository",
       method: "list",
       type: 0
+    }
+  };
+};
+
+repositories.delete = id => {
+  return {
+    type: "DELETE_PACKAGEREPOSITORY",
+    meta: {
+      model: "packagerepository",
+      method: "delete",
+      type: 0
+    },
+    payload: {
+      params: {
+        id
+      }
     }
   };
 };

--- a/ui/src/app/settings/actions/repositories.test.js
+++ b/ui/src/app/settings/actions/repositories.test.js
@@ -3,7 +3,7 @@ import repositories from "./repositories";
 describe("repository actions", () => {
   it("should handle fetching repositories", () => {
     expect(repositories.fetch()).toEqual({
-      type: "FETCH_REPOSITORIES",
+      type: "FETCH_PACKAGEREPOSITORY",
       payload: {
         params: { limit: 50 }
       },
@@ -11,6 +11,22 @@ describe("repository actions", () => {
         model: "packagerepository",
         method: "list",
         type: 0
+      }
+    });
+  });
+
+  it("can handle deleting repositories", () => {
+    expect(repositories.delete(911)).toEqual({
+      type: "DELETE_PACKAGEREPOSITORY",
+      meta: {
+        model: "packagerepository",
+        method: "delete",
+        type: 0
+      },
+      payload: {
+        params: {
+          id: 911
+        }
       }
     });
   });

--- a/ui/src/app/settings/actions/users.js
+++ b/ui/src/app/settings/actions/users.js
@@ -2,7 +2,7 @@ const users = {};
 
 users.fetch = () => {
   return {
-    type: "FETCH_USERS",
+    type: "FETCH_USER",
     meta: {
       model: "user",
       method: "list",
@@ -13,7 +13,7 @@ users.fetch = () => {
 
 users.create = params => {
   return {
-    type: "CREATE_USERS",
+    type: "CREATE_USER",
     meta: {
       model: "user",
       method: "create",
@@ -27,7 +27,7 @@ users.create = params => {
 
 users.update = params => {
   return {
-    type: "UPDATE_USERS",
+    type: "UPDATE_USER",
     meta: {
       model: "user",
       method: "update",
@@ -41,7 +41,7 @@ users.update = params => {
 
 users.delete = id => {
   return {
-    type: "DELETE_USERS",
+    type: "DELETE_USER",
     meta: {
       model: "user",
       method: "delete",
@@ -57,7 +57,7 @@ users.delete = id => {
 
 users.cleanup = () => {
   return {
-    type: "CLEANUP_USERS"
+    type: "CLEANUP_USER"
   };
 };
 

--- a/ui/src/app/settings/actions/users.test.js
+++ b/ui/src/app/settings/actions/users.test.js
@@ -3,7 +3,7 @@ import users from "./users";
 describe("user actions", () => {
   it("should handle fetching users", () => {
     expect(users.fetch()).toEqual({
-      type: "FETCH_USERS",
+      type: "FETCH_USER",
       meta: {
         model: "user",
         method: "list",
@@ -14,7 +14,7 @@ describe("user actions", () => {
 
   it("can handle creating users", () => {
     expect(users.create({ name: "kangaroo" })).toEqual({
-      type: "CREATE_USERS",
+      type: "CREATE_USER",
       meta: {
         model: "user",
         method: "create",
@@ -30,7 +30,7 @@ describe("user actions", () => {
 
   it("can handle updating users", () => {
     expect(users.update({ name: "kookaburra" })).toEqual({
-      type: "UPDATE_USERS",
+      type: "UPDATE_USER",
       meta: {
         model: "user",
         method: "update",
@@ -46,7 +46,7 @@ describe("user actions", () => {
 
   it("can handle deleting users", () => {
     expect(users.delete(808)).toEqual({
-      type: "DELETE_USERS",
+      type: "DELETE_USER",
       meta: {
         model: "user",
         method: "delete",
@@ -62,7 +62,7 @@ describe("user actions", () => {
 
   it("can handle cleaning users", () => {
     expect(users.cleanup({ name: "kookaburra" })).toEqual({
-      type: "CLEANUP_USERS"
+      type: "CLEANUP_USER"
     });
   });
 });

--- a/ui/src/app/settings/reducers/packagerepository.js
+++ b/ui/src/app/settings/reducers/packagerepository.js
@@ -3,22 +3,43 @@ import produce from "immer";
 const packagerepository = produce(
   (draft, action) => {
     switch (action.type) {
-      case "FETCH_REPOSITORIES_START":
+      case "FETCH_PACKAGEREPOSITORY_START":
         draft.loading = true;
         break;
-      case "FETCH_REPOSITORIES_SUCCESS":
+      case "FETCH_PACKAGEREPOSITORY_SUCCESS":
         draft.loading = false;
         draft.loaded = true;
         draft.items = action.payload;
+        break;
+      case "DELETE_PACKAGEREPOSITORY_START":
+        draft.saved = false;
+        draft.saving = true;
+        break;
+      case "DELETE_PACKAGEREPOSITORY_SUCCESS":
+        draft.errors = {};
+        draft.saved = true;
+        draft.saving = false;
+        break;
+      case "FETCH_PACKAGEREPOSITORY_ERROR":
+      case "DELETE_PACKAGEREPOSITORY_ERROR":
+        draft.errors = action.error;
+        draft.saving = false;
+        break;
+      case "DELETE_PACKAGEREPOSITORY_SYNC":
+        const index = draft.items.findIndex(item => item.id === action.payload);
+        draft.items.splice(index, 1);
         break;
       default:
         return draft;
     }
   },
   {
-    loading: false,
+    errors: {},
+    items: [],
     loaded: false,
-    items: []
+    loading: false,
+    saved: false,
+    saving: false
   }
 );
 

--- a/ui/src/app/settings/reducers/packagerepository.test.js
+++ b/ui/src/app/settings/reducers/packagerepository.test.js
@@ -3,41 +3,157 @@ import packagerepository from "./packagerepository";
 describe("packagerepository reducer", () => {
   it("should return the initial state", () => {
     expect(packagerepository(undefined, {})).toEqual({
-      loading: false,
+      errors: {},
+      items: [],
       loaded: false,
-      items: []
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
-  it("should correctly reduce FETCH_REPOSITORIES_START", () => {
+  it("should correctly reduce FETCH_PACKAGEREPOSITORY_START", () => {
     expect(
       packagerepository(undefined, {
-        type: "FETCH_REPOSITORIES_START"
+        type: "FETCH_PACKAGEREPOSITORY_START"
       })
     ).toEqual({
-      loading: true,
+      errors: {},
+      items: [],
       loaded: false,
-      items: []
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
-  it("should correctly reduce FETCH_REPOSITORIES_SUCCESS", () => {
+  it("should correctly reduce FETCH_PACKAGEREPOSITORY_SUCCESS", () => {
     expect(
       packagerepository(
         {
-          loading: true,
+          errors: {},
+          items: [],
           loaded: false,
-          items: []
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
-          type: "FETCH_REPOSITORIES_SUCCESS",
+          type: "FETCH_PACKAGEREPOSITORY_SUCCESS",
           payload: [1, 2, 3]
         }
       )
     ).toEqual({
-      loading: false,
+      errors: {},
+      items: [1, 2, 3],
       loaded: true,
-      items: [1, 2, 3]
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_PACKAGEREPOSITORY_START", () => {
+    expect(
+      packagerepository(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false
+        },
+        {
+          type: "DELETE_PACKAGEREPOSITORY_START"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce DELETE_PACKAGEREPOSITORY_SUCCESS", () => {
+    expect(
+      packagerepository(
+        {
+          errors: { name: "Name already exists" },
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          type: "DELETE_PACKAGEREPOSITORY_SUCCESS"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: true,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_PACKAGEREPOSITORY_ERROR", () => {
+    expect(
+      packagerepository(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: "Could not delete repository",
+          type: "DELETE_PACKAGEREPOSITORY_ERROR"
+        }
+      )
+    ).toEqual({
+      errors: "Could not delete repository",
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_PACKAGEREPOSITORY_SYNC", () => {
+    expect(
+      packagerepository(
+        {
+          auth: {},
+          errors: {},
+          items: [{ id: 1, name: "repo1" }, { id: 2, name: "repo2" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          payload: 2,
+          type: "DELETE_PACKAGEREPOSITORY_SYNC"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: {},
+      items: [{ id: 1, name: "repo1" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/settings/reducers/user.js
+++ b/ui/src/app/settings/reducers/user.js
@@ -3,29 +3,29 @@ import produce from "immer";
 const user = produce(
   (draft, action) => {
     switch (action.type) {
-      case "FETCH_USERS_START":
+      case "FETCH_USER_START":
         draft.loading = true;
         break;
-      case "FETCH_USERS_SUCCESS":
+      case "FETCH_USER_SUCCESS":
         draft.loading = false;
         draft.loaded = true;
         draft.items = action.payload;
         break;
-      case "UPDATE_USERS_START":
-      case "CREATE_USERS_START":
-      case "DELETE_USERS_START":
+      case "UPDATE_USER_START":
+      case "CREATE_USER_START":
+      case "DELETE_USER_START":
         draft.saved = false;
         draft.saving = true;
         break;
-      case "UPDATE_USERS_ERROR":
-      case "CREATE_USERS_ERROR":
-      case "DELETE_USERS_ERROR":
+      case "UPDATE_USER_ERROR":
+      case "CREATE_USER_ERROR":
+      case "DELETE_USER_ERROR":
         draft.errors = action.error;
         draft.saving = false;
         break;
-      case "UPDATE_USERS_SUCCESS":
-      case "CREATE_USERS_SUCCESS":
-      case "DELETE_USERS_SUCCESS":
+      case "UPDATE_USER_SUCCESS":
+      case "CREATE_USER_SUCCESS":
+      case "DELETE_USER_SUCCESS":
         draft.errors = {};
         draft.saved = true;
         draft.saving = false;
@@ -45,7 +45,7 @@ const user = produce(
         const index = draft.items.findIndex(item => item.id === action.payload);
         draft.items.splice(index, 1);
         break;
-      case "CLEANUP_USERS":
+      case "CLEANUP_USER":
         draft.errors = {};
         draft.saved = false;
         draft.saving = false;

--- a/ui/src/app/settings/reducers/user.test.js
+++ b/ui/src/app/settings/reducers/user.test.js
@@ -13,10 +13,10 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce FETCH_USERS_START", () => {
+  it("should correctly reduce FETCH_USER_START", () => {
     expect(
       user(undefined, {
-        type: "FETCH_USERS_START"
+        type: "FETCH_USER_START"
       })
     ).toEqual({
       auth: {},
@@ -29,7 +29,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce FETCH_USERS_SUCCESS", () => {
+  it("should correctly reduce FETCH_USER_SUCCESS", () => {
     expect(
       user(
         {
@@ -42,7 +42,7 @@ describe("users reducer", () => {
           saving: false
         },
         {
-          type: "FETCH_USERS_SUCCESS",
+          type: "FETCH_USER_SUCCESS",
           payload: [{ id: 1, username: "admin" }, { id: 2, username: "user1" }]
         }
       )
@@ -57,7 +57,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce UPDATE_USERS_START", () => {
+  it("should correctly reduce UPDATE_USER_START", () => {
     expect(
       user(
         {
@@ -70,7 +70,7 @@ describe("users reducer", () => {
           saving: false
         },
         {
-          type: "UPDATE_USERS_START"
+          type: "UPDATE_USER_START"
         }
       )
     ).toEqual({
@@ -84,7 +84,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce CREATE_USERS_START", () => {
+  it("should correctly reduce CREATE_USER_START", () => {
     expect(
       user(
         {
@@ -97,7 +97,7 @@ describe("users reducer", () => {
           saving: false
         },
         {
-          type: "CREATE_USERS_START"
+          type: "CREATE_USER_START"
         }
       )
     ).toEqual({
@@ -111,7 +111,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce DELETE_USERS_START", () => {
+  it("should correctly reduce DELETE_USER_START", () => {
     expect(
       user(
         {
@@ -124,7 +124,7 @@ describe("users reducer", () => {
           saving: false
         },
         {
-          type: "DELETE_USERS_START"
+          type: "DELETE_USER_START"
         }
       )
     ).toEqual({
@@ -138,7 +138,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce UPDATE_USERS_ERROR", () => {
+  it("should correctly reduce UPDATE_USER_ERROR", () => {
     expect(
       user(
         {
@@ -152,7 +152,7 @@ describe("users reducer", () => {
         },
         {
           error: { username: "Username already exists" },
-          type: "UPDATE_USERS_ERROR"
+          type: "UPDATE_USER_ERROR"
         }
       )
     ).toEqual({
@@ -166,7 +166,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce CREATE_USERS_ERROR", () => {
+  it("should correctly reduce CREATE_USER_ERROR", () => {
     expect(
       user(
         {
@@ -180,7 +180,7 @@ describe("users reducer", () => {
         },
         {
           error: { username: "Username already exists" },
-          type: "CREATE_USERS_ERROR"
+          type: "CREATE_USER_ERROR"
         }
       )
     ).toEqual({
@@ -194,7 +194,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce DELETE_USERS_ERROR", () => {
+  it("should correctly reduce DELETE_USER_ERROR", () => {
     expect(
       user(
         {
@@ -208,7 +208,7 @@ describe("users reducer", () => {
         },
         {
           error: "Could not delete",
-          type: "DELETE_USERS_ERROR"
+          type: "DELETE_USER_ERROR"
         }
       )
     ).toEqual({
@@ -309,7 +309,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce CLEANUP_USERS", () => {
+  it("should correctly reduce CLEANUP_USER", () => {
     expect(
       user(
         {
@@ -322,7 +322,7 @@ describe("users reducer", () => {
           saving: true
         },
         {
-          type: "CLEANUP_USERS"
+          type: "CLEANUP_USER"
         }
       )
     ).toEqual({

--- a/ui/src/app/settings/selectors/repositories.js
+++ b/ui/src/app/settings/selectors/repositories.js
@@ -29,6 +29,27 @@ repositories.loading = state => state.packagerepository.loading;
 repositories.loaded = state => state.packagerepository.loaded;
 
 /**
+ * Get the saving state.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Repositories are saving.
+ */
+repositories.saving = state => state.packagerepository.saving;
+
+/**
+ * Get the saved state.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Repositories have saved.
+ */
+repositories.saved = state => state.packagerepository.saved;
+
+/**
+ * Returns repositories errors.
+ * @param {Object} state - The redux state.
+ * @returns {Object} Errors for repositories.
+ */
+repositories.errors = state => state.packagerepository.errors;
+
+/**
  * Get repositories that match a term.
  * @param {Object} state - The redux state.
  * @param {String} term - The term to match against.

--- a/ui/src/app/settings/selectors/repositories.test.js
+++ b/ui/src/app/settings/selectors/repositories.test.js
@@ -30,6 +30,38 @@ describe("repositories selectors", () => {
     expect(repositories.loaded(state)).toEqual(true);
   });
 
+  it("can get the saving state", () => {
+    const state = {
+      packagerepository: {
+        saving: true,
+        items: []
+      }
+    };
+    expect(repositories.saving(state)).toEqual(true);
+  });
+
+  it("can get the saved state", () => {
+    const state = {
+      packagerepository: {
+        saved: true,
+        items: []
+      }
+    };
+    expect(repositories.saved(state)).toEqual(true);
+  });
+
+  it("can get packagerepository errors", () => {
+    const state = {
+      packagerepository: {
+        errors: { name: "Name already exists" },
+        items: []
+      }
+    };
+    expect(repositories.errors(state)).toStrictEqual({
+      name: "Name already exists"
+    });
+  });
+
   it("can get the count", () => {
     const state = {
       packagerepository: {

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
@@ -13,7 +13,12 @@ import Pagination from "app/base/components/Pagination";
 import Row from "app/base/components/Row";
 import SearchBox from "app/base/components/SearchBox";
 
-const generateRepositoryRows = (repositories, expandedId, setExpandedId) =>
+const generateRepositoryRows = (
+  repositories,
+  expandedId,
+  setExpandedId,
+  dispatch
+) =>
   repositories.map(repo => {
     let name = "";
     if (repo.name === "main_archive") {
@@ -78,7 +83,15 @@ const generateRepositoryRows = (repositories, expandedId, setExpandedId) =>
           </Col>
           <Col size="3" className="u-align--right">
             <Button onClick={() => setExpandedId()}>Cancel</Button>
-            <Button appearance="negative">Delete</Button>
+            <Button
+              appearance="negative"
+              onClick={() => {
+                dispatch(actions.repositories.delete(repo.id));
+                setExpandedId();
+              }}
+            >
+              Delete
+            </Button>
           </Col>
         </Row>
       ),
@@ -142,7 +155,12 @@ export const Repositories = ({ initialCount = 20 }) => {
             { content: "Actions", className: "u-align--right" }
           ]}
           rowLimit={itemsPerPage}
-          rows={generateRepositoryRows(repositories, expandedId, setExpandedId)}
+          rows={generateRepositoryRows(
+            repositories,
+            expandedId,
+            setExpandedId,
+            dispatch
+          )}
           rowStartIndex={indexOfFirstItem}
           sortable
         />

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
@@ -113,6 +113,49 @@ describe("RepositoriesList", () => {
     expect(row.expanded).toBe(true);
   });
 
+  it("can delete a repository", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/settings/repositories", key: "testKey" }
+          ]}
+        >
+          <RepositoriesList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click on the delete button:
+    wrapper
+      .find("TableRow")
+      .at(3)
+      .find("Button")
+      .at(1)
+      .simulate("click");
+    // Click on the delete confirm button
+    wrapper
+      .find("TableRow")
+      .at(3)
+      .find("Button")
+      .at(3)
+      .simulate("click");
+    expect(store.getActions()[1]).toEqual({
+      type: "DELETE_PACKAGEREPOSITORY",
+      payload: {
+        params: {
+          id: 3
+        }
+      },
+      meta: {
+        model: "packagerepository",
+        method: "delete",
+        type: 0
+      }
+    });
+  });
+
   it("can filter repositories", () => {
     const state = { ...initialState };
     const store = mockStore(state);

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -48,7 +48,7 @@ describe("UserForm", () => {
     wrapper.unmount();
     expect(store.getActions()).toEqual([
       {
-        type: "CLEANUP_USERS"
+        type: "CLEANUP_USER"
       }
     ]);
   });
@@ -98,7 +98,7 @@ describe("UserForm", () => {
       });
     expect(store.getActions()).toEqual([
       {
-        type: "UPDATE_USERS",
+        type: "UPDATE_USER",
         payload: {
           params: {
             email: "test@example.com",
@@ -140,7 +140,7 @@ describe("UserForm", () => {
       });
     expect(store.getActions()).toEqual([
       {
-        type: "CREATE_USERS",
+        type: "CREATE_USER",
         payload: {
           params: {
             email: "test@example.com",

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -140,7 +140,7 @@ describe("UsersList", () => {
       .at(3)
       .simulate("click");
     expect(store.getActions()[1]).toEqual({
-      type: "DELETE_USERS",
+      type: "DELETE_USER",
       payload: {
         params: {
           id: 2


### PR DESCRIPTION
## Done
- Implemented deleting repos over the api
- Renamed actions to match model names
  - `REPOSITORIES` => `PACKAGEREPOSITORY`
  - `USERS` => `USER`

## QA
- Add some repos at `:5240/MAAS/#/settings/repositories`
- Go to `:8000/MAAS/settings/repositories` and see that you can delete them successfully
- Refresh maas-ui and check back on `:5240/MAAS/#/settings/repositories` to make sure they're gone for real
- Do the same for users just in case the renaming messed something up unexpectedly