### PR TITLE
Fix bug where changing Ubuntu kernel options while image was downloading would crash the app.

### DIFF
--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.js
@@ -31,16 +31,17 @@ const CommissioningFormFields = ({ formikProps }) => {
         fieldKey="commissioning_distro_series"
         formikProps={formikProps}
         onChange={e => {
+          const kernelValue =
+            allUbuntuKernelOptions[e.target.value] &&
+            allUbuntuKernelOptions[e.target.value][0].value;
+
           formikProps.handleChange(e);
           formikProps.setFieldTouched(
             "commissioning_distro_series",
             true,
             true
           );
-          formikProps.setFieldValue(
-            "default_min_hwe_kernel",
-            allUbuntuKernelOptions[e.target.value][0].value
-          );
+          formikProps.setFieldValue("default_min_hwe_kernel", kernelValue);
           formikProps.setFieldTouched("default_min_hwe_kernel", true, true);
         }}
       />


### PR DESCRIPTION
## Done
- Fix bug where changing Ubuntu kernel options while image was downloading would crash the app.

## QA
- Start downloading an Ubuntu image.
- Go to `<MAAS-IP>:8000/MAAS/r/settings/configuration/commissioning`
- Check that clicking open the kernel select and selecting any option does not crash the app.
- Wait until the image has finished downloading, and check that the kernel select now has the options for that release.

Fixes #150 