### PR TITLE
Display license keys in table, with search.

### DIFF
--- a/ui/src/app/base/selectors/licensekeys/licensekeys.js
+++ b/ui/src/app/base/selectors/licensekeys/licensekeys.js
@@ -37,4 +37,15 @@ licensekeys.hasErrors = state =>
  */
 licensekeys.errors = state => state.licensekeys.errors;
 
+/**
+ * Get license keys that match a term.
+ * @param {Object} state - The redux state.
+ * @param {String} term - The term to match against.
+ * @returns {Array} A filtered list of license keys.
+ */
+licensekeys.search = (state, term) =>
+  state.licensekeys.items.filter(
+    item => item.osystem.includes(term) || item.distro_series.includes(term)
+  );
+
 export default licensekeys;

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
@@ -1,27 +1,103 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import Button from "app/base/components/Button";
+import Loader from "app/base/components/Loader";
+import MainTable from "app/base/components/MainTable";
+import SearchBox from "app/base/components/SearchBox";
 
 import { licensekeys as licenseKeysActions } from "app/base/actions";
 import { licensekeys as licenseKeysSelectors } from "app/base/selectors";
 
-const LicenseKeyList = () => {
-  const dispatch = useDispatch();
-  const licenseKeys = useSelector(licenseKeysSelectors.all);
+const generateRows = licenseKeys =>
+  licenseKeys.map(licenseKey => {
+    return {
+      className: "p-table__row",
+      columns: [
+        {
+          content: licenseKey.osystem,
+          role: "rowheader"
+        },
+        {
+          content: licenseKey.distro_series
+        },
+        {
+          content: (
+            <>
+              <Button
+                appearance="base"
+                element={Link}
+                to={`/settings/license-keys/edit`}
+                className="is-small u-justify-table-icon"
+              >
+                <i className="p-icon--edit">Edit</i>
+              </Button>
+              <Button
+                appearance="base"
+                className="is-small u-justify-table-icon"
+              >
+                <i className="p-icon--delete">Delete</i>
+              </Button>
+            </>
+          ),
+          className: "u-align--right u-align-icons--top"
+        }
+      ],
+      key: licenseKey.license_key,
+      sortData: {
+        osystem: licenseKey.osystem,
+        title: licenseKey.title
+      }
+    };
+  });
 
+const LicenseKeyList = () => {
+  const [searchText, setSearchText] = useState("");
+  const licenseKeys = useSelector(state =>
+    licenseKeysSelectors.search(state, searchText)
+  );
+  const licenseKeysLoading = useSelector(licenseKeysSelectors.loading);
+  const licenseKeysLoaded = useSelector(licenseKeysSelectors.loaded);
+
+  const dispatch = useDispatch();
   useEffect(() => {
     dispatch(licenseKeysActions.fetch());
   }, [dispatch]);
 
   return (
     <>
-      <h4>License keys</h4>
-      <ul>
-        {licenseKeys.map(key => (
-          <li key={key.license_key}>
-            {key.osystem} | {key.license_key}
-          </li>
-        ))}
-      </ul>
+      {licenseKeysLoading && <Loader text="Loading..." />}
+      <div className="p-table-actions">
+        <SearchBox onChange={setSearchText} value={searchText} />
+        <Button element={Link} to={`/settings/license-keys/add`}>
+          Add license key
+        </Button>
+      </div>
+
+      {licenseKeysLoaded && (
+        <MainTable
+          className="p-table-expanding--light"
+          expanding={true}
+          headers={[
+            {
+              content: "Operating System",
+              sortKey: "osystem"
+            },
+            {
+              content: "Distro Series",
+              sortKey: "distro_series"
+            },
+            {
+              content: "Actions",
+              className: "u-align--right"
+            }
+          ]}
+          paginate={20}
+          rows={generateRows(licenseKeys)}
+          sortable={true}
+        />
+      )}
     </>
   );
 };

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.js
@@ -1,0 +1,100 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import LicenseKeyList from ".";
+
+const mockStore = configureStore();
+
+describe("LicenseKeyList", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      licensekeys: {
+        loading: false,
+        loaded: true,
+        errors: {},
+        items: [
+          {
+            osystem: "windows",
+            distro_series: "win2012",
+            license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+          },
+          {
+            osystem: "windows",
+            distro_series: "win2019",
+            license_key: "XXXXX-XXXXX-XXXXX-XXXXX-AAABBB"
+          }
+        ]
+      }
+    };
+  });
+
+  it("displays a loading component if loading", () => {
+    const state = { ...initialState };
+    state.licensekeys.loading = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <LicenseKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("hides the table if license keys haven't loaded", () => {
+    const state = { ...initialState };
+    state.licensekeys.loaded = false;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <LicenseKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("MainTable").exists()).toBe(false);
+  });
+
+  it("shows the table if there are license keys", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <LicenseKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+
+  it("dispatches action to fetch license keys on load", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <LicenseKeyList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(store.getActions()).toEqual([
+      {
+        type: "FETCH_LICENSE_KEYS"
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
## Done
Display license keys in table

## QA
* Visit /settings/license-keys, ensure your license keys are displayed in the table.
* Ensure search works