### PR TITLE
Delete dhcp

### DIFF
--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import Button from "app/base/components/Button";
+import Col from "app/base/components/Col";
+import Row from "app/base/components/Row";
+
+const TableDeleteConfirm = ({ modelName, modelType, onCancel, onConfirm }) => {
+  return (
+    <Row>
+      <Col size="7">
+        Are you sure you want to delete {modelType} "{modelName}"?{" "}
+        <span className="u-text--light">
+          This action is permanent and can not be undone.
+        </span>
+      </Col>
+      <Col size="3" className="u-align--right">
+        <Button onClick={onCancel}>Cancel</Button>
+        <Button appearance="negative" onClick={onConfirm}>
+          Delete
+        </Button>
+      </Col>
+    </Row>
+  );
+};
+
+TableDeleteConfirm.propTypes = {
+  modelName: PropTypes.string,
+  modelType: PropTypes.string,
+  onCancel: PropTypes.func,
+  onConfirm: PropTypes.func
+};
+
+export default TableDeleteConfirm;

--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.test.js
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.test.js
@@ -1,0 +1,18 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import TableDeleteConfirm from "./TableDeleteConfirm";
+
+describe("TableDeleteConfirm", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <TableDeleteConfirm
+        modelName="Cobba"
+        modelType="user"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
+++ b/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableDeleteConfirm renders 1`] = `
+<Row>
+  <Col
+    size="7"
+  >
+    Are you sure you want to delete 
+    user
+     "
+    Cobba
+    "?
+     
+    <span
+      className="u-text--light"
+    >
+      This action is permanent and can not be undone.
+    </span>
+  </Col>
+  <Col
+    className="u-align--right"
+    size="3"
+  >
+    <Button
+      onClick={[MockFunction]}
+    >
+      Cancel
+    </Button>
+    <Button
+      appearance="negative"
+      onClick={[MockFunction]}
+    >
+      Delete
+    </Button>
+  </Col>
+</Row>
+`;

--- a/ui/src/app/base/components/TableDeleteConfirm/index.js
+++ b/ui/src/app/base/components/TableDeleteConfirm/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TableDeleteConfirm";

--- a/ui/src/app/settings/actions/dhcpsnippet.js
+++ b/ui/src/app/settings/actions/dhcpsnippet.js
@@ -10,4 +10,25 @@ dhcpsnippet.fetch = () => {
   };
 };
 
+dhcpsnippet.delete = id => {
+  return {
+    type: "DELETE_DHCPSNIPPET",
+    meta: {
+      model: "dhcpsnippet",
+      method: "delete"
+    },
+    payload: {
+      params: {
+        id
+      }
+    }
+  };
+};
+
+dhcpsnippet.cleanup = () => {
+  return {
+    type: "CLEANUP_DHCPSNIPPET"
+  };
+};
+
 export default dhcpsnippet;

--- a/ui/src/app/settings/actions/dhcpsnippet.test.js
+++ b/ui/src/app/settings/actions/dhcpsnippet.test.js
@@ -10,4 +10,25 @@ describe("dhcpsnippet actions", () => {
       }
     });
   });
+
+  it("can handle deleting dhcp snippets", () => {
+    expect(dhcpsnippet.delete(808)).toEqual({
+      type: "DELETE_DHCPSNIPPET",
+      meta: {
+        model: "dhcpsnippet",
+        method: "delete"
+      },
+      payload: {
+        params: {
+          id: 808
+        }
+      }
+    });
+  });
+
+  it("can handle cleaning dhcp snippets", () => {
+    expect(dhcpsnippet.cleanup({ name: "kookaburra" })).toEqual({
+      type: "CLEANUP_DHCPSNIPPET"
+    });
+  });
 });

--- a/ui/src/app/settings/reducers/dhcpsnippet.js
+++ b/ui/src/app/settings/reducers/dhcpsnippet.js
@@ -11,14 +11,39 @@ const dhcpsnippet = produce(
         draft.loaded = true;
         draft.items = action.payload;
         break;
+      case "DELETE_DHCPSNIPPET_START":
+        draft.saved = false;
+        draft.saving = true;
+        break;
+      case "DELETE_DHCPSNIPPET_ERROR":
+        draft.errors = action.error;
+        draft.saving = false;
+        break;
+      case "DELETE_DHCPSNIPPET_SUCCESS":
+        draft.errors = {};
+        draft.saved = true;
+        draft.saving = false;
+        break;
+      case "DELETE_DHCPSNIPPET_NOTIFY":
+        const index = draft.items.findIndex(item => item.id === action.payload);
+        draft.items.splice(index, 1);
+        break;
+      case "CLEANUP_DHCPSNIPPET":
+        draft.errors = {};
+        draft.saved = false;
+        draft.saving = false;
+        break;
       default:
         return draft;
     }
   },
   {
+    errors: {},
     items: [],
     loaded: false,
-    loading: false
+    loading: false,
+    saved: false,
+    saving: false
   }
 );
 

--- a/ui/src/app/settings/reducers/dhcpsnippet.test.js
+++ b/ui/src/app/settings/reducers/dhcpsnippet.test.js
@@ -3,9 +3,12 @@ import dhcpsnippet from "./dhcpsnippet";
 describe("dhcpsnippet reducer", () => {
   it("should return the initial state", () => {
     expect(dhcpsnippet(undefined, {})).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -15,9 +18,12 @@ describe("dhcpsnippet reducer", () => {
         type: "FETCH_DHCPSNIPPET_START"
       })
     ).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -25,9 +31,12 @@ describe("dhcpsnippet reducer", () => {
     expect(
       dhcpsnippet(
         {
+          errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_DHCPSNIPPET_SUCCESS",
@@ -35,9 +44,114 @@ describe("dhcpsnippet reducer", () => {
         }
       )
     ).toEqual({
+      errors: {},
+      items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }],
       loading: false,
       loaded: true,
-      items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }]
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_DHCPSNIPPET_START", () => {
+    expect(
+      dhcpsnippet(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false
+        },
+        {
+          type: "DELETE_DHCPSNIPPET_START"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce DELETE_DHCPSNIPPET_ERROR", () => {
+    expect(
+      dhcpsnippet(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: "Could not delete",
+          type: "DELETE_DHCPSNIPPET_ERROR"
+        }
+      )
+    ).toEqual({
+      errors: "Could not delete",
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_DHCPSNIPPET_NOTIFY", () => {
+    expect(
+      dhcpsnippet(
+        {
+          errors: {},
+          items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          payload: 2,
+          type: "DELETE_DHCPSNIPPET_NOTIFY"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, name: "class" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CLEANUP_DHCPSNIPPET", () => {
+    expect(
+      dhcpsnippet(
+        {
+          errors: { name: "Name not provided" },
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: true
+        },
+        {
+          type: "CLEANUP_DHCPSNIPPET"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/settings/selectors/dhcpsnippet.js
+++ b/ui/src/app/settings/selectors/dhcpsnippet.js
@@ -41,4 +41,25 @@ dhcpsnippet.loading = state => state.dhcpsnippet.loading;
  */
 dhcpsnippet.loaded = state => state.dhcpsnippet.loaded;
 
+/**
+ * Returns dhcp snippets errors.
+ * @param {Object} state - The redux state.
+ * @returns {Object} Errors for a dhcp snippet.
+ */
+dhcpsnippet.errors = state => state.dhcpsnippet.errors;
+
+/**
+ * Get the saving state.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether dhcp snippets are being saved.
+ */
+dhcpsnippet.saving = state => state.dhcpsnippet.saving;
+
+/**
+ * Get the saved state.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether dhcp snippets have been saved.
+ */
+dhcpsnippet.saved = state => state.dhcpsnippet.saved;
+
 export default dhcpsnippet;

--- a/ui/src/app/settings/selectors/dhcpsnippet.test.js
+++ b/ui/src/app/settings/selectors/dhcpsnippet.test.js
@@ -70,4 +70,36 @@ describe("dhcpsnippet selectors", () => {
     };
     expect(dhcpsnippet.count(state)).toEqual(2);
   });
+
+  it("can get the saving state", () => {
+    const state = {
+      dhcpsnippet: {
+        saving: true,
+        items: []
+      }
+    };
+    expect(dhcpsnippet.saving(state)).toEqual(true);
+  });
+
+  it("can get the saved state", () => {
+    const state = {
+      dhcpsnippet: {
+        saved: true,
+        items: []
+      }
+    };
+    expect(dhcpsnippet.saved(state)).toEqual(true);
+  });
+
+  it("can get errors", () => {
+    const state = {
+      dhcpsnippet: {
+        errors: { name: "Name not provided" },
+        items: []
+      }
+    };
+    expect(dhcpsnippet.errors(state)).toStrictEqual({
+      name: "Name not provided"
+    });
+  });
 });

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
@@ -28,6 +28,7 @@ import Pagination from "app/base/components/Pagination";
 import Row from "app/base/components/Row";
 import SearchBox from "app/base/components/SearchBox";
 import selectors from "app/settings/selectors";
+import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 const getTargetName = (
   controllers,
@@ -151,27 +152,16 @@ const generateRows = (
       expandedContent:
         expanded &&
         (showDelete ? (
-          <Row>
-            <Col size="7">
-              Are you sure you want to delete DHCP snippet "{dhcpsnippet.name}"?{" "}
-              <span className="u-text--light">
-                This action is permanent and can not be undone.
-              </span>
-            </Col>
-            <Col size="3" className="u-align--right">
-              <Button onClick={hideExpanded}>Cancel</Button>
-              <Button
-                appearance="negative"
-                onClick={() => {
-                  dispatch(actions.dhcpsnippet.delete(dhcpsnippet.id));
-                  setDeleting(dhcpsnippet.name);
-                  hideExpanded();
-                }}
-              >
-                Delete
-              </Button>
-            </Col>
-          </Row>
+          <TableDeleteConfirm
+            modelName={dhcpsnippet.name}
+            modelType="DHCP snippet"
+            onCancel={hideExpanded}
+            onConfirm={() => {
+              dispatch(actions.dhcpsnippet.delete(dhcpsnippet.id));
+              setDeleting(dhcpsnippet.name);
+              hideExpanded();
+            }}
+          />
         ) : (
           <Row>
             <Col size="10">

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
@@ -116,6 +116,74 @@ describe("DhcpList", () => {
     expect(row.expanded).toBe(true);
   });
 
+  it("can delete a dhcp snippet", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <DhcpList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click on the delete button:
+    wrapper
+      .find("TableRow")
+      .at(2)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .simulate("click");
+    // Click on the delete confirm button
+    wrapper
+      .find("TableRow")
+      .at(2)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .last()
+      .simulate("click");
+    expect(
+      store.getActions().find(action => action.type === "DELETE_DHCPSNIPPET")
+    ).toEqual({
+      type: "DELETE_DHCPSNIPPET",
+      payload: {
+        params: {
+          id: 2
+        }
+      },
+      meta: {
+        model: "dhcpsnippet",
+        method: "delete"
+      }
+    });
+  });
+
+  it("can add a message when a dhcp snippet is deleted", () => {
+    state.dhcpsnippet.saved = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <DhcpList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click on the delete button:
+    wrapper
+      .find("TableRow")
+      .at(2)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .simulate("click");
+    // Click on the delete confirm button
+    wrapper
+      .find("TableRow")
+      .at(2)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .last()
+      .simulate("click");
+    const actions = store.getActions();
+    expect(actions.some(action => action.type === "CLEANUP_DHCPSNIPPET")).toBe(
+      true
+    );
+    expect(actions.some(action => action.type === "ADD_MESSAGE")).toBe(true);
+  });
+
   it("can show snippet details", () => {
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
@@ -8,12 +8,11 @@ import { getRepoDisplayName } from "../utils";
 import { messages } from "app/base/actions";
 import selectors from "app/settings/selectors";
 import Button from "app/base/components/Button";
-import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
 import MainTable from "app/base/components/MainTable";
 import Pagination from "app/base/components/Pagination";
-import Row from "app/base/components/Row";
 import SearchBox from "app/base/components/SearchBox";
+import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 const generateRepositoryRows = (
   dispatch,
@@ -71,27 +70,16 @@ const generateRepositoryRows = (
       ],
       expanded: expanded,
       expandedContent: expanded && (
-        <Row>
-          <Col size="7">
-            Are you sure you want to delete repository "{repo.name}"?{" "}
-            <span className="u-text--light">
-              This action is permanent and can not be undone.
-            </span>
-          </Col>
-          <Col size="3" className="u-align--right">
-            <Button onClick={() => setExpandedId()}>Cancel</Button>
-            <Button
-              appearance="negative"
-              onClick={() => {
-                dispatch(actions.repositories.delete(repo.id));
-                setDeletedRepo(repo.name);
-                setExpandedId();
-              }}
-            >
-              Delete
-            </Button>
-          </Col>
-        </Row>
+        <TableDeleteConfirm
+          modelName={repo.name}
+          modelType="repository"
+          onCancel={setExpandedId}
+          onConfirm={() => {
+            dispatch(actions.repositories.delete(repo.id));
+            setDeletedRepo(repo.name);
+            setExpandedId();
+          }}
+        />
       ),
       key: repo.id,
       sortData: {

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.js
@@ -11,12 +11,11 @@ import actions from "app/settings/actions";
 import selectors from "app/settings/selectors";
 import { auth } from "app/base/selectors";
 import Button from "app/base/components/Button";
-import Col from "app/base/components/Col";
 import Loader from "app/base/components/Loader";
 import Pagination from "app/base/components/Pagination";
 import MainTable from "app/base/components/MainTable";
-import Row from "app/base/components/Row";
 import SearchBox from "app/base/components/SearchBox";
+import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 const generateUserRows = (
   users,
@@ -91,27 +90,16 @@ const generateUserRows = (
       ],
       expanded: expanded,
       expandedContent: expanded && (
-        <Row>
-          <Col size="7">
-            Are you sure you want to delete user "{user.username}"?{" "}
-            <span className="u-text--light">
-              This action is permanent and can not be undone.
-            </span>
-          </Col>
-          <Col size="3" className="u-align--right">
-            <Button onClick={() => setExpandedId()}>Cancel</Button>
-            <Button
-              appearance="negative"
-              onClick={() => {
-                dispatch(actions.users.delete(user.id));
-                setDeleting(user.username);
-                setExpandedId();
-              }}
-            >
-              Delete
-            </Button>
-          </Col>
-        </Row>
+        <TableDeleteConfirm
+          modelName={user.username}
+          modelType="user"
+          onCancel={setExpandedId}
+          onConfirm={() => {
+            dispatch(actions.users.delete(user.id));
+            setDeleting(user.username);
+            setExpandedId();
+          }}
+        />
       ),
       key: user.username,
       sortData: {


### PR DESCRIPTION
Done:
- Added deleting DHCP snippets from the list. Fixes: #77.
- Move the delete confirmation to a reusable component.

QA:
- Open the dhcp list.
- Click delete and confirm.
- The snippet should be removed from the list and a message should appear.