### PR TITLE
Fetch machines, controllers and devices

### DIFF
--- a/ui/src/app/base/actions/controller.js
+++ b/ui/src/app/base/actions/controller.js
@@ -1,0 +1,13 @@
+const controller = {};
+
+controller.fetch = () => {
+  return {
+    type: "FETCH_CONTROLLER",
+    meta: {
+      model: "controller",
+      method: "list"
+    }
+  };
+};
+
+export default controller;

--- a/ui/src/app/base/actions/controller.test.js
+++ b/ui/src/app/base/actions/controller.test.js
@@ -1,0 +1,13 @@
+import controller from "./controller";
+
+describe("controller actions", () => {
+  it("should handle fetching controllers", () => {
+    expect(controller.fetch()).toEqual({
+      type: "FETCH_CONTROLLER",
+      meta: {
+        model: "controller",
+        method: "list"
+      }
+    });
+  });
+});

--- a/ui/src/app/base/actions/device.js
+++ b/ui/src/app/base/actions/device.js
@@ -1,0 +1,13 @@
+const device = {};
+
+device.fetch = () => {
+  return {
+    type: "FETCH_DEVICE",
+    meta: {
+      model: "device",
+      method: "list"
+    }
+  };
+};
+
+export default device;

--- a/ui/src/app/base/actions/device.test.js
+++ b/ui/src/app/base/actions/device.test.js
@@ -1,0 +1,13 @@
+import device from "./device";
+
+describe("device actions", () => {
+  it("should handle fetching devices", () => {
+    expect(device.fetch()).toEqual({
+      type: "FETCH_DEVICE",
+      meta: {
+        model: "device",
+        method: "list"
+      }
+    });
+  });
+});

--- a/ui/src/app/base/actions/index.js
+++ b/ui/src/app/base/actions/index.js
@@ -1,3 +1,6 @@
 export { default as auth } from "./auth";
+export { default as controller } from "./controller";
+export { default as device } from "./device";
+export { default as machine } from "./machine";
 export { default as messages } from "./messages";
 export { default as websocket } from "./websocket";

--- a/ui/src/app/base/actions/machine.js
+++ b/ui/src/app/base/actions/machine.js
@@ -1,0 +1,13 @@
+const machine = {};
+
+machine.fetch = () => {
+  return {
+    type: "FETCH_MACHINE",
+    meta: {
+      model: "machine",
+      method: "list"
+    }
+  };
+};
+
+export default machine;

--- a/ui/src/app/base/actions/machine.test.js
+++ b/ui/src/app/base/actions/machine.test.js
@@ -1,0 +1,13 @@
+import machine from "./machine";
+
+describe("machine actions", () => {
+  it("should handle fetching machines", () => {
+    expect(machine.fetch()).toEqual({
+      type: "FETCH_MACHINE",
+      meta: {
+        model: "machine",
+        method: "list"
+      }
+    });
+  });
+});

--- a/ui/src/app/base/reducers/controller.js
+++ b/ui/src/app/base/reducers/controller.js
@@ -1,0 +1,25 @@
+import produce from "immer";
+
+const controller = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case "FETCH_CONTROLLER_START":
+        draft.loading = true;
+        break;
+      case "FETCH_CONTROLLER_SUCCESS":
+        draft.loading = false;
+        draft.loaded = true;
+        draft.items = action.payload;
+        break;
+      default:
+        return draft;
+    }
+  },
+  {
+    items: [],
+    loaded: false,
+    loading: false
+  }
+);
+
+export default controller;

--- a/ui/src/app/base/reducers/controller.test.js
+++ b/ui/src/app/base/reducers/controller.test.js
@@ -1,0 +1,43 @@
+import controller from "./controller";
+
+describe("controller reducer", () => {
+  it("should return the initial state", () => {
+    expect(controller(undefined, {})).toEqual({
+      items: [],
+      loaded: false,
+      loading: false
+    });
+  });
+
+  it("should correctly reduce FETCH_CONTROLLER_START", () => {
+    expect(
+      controller(undefined, {
+        type: "FETCH_CONTROLLER_START"
+      })
+    ).toEqual({
+      items: [],
+      loaded: false,
+      loading: true
+    });
+  });
+
+  it("should correctly reduce FETCH_CONTROLLER_SUCCESS", () => {
+    expect(
+      controller(
+        {
+          items: [],
+          loaded: false,
+          loading: true
+        },
+        {
+          type: "FETCH_CONTROLLER_SUCCESS",
+          payload: [{ id: 1, hostname: "rack" }, { id: 2, hostname: "maas" }]
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: true,
+      items: [{ id: 1, hostname: "rack" }, { id: 2, hostname: "maas" }]
+    });
+  });
+});

--- a/ui/src/app/base/reducers/device.js
+++ b/ui/src/app/base/reducers/device.js
@@ -1,0 +1,25 @@
+import produce from "immer";
+
+const device = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case "FETCH_DEVICE_START":
+        draft.loading = true;
+        break;
+      case "FETCH_DEVICE_SUCCESS":
+        draft.loading = false;
+        draft.loaded = true;
+        draft.items = action.payload;
+        break;
+      default:
+        return draft;
+    }
+  },
+  {
+    items: [],
+    loaded: false,
+    loading: false
+  }
+);
+
+export default device;

