### PR TITLE
Add MESSAGE_TYPES const and rename SYNC to NOTIFY.

### DIFF
--- a/ui/src/app/base/actions.js
+++ b/ui/src/app/base/actions.js
@@ -1,5 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
-
 export const connectWebSocket = () => {
   return {
     type: "WEBSOCKET_CONNECT"
@@ -11,8 +9,7 @@ export const fetchAuthUser = () => {
     type: "FETCH_AUTH_USER",
     meta: {
       model: "user",
-      method: "auth_user",
-      type: MESSAGE_TYPES.REQUEST
+      method: "auth_user"
     }
   };
 };

--- a/ui/src/app/base/actions.js
+++ b/ui/src/app/base/actions.js
@@ -1,3 +1,5 @@
+import MESSAGE_TYPES from "app/base/constants";
+
 export const connectWebSocket = () => {
   return {
     type: "WEBSOCKET_CONNECT"
@@ -10,7 +12,7 @@ export const fetchAuthUser = () => {
     meta: {
       model: "user",
       method: "auth_user",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     }
   };
 };

--- a/ui/src/app/base/actions.test.js
+++ b/ui/src/app/base/actions.test.js
@@ -1,3 +1,4 @@
+import MESSAGE_TYPES from "app/base/constants";
 import { connectWebSocket, fetchAuthUser } from "./actions";
 
 describe("base actions", () => {
@@ -13,7 +14,7 @@ describe("base actions", () => {
       meta: {
         model: "user",
         method: "auth_user",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });

--- a/ui/src/app/base/actions.test.js
+++ b/ui/src/app/base/actions.test.js
@@ -1,4 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
 import { connectWebSocket, fetchAuthUser } from "./actions";
 
 describe("base actions", () => {
@@ -13,8 +12,7 @@ describe("base actions", () => {
       type: "FETCH_AUTH_USER",
       meta: {
         model: "user",
-        method: "auth_user",
-        type: MESSAGE_TYPES.REQUEST
+        method: "auth_user"
       }
     });
   });

--- a/ui/src/app/base/constants.js
+++ b/ui/src/app/base/constants.js
@@ -1,0 +1,10 @@
+/**
+ * Message types defined by MAAS websocket API
+ */
+const MESSAGE_TYPES = {
+  REQUEST: 0,
+  RESPONSE: 1,
+  SYNC: 2
+};
+
+export default MESSAGE_TYPES;

--- a/ui/src/app/base/constants.js
+++ b/ui/src/app/base/constants.js
@@ -4,7 +4,7 @@
 const MESSAGE_TYPES = {
   REQUEST: 0,
   RESPONSE: 1,
-  SYNC: 2
+  NOTIFY: 2
 };
 
 export default MESSAGE_TYPES;

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -137,7 +137,7 @@ const isWebsocketRequestAction = action => action.meta && action.meta.method;
 const buildMessage = (meta, params) => {
   const message = {
     method: `${meta.model}.${meta.method}`,
-    type: meta.type
+    type: MESSAGE_TYPES.REQUEST
   };
   if (params) {
     message.params = params;

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -1,10 +1,9 @@
 import { eventChannel } from "redux-saga";
 import { all, call, put, select, take, race } from "redux-saga/effects";
 
+import MESSAGE_TYPES from "app/base/constants";
 import getCookie from "./utils";
 import WebSocketClient from "../../../websocket-client";
-
-const SYNC_MESSAGE = 2; // 'type: 2' in a ws message
 
 /**
  * Has data already been fetched into state?
@@ -92,7 +91,7 @@ export function* handleSyncMessage(response) {
 export function* handleMessage(socketChannel, socketClient) {
   while (true) {
     const response = yield take(socketChannel);
-    if (response.type === SYNC_MESSAGE) {
+    if (response.type === MESSAGE_TYPES.SYNC) {
       // this is an incoming 'sync' message
       yield call(handleSyncMessage, response);
     } else {

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -65,22 +65,22 @@ export function watchMessages(socketClient) {
 }
 
 /**
- * Handle incoming 'sync' messages.
+ * Handle incoming notify messages.
  *
- * 'sync' messages have an action and a payload:
+ * Notify messages have an action and a payload:
  * {"type": 2,
  *  "name": "config",
  *  "action": "update",
  *  "data": {"name": "maas_name", "value": "maas-hysteria"}}
  *
  * Although we receive a corresponding response for each websocket requests,
- * the store is only updated once a sync message has been received.
+ * the store is only updated once a notify message has been received.
  */
-export function* handleSyncMessage(response) {
+export function* handleNotifyMessage(response) {
   const action = response.action.toUpperCase();
   const name = response.name.toUpperCase();
   yield put({
-    type: `${action}_${name}_SYNC`,
+    type: `${action}_${name}_NOTIFY`,
     payload: response.data
   });
 }
@@ -91,9 +91,8 @@ export function* handleSyncMessage(response) {
 export function* handleMessage(socketChannel, socketClient) {
   while (true) {
     const response = yield take(socketChannel);
-    if (response.type === MESSAGE_TYPES.SYNC) {
-      // this is an incoming 'sync' message
-      yield call(handleSyncMessage, response);
+    if (response.type === MESSAGE_TYPES.NOTIFY) {
+      yield call(handleNotifyMessage, response);
     } else {
       // this is a response message
       const action_type = yield call(
@@ -179,9 +178,9 @@ export function* sendMessage(socketClient) {
           // important for dependant config like commissioning_distro_series
           // and default_min_hwe_kernel.
           // There is an edge case where a different CLI or server event could
-          // dispatch a SYNC of the same type which is received before our expected SYNC,
+          // dispatch a NOTIFY of the same type which is received before our expected NOTIFY,
           // but this _probably_ does not matter in practice.
-          yield take(`${type}_SYNC`);
+          yield take(`${type}_NOTIFY`);
         }
       } else {
         yield call(

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -5,7 +5,7 @@ import MESSAGE_TYPES from "app/base/constants";
 import {
   createConnection,
   handleMessage,
-  handleSyncMessage,
+  handleNotifyMessage,
   sendMessage,
   watchMessages,
   watchWebSockets
@@ -158,7 +158,7 @@ describe("websocket sagas", () => {
         params: { name: "foo", value: "bar" }
       })
     );
-    expect(saga.next().value).toEqual(take("TEST_ACTION_SYNC"));
+    expect(saga.next().value).toEqual(take("TEST_ACTION_NOTIFY"));
 
     expect(saga.next().value).toEqual(
       call([socketClient, socketClient.send], "TEST_ACTION", {
@@ -167,7 +167,7 @@ describe("websocket sagas", () => {
         params: { name: "baz", value: "qux" }
       })
     );
-    expect(saga.next().value).toEqual(take("TEST_ACTION_SYNC"));
+    expect(saga.next().value).toEqual(take("TEST_ACTION_NOTIFY"));
   });
 
   it("can handle errors when sending a WebSocket message", () => {
@@ -235,17 +235,17 @@ describe("websocket sagas", () => {
     );
   });
 
-  it("can handle a WebSocket sync message", () => {
+  it("can handle a WebSocket notify message", () => {
     const saga = handleMessage(socketChannel, socketClient);
     const response = {
-      type: MESSAGE_TYPES.SYNC,
+      type: MESSAGE_TYPES.NOTIFY,
       name: "config",
       action: "update",
       data: { name: "foo", value: "bar" }
     };
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(saga.next(response).value).toEqual(
-      call(handleSyncMessage, response)
+      call(handleNotifyMessage, response)
     );
     // yield no further, take a new message
     expect(saga.next().value).toEqual(take(socketChannel));

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -1,6 +1,7 @@
 import { call, put, take } from "redux-saga/effects";
 import { expectSaga } from "redux-saga-test-plan";
 
+import MESSAGE_TYPES from "app/base/constants";
 import {
   createConnection,
   handleMessage,
@@ -237,7 +238,7 @@ describe("websocket sagas", () => {
   it("can handle a WebSocket sync message", () => {
     const saga = handleMessage(socketChannel, socketClient);
     const response = {
-      type: 2,
+      type: MESSAGE_TYPES.SYNC,
       name: "config",
       action: "update",
       data: { name: "foo", value: "bar" }

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -102,7 +102,7 @@ describe("websocket sagas", () => {
         meta: {
           model: "test",
           method: "method",
-          type: 0
+          type: MESSAGE_TYPES.REQUEST
         },
         payload: {
           params: { foo: "bar" }
@@ -112,7 +112,7 @@ describe("websocket sagas", () => {
     expect(saga.next().value).toEqual(
       call([socketClient, socketClient.send], "TEST_ACTION", {
         method: "test.method",
-        type: 0,
+        type: MESSAGE_TYPES.REQUEST,
         params: { foo: "bar" }
       })
     );
@@ -125,7 +125,7 @@ describe("websocket sagas", () => {
       meta: {
         model: "test",
         method: "test.list",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     };
     saga.next();
@@ -143,7 +143,7 @@ describe("websocket sagas", () => {
         meta: {
           model: "test",
           method: "method",
-          type: 0
+          type: MESSAGE_TYPES.REQUEST
         },
         payload: {
           params: [{ name: "foo", value: "bar" }, { name: "baz", value: "qux" }]
@@ -154,7 +154,7 @@ describe("websocket sagas", () => {
     expect(saga.next().value).toEqual(
       call([socketClient, socketClient.send], "TEST_ACTION", {
         method: "test.method",
-        type: 0,
+        type: MESSAGE_TYPES.REQUEST,
         params: { name: "foo", value: "bar" }
       })
     );
@@ -163,7 +163,7 @@ describe("websocket sagas", () => {
     expect(saga.next().value).toEqual(
       call([socketClient, socketClient.send], "TEST_ACTION", {
         method: "test.method",
-        type: 0,
+        type: MESSAGE_TYPES.REQUEST,
         params: { name: "baz", value: "qux" }
       })
     );
@@ -178,7 +178,7 @@ describe("websocket sagas", () => {
       meta: {
         model: "test",
         method: "method",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       },
       payload: {
         params: { foo: "bar" }

--- a/ui/src/app/settings/actions/config.js
+++ b/ui/src/app/settings/actions/config.js
@@ -1,3 +1,5 @@
+import MESSAGE_TYPES from "app/base/constants";
+
 const config = {};
 
 config.fetch = () => {
@@ -6,7 +8,7 @@ config.fetch = () => {
     meta: {
       model: "config",
       method: "list",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     }
   };
 };
@@ -25,7 +27,7 @@ config.update = values => {
     meta: {
       model: "config",
       method: "update",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     }
   };
 };

--- a/ui/src/app/settings/actions/config.js
+++ b/ui/src/app/settings/actions/config.js
@@ -1,5 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
-
 const config = {};
 
 config.fetch = () => {
@@ -7,8 +5,7 @@ config.fetch = () => {
     type: "FETCH_CONFIG",
     meta: {
       model: "config",
-      method: "list",
-      type: MESSAGE_TYPES.REQUEST
+      method: "list"
     }
   };
 };
@@ -26,8 +23,7 @@ config.update = values => {
     },
     meta: {
       model: "config",
-      method: "update",
-      type: MESSAGE_TYPES.REQUEST
+      method: "update"
     }
   };
 };

--- a/ui/src/app/settings/actions/config.test.js
+++ b/ui/src/app/settings/actions/config.test.js
@@ -1,5 +1,4 @@
 import config from "./config";
-import MESSAGE_TYPES from "app/base/constants";
 
 describe("config actions", () => {
   it("should handle fetching config", () => {
@@ -7,8 +6,7 @@ describe("config actions", () => {
       type: "FETCH_CONFIG",
       meta: {
         model: "config",
-        method: "list",
-        type: MESSAGE_TYPES.REQUEST
+        method: "list"
       }
     });
   });
@@ -29,8 +27,7 @@ describe("config actions", () => {
       },
       meta: {
         model: "config",
-        method: "update",
-        type: MESSAGE_TYPES.REQUEST
+        method: "update"
       }
     });
   });

--- a/ui/src/app/settings/actions/config.test.js
+++ b/ui/src/app/settings/actions/config.test.js
@@ -1,4 +1,5 @@
 import config from "./config";
+import MESSAGE_TYPES from "app/base/constants";
 
 describe("config actions", () => {
   it("should handle fetching config", () => {
@@ -7,7 +8,7 @@ describe("config actions", () => {
       meta: {
         model: "config",
         method: "list",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });
@@ -29,7 +30,7 @@ describe("config actions", () => {
       meta: {
         model: "config",
         method: "update",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });

--- a/ui/src/app/settings/actions/general/general.js
+++ b/ui/src/app/settings/actions/general/general.js
@@ -1,5 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
-
 const general = {};
 
 general.fetchOsInfo = () => {
@@ -7,8 +5,7 @@ general.fetchOsInfo = () => {
     type: "FETCH_GENERAL_OSINFO",
     meta: {
       model: "general",
-      method: "osinfo",
-      type: MESSAGE_TYPES.REQUEST
+      method: "osinfo"
     }
   };
 };

--- a/ui/src/app/settings/actions/general/general.js
+++ b/ui/src/app/settings/actions/general/general.js
@@ -1,3 +1,5 @@
+import MESSAGE_TYPES from "app/base/constants";
+
 const general = {};
 
 general.fetchOsInfo = () => {
@@ -6,7 +8,7 @@ general.fetchOsInfo = () => {
     meta: {
       model: "general",
       method: "osinfo",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     }
   };
 };

--- a/ui/src/app/settings/actions/general/general.test.js
+++ b/ui/src/app/settings/actions/general/general.test.js
@@ -1,5 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
-
 import general from "./general";
 
 describe("general actions", () => {
@@ -8,8 +6,7 @@ describe("general actions", () => {
       type: "FETCH_GENERAL_OSINFO",
       meta: {
         model: "general",
-        method: "osinfo",
-        type: MESSAGE_TYPES.REQUEST
+        method: "osinfo"
       }
     });
   });

--- a/ui/src/app/settings/actions/general/general.test.js
+++ b/ui/src/app/settings/actions/general/general.test.js
@@ -1,3 +1,5 @@
+import MESSAGE_TYPES from "app/base/constants";
+
 import general from "./general";
 
 describe("general actions", () => {
@@ -7,7 +9,7 @@ describe("general actions", () => {
       meta: {
         model: "general",
         method: "osinfo",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });

--- a/ui/src/app/settings/actions/repositories.js
+++ b/ui/src/app/settings/actions/repositories.js
@@ -1,3 +1,5 @@
+import MESSAGE_TYPES from "app/base/constants";
+
 const repositories = {};
 
 repositories.fetch = () => {
@@ -9,7 +11,7 @@ repositories.fetch = () => {
     meta: {
       model: "packagerepository",
       method: "list",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     }
   };
 };
@@ -20,7 +22,7 @@ repositories.delete = id => {
     meta: {
       model: "packagerepository",
       method: "delete",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     },
     payload: {
       params: {

--- a/ui/src/app/settings/actions/repositories.js
+++ b/ui/src/app/settings/actions/repositories.js
@@ -1,5 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
-
 const repositories = {};
 
 repositories.fetch = () => {
@@ -10,8 +8,7 @@ repositories.fetch = () => {
     },
     meta: {
       model: "packagerepository",
-      method: "list",
-      type: MESSAGE_TYPES.REQUEST
+      method: "list"
     }
   };
 };
@@ -21,8 +18,7 @@ repositories.delete = id => {
     type: "DELETE_PACKAGEREPOSITORY",
     meta: {
       model: "packagerepository",
-      method: "delete",
-      type: MESSAGE_TYPES.REQUEST
+      method: "delete"
     },
     payload: {
       params: {

--- a/ui/src/app/settings/actions/repositories.test.js
+++ b/ui/src/app/settings/actions/repositories.test.js
@@ -1,4 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
 import repositories from "./repositories";
 
 describe("repository actions", () => {
@@ -10,8 +9,7 @@ describe("repository actions", () => {
       },
       meta: {
         model: "packagerepository",
-        method: "list",
-        type: MESSAGE_TYPES.REQUEST
+        method: "list"
       }
     });
   });
@@ -21,8 +19,7 @@ describe("repository actions", () => {
       type: "DELETE_PACKAGEREPOSITORY",
       meta: {
         model: "packagerepository",
-        method: "delete",
-        type: MESSAGE_TYPES.REQUEST
+        method: "delete"
       },
       payload: {
         params: {

--- a/ui/src/app/settings/actions/repositories.test.js
+++ b/ui/src/app/settings/actions/repositories.test.js
@@ -1,3 +1,4 @@
+import MESSAGE_TYPES from "app/base/constants";
 import repositories from "./repositories";
 
 describe("repository actions", () => {
@@ -10,7 +11,7 @@ describe("repository actions", () => {
       meta: {
         model: "packagerepository",
         method: "list",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });
@@ -21,7 +22,7 @@ describe("repository actions", () => {
       meta: {
         model: "packagerepository",
         method: "delete",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       },
       payload: {
         params: {

--- a/ui/src/app/settings/actions/users.js
+++ b/ui/src/app/settings/actions/users.js
@@ -1,5 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
-
 const users = {};
 
 users.fetch = () => {
@@ -7,8 +5,7 @@ users.fetch = () => {
     type: "FETCH_USER",
     meta: {
       model: "user",
-      method: "list",
-      type: MESSAGE_TYPES.REQUEST
+      method: "list"
     }
   };
 };
@@ -18,8 +15,7 @@ users.create = params => {
     type: "CREATE_USER",
     meta: {
       model: "user",
-      method: "create",
-      type: MESSAGE_TYPES.REQUEST
+      method: "create"
     },
     payload: {
       params
@@ -32,8 +28,7 @@ users.update = params => {
     type: "UPDATE_USER",
     meta: {
       model: "user",
-      method: "update",
-      type: MESSAGE_TYPES.REQUEST
+      method: "update"
     },
     payload: {
       params
@@ -46,8 +41,7 @@ users.delete = id => {
     type: "DELETE_USER",
     meta: {
       model: "user",
-      method: "delete",
-      type: MESSAGE_TYPES.REQUEST
+      method: "delete"
     },
     payload: {
       params: {

--- a/ui/src/app/settings/actions/users.js
+++ b/ui/src/app/settings/actions/users.js
@@ -1,3 +1,5 @@
+import MESSAGE_TYPES from "app/base/constants";
+
 const users = {};
 
 users.fetch = () => {
@@ -6,7 +8,7 @@ users.fetch = () => {
     meta: {
       model: "user",
       method: "list",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     }
   };
 };
@@ -17,7 +19,7 @@ users.create = params => {
     meta: {
       model: "user",
       method: "create",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     },
     payload: {
       params
@@ -31,7 +33,7 @@ users.update = params => {
     meta: {
       model: "user",
       method: "update",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     },
     payload: {
       params
@@ -45,7 +47,7 @@ users.delete = id => {
     meta: {
       model: "user",
       method: "delete",
-      type: 0
+      type: MESSAGE_TYPES.REQUEST
     },
     payload: {
       params: {

--- a/ui/src/app/settings/actions/users.test.js
+++ b/ui/src/app/settings/actions/users.test.js
@@ -1,3 +1,4 @@
+import MESSAGE_TYPES from "app/base/constants";
 import users from "./users";
 
 describe("user actions", () => {
@@ -7,7 +8,7 @@ describe("user actions", () => {
       meta: {
         model: "user",
         method: "list",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });
@@ -18,7 +19,7 @@ describe("user actions", () => {
       meta: {
         model: "user",
         method: "create",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       },
       payload: {
         params: {
@@ -34,7 +35,7 @@ describe("user actions", () => {
       meta: {
         model: "user",
         method: "update",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       },
       payload: {
         params: {
@@ -50,7 +51,7 @@ describe("user actions", () => {
       meta: {
         model: "user",
         method: "delete",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       },
       payload: {
         params: {

--- a/ui/src/app/settings/actions/users.test.js
+++ b/ui/src/app/settings/actions/users.test.js
@@ -1,4 +1,3 @@
-import MESSAGE_TYPES from "app/base/constants";
 import users from "./users";
 
 describe("user actions", () => {
@@ -7,8 +6,7 @@ describe("user actions", () => {
       type: "FETCH_USER",
       meta: {
         model: "user",
-        method: "list",
-        type: MESSAGE_TYPES.REQUEST
+        method: "list"
       }
     });
   });
@@ -18,8 +16,7 @@ describe("user actions", () => {
       type: "CREATE_USER",
       meta: {
         model: "user",
-        method: "create",
-        type: MESSAGE_TYPES.REQUEST
+        method: "create"
       },
       payload: {
         params: {
@@ -34,8 +31,7 @@ describe("user actions", () => {
       type: "UPDATE_USER",
       meta: {
         model: "user",
-        method: "update",
-        type: MESSAGE_TYPES.REQUEST
+        method: "update"
       },
       payload: {
         params: {
@@ -50,8 +46,7 @@ describe("user actions", () => {
       type: "DELETE_USER",
       meta: {
         model: "user",
-        method: "delete",
-        type: MESSAGE_TYPES.REQUEST
+        method: "delete"
       },
       payload: {
         params: {

--- a/ui/src/app/settings/reducers/config.js
+++ b/ui/src/app/settings/reducers/config.js
@@ -19,7 +19,7 @@ const config = produce(
         draft.saving = false;
         draft.saved = true;
         break;
-      case "UPDATE_CONFIG_SYNC":
+      case "UPDATE_CONFIG_NOTIFY":
         for (let i in draft.items) {
           if (draft.items[i].name === action.payload.name) {
             draft.items[i] = action.payload;

--- a/ui/src/app/settings/reducers/config.test.js
+++ b/ui/src/app/settings/reducers/config.test.js
@@ -100,7 +100,7 @@ describe("config reducer", () => {
     });
   });
 
-  it("should correctly reduce UPDATE_CONFIG_SYNC, updating the store", () => {
+  it("should correctly reduce UPDATE_CONFIG_NOTIFY, updating the store", () => {
     expect(
       config(
         {
@@ -114,7 +114,7 @@ describe("config reducer", () => {
           ]
         },
         {
-          type: "UPDATE_CONFIG_SYNC",
+          type: "UPDATE_CONFIG_NOTIFY",
           payload: { name: "default_storage_layout", value: "flat" }
         }
       )

--- a/ui/src/app/settings/reducers/packagerepository.js
+++ b/ui/src/app/settings/reducers/packagerepository.js
@@ -25,7 +25,7 @@ const packagerepository = produce(
         draft.errors = action.error;
         draft.saving = false;
         break;
-      case "DELETE_PACKAGEREPOSITORY_SYNC":
+      case "DELETE_PACKAGEREPOSITORY_NOTIFY":
         const index = draft.items.findIndex(item => item.id === action.payload);
         draft.items.splice(index, 1);
         break;

--- a/ui/src/app/settings/reducers/packagerepository.test.js
+++ b/ui/src/app/settings/reducers/packagerepository.test.js
@@ -129,7 +129,7 @@ describe("packagerepository reducer", () => {
     });
   });
 
-  it("should correctly reduce DELETE_PACKAGEREPOSITORY_SYNC", () => {
+  it("should correctly reduce DELETE_PACKAGEREPOSITORY_NOTIFY", () => {
     expect(
       packagerepository(
         {
@@ -143,7 +143,7 @@ describe("packagerepository reducer", () => {
         },
         {
           payload: 2,
-          type: "DELETE_PACKAGEREPOSITORY_SYNC"
+          type: "DELETE_PACKAGEREPOSITORY_NOTIFY"
         }
       )
     ).toEqual({

--- a/ui/src/app/settings/reducers/user.js
+++ b/ui/src/app/settings/reducers/user.js
@@ -30,7 +30,7 @@ const user = produce(
         draft.saved = true;
         draft.saving = false;
         break;
-      case "UPDATE_USER_SYNC":
+      case "UPDATE_USER_NOTIFY":
         for (let i in draft.items) {
           if (draft.items[i].id === action.payload.id) {
             draft.items[i] = action.payload;
@@ -38,10 +38,10 @@ const user = produce(
           }
         }
         break;
-      case "CREATE_USER_SYNC":
+      case "CREATE_USER_NOTIFY":
         draft.items.push(action.payload);
         break;
-      case "DELETE_USER_SYNC":
+      case "DELETE_USER_NOTIFY":
         const index = draft.items.findIndex(item => item.id === action.payload);
         draft.items.splice(index, 1);
         break;

--- a/ui/src/app/settings/reducers/user.test.js
+++ b/ui/src/app/settings/reducers/user.test.js
@@ -222,7 +222,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce UPDATE_USER_SYNC", () => {
+  it("should correctly reduce UPDATE_USER_NOTIFY", () => {
     expect(
       user(
         {
@@ -239,7 +239,7 @@ describe("users reducer", () => {
             id: 1,
             username: "kangaroo"
           },
-          type: "UPDATE_USER_SYNC"
+          type: "UPDATE_USER_NOTIFY"
         }
       )
     ).toEqual({
@@ -253,7 +253,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce CREATE_USER_SYNC", () => {
+  it("should correctly reduce CREATE_USER_NOTIFY", () => {
     expect(
       user(
         {
@@ -267,7 +267,7 @@ describe("users reducer", () => {
         },
         {
           payload: { id: 2, username: "user1" },
-          type: "CREATE_USER_SYNC"
+          type: "CREATE_USER_NOTIFY"
         }
       )
     ).toEqual({
@@ -281,7 +281,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce DELETE_USER_SYNC", () => {
+  it("should correctly reduce DELETE_USER_NOTIFY", () => {
     expect(
       user(
         {
@@ -295,7 +295,7 @@ describe("users reducer", () => {
         },
         {
           payload: 2,
-          type: "DELETE_USER_SYNC"
+          type: "DELETE_USER_NOTIFY"
         }
       )
     ).toEqual({

--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
@@ -81,8 +81,7 @@ describe("Commissioning", () => {
       type: "FETCH_GENERAL_OSINFO",
       meta: {
         model: "general",
-        method: "osinfo",
-        type: 0
+        method: "osinfo"
       }
     });
   });

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
@@ -77,8 +77,7 @@ describe("CommissioningForm", () => {
         },
         meta: {
           model: "config",
-          method: "update",
-          type: MESSAGE_TYPES.REQUEST
+          method: "update"
         }
       });
       done();
@@ -103,8 +102,7 @@ describe("CommissioningForm", () => {
       type: "FETCH_GENERAL_OSINFO",
       meta: {
         model: "general",
-        method: "osinfo",
-        type: MESSAGE_TYPES.REQUEST
+        method: "osinfo"
       }
     });
   });

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.js
@@ -3,6 +3,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import MESSAGE_TYPES from "app/base/constants";
 import CommissioningForm from "./CommissioningForm";
 
 const mockStore = configureStore();
@@ -77,7 +78,7 @@ describe("CommissioningForm", () => {
         meta: {
           model: "config",
           method: "update",
-          type: 0
+          type: MESSAGE_TYPES.REQUEST
         }
       });
       done();
@@ -103,7 +104,7 @@ describe("CommissioningForm", () => {
       meta: {
         model: "general",
         method: "osinfo",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });

--- a/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
+++ b/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
@@ -46,8 +46,7 @@ describe("Deploy", () => {
       type: "FETCH_GENERAL_OSINFO",
       meta: {
         model: "general",
-        method: "osinfo",
-        type: 0
+        method: "osinfo"
       }
     });
   });

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
@@ -3,6 +3,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import MESSAGE_TYPES from "app/base/constants";
 import DnsForm from "./DnsForm";
 
 const mockStore = configureStore();
@@ -73,7 +74,7 @@ describe("DnsForm", () => {
           meta: {
             model: "config",
             method: "update",
-            type: 0
+            type: MESSAGE_TYPES.REQUEST
           }
         }
       ]);

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import MESSAGE_TYPES from "app/base/constants";
 import DnsForm from "./DnsForm";
 
 const mockStore = configureStore();
@@ -73,8 +72,7 @@ describe("DnsForm", () => {
           },
           meta: {
             model: "config",
-            method: "update",
-            type: MESSAGE_TYPES.REQUEST
+            method: "update"
           }
         }
       ]);

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import MESSAGE_TYPES from "app/base/constants";
 import NetworkDiscoveryForm from "./NetworkDiscoveryForm";
 
 const mockStore = configureStore();
@@ -84,8 +83,7 @@ describe("NetworkDiscoveryForm", () => {
           },
           meta: {
             model: "config",
-            method: "update",
-            type: MESSAGE_TYPES.REQUEST
+            method: "update"
           }
         }
       ]);

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
@@ -3,6 +3,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import MESSAGE_TYPES from "app/base/constants";
 import NetworkDiscoveryForm from "./NetworkDiscoveryForm";
 
 const mockStore = configureStore();
@@ -84,7 +85,7 @@ describe("NetworkDiscoveryForm", () => {
           meta: {
             model: "config",
             method: "update",
-            type: 0
+            type: MESSAGE_TYPES.REQUEST
           }
         }
       ]);

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import MESSAGE_TYPES from "app/base/constants";
 import NtpForm from "./NtpForm";
 
 const mockStore = configureStore();
@@ -66,8 +65,7 @@ describe("NtpForm", () => {
           },
           meta: {
             model: "config",
-            method: "update",
-            type: MESSAGE_TYPES.REQUEST
+            method: "update"
           }
         }
       ]);

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
@@ -3,6 +3,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import MESSAGE_TYPES from "app/base/constants";
 import NtpForm from "./NtpForm";
 
 const mockStore = configureStore();
@@ -66,7 +67,7 @@ describe("NtpForm", () => {
           meta: {
             model: "config",
             method: "update",
-            type: 0
+            type: MESSAGE_TYPES.REQUEST
           }
         }
       ]);

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
@@ -3,6 +3,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import MESSAGE_TYPES from "app/base/constants";
 import SyslogForm from "./SyslogForm";
 
 const mockStore = configureStore();
@@ -64,7 +65,7 @@ describe("SyslogForm", () => {
           meta: {
             model: "config",
             method: "update",
-            type: 0
+            type: MESSAGE_TYPES.REQUEST
           }
         }
       ]);

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import MESSAGE_TYPES from "app/base/constants";
 import SyslogForm from "./SyslogForm";
 
 const mockStore = configureStore();
@@ -64,8 +63,7 @@ describe("SyslogForm", () => {
           },
           meta: {
             model: "config",
-            method: "update",
-            type: MESSAGE_TYPES.REQUEST
+            method: "update"
           }
         }
       ]);

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
@@ -5,6 +5,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
+import MESSAGE_TYPES from "app/base/constants";
 import RepositoriesList from "./RepositoriesList";
 
 const mockStore = configureStore();
@@ -151,7 +152,7 @@ describe("RepositoriesList", () => {
       meta: {
         model: "packagerepository",
         method: "delete",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
@@ -5,7 +5,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import MESSAGE_TYPES from "app/base/constants";
 import RepositoriesList from "./RepositoriesList";
 
 const mockStore = configureStore();
@@ -151,8 +150,7 @@ describe("RepositoriesList", () => {
       },
       meta: {
         model: "packagerepository",
-        method: "delete",
-        type: MESSAGE_TYPES.REQUEST
+        method: "delete"
       }
     });
   });

--- a/ui/src/app/settings/views/Settings.test.js
+++ b/ui/src/app/settings/views/Settings.test.js
@@ -3,6 +3,8 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { MemoryRouter } from "react-router-dom";
+
+import MESSAGE_TYPES from "app/base/constants";
 import Settings from "./Settings";
 
 const mockStore = configureStore();
@@ -36,7 +38,7 @@ describe("Settings", () => {
       meta: {
         model: "config",
         method: "list",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });

--- a/ui/src/app/settings/views/Settings.test.js
+++ b/ui/src/app/settings/views/Settings.test.js
@@ -4,7 +4,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { MemoryRouter } from "react-router-dom";
 
-import MESSAGE_TYPES from "app/base/constants";
 import Settings from "./Settings";
 
 const mockStore = configureStore();
@@ -37,8 +36,7 @@ describe("Settings", () => {
       type: "FETCH_CONFIG",
       meta: {
         model: "config",
-        method: "list",
-        type: MESSAGE_TYPES.REQUEST
+        method: "list"
       }
     });
   });

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
@@ -3,6 +3,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import MESSAGE_TYPES from "app/base/constants";
 import StorageForm from "./StorageForm";
 
 const mockStore = configureStore();
@@ -69,7 +70,7 @@ describe("StorageForm", () => {
           meta: {
             model: "config",
             method: "update",
-            type: 0
+            type: MESSAGE_TYPES.REQUEST
           }
         }
       ]);

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import MESSAGE_TYPES from "app/base/constants";
 import StorageForm from "./StorageForm";
 
 const mockStore = configureStore();
@@ -69,8 +68,7 @@ describe("StorageForm", () => {
           },
           meta: {
             model: "config",
-            method: "update",
-            type: MESSAGE_TYPES.REQUEST
+            method: "update"
           }
         }
       ]);

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -4,6 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
+import MESSAGE_TYPES from "app/base/constants";
 import { UserForm } from "./UserForm";
 
 jest.mock("uuid/v4", () =>
@@ -114,7 +115,7 @@ describe("UserForm", () => {
         meta: {
           model: "user",
           method: "update",
-          type: 0
+          type: MESSAGE_TYPES.REQUEST
         }
       }
     ]);
@@ -155,7 +156,7 @@ describe("UserForm", () => {
         meta: {
           model: "user",
           method: "create",
-          type: 0
+          type: MESSAGE_TYPES.REQUEST
         }
       }
     ]);

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -114,8 +114,7 @@ describe("UserForm", () => {
         },
         meta: {
           model: "user",
-          method: "update",
-          type: MESSAGE_TYPES.REQUEST
+          method: "update"
         }
       }
     ]);
@@ -155,8 +154,7 @@ describe("UserForm", () => {
         },
         meta: {
           model: "user",
-          method: "create",
-          type: MESSAGE_TYPES.REQUEST
+          method: "create"
         }
       }
     ]);

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -5,7 +5,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import MESSAGE_TYPES from "app/base/constants";
 import UsersList from "./UsersList";
 
 const mockStore = configureStore();
@@ -150,8 +149,7 @@ describe("UsersList", () => {
       },
       meta: {
         model: "user",
-        method: "delete",
-        type: MESSAGE_TYPES.REQUEST
+        method: "delete"
       }
     });
   });

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -4,6 +4,8 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
+
+import MESSAGE_TYPES from "app/base/constants";
 import UsersList from "./UsersList";
 
 const mockStore = configureStore();
@@ -149,7 +151,7 @@ describe("UsersList", () => {
       meta: {
         model: "user",
         method: "delete",
-        type: 0
+        type: MESSAGE_TYPES.REQUEST
       }
     });
   });


### PR DESCRIPTION
## Done
* Replace magic websocket request type integers with more descriptive constant values (e.g. `type: 0` -> `MESSAGE_TYPES.REQUEST`).
* Rename `SYNC` to `NOTIFY` as that's what update messages are referred to as on the server.

from `protocols.py`:

```python
class MSG_TYPE:
    #: Request made from client.
    REQUEST = 0

    #: Response from server.
    RESPONSE = 1

    #: Notify message from server.
    NOTIFY = 2

    #: Connectivity checks
    PING = 3
    PING_REPLY = 4
```

We don't handle pings so I've left these out.

## QA
Ensure the app still works (sorry, realise that's pretty vague).