### PR TITLE
Fetch dhcp snippets and subnets

### DIFF
--- a/ui/src/app/settings/actions/dhcpsnippet.js
+++ b/ui/src/app/settings/actions/dhcpsnippet.js
@@ -1,0 +1,13 @@
+const dhcpsnippet = {};
+
+dhcpsnippet.fetch = () => {
+  return {
+    type: "FETCH_DHCPSNIPPET",
+    meta: {
+      model: "dhcpsnippet",
+      method: "list"
+    }
+  };
+};
+
+export default dhcpsnippet;

--- a/ui/src/app/settings/actions/dhcpsnippet.test.js
+++ b/ui/src/app/settings/actions/dhcpsnippet.test.js
@@ -1,0 +1,13 @@
+import dhcpsnippet from "./dhcpsnippet";
+
+describe("dhcpsnippet actions", () => {
+  it("should handle fetching dhcp snippets", () => {
+    expect(dhcpsnippet.fetch()).toEqual({
+      type: "FETCH_DHCPSNIPPET",
+      meta: {
+        model: "dhcpsnippet",
+        method: "list"
+      }
+    });
+  });
+});

--- a/ui/src/app/settings/actions/index.js
+++ b/ui/src/app/settings/actions/index.js
@@ -1,11 +1,15 @@
 import config from "./config";
+import dhcpsnippet from "./dhcpsnippet";
 import general from "./general";
 import repositories from "./repositories";
+import subnet from "./subnet";
 import users from "./users";
 
 export default {
   config,
+  dhcpsnippet,
   general,
   repositories,
+  subnet,
   users
 };

--- a/ui/src/app/settings/actions/subnet.js
+++ b/ui/src/app/settings/actions/subnet.js
@@ -1,0 +1,13 @@
+const subnet = {};
+
+subnet.fetch = () => {
+  return {
+    type: "FETCH_SUBNET",
+    meta: {
+      model: "subnet",
+      method: "list"
+    }
+  };
+};
+
+export default subnet;

--- a/ui/src/app/settings/actions/subnet.test.js
+++ b/ui/src/app/settings/actions/subnet.test.js
@@ -1,0 +1,13 @@
+import subnet from "./subnet";
+
+describe("subnet actions", () => {
+  it("should handle fetching subnets", () => {
+    expect(subnet.fetch()).toEqual({
+      type: "FETCH_SUBNET",
+      meta: {
+        model: "subnet",
+        method: "list"
+      }
+    });
+  });
+});

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -3,7 +3,7 @@ import { Route, Redirect, Switch } from "react-router-dom";
 
 import Commissioning from "app/settings/views/Configuration/Commissioning";
 import Deploy from "app/settings/views/Configuration/Deploy";
-import Dhcp from "app/settings/views/Dhcp";
+import DhcpList from "app/settings/views/Dhcp/DhcpList";
 import DnsForm from "app/settings/views/Network/DnsForm";
 import General from "app/settings/views/Configuration/General";
 import KernelParameters from "app/settings/views/Configuration/KernelParameters";
@@ -54,7 +54,7 @@ const Routes = () => (
     />
     <Redirect from="/network" to="/network/proxy" />
     <Route exact path="/scripts" component={Scripts} />
-    <Route exact path="/dhcp" component={Dhcp} />
+    <Route exact path="/dhcp" component={DhcpList} />
     <Route exact path="/repositories" component={RepositoriesList} />
     <Route exact path="/repositories/add" component={RepositoryAdd} />
     <Route exact path="/repositories/:id/edit" component={RepositoryEdit} />

--- a/ui/src/app/settings/reducers/dhcpsnippet.js
+++ b/ui/src/app/settings/reducers/dhcpsnippet.js
@@ -1,0 +1,25 @@
+import produce from "immer";
+
+const dhcpsnippet = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case "FETCH_DHCPSNIPPET_START":
+        draft.loading = true;
+        break;
+      case "FETCH_DHCPSNIPPET_SUCCESS":
+        draft.loading = false;
+        draft.loaded = true;
+        draft.items = action.payload;
+        break;
+      default:
+        return draft;
+    }
+  },
+  {
+    items: [],
+    loaded: false,
+    loading: false
+  }
+);
+
+export default dhcpsnippet;

