### PR TITLE
Use takeEvery to handle sending messages

### DIFF
--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -218,6 +218,8 @@ export function* watchWebSockets() {
       let { cancel } = yield race({
         task: all([
           call(handleMessage, socketChannel, socketClient),
+          // Using takeEvery() instead of call() here to get around this issue:
+          // https://github.com/canonical-web-and-design/maas-ui/issues/172
           takeEvery(
             action => isWebsocketRequestAction(action),
             sendMessage,

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
@@ -1,6 +1,6 @@
 import { format, parse } from "date-fns";
 import { Link } from "react-router-dom";
-import { shallowEqual, useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
@@ -195,12 +195,8 @@ const DhcpList = ({ initialCount = 20 }) => {
   const [itemsPerPage] = useState(initialCount);
   const dhcpsnippetLoading = useSelector(selectors.dhcpsnippet.loading);
   const dhcpsnippetLoaded = useSelector(selectors.dhcpsnippet.loaded);
-  const dhcpsnippets = useSelector(
-    state => selectors.dhcpsnippet.search(state, searchText),
-    // Without this method of the comparing the state then the dispatches are
-    // not received by the websocket saga. See:
-    // https://github.com/canonical-web-and-design/maas-ui/issues/172
-    shallowEqual
+  const dhcpsnippets = useSelector(state =>
+    selectors.dhcpsnippet.search(state, searchText)
   );
   const dhcpsnippetCount = useSelector(selectors.dhcpsnippet.count);
   const subnets = useSelector(selectors.subnet.all);


### PR DESCRIPTION
Done:
- Updated the websocket saga to prevent rogue useSelector calls to prevent actions from being taken. This may not be the proper fix, but should get things working for now. See: https://github.com/canonical-web-and-design/maas-ui/issues/172. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/177

QA:
- Open DhcpList.js and add `const blocking = useSelector(state => []);` somewhere near the top.
- Loading /dhcp should display the list of DHCP snippets.