### PR TITLE
Toggle username

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
     "classnames": "2.2.6",
     "connected-react-router": "6.5.2",
     "cross-env": "5.2.0",
+    "date-fns": "^2.0.0",
     "formik": "1.5.8",
     "immer": "3.2.0",
     "prop-types": "15.7.2",

--- a/ui/src/app/base/proptypes.js
+++ b/ui/src/app/base/proptypes.js
@@ -5,8 +5,11 @@ export const UserShape = PropTypes.shape({
   first_name: PropTypes.string,
   global_permissions: PropTypes.arrayOf(PropTypes.string),
   id: PropTypes.number.isRequired,
+  is_local: PropTypes.bool,
   is_superuser: PropTypes.bool.isRequired,
   last_name: PropTypes.string,
+  last_login: PropTypes.string,
+  machines_count: PropTypes.number,
   sshkeys_count: PropTypes.number,
   username: PropTypes.string.isRequired
 });

--- a/ui/src/app/settings/selectors/users.js
+++ b/ui/src/app/settings/selectors/users.js
@@ -21,7 +21,11 @@ users.get = (state, batch) => {
  */
 users.search = (state, term) => {
   return state.user.items.filter(
-    user => user.username.includes(term) || user.email.includes(term)
+    user =>
+      user.username.includes(term) ||
+      user.email.includes(term) ||
+      user.first_name.includes(term) ||
+      user.last_name.includes(term)
   );
 };
 

--- a/ui/src/app/settings/selectors/users.test.js
+++ b/ui/src/app/settings/selectors/users.test.js
@@ -77,15 +77,68 @@ describe("users selectors", () => {
     const state = {
       user: {
         items: [
-          { username: "admin", email: "test@example.com" },
-          { username: "me", email: "minnie@example.com" },
-          { username: "richie", email: "richie@example.com" }
+          {
+            username: "admin",
+            email: "test@example.com",
+            first_name: "",
+            last_name: ""
+          },
+          {
+            username: "me",
+            email: "minnie@example.com",
+            first_name: "",
+            last_name: ""
+          },
+          {
+            username: "richie",
+            email: "richie@example.com",
+            first_name: "",
+            last_name: ""
+          },
+          {
+            username: "boris",
+            email: "boris@example.com",
+            first_name: "mine",
+            last_name: ""
+          },
+          {
+            username: "adam",
+            email: "adam@example.com",
+            first_name: "",
+            last_name: "minichiello"
+          }
         ]
       }
     };
     expect(users.search(state, "min")).toEqual([
-      { username: "admin", email: "test@example.com" },
-      { username: "me", email: "minnie@example.com" }
+      // Matches username:
+      {
+        username: "admin",
+        email: "test@example.com",
+        first_name: "",
+        last_name: ""
+      },
+      // Matches email:
+      {
+        username: "me",
+        email: "minnie@example.com",
+        first_name: "",
+        last_name: ""
+      },
+      // Matches first name:
+      {
+        username: "boris",
+        email: "boris@example.com",
+        first_name: "mine",
+        last_name: ""
+      },
+      // Matches last name:
+      {
+        username: "adam",
+        email: "adam@example.com",
+        first_name: "",
+        last_name: "minichiello"
+      }
     ]);
   });
 

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.js
@@ -11,7 +11,6 @@ import selectors from "app/settings/selectors";
 import baseSelectors from "app/base/selectors";
 import Button from "app/base/components/Button";
 import Col from "app/base/components/Col";
-import VanillaLink from "app/base/components/Link";
 import Loader from "app/base/components/Loader";
 import Pagination from "app/base/components/Pagination";
 import MainTable from "app/base/components/MainTable";
@@ -28,7 +27,6 @@ const generateUserRows = (
 ) =>
   users.map(user => {
     const expanded = expandedId === user.id;
-    // const last_login = parse(user.last_login, "yyyy-LL-DD H:mm", "bob");
     // Dates are in the format: Thu, 15 Aug. 2019 06:21:39.
     const last_login = user.last_login
       ? format(
@@ -43,7 +41,7 @@ const generateUserRows = (
       className: expanded ? "p-table__row is-active" : null,
       columns: [
         {
-          content: displayUsername ? user.username : fullName || "N/A",
+          content: displayUsername ? user.username : fullName || <>&mdash;</>,
           role: "rowheader"
         },
         { content: user.email },
@@ -170,29 +168,25 @@ const Users = ({ initialCount = 20 }) => {
               className: "p-table-multi-header",
               content: (
                 <>
-                  <VanillaLink
+                  <Button
+                    appearance="link"
                     className={classNames("p-table-multi-header__link", {
                       "is-active": displayUsername
                     })}
-                    onClick={e => {
-                      e.preventDefault();
-                      setDisplayUsername(true);
-                    }}
+                    onClick={() => setDisplayUsername(true)}
                   >
                     Username
-                  </VanillaLink>
+                  </Button>
                   <span className="p-table-multi-header__spacer">|</span>
-                  <VanillaLink
+                  <Button
+                    appearance="link"
                     className={classNames("p-table-multi-header__link", {
                       "is-active": !displayUsername
                     })}
-                    onClick={e => {
-                      e.preventDefault();
-                      setDisplayUsername(false);
-                    }}
+                    onClick={() => setDisplayUsername(false)}
                   >
                     Real name
-                  </VanillaLink>
+                  </Button>
                 </>
               ),
               sortKey: displayUsername ? "username" : "fullName"

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -16,7 +16,7 @@ describe("UsersList", () => {
     users = [
       {
         email: "admin@example.com",
-        first_name: "",
+        first_name: "Kangaroo",
         global_permissions: ["machine_create"],
         id: 1,
         is_superuser: true,
@@ -26,7 +26,7 @@ describe("UsersList", () => {
       },
       {
         email: "user@example.com",
-        first_name: "",
+        first_name: "Koala",
         global_permissions: ["machine_create"],
         id: 2,
         is_superuser: false,
@@ -176,5 +176,39 @@ describe("UsersList", () => {
     wrapper.update();
     rows = wrapper.find("MainTable").prop("rows");
     expect(rows.length).toBe(1);
+  });
+
+  it("can toggle username and real name", () => {
+    const store = mockStore(defaultStore);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
+        >
+          <UsersList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("TableRow")
+        .at(2)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual("user1");
+    // Click on the header toggle.
+    wrapper
+      .find(".p-table-multi-header__link")
+      .at(2)
+      .simulate("click");
+    expect(
+      wrapper
+        .find("TableRow")
+        .at(2)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual("Kangaroo");
   });
 });

--- a/ui/src/scss/_patterns_button.scss
+++ b/ui/src/scss/_patterns_button.scss
@@ -1,0 +1,30 @@
+.p-button--link {
+  @extend %p-button--base;
+  color: $color-link;
+  font-size: inherit;
+  line-height: 1.25rem;
+  margin-bottom: 0;
+  padding: 0;
+  pointer-events: all;
+  text-align: left;
+  text-transform: inherit;
+
+  &:hover {
+    background-color: inherit;
+    text-decoration: underline;
+  }
+
+  &:visited {
+    color: $color-link;
+  }
+}
+
+table .p-button--link {
+  margin-bottom: 0;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.p-button--link:not(:last-of-type):not(:only-of-type) {
+  margin-right: 0;
+}

--- a/ui/src/scss/_patterns_table.scss
+++ b/ui/src/scss/_patterns_table.scss
@@ -7,3 +7,39 @@
 .p-table-expanding--light .p-table__row.is-active {
   background-color: $color-x-light;
 }
+
+.p-table--sortable th[role="columnheader"][aria-sort].p-table-multi-header {
+  &::after {
+    display: none;
+  }
+
+  &[aria-sort]:hover {
+    color: $color-mid-dark;
+    text-decoration: none;
+  }
+}
+
+.p-table-multi-header .p-table-multi-header__link {
+  color: $color-mid-dark;
+
+  &:hover {
+    color: $color-link;
+  }
+}
+
+.p-table-multi-header[aria-sort="ascending"]
+  .p-table-multi-header__link.is-active::after {
+  @extend %heading-icon;
+}
+
+.p-table-multi-header[aria-sort="descending"]
+  .p-table-multi-header__link.is-active::after {
+  @extend %heading-icon;
+  -webkit-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.p-table-multi-header__spacer {
+  margin-left: $sp-x-small;
+  margin-right: $sp-x-small;
+}

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -1,6 +1,7 @@
 // Vanilla settings:
 @import "vanilla";
 @import "vanilla-overrides";
+@import "./patterns_button";
 @import "./patterns_navigation";
 @import "./patterns_table";
 @import "./patterns_table-actions";
@@ -37,7 +38,7 @@ body {
 
 .p-form-validation__message [class*="p-icon--"] {
   @extend %icon;
-  @include vf-icon-size(.875rem);
+  @include vf-icon-size(0.875rem);
 }
 
 .u-text--light {


### PR DESCRIPTION
Done:
- Added toggle between username and full name. Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1404.
- Added missing user details.

QA:
- View the user list.
- You should see machine count, last login and type for users with those details.
- In the first column click on "Real name", you should see the real name for those users that have one.