### PR TITLE
Stack form card heading

### DIFF
--- a/ui/src/app/base/components/FormCard/FormCard.js
+++ b/ui/src/app/base/components/FormCard/FormCard.js
@@ -6,21 +6,29 @@ import Col from "app/base/components/Col";
 import Card from "app/base/components/Card";
 import Row from "app/base/components/Row";
 
-export const FormCard = ({ children, title }) => {
+export const FormCard = ({ children, stacked, title }) => {
+  const titleNode = <h4 className="form-card__title">{title}</h4>;
+  const content = stacked ? (
+    <>
+      {titleNode}
+      {children}
+    </>
+  ) : (
+    <Row>
+      <Col size="2">{titleNode}</Col>
+      <Col size="8">{children}</Col>
+    </Row>
+  );
   return (
     <Card highlighted={true} className="card-form">
-      <Row>
-        <Col size="2">
-          <h4 className="form-card__title">{title}</h4>
-        </Col>
-        <Col size="8">{children}</Col>
-      </Row>
+      {content}
     </Card>
   );
 };
 
 FormCard.propTypes = {
   children: PropTypes.node,
+  stacked: PropTypes.bool,
   title: PropTypes.node.isRequired
 };
 

--- a/ui/src/app/base/components/FormCard/FormCard.test.js
+++ b/ui/src/app/base/components/FormCard/FormCard.test.js
@@ -8,4 +8,9 @@ describe("FormCard ", () => {
     const wrapper = shallow(<FormCard title="Add user" />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("can display the heading on a separate row", () => {
+    const wrapper = shallow(<FormCard stacked title="Add user" />);
+    expect(wrapper.find("Col").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.js
@@ -8,8 +8,8 @@ import { useDropzone } from "react-dropzone";
 import "./ScriptsUpload.scss";
 import readScript from "./readScript";
 import { messages } from "app/base/actions";
-import Card from "app/base/components/Card";
 import Form from "app/base/components/Form";
+import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import Row from "app/base/components/Row";
 import { scripts as scriptActions } from "app/base/actions";
@@ -100,8 +100,7 @@ const ScriptsUpload = ({ type }) => {
   }
 
   return (
-    <Card>
-      <h4>{`Upload ${type} Script`}</h4>
+    <FormCard stacked title={`Upload ${type} Script`}>
       <Row>
         <div
           {...getRootProps()}
@@ -152,7 +151,7 @@ const ScriptsUpload = ({ type }) => {
           />
         </Form>
       </Row>
-    </Card>
+    </FormCard>
   );
 };
 


### PR DESCRIPTION
Done:
- Add an option to stack form card headings. Fixes: #210.

QA:
- View /settings/scripts/testing/upload, the heading should be above the drop area.
- View /settings/users/add, the heading should be to the left.