--- a/ui/src/app/settings/reducers/dhcpsnippet.test.js
+++ b/ui/src/app/settings/reducers/dhcpsnippet.test.js
@@ -1,0 +1,43 @@
+import dhcpsnippet from "./dhcpsnippet";
+
+describe("dhcpsnippet reducer", () => {
+  it("should return the initial state", () => {
+    expect(dhcpsnippet(undefined, {})).toEqual({
+      items: [],
+      loaded: false,
+      loading: false
+    });
+  });
+
+  it("should correctly reduce FETCH_DHCPSNIPPET_START", () => {
+    expect(
+      dhcpsnippet(undefined, {
+        type: "FETCH_DHCPSNIPPET_START"
+      })
+    ).toEqual({
+      items: [],
+      loaded: false,
+      loading: true
+    });
+  });
+
+  it("should correctly reduce FETCH_DHCPSNIPPET_SUCCESS", () => {
+    expect(
+      dhcpsnippet(
+        {
+          items: [],
+          loaded: false,
+          loading: true
+        },
+        {
+          type: "FETCH_DHCPSNIPPET_SUCCESS",
+          payload: [{ id: 1, name: "class" }, { id: 2, name: "lease" }]
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: true,
+      items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }]
+    });
+  });
+});

--- a/ui/src/app/settings/reducers/index.js
+++ b/ui/src/app/settings/reducers/index.js
@@ -1,6 +1,15 @@
 import config from "./config";
+import dhcpsnippet from "./dhcpsnippet";
 import general from "./general";
 import packagerepository from "./packagerepository";
+import subnet from "./subnet";
 import user from "./user";
 
-export default { config, general, packagerepository, user };
+export default {
+  config,
+  dhcpsnippet,
+  general,
+  packagerepository,
+  subnet,
+  user
+};

--- a/ui/src/app/settings/reducers/subnet.js
+++ b/ui/src/app/settings/reducers/subnet.js
@@ -1,0 +1,25 @@
+import produce from "immer";
+
+const subnet = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case "FETCH_SUBNET_START":
+        draft.loading = true;
+        break;
+      case "FETCH_SUBNET_SUCCESS":
+        draft.loading = false;
+        draft.loaded = true;
+        draft.items = action.payload;
+        break;
+      default:
+        return draft;
+    }
+  },
+  {
+    items: [],
+    loaded: false,
+    loading: false
+  }
+);
+
+export default subnet;

