### PR TITLE
Display a list of SSL keys

### DIFF
--- a/ui/src/app/preferences/actions/index.js
+++ b/ui/src/app/preferences/actions/index.js
@@ -1,1 +1,2 @@
 export { default as sshkey } from "./sshkey";
+export { default as sslkey } from "./sslkey";

--- a/ui/src/app/preferences/actions/sslkey/index.js
+++ b/ui/src/app/preferences/actions/sslkey/index.js
@@ -1,0 +1,1 @@
+export { default } from "./sslkey";

--- a/ui/src/app/preferences/actions/sslkey/sslkey.js
+++ b/ui/src/app/preferences/actions/sslkey/sslkey.js
@@ -1,0 +1,11 @@
+const sslkey = {};
+
+sslkey.fetch = () => ({
+  type: "FETCH_SSLKEY",
+  meta: {
+    model: "sslkey",
+    method: "list"
+  }
+});
+
+export default sslkey;

--- a/ui/src/app/preferences/actions/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/actions/sslkey/sslkey.test.js
@@ -1,0 +1,13 @@
+import sslkey from "./sslkey";
+
+describe("sslkey actions", () => {
+  it("should handle fetching SSL keys", () => {
+    expect(sslkey.fetch()).toEqual({
+      type: "FETCH_SSLKEY",
+      meta: {
+        model: "sslkey",
+        method: "list"
+      }
+    });
+  });
+});

--- a/ui/src/app/preferences/components/Routes/Routes.js
+++ b/ui/src/app/preferences/components/Routes/Routes.js
@@ -4,6 +4,7 @@ import { Route, Redirect, Switch } from "react-router-dom";
 import { useRouter } from "app/base/hooks";
 import Details from "app/preferences/views/Details";
 import SSHKeyList from "app/preferences/views/SSHKeyList";
+import SSLKeyList from "app/preferences/views/SSLKeyList";
 
 const Routes = () => {
   const { match } = useRouter();
@@ -12,6 +13,7 @@ const Routes = () => {
       <Redirect exact from={`${match.path}/`} to={`${match.path}/details`} />
       <Route exact path={`${match.path}/details`} component={Details} />
       <Route exact path={`${match.path}/ssh-keys`} component={SSHKeyList} />
+      <Route exact path={`${match.path}/ssl-keys`} component={SSLKeyList} />
     </Switch>
   );
 };

--- a/ui/src/app/preferences/reducers/index.js
+++ b/ui/src/app/preferences/reducers/index.js
@@ -1,1 +1,2 @@
 export { default as sshkey } from "./sshkey";
+export { default as sslkey } from "./sslkey";

--- a/ui/src/app/preferences/reducers/sslkey/index.js
+++ b/ui/src/app/preferences/reducers/sslkey/index.js
@@ -1,0 +1,1 @@
+export { default } from "./sslkey";

--- a/ui/src/app/preferences/reducers/sslkey/sslkey.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.js
@@ -1,18 +1,18 @@
 import produce from "immer";
 
