### PR TITLE
Add SSL keys form

### DIFF
--- a/ui/src/app/base/actions/user/user.test.js
+++ b/ui/src/app/base/actions/user/user.test.js
@@ -57,7 +57,7 @@ describe("user actions", () => {
   });
 
   it("can handle cleaning users", () => {
-    expect(user.cleanup({ name: "kookaburra" })).toEqual({
+    expect(user.cleanup()).toEqual({
       type: "CLEANUP_USER"
     });
   });

--- a/ui/src/app/base/components/Textarea/Textarea.js
+++ b/ui/src/app/base/components/Textarea/Textarea.js
@@ -40,13 +40,14 @@ const Textarea = ({
           }
         }}
         style={
-          grow && {
+          (grow && {
             minHeight: "5rem",
             resize: "none",
             overflow: "hidden",
             boxSizing: "border-box",
             ...style
-          }
+          }) ||
+          style
         }
         {...props}
       />

--- a/ui/src/app/preferences/actions/sslkey/sslkey.js
+++ b/ui/src/app/preferences/actions/sslkey/sslkey.js
@@ -8,4 +8,19 @@ sslkey.fetch = () => ({
   }
 });
 
+sslkey.create = params => ({
+  type: "CREATE_SSLKEY",
+  meta: {
+    model: "sslkey",
+    method: "create"
+  },
+  payload: {
+    params
+  }
+});
+
+sslkey.cleanup = params => ({
+  type: "CLEANUP_SSLKEY"
+});
+
 export default sslkey;

--- a/ui/src/app/preferences/actions/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/actions/sslkey/sslkey.test.js
@@ -10,4 +10,25 @@ describe("sslkey actions", () => {
       }
     });
   });
+
+  it("can handle creating SSL keys", () => {
+    expect(sslkey.create({ key: "---begin cert---..." })).toEqual({
+      type: "CREATE_SSLKEY",
+      meta: {
+        model: "sslkey",
+        method: "create"
+      },
+      payload: {
+        params: {
+          key: "---begin cert---..."
+        }
+      }
+    });
+  });
+
+  it("can clean up", () => {
+    expect(sslkey.cleanup()).toEqual({
+      type: "CLEANUP_SSLKEY"
+    });
+  });
 });

--- a/ui/src/app/preferences/components/Routes/Routes.js
+++ b/ui/src/app/preferences/components/Routes/Routes.js
@@ -5,6 +5,7 @@ import { useRouter } from "app/base/hooks";
 import Details from "app/preferences/views/Details";
 import SSHKeyList from "app/preferences/views/SSHKeyList";
 import SSLKeyList from "app/preferences/views/SSLKeys/SSLKeyList";
+import AddSSLKey from "app/preferences/views/SSLKeys/AddSSLKey";
 
 const Routes = () => {
   const { match } = useRouter();
@@ -14,6 +15,7 @@ const Routes = () => {
       <Route exact path={`${match.path}/details`} component={Details} />
       <Route exact path={`${match.path}/ssh-keys`} component={SSHKeyList} />
       <Route exact path={`${match.path}/ssl-keys`} component={SSLKeyList} />
+      <Route exact path={`${match.path}/ssl-keys/add`} component={AddSSLKey} />
     </Switch>
   );
 };

--- a/ui/src/app/preferences/reducers/sslkey/sslkey.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.js
@@ -17,15 +17,35 @@ const sslkey = produce(
         draft.loaded = false;
         draft.errors = action.error;
         break;
+      case "CREATE_SSLKEY_START":
+        draft.saved = false;
+        draft.saving = true;
+        break;
+      case "CREATE_SSLKEY_ERROR":
+        draft.errors = action.error;
+        draft.saving = false;
+        break;
+      case "CREATE_SSLKEY_SUCCESS":
+        draft.errors = {};
+        draft.saved = true;
+        draft.saving = false;
+        break;
+      case "CLEANUP_SSLKEY":
+        draft.errors = {};
+        draft.saved = false;
+        draft.saving = false;
+        break;
       default:
         return draft;
     }
   },
   {
     errors: null,
-    loading: false,
+    items: [],
     loaded: false,
-    items: []
+    loading: false,
+    saved: false,
+    saving: false
   }
 );
 