--- a/ui/src/app/base/reducers/device.test.js
+++ b/ui/src/app/base/reducers/device.test.js
@@ -1,0 +1,43 @@
+import device from "./device";
+
+describe("device reducer", () => {
+  it("should return the initial state", () => {
+    expect(device(undefined, {})).toEqual({
+      items: [],
+      loaded: false,
+      loading: false
+    });
+  });
+
+  it("should correctly reduce FETCH_DEVICE_START", () => {
+    expect(
+      device(undefined, {
+        type: "FETCH_DEVICE_START"
+      })
+    ).toEqual({
+      items: [],
+      loaded: false,
+      loading: true
+    });
+  });
+
+  it("should correctly reduce FETCH_DEVICE_SUCCESS", () => {
+    expect(
+      device(
+        {
+          items: [],
+          loaded: false,
+          loading: true
+        },
+        {
+          type: "FETCH_DEVICE_SUCCESS",
+          payload: [{ id: 1, hostname: "test1" }, { id: 2, hostname: "test2" }]
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: true,
+      items: [{ id: 1, hostname: "test1" }, { id: 2, hostname: "test2" }]
+    });
+  });
+});

--- a/ui/src/app/base/reducers/index.js
+++ b/ui/src/app/base/reducers/index.js
@@ -1,3 +1,6 @@
 export { default as auth } from "./auth";
+export { default as controller } from "./controller";
+export { default as device } from "./device";
+export { default as machine } from "./machine";
 export { default as messages } from "./messages";
 export { default as status } from "./status";

--- a/ui/src/app/base/reducers/machine.js
+++ b/ui/src/app/base/reducers/machine.js
@@ -1,0 +1,25 @@
+import produce from "immer";
+
+const machine = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case "FETCH_MACHINE_START":
+        draft.loading = true;
+        break;
+      case "FETCH_MACHINE_SUCCESS":
+        draft.loading = false;
+        draft.loaded = true;
+        draft.items = action.payload;
+        break;
+      default:
+        return draft;
+    }
+  },
+  {
+    items: [],
+    loaded: false,
+    loading: false
+  }
+);
+
+export default machine;

--- a/ui/src/app/base/reducers/machine.test.js
+++ b/ui/src/app/base/reducers/machine.test.js
@@ -1,0 +1,43 @@
+import machine from "./machine";
+
+describe("machine reducer", () => {
+  it("should return the initial state", () => {
+    expect(machine(undefined, {})).toEqual({
+      items: [],
+      loaded: false,
+      loading: false
+    });
+  });
+
+  it("should correctly reduce FETCH_MACHINE_START", () => {
+    expect(
+      machine(undefined, {
+        type: "FETCH_MACHINE_START"
+      })
+    ).toEqual({
+      items: [],
+      loaded: false,
+      loading: true
+    });
+  });
+
+  it("should correctly reduce FETCH_MACHINE_SUCCESS", () => {
+    expect(
+      machine(
+        {
+          items: [],
+          loaded: false,
+          loading: true
+        },
+        {
+          type: "FETCH_MACHINE_SUCCESS",
+          payload: [{ id: 1, hostname: "node1" }, { id: 2, hostname: "node2" }]
+        }
+      )
+    ).toEqual({
+      loading: false,
+      loaded: true,
+      items: [{ id: 1, hostname: "node1" }, { id: 2, hostname: "node2" }]
+    });
+  });
+});

