### PR TITLE
Fetch scripts, add routes and basic component.

### DIFF
--- a/ui/.env.development
+++ b/ui/.env.development
@@ -1,3 +1,4 @@
 REACT_APP_BASENAME="/MAAS/settings"
+REACT_APP_BASE_URL="http://localhost:5240/"
 REACT_APP_MAAS_URL="http://localhost:5240/MAAS"
 REACT_APP_WEBSOCKET_URL="ws://localhost:5240/MAAS/ws"

--- a/ui/README.md
+++ b/ui/README.md
@@ -65,7 +65,7 @@ From the root of the MAAS UI project run:
 ./run
 ```
 
-From here you should be able to view the project at &lt;your-local-maas-ip>:8000A
+From here you should be able to view the project at &lt;your-local-maas-ip>:8000
 
 ## Note
 If you are running MAAS on a different host in development, you will need to copy both cookies for `csrftoken` and `sessionid` after authenticating with MAAS into your browser session for maas-ui.

--- a/ui/README.md
+++ b/ui/README.md
@@ -65,7 +65,10 @@ From the root of the MAAS UI project run:
 ./run
 ```
 
-From here you should be able to view the project at &lt;your-local-maas-ip>:8000
+From here you should be able to view the project at &lt;your-local-maas-ip>:8000A
+
+## Note
+If you are running MAAS on a different host in development, you will need to copy both cookies for `csrftoken` and `sessionid` after authenticating with MAAS into your browser session for maas-ui.
 
 # Changelog Process
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
     "cross-env": "5.2.0",
     "date-fns": "2.0.1",
     "formik": "1.5.8",
+    "http-proxy-middleware": "^0.19.1",
     "immer": "3.2.0",
     "prop-types": "15.7.2",
     "react": "16.9.0",

--- a/ui/src/app/Routes.js
+++ b/ui/src/app/Routes.js
@@ -3,7 +3,7 @@ import { Route } from "react-router-dom";
 
 import Settings from "app/settings/views/Settings";
 
-// This component currently routes everying to settings, but exists to
+// This component currently routes everything to settings, but exists to
 // facilitate more top level URLS in the future.
 const Routes = () => <Route path="/" component={Settings} />;
 

--- a/ui/src/app/base/sagas/http.js
+++ b/ui/src/app/base/sagas/http.js
@@ -11,7 +11,12 @@ export const api = {
       Accept: "application/json",
       "X-CSRFToken": csrftoken
     };
-    return fetch(SCRIPTS_API, { headers }).then(response => response.json());
+    return fetch(SCRIPTS_API, { headers }).then(response => {
+      if (!response.ok) {
+        throw Error(response.statusText);
+      }
+      return response.json();
+    });
   }
 };
 
@@ -28,7 +33,7 @@ export function* fetchScriptsSaga() {
   } catch (error) {
     yield put({
       type: `FETCH_SCRIPTS_ERROR`,
-      error
+      error: error.message
     });
   }
 }

--- a/ui/src/app/base/sagas/http.js
+++ b/ui/src/app/base/sagas/http.js
@@ -1,0 +1,38 @@
+import { call, put, takeLatest } from "redux-saga/effects";
+
+import getCookie from "./utils";
+
+const SCRIPTS_API = `/MAAS/api/2.0/scripts/`;
+
+export const api = {
+  fetchScripts: csrftoken => {
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "X-CSRFToken": csrftoken
+    };
+    return fetch(SCRIPTS_API, { headers }).then(response => response.json());
+  }
+};
+
+export function* fetchScriptsSaga() {
+  const csrftoken = yield call(getCookie, "csrftoken");
+  let response;
+  try {
+    yield put({ type: `FETCH_SCRIPTS_START` });
+    response = yield call(api.fetchScripts, csrftoken);
+    yield put({
+      type: `FETCH_SCRIPTS_SUCCESS`,
+      payload: response
+    });
+  } catch (error) {
+    yield put({
+      type: `FETCH_SCRIPTS_ERROR`,
+      error
+    });
+  }
+}
+
+export function* watchFetchScripts() {
+  yield takeLatest("FETCH_SCRIPTS", fetchScriptsSaga);
+}

