### PR TITLE
Add DHCP snippet add/edit views

### DIFF
--- a/ui/src/app/base/components/FormCard/FormCard.js
+++ b/ui/src/app/base/components/FormCard/FormCard.js
@@ -21,7 +21,7 @@ export const FormCard = ({ children, title }) => {
 
 FormCard.propTypes = {
   children: PropTypes.node,
-  title: PropTypes.string.isRequired
+  title: PropTypes.node.isRequired
 };
 
 export default FormCard;

--- a/ui/src/app/base/components/Textarea/Textarea.js
+++ b/ui/src/app/base/components/Textarea/Textarea.js
@@ -8,11 +8,14 @@ const Textarea = ({
   caution,
   className,
   error,
+  grow,
   help,
   id,
   label,
+  onKeyUp,
   required,
   stacked,
+  style,
   success,
   ...props
 }) => {
@@ -30,6 +33,21 @@ const Textarea = ({
       <textarea
         className={classNames("p-form-validation__input", className)}
         id={id}
+        onKeyUp={evt => {
+          if (grow) {
+            evt.currentTarget.style.height =
+              evt.currentTarget.scrollHeight + "px";
+          }
+        }}
+        style={
+          grow && {
+            minHeight: "5rem",
+            resize: "none",
+            overflow: "hidden",
+            boxSizing: "border-box",
+            ...style
+          }
+        }
         {...props}
       />
     </Field>
@@ -40,11 +58,14 @@ Textarea.propTypes = {
   caution: PropTypes.string,
   className: PropTypes.string,
   error: PropTypes.string,
+  grow: PropTypes.bool,
   help: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,
+  onKeyUp: PropTypes.func,
   required: PropTypes.bool,
   stacked: PropTypes.bool,
+  style: PropTypes.object,
   success: PropTypes.string
 };
 

--- a/ui/src/app/base/components/Textarea/__snapshots__/Textarea.test.js.snap
+++ b/ui/src/app/base/components/Textarea/__snapshots__/Textarea.test.js.snap
@@ -7,6 +7,7 @@ exports[`Textarea  renders 1`] = `
   <textarea
     className="p-form-validation__input"
     id="test-id"
+    onKeyUp={[Function]}
   />
 </Field>
 `;

--- a/ui/src/app/settings/actions/dhcpsnippet.js
+++ b/ui/src/app/settings/actions/dhcpsnippet.js
@@ -10,6 +10,32 @@ dhcpsnippet.fetch = () => {
   };
 };
 
+dhcpsnippet.create = params => {
+  return {
+    type: "CREATE_DHCPSNIPPET",
+    meta: {
+      model: "dhcpsnippet",
+      method: "create"
+    },
+    payload: {
+      params
+    }
+  };
+};
+
+dhcpsnippet.update = params => {
+  return {
+    type: "UPDATE_DHCPSNIPPET",
+    meta: {
+      model: "dhcpsnippet",
+      method: "update"
+    },
+    payload: {
+      params
+    }
+  };
+};
+
 dhcpsnippet.delete = id => {
   return {
     type: "DELETE_DHCPSNIPPET",

--- a/ui/src/app/settings/actions/dhcpsnippet.test.js
+++ b/ui/src/app/settings/actions/dhcpsnippet.test.js
@@ -11,6 +11,36 @@ describe("dhcpsnippet actions", () => {
     });
   });
 
+  it("can handle creating dhcp snippets", () => {
+    expect(dhcpsnippet.create({ name: "kangaroo" })).toEqual({
+      type: "CREATE_DHCPSNIPPET",
+      meta: {
+        model: "dhcpsnippet",
+        method: "create"
+      },
+      payload: {
+        params: {
+          name: "kangaroo"
+        }
+      }
+    });
+  });
+
+  it("can handle updating dhcp snippets", () => {
+    expect(dhcpsnippet.update({ name: "kookaburra" })).toEqual({
+      type: "UPDATE_DHCPSNIPPET",
+      meta: {
+        model: "dhcpsnippet",
+        method: "update"
+      },
+      payload: {
+        params: {
+          name: "kookaburra"
+        }
+      }
+    });
+  });
+
   it("can handle deleting dhcp snippets", () => {
     expect(dhcpsnippet.delete(808)).toEqual({
       type: "DELETE_DHCPSNIPPET",

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -3,6 +3,8 @@ import { Route, Redirect, Switch } from "react-router-dom";
 
 import Commissioning from "app/settings/views/Configuration/Commissioning";
 import Deploy from "app/settings/views/Configuration/Deploy";
+import DhcpAdd from "app/settings/views/Dhcp/DhcpAdd";
+import DhcpEdit from "app/settings/views/Dhcp/DhcpEdit";
 import DhcpList from "app/settings/views/Dhcp/DhcpList";
 import DnsForm from "app/settings/views/Network/DnsForm";
 import General from "app/settings/views/Configuration/General";
@@ -64,6 +66,8 @@ const Routes = () => (
       render={props => <ScriptsList {...props} type="testing" />}
     />
     <Route exact path="/dhcp" component={DhcpList} />
+    <Route exact path="/dhcp/add" component={DhcpAdd} />
+    <Route exact path="/dhcp/:id/edit" component={DhcpEdit} />
     <Route exact path="/repositories" component={RepositoriesList} />
     <Route exact path="/repositories/add/:type" component={RepositoryAdd} />
     <Route

--- a/ui/src/app/settings/hooks.js
+++ b/ui/src/app/settings/hooks.js
@@ -1,0 +1,48 @@
+import { useSelector } from "react-redux";
+
+import {
+  controller as controllerSelectors,
+  device as deviceSelectors,
+  machine as machineSelectors
+} from "app/base/selectors";
+import selectors from "app/settings/selectors";
+
+export const useDhcpTarget = (nodeId, subnetId) => {
+  const subnetLoading = useSelector(selectors.subnet.loading);
+  const subnetLoaded = useSelector(selectors.subnet.loaded);
+  const subnet = useSelector(state =>
+    selectors.subnet.getById(state, subnetId)
+  );
+  const controllerLoading = useSelector(controllerSelectors.loading);
+  const controllerLoaded = useSelector(controllerSelectors.loaded);
+  const controller = useSelector(state =>
+    controllerSelectors.getBySystemId(state, nodeId)
+  );
+  const deviceLoading = useSelector(deviceSelectors.loading);
+  const deviceLoaded = useSelector(deviceSelectors.loaded);
+  const device = useSelector(state =>
+    deviceSelectors.getBySystemId(state, nodeId)
+  );
+  const machineLoading = useSelector(machineSelectors.loading);
+  const machineLoaded = useSelector(machineSelectors.loaded);
+  const machine = useSelector(state =>
+    machineSelectors.getBySystemId(state, nodeId)
+  );
+  const isLoading =
+    (subnetId && subnetLoading) ||
+    (nodeId && (controllerLoading || deviceLoading || machineLoading));
+  const hasLoaded =
+    (subnetId && subnetLoaded) ||
+    (nodeId && controllerLoaded && deviceLoaded && machineLoaded);
+
+  return {
+    loading: isLoading,
+    loaded: hasLoaded,
+    target: subnet || machine || device || controller,
+    type:
+      (subnet && "subnet") ||
+      (controller && "controller") ||
+      (device && "device") ||
+      (machine && "machine")
+  };
+};

--- a/ui/src/app/settings/proptypes.js
+++ b/ui/src/app/settings/proptypes.js
@@ -37,3 +37,16 @@ export const extendFormikShape = values => {
     })
   };
 };
+
+export const DhcpSnippetShape = PropTypes.shape({
+  created: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  enabled: PropTypes.bool,
+  history: PropTypes.arrayOf(PropTypes.object),
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  node: PropTypes.string,
+  subnet: PropTypes.number,
+  updated: PropTypes.string.isRequired,
+  value: PropTypes.string
+});

--- a/ui/src/app/settings/reducers/dhcpsnippet.js
+++ b/ui/src/app/settings/reducers/dhcpsnippet.js
@@ -11,18 +11,35 @@ const dhcpsnippet = produce(
         draft.loaded = true;
         draft.items = action.payload;
         break;
+      case "UPDATE_DHCPSNIPPET_START":
+      case "CREATE_DHCPSNIPPET_START":
       case "DELETE_DHCPSNIPPET_START":
         draft.saved = false;
         draft.saving = true;
         break;
+      case "UPDATE_DHCPSNIPPET_ERROR":
+      case "CREATE_DHCPSNIPPET_ERROR":
       case "DELETE_DHCPSNIPPET_ERROR":
         draft.errors = action.error;
         draft.saving = false;
         break;
+      case "UPDATE_DHCPSNIPPET_SUCCESS":
+      case "CREATE_DHCPSNIPPET_SUCCESS":
       case "DELETE_DHCPSNIPPET_SUCCESS":
         draft.errors = {};
         draft.saved = true;
         draft.saving = false;
+        break;
+      case "UPDATE_DHCPSNIPPET_NOTIFY":
+        for (let i in draft.items) {
+          if (draft.items[i].id === action.payload.id) {
+            draft.items[i] = action.payload;
+            break;
+          }
+        }
+        break;
+      case "CREATE_DHCPSNIPPET_NOTIFY":
+        draft.items.push(action.payload);
         break;
       case "DELETE_DHCPSNIPPET_NOTIFY":
         const index = draft.items.findIndex(item => item.id === action.payload);

--- a/ui/src/app/settings/reducers/dhcpsnippet.test.js
+++ b/ui/src/app/settings/reducers/dhcpsnippet.test.js
@@ -53,6 +53,60 @@ describe("dhcpsnippet reducer", () => {
     });
   });
 
+  it("should correctly reduce UPDATE_DHCPSNIPPET_START", () => {
+    expect(
+      dhcpsnippet(
+        {
+          auth: {},
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false
+        },
+        {
+          type: "UPDATE_DHCPSNIPPET_START"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce CREATE_DHCPSNIPPET_START", () => {
+    expect(
+      dhcpsnippet(
+        {
+          auth: {},
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false
+        },
+        {
+          type: "CREATE_DHCPSNIPPET_START"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
   it("should correctly reduce DELETE_DHCPSNIPPET_START", () => {
     expect(
       dhcpsnippet(
@@ -78,6 +132,62 @@ describe("dhcpsnippet reducer", () => {
     });
   });
 
+  it("should correctly reduce UPDATE_DHCPSNIPPET_ERROR", () => {
+    expect(
+      dhcpsnippet(
+        {
+          auth: {},
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: { name: "Name not provided" },
+          type: "UPDATE_DHCPSNIPPET_ERROR"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: { name: "Name not provided" },
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CREATE_DHCPSNIPPET_ERROR", () => {
+    expect(
+      dhcpsnippet(
+        {
+          auth: {},
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: { name: "Name not provided" },
+          type: "CREATE_DHCPSNIPPET_ERROR"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: { name: "Name not provided" },
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
   it("should correctly reduce DELETE_DHCPSNIPPET_ERROR", () => {
     expect(
       dhcpsnippet(
@@ -97,6 +207,143 @@ describe("dhcpsnippet reducer", () => {
     ).toEqual({
       errors: "Could not delete",
       items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce UPDATE_DHCPSNIPPET_SUCCESS", () => {
+    expect(
+      dhcpsnippet(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: true,
+          saved: false,
+          saving: false
+        },
+        {
+          type: "FETCH_DHCPSNIPPET_SUCCESS",
+          payload: [{ id: 1, name: "class" }, { id: 2, name: "lease" }]
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }],
+      loading: false,
+      loaded: true,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CREATE_DHCPSNIPPET_SUCCESS", () => {
+    expect(
+      dhcpsnippet(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: true,
+          saved: false,
+          saving: false
+        },
+        {
+          type: "FETCH_DHCPSNIPPET_SUCCESS",
+          payload: [{ id: 1, name: "class" }, { id: 2, name: "lease" }]
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }],
+      loading: false,
+      loaded: true,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_DHCPSNIPPET_SUCCESS", () => {
+    expect(
+      dhcpsnippet(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: true,
+          saved: false,
+          saving: false
+        },
+        {
+          type: "FETCH_DHCPSNIPPET_SUCCESS",
+          payload: [{ id: 1, name: "class" }, { id: 2, name: "lease" }]
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }],
+      loading: false,
+      loaded: true,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce UPDATE_DHCPSNIPPET_NOTIFY", () => {
+    expect(
+      dhcpsnippet(
+        {
+          auth: {},
+          errors: {},
+          items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          payload: {
+            id: 1,
+            name: "class2"
+          },
+          type: "UPDATE_DHCPSNIPPET_NOTIFY"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: {},
+      items: [{ id: 1, name: "class2" }, { id: 2, name: "lease" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CREATE_DHCPSNIPPET_NOTIFY", () => {
+    expect(
+      dhcpsnippet(
+        {
+          auth: {},
+          errors: {},
+          items: [{ id: 1, name: "class" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          payload: { id: 2, name: "lease" },
+          type: "CREATE_DHCPSNIPPET_NOTIFY"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: {},
+      items: [{ id: 1, name: "class" }, { id: 2, name: "lease" }],
       loaded: false,
       loading: false,
       saved: false,

--- a/ui/src/app/settings/selectors/dhcpsnippet.js
+++ b/ui/src/app/settings/selectors/dhcpsnippet.js
@@ -62,4 +62,12 @@ dhcpsnippet.saving = state => state.dhcpsnippet.saving;
  */
 dhcpsnippet.saved = state => state.dhcpsnippet.saved;
 
+/**
+ * Returns a dhcp snippet for the given id.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A dhcp snippet.
+ */
+dhcpsnippet.getById = (state, id) =>
+  state.dhcpsnippet.items.find(dhcpsnippet => dhcpsnippet.id === id);
+
 export default dhcpsnippet;

--- a/ui/src/app/settings/selectors/dhcpsnippet.test.js
+++ b/ui/src/app/settings/selectors/dhcpsnippet.test.js
@@ -102,4 +102,17 @@ describe("dhcpsnippet selectors", () => {
       name: "Name not provided"
     });
   });
+
+  it("can get a dhcp snippet by id", () => {
+    const state = {
+      dhcpsnippet: {
+        loading: true,
+        items: [{ name: "class", id: 808 }, { name: "lease", id: 909 }]
+      }
+    };
+    expect(dhcpsnippet.getById(state, 909)).toStrictEqual({
+      name: "lease",
+      id: 909
+    });
+  });
 });

--- a/ui/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+import DhcpForm from "../DhcpForm";
+
+export const DhcpAdd = () => {
+  return <DhcpForm />;
+};
+
+export default DhcpAdd;

--- a/ui/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.test.js
@@ -1,0 +1,11 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import { DhcpAdd } from "./DhcpAdd";
+
+describe("DhcpAdd", () => {
+  it("can render", () => {
+    const wrapper = shallow(<DhcpAdd />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/settings/views/Dhcp/DhcpAdd/__snapshots__/DhcpAdd.test.js.snap
+++ b/ui/src/app/settings/views/Dhcp/DhcpAdd/__snapshots__/DhcpAdd.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DhcpAdd can render 1`] = `<DhcpForm />`;

--- a/ui/src/app/settings/views/Dhcp/DhcpAdd/index.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpAdd/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DhcpAdd";

--- a/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.js
@@ -1,0 +1,31 @@
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect } from "react";
+
+import { useParams } from "app/base/hooks";
+import actions from "app/settings/actions";
+import Loader from "app/base/components/Loader";
+import selectors from "app/settings/selectors";
+import DhcpForm from "../DhcpForm";
+
+export const DhcpEdit = () => {
+  const dispatch = useDispatch();
+  const { id } = useParams();
+  const loading = useSelector(selectors.dhcpsnippet.loading);
+  const dhcpsnippet = useSelector(state =>
+    selectors.dhcpsnippet.getById(state, parseInt(id))
+  );
+
+  useEffect(() => {
+    dispatch(actions.dhcpsnippet.fetch());
+  }, [dispatch]);
+
+  if (loading) {
+    return <Loader text="Loading..." />;
+  }
+  if (!dhcpsnippet) {
+    return <h4>DHCP snippet not found</h4>;
+  }
+  return <DhcpForm dhcpSnippet={dhcpsnippet} />;
+};
+
+export default DhcpEdit;

--- a/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.js
@@ -1,0 +1,100 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { MemoryRouter, Route } from "react-router-dom";
+
+import { DhcpEdit } from "./DhcpEdit";
+
+const mockStore = configureStore();
+
+describe("DhcpEdit", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      controller: { items: [] },
+      device: { items: [] },
+      dhcpsnippet: {
+        errors: {},
+        items: [
+          {
+            created: "Thu, 15 Aug. 2019 06:21:39",
+            id: 1,
+            name: "lease",
+            updated: "Thu, 15 Aug. 2019 06:21:39",
+            value: "lease 10"
+          },
+          {
+            created: "Thu, 15 Aug. 2019 06:21:39",
+            id: 2,
+            name: "class",
+            updated: "Thu, 15 Aug. 2019 06:21:39"
+          }
+        ],
+        loaded: true,
+        loading: false,
+        saving: false,
+        saved: false
+      },
+      machine: { items: [] },
+      subnet: { items: [] }
+    };
+  });
+
+  it("displays a loading component if loading", () => {
+    state.dhcpsnippet.loading = true;
+    state.dhcpsnippet.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/settings/dhcp/1/edit", key: "testKey" }
+          ]}
+        >
+          <DhcpEdit />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("handles dhcp snippet not found", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/settings/dhcp/99999/edit", key: "testKey" }
+          ]}
+        >
+          <DhcpEdit />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("h4").text()).toBe("DHCP snippet not found");
+  });
+
+  it("can display a dhcp snippet edit form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/settings/dhcp/1/edit", key: "testKey" }
+          ]}
+        >
+          <Route
+            exact
+            path="/settings/dhcp/:id/edit"
+            component={props => <DhcpEdit {...props} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const form = wrapper.find("DhcpForm");
+    expect(form.exists()).toBe(true);
+    expect(form.prop("dhcpSnippet")).toStrictEqual(state.dhcpsnippet.items[0]);
+  });
+});

--- a/ui/src/app/settings/views/Dhcp/DhcpEdit/index.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpEdit/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DhcpEdit";

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
@@ -1,0 +1,127 @@
+import { Formik } from "formik";
+import { Redirect } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+import React, { useEffect, useState } from "react";
+
+import {
+  controller as controllerActions,
+  device as deviceActions,
+  machine as machineActions
+} from "app/base/actions";
+import { DhcpSnippetShape } from "app/settings/proptypes";
+import { messages } from "app/base/actions";
+import { useDhcpTarget } from "app/settings/hooks";
+import actions from "app/settings/actions";
+import DhcpFormFields from "../DhcpFormFields";
+import FormCard from "app/base/components/FormCard";
+import Loader from "app/base/components/Loader";
+import selectors from "app/settings/selectors";
+
+const DhcpSchema = Yup.object().shape({
+  description: Yup.string(),
+  enabled: Yup.boolean(),
+  entity: Yup.string().when("type", {
+    is: val => val && val.length > 0,
+    then: Yup.string().required(
+      "You must choose an entity for this snippet type"
+    )
+  }),
+  name: Yup.string().required("Snippet name is required"),
+  value: Yup.string().required("DHCP snippet is required"),
+  type: Yup.string()
+});
+
+export const DhcpForm = ({ dhcpSnippet }) => {
+  const [savingDhcp, setSaving] = useState();
+  const [name, setName] = useState();
+  const saved = useSelector(selectors.dhcpsnippet.saved);
+  const dispatch = useDispatch();
+  const editing = !!dhcpSnippet;
+  const { loading, loaded, type } = useDhcpTarget(
+    editing ? dhcpSnippet.node : null,
+    editing ? dhcpSnippet.subnet : null
+  );
+
+  useEffect(() => {
+    dispatch(actions.subnet.fetch());
+    dispatch(controllerActions.fetch());
+    dispatch(deviceActions.fetch());
+    dispatch(machineActions.fetch());
+    return () => {
+      // Clean up saved and error states on unmount.
+      dispatch(actions.dhcpsnippet.cleanup());
+    };
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (saved) {
+      const action = editing ? "updated" : "added";
+      dispatch(actions.dhcpsnippet.cleanup());
+      dispatch(
+        messages.add(`${savingDhcp} ${action} successfully.`, "information")
+      );
+      setSaving();
+    }
+  }, [dispatch, editing, saved, savingDhcp]);
+
+  if (saved) {
+    // The snippet was successfully created/updated so redirect to the dhcp list.
+    return <Redirect to="/dhcp" />;
+  }
+
+  if (
+    editing &&
+    ((dhcpSnippet.node || dhcpSnippet.subnet) && (loading || !loaded))
+  ) {
+    return <Loader text="Loading..." />;
+  }
+
+  let title = editing ? <>Editing `{name}`</> : "Add DHCP snippet";
+
+  return (
+    <FormCard title={title}>
+      <Formik
+        initialValues={{
+          description: dhcpSnippet ? dhcpSnippet.description : "",
+          enabled: dhcpSnippet ? dhcpSnippet.enabled : false,
+          entity: dhcpSnippet ? dhcpSnippet.node || dhcpSnippet.subnet : "",
+          name: dhcpSnippet ? dhcpSnippet.name : "",
+          type: dhcpSnippet ? type : "",
+          value: dhcpSnippet ? dhcpSnippet.value : ""
+        }}
+        validationSchema={DhcpSchema}
+        onSubmit={values => {
+          const params = {
+            description: values.description,
+            enabled: values.enabled,
+            name: values.name,
+            value: values.value
+          };
+          if (values.type === "subnet") {
+            params.subnet = values.entity;
+          } else if (values.type) {
+            params.node = values.entity;
+          }
+          if (editing) {
+            params.id = dhcpSnippet.id;
+            dispatch(actions.dhcpsnippet.update(params));
+          } else {
+            dispatch(actions.dhcpsnippet.create(params));
+          }
+          setSaving(params.name);
+        }}
+        render={formikProps => {
+          setName(formikProps.values.name);
+          return <DhcpFormFields editing={editing} formikProps={formikProps} />;
+        }}
+      ></Formik>
+    </FormCard>
+  );
+};
+
+DhcpForm.propTypes = {
+  dhcpSnippet: DhcpSnippetShape
+};
+
+export default DhcpForm;

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.js
@@ -1,0 +1,241 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import { compareJSX } from "testing/utils";
+import { DhcpForm } from "./DhcpForm";
+
+jest.mock("uuid/v4", () =>
+  jest.fn(() => "00000000-0000-0000-0000-000000000000")
+);
+
+const mockStore = configureStore();
+
+describe("DhcpForm", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      controller: { items: [] },
+      device: { items: [] },
+      dhcpsnippet: {
+        errors: {},
+        items: [
+          {
+            created: "Thu, 15 Aug. 2019 06:21:39",
+            id: 1,
+            name: "lease",
+            updated: "Thu, 15 Aug. 2019 06:21:39",
+            value: "lease 10"
+          },
+          {
+            created: "Thu, 15 Aug. 2019 06:21:39",
+            id: 2,
+            name: "class",
+            updated: "Thu, 15 Aug. 2019 06:21:39"
+          }
+        ],
+        loaded: true,
+        loading: false,
+        saved: false,
+        saving: false
+      },
+      machine: { items: [] },
+      subnet: { items: [] }
+    };
+  });
+
+  it("can render", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("DhcpForm").exists()).toBe(true);
+  });
+
+  it("cleans up when unmounting", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.unmount();
+    expect(
+      store.getActions().some(action => action.type === "CLEANUP_DHCPSNIPPET")
+    ).toBe(true);
+  });
+
+  it("redirects when the snippet is saved", () => {
+    state.dhcpsnippet.saved = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+  });
+
+  it("can update a snippet", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm dhcpSnippet={state.dhcpsnippet.items[0]} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          name: "new-lease",
+          id: 1
+        })
+    );
+    expect(
+      store.getActions().find(action => action.type === "UPDATE_DHCPSNIPPET")
+    ).toStrictEqual({
+      type: "UPDATE_DHCPSNIPPET",
+      payload: {
+        params: {
+          description: undefined,
+          enabled: undefined,
+          id: 1,
+          name: "new-lease",
+          value: undefined
+        }
+      },
+      meta: {
+        model: "dhcpsnippet",
+        method: "update"
+      }
+    });
+  });
+
+  it("can create a snippet", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          name: "new-lease"
+        })
+    );
+    expect(
+      store.getActions().find(action => action.type === "CREATE_DHCPSNIPPET")
+    ).toStrictEqual({
+      type: "CREATE_DHCPSNIPPET",
+      payload: {
+        params: {
+          description: undefined,
+          enabled: undefined,
+          value: undefined,
+          name: "new-lease"
+        }
+      },
+      meta: {
+        model: "dhcpsnippet",
+        method: "create"
+      }
+    });
+  });
+
+  it("adds a message when a snippet is added", () => {
+    state.dhcpsnippet.saved = true;
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    const actions = store.getActions();
+    expect(actions.some(action => action.type === "CLEANUP_DHCPSNIPPET")).toBe(
+      true
+    );
+    expect(actions.some(action => action.type === "ADD_MESSAGE")).toBe(true);
+  });
+
+  it("fetches models when editing", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm dhcpSnippet={state.dhcpsnippet.items[0]} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const actions = store.getActions();
+    expect(actions.some(action => action.type === "FETCH_MACHINE")).toBe(true);
+    expect(actions.some(action => action.type === "FETCH_DEVICE")).toBe(true);
+    expect(actions.some(action => action.type === "FETCH_SUBNET")).toBe(true);
+    expect(actions.some(action => action.type === "FETCH_CONTROLLER")).toBe(
+      true
+    );
+  });
+
+  it("shows a spinner when loading models", () => {
+    state.subnet.loading = true;
+    state.device.loading = true;
+    state.controller.loading = true;
+    state.machine.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm
+            dhcpSnippet={{
+              created: "Thu, 15 Aug. 2019 06:21:39",
+              id: 1,
+              name: "lease",
+              updated: "Thu, 15 Aug. 2019 06:21:39",
+              node: "xyz"
+            }}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+    expect(wrapper.find("FormCard").exists()).toBe(false);
+  });
+
+  it("shows the snippet name in the title when editing", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <DhcpForm dhcpSnippet={state.dhcpsnippet.items[0]} />
+        </MemoryRouter>
+      </Provider>
+    );
+    compareJSX(
+      wrapper.find(".card-form h4"),
+      <h4>
+        <>Editing `{"lease"}`</>
+      </h4>
+    );
+  });
+});

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/index.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DhcpForm";

--- a/ui/src/app/settings/views/Dhcp/DhcpFormFields/DhcpFormFields.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpFormFields/DhcpFormFields.js
@@ -1,0 +1,192 @@
+import { useSelector } from "react-redux";
+import PropTypes from "prop-types";
+import React from "react";
+
+import {
+  controller as controllerSelectors,
+  device as deviceSelectors,
+  machine as machineSelectors
+} from "app/base/selectors";
+import { formikFormDisabled } from "app/settings/utils";
+import { useFormikErrors } from "app/base/hooks";
+import Col from "app/base/components/Col";
+import Form from "app/base/components/Form";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikField from "app/base/components/FormikField";
+import Loader from "app/base/components/Loader";
+import Notification from "app/base/components/Notification";
+import Row from "app/base/components/Row";
+import Select from "app/base/components/Select";
+import selectors from "app/settings/selectors";
+import Textarea from "app/base/components/Textarea";
+
+const generateOptions = (type, models) =>
+  [
+    {
+      value: "",
+      label: `Choose ${type}`
+    }
+  ].concat(
+    models.map(model => ({
+      value: type === "subnet" ? model.id : model.system_id,
+      label: type === "subnet" ? model.name : model.fqdn
+    }))
+  );
+
+export const DhcpFormFields = ({ editing, formikProps }) => {
+  const saving = useSelector(selectors.dhcpsnippet.saving);
+  const saved = useSelector(selectors.dhcpsnippet.saved);
+  const errors = useSelector(selectors.dhcpsnippet.errors);
+  const subnets = useSelector(selectors.subnet.all);
+  const controllers = useSelector(controllerSelectors.all);
+  const devices = useSelector(deviceSelectors.all);
+  const machines = useSelector(machineSelectors.all);
+  const subnetLoading = useSelector(selectors.subnet.loading);
+  const subnetLoaded = useSelector(selectors.subnet.loaded);
+  const controllerLoading = useSelector(controllerSelectors.loading);
+  const controllerLoaded = useSelector(controllerSelectors.loaded);
+  const deviceLoading = useSelector(deviceSelectors.loading);
+  const deviceLoaded = useSelector(deviceSelectors.loaded);
+  const machineLoading = useSelector(machineSelectors.loading);
+  const machineLoaded = useSelector(machineSelectors.loaded);
+  useFormikErrors(errors, formikProps);
+  const isLoading =
+    subnetLoading || controllerLoading || deviceLoading || machineLoading;
+  const hasLoaded =
+    subnetLoaded && controllerLoaded && deviceLoaded && machineLoaded;
+  const { enabled, type } = formikProps.values;
+  let models;
+  switch (type) {
+    case "subnet":
+      models = subnets;
+      break;
+    case "controller":
+      models = controllers;
+      break;
+    case "machine":
+      models = machines;
+      break;
+    case "device":
+      models = devices;
+      break;
+    default:
+      models = null;
+  }
+
+  return (
+    <>
+      {editing && !enabled && (
+        <Notification type="caution" status="Warning:">
+          This snippet is disabled and will not be used by MAAS.
+        </Notification>
+      )}
+      <Form onSubmit={formikProps.handleSubmit}>
+        <Row>
+          <Col size="4">
+            <FormikField
+              formikProps={formikProps}
+              fieldKey="name"
+              label="Snippet name"
+              required={true}
+              type="text"
+            />
+            <FormikField
+              formikProps={formikProps}
+              fieldKey="enabled"
+              label="Enabled"
+              type="checkbox"
+            />
+            <FormikField
+              component={Textarea}
+              formikProps={formikProps}
+              fieldKey="description"
+              label="Description"
+            />
+          </Col>
+          <Col size="4">
+            <FormikField
+              component={Select}
+              formikProps={formikProps}
+              fieldKey="type"
+              label="Type"
+              onChange={e => {
+                formikProps.handleChange(e);
+                formikProps.setFieldValue("entity", "");
+                formikProps.setFieldTouched("entity", false, false);
+              }}
+              options={[
+                { value: "", label: "Global" },
+                { value: "subnet", label: "Subnet" },
+                { value: "controller", label: "Controller" },
+                { value: "machine", label: "Machine" },
+                { value: "device", label: "Device" }
+              ]}
+            />
+            {type &&
+              (isLoading || !hasLoaded ? (
+                <Loader text="loading..." />
+              ) : (
+                <FormikField
+                  component={Select}
+                  formikProps={formikProps}
+                  fieldKey="entity"
+                  label="Applies to"
+                  options={generateOptions(type, models)}
+                />
+              ))}
+          </Col>
+        </Row>
+        <FormikField
+          component={Textarea}
+          formikProps={formikProps}
+          fieldKey="value"
+          grow
+          label="DHCP snippet"
+          placeholder="Custom DHCP snippet"
+          required
+        />
+        <FormCardButtons
+          actionDisabled={saving || formikFormDisabled(formikProps)}
+          actionLabel="Save snippet"
+          actionLoading={saving}
+          actionSuccess={saved}
+        />
+      </Form>
+    </>
+  );
+};
+
+DhcpFormFields.propTypes = {
+  editing: PropTypes.bool,
+  formikProps: PropTypes.shape({
+    errors: PropTypes.shape({
+      description: PropTypes.string,
+      enabled: PropTypes.string,
+      entity: PropTypes.string,
+      name: PropTypes.string,
+      type: PropTypes.string,
+      value: PropTypes.string
+    }).isRequired,
+    handleBlur: PropTypes.func.isRequired,
+    handleChange: PropTypes.func.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    touched: PropTypes.shape({
+      description: PropTypes.bool,
+      enabled: PropTypes.bool,
+      entity: PropTypes.bool,
+      name: PropTypes.bool,
+      type: PropTypes.bool,
+      value: PropTypes.bool
+    }).isRequired,
+    values: PropTypes.shape({
+      description: PropTypes.string,
+      enabled: PropTypes.bool,
+      entity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      name: PropTypes.string.isRequired,
+      type: PropTypes.string,
+      value: PropTypes.string.isRequired
+    }).isRequired
+  })
+};
+
+export default DhcpFormFields;

--- a/ui/src/app/settings/views/Dhcp/DhcpFormFields/DhcpFormFields.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpFormFields/DhcpFormFields.test.js
@@ -1,0 +1,179 @@
+import configureStore from "redux-mock-store";
+import { mount } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { Provider } from "react-redux";
+
+import { DhcpFormFields } from "./DhcpFormFields";
+
+jest.mock("uuid/v4", () =>
+  jest.fn(() => "00000000-0000-0000-0000-000000000000")
+);
+
+const mockStore = configureStore();
+
+describe("DhcpFormFields", () => {
+  let formikProps, state;
+
+  beforeEach(() => {
+    formikProps = {
+      errors: {},
+      handleBlur: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      setFieldTouched: jest.fn(),
+      setFieldValue: jest.fn(),
+      setStatus: jest.fn(),
+      touched: {},
+      values: {
+        enabled: false,
+        name: "lease",
+        value: "lease 10"
+      }
+    };
+    state = {
+      controller: { items: [], loaded: true },
+      device: { items: [], loaded: true },
+      dhcpsnippet: {
+        errors: {},
+        items: [
+          {
+            created: "Thu, 15 Aug. 2019 06:21:39",
+            id: 1,
+            name: "lease",
+            updated: "Thu, 15 Aug. 2019 06:21:39",
+            value: "lease 10"
+          },
+          {
+            created: "Thu, 15 Aug. 2019 06:21:39",
+            id: 2,
+            name: "class",
+            updated: "Thu, 15 Aug. 2019 06:21:39"
+          }
+        ],
+        loaded: true,
+        loading: false,
+        saved: false,
+        saving: false
+      },
+      machine: { items: [], loaded: true },
+      subnet: {
+        items: [
+          {
+            id: 1,
+            name: "test.local"
+          }
+        ],
+        loaded: true
+      }
+    };
+  });
+
+  it("can render", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DhcpFormFields formikProps={formikProps} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("DhcpFormFields").exists()).toBe(true);
+  });
+
+  it("can set error status", () => {
+    state.dhcpsnippet.errors = {
+      name: ["Name not provided"]
+    };
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DhcpFormFields formikProps={formikProps} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(formikProps.setStatus).toHaveBeenCalled();
+  });
+
+  it("shows a notification if editing and disabled", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DhcpFormFields formikProps={formikProps} editing />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
+  });
+
+  it("shows a loader if the models have not loaded", () => {
+    state.subnet.loading = true;
+    state.device.loading = true;
+    state.controller.loading = true;
+    state.machine.loading = true;
+    state.subnet.loaded = false;
+    state.device.loaded = false;
+    state.controller.loaded = false;
+    state.machine.loaded = false;
+    formikProps.values.type = "subnet";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DhcpFormFields formikProps={formikProps} editing />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+    expect(
+      wrapper
+        .findWhere(
+          n => n.name() === "FormikField" && n.prop("fieldKey") === "entity"
+        )
+        .exists()
+    ).toBe(false);
+  });
+
+  it("shows the entity options for a chosen type", () => {
+    formikProps.values.type = "subnet";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DhcpFormFields formikProps={formikProps} editing />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(false);
+    expect(
+      wrapper
+        .findWhere(
+          n => n.name() === "FormikField" && n.prop("fieldKey") === "entity"
+        )
+        .exists()
+    ).toBe(true);
+  });
+
+  it("resets the entity if the type changes", () => {
+    formikProps.values.type = "subnet";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <DhcpFormFields formikProps={formikProps} editing />
+        </MemoryRouter>
+      </Provider>
+    );
+    const typeSelect = wrapper
+      .findWhere(
+        n => n.name() === "FormikField" && n.prop("fieldKey") === "type"
+      )
+      .find("select");
+    typeSelect.value = "subnet";
+    typeSelect.simulate("change");
+    expect(formikProps.setFieldValue).toHaveBeenCalled();
+    expect(formikProps.setFieldValue.mock.calls[0]).toEqual(["entity", ""]);
+  });
+});

--- a/ui/src/app/settings/views/Dhcp/DhcpFormFields/index.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpFormFields/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DhcpFormFields";

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
@@ -1,65 +1,28 @@
-import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import React from "react";
 
-import {
-  controller as controllerSelectors,
-  device as deviceSelectors,
-  machine as machineSelectors
-} from "app/base/selectors";
+import { useDhcpTarget } from "app/settings/hooks";
 import Link from "app/base/components/Link";
 import Loader from "app/base/components/Loader";
-import selectors from "app/settings/selectors";
 
 const generateURL = url => `${process.env.REACT_APP_MAAS_URL}/${url}`;
 
 const DhcpTarget = ({ nodeId, subnetId }) => {
-  const subnetLoading = useSelector(selectors.subnet.loading);
-  const subnetLoaded = useSelector(selectors.subnet.loaded);
-  const subnet = useSelector(state =>
-    selectors.subnet.getById(state, subnetId)
-  );
-  const controllerLoading = useSelector(controllerSelectors.loading);
-  const controllerLoaded = useSelector(controllerSelectors.loaded);
-  const controller = useSelector(state =>
-    controllerSelectors.getBySystemId(state, nodeId)
-  );
-  const deviceLoading = useSelector(deviceSelectors.loading);
-  const deviceLoaded = useSelector(deviceSelectors.loaded);
-  const device = useSelector(state =>
-    deviceSelectors.getBySystemId(state, nodeId)
-  );
-  const machineLoading = useSelector(machineSelectors.loading);
-  const machineLoaded = useSelector(machineSelectors.loaded);
-  const machine = useSelector(state =>
-    machineSelectors.getBySystemId(state, nodeId)
-  );
-  const isLoading =
-    (subnetId && subnetLoading) ||
-    (nodeId && (controllerLoading || deviceLoading || machineLoading));
-  const hasLoaded =
-    (subnetId && subnetLoaded) ||
-    (nodeId && controllerLoaded && deviceLoaded && machineLoaded);
+  const { loading, loaded, target, type } = useDhcpTarget(nodeId, subnetId);
 
-  if (isLoading || !hasLoaded) {
+  if (loading || !loaded) {
     return <Loader inline className="u-no-margin u-no-padding" />;
   }
 
-  let path =
-    (subnet && "subnet") ||
-    (controller && "controller") ||
-    (device && "device") ||
-    (machine && "machine");
-  const node = machine || device || controller;
-  const name = subnet ? (
-    subnet.name
+  const name = subnetId ? (
+    target.name
   ) : (
     <>
-      {node.hostname}
-      <small>.{node.domain.name}</small>
+      {target.hostname}
+      <small>.{target.domain.name}</small>
     </>
   );
-  const url = generateURL(`#/${path}/${nodeId || subnetId}`);
+  const url = generateURL(`#/${type}/${nodeId || subnetId}`);
   return <Link href={url}>{name}</Link>;
 };
 


### PR DESCRIPTION
Done:
- Added reducers, actions and selectors for creating and updating dhcp snippets.
- Added add/edit forms and views. Fixes: #76. Fixes: #75.

QA:
- View the DHCP snippet list.
- Click the "Add snippet" button and create a snippet using the form.
- Click the pencil icon next to a snippet.
- Change some details and click save.