### PR TITLE
Explicitly fetch config in components that require it.

### DIFF
--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.js
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.js
@@ -9,14 +9,20 @@ import Row from "app/base/components/Row";
 import CommissioningForm from "../CommissioningForm";
 
 const Commissioning = () => {
-  const loaded = useSelector(selectors.config.loaded);
-  const loading = useSelector(selectors.config.loading);
+  const configLoaded = useSelector(selectors.config.loaded);
+  const configLoading = useSelector(selectors.config.loading);
+  const osInfoLoaded = useSelector(selectors.general.osInfo.loaded);
+  const osInfoLoading = useSelector(selectors.general.osInfo.loading);
+  const loaded = configLoaded && osInfoLoaded;
+  const loading = configLoading || osInfoLoading;
 
   const dispatch = useDispatch();
-
   useEffect(() => {
-    dispatch(actions.general.fetchOsInfo());
-  }, [dispatch]);
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+      dispatch(actions.general.fetchOsInfo());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
@@ -65,8 +65,10 @@ describe("Commissioning", () => {
     expect(wrapper.find("CommissioningForm").exists()).toBe(true);
   });
 
-  it("dispatches action to fetch general os info on load", () => {
+  it(`dispatches actions to fetch config and general os info if either has not
+    already loaded`, () => {
     const state = { ...initialState };
+    state.config.loaded = false;
     const store = mockStore(state);
 
     mount(
@@ -75,16 +77,19 @@ describe("Commissioning", () => {
       </Provider>
     );
 
-    const fetchGeneralOsinfoAction = store
+    const fetchActions = store
       .getActions()
-      .find(action => action.type === "FETCH_GENERAL_OSINFO");
+      .filter(action => action.type.startsWith("FETCH"));
 
-    expect(fetchGeneralOsinfoAction).toEqual({
-      type: "FETCH_GENERAL_OSINFO",
-      meta: {
-        model: "general",
-        method: "osinfo"
+    expect(fetchActions).toEqual([
+      { type: "FETCH_CONFIG", meta: { model: "config", method: "list" } },
+      {
+        type: "FETCH_GENERAL_OSINFO",
+        meta: {
+          model: "general",
+          method: "osinfo"
+        }
       }
-    });
+    ]);
   });
 });

--- a/ui/src/app/settings/views/Configuration/Deploy/Deploy.js
+++ b/ui/src/app/settings/views/Configuration/Deploy/Deploy.js
@@ -9,14 +9,20 @@ import Row from "app/base/components/Row";
 import DeployForm from "app/settings/views/Configuration/DeployForm";
 
 const Deploy = () => {
-  const loaded = useSelector(selectors.config.loaded);
-  const loading = useSelector(selectors.config.loading);
+  const configLoaded = useSelector(selectors.config.loaded);
+  const configLoading = useSelector(selectors.config.loading);
+  const osInfoLoaded = useSelector(selectors.general.osInfo.loaded);
+  const osInfoLoading = useSelector(selectors.general.osInfo.loading);
+  const loaded = configLoaded && osInfoLoaded;
+  const loading = configLoading || osInfoLoading;
 
   const dispatch = useDispatch();
-
   useEffect(() => {
-    dispatch(actions.general.fetchOsInfo());
-  }, [dispatch]);
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+      dispatch(actions.general.fetchOsInfo());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
+++ b/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
@@ -12,7 +12,9 @@ describe("Deploy", () => {
   beforeEach(() => {
     initialState = {
       config: {},
-      general: {}
+      general: {
+        osInfo: {}
+      }
     };
   });
 
@@ -28,8 +30,10 @@ describe("Deploy", () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it("dispatches action to fetch general os info on load", () => {
+  it(`dispatches actions to fetch config and general os info if either has not
+    already loaded`, () => {
     const state = { ...initialState };
+    state.config.loaded = false;
     const store = mockStore(state);
 
     mount(
@@ -38,16 +42,19 @@ describe("Deploy", () => {
       </Provider>
     );
 
-    const fetchGeneralOsinfoAction = store
+    const fetchActions = store
       .getActions()
-      .find(action => action.type === "FETCH_GENERAL_OSINFO");
+      .filter(action => action.type.startsWith("FETCH"));
 
-    expect(fetchGeneralOsinfoAction).toEqual({
-      type: "FETCH_GENERAL_OSINFO",
-      meta: {
-        model: "general",
-        method: "osinfo"
+    expect(fetchActions).toEqual([
+      { type: "FETCH_CONFIG", meta: { model: "config", method: "list" } },
+      {
+        type: "FETCH_GENERAL_OSINFO",
+        meta: {
+          model: "general",
+          method: "osinfo"
+        }
       }
-    });
+    ]);
   });
 });

--- a/ui/src/app/settings/views/Configuration/General/General.js
+++ b/ui/src/app/settings/views/Configuration/General/General.js
@@ -1,6 +1,7 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
+import actions from "app/settings/actions";
 import selectors from "app/settings/selectors";
 import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
@@ -10,6 +11,13 @@ import GeneralForm from "../GeneralForm";
 const General = () => {
   const loaded = useSelector(selectors.config.loaded);
   const loading = useSelector(selectors.config.loading);
+
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Configuration/General/General.test.js
+++ b/ui/src/app/settings/views/Configuration/General/General.test.js
@@ -55,4 +55,30 @@ describe("General", () => {
 
     expect(wrapper.find("GeneralForm").exists()).toBe(true);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <General />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.js
+++ b/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.js
@@ -1,6 +1,7 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
+import actions from "app/settings/actions";
 import selectors from "app/settings/selectors";
 import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
@@ -10,6 +11,13 @@ import KernelParametersForm from "../KernelParametersForm";
 const KernelParameters = () => {
   const loaded = useSelector(selectors.config.loaded);
   const loading = useSelector(selectors.config.loading);
+
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.js
+++ b/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.js
@@ -51,4 +51,30 @@ describe("KernelParameters", () => {
 
     expect(wrapper.find("KernelParametersForm").exists()).toBe(true);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <KernelParameters />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.js
+++ b/ui/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.js
@@ -1,6 +1,7 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
+import actions from "app/settings/actions";
 import selectors from "app/settings/selectors";
 import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
@@ -10,6 +11,13 @@ import ThirdPartyDriversForm from "../ThirdPartyDriversForm";
 const ThirdPartyDrivers = () => {
   const loaded = useSelector(selectors.config.loaded);
   const loading = useSelector(selectors.config.loading);
+
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Images/VMWare/VMWare.js
+++ b/ui/src/app/settings/views/Images/VMWare/VMWare.js
@@ -1,6 +1,7 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
+import actions from "app/settings/actions";
 import selectors from "app/settings/selectors";
 import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
@@ -10,6 +11,13 @@ import VMWareForm from "../VMWareForm";
 const VMWare = () => {
   const loaded = useSelector(selectors.config.loaded);
   const loading = useSelector(selectors.config.loading);
+
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Images/VMWare/VMWare.test.js
+++ b/ui/src/app/settings/views/Images/VMWare/VMWare.test.js
@@ -47,4 +47,30 @@ describe("VMWare", () => {
 
     expect(wrapper.find("VMWareForm").exists()).toBe(true);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <VMWare />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Images/Windows/Windows.js
+++ b/ui/src/app/settings/views/Images/Windows/Windows.js
@@ -1,6 +1,7 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
+import actions from "app/settings/actions";
 import selectors from "app/settings/selectors";
 import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
@@ -10,6 +11,13 @@ import WindowsForm from "../WindowsForm";
 const Windows = () => {
   const loaded = useSelector(selectors.config.loaded);
   const loading = useSelector(selectors.config.loading);
+
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Images/Windows/Windows.test.js
+++ b/ui/src/app/settings/views/Images/Windows/Windows.test.js
@@ -47,4 +47,30 @@ describe("Windows", () => {
 
     expect(wrapper.find("WindowsForm").exists()).toBe(true);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <Windows />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.js
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.js
@@ -1,5 +1,5 @@
 import { Formik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -33,6 +33,12 @@ const DnsForm = () => {
   const dnssecValidation = useSelector(config.dnssecValidation);
   const dnsTrustedAcl = useSelector(config.dnsTrustedAcl);
   const upstreamDns = useSelector(config.upstreamDns);
+
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
@@ -79,4 +79,30 @@ describe("DnsForm", () => {
       done();
     }, 0);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <DnsForm />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.js
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.js
@@ -1,5 +1,5 @@
 import { Formik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -29,6 +29,12 @@ const NetworkDiscoveryForm = () => {
 
   const activeDiscoveryInterval = useSelector(config.activeDiscoveryInterval);
   const networkDiscovery = useSelector(config.networkDiscovery);
+
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
@@ -90,4 +90,30 @@ describe("NetworkDiscoveryForm", () => {
       done();
     }, 0);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <NetworkDiscoveryForm />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.js
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.js
@@ -1,5 +1,5 @@
 import { Formik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -29,6 +29,12 @@ const NtpForm = () => {
 
   const ntpExternalOnly = useSelector(config.ntpExternalOnly);
   const ntpServers = useSelector(config.ntpServers);
+
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
@@ -72,4 +72,30 @@ describe("NtpForm", () => {
       done();
     }, 0);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <NtpForm />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.js
+++ b/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.js
@@ -1,5 +1,5 @@
 import { Formik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -34,6 +34,12 @@ const ProxyForm = () => {
 
   const httpProxy = useSelector(config.httpProxy);
   const proxyType = useSelector(config.proxyType);
+
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.test.js
+++ b/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.test.js
@@ -68,4 +68,30 @@ describe("ProxyForm", () => {
     );
     expect(wrapper.find("Input[type='text']").exists()).toBe(true);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <ProxyForm />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.js
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.js
@@ -1,5 +1,5 @@
 import { Formik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -27,6 +27,12 @@ const SyslogForm = () => {
   const saving = useSelector(config.saving);
 
   const remoteSyslog = useSelector(config.remoteSyslog);
+
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
@@ -70,4 +70,30 @@ describe("SyslogForm", () => {
       done();
     }, 0);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <SyslogForm />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.js
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.js
@@ -1,5 +1,5 @@
 import { Formik } from "formik";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -33,6 +33,12 @@ const StorageForm = () => {
   const diskEraseWithQuick = useSelector(config.diskEraseWithQuick);
   const diskEraseWithSecure = useSelector(config.diskEraseWithSecure);
   const enableDiskErasing = useSelector(config.enableDiskErasing);
+
+  useEffect(() => {
+    if (!loaded) {
+      dispatch(actions.config.fetch());
+    }
+  }, [dispatch, loaded]);
 
   return (
     <Row>

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
@@ -75,4 +75,30 @@ describe("StorageForm", () => {
       done();
     }, 0);
   });
+
+  it("dispatches action to fetch config if not already loaded", () => {
+    const state = { ...initialState };
+    state.config.loaded = false;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <StorageForm />
+      </Provider>
+    );
+
+    const fetchActions = store
+      .getActions()
+      .filter(action => action.type.startsWith("FETCH"));
+
+    expect(fetchActions).toEqual([
+      {
+        type: "FETCH_CONFIG",
+        meta: {
+          model: "config",
+          method: "list"
+        }
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
## Done
- Explicitly fetch config in components that require it, if it hasn't already been loaded

## QA
- Load the app from users
- Navigate to a form that requires config (e.g. General)
- Check that the page actually loads.