### PR TITLE
Add labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+Maintenance 🔨:
+- package.json
+- yarn.lock

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Theoretically this should add a "Maintenance 🔨" label to any PRs touching `package.json` or `yarn.lock`. No idea how we go about testing this 🤷‍♂ 

I guess we land this and retry Update dependency react-redux to v7.1.1?