--- a/ui/src/app/base/selectors/controller.js
+++ b/ui/src/app/base/selectors/controller.js
@@ -1,0 +1,32 @@
+const controller = {};
+
+/**
+ * Returns all controllers.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all controllers.
+ */
+controller.all = state => state.controller.items;
+
+/**
+ * Whether controllers are loading.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Controllers loading state.
+ */
+controller.loading = state => state.controller.loading;
+
+/**
+ * Whether controllers have been loaded.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Controllers loaded state.
+ */
+controller.loaded = state => state.controller.loaded;
+
+/**
+ * Returns a controller for the given id.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A controller.
+ */
+controller.getBySystemId = (state, id) =>
+  state.controller.items.find(controller => controller.system_id === id);
+
+export default controller;

--- a/ui/src/app/base/selectors/controller.test.js
+++ b/ui/src/app/base/selectors/controller.test.js
@@ -1,0 +1,47 @@
+import controller from "./controller";
+
+describe("controller selectors", () => {
+  it("can get all items", () => {
+    const state = {
+      controller: {
+        items: [{ name: "maas.test" }]
+      }
+    };
+    expect(controller.all(state)).toEqual([{ name: "maas.test" }]);
+  });
+
+  it("can get the loading state", () => {
+    const state = {
+      controller: {
+        loading: true,
+        items: []
+      }
+    };
+    expect(controller.loading(state)).toEqual(true);
+  });
+
+  it("can get the loaded state", () => {
+    const state = {
+      controller: {
+        loaded: true,
+        items: []
+      }
+    };
+    expect(controller.loaded(state)).toEqual(true);
+  });
+
+  it("can get a controller by id", () => {
+    const state = {
+      controller: {
+        items: [
+          { name: "maas.test", system_id: 808 },
+          { name: "10.0.0.99", system_id: 909 }
+        ]
+      }
+    };
+    expect(controller.getBySystemId(state, 909)).toStrictEqual({
+      name: "10.0.0.99",
+      system_id: 909
+    });
+  });
+});

--- a/ui/src/app/base/selectors/device.js
+++ b/ui/src/app/base/selectors/device.js
@@ -1,0 +1,32 @@
+const device = {};
+
+/**
+ * Returns all devices.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all devices.
+ */
+device.all = state => state.device.items;
+
+/**
+ * Whether devices are loading.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Devices loading state.
+ */
+device.loading = state => state.device.loading;
+
+/**
+ * Whether devices have been loaded.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Devices loaded state.
+ */
+device.loaded = state => state.device.loaded;
+
+/**
+ * Returns a device for the given id.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A device.
+ */
+device.getBySystemId = (state, id) =>
+  state.device.items.find(device => device.system_id === id);
+
+export default device;

--- a/ui/src/app/base/selectors/device.test.js
+++ b/ui/src/app/base/selectors/device.test.js
@@ -1,0 +1,47 @@
+import device from "./device";
+
+describe("device selectors", () => {
+  it("can get all items", () => {
+    const state = {
+      device: {
+        items: [{ name: "maas.test" }]
+      }
+    };
+    expect(device.all(state)).toEqual([{ name: "maas.test" }]);
+  });
+
+  it("can get the loading state", () => {
+    const state = {
+      device: {
+        loading: true,
+        items: []
+      }
+    };
+    expect(device.loading(state)).toEqual(true);
+  });
+
+  it("can get the loaded state", () => {
+    const state = {
+      device: {
+        loaded: true,
+        items: []
+      }
+    };
+    expect(device.loaded(state)).toEqual(true);
+  });
+
+  it("can get a device by id", () => {
+    const state = {
+      device: {
+        items: [
+          { name: "maas.test", system_id: 808 },
+          { name: "10.0.0.99", system_id: 909 }
+        ]
+      }
+    };
+    expect(device.getBySystemId(state, 909)).toStrictEqual({
+      name: "10.0.0.99",
+      system_id: 909
+    });
+  });
+});

--- a/ui/src/app/base/selectors/index.js
+++ b/ui/src/app/base/selectors/index.js
@@ -1,3 +1,6 @@
 export { default as auth } from "./auth";
+export { default as controller } from "./controller";
+export { default as device } from "./device";
+export { default as machine } from "./machine";
 export { default as messages } from "./messages";
 export { default as status } from "./status";

--- a/ui/src/app/base/selectors/machine.js
+++ b/ui/src/app/base/selectors/machine.js
@@ -1,0 +1,32 @@
+const machine = {};
+
+/**
+ * Returns all machines.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all machines.
+ */
+machine.all = state => state.machine.items;
+
+/**
+ * Whether machines are loading.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Machines loading state.
+ */
+machine.loading = state => state.machine.loading;
+
+/**
+ * Whether machines have been loaded.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Machines loaded state.
+ */
+machine.loaded = state => state.machine.loaded;
+
+/**
+ * Returns a machine for the given id.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A machine.
+ */
+machine.getBySystemId = (state, id) =>
+  state.machine.items.find(machine => machine.system_id === id);
+
+export default machine;

