### PR TITLE
Sync SSL Keys

### DIFF
--- a/ui/src/app/preferences/reducers/sslkey/sslkey.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.js
@@ -33,6 +33,13 @@ const sslkey = produce(
         draft.saved = true;
         draft.saving = false;
         break;
+      case "CREATE_SSLKEY_NOTIFY":
+        draft.items.push(action.payload);
+        break;
+      case "DELETE_SSLKEY_NOTIFY":
+        const index = draft.items.findIndex(item => item.id === action.payload);
+        draft.items.splice(index, 1);
+        break;
       case "CLEANUP_SSLKEY":
         draft.errors = {};
         draft.saved = false;

--- a/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/reducers/sslkey/sslkey.test.js
@@ -224,6 +224,63 @@ describe("sslkey reducer", () => {
     });
   });
 
+  it("should correctly reduce CREATE_SSLKEY_NOTIFY", () => {
+    expect(
+      sslkey(
+        {
+          auth: {},
+          errors: {},
+          items: [{ id: 1, key: "ssh-rsa aabb" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          payload: { id: 2, key: "ssh-rsa ccdd" },
+          type: "CREATE_SSLKEY_NOTIFY"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: {},
+      items: [{ id: 1, key: "ssh-rsa aabb" }, { id: 2, key: "ssh-rsa ccdd" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce DELETE_SSLKEY_NOTIFY", () => {
+    expect(
+      sslkey(
+        {
+          errors: {},
+          items: [
+            { id: 1, key: "ssh-rsa aabb" },
+            { id: 2, key: "ssh-rsa ccdd" }
+          ],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          payload: 2,
+          type: "DELETE_SSLKEY_NOTIFY"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, key: "ssh-rsa aabb" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
   it("should correctly reduce CLEANUP_SSLKEY", () => {
     expect(
       sslkey(


### PR DESCRIPTION
Done:
- Sync update messages for SSL keys. Fixes: #238.

QA:
- Update your MAAS to the latest master (you might need to syncdb etc.)
- View the SSL keys in your preferences.
- Add a SSL key, the list should update.
- Remove a SSL key, the list should update.