### PR TITLE
Delete SSL keys

### DIFF
--- a/ui/src/app/preferences/actions/sslkey/sslkey.js
+++ b/ui/src/app/preferences/actions/sslkey/sslkey.js
@@ -19,6 +19,19 @@ sslkey.create = params => ({
   }
 });
 
+sslkey.delete = id => ({
+  type: "DELETE_SSLKEY",
+  meta: {
+    model: "sslkey",
+    method: "delete"
+  },
+  payload: {
+    params: {
+      id
+    }
+  }
+});
+
 sslkey.cleanup = params => ({
   type: "CLEANUP_SSLKEY"
 });

--- a/ui/src/app/preferences/actions/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/actions/sslkey/sslkey.test.js
@@ -26,6 +26,21 @@ describe("sslkey actions", () => {
     });
   });
 
+  it("can handle deleting SSL keys", () => {
+    expect(sslkey.delete(808)).toEqual({
+      type: "DELETE_SSLKEY",
+      meta: {
+        model: "sslkey",
+        method: "delete"
+      },
+      payload: {
+        params: {
+          id: 808
+        }
+      }
+    });
+  });
+
   it("can clean up", () => {
     expect(sslkey.cleanup()).toEqual({
       type: "CLEANUP_SSLKEY"

--- a/ui/src/app/preferences/reducers/sslkey/sslkey.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.js
@@ -18,14 +18,17 @@ const sslkey = produce(
         draft.errors = action.error;
         break;
       case "CREATE_SSLKEY_START":
+      case "DELETE_SSLKEY_START":
         draft.saved = false;
         draft.saving = true;
         break;
       case "CREATE_SSLKEY_ERROR":
+      case "DELETE_SSLKEY_ERROR":
         draft.errors = action.error;
         draft.saving = false;
         break;
       case "CREATE_SSLKEY_SUCCESS":
+      case "DELETE_SSLKEY_SUCCESS":
         draft.errors = {};
         draft.saved = true;
         draft.saving = false;

--- a/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
@@ -148,6 +148,82 @@ describe("sslkey reducer", () => {
     });
   });
 
+  it("should correctly reduce DELETE_SSLKEY_START", () => {
+    expect(
+      sslkey(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false
+        },
+        {
+          type: "DELETE_SSLKEY_START"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce DELETE_SSLKEY_ERROR", () => {
+    expect(
+      sslkey(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: "Could not delete",
+          type: "DELETE_SSLKEY_ERROR"
+        }
+      )
+    ).toEqual({
+      errors: "Could not delete",
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_SSLKEY_SUCCESS", () => {
+    expect(
+      sslkey(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: true,
+          saved: false,
+          saving: false
+        },
+        {
+          type: "DELETE_SSLKEY_SUCCESS"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loading: true,
+      loaded: false,
+      saved: true,
+      saving: false
+    });
+  });
+
   it("should correctly reduce CLEANUP_SSLKEY", () => {
     expect(
       sslkey(

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.js
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import "./SSLKeyList.scss";
 import { sslkey as sslkeyActions } from "app/preferences/actions";
 import { sslkey as sslkeySelectors } from "app/preferences/selectors";
+import { useAddMessage } from "app/base/hooks";
 import Button from "app/base/components/Button";
 import Loader from "app/base/components/Loader";
 import MainTable from "app/base/components/MainTable";
@@ -52,7 +53,10 @@ const generateRows = (
           modelName={display}
           modelType="SSL key"
           onCancel={hideExpanded}
-          onConfirm={() => {}}
+          onConfirm={() => {
+            dispatch(sslkeyActions.delete(id));
+            hideExpanded();
+          }}
         />
       ),
       key: id,
@@ -68,7 +72,10 @@ const SSLKeyList = () => {
   const sslkeyLoading = useSelector(sslkeySelectors.loading);
   const sslkeyLoaded = useSelector(sslkeySelectors.loaded);
   const sslkeys = useSelector(sslkeySelectors.all);
+  const saved = useSelector(sslkeySelectors.saved);
   const dispatch = useDispatch();
+
+  useAddMessage(saved, sslkeyActions.cleanup, "SSL key removed successfully.");
 
   const hideExpanded = () => {
     setExpandedId();

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.js
@@ -94,4 +94,103 @@ describe("SSLKeyList", () => {
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
   });
+
+  it("can show a delete confirmation", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/account/prefs/ssl-keys", key: "testKey" }
+          ]}
+        >
+          <SSLKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+    let row = wrapper.find("MainTable").prop("rows")[0];
+    expect(row.expanded).toBe(false);
+    // Click on the delete button:
+    wrapper
+      .find("tbody TableRow")
+      .at(0)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .simulate("click");
+    row = wrapper.find("MainTable").prop("rows")[0];
+    expect(row.expanded).toBe(true);
+  });
+
+  it("can delete a SSL key", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/account/prefs/ssl-keys", key: "testKey" }
+          ]}
+        >
+          <SSLKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click on the delete button:
+    wrapper
+      .find("tbody TableRow")
+      .at(0)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .simulate("click");
+    // Click on the delete confirm button
+    wrapper
+      .find("tbody TableRow")
+      .at(0)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .last()
+      .simulate("click");
+    expect(
+      store.getActions().find(action => action.type === "DELETE_SSLKEY")
+    ).toEqual({
+      type: "DELETE_SSLKEY",
+      payload: {
+        params: {
+          id: 1
+        }
+      },
+      meta: {
+        model: "sslkey",
+        method: "delete"
+      }
+    });
+  });
+
+  it("can add a message when a SSL key is deleted", () => {
+    state.sslkey.saved = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/account/prefs/ssl-keys", key: "testKey" }
+          ]}
+        >
+          <SSLKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click on the delete button:
+    wrapper
+      .find("tbody TableRow")
+      .at(0)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .simulate("click");
+    // Click on the delete confirm button
+    wrapper
+      .find("tbody TableRow")
+      .at(0)
+      .findWhere(n => n.name() === "Button" && n.text() === "Delete")
+      .last()
+      .simulate("click");
+    const actions = store.getActions();
+    expect(actions.some(action => action.type === "CLEANUP_SSLKEY")).toBe(true);
+    expect(actions.some(action => action.type === "ADD_MESSAGE")).toBe(true);
+  });
 });


### PR DESCRIPTION
QA:
- Delete SSL keys from the list. Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1516.

QA:
- View the list of SSL keys in preferences.
- Click delete and confirm.
- Refresh and the key should be removed (bugs have been filed about API syncing support).