--- a/ui/src/app/base/sagas/http.test.js
+++ b/ui/src/app/base/sagas/http.test.js
@@ -1,0 +1,34 @@
+import { call } from "redux-saga/effects";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { throwError } from "redux-saga-test-plan/providers";
+
+import { expectSaga } from "redux-saga-test-plan";
+
+import getCookie from "./utils";
+import { api, fetchScriptsSaga } from "./http";
+
+describe("http sagas", () => {
+  it("returns a SUCCESS action", () => {
+    const payload = [{ name: "script1" }];
+    return expectSaga(fetchScriptsSaga)
+      .provide([
+        [matchers.call.fn(getCookie, "csrftoken"), "csrf-token"],
+        [matchers.call.fn(api.fetchScripts, "csrf-token"), payload]
+      ])
+      .put({ type: "FETCH_SCRIPTS_START" })
+      .put({ type: "FETCH_SCRIPTS_SUCCESS", payload })
+      .run();
+  });
+
+  it("handles errors", () => {
+    const error = new Error("kerblam!");
+    return expectSaga(fetchScriptsSaga)
+      .provide([
+        [matchers.call.fn(getCookie, "csrftoken"), "csrf-token"],
+        [matchers.call.fn(api.fetchScripts, "csrf-token"), throwError(error)]
+      ])
+      .put({ type: "FETCH_SCRIPTS_START" })
+      .put({ type: "FETCH_SCRIPTS_ERROR", error })
+      .run();
+  });
+});

--- a/ui/src/app/base/sagas/http.test.js
+++ b/ui/src/app/base/sagas/http.test.js
@@ -27,7 +27,7 @@ describe("http sagas", () => {
         [matchers.call.fn(api.fetchScripts, "csrf-token"), throwError(error)]
       ])
       .put({ type: "FETCH_SCRIPTS_START" })
-      .put({ type: "FETCH_SCRIPTS_ERROR", error })
+      .put({ type: "FETCH_SCRIPTS_ERROR", error: error.message })
       .run();
   });
 });

--- a/ui/src/app/base/sagas/http.test.js
+++ b/ui/src/app/base/sagas/http.test.js
@@ -1,4 +1,3 @@
-import { call } from "redux-saga/effects";
 import * as matchers from "redux-saga-test-plan/matchers";
 import { throwError } from "redux-saga-test-plan/providers";
 

--- a/ui/src/app/base/sagas/index.js
+++ b/ui/src/app/base/sagas/index.js
@@ -1,3 +1,4 @@
 import { watchWebSockets } from "./websockets";
+import { watchFetchScripts } from "./http";
 
-export { watchWebSockets };
+export { watchWebSockets, watchFetchScripts };

--- a/ui/src/app/settings/actions/index.js
+++ b/ui/src/app/settings/actions/index.js
@@ -1,6 +1,7 @@
 import config from "./config";
 import dhcpsnippet from "./dhcpsnippet";
 import general from "./general";
+import scripts from "./scripts";
 import repositories from "./repositories";
 import subnet from "./subnet";
 import users from "./users";
