### PR TITLE
Document release process and add release yarn script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "build": "cd ui && yarn run build",
+    "release": "cd ui && yarn run release",
     "serve": "cd ui && yarn run start",
     "test": "cd ui && yarn run test",
     "clean": "rm -rf node_modules && cd ui && yarn run clean"

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -14,14 +14,15 @@ yarn.lock
 
 # production
 /build
+/dist
 
 # misc
 *.swp
 .DS_Store
-.env.local
 .env.development.local
-.env.test.local
+.env.local
 .env.production.local
+.env.test.local
 
 # [env] Local environment settings
 .docker-project

--- a/ui/README.md
+++ b/ui/README.md
@@ -79,4 +79,4 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for details.
 2. Run `yarn release ${version}`. (e.g. `yarn release 0.1.1`, note no 'v'). Please ensure correct [semantic versioning](https://semver.org/).
 3. Make a commit with `git commit -am "Release v${version}."`.
 4. Push the release with `git push --tags <upstream> master`.
-5. [Draft a new release on Github](https://github.com/canonical-web-and-design/maas-ui/releases/new) using the new version as the *Release title*, copying the changelog section for the new release into the *description* field, and uploading the production tarball produced by `yarn build`.
+5. [Draft a new release on Github](https://github.com/canonical-web-and-design/maas-ui/releases/new) using the new version as the *Release title*, copying the changelog section for the new release into the *description* field, and uploading the production tarball in `./dist`.

--- a/ui/README.md
+++ b/ui/README.md
@@ -75,6 +75,8 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for details.
 
 # Release Process
 
+Note: Releasing is not currently supported by the `run` script (see [issue](https://github.com/canonical-web-and-design/generator-canonical-webteam/issues/116) for details), so please perform the following directly in a container or on your host.
+
 1. Update CHANGELOG.md, moving unreleased changes to a new heading for the release version.
 2. Run `yarn release ${version}`. (e.g. `yarn release 0.1.1`, note no 'v'). Please ensure correct [semantic versioning](https://semver.org/).
 3. Make a commit with `git commit -am "Release v${version}."`.

--- a/ui/README.md
+++ b/ui/README.md
@@ -75,12 +75,8 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for details.
 
 # Release Process
 
-1. Run `yarn clean`.
-2. Run `yarn install`.
-3. Ensure tests pass with `yarn test`.
-4. Bump `version` in package.json with correct semantic versioning.
-5. Update CHANGELOG.md, moving unreleased changes to a new heading for the release version.
-6. Make a commit with `git commit -am "Release v${version}."`.
-7. Tag the commit with `git tag v${version}`, and push with `git push --tags <upstream> master`.
-8. Build maas-ui with `yarn build`.
-9. [Draft a new release on Github](https://github.com/canonical-web-and-design/maas-ui/releases/new), copying the changelog section for the new release into the description field, and uploading the production tarball produced by `yarn build`.
+1. Update CHANGELOG.md, moving unreleased changes to a new heading for the release version.
+2. Run `yarn release ${version}`. (e.g. `yarn release 0.1.1`, note no 'v'). Please ensure correct [semantic versioning](https://semver.org/).
+3. Make a commit with `git commit -am "Release v${version}."`.
+4. Push the release with `git push --tags <upstream> master`.
+5. [Draft a new release on Github](https://github.com/canonical-web-and-design/maas-ui/releases/new) using the new version as the *Release title*, copying the changelog section for the new release into the *description* field, and uploading the production tarball produced by `yarn build`.

--- a/ui/README.md
+++ b/ui/README.md
@@ -72,3 +72,15 @@ From here you should be able to view the project at &lt;your-local-maas-ip>:8000
 When proposing changes to maas-ui, ensure you update CHANGELOG.md appropriately, describing your changes under either a "Fixed", "Added", "Removed", or "Changed" subheading under "Unreleased".
 
 See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for details.
+
+# Release Process
+
+1. Run `yarn clean`.
+2. Run `yarn install`.
+3. Ensure tests pass with `yarn test`.
+4. Bump `version` in package.json with correct semantic versioning.
+5. Update CHANGELOG.md, moving unreleased changes to a new heading for the release version.
+6. Make a commit with `git commit -am "Release v${version}."`.
+7. Tag the commit with `git tag v${version}`, and push with `git push --tags <upstream> master`.
+8. Build maas-ui with `yarn build`.
+9. [Draft a new release on Github](https://github.com/canonical-web-and-design/maas-ui/releases/new), copying the changelog section for the new release into the description field, and uploading the production tarball produced by `yarn build`.

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,10 +29,12 @@
     "start": "react-scripts start",
     "serve": "react-scripts start",
     "build": "react-scripts build",
+    "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
+    "postbuild": "mkdir -p dist && tar -C build -czvf dist/maas-ui-v$npm_package_version.tar.gz .",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src",
-    "clean": "rm -rf node_modules build"
+    "clean": "rm -rf node_modules build dist"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Done
* Add new section to README documenting release process.
* Add new yarn script `yarn release`.

## QA
* Do a fake release with `yarn release 1.0.0`, and ensure the following:
  * Tests pass.
  * A tarball called `maas-ui-v1.0.0.tar.gz` is built in `./dist`.
  * A git tag "v1.0.0" is created (remember to delete your tag afterwards).
  * The app version has been bumped in `package.json`.