--- a/ui/src/app/base/selectors/machine.test.js
+++ b/ui/src/app/base/selectors/machine.test.js
@@ -1,0 +1,47 @@
+import machine from "./machine";
+
+describe("machine selectors", () => {
+  it("can get all items", () => {
+    const state = {
+      machine: {
+        items: [{ name: "maas.test" }]
+      }
+    };
+    expect(machine.all(state)).toEqual([{ name: "maas.test" }]);
+  });
+
+  it("can get the loading state", () => {
+    const state = {
+      machine: {
+        loading: true,
+        items: []
+      }
+    };
+    expect(machine.loading(state)).toEqual(true);
+  });
+
+  it("can get the loaded state", () => {
+    const state = {
+      machine: {
+        loaded: true,
+        items: []
+      }
+    };
+    expect(machine.loaded(state)).toEqual(true);
+  });
+
+  it("can get a machine by id", () => {
+    const state = {
+      machine: {
+        items: [
+          { name: "maas.test", system_id: 808 },
+          { name: "10.0.0.99", system_id: 909 }
+        ]
+      }
+    };
+    expect(machine.getBySystemId(state, 909)).toStrictEqual({
+      name: "10.0.0.99",
+      system_id: 909
+    });
+  });
+});

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
@@ -12,10 +12,29 @@ describe("DhcpList", () => {
 
   beforeEach(() => {
     state = {
+      controller: {
+        loading: false,
+        loaded: true,
+        items: []
+      },
+      device: {
+        loading: false,
+        loaded: true,
+        items: []
+      },
       dhcpsnippet: {
         loading: false,
         loaded: true,
-        items: [{ id: 1, name: "class" }, { id: 2, name: "lease", subnet: 2 }]
+        items: [
+          { id: 1, name: "class" },
+          { id: 2, name: "lease", subnet: 2 },
+          { id: 3, name: "boot", node: "xyz" }
+        ]
+      },
+      machine: {
+        loading: false,
+        loaded: true,
+        items: [{ system_id: "xyz", hostname: "machine.maas" }]
       },
       subnet: {
         loading: false,
@@ -26,7 +45,10 @@ describe("DhcpList", () => {
   });
 
   it("displays a loading component if loading", () => {
+    state.controller.loading = true;
+    state.device.loading = true;
     state.dhcpsnippet.loading = true;
+    state.machine.loading = true;
     state.subnet.loading = true;
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/settings/views/Dhcp/DhcpList/__snapshots__/DhcpList.test.js.snap
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/__snapshots__/DhcpList.test.js.snap
@@ -11,6 +11,7 @@ exports[`DhcpList displays a list of dhcp snippets 1`] = `
       <li>
         class
          
+         
       </li>
     </DhcpListItem>
     <DhcpListItem
@@ -23,6 +24,20 @@ exports[`DhcpList displays a list of dhcp snippets 1`] = `
         lease
          
         (subnet: test.maas)
+         
+      </li>
+    </DhcpListItem>
+    <DhcpListItem
+      id={3}
+      key="3"
+      name="boot"
+      node="xyz"
+    >
+      <li>
+        boot
+         
+         
+        (machine: machine.maas)
       </li>
     </DhcpListItem>
   </ul>

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -3,17 +3,27 @@ import { combineReducers } from "redux";
 import { connectRouter } from "connected-react-router";
 
 import settingsReducers from "./app/settings/reducers";
-import { auth, messages, status } from "./app/base/reducers";
+import {
+  auth,
+  controller,
+  device,
+  machine,
+  messages,
+  status
+} from "./app/base/reducers";
 
 export default history =>
   combineReducers({
     config: settingsReducers.config,
+    controller,
+    device,
     dhcpsnippet: settingsReducers.dhcpsnippet,
     general: settingsReducers.general,
-    messages: messages,
+    machine,
+    messages,
     packagerepository: settingsReducers.packagerepository,
     router: connectRouter(history),
-    status: status,
+    status,
     subnet: settingsReducers.subnet,
     user: reduceReducers(settingsReducers.user, auth)
   });


### PR DESCRIPTION
Done:
- Implement actions, reducers and selectors for machines, controllers and devices. Fixes: #164.

QA:
- Visit /settings/dhcp.
- You should subnets, machines, controllers or devices in brackets after some items.