### PR TITLE
Add redirect from settings to configuration. Fixes #147

### DIFF
--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -37,6 +37,7 @@ const Routes = () => (
       component={KernelParameters}
     />
     <Route exact path="/configuration/deploy" component={Deploy} />
+    <Redirect exact from="/" to="/configuration" />
     <Redirect from="/configuration" to="/configuration/general" />
     <Route exact path="/users" component={UsersList} />
     <Route exact path="/users/add" component={UserAdd} />


### PR DESCRIPTION
## Done
Add a redirect from `/settings` to `/configuration` so that the user doesn't see a blank screen.

## QA
- Go to `/settings` and see that you are redirected to the first configuration section
- Click on all the other headings/links in the navigation and see that you are able to go to those pages