### PR TITLE
Upgrade to react-redux 7.1.1 and update snapshots.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "prop-types": "15.7.2",
     "react": "16.9.0",
     "react-dom": "16.9.0",
-    "react-redux": "7.1.0",
+    "react-redux": "7.1.1",
     "react-router-dom": "5.0.1",
     "react-router-hash-link": "1.2.2",
     "react-router-prop-types": "1.0.4",

--- a/ui/src/app/settings/views/Configuration/GeneralForm/__snapshots__/GeneralForm.test.js.snap
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/__snapshots__/GeneralForm.test.js.snap
@@ -15,10 +15,7 @@ exports[`GeneralForm can render 1`] = `
       "subscription": Subscription {
         "handleChangeWrapper": [Function],
         "listeners": Object {
-          "clear": [Function],
-          "get": [Function],
           "notify": [Function],
-          "subscribe": [Function],
         },
         "onStateChange": [Function],
         "parentSub": undefined,
@@ -30,7 +27,7 @@ exports[`GeneralForm can render 1`] = `
           "replaceReducer": [Function],
           "subscribe": [Function],
         },
-        "unsubscribe": [Function],
+        "unsubscribe": null,
       },
     }
   }

--- a/ui/src/app/settings/views/Images/ThirdPartyDriversForm/__snapshots__/ThirdPartyDriversForm.test.js.snap
+++ b/ui/src/app/settings/views/Images/ThirdPartyDriversForm/__snapshots__/ThirdPartyDriversForm.test.js.snap
@@ -15,10 +15,7 @@ exports[`ThirdPartyDriversForm can render 1`] = `
       "subscription": Subscription {
         "handleChangeWrapper": [Function],
         "listeners": Object {
-          "clear": [Function],
-          "get": [Function],
           "notify": [Function],
-          "subscribe": [Function],
         },
         "onStateChange": [Function],
         "parentSub": undefined,
@@ -30,7 +27,7 @@ exports[`ThirdPartyDriversForm can render 1`] = `
           "replaceReducer": [Function],
           "subscribe": [Function],
         },
-        "unsubscribe": [Function],
+        "unsubscribe": null,
       },
     }
   }

--- a/ui/src/app/settings/views/Images/VMWareForm/__snapshots__/VMWareForm.test.js.snap
+++ b/ui/src/app/settings/views/Images/VMWareForm/__snapshots__/VMWareForm.test.js.snap
@@ -15,10 +15,7 @@ exports[`VMWareForm can render 1`] = `
       "subscription": Subscription {
         "handleChangeWrapper": [Function],
         "listeners": Object {
-          "clear": [Function],
-          "get": [Function],
           "notify": [Function],
-          "subscribe": [Function],
         },
         "onStateChange": [Function],
         "parentSub": undefined,
@@ -30,7 +27,7 @@ exports[`VMWareForm can render 1`] = `
           "replaceReducer": [Function],
           "subscribe": [Function],
         },
-        "unsubscribe": [Function],
+        "unsubscribe": null,
       },
     }
   }

--- a/ui/src/app/settings/views/Images/WindowsForm/__snapshots__/WindowsForm.test.js.snap
+++ b/ui/src/app/settings/views/Images/WindowsForm/__snapshots__/WindowsForm.test.js.snap
@@ -15,10 +15,7 @@ exports[`WindowsForm can render 1`] = `
       "subscription": Subscription {
         "handleChangeWrapper": [Function],
         "listeners": Object {
-          "clear": [Function],
-          "get": [Function],
           "notify": [Function],
-          "subscribe": [Function],
         },
         "onStateChange": [Function],
         "parentSub": undefined,
@@ -30,7 +27,7 @@ exports[`WindowsForm can render 1`] = `
           "replaceReducer": [Function],
           "subscribe": [Function],
         },
-        "unsubscribe": [Function],
+        "unsubscribe": null,
       },
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,7 +807,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.3.2"
 
-"@babel/runtime@7.5.5":
+"@babel/runtime@7.5.5", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -9440,22 +9440,27 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
+react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.0.tgz#72af7cf490a74acdc516ea9c1dd80e25af9ea0b2"
-  integrity sha512-hyu/PoFK3vZgdLTg9ozbt7WF3GgX5+Yn3pZm5/96/o4UueXA+zj08aiSC9Mfj2WtD1bvpIb3C5yvskzZySzzaw==
+react-redux@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"
+  integrity sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==
   dependencies:
-    "@babel/runtime" "^7.4.5"
+    "@babel/runtime" "^7.5.5"
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
-    react-is "^16.8.6"
+    react-is "^16.9.0"
 
 react-router-dom@5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## Done
Upgrade from react-redux 7.1.0 -> 7.1.1. Normally we would let renovate do this, but it broke some snapshots.