### PR TITLE
Fix redirect for network section of settings

### DIFF
--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -74,10 +74,11 @@ const Routes = () => {
       />
       <Route
         exact
-        path={`${match.path}/network/network-discovery"`}
+        path={`${match.path}/network/network-discovery`}
         component={NetworkDiscoveryForm}
       />
       <Redirect
+        exact
         from={`${match.path}/network`}
         to={`${match.path}/network/proxy`}
       />


### PR DESCRIPTION
## Done
Add the exact property to the redirect in the network section so other views are reachable. Fixes #220

## QA
- Go to the settings section
- Click the **Network discovery** link in the side navigation
- See that you are able to get to that view
- Change the URL so you are only going to `/network`
- See that it still redirects to `/network/proxy`