### PR TITLE
Extend SSH key borders

### DIFF
--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.js
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.js
@@ -53,15 +53,13 @@ const groupBySource = sshkeys => {
   return Array.from(groups);
 };
 
-const generateKeyCols = keys => {
-  if (keys.length === 1) {
-    return formatKey(keys[0].key);
-  }
+const generateKeyCols = (keys, deleteButton) => {
   return (
     <ul className="p-table-sub-cols__list">
-      {keys.map(key => (
-        <div className="p-table-sub-cols__item" key={key.id}>
+      {keys.map((key, i) => (
+        <div className="p-table-sub-cols__item" key={key}>
           {formatKey(key.key)}
+          {i === 0 && deleteButton}
         </div>
       ))}
     </ul>
@@ -86,22 +84,19 @@ const generateRows = (
         },
         { content: group.id },
         {
-          className: "p-table-sub-cols",
-          content: generateKeyCols(group.keys)
-        },
-        {
-          content: (
+          className: "p-table-sub-cols u-align-icons--top",
+          content: generateKeyCols(
+            group.keys,
             <Button
               appearance="base"
-              className="is-small u-justify-table-icon"
+              className="is-small u-justify-table-icon sshkey-list__delete"
               onClick={() => {
                 setExpandedId(id);
               }}
             >
               <i className="p-icon--delete">Delete</i>
             </Button>
-          ),
-          className: "u-align--right u-align-icons--top"
+          )
         }
       ],
       expanded: expanded,
@@ -174,11 +169,12 @@ const SSHKeyList = () => {
               sortKey: "id"
             },
             {
-              content: "Key"
-            },
-            {
-              content: "Actions",
-              className: "u-align--right"
+              content: (
+                <>
+                  Key
+                  <span className="sshkey-list__header-delete">Actions</span>
+                </>
+              )
             }
           ]}
           paginate={20}

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.js
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.js
@@ -57,7 +57,7 @@ const generateKeyCols = (keys, deleteButton) => {
   return (
     <ul className="p-table-sub-cols__list">
       {keys.map((key, i) => (
-        <div className="p-table-sub-cols__item" key={key}>
+        <div className="p-table-sub-cols__item" key={key.key}>
           {formatKey(key.key)}
           {i === 0 && deleteButton}
         </div>

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.scss
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.scss
@@ -1,7 +1,8 @@
-.sshkey-list td,
-.sshkey-list th {
-  // Actions:
-  &:nth-child(4) {
-    flex: 0 0 10%;
-  }
+.sshkey-list__delete {
+  float: right;
+}
+
+.sshkey-list__header-delete {
+  flex: 1 0 auto;
+  text-align: right;
 }

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.js
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.js
@@ -97,7 +97,12 @@ describe("SSHKeyList", () => {
       state.sshkey.items.length - 1
     );
     // The grouped keys should be displayed in sub cols.
-    expect(wrapper.find(".p-table-sub-cols__item").length).toBe(2);
+    expect(
+      wrapper
+        .find("MainTable tbody tr")
+        .at(1)
+        .find(".p-table-sub-cols__item").length
+    ).toBe(2);
   });
 
   it("can display uploaded keys", () => {
@@ -119,7 +124,12 @@ describe("SSHKeyList", () => {
       .find("td");
     expect(cols.at(0).text()).toEqual("Upload");
     expect(cols.at(1).text()).toEqual("");
-    expect(cols.at(2).text()).toEqual("ssh-rsa gghh...");
+    expect(
+      cols
+        .at(2)
+        .text()
+        .includes("ssh-rsa gghh...")
+    ).toBe(true);
   });
 
   it("can display imported keys", () => {
@@ -141,7 +151,12 @@ describe("SSHKeyList", () => {
       .find("td");
     expect(cols.at(0).text()).toEqual("Launchpad");
     expect(cols.at(1).text()).toEqual("koalaparty");
-    expect(cols.at(2).text()).toEqual("ssh-rsa aabb...");
+    expect(
+      cols
+        .at(2)
+        .text()
+        .includes("ssh-rsa aabb...")
+    ).toBe(true);
   });
 
   it("can show a delete confirmation", () => {


### PR DESCRIPTION
Done:
- Extend grouped SSH key borders to the edge of the row. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/243.

QA:
- Visit /account/prefs/ssh-keys.
- Add an account with multiple keys (e.g. hatch on Launchpad).
- The borders for the group of keys should go past the delete icon.