--- a/ui/src/app/settings/reducers/subnet.test.js
+++ b/ui/src/app/settings/reducers/subnet.test.js
@@ -1,0 +1,43 @@
+import subnet from "./subnet";
+
+describe("subnet reducer", () => {
+  it("should return the initial state", () => {
+    expect(subnet(undefined, {})).toEqual({
+      items: [],
+      loaded: false,
+      loading: false
+    });
+  });
+
+  it("should correctly reduce FETCH_SUBNET_START", () => {
+    expect(
+      subnet(undefined, {
+        type: "FETCH_SUBNET_START"
+      })
+    ).toEqual({
+      items: [],
+      loaded: false,
+      loading: true
+    });
+  });
+
+  it("should correctly reduce FETCH_SUBNET_SUCCESS", () => {
+    expect(
+      subnet(
+        {
+          items: [],
+          loaded: false,
+          loading: true
+        },
+        {
+          type: "FETCH_SUBNET_SUCCESS",
+          payload: [{ id: 1, name: "10.0.0.99" }, { id: 2, name: "test.maas" }]
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: true,
+      items: [{ id: 1, name: "10.0.0.99" }, { id: 2, name: "test.maas" }]
+    });
+  });
+});

--- a/ui/src/app/settings/selectors/dhcpsnippet.js
+++ b/ui/src/app/settings/selectors/dhcpsnippet.js
@@ -1,0 +1,24 @@
+const dhcpsnippet = {};
+
+/**
+ * Returns all dhcp snippets.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all dhcp snippets.
+ */
+dhcpsnippet.all = state => state.dhcpsnippet.items;
+
+/**
+ * Whether dhcp snippets are loading.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} DHCP snippets are loading.
+ */
+dhcpsnippet.loading = state => state.dhcpsnippet.loading;
+
+/**
+ * Whether dhcp snippets have been loaded.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} DHCP snippets have loaded.
+ */
+dhcpsnippet.loaded = state => state.dhcpsnippet.loaded;
+
+export default dhcpsnippet;

--- a/ui/src/app/settings/selectors/dhcpsnippet.test.js
+++ b/ui/src/app/settings/selectors/dhcpsnippet.test.js
@@ -1,0 +1,32 @@
+import dhcpsnippet from "./dhcpsnippet";
+
+describe("dhcpsnippet selectors", () => {
+  it("can get all items", () => {
+    const state = {
+      dhcpsnippet: {
+        items: [{ name: "lease" }]
+      }
+    };
+    expect(dhcpsnippet.all(state)).toEqual([{ name: "lease" }]);
+  });
+
+  it("can get the loading state", () => {
+    const state = {
+      dhcpsnippet: {
+        loading: true,
+        items: []
+      }
+    };
+    expect(dhcpsnippet.loading(state)).toEqual(true);
+  });
+
+  it("can get the loaded state", () => {
+    const state = {
+      dhcpsnippet: {
+        loaded: true,
+        items: []
+      }
+    };
+    expect(dhcpsnippet.loaded(state)).toEqual(true);
+  });
+});

--- a/ui/src/app/settings/selectors/index.js
+++ b/ui/src/app/settings/selectors/index.js
@@ -1,12 +1,16 @@
 import config from "./config";
+import dhcpsnippet from "./dhcpsnippet";
 import general from "./general";
 import repositories from "./repositories";
+import subnet from "./subnet";
 import users from "./users";
 
 export const selectors = {
   config,
+  dhcpsnippet,
   general,
   repositories,
+  subnet,
   users
 };
 

--- a/ui/src/app/settings/selectors/subnet.js
+++ b/ui/src/app/settings/selectors/subnet.js
@@ -1,0 +1,32 @@
+const subnet = {};
+
+/**
+ * Returns all subnets.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all subnets.
+ */
+subnet.all = state => state.subnet.items;
+
+/**
+ * Whether subnets are loading.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Subnets are loading.
+ */
+subnet.loading = state => state.subnet.loading;
+
+/**
+ * Whether subnets have been loaded.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Subnets have loaded.
+ */
+subnet.loaded = state => state.subnet.loaded;
+
+/**
+ * Returns a subnet for the given id.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A subnet.
+ */
+subnet.getById = (state, id) =>
+  state.subnet.items.find(subnet => subnet.id === id);
+
+export default subnet;

--- a/ui/src/app/settings/selectors/subnet.test.js
+++ b/ui/src/app/settings/selectors/subnet.test.js
@@ -1,0 +1,44 @@
+import subnet from "./subnet";
+
+describe("subnet selectors", () => {
+  it("can get all items", () => {
+    const state = {
+      subnet: {
+        items: [{ name: "maas.test" }]
+      }
+    };
+    expect(subnet.all(state)).toEqual([{ name: "maas.test" }]);
+  });
+
+  it("can get the loading state", () => {
+    const state = {
+      subnet: {
+        loading: true,
+        items: []
+      }
+    };
+    expect(subnet.loading(state)).toEqual(true);
+  });
+
+  it("can get the loaded state", () => {
+    const state = {
+      subnet: {
+        loaded: true,
+        items: []
+      }
+    };
+    expect(subnet.loaded(state)).toEqual(true);
+  });
+
+  it("can get a subnet by id", () => {
+    const state = {
+      subnet: {
+        items: [{ name: "maas.test", id: 808 }, { name: "10.0.0.99", id: 909 }]
+      }
+    };
+    expect(subnet.getById(state, 909)).toStrictEqual({
+      name: "10.0.0.99",
+      id: 909
+    });
+  });
+});

--- a/ui/src/app/settings/selectors/users.js
+++ b/ui/src/app/settings/selectors/users.js
@@ -72,10 +72,9 @@ users.saving = state => state.user.saving;
 users.saved = state => state.user.saved;
 
 /**
- * Returns all users
+ * Returns a user for the given id.
  * @param {Object} state - The redux state.
- * @param {Number} batch - Number of users to return.
- * @returns {Array} A list of all users.
+ * @returns {Array} A user.
  */
 users.getById = (state, id) => state.user.items.find(user => user.id === id);
 

--- a/ui/src/app/settings/views/Dhcp/Dhcp.js
+++ b/ui/src/app/settings/views/Dhcp/Dhcp.js
@@ -1,5 +1,0 @@
-import React from "react";
-
-const Dhcp = () => <h4>Dhcp</h4>;
-
-export default Dhcp;

--- a/ui/src/app/settings/views/Dhcp/Dhcp.test.js
+++ b/ui/src/app/settings/views/Dhcp/Dhcp.test.js
@@ -1,8 +1,0 @@
-import { shallow } from "enzyme";
-import React from "react";
-import Dhcp from "./Dhcp";
-
-it("works with enzyme", () => {
-  const wrapper = shallow(<Dhcp />);
-  expect(wrapper).toMatchSnapshot();
-});

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
@@ -1,0 +1,42 @@
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect } from "react";
+
+import actions from "app/settings/actions";
+import Loader from "app/base/components/Loader";
+import selectors from "app/settings/selectors";
+
+// Temporarily create a item component, this will be replaced with a table.
+const DhcpListItem = ({ id, name, subnet }) => {
+  const subnetItem = useSelector(state =>
+    selectors.subnet.getById(state, subnet)
+  );
+  return (
+    <li>
+      {name} {subnet && `(subnet: ${subnetItem.name})`}
+    </li>
+  );
+};
+
+const DhcpList = () => {
+  const dhcpsnippetLoading = useSelector(selectors.dhcpsnippet.loading);
+  const dhcpsnippetLoaded = useSelector(selectors.dhcpsnippet.loaded);
+  const dhcpsnippets = useSelector(selectors.dhcpsnippet.all);
+  const subnetLoading = useSelector(selectors.subnet.loading);
+  const subnetLoaded = useSelector(selectors.subnet.loaded);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(actions.dhcpsnippet.fetch());
+    dispatch(actions.subnet.fetch());
+  }, [dispatch]);
+
+  if (dhcpsnippetLoading || subnetLoading) {
+    return <Loader text="Loading..." />;
+  }
+  const snippets = dhcpsnippets.map(dhcpsnippet => (
+    <DhcpListItem {...dhcpsnippet} key={dhcpsnippet.id} />
+  ));
+  return dhcpsnippetLoaded && subnetLoaded && <ul>{snippets}</ul>;
+};
+
+export default DhcpList;

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
@@ -1,0 +1,49 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import DhcpList from "./DhcpList";
+
+const mockStore = configureStore();
+
+describe("DhcpList", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      dhcpsnippet: {
+        loading: false,
+        loaded: true,
+        items: [{ id: 1, name: "class" }, { id: 2, name: "lease", subnet: 2 }]
+      },
+      subnet: {
+        loading: false,
+        loaded: true,
+        items: [{ id: 1, name: "10.0.0.99" }, { id: 2, name: "test.maas" }]
+      }
+    };
+  });
+
+  it("displays a loading component if loading", () => {
+    state.dhcpsnippet.loading = true;
+    state.subnet.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DhcpList />
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("displays a list of dhcp snippets", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DhcpList />
+      </Provider>
+    );
+    expect(wrapper.find("DhcpList")).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/settings/views/Dhcp/DhcpList/__snapshots__/DhcpList.test.js.snap
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/__snapshots__/DhcpList.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DhcpList displays a list of dhcp snippets 1`] = `
+<DhcpList>
+  <ul>
+    <DhcpListItem
+      id={1}
+      key="1"
+      name="class"
+    >
+      <li>
+        class
+         
+      </li>
+    </DhcpListItem>
+    <DhcpListItem
+      id={2}
+      key="2"
+      name="lease"
+      subnet={2}
+    >
+      <li>
+        lease
+         
+        (subnet: test.maas)
+      </li>
+    </DhcpListItem>
+  </ul>
+</DhcpList>
+`;

--- a/ui/src/app/settings/views/Dhcp/DhcpList/index.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DhcpList";

--- a/ui/src/app/settings/views/Dhcp/__snapshots__/Dhcp.test.js.snap
+++ b/ui/src/app/settings/views/Dhcp/__snapshots__/Dhcp.test.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`works with enzyme 1`] = `
-<h4>
-  Dhcp
-</h4>
-`;

--- a/ui/src/app/settings/views/Dhcp/index.js
+++ b/ui/src/app/settings/views/Dhcp/index.js
@@ -1,1 +1,0 @@
-export { default } from "./Dhcp";

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -8,9 +8,11 @@ import baseReducers from "./app/base/reducers";
 export default history =>
   combineReducers({
     config: settingsReducers.config,
+    dhcpsnippet: settingsReducers.dhcpsnippet,
     general: settingsReducers.general,
     packagerepository: settingsReducers.packagerepository,
-    user: reduceReducers(settingsReducers.user, baseReducers.auth),
     router: connectRouter(history),
-    status: baseReducers.status
+    status: baseReducers.status,
+    subnet: settingsReducers.subnet,
+    user: reduceReducers(settingsReducers.user, baseReducers.auth)
   });


### PR DESCRIPTION
Done:
- Added actions, selectors and reducers for listing dhcp snippets and subnets. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/73.

QA:
- Visit /settings/dhcp
- You should see a basic list of dhcp snippets and subnets (if they exist).