-const sshkey = produce(
+const sslkey = produce(
   (draft, action) => {
     switch (action.type) {
-      case "FETCH_SSHKEY_START":
+      case "FETCH_SSLKEY_START":
         draft.loading = true;
         break;
-      case "FETCH_SSHKEY_SUCCESS":
+      case "FETCH_SSLKEY_SUCCESS":
         draft.errors = null;
         draft.loading = false;
         draft.loaded = true;
         draft.items = action.payload;
         break;
-      case "FETCH_SSHKEY_ERROR":
+      case "FETCH_SSLKEY_ERROR":
         draft.loading = false;
         draft.loaded = false;
         draft.errors = action.error;
@@ -29,4 +29,4 @@ const sshkey = produce(
   }
 );
 
-export default sshkey;
+export default sslkey;

--- a/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
@@ -1,0 +1,64 @@
+import sslkey from "./sslkey";
+
+describe("sslkey reducer", () => {
+  it("should return the initial state", () => {
+    expect(sslkey(undefined, {})).toEqual({
+      errors: null,
+      loading: false,
+      loaded: false,
+      items: []
+    });
+  });
+
+  it("should correctly reduce FETCH_SSLKEY_START", () => {
+    expect(
+      sslkey(undefined, {
+        type: "FETCH_SSLKEY_START"
+      })
+    ).toEqual({
+      errors: null,
+      loading: true,
+      loaded: false,
+      items: []
+    });
+  });
+
+  it("should correctly reduce FETCH_SSLKEY_SUCCESS", () => {
+    expect(
+      sslkey(
+        {
+          errors: null,
+          loading: true,
+          loaded: false,
+          items: []
+        },
+        {
+          type: "FETCH_SSLKEY_SUCCESS",
+          payload: [
+            { id: 1, key: "ssh-rsa aabb" },
+            { id: 2, key: "ssh-rsa ccdd" }
+          ]
+        }
+      )
+    ).toEqual({
+      errors: null,
+      loading: false,
+      loaded: true,
+      items: [{ id: 1, key: "ssh-rsa aabb" }, { id: 2, key: "ssh-rsa ccdd" }]
+    });
+  });
+
+  it("should correctly reduce FETCH_SSLKEY_ERROR", () => {
+    expect(
+      sslkey(undefined, {
+        type: "FETCH_SSLKEY_ERROR",
+        error: "Unable to list SSL keys"
+      })
+    ).toEqual({
+      errors: "Unable to list SSL keys",
+      loading: false,
+      loaded: false,
+      items: []
+    });
+  });
+});

--- a/ui/src/app/preferences/selectors/index.js
+++ b/ui/src/app/preferences/selectors/index.js
@@ -1,1 +1,2 @@
 export { default as sshkey } from "./sshkey";
+export { default as sslkey } from "./sslkey";

--- a/ui/src/app/preferences/selectors/sslkey/index.js
+++ b/ui/src/app/preferences/selectors/sslkey/index.js
@@ -1,0 +1,1 @@
+export { default } from "./sslkey";

--- a/ui/src/app/preferences/selectors/sslkey/sslkey.js
+++ b/ui/src/app/preferences/selectors/sslkey/sslkey.js
@@ -1,0 +1,31 @@
+const sslkey = {};
+
+/**
+ * Returns a list of all SSL keys.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all state.sslkey.items.
+ */
+sslkey.all = state => state.sslkey.items;
+
+/**
+ * Whether the SSL keys are loading.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether SSL keys are loading.
+ */
+sslkey.loading = state => state.sslkey.loading;
+
+/**
+ * Whether the SSL keys have been loaded.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether SSL keys have loaded.
+ */
+sslkey.loaded = state => state.sslkey.loaded;
+
+/**
+ * Get the SSL key errors.
+ * @param {Object} state - The redux state.
+ * @returns {String} The errors from the API.
+ */
+sslkey.errors = state => state.sslkey.errors;
+
+export default sslkey;

--- a/ui/src/app/preferences/selectors/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/selectors/sslkey/sslkey.test.js
@@ -1,0 +1,62 @@
+import sslkey from "./sslkey";
+
+describe("sslkey selectors", () => {
+  describe("all", () => {
+    it("returns list of all MAAS configs", () => {
+      const state = {
+        sslkey: {
+          loading: false,
+          loaded: true,
+          items: [
+            { id: 1, key: "ssh-rsa aabb" },
+            { id: 2, key: "ssh-rsa ccdd" }
+          ]
+        }
+      };
+      expect(sslkey.all(state)).toStrictEqual([
+        { id: 1, key: "ssh-rsa aabb" },
+        { id: 2, key: "ssh-rsa ccdd" }
+      ]);
+    });
+  });
+
+  describe("loading", () => {
+    it("returns sslkey loading state", () => {
+      const state = {
+        sslkey: {
+          loading: false,
+          loaded: true,
+          items: []
+        }
+      };
+      expect(sslkey.loading(state)).toStrictEqual(false);
+    });
+  });
+
+  describe("loaded", () => {
+    it("returns sslkey loaded state", () => {
+      const state = {
+        sslkey: {
+          loading: false,
+          loaded: true,
+          items: []
+        }
+      };
+      expect(sslkey.loaded(state)).toStrictEqual(true);
+    });
+  });
+
+  describe("errors", () => {
+    it("returns sslkey error state", () => {
+      const state = {
+        sslkey: {
+          errors: "Unable to list SSL keys.",
+          loading: false,
+          loaded: true,
+          items: []
+        }
+      };
+      expect(sslkey.errors(state)).toEqual("Unable to list SSL keys.");
+    });
+  });
+});

--- a/ui/src/app/preferences/views/SSHKeyList/SSHKeyList.js
+++ b/ui/src/app/preferences/views/SSHKeyList/SSHKeyList.js
@@ -147,7 +147,7 @@ const SSHKeyList = () => {
       {sshkeyLoading && <Loader text="Loading..." />}
       <div className="p-table-actions">
         <div className="p-table-actions__space-left"></div>
-        <Button element={Link} to="/settings/dhcp/add">
+        <Button element={Link} to="/account/prefs/ssh-keys/add">
           Import SSH key
         </Button>
       </div>

--- a/ui/src/app/preferences/views/SSLKeyList/SSLKeyList.js
+++ b/ui/src/app/preferences/views/SSLKeyList/SSLKeyList.js
@@ -1,0 +1,129 @@
+import { Link } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect, useState } from "react";
+
+import "./SSLKeyList.scss";
+import { sslkey as sslkeyActions } from "app/preferences/actions";
+import { sslkey as sslkeySelectors } from "app/preferences/selectors";
+import Button from "app/base/components/Button";
+import Loader from "app/base/components/Loader";
+import MainTable from "app/base/components/MainTable";
+import Notification from "app/base/components/Notification";
+import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+
+const generateRows = (
+  sslkeys,
+  expandedId,
+  setExpandedId,
+  hideExpanded,
+  dispatch
+) =>
+  sslkeys.map(({ id, display }) => {
+    const expanded = expandedId === id;
+    return {
+      className: expanded ? "p-table__row is-active" : null,
+      columns: [
+        {
+          content: display,
+          role: "rowheader"
+        },
+        {
+          content: (
+            <>
+              <Button
+                appearance="base"
+                className="is-small u-justify-table-icon u-no-margin--right"
+                onClick={() => {}}
+              >
+                <i className="p-icon--copy">Copy</i>
+              </Button>
+              <Button
+                appearance="base"
+                className="is-small u-justify-table-icon"
+                onClick={() => {
+                  setExpandedId(id);
+                }}
+              >
+                <i className="p-icon--delete">Delete</i>
+              </Button>
+            </>
+          ),
+          className: "u-align--right u-align-icons--top"
+        }
+      ],
+      expanded: expanded,
+      expandedContent: expanded && (
+        <TableDeleteConfirm
+          modelName={display}
+          modelType="SSL key"
+          onCancel={hideExpanded}
+          onConfirm={() => {}}
+        />
+      ),
+      key: id,
+      sortData: {
+        key: display
+      }
+    };
+  });
+
+const SSLKeyList = () => {
+  const [expandedId, setExpandedId] = useState();
+  const sslkeyErrors = useSelector(sslkeySelectors.errors);
+  const sslkeyLoading = useSelector(sslkeySelectors.loading);
+  const sslkeyLoaded = useSelector(sslkeySelectors.loaded);
+  const sslkeys = useSelector(sslkeySelectors.all);
+  const dispatch = useDispatch();
+
+  const hideExpanded = () => {
+    setExpandedId();
+  };
+
+  useEffect(() => {
+    dispatch(sslkeyActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <>
+      {sslkeyErrors && (
+        <Notification type="negative" status="Error:">
+          {sslkeyErrors}
+        </Notification>
+      )}
+      {sslkeyLoading && <Loader text="Loading..." />}
+      <div className="p-table-actions">
+        <div className="p-table-actions__space-left"></div>
+        <Button element={Link} to="/account/prefs/ssl-keys/add">
+          Add SSL key
+        </Button>
+      </div>
+      {sslkeyLoaded && (
+        <MainTable
+          className="p-table-expanding--light sslkey-list"
+          expanding={true}
+          headers={[
+            {
+              content: "Key",
+              sortKey: "key"
+            },
+            {
+              content: "Actions",
+              className: "u-align--right"
+            }
+          ]}
+          paginate={20}
+          rows={generateRows(
+            sslkeys,
+            expandedId,
+            setExpandedId,
+            hideExpanded,
+            dispatch
+          )}
+          sortable={true}
+        />
+      )}
+    </>
+  );
+};
+
+export default SSLKeyList;

--- a/ui/src/app/preferences/views/SSLKeyList/SSLKeyList.scss
+++ b/ui/src/app/preferences/views/SSLKeyList/SSLKeyList.scss
@@ -1,0 +1,7 @@
+.sslkey-list td,
+.sslkey-list th {
+  // Actions:
+  &:nth-child(2) {
+    flex: 0 0 10%;
+  }
+}

--- a/ui/src/app/preferences/views/SSLKeyList/SSLKeyList.test.js
+++ b/ui/src/app/preferences/views/SSLKeyList/SSLKeyList.test.js
@@ -1,0 +1,97 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import SSLKeyList from "./SSLKeyList";
+
+const mockStore = configureStore();
+
+describe("SSLKeyList", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      sslkey: {
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            id: 1,
+            key: "ssh-rsa aabb",
+            keysource: { protocol: "lp", auth_id: "koalaparty" }
+          },
+          {
+            id: 2,
+            key: "ssh-rsa ccdd",
+            keysource: { protocol: "gh", auth_id: "koalaparty" }
+          },
+          {
+            id: 3,
+            key: "ssh-rsa eeff",
+            keysource: { protocol: "lp", auth_id: "maaate" }
+          },
+          {
+            id: 4,
+            key: "ssh-rsa gghh",
+            keysource: { protocol: "gh", auth_id: "koalaparty" }
+          },
+          { id: 5, key: "ssh-rsa gghh" }
+        ]
+      }
+    };
+  });
+
+  it("displays a loading component if machines are loading", () => {
+    state.sslkey.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/account/prefs/ssl-keys", key: "testKey" }
+          ]}
+        >
+          <SSLKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("can display errors", () => {
+    state.sslkey.errors = "Unable to list SSL keys.";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/account/prefs/ssl-keys", key: "testKey" }
+          ]}
+        >
+          <SSLKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").text()).toEqual(
+      "Error:Unable to list SSL keys."
+    );
+  });
+
+  it("can render the table", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/account/prefs/ssl-keys", key: "testKey" }
+          ]}
+        >
+          <SSLKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/preferences/views/SSLKeyList/index.js
+++ b/ui/src/app/preferences/views/SSLKeyList/index.js
@@ -1,0 +1,1 @@
+export { default } from "./SSLKeyList";

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -22,6 +22,7 @@ import {
 } from "./app/base/reducers";
 import { config } from "./app/settings/reducers";
 import { sshkey } from "./app/preferences/reducers";
+import { sslkey } from "./app/preferences/reducers";
 
 export default history =>
   combineReducers({
@@ -38,6 +39,7 @@ export default history =>
     scripts,
     service,
     sshkey,
+    sslkey,
     status,
     subnet,
     tag,


### PR DESCRIPTION
Done:
- Fetch and list SSL keys. Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/1535

QA:
- Add some SSL keys via the old preferences UI (you'll find some examples if you search "BEGIN CERTIFICATE" in the maas code).
- Visit /account/prefs/ssl-keys.
- You should see your keys.
Note: copying to clipboard has not yet been implemented.