### PR TITLE
Allow server to parse metadata if header exists.

### DIFF
--- a/ui/src/app/base/actions/scripts/scripts.js
+++ b/ui/src/app/base/actions/scripts/scripts.js
@@ -4,14 +4,19 @@ scripts.fetch = () => ({
   type: "FETCH_SCRIPTS"
 });
 
-scripts.upload = (name, type, contents) => ({
-  type: "UPLOAD_SCRIPT",
-  payload: {
-    name,
+scripts.upload = (type, contents, name) => {
+  const payload = {
     type,
     contents
+  };
+  if (name) {
+    payload.name = name;
   }
-});
+  return {
+    type: "UPLOAD_SCRIPT",
+    payload
+  };
+};
 
 scripts.delete = script => ({
   type: "DELETE_SCRIPT",

--- a/ui/src/app/base/actions/scripts/scripts.test.js
+++ b/ui/src/app/base/actions/scripts/scripts.test.js
@@ -8,10 +8,20 @@ describe("scripts actions", () => {
   });
 
   it("should handle uploading scripts", () => {
-    expect(scripts.upload("script-1", "testing", "contents")).toEqual({
+    expect(scripts.upload("testing", "contents", "script-1")).toEqual({
       type: "UPLOAD_SCRIPT",
       payload: {
         name: "script-1",
+        type: "testing",
+        contents: "contents"
+      }
+    });
+  });
+
+  it("should handle uploading scripts with an optional name", () => {
+    expect(scripts.upload("testing", "contents")).toEqual({
+      type: "UPLOAD_SCRIPT",
+      payload: {
         type: "testing",
         contents: "contents"
       }

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.js
@@ -109,7 +109,7 @@ const ScriptsUpload = ({ type }) => {
     isDragReject
   } = useDropzone({
     onDrop,
-    accept: "text/*",
+    accept: "text/*, application/x-csh, application/x-sh",
     maxSize: MAX_SIZE_BYTES,
     multiple: false
   });
@@ -146,7 +146,7 @@ const ScriptsUpload = ({ type }) => {
             <p className="u-no-margin--bottom">Drop the file here ...</p>
           ) : (
             <p className="u-no-margin--bottom">
-              Drag 'n' drop a file here, or click to select a file
+              Drag 'n' drop a script here ('.sh' file ext required), or click to select a file
             </p>
           )}
         </div>

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.js
@@ -1,12 +1,12 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router";
 import { useDropzone } from "react-dropzone";
-import pathParse from "path-parse";
 
 import "./ScriptsUpload.scss";
+import readScript from "./readScript";
 import { messages } from "app/base/actions";
 import Card from "app/base/components/Card";
 import Form from "app/base/components/Form";
@@ -20,8 +20,8 @@ const ScriptsUpload = ({ type }) => {
   const hasErrors = useSelector(scriptSelectors.hasErrors);
   const errors = useSelector(scriptSelectors.errors);
   const saved = useSelector(scriptSelectors.saved);
-  const [savedScript, setSavedScript] = React.useState();
-  const [script, setScript] = React.useState();
+  const [savedScript, setSavedScript] = useState();
+  const [script, setScript] = useState();
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -65,37 +65,7 @@ const ScriptsUpload = ({ type }) => {
       }
 
       const acceptedFile = acceptedFiles[0];
-      const scriptName = pathParse(acceptedFile.path).name;
-      const reader = new FileReader();
-
-      reader.onabort = () => {
-        dispatch(messages.add("Reading file aborted.", "negative"));
-      };
-      reader.onerror = () => {
-        dispatch(messages.add("Error reading file.", "negative"));
-      };
-
-      let hasMetadata = false;
-      reader.onload = () => {
-        const binaryStr = reader.result;
-        try {
-          const scriptArray = binaryStr.split("\n");
-          scriptArray.forEach(line => {
-            if (line.includes("--- Start MAAS 1.0 script metadata ---")) {
-              hasMetadata = true;
-            }
-          });
-        } catch {
-          console.error("Unable to parse script for metadata.");
-        }
-        setScript({
-          name: scriptName,
-          script: binaryStr,
-          hasMetadata
-        });
-      };
-
-      reader.readAsBinaryString(acceptedFile);
+      readScript(acceptedFile, dispatch, setScript);
     },
     [dispatch]
   );

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.js
@@ -146,7 +146,8 @@ const ScriptsUpload = ({ type }) => {
             <p className="u-no-margin--bottom">Drop the file here ...</p>
           ) : (
             <p className="u-no-margin--bottom">
-              Drag 'n' drop a script here ('.sh' file ext required), or click to select a file
+              Drag 'n' drop a script here ('.sh' file ext required), or click to
+              select a file
             </p>
           )}
         </div>

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
@@ -133,4 +133,41 @@ describe("ScriptsUpload", () => {
       "Only a single file may be uploaded."
     );
   });
+
+  it("Correctly sets hasMetadata if script contains metadata header", async () => {
+    const setState = jest.fn();
+    const useStateSpy = jest.spyOn(React, "useState");
+    useStateSpy.mockImplementation(init => [init, setState]);
+
+    const store = mockStore(initialState);
+    const contents = "# --- Start MAAS 1.0 script metadata ---";
+
+    const files = [createFile("foo.sh", 1000, "text/script", contents)];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <ScriptsUpload type="testing" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      wrapper.find("input").simulate("change", {
+        target: { files },
+        preventDefault: () => {},
+        persist: () => {}
+      });
+    });
+
+    await act(async () => {
+      wrapper.find("Form").simulate("submit");
+    });
+
+    expect(setState).toHaveBeenCalledWith({
+      hasMetadata: true,
+      name: "foo",
+      script: contents
+    });
+  });
 });

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
@@ -25,16 +25,6 @@ const createFile = (name, size, type, contents = "") => {
 describe("ScriptsUpload", () => {
   let initialState;
   beforeEach(() => {
-    /*
-    readScript.mockImplementation((file, dispatch, callback) => {
-      callback({
-        name: "foo",
-        script: "contents",
-        hasMetadata: true
-      });
-    });
-    */
-
     initialState = {
       scripts: {
         loading: false,

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
@@ -138,16 +138,15 @@ describe("ScriptsUpload", () => {
   });
 
   it("dispatches uploadScript without a name if script has metadata", async () => {
+    const store = mockStore(initialState);
+    const contents = "# --- Start MAAS 1.0 script metadata ---";
     readScript.mockImplementation((file, dispatch, callback) => {
       callback({
         name: "foo",
-        script: "contents",
+        script: contents,
         hasMetadata: true
       });
     });
-    const store = mockStore(initialState);
-    const contents = "# --- Start MAAS 1.0 script metadata ---";
-
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
 
     const wrapper = mount(
@@ -173,23 +172,22 @@ describe("ScriptsUpload", () => {
     expect(store.getActions()).toEqual([
       { type: "CLEANUP_SCRIPTS" },
       {
-        payload: { contents: "contents", type: "testing" },
+        payload: { contents, type: "testing" },
         type: "UPLOAD_SCRIPT"
       }
     ]);
   });
 
   it("dispatches uploadScript with a name if script has no metadata", async () => {
+    const store = mockStore(initialState);
+    const contents = "#!/bin/bash\necho 'foo';\n";
     readScript.mockImplementation((file, dispatch, callback) => {
       callback({
         name: "foo",
-        script: "contents",
+        script: contents,
         hasMetadata: false
       });
     });
-    const store = mockStore(initialState);
-    const contents = "# --- Start MAAS 1.0 script metadata ---";
-
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
 
     const wrapper = mount(
@@ -215,7 +213,7 @@ describe("ScriptsUpload", () => {
     expect(store.getActions()).toEqual([
       { type: "CLEANUP_SCRIPTS" },
       {
-        payload: { contents: "contents", type: "testing", name: "foo" },
+        payload: { contents, type: "testing", name: "foo" },
         type: "UPLOAD_SCRIPT"
       }
     ]);

--- a/ui/src/app/settings/views/Scripts/readScript.js
+++ b/ui/src/app/settings/views/Scripts/readScript.js
@@ -1,0 +1,47 @@
+import pathParse from "path-parse";
+
+import { messages } from "app/base/actions";
+
+export const hasMetadata = binaryStr => {
+  let hasMeta = false;
+  try {
+    const scriptArray = binaryStr.split("\n");
+    scriptArray.forEach(line => {
+      if (line.includes("--- Start MAAS 1.0 script metadata ---")) {
+        hasMeta = true;
+      }
+    });
+  } catch {
+    console.error("Unable to parse script for metadata.");
+    hasMeta = false;
+  }
+  return hasMeta;
+};
+
+const readScript = (file, dispatch, callback) => {
+  const scriptName = pathParse(file.path).name;
+
+  const reader = new FileReader();
+
+  reader.onabort = () => {
+    dispatch(messages.add("Reading file aborted.", "negative"));
+  };
+  reader.onerror = () => {
+    dispatch(messages.add("Error reading file.", "negative"));
+  };
+
+  reader.onload = () => {
+    const binaryStr = reader.result;
+    const meta = hasMetadata(binaryStr);
+
+    callback({
+      name: scriptName,
+      script: binaryStr,
+      hasMetadata: meta
+    });
+  };
+
+  reader.readAsBinaryString(file);
+};
+
+export default readScript;

--- a/ui/src/app/settings/views/Scripts/readScript.test.js
+++ b/ui/src/app/settings/views/Scripts/readScript.test.js
@@ -1,0 +1,17 @@
+import { hasMetadata } from "./readScript";
+
+describe("readScript", () => {
+  describe("hasMetadata", () => {
+    it("returns true if a file has a metadata header", () => {
+      const contents = "# --- Start MAAS 1.0 script metadata ---\n";
+
+      expect(hasMetadata(contents)).toEqual(true);
+    });
+
+    it("returns false if a file has no metadata header", () => {
+      const contents = "#!bin/sh\necho 'foo'\n";
+
+      expect(hasMetadata(contents)).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
## Done
If a script is uploaded without any additional parameters, the server will in fact look for the presence of a metadata header, hence there's no need to parse the yaml clientside other than to check for the presence of the header.

## QA
Upload a script with a metadata header, e.g.

```script
#!/bin/bash
# --- Start MAAS 1.0 script metadata ---
# name: my-script
# title: My Script
# description: An amazing script
# --- End MAAS 1.0 script metadata ---
echo 'This script is amazing'.
```

Ensure the name and description are set appropriately.

Additionally, upload a normal script, without a metadata header, it should upload correctly as well.