### PR TITLE
Use reconnecting-websocket.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "react-router-hash-link": "1.2.2",
     "react-router-prop-types": "1.0.4",
     "react-scripts": "3.1.1",
+    "reconnecting-websocket": "4.2.0",
     "reduce-reducers": "1.0.4",
     "redux": "4.0.4",
     "redux-devtools-extension": "2.13.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,6 +61,7 @@
     "enzyme-to-json": "3.4.0",
     "eslint-plugin-no-only-tests": "2.3.1",
     "eslint-plugin-prettier": "3.1.0",
+    "mock-socket": "9.0.0",
     "node-sass": "4.12.0",
     "prettier": "1.18.2",
     "react-styleguidist": "9.1.16",

--- a/ui/src/websocket-client.js
+++ b/ui/src/websocket-client.js
@@ -1,6 +1,8 @@
+import ReconnectingWebSocket from "reconnecting-websocket";
+
 class WebSocketClient {
   constructor(websocket_url) {
-    this.socket = new WebSocket(websocket_url);
+    this.socket = new ReconnectingWebSocket(websocket_url);
     this._nextId = 0;
     this._requests = new Map();
   }

--- a/ui/src/websocket-client.test.js
+++ b/ui/src/websocket-client.test.js
@@ -5,7 +5,7 @@ describe("websocket client", () => {
   let client, windowWebsocket;
 
   beforeAll(() => {
-    windowWebsocket = WebSocket;
+    windowWebsocket = window.WebSocket;
   });
 
   beforeEach(() => {

--- a/ui/src/websocket-client.test.js
+++ b/ui/src/websocket-client.test.js
@@ -1,21 +1,17 @@
 import WebSocketClient from "./websocket-client";
-
-class MockSocket {
-  constructor() {
-    this.send = jest.fn();
-  }
-}
+import { WebSocket } from "mock-socket";
 
 describe("websocket client", () => {
   let client, windowWebsocket;
 
   beforeAll(() => {
-    windowWebsocket = window.WebSocket;
+    windowWebsocket = WebSocket;
   });
 
   beforeEach(() => {
-    window.WebSocket = MockSocket;
+    window.WebSocket = WebSocket;
     client = new WebSocketClient("ws://example.com/ws");
+    client.socket.send = jest.fn();
   });
 
   afterAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7436,6 +7436,13 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
+mock-socket@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/mock-socket/-/mock-socket-9.0.0.tgz#2ac6b652aff10bb82d41aed4a36165c017b7ebf1"
+  integrity sha512-8Q3y/chmcYRJ6oxhAO9QJwSr6ZWU2zuzD0A7tHa0HOyL83nInIqimFWuke7936IYjEuhBaOrruV+aemlB1f+aA==
+  dependencies:
+    url-parse "^1.4.4"
+
 moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
@@ -11663,7 +11670,7 @@ url-loader@2.1.0:
     mime "^2.4.4"
     schema-utils "^2.0.0"
 
-url-parse@^1.4.3:
+url-parse@^1.4.3, url-parse@^1.4.4:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9799,6 +9799,11 @@ recast@^0.17.3, recast@^0.17.4:
     private "^0.1.8"
     source-map "~0.6.1"
 
+reconnecting-websocket@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-4.2.0.tgz#2395f84b5d0acee439ff5df34c3fd0853d11be7c"
+  integrity sha512-HMD8A0sv40xhkHf/T4qxktyOvHx7K3d2A9i1QG2wRIYdMecxQJMhTIBH4aQ8KfQLfQW4UOqNSfxTgv0C+MbPIA==
+
 recursive-readdir@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"


### PR DESCRIPTION
## Done
* Use reconnecting-websocket with defaults.
* Use `mock-socket` in websocket-client tests as ReconnectingWebsocket requires a mock implementation closer to a real WebSocket. (Tests fail with "No valid WebSocket class provided" otherwise).

## QA
* Ensure the app still works (data is fetched, updated, deleted etc).
* Not strictly necessary, but if you'd like to see the library in action:

In websocket-client.js replace:

` this.socket = new ReconnectingWebSocket(websocket_url);`

with:

`this.socket = new ReconnectingWebSocket(websocket_url, [], {debug: true});`

Restart MAAS server, and watch the websocket disconnect, and then reconnect once it is back up.