### PR TITLE
Add create license key form

### DIFF
--- a/ui/src/app/base/actions/licensekeys/licensekeys.js
+++ b/ui/src/app/base/actions/licensekeys/licensekeys.js
@@ -1,12 +1,19 @@
 const licenseKeys = {};
 
-licenseKeys.fetch = () => ({
-  type: "FETCH_LICENSE_KEYS"
-});
+licenseKeys.create = params => {
+  return {
+    type: "CREATE_LICENSE_KEY",
+    payload: params
+  };
+};
 
 licenseKeys.delete = licenseKey => ({
   type: "DELETE_LICENSE_KEY",
   payload: licenseKey
+});
+
+licenseKeys.fetch = () => ({
+  type: "FETCH_LICENSE_KEYS"
 });
 
 licenseKeys.cleanup = () => ({

--- a/ui/src/app/base/actions/licensekeys/licensekeys.test.js
+++ b/ui/src/app/base/actions/licensekeys/licensekeys.test.js
@@ -1,6 +1,19 @@
 import licenseKeys from "./licensekeys";
 
 describe("licenseKeys actions", () => {
+  it("can create a license key", () => {
+    const payload = {
+      osystem: "windows",
+      distro_series: "2012",
+      license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+    };
+
+    expect(licenseKeys.create(payload)).toEqual({
+      type: "CREATE_LICENSE_KEY",
+      payload
+    });
+  });
+
   it("can fetch license keys", () => {
     expect(licenseKeys.fetch()).toEqual({
       type: "FETCH_LICENSE_KEYS"

--- a/ui/src/app/base/reducers/licensekeys/licensekeys.js
+++ b/ui/src/app/base/reducers/licensekeys/licensekeys.js
@@ -16,6 +16,7 @@ const licensekeys = produce(
         draft.loaded = false;
         draft.errors = action.errors;
         break;
+      case "CREATE_LICENSE_KEY_START":
       case "DELETE_LICENSE_KEY_START":
         draft.saved = false;
         draft.saving = true;
@@ -31,8 +32,14 @@ const licensekeys = produce(
         );
         draft.items.splice(index, 1);
         break;
+      case "CREATE_LICENSE_KEY_ERROR":
       case "DELETE_LICENSE_KEY_ERROR":
         draft.errors = action.errors;
+        draft.saving = false;
+        break;
+      case "CREATE_LICENSE_KEY_SUCCESS":
+        draft.errors = {};
+        draft.saved = true;
         draft.saving = false;
         break;
       case "CLEANUP_LICENSE_KEYS":

--- a/ui/src/app/base/reducers/licensekeys/licensekeys.test.js
+++ b/ui/src/app/base/reducers/licensekeys/licensekeys.test.js
@@ -10,6 +10,82 @@ describe("licenseKeys reducer", () => {
     });
   });
 
+  it("should correctly reduce CREATE_LICENSE_KEY_START", () => {
+    expect(
+      licenseKeys(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false
+        },
+        {
+          type: "CREATE_LICENSE_KEY_START"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce CREATE_LICENSE_KEY_SUCCESS", () => {
+    expect(
+      licenseKeys(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          type: "CREATE_LICENSE_KEY_SUCCESS"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: true,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce CREATE_LICENSE_KEY_ERROR", () => {
+    expect(
+      licenseKeys(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          errors: { error: "Invalid license key." },
+          type: "CREATE_LICENSE_KEY_ERROR"
+        }
+      )
+    ).toEqual({
+      errors: { error: "Invalid license key." },
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
   it("should correctly reduce FETCH_LICENSE_KEYS_START", () => {
     expect(
       licenseKeys(undefined, {

--- a/ui/src/app/base/sagas/index.js
+++ b/ui/src/app/base/sagas/index.js
@@ -1,17 +1,19 @@
 import { watchWebSockets } from "./websockets";
 import {
-  watchFetchLicenseKeys,
+  watchCreateLicenseKey,
   watchDeleteLicenseKey,
-  watchFetchScripts,
+  watchFetchLicenseKeys,
   watchDeleteScript,
+  watchFetchScripts,
   watchUploadScript
 } from "./http";
 
 export {
   watchWebSockets,
-  watchFetchLicenseKeys,
+  watchCreateLicenseKey,
   watchDeleteLicenseKey,
-  watchFetchScripts,
+  watchFetchLicenseKeys,
   watchDeleteScript,
+  watchFetchScripts,
   watchUploadScript
 };

--- a/ui/src/app/base/selectors/general/osInfo.js
+++ b/ui/src/app/base/selectors/general/osInfo.js
@@ -1,7 +1,7 @@
 /**
  * Selector for os info.
  */
-
+import { createSelector } from "reselect";
 import { generateGeneralSelector } from "./utils";
 
 const osInfo = generateGeneralSelector("osInfo");
@@ -86,5 +86,46 @@ osInfo.getAllOsReleases = state => {
 
   return allOsReleases;
 };
+
+/**
+ * Returns an object with all OS releases
+ * @param {Object} state - the redux state
+ * @returns {Object} - all OS releases
+ *
+ */
+osInfo.getLicensedOsReleases = createSelector(
+  [osInfo.getAllOsReleases],
+  releases => {
+    let results = {};
+    for (let [key, value] of Object.entries(releases)) {
+      const licensedReleases = value.filter(release => {
+        return release.value.endsWith("*");
+      });
+
+      if (licensedReleases.length > 0) {
+        const releases = licensedReleases.map(r => {
+          r.value = r.value.slice(0, -1);
+          return r;
+        });
+        results[key] = releases;
+      }
+    }
+    return results;
+  }
+);
+
+osInfo.getLicensedOsystems = createSelector(
+  [osInfo.getLicensedOsReleases],
+  releases => {
+    const osystems = Object.keys(releases);
+    if (osystems) {
+      return osystems.map(osystem => [
+        osystem,
+        `${osystem.charAt(0).toUpperCase()}${osystem.slice(1)}`
+      ]);
+    }
+    return [];
+  }
+);
 
 export default osInfo;

--- a/ui/src/app/base/selectors/general/osInfo.test.js
+++ b/ui/src/app/base/selectors/general/osInfo.test.js
@@ -229,4 +229,64 @@ describe("osInfo selectors", () => {
       });
     });
   });
+
+  describe("getLicensedOsReleases", () => {
+    const data = {
+      osystems: [["ubuntu", "Ubuntu"], ["windows", "Windows"]],
+      releases: [
+        ["centos/centos66", "CentOS 6"],
+        ["centos/centos70", "CentOS 7"],
+        ["windows/win2012*", "Windows 2012 Server"]
+      ]
+    };
+    let state;
+
+    beforeEach(() => {
+      state = {
+        general: {
+          osInfo: {
+            loading: false,
+            loaded: true,
+            data
+          }
+        }
+      };
+    });
+
+    it("returns only licensed releases", () => {
+      expect(osInfo.getLicensedOsReleases(state)).toEqual({
+        windows: [{ value: "win2012", label: "Windows 2012 Server" }]
+      });
+    });
+  });
+
+  describe("getLicensedOsystems", () => {
+    const data = {
+      osystems: [["ubuntu", "Ubuntu"], ["windows", "Windows"]],
+      releases: [
+        ["centos/centos66", "CentOS 6"],
+        ["centos/centos70", "CentOS 7"],
+        ["windows/win2012*", "Windows 2012 Server"]
+      ]
+    };
+    let state;
+
+    beforeEach(() => {
+      state = {
+        general: {
+          osInfo: {
+            loading: false,
+            loaded: true,
+            data
+          }
+        }
+      };
+    });
+
+    it("returns only licensed operating systems", () => {
+      expect(osInfo.getLicensedOsystems(state)).toEqual([
+        ["windows", "Windows"]
+      ]);
+    });
+  });
 });

--- a/ui/src/app/base/selectors/licensekeys/licensekeys.js
+++ b/ui/src/app/base/selectors/licensekeys/licensekeys.js
@@ -55,4 +55,18 @@ licensekeys.search = (state, term) =>
     item => item.osystem.includes(term) || item.distro_series.includes(term)
   );
 
+/**
+ * Get the saving state.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether license keys are being saved.
+ */
+licensekeys.saving = state => state.licensekeys.saving;
+
+/**
+ * Get the saved state.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether license keys have been saved.
+ */
+licensekeys.saved = state => state.licensekeys.saved;
+
 export default licensekeys;

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -11,6 +11,7 @@ import DnsForm from "app/settings/views/Network/DnsForm";
 import General from "app/settings/views/Configuration/General";
 import KernelParameters from "app/settings/views/Configuration/KernelParameters";
 import LicenseKeyList from "app/settings/views/LicenseKeys/LicenseKeyList";
+import LicenseKeyAdd from "app/settings/views/LicenseKeys/LicenseKeyAdd";
 import NetworkDiscoveryForm from "app/settings/views/Network/NetworkDiscoveryForm";
 import NtpForm from "app/settings/views/Network/NtpForm";
 import ProxyForm from "app/settings/views/Network/ProxyForm";
@@ -68,6 +69,11 @@ const Routes = () => {
         exact
         path={`${match.path}/license-keys`}
         component={LicenseKeyList}
+      />
+      <Route
+        exact
+        path={`${match.path}/license-keys/add`}
+        component={LicenseKeyAdd}
       />
       <Route exact path={`${match.path}/storage`} component={StorageForm} />
       <Route exact path={`${match.path}/network/proxy`} component={ProxyForm} />

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyAdd/LicenseKeyAdd.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyAdd/LicenseKeyAdd.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+import LicenseKeyForm from "../LicenseKeyForm";
+
+export const LicenseKeyAdd = () => {
+  return <LicenseKeyForm />;
+};
+
+export default LicenseKeyAdd;

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyAdd/index.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyAdd/index.js
@@ -1,0 +1,1 @@
+export { default } from "./LicenseKeyAdd";

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
@@ -1,0 +1,93 @@
+import { Formik } from "formik";
+import { Redirect } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+import React, { useEffect, useState } from "react";
+
+import { general as generalActions } from "app/base/actions";
+import { general as generalSelectors } from "app/base/selectors";
+import { licensekeys as licenseKeysActions } from "app/base/actions";
+import { licensekeys as licenseKeysSelectors } from "app/base/selectors";
+import { useAddMessage } from "app/base/hooks";
+import Loader from "app/base/components/Loader";
+import LicenseKeyFormFields from "../LicenseKeyFormFields";
+import FormCard from "app/base/components/FormCard";
+
+const LicenseKeySchema = Yup.object().shape({
+  osystem: Yup.string().required("Operating system is required"),
+  distro_series: Yup.string().required("Release is required"),
+  license_key: Yup.string().required("A license key is required")
+});
+
+export const LicenseKeyForm = () => {
+  const [savingLicenseKey, setSaving] = useState();
+  const saved = useSelector(licenseKeysSelectors.saved);
+  const osInfoLoaded = useSelector(generalSelectors.osInfo.loaded);
+  const licenseKeysLoaded = useSelector(licenseKeysSelectors.loaded);
+  const dispatch = useDispatch();
+  const isLoaded = licenseKeysLoaded && osInfoLoaded;
+  const releases = useSelector(generalSelectors.osInfo.getLicensedOsReleases);
+  const osystems = useSelector(generalSelectors.osInfo.getLicensedOsystems);
+
+  useAddMessage(
+    saved,
+    licenseKeysActions.cleanup,
+    `${savingLicenseKey} added successfully.`,
+    setSaving
+  );
+
+  useEffect(() => {
+    if (!osInfoLoaded) {
+      dispatch(generalActions.fetchOsInfo());
+    }
+    if (!licenseKeysLoaded) {
+      dispatch(licenseKeysActions.fetch());
+    }
+    return () => {
+      // Clean up saved and error states on unmount.
+      dispatch(licenseKeysActions.cleanup());
+    };
+  }, [dispatch, osInfoLoaded, licenseKeysLoaded]);
+
+  if (saved) {
+    // The license key was successfully created/updated so redirect to the license key list.
+    return <Redirect to="/settings/license-keys" />;
+  }
+
+  return (
+    <FormCard title="Add license key">
+      {!isLoaded ? (
+        <Loader text="loading..." />
+      ) : (
+        <Formik
+          initialValues={{
+            osystem: osystems[0][0],
+            distro_series: releases[osystems[0][0]][0].value,
+            license_key: ""
+          }}
+          validationSchema={LicenseKeySchema}
+          onSubmit={values => {
+            const params = {
+              osystem: values.osystem,
+              distro_series: values.distro_series,
+              license_key: values.license_key
+            };
+            dispatch(licenseKeysActions.create(params));
+            setSaving(`${params.osystem} (${params.distro_series})`);
+          }}
+          render={formikProps => {
+            return (
+              <LicenseKeyFormFields
+                osystems={osystems}
+                releases={releases}
+                formikProps={formikProps}
+              />
+            );
+          }}
+        />
+      )}
+    </FormCard>
+  );
+};
+
+export default LicenseKeyForm;

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.js
@@ -1,0 +1,164 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import { LicenseKeyForm } from "./LicenseKeyForm";
+
+const mockStore = configureStore();
+
+describe("LicenseKeyForm", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      general: {
+        osInfo: {
+          loaded: true,
+          loading: false,
+          data: {
+            osystems: [["ubuntu", "Ubuntu"], ["windows", "Windows"]],
+            releases: [
+              ["ubuntu/bionic", "Ubuntu 18.04 LTS 'Bionic Beaver'"],
+              ["windows/win2012*", "Windows Server 2012"]
+            ]
+          }
+        }
+      },
+      licensekeys: {
+        loading: false,
+        loaded: true,
+        saved: false,
+        errors: {},
+        items: []
+      }
+    };
+  });
+
+  it("can render", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("LicenseKeyForm").exists()).toBe(true);
+  });
+
+  it("cleans up when unmounting", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.unmount();
+
+    expect(
+      store.getActions().some(action => action.type === "CLEANUP_LICENSE_KEYS")
+    ).toBe(true);
+  });
+
+  it("fetches OsInfo if not loaded", () => {
+    state.general.osInfo.loaded = false;
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some(action => action.type === "FETCH_GENERAL_OSINFO")
+    ).toBe(true);
+  });
+
+  it("fetches license keys if not loaded", () => {
+    state.licensekeys.loaded = false;
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some(action => action.type === "FETCH_LICENSE_KEYS")
+    ).toBe(true);
+  });
+
+  it("redirects when the snippet is saved", () => {
+    state.licensekeys.saved = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+  });
+
+  it("can add a key", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          osystem: "windows",
+          distro_series: "win2012",
+          license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+        })
+    );
+
+    expect(
+      store.getActions().find(action => action.type === "CREATE_LICENSE_KEY")
+    ).toStrictEqual({
+      type: "CREATE_LICENSE_KEY",
+      payload: {
+        osystem: "windows",
+        distro_series: "win2012",
+        license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+      }
+    });
+  });
+
+  it("adds a message when a license key is created", () => {
+    state.licensekeys.saved = true;
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    const actions = store.getActions();
+
+    expect(actions.some(action => action.type === "CLEANUP_LICENSE_KEYS")).toBe(
+      true
+    );
+    expect(actions.some(action => action.type === "ADD_MESSAGE")).toBe(true);
+  });
+});

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/index.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/index.js
@@ -1,0 +1,1 @@
+export { default } from "./LicenseKeyForm";

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.js
@@ -1,0 +1,115 @@
+import { useSelector } from "react-redux";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { licensekeys as licenseKeysSelectors } from "app/base/selectors";
+import { formikFormDisabled } from "app/settings/utils";
+import { useFormikErrors } from "app/base/hooks";
+import Form from "app/base/components/Form";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikField from "app/base/components/FormikField";
+import Notification from "app/base/components/Notification";
+import Select from "app/base/components/Select";
+
+export const LicenseKeyFormFields = ({ osystems, releases, formikProps }) => {
+  const saving = useSelector(licenseKeysSelectors.saving);
+  const saved = useSelector(licenseKeysSelectors.saved);
+  const errors = useSelector(licenseKeysSelectors.errors);
+
+  useFormikErrors(errors, formikProps);
+
+  let licenseKeyErrors;
+  if (errors) {
+    if (typeof errors === "string") {
+      licenseKeyErrors = errors;
+    } else if ("__all__" in errors) {
+      licenseKeyErrors = errors["__all__"].join(" ");
+    }
+  }
+
+  const distroSeriesOptions = releases[formikProps.values.osystem];
+
+  return (
+    <>
+      {licenseKeyErrors && (
+        <Notification type="negative" status="Error:">
+          {licenseKeyErrors}
+        </Notification>
+      )}
+      <Form onSubmit={formikProps.handleSubmit}>
+        <>
+          <FormikField
+            formikProps={formikProps}
+            component={Select}
+            fieldKey="osystem"
+            label="Operating System"
+            required={true}
+            options={osystems.map(osystem => {
+              const [os, label] = osystem;
+              return { value: os, label };
+            })}
+            onChange={e => {
+              formikProps.handleChange(e);
+              formikProps.setFieldTouched("distro_series", true, true);
+              formikProps.setFieldValue(
+                "distro_series",
+                releases[e.target.value][0]
+              );
+            }}
+          />
+          <FormikField
+            formikProps={formikProps}
+            component={Select}
+            fieldKey="distro_series"
+            label="Release"
+            required={true}
+            options={distroSeriesOptions}
+            onChange={e => {
+              formikProps.handleChange(e);
+              formikProps.setFieldTouched("osystem", true, true);
+            }}
+          />
+          <FormikField
+            formikProps={formikProps}
+            fieldKey="license_key"
+            label="License key"
+            type="text"
+            required={true}
+          />
+        </>
+        <FormCardButtons
+          actionDisabled={saving || formikFormDisabled(formikProps)}
+          actionLabel="Add license key"
+          actionLoading={saving}
+          actionSuccess={saved}
+        />
+      </Form>
+    </>
+  );
+};
+
+LicenseKeyFormFields.propTypes = {
+  osystems: PropTypes.array.isRequired,
+  releases: PropTypes.object.isRequired,
+  formikProps: PropTypes.shape({
+    errors: PropTypes.shape({
+      osystem: PropTypes.bool,
+      distro_series: PropTypes.bool,
+      license_key: PropTypes.string
+    }).isRequired,
+    handleBlur: PropTypes.func.isRequired,
+    handleChange: PropTypes.func.isRequired,
+    handleSubmit: PropTypes.func.isRequired,
+    touched: PropTypes.shape({
+      osystem: PropTypes.bool,
+      distro_series: PropTypes.bool,
+      license_key: PropTypes.bool
+    }).isRequired,
+    values: PropTypes.shape({
+      osystem: PropTypes.string,
+      distro_series: PropTypes.string,
+      license_key: PropTypes.string
+    }).isRequired
+  })
+};
+export default LicenseKeyFormFields;

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.test.js
@@ -1,0 +1,80 @@
+import configureStore from "redux-mock-store";
+import { mount } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { Provider } from "react-redux";
+
+import { LicenseKeyFormFields } from "./LicenseKeyFormFields";
+
+const mockStore = configureStore();
+
+describe("LicenseKeyFormFields", () => {
+  let formikProps, state, osystems, releases;
+
+  beforeEach(() => {
+    osystems = [["windows", "Windows"]];
+    releases = {
+      windows: [{ value: "win2012", label: "Windows Server 2012" }]
+    };
+
+    formikProps = {
+      errors: {},
+      handleBlur: jest.fn(),
+      handleChange: jest.fn(),
+      handleSubmit: jest.fn(),
+      setFieldTouched: jest.fn(),
+      setFieldValue: jest.fn(),
+      setStatus: jest.fn(),
+      touched: {},
+      values: {
+        osystem: "windows",
+        distro_series: "win2012",
+        license_key: ""
+      }
+    };
+    state = {
+      licensekeys: {
+        loading: false,
+        loaded: true,
+        saved: false,
+        errors: {},
+        items: []
+      }
+    };
+  });
+
+  it("can render", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <LicenseKeyFormFields
+            osystems={osystems}
+            releases={releases}
+            formikProps={formikProps}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("LicenseKeyFormFields").exists()).toBe(true);
+  });
+
+  it("can set error status", () => {
+    state.licensekeys.errors = {
+      license_key: ["License key is required."]
+    };
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <LicenseKeyFormFields
+            osystems={osystems}
+            releases={releases}
+            formikProps={formikProps}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(formikProps.setStatus).toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/index.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/index.js
@@ -1,0 +1,1 @@
+export { default } from "./LicenseKeyFormFields";

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
@@ -105,8 +105,9 @@ const LicenseKeyList = () => {
     `License key ${title} removed successfully.`,
     setDeleting
   );
+
   useAddMessage(
-    hasErrors,
+    hasErrors && typeof errors === "string",
     licenseKeysActions.cleanup,
     `Error removing license key ${title}: ${errors}`,
     null,

--- a/ui/src/app/settings/views/Scripts/ScriptsList.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsList.js
@@ -161,6 +161,7 @@ const ScriptsList = ({ type = "commissioning" }) => {
     `${deletingScript} removed successfully.`,
     setDeleting
   );
+
   useAddMessage(
     hasErrors,
     scriptActions.cleanup,

--- a/ui/src/root-saga.js
+++ b/ui/src/root-saga.js
@@ -2,20 +2,22 @@ import { all } from "redux-saga/effects";
 
 import {
   watchWebSockets,
-  watchFetchLicenseKeys,
+  watchCreateLicenseKey,
   watchDeleteLicenseKey,
-  watchFetchScripts,
+  watchFetchLicenseKeys,
   watchDeleteScript,
+  watchFetchScripts,
   watchUploadScript
 } from "./app/base/sagas";
 
 export default function* rootSaga() {
   yield all([
     watchWebSockets(),
-    watchFetchLicenseKeys(),
+    watchCreateLicenseKey(),
     watchDeleteLicenseKey(),
-    watchFetchScripts(),
+    watchFetchLicenseKeys(),
     watchDeleteScript(),
+    watchFetchScripts(),
     watchUploadScript()
   ]);
 }


### PR DESCRIPTION
## Done
Added form for creating license keys.

## QA
1. Ensure you have a fake windows image uploaded (if not see _Creating a fake windows image_).
2. Visit /MAAS/settings/license-keys in maas-ui, click the _add license key_ button, and create a new license key (windows license keys are in the form `XXXXX-XXXXX-XXXXX-XXXXX-XXXXX`.
3. The form should redirect you to the licence key list with a success message. You should see your new key.

## Creating a fake windows image
1. Ensure you have an amd64 ubuntu image downloaded (via http://maas.local:5240/MAAS/#/images), this is required to populate architecture for the following steps.
2. Create a fake windows image with `dd if=/dev/zero of=windows-dd bs=512 count=10000`
3. Upload the image you've created with `maas {profile} boot-resources create name=windows/win2012 title="Windows Server 2012" architecture=amd64/generic filetype=ddtgz content@=windows-dd`. If you haven't used the maas cli before, you'll need to maas login first and create a profile.


