### PR TITLE
Revert "Redirect settings base url to first form (#149)"

### DIFF
--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -37,7 +37,6 @@ const Routes = () => (
       component={KernelParameters}
     />
     <Route exact path="/configuration/deploy" component={Deploy} />
-    <Redirect from="/" to="/configuration/general" />
     <Redirect from="/configuration" to="/configuration/general" />
     <Route exact path="/users" component={UsersList} />
     <Route exact path="/users/add" component={UserAdd} />


### PR DESCRIPTION
This reverts commit cf2dd5d63f92ade15a724769600f894840ceec49 because it introduced a bug that redirected every url under `/configuration`.