### PR TITLE
Add license key editing form.

### DIFF
--- a/ui/src/app/base/actions/licensekeys/licensekeys.js
+++ b/ui/src/app/base/actions/licensekeys/licensekeys.js
@@ -12,6 +12,11 @@ licenseKeys.delete = licenseKey => ({
   payload: licenseKey
 });
 
+licenseKeys.update = licenseKey => ({
+  type: "UPDATE_LICENSE_KEY",
+  payload: licenseKey
+});
+
 licenseKeys.fetch = () => ({
   type: "FETCH_LICENSE_KEYS"
 });

--- a/ui/src/app/base/actions/licensekeys/licensekeys.test.js
+++ b/ui/src/app/base/actions/licensekeys/licensekeys.test.js
@@ -28,6 +28,14 @@ describe("licenseKeys actions", () => {
     });
   });
 
+  it("can update license keys", () => {
+    const payload = { osystem: "windows", distro_series: "2012" };
+    expect(licenseKeys.update(payload)).toEqual({
+      type: "UPDATE_LICENSE_KEY",
+      payload
+    });
+  });
+
   it("can clean up license keys", () => {
     expect(licenseKeys.cleanup()).toEqual({
       type: "CLEANUP_LICENSE_KEYS"

--- a/ui/src/app/base/reducers/licensekeys/licensekeys.js
+++ b/ui/src/app/base/reducers/licensekeys/licensekeys.js
@@ -18,6 +18,7 @@ const licensekeys = produce(
         break;
       case "CREATE_LICENSE_KEY_START":
       case "DELETE_LICENSE_KEY_START":
+      case "UPDATE_LICENSE_KEY_START":
         draft.saved = false;
         draft.saving = true;
         break;
@@ -25,15 +26,27 @@ const licensekeys = produce(
         draft.errors = {};
         draft.saved = true;
         draft.saving = false;
-        const index = draft.items.findIndex(
+        const deleteIndex = draft.items.findIndex(
           item =>
             item.osystem === action.payload.osystem &&
             item.distro_series === action.payload.distro_series
         );
-        draft.items.splice(index, 1);
+        draft.items.splice(deleteIndex, 1);
+        break;
+      case "UPDATE_LICENSE_KEY_SUCCESS":
+        draft.errors = {};
+        draft.saved = true;
+        draft.saving = false;
+        const updateIndex = draft.items.findIndex(
+          item =>
+            item.osystem === action.payload.osystem &&
+            item.distro_series === action.payload.distro_series
+        );
+        draft.items[updateIndex] = action.payload;
         break;
       case "CREATE_LICENSE_KEY_ERROR":
       case "DELETE_LICENSE_KEY_ERROR":
+      case "UPDATE_LICENSE_KEY_ERROR":
         draft.errors = action.errors;
         draft.saving = false;
         break;

--- a/ui/src/app/base/reducers/licensekeys/licensekeys.test.js
+++ b/ui/src/app/base/reducers/licensekeys/licensekeys.test.js
@@ -139,6 +139,93 @@ describe("licenseKeys reducer", () => {
     });
   });
 
+  it("should correctly reduce UPDATE_LICENSE_KEY_START", () => {
+    expect(
+      licenseKeys(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false
+        },
+        {
+          type: "UPDATE_LICENSE_KEY_START"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce UPDATE_LICENSE_KEY_SUCCESS", () => {
+    expect(
+      licenseKeys(
+        {
+          errors: {},
+          items: [
+            { osystem: "windows", distro_series: "2012", license_key: "foo" },
+            { osystem: "windows", distro_series: "2019", license_key: "bar" }
+          ],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          type: "UPDATE_LICENSE_KEY_SUCCESS",
+          payload: {
+            osystem: "windows",
+            distro_series: "2019",
+            license_key: "baz"
+          }
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [
+        { osystem: "windows", distro_series: "2012", license_key: "foo" },
+        { osystem: "windows", distro_series: "2019", license_key: "baz" }
+      ],
+      loaded: false,
+      loading: false,
+      saved: true,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce UPDATE_LICENSE_KEY_ERROR", () => {
+    expect(
+      licenseKeys(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          errors: { error: "Not found" },
+          type: "UPDATE_LICENSE_KEY_ERROR"
+        }
+      )
+    ).toEqual({
+      errors: { error: "Not found" },
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
   it("should correctly reduce DELETE_LICENSE_KEY_START", () => {
     expect(
       licenseKeys(

--- a/ui/src/app/base/sagas/http.test.js
+++ b/ui/src/app/base/sagas/http.test.js
@@ -10,6 +10,7 @@ import {
   deleteScriptSaga,
   uploadScriptSaga,
   fetchLicenseKeysSaga,
+  updateLicenseKeySaga,
   deleteLicenseKeySaga
 } from "./http";
 
@@ -146,6 +147,35 @@ describe("http sagas", () => {
           ])
           .put({ type: "FETCH_LICENSE_KEYS_START" })
           .put({ type: "FETCH_LICENSE_KEYS_SUCCESS", payload })
+          .run();
+      });
+    });
+
+    describe("update license keys", () => {
+      it("returns a SUCCESS action", () => {
+        const payload = {
+          osystem: "windows",
+          distro_series: "2012",
+          license_key: "foo"
+        };
+        const action = {
+          type: "UPDATE_LICENSE_KEY",
+          payload
+        };
+        return expectSaga(updateLicenseKeySaga, action)
+          .provide([
+            [matchers.call.fn(getCookie, "csrftoken"), "csrf-token"],
+            [
+              matchers.call.fn(
+                api.licenseKeys.update,
+                payload.license_key,
+                "csrf-token"
+              ),
+              payload
+            ]
+          ])
+          .put({ type: "UPDATE_LICENSE_KEY_START" })
+          .put({ type: "UPDATE_LICENSE_KEY_SUCCESS", payload })
           .run();
       });
     });

--- a/ui/src/app/base/sagas/index.js
+++ b/ui/src/app/base/sagas/index.js
@@ -1,6 +1,7 @@
 import { watchWebSockets } from "./websockets";
 import {
   watchCreateLicenseKey,
+  watchUpdateLicenseKey,
   watchDeleteLicenseKey,
   watchFetchLicenseKeys,
   watchDeleteScript,
@@ -11,6 +12,7 @@ import {
 export {
   watchWebSockets,
   watchCreateLicenseKey,
+  watchUpdateLicenseKey,
   watchDeleteLicenseKey,
   watchFetchLicenseKeys,
   watchDeleteScript,

--- a/ui/src/app/base/selectors/licensekeys/licensekeys.js
+++ b/ui/src/app/base/selectors/licensekeys/licensekeys.js
@@ -56,6 +56,18 @@ licensekeys.search = (state, term) =>
   );
 
 /**
+ * Get license keys for a given osystem and distro_series.
+ * @param {Object} state - The redux state.
+ * @param {String} osystem - The operating system for the license key.
+ * @param {String} distro_series - The distro series for the license key.
+ * @returns {Object} A matching license key.
+ */
+licensekeys.getByOsystemAndDistroSeries = (state, osystem, distro_series) =>
+  state.licensekeys.items.filter(
+    item => item.osystem === osystem && item.distro_series === distro_series
+  )[0];
+
+/**
  * Get the saving state.
  * @param {Object} state - The redux state.
  * @returns {Boolean} Whether license keys are being saved.

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -12,6 +12,7 @@ import General from "app/settings/views/Configuration/General";
 import KernelParameters from "app/settings/views/Configuration/KernelParameters";
 import LicenseKeyList from "app/settings/views/LicenseKeys/LicenseKeyList";
 import LicenseKeyAdd from "app/settings/views/LicenseKeys/LicenseKeyAdd";
+import LicenseKeyEdit from "app/settings/views/LicenseKeys/LicenseKeyEdit";
 import NetworkDiscoveryForm from "app/settings/views/Network/NetworkDiscoveryForm";
 import NotFound from "app/base/views/NotFound";
 import NtpForm from "app/settings/views/Network/NtpForm";
@@ -75,6 +76,11 @@ const Routes = () => {
         exact
         path={`${match.path}/license-keys/add`}
         component={LicenseKeyAdd}
+      />
+      <Route
+        exact
+        path={`${match.path}/license-keys/:osystem/:distro_series/edit`}
+        component={LicenseKeyEdit}
       />
       <Route exact path={`${match.path}/storage`} component={StorageForm} />
       <Route exact path={`${match.path}/network/proxy`} component={ProxyForm} />

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.js
@@ -1,0 +1,37 @@
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect } from "react";
+
+import { useParams } from "app/base/hooks";
+import { licensekeys as licenseKeysActions } from "app/base/actions";
+import { licensekeys as licenseKeysSelectors } from "app/base/selectors";
+
+import Loader from "app/base/components/Loader";
+import LicenseKeyForm from "../LicenseKeyForm";
+
+export const LicenseKeyEdit = () => {
+  const dispatch = useDispatch();
+  const { osystem, distro_series } = useParams();
+  const loading = useSelector(licenseKeysSelectors.loading);
+
+  const licenseKey = useSelector(state =>
+    licenseKeysSelectors.getByOsystemAndDistroSeries(
+      state,
+      osystem,
+      distro_series
+    )
+  );
+
+  useEffect(() => {
+    dispatch(licenseKeysActions.fetch());
+  }, [dispatch]);
+
+  if (loading) {
+    return <Loader text="Loading..." />;
+  }
+  if (!licenseKey) {
+    return <h4>License key not found</h4>;
+  }
+  return <LicenseKeyForm licenseKey={licenseKey} />;
+};
+
+export default LicenseKeyEdit;

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.js
@@ -13,6 +13,9 @@ describe("LicenseKeyEdit", () => {
 
   beforeEach(() => {
     state = {
+      config: {
+        items: []
+      },
       general: {
         osInfo: {
           loaded: true,

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.js
@@ -1,0 +1,116 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { MemoryRouter, Route } from "react-router-dom";
+
+import { LicenseKeyEdit } from "./LicenseKeyEdit";
+
+const mockStore = configureStore();
+
+describe("LicenseKeyEdit", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      general: {
+        osInfo: {
+          loaded: true,
+          loading: false,
+          data: {
+            osystems: [["ubuntu", "Ubuntu"], ["windows", "Windows"]],
+            releases: [
+              ["ubuntu/bionic", "Ubuntu 18.04 LTS 'Bionic Beaver'"],
+              ["windows/win2012*", "Windows Server 2012"],
+              ["windows/win2019*", "Windows Server 2019"]
+            ]
+          }
+        }
+      },
+      licensekeys: {
+        errors: {},
+        items: [
+          {
+            osystem: "windows",
+            distro_series: "win2012",
+            license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXA",
+            resource_uri: "/MAAS/api/2.0/license-key/windows/win2012"
+          },
+          {
+            osystem: "windows",
+            distro_series: "win2019",
+            license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXX7",
+            resource_uri: "/MAAS/api/2.0/license-key/windows/win2019"
+          }
+        ],
+        loaded: true,
+        loading: false,
+        saving: false,
+        saved: false
+      }
+    };
+  });
+
+  it("displays a loading component if loading", () => {
+    state.licensekeys.loading = true;
+    state.licensekeys.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/settings/license-keys/window/windows2012/edit",
+              key: "testKey"
+            }
+          ]}
+        >
+          <LicenseKeyEdit />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("handles license key not found", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/settings/license-keys/foo/bar/edit", key: "testKey" }
+          ]}
+        >
+          <LicenseKeyEdit />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("h4").text()).toBe("License key not found");
+  });
+
+  it("can display a license key edit form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/settings/license-keys/windows/win2012/edit",
+              key: "testKey"
+            }
+          ]}
+        >
+          <Route
+            exact
+            path="/settings/license-keys/:osystem/:distro_series/edit"
+            component={props => <LicenseKeyEdit {...props} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const form = wrapper.find("LicenseKeyForm");
+    expect(form.exists()).toBe(true);
+    expect(form.prop("licenseKey")).toStrictEqual(state.licensekeys.items[0]);
+  });
+});

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/index.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyEdit/index.js
@@ -1,0 +1,1 @@
+export { default } from "./LicenseKeyEdit";

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
@@ -20,7 +20,7 @@ const LicenseKeySchema = Yup.object().shape({
   license_key: Yup.string().required("A license key is required")
 });
 
-export const LicenseKeyForm = () => {
+export const LicenseKeyForm = ({ licenseKey }) => {
   const [savingLicenseKey, setSaving] = useState();
   const saved = useSelector(licenseKeysSelectors.saved);
   const osInfoLoaded = useSelector(generalSelectors.osInfo.loaded);
@@ -32,10 +32,12 @@ export const LicenseKeyForm = () => {
 
   useWindowTitle("Add license key");
 
+  const editing = !!licenseKey;
+
   useAddMessage(
     saved,
     licenseKeysActions.cleanup,
-    `${savingLicenseKey} added successfully.`,
+    `${savingLicenseKey} ${editing ? "updated" : "added"} successfully.`,
     setSaving
   );
 
@@ -57,16 +59,20 @@ export const LicenseKeyForm = () => {
     return <Redirect to="/settings/license-keys" />;
   }
 
+  const title = licenseKey ? "Update license key" : "Add license key";
+
   return (
-    <FormCard title="Add license key">
+    <FormCard title={title}>
       {!isLoaded ? (
         <Loader text="loading..." />
       ) : (
         <Formik
           initialValues={{
-            osystem: osystems[0][0],
-            distro_series: releases[osystems[0][0]][0].value,
-            license_key: ""
+            osystem: licenseKey ? licenseKey.osystem : osystems[0][0],
+            distro_series: licenseKey
+              ? licenseKey.distro_series
+              : releases[osystems[0][0]][0].value,
+            license_key: licenseKey ? licenseKey.license_key : ""
           }}
           validationSchema={LicenseKeySchema}
           onSubmit={values => {
@@ -75,12 +81,17 @@ export const LicenseKeyForm = () => {
               distro_series: values.distro_series,
               license_key: values.license_key
             };
-            dispatch(licenseKeysActions.create(params));
+            if (editing) {
+              dispatch(licenseKeysActions.update(params));
+            } else {
+              dispatch(licenseKeysActions.create(params));
+            }
             setSaving(`${params.osystem} (${params.distro_series})`);
           }}
           render={formikProps => {
             return (
               <LicenseKeyFormFields
+                editing={editing}
                 osystems={osystems}
                 releases={releases}
                 formikProps={formikProps}

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
@@ -26,11 +26,13 @@ export const LicenseKeyForm = ({ licenseKey }) => {
   const osInfoLoaded = useSelector(generalSelectors.osInfo.loaded);
   const licenseKeysLoaded = useSelector(licenseKeysSelectors.loaded);
   const dispatch = useDispatch();
-  const isLoaded = licenseKeysLoaded && osInfoLoaded;
   const releases = useSelector(generalSelectors.osInfo.getLicensedOsReleases);
   const osystems = useSelector(generalSelectors.osInfo.getLicensedOsystems);
+  const isLoaded = licenseKeysLoaded && osInfoLoaded;
 
-  useWindowTitle("Add license key");
+  const title = licenseKey ? "Update license key" : "Add license key";
+
+  useWindowTitle(title);
 
   const editing = !!licenseKey;
 
@@ -59,13 +61,11 @@ export const LicenseKeyForm = ({ licenseKey }) => {
     return <Redirect to="/settings/license-keys" />;
   }
 
-  const title = licenseKey ? "Update license key" : "Add license key";
-
   return (
     <FormCard title={title}>
       {!isLoaded ? (
         <Loader text="loading..." />
-      ) : (
+      ) : osystems.length > 0 ? (
         <Formik
           initialValues={{
             osystem: licenseKey ? licenseKey.osystem : osystems[0][0],
@@ -99,6 +99,8 @@ export const LicenseKeyForm = ({ licenseKey }) => {
             );
           }}
         />
+      ) : (
+        <span>No available licensed operating systems.</span>
       )}
     </FormCard>
   );

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.js
@@ -147,6 +147,39 @@ describe("LicenseKeyForm", () => {
     });
   });
 
+  it("can update a key", () => {
+    const store = mockStore(state);
+    const licenseKey = {
+      osystem: "windows",
+      distro_series: "win2012",
+      license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+    };
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LicenseKeyForm licenseKey={licenseKey} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit(licenseKey)
+    );
+
+    expect(
+      store.getActions().find(action => action.type === "UPDATE_LICENSE_KEY")
+    ).toStrictEqual({
+      type: "UPDATE_LICENSE_KEY",
+      payload: {
+        osystem: "windows",
+        distro_series: "win2012",
+        license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+      }
+    });
+  });
+
   it("adds a message when a license key is created", () => {
     state.licensekeys.saved = true;
     const store = mockStore(state);

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.js
@@ -11,7 +11,12 @@ import FormikField from "app/base/components/FormikField";
 import Notification from "app/base/components/Notification";
 import Select from "app/base/components/Select";
 
-export const LicenseKeyFormFields = ({ osystems, releases, formikProps }) => {
+export const LicenseKeyFormFields = ({
+  editing = false,
+  osystems,
+  releases,
+  formikProps
+}) => {
   const saving = useSelector(licenseKeysSelectors.saving);
   const saved = useSelector(licenseKeysSelectors.saved);
   const errors = useSelector(licenseKeysSelectors.errors);
@@ -79,7 +84,7 @@ export const LicenseKeyFormFields = ({ osystems, releases, formikProps }) => {
         </>
         <FormCardButtons
           actionDisabled={saving || formikFormDisabled(formikProps)}
-          actionLabel="Add license key"
+          actionLabel={editing ? "Update license key" : "Add license key"}
           actionLoading={saving}
           actionSuccess={saved}
         />
@@ -89,6 +94,7 @@ export const LicenseKeyFormFields = ({ osystems, releases, formikProps }) => {
 };
 
 LicenseKeyFormFields.propTypes = {
+  editing: PropTypes.bool,
   osystems: PropTypes.array.isRequired,
   releases: PropTypes.object.isRequired,
   formikProps: PropTypes.shape({

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
@@ -40,7 +40,7 @@ const generateRows = (
               <Button
                 appearance="base"
                 element={Link}
-                to={`/settings/license-keys/edit`}
+                to={`/settings/license-keys/${licenseKey.osystem}/${licenseKey.distro_series}/edit`}
                 className="is-small u-justify-table-icon"
               >
                 <i className="p-icon--edit">Edit</i>

--- a/ui/src/root-saga.js
+++ b/ui/src/root-saga.js
@@ -3,6 +3,7 @@ import { all } from "redux-saga/effects";
 import {
   watchWebSockets,
   watchCreateLicenseKey,
+  watchUpdateLicenseKey,
   watchDeleteLicenseKey,
   watchFetchLicenseKeys,
   watchDeleteScript,
@@ -14,6 +15,7 @@ export default function* rootSaga() {
   yield all([
     watchWebSockets(),
     watchCreateLicenseKey(),
+    watchUpdateLicenseKey(),
     watchDeleteLicenseKey(),
     watchFetchLicenseKeys(),
     watchDeleteScript(),


### PR DESCRIPTION
## Done
Added form for editing/updating license keys.

## QA
1. Ensure you have a fake windows image uploaded (if not see _Creating a fake windows image_).
2. Visit /MAAS/settings/license-keys in maas-ui, click the _add license key_ button, and create a new license key (windows license keys are in the form `XXXXX-XXXXX-XXXXX-XXXXX-XXXXX`).
3. Return to the license key list, click the edit button next to your key.
4. Ensure the edit license key form displays the correct key data. 
5. Edit your key, and click "update license key".
6. The form should redirect you to the licence key list with a success message.
7. Edit your key again, and ensure the new key is reflected in the form.

## Creating a fake windows image
1. Ensure you have an amd64 ubuntu image downloaded (via http://maas.local:5240/MAAS/#/images), this is required to populate architecture for the following steps.
2. Create a fake windows image with `dd if=/dev/zero of=windows-dd bs=512 count=10000`
3. Upload the image you've created with `maas {profile} boot-resources create name=windows/win2012 title="Windows Server 2012" architecture=amd64/generic filetype=ddtgz content@=windows-dd`. If you haven't used the maas cli before, you'll need to maas login first and create a profile.