@@ -9,6 +10,7 @@ export default {
   config,
   dhcpsnippet,
   general,
+  scripts,
   repositories,
   subnet,
   users

--- a/ui/src/app/settings/actions/scripts/index.js
+++ b/ui/src/app/settings/actions/scripts/index.js
@@ -1,0 +1,3 @@
+import scripts from "./scripts";
+
+export default scripts;

--- a/ui/src/app/settings/actions/scripts/scripts.js
+++ b/ui/src/app/settings/actions/scripts/scripts.js
@@ -1,0 +1,9 @@
+const scripts = {};
+
+scripts.fetch = () => {
+  return {
+    type: "FETCH_SCRIPTS"
+  };
+};
+
+export default scripts;

--- a/ui/src/app/settings/actions/scripts/scripts.test.js
+++ b/ui/src/app/settings/actions/scripts/scripts.test.js
@@ -1,0 +1,9 @@
+import scripts from "./scripts";
+
+describe("scripts actions", () => {
+  it("should handle fetching scripts", () => {
+    expect(scripts.fetch()).toEqual({
+      type: "FETCH_SCRIPTS"
+    });
+  });
+});

--- a/ui/src/app/settings/components/Nav/Nav.js
+++ b/ui/src/app/settings/components/Nav/Nav.js
@@ -91,11 +91,10 @@ export const Nav = () => {
       ]
     },
     {
-      path: "/scripts",
       label: "Scripts",
       subNav: [
-        { path: "user-scripts", label: "User scripts" },
-        { path: "built-in-scripts", label: "Built-in scripts" }
+        { path: "/scripts/commissioning", label: "Commissioning scripts" },
+        { path: "/scripts/testing", label: "Testing scripts" }
       ]
     },
     {

--- a/ui/src/app/settings/components/Nav/__snapshots__/Nav.test.js.snap
+++ b/ui/src/app/settings/components/Nav/__snapshots__/Nav.test.js.snap
@@ -292,58 +292,45 @@ exports[`Nav renders 1`] = `
       </li>
       <li
         className="settings-nav__item"
-        key="/scripts"
+        key="Scripts"
       >
-        <strong
-          className=""
-        >
-          <Link
-            className="p-link--soft"
-            to="/scripts"
-          >
-            <a
-              className="p-link--soft"
-              href="/scripts"
-              onClick={[Function]}
-            >
-              Scripts
-            </a>
-          </Link>
+        <strong>
+          Scripts
         </strong>
         <ul
           className="settings-nav__list"
         >
           <li
             className="settings-nav__item"
-            key="user-scripts"
+            key="/scripts/commissioning"
           >
             <Link
               className="p-link--soft"
-              to="user-scripts"
+              to="/scripts/commissioning"
             >
               <a
                 className="p-link--soft"
-                href="/user-scripts"
+                href="/scripts/commissioning"
                 onClick={[Function]}
               >
-                User scripts
+                Commissioning scripts
               </a>
             </Link>
           </li>
           <li
             className="settings-nav__item"
-            key="built-in-scripts"
+            key="/scripts/testing"
           >
             <Link
               className="p-link--soft"
-              to="built-in-scripts"
+              to="/scripts/testing"
             >
               <a
                 className="p-link--soft"
-                href="/built-in-scripts"
+                href="/scripts/testing"
                 onClick={[Function]}
               >
-                Built-in scripts
+                Testing scripts
               </a>
             </Link>
           </li>

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -13,7 +13,7 @@ import ProxyForm from "app/settings/views/Network/ProxyForm";
 import RepositoriesList from "app/settings/views/Repositories/RepositoriesList";
 import RepositoryAdd from "app/settings/views/Repositories/RepositoryAdd";
 import RepositoryEdit from "app/settings/views/Repositories/RepositoryEdit";
-import Scripts from "app/settings/views/Scripts";
+import Scripts from "app/settings/views/Scripts/Scripts";
 import StorageForm from "app/settings/views/Storage/StorageForm";
 import SyslogForm from "app/settings/views/Network/SyslogForm";
 import ThirdPartyDrivers from "app/settings/views/Images/ThirdPartyDrivers";
@@ -53,7 +53,16 @@ const Routes = () => (
       component={NetworkDiscoveryForm}
     />
     <Redirect from="/network" to="/network/proxy" />
-    <Route exact path="/scripts" component={Scripts} />
+    <Route
+      exact
+      path="/scripts/commissioning"
+      render={props => <Scripts {...props} type="commissioning" />}
+    />
+    <Route
+      exact
+      path="/scripts/testing"
+      render={props => <Scripts {...props} type="testing" />}
+    />
     <Route exact path="/dhcp" component={DhcpList} />
     <Route exact path="/repositories" component={RepositoriesList} />
     <Route exact path="/repositories/add/:type" component={RepositoryAdd} />

--- a/ui/src/app/settings/reducers/index.js
+++ b/ui/src/app/settings/reducers/index.js
@@ -2,6 +2,7 @@ import config from "./config";
 import dhcpsnippet from "./dhcpsnippet";
 import general from "./general";
 import packagerepository from "./packagerepository";
+import scripts from "./scripts";
 import subnet from "./subnet";
 import user from "./user";
 
@@ -10,6 +11,7 @@ export default {
   dhcpsnippet,
   general,
   packagerepository,
+  scripts,
   subnet,
   user
 };

--- a/ui/src/app/settings/reducers/scripts/index.js
+++ b/ui/src/app/settings/reducers/scripts/index.js
@@ -1,0 +1,3 @@
+import scripts from "./scripts";
+
+export default scripts;

--- a/ui/src/app/settings/reducers/scripts/scripts.js
+++ b/ui/src/app/settings/reducers/scripts/scripts.js
@@ -1,0 +1,30 @@
+import produce from "immer";
+
+const scripts = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case "FETCH_SCRIPTS_START":
+        draft.loading = true;
+        break;
+      case "FETCH_SCRIPTS_SUCCESS":
+        draft.loading = false;
+        draft.loaded = true;
+        draft.items = action.payload;
+        break;
+      case "FETCH_SCRIPTS_ERROR":
+        draft.loading = false;
+        draft.loaded = false;
+        draft.error = action.error;
+        break;
+      default:
+        return draft;
+    }
+  },
+  {
+    loading: false,
+    loaded: false,
+    items: []
+  }
+);
+
+export default scripts;

--- a/ui/src/app/settings/reducers/scripts/scripts.js
+++ b/ui/src/app/settings/reducers/scripts/scripts.js
@@ -23,7 +23,8 @@ const scripts = produce(
   {
     loading: false,
     loaded: false,
-    items: []
+    items: [],
+    error: {}
   }
 );
 

--- a/ui/src/app/settings/reducers/scripts/scripts.test.js
+++ b/ui/src/app/settings/reducers/scripts/scripts.test.js
@@ -3,6 +3,7 @@ import scripts from "./scripts";
 describe("scripts reducer", () => {
   it("should return the initial state", () => {
     expect(scripts(undefined, {})).toEqual({
+      error: {},
       items: [],
       loaded: false,
       loading: false
@@ -15,6 +16,7 @@ describe("scripts reducer", () => {
         type: "FETCH_SCRIPTS_START"
       })
     ).toEqual({
+      error: {},
       items: [],
       loaded: false,
       loading: true

--- a/ui/src/app/settings/reducers/scripts/scripts.test.js
+++ b/ui/src/app/settings/reducers/scripts/scripts.test.js
@@ -1,0 +1,57 @@
+import scripts from "./scripts";
+
+describe("scripts reducer", () => {
+  it("should return the initial state", () => {
+    expect(scripts(undefined, {})).toEqual({
+      items: [],
+      loaded: false,
+      loading: false
+    });
+  });
+
+  it("should correctly reduce FETCH_SCRIPTS_START", () => {
+    expect(
+      scripts(undefined, {
+        type: "FETCH_SCRIPTS_START"
+      })
+    ).toEqual({
+      items: [],
+      loaded: false,
+      loading: true
+    });
+  });
+
+  it("should correctly reduce FETCH_SCRIPTS_ERROR", () => {
+    expect(
+      scripts(undefined, {
+        type: "FETCH_SCRIPTS_ERROR",
+        error: "Unable to fetch scripts"
+      })
+    ).toEqual({
+      items: [],
+      error: "Unable to fetch scripts",
+      loaded: false,
+      loading: false
+    });
+  });
+
+  it("should correctly reduce FETCH_SCRIPTS_SUCCESS", () => {
+    expect(
+      scripts(
+        {
+          items: [],
+          loaded: false,
+          loading: true
+        },
+        {
+          type: "FETCH_SCRIPTS_SUCCESS",
+          payload: [{ name: "script 1" }, { name: "script2" }]
+        }
+      )
+    ).toEqual({
+      items: [{ name: "script 1" }, { name: "script2" }],
+      loaded: true,
+      loading: false
+    });
+  });
+});

--- a/ui/src/app/settings/selectors/scripts/index.js
+++ b/ui/src/app/settings/selectors/scripts/index.js
@@ -1,0 +1,3 @@
+import scripts from "./scripts";
+
+export default scripts;

--- a/ui/src/app/settings/selectors/scripts/scripts.js
+++ b/ui/src/app/settings/selectors/scripts/scripts.js
@@ -1,0 +1,46 @@
+const SCRIPT_TYPES = {
+  COMMISSIONING: 0,
+  TESTING: 2
+};
+
+const scripts = {};
+
+/**
+ * Returns list of all scripts.
+ * @param {Object} state - Redux state
+ * @returns {Array} Scripts
+ */
+scripts.all = state => state.scripts.items;
+
+/**
+ * Returns true if scripts are loading
+ * @param {Object} state - Redux state
+ * @returns {Boolean} Scripts are loading
+ */
+
+scripts.loading = state => state.scripts.loading;
+
+/**
+ * Returns true if scripts have loaded
+ * @param {Object} state - Redux state
+ * @returns {Boolean} Scripts have loaded
+ */
+scripts.loaded = state => state.scripts.loaded;
+
+/**
+ * Returns all commissioning scripts
+ * @param {Object} state - Redux state
+ * @returns {Array} Commissioning scripts
+ */
+scripts.commissioning = state =>
+  state.scripts.items.filter(item => item.type === SCRIPT_TYPES.COMMISSIONING);
+
+/**
+ * Returns all testing scripts
+ * @param {Object} state - Redux state
+ * @returns {Array} Testing scripts
+ */
+scripts.testing = state =>
+  state.scripts.items.filter(item => item.type === SCRIPT_TYPES.TESTING);
+
+export default scripts;

--- a/ui/src/app/settings/selectors/scripts/scripts.test.js
+++ b/ui/src/app/settings/selectors/scripts/scripts.test.js
@@ -1,0 +1,139 @@
+import scripts from "./scripts";
+
+describe("scripts selectors", () => {
+  describe("all", () => {
+    it("returns all scripts", () => {
+      const items = [
+        {
+          name: "commissioning script",
+          description: "a commissioning script",
+          type: 0
+        },
+        {
+          name: "testing script",
+          description: "a testing script",
+          type: 2
+        }
+      ];
+      const state = {
+        scripts: {
+          loading: false,
+          loaded: true,
+          items
+        }
+      };
+
+      expect(scripts.all(state)).toStrictEqual(items);
+    });
+  });
+
+  describe("loading", () => {
+    it("returns scripts loading state", () => {
+      const state = {
+        scripts: {
+          loading: true,
+          loaded: false,
+          items: []
+        }
+      };
+      expect(scripts.loading(state)).toStrictEqual(true);
+    });
+  });
+
+  describe("loaded", () => {
+    it("returns scripts loaded state", () => {
+      const state = {
+        scripts: {
+          loading: false,
+          loaded: true,
+          items: []
+        }
+      };
+      expect(scripts.loaded(state)).toStrictEqual(true);
+    });
+  });
+
+  describe("commissioning", () => {
+    it("returns all commissioning scripts", () => {
+      const items = [
+        {
+          name: "commissioning script",
+          description: "a commissioning script",
+          type: 0
+        },
+        {
+          name: "testing script",
+          description: "a testing script",
+          type: 2
+        },
+        {
+          name: "commissioning script two",
+          description: "another commissioning script",
+          type: 0
+        }
+      ];
+      const state = {
+        scripts: {
+          loading: false,
+          loaded: true,
+          items
+        }
+      };
+
+      expect(scripts.commissioning(state)).toEqual([
+        {
+          name: "commissioning script",
+          description: "a commissioning script",
+          type: 0
+        },
+        {
+          name: "commissioning script two",
+          description: "another commissioning script",
+          type: 0
+        }
+      ]);
+    });
+  });
+
+  describe("testing", () => {
+    it("returns all testing scripts", () => {
+      const items = [
+        {
+          name: "commissioning script",
+          description: "a commissioning script",
+          type: 0
+        },
+        {
+          name: "testing script",
+          description: "a testing script",
+          type: 2
+        },
+        {
+          name: "testing script two",
+          description: "another testing script",
+          type: 2
+        }
+      ];
+      const state = {
+        scripts: {
+          loading: false,
+          loaded: true,
+          items
+        }
+      };
+
+      expect(scripts.testing(state)).toEqual([
+        {
+          name: "testing script",
+          description: "a testing script",
+          type: 2
+        },
+        {
+          name: "testing script two",
+          description: "another testing script",
+          type: 2
+        }
+      ]);
+    });
+  });
+});

--- a/ui/src/app/settings/views/Scripts/Scripts.js
+++ b/ui/src/app/settings/views/Scripts/Scripts.js
@@ -1,5 +1,37 @@
-import React from "react";
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import { useDispatch, useSelector } from "react-redux";
+import actions from "app/settings/actions";
+import scripts from "app/settings/selectors/scripts";
 
-const Scripts = () => <h4>Scripts</h4>;
+const Scripts = ({ type = "commissioning" }) => {
+  const dispatch = useDispatch();
+  const scriptsSelector =
+    type === "commissioning" ? scripts.commissioning : scripts.testing;
+  const userScripts = useSelector(scriptsSelector);
+
+  useEffect(() => {
+    dispatch(actions.scripts.fetch());
+  }, [dispatch]);
+
+  return (
+    <>
+      <h4>
+        <span style={{ textTransform: "capitalize" }}>{type}</span> Scripts
+      </h4>
+      <ul>
+        {userScripts.map(item => (
+          <li key={item.name}>
+            {item.title || item.name} - {item.description}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+Scripts.propTypes = {
+  type: PropTypes.string
+};
 
 export default Scripts;

--- a/ui/src/app/settings/views/Scripts/Scripts.js
+++ b/ui/src/app/settings/views/Scripts/Scripts.js
@@ -12,7 +12,7 @@ const Scripts = ({ type = "commissioning" }) => {
 
   useEffect(() => {
     dispatch(actions.scripts.fetch());
-  }, [dispatch]);
+  }, [dispatch, type]);
 
   return (
     <>

--- a/ui/src/app/settings/views/Scripts/Scripts.test.js
+++ b/ui/src/app/settings/views/Scripts/Scripts.test.js
@@ -1,8 +1,101 @@
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import React from "react";
-import Scripts from "./Scripts";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
-it("works with enzyme", () => {
-  const wrapper = shallow(<Scripts />);
-  expect(wrapper).toMatchSnapshot();
+import Scripts from ".";
+
+const mockStore = configureStore();
+
+describe("Scripts", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      scripts: {
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "commissioning script",
+            description: "a commissioning script",
+            type: 0
+          },
+          {
+            name: "testing script",
+            description: "a testing script",
+            type: 2
+          },
+          {
+            name: "testing script two",
+            description: "another testing script",
+            type: 2
+          }
+        ]
+      }
+    };
+  });
+
+  it("dispatches action to fetch scripts load", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <Scripts />
+      </Provider>
+    );
+
+    expect(store.getActions()).toEqual([
+      {
+        type: "FETCH_SCRIPTS"
+      }
+    ]);
+  });
+
+  it("Displays commissioning scripts by default", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Scripts />
+      </Provider>
+    );
+
+    expect(wrapper.find("ul").children().length).toEqual(1);
+    expect(
+      wrapper
+        .find("ul")
+        .children()
+        .first()
+        .text()
+    ).toEqual("commissioning script - a commissioning script");
+  });
+
+  it("Displays testing scripts", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Scripts type="testing" />
+      </Provider>
+    );
+
+    expect(wrapper.find("ul").children().length).toEqual(2);
+    expect(
+      wrapper
+        .find("ul")
+        .children()
+        .first()
+        .text()
+    ).toEqual("testing script - a testing script");
+    expect(
+      wrapper
+        .find("ul")
+        .children()
+        .at(1)
+        .text()
+    ).toEqual("testing script two - another testing script");
+  });
 });

--- a/ui/src/app/settings/views/Scripts/__snapshots__/Scripts.test.js.snap
+++ b/ui/src/app/settings/views/Scripts/__snapshots__/Scripts.test.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`works with enzyme 1`] = `
-<h4>
-  Scripts
-</h4>
-`;

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -5,7 +5,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import MESSAGE_TYPES from "app/base/constants";
 import { UserForm } from "./UserForm";
 
 jest.mock("uuid/v4", () =>

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -10,10 +10,11 @@ export default history =>
     config: settingsReducers.config,
     dhcpsnippet: settingsReducers.dhcpsnippet,
     general: settingsReducers.general,
-    messages: messages,
+    messages,
     packagerepository: settingsReducers.packagerepository,
     router: connectRouter(history),
-    status: status,
+    scripts: settingsReducers.scripts,
+    status,
     subnet: settingsReducers.subnet,
     user: reduceReducers(settingsReducers.user, auth)
   });

--- a/ui/src/root-saga.js
+++ b/ui/src/root-saga.js
@@ -1,13 +1,7 @@
 import { all } from "redux-saga/effects";
 
-import {
-  watchWebSockets,
-  watchFetchScripts
-} from "./app/base/sagas";
+import { watchWebSockets, watchFetchScripts } from "./app/base/sagas";
 
 export default function* rootSaga() {
-  yield all([
-    watchWebSockets(),
-    watchFetchScripts()
-  ]);
+  yield all([watchWebSockets(), watchFetchScripts()]);
 }

--- a/ui/src/root-saga.js
+++ b/ui/src/root-saga.js
@@ -1,7 +1,13 @@
 import { all } from "redux-saga/effects";
 
-import { watchWebSockets } from "./app/base/sagas";
+import {
+  watchWebSockets,
+  watchFetchScripts
+} from "./app/base/sagas";
 
 export default function* rootSaga() {
-  yield all([watchWebSockets()]);
+  yield all([
+    watchWebSockets(),
+    watchFetchScripts()
+  ]);
 }

--- a/ui/src/setupProxy.js
+++ b/ui/src/setupProxy.js
@@ -1,0 +1,5 @@
+const proxy = require("http-proxy-middleware");
+
+module.exports = function(app) {
+  app.use(proxy("/MAAS/api", { target: process.env.REACT_APP_BASE_URL }));
+};


### PR DESCRIPTION
## Done
* Configure [http-proxy-middleware](https://create-react-app.dev/docs/proxying-api-requests-in-development#configuring-the-proxy-manually) to work around CORS issues when running the dev server.
* Fetch scripts from http API.
* Add basic component, displaying lists of commissioning and testing scripts.

## QA
* Upload a commissioning script if you don't have one from old maas.
* Visit /MAAS/scripts/testing and /MAAS/scripts/commissioning - you should see a list of scripts.
* Confirm that scripts are in state.

### Note
* As this is using the http api, and we have no push updates, the Scripts component deliberately refetches and refreshes scripts on every load.