### PR TITLE
Only restrict settings to admins

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -17,7 +17,6 @@ import Section from "app/base/components/Section";
 export const App = () => {
   const authenticated = useSelector(status.authenticated);
   const authenticating = useSelector(status.authenticating);
-  const authUser = useSelector(authSelectors.get);
   const connected = useSelector(status.connected);
   const connecting = useSelector(status.connecting);
   const connectionError = useSelector(status.error);
@@ -57,8 +56,6 @@ export const App = () => {
         </Notification>
       </Section>
     );
-  } else if (!authUser || !authUser.is_superuser) {
-    content = <Section title="You do not have permission to view this page." />;
   } else if (connected) {
     content = <Routes />;
   }

--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -222,20 +222,4 @@ describe("App", () => {
     );
     expect(wrapper.find("Login").exists()).toBe(true);
   });
-
-  it("displays a message if not an admin", () => {
-    state.status.authenticated = true;
-    state.user.auth.user.is_superuser = false;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <App />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Section").prop("title")).toEqual(
-      "You do not have permission to view this page."
-    );
-  });
 });

--- a/ui/src/app/settings/views/Settings.js
+++ b/ui/src/app/settings/views/Settings.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
+import { auth as authSelectors } from "app/base/selectors";
 import { config as configActions } from "app/settings/actions";
 import Routes from "app/settings/components/Routes";
 import Section from "app/base/components/Section";
@@ -8,9 +9,15 @@ import SettingsNav from "app/settings/components/Nav";
 
 const Settings = () => {
   const dispatch = useDispatch();
+  const authUser = useSelector(authSelectors.get);
+
   useEffect(() => {
     dispatch(configActions.fetch());
   }, [dispatch]);
+
+  if (!authUser.is_superuser) {
+    return <Section title="You do not have permission to view this page." />;
+  }
 
   return (
     <Section title="Settings" sidebar={<SettingsNav />}>

--- a/ui/src/app/settings/views/Settings.test.js
+++ b/ui/src/app/settings/views/Settings.test.js
@@ -9,8 +9,10 @@ import Settings from "./Settings";
 const mockStore = configureStore();
 
 describe("Settings", () => {
-  it("dispatches action to fetch config on load", () => {
-    const store = mockStore({
+  let state;
+
+  beforeEach(() => {
+    state = {
       config: {
         loading: false,
         loaded: false,
@@ -18,9 +20,19 @@ describe("Settings", () => {
       },
       messages: {
         items: []
+      },
+      user: {
+        auth: {
+          user: {
+            is_superuser: true
+          }
+        }
       }
-    });
+    };
+  });
 
+  it("dispatches action to fetch config on load", () => {
+    const store = mockStore(state);
     mount(
       <Provider store={store}>
         <MemoryRouter
@@ -42,5 +54,22 @@ describe("Settings", () => {
         method: "list"
       }
     });
+  });
+
+  it("displays a message if not an admin", () => {
+    state.user.auth.user.is_superuser = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/settings", key: "testKey" }]}
+        >
+          <Settings />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Section").prop("title")).toEqual(
+      "You do not have permission to view this page."
+    );
   });
 });


### PR DESCRIPTION
- Allow non-admins to view everything but settings. Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1536.

QA:
- Log in as an admin, you should be able to see settings, machines and preferences.
- Log in as a non-admin, you should be able to see machines and preferences but not settings.