### PR TITLE
Redirect settings base url to first form

### DIFF
--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -37,6 +37,7 @@ const Routes = () => (
       component={KernelParameters}
     />
     <Route exact path="/configuration/deploy" component={Deploy} />
+    <Redirect from="/" to="/configuration/general" />
     <Redirect from="/configuration" to="/configuration/general" />
     <Route exact path="/users" component={UsersList} />
     <Route exact path="/users/add" component={UserAdd} />


### PR DESCRIPTION
## Done
Redirect `/settings` to `/settings/configuration/general` which is the first form in the settings navigation. Otherwise `/settings` just shows a blank page. Fixes #147 

## QA
Go to `/settings` and see that you are redirected to `/settings/configuration/general`