--- a/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
@@ -6,7 +6,9 @@ describe("sslkey reducer", () => {
       errors: null,
       loading: false,
       loaded: false,
-      items: []
+      items: [],
+      saved: false,
+      saving: false
     });
   });
 
@@ -19,7 +21,9 @@ describe("sslkey reducer", () => {
       errors: null,
       loading: true,
       loaded: false,
-      items: []
+      items: [],
+      saved: false,
+      saving: false
     });
   });
 
@@ -30,7 +34,9 @@ describe("sslkey reducer", () => {
           errors: null,
           loading: true,
           loaded: false,
-          items: []
+          items: [],
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_SSLKEY_SUCCESS",
@@ -44,7 +50,9 @@ describe("sslkey reducer", () => {
       errors: null,
       loading: false,
       loaded: true,
-      items: [{ id: 1, key: "ssh-rsa aabb" }, { id: 2, key: "ssh-rsa ccdd" }]
+      items: [{ id: 1, key: "ssh-rsa aabb" }, { id: 2, key: "ssh-rsa ccdd" }],
+      saved: false,
+      saving: false
     });
   });
 
@@ -58,7 +66,110 @@ describe("sslkey reducer", () => {
       errors: "Unable to list SSL keys",
       loading: false,
       loaded: false,
-      items: []
+      items: [],
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CREATE_SSLKEY_START", () => {
+    expect(
+      sslkey(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          type: "CREATE_SSLKEY_START"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce CREATE_SSLKEY_ERROR", () => {
+    expect(
+      sslkey(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: { key: "Key already exists" },
+          type: "CREATE_SSLKEY_ERROR"
+        }
+      )
+    ).toEqual({
+      errors: { key: "Key already exists" },
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CREATE_SSLKEY_SUCCESS", () => {
+    expect(
+      sslkey(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          type: "CREATE_SSLKEY_SUCCESS"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: true,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CLEANUP_SSLKEY", () => {
+    expect(
+      sslkey(
+        {
+          errors: { key: "Key already exists" },
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: true
+        },
+        {
+          type: "CLEANUP_SSLKEY"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/preferences/selectors/sslkey/sslkey.js
+++ b/ui/src/app/preferences/selectors/sslkey/sslkey.js
@@ -28,4 +28,18 @@ sslkey.loaded = state => state.sslkey.loaded;
  */
 sslkey.errors = state => state.sslkey.errors;
 
+/**
+ * Whether the SSL keys are saving.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether SSL keys are saving.
+ */
+sslkey.saving = state => state.sslkey.saving;
+
+/**
+ * Whether the SSL keys have been saved.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether SSL keys have saved.
+ */
+sslkey.saved = state => state.sslkey.saved;
+
 export default sslkey;

--- a/ui/src/app/preferences/selectors/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/selectors/sslkey/sslkey.test.js
@@ -59,4 +59,28 @@ describe("sslkey selectors", () => {
       expect(sslkey.errors(state)).toEqual("Unable to list SSL keys.");
     });
   });
+
+  describe("saving", () => {
+    it("returns sslkey saving state", () => {
+      const state = {
+        sslkey: {
+          saving: false,
+          items: []
+        }
+      };
+      expect(sslkey.saving(state)).toStrictEqual(false);
+    });
+  });
+
+  describe("saved", () => {
+    it("returns sslkey saved state", () => {
+      const state = {
+        sslkey: {
+          saved: true,
+          items: []
+        }
+      };
+      expect(sslkey.saved(state)).toStrictEqual(true);
+    });
+  });
 });

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.js
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.js
@@ -1,0 +1,48 @@
+import { Formik } from "formik";
+import { Redirect } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+import React, { useEffect } from "react";
+
+import { sslkey as sslkeyActions } from "app/preferences/actions";
+import { sslkey as sslkeySelectors } from "app/preferences/selectors";
+import { useAddMessage } from "app/base/hooks";
+import SSLKeyFormFields from "../SSLKeyFormFields";
+import FormCard from "app/base/components/FormCard";
+
+const SSLKeySchema = Yup.object().shape({
+  key: Yup.string().required("SSL key is required")
+});
+
+export const AddSSLKey = () => {
+  const saved = useSelector(sslkeySelectors.saved);
+  const dispatch = useDispatch();
+  useAddMessage(saved, sslkeyActions.cleanup, "SSL key successfully added.");
+
+  useEffect(() => {
+    return () => {
+      // Clean up saved and error states on unmount.
+      dispatch(sslkeyActions.cleanup());
+    };
+  }, [dispatch]);
+
+  if (saved) {
+    // The snippet was successfully created/updated so redirect to the list.
+    return <Redirect to="/account/prefs/ssl-keys" />;
+  }
+
+  return (
+    <FormCard title="Add SSL key">
+      <Formik
+        initialValues={{ key: "" }}
+        validationSchema={SSLKeySchema}
+        onSubmit={values => {
+          dispatch(sslkeyActions.create(values));
+        }}
+        render={formikProps => <SSLKeyFormFields formikProps={formikProps} />}
+      ></Formik>
+    </FormCard>
+  );
+};
+
+export default AddSSLKey;

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.js
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.js
@@ -1,0 +1,116 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import { AddSSLKey } from "./AddSSLKey";
+
+jest.mock("uuid/v4", () =>
+  jest.fn(() => "00000000-0000-0000-0000-000000000000")
+);
+
+const mockStore = configureStore();
+
+describe("AddSSLKey", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      sslkey: {
+        loading: false,
+        loaded: true,
+        items: []
+      }
+    };
+  });
+
+  it("can render", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <AddSSLKey />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("AddSSLKey").exists()).toBe(true);
+  });
+
+  it("cleans up when unmounting", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <AddSSLKey />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.unmount();
+    expect(
+      store.getActions().some(action => action.type === "CLEANUP_SSLKEY")
+    ).toBe(true);
+  });
+
+  it("redirects when the SSL key is saved", () => {
+    state.sslkey.saved = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <AddSSLKey />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+  });
+
+  it("can create a SSL key", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <AddSSLKey />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          key: "--- begin cert ---..."
+        })
+    );
+    expect(
+      store.getActions().find(action => action.type === "CREATE_SSLKEY")
+    ).toStrictEqual({
+      type: "CREATE_SSLKEY",
+      payload: {
+        params: {
+          key: "--- begin cert ---..."
+        }
+      },
+      meta: {
+        model: "sslkey",
+        method: "create"
+      }
+    });
+  });
+
+  it("adds a message when a SSL key is added", () => {
+    state.sslkey.saved = true;
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <AddSSLKey />
+        </MemoryRouter>
+      </Provider>
+    );
+    const actions = store.getActions();
+    expect(actions.some(action => action.type === "CLEANUP_SSLKEY")).toBe(true);
+    expect(actions.some(action => action.type === "ADD_MESSAGE")).toBe(true);
+  });
+});

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/index.js
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AddSSLKey";

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyFormFields/SSLKeyFormFields.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyFormFields/SSLKeyFormFields.js
@@ -1,0 +1,77 @@
+import { useSelector } from "react-redux";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { sslkey as sslkeySelectors } from "app/preferences/selectors";
+import { formikFormDisabled } from "app/settings/utils";
+import { useFormikErrors } from "app/base/hooks";
+import Col from "app/base/components/Col";
+import Form from "app/base/components/Form";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikField from "app/base/components/FormikField";
+import Notification from "app/base/components/Notification";
+import Row from "app/base/components/Row";
+import Textarea from "app/base/components/Textarea";
+
+export const SSLKeyFormFields = ({ editing, formikProps }) => {
+  const saving = useSelector(sslkeySelectors.saving);
+  const saved = useSelector(sslkeySelectors.saved);
+  const errors = useSelector(sslkeySelectors.errors);
+  useFormikErrors(errors, formikProps);
+  const hasError = errors && typeof errors === "string";
+
+  return (
+    <>
+      {hasError && (
+        <Notification type="negative" status="Error:">
+          {errors}
+        </Notification>
+      )}
+      <Form onSubmit={formikProps.handleSubmit}>
+        <Row>
+          <Col size="4">
+            <FormikField
+              component={Textarea}
+              formikProps={formikProps}
+              fieldKey="key"
+              label="SSL key"
+              style={{ minHeight: "20rem" }}
+            />
+          </Col>
+          <Col size="4">
+            <p className="p-form-help-text" style={{ marginTop: "0.5rem" }}>
+              You will be able to access Windows winrm service with a registered
+              key.
+            </p>
+          </Col>
+        </Row>
+        <FormCardButtons
+          actionDisabled={saving || formikFormDisabled(formikProps)}
+          actionLabel="Save SSL key"
+          actionLoading={saving}
+          actionSuccess={saved}
+        />
+      </Form>
+    </>
+  );
+};
+
+SSLKeyFormFields.propTypes = {
+  editing: PropTypes.bool,
+  formikProps: PropTypes.shape({
+    errors: PropTypes.shape({
+      key: PropTypes.string
+    }).isRequired,
+    handleBlur: PropTypes.func.isRequired,
+    handleChange: PropTypes.func.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    touched: PropTypes.shape({
+      key: PropTypes.bool
+    }).isRequired,
+    values: PropTypes.shape({
+      key: PropTypes.string
+    }).isRequired
+  })
+};
+
+export default SSLKeyFormFields;

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyFormFields/SSLKeyFormFields.test.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyFormFields/SSLKeyFormFields.test.js
@@ -1,0 +1,67 @@
+import configureStore from "redux-mock-store";
+import { mount } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { Provider } from "react-redux";
+
+import { SSLKeyFormFields } from "./SSLKeyFormFields";
+
+jest.mock("uuid/v4", () =>
+  jest.fn(() => "00000000-0000-0000-0000-000000000000")
+);
+
+const mockStore = configureStore();
+
+describe("SSLKeyFormFields", () => {
+  let formikProps, state;
+
+  beforeEach(() => {
+    formikProps = {
+      errors: {},
+      handleBlur: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      setFieldTouched: jest.fn(),
+      setFieldValue: jest.fn(),
+      setStatus: jest.fn(),
+      touched: {},
+      values: {
+        key: ""
+      }
+    };
+    state = {
+      sslkey: {
+        loading: false,
+        loaded: true,
+        items: []
+      }
+    };
+  });
+
+  it("can render", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <SSLKeyFormFields formikProps={formikProps} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("SSLKeyFormFields").exists()).toBe(true);
+  });
+
+  it("can set error status", () => {
+    state.sslkey.errors = {
+      key: ["Key not provided"]
+    };
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <SSLKeyFormFields formikProps={formikProps} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(formikProps.setStatus).toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyFormFields/index.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyFormFields/index.js
@@ -1,0 +1,1 @@
+export { default } from "./SSLKeyFormFields";

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.js
@@ -80,7 +80,7 @@ const SSLKeyList = () => {
 
   return (
     <>
-      {sslkeyErrors && (
+      {sslkeyErrors && typeof sslkeyErrors === "string" && (
         <Notification type="negative" status="Error:">
           {sslkeyErrors}
         </Notification>


### PR DESCRIPTION
Done:
- Add a form for adding SSL keys. Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1508.

QA:
- Visit /account/prefs/ssl-keys.
- Click "Add SSL key".
- Paste a key (search MAAS for "-----BEGIN CERTIFICATE-----").
- Save and you should be redirected back to the list.
- Refresh and the key should be in the list (waiting on API support for sync: https://github.com/canonical-web-and-design/maas-ui/issues/238).