### PR TITLE
Add SITE_NAME config.

### DIFF
--- a/legacy/src/app/directives/version_reloader.js
+++ b/legacy/src/app/directives/version_reloader.js
@@ -12,7 +12,9 @@ function maasVersionReloader(
   $window,
   GeneralManager,
   ManagerHelperService,
-  LogService
+  LogService,
+  SITE_NAME,
+  VERSION
 ) {
   return {
     restrict: "A",
@@ -24,27 +26,20 @@ function maasVersionReloader(
     $scope.version = GeneralManager.getData("version");
 
     // Reload the page by-passing the browser cache.
-    $scope.reloadPage = function() {
+    $scope.reloadPage = () => {
       // Force cache reload by passing true.
       $window.location.reload(true);
     };
 
-    ManagerHelperService.loadManager($scope, GeneralManager).then(function() {
+    ManagerHelperService.loadManager($scope, GeneralManager).then(() => {
       GeneralManager.enableAutoReload(true);
       LogService.info(
-        'Version reloader: Monitoring MAAS "' + $scope.site + '"; version',
-        $scope.version.text,
-        "via",
-        $window.location.href
+        `Version reloader: Monitoring MAAS "${SITE_NAME}" version ${VERSION.version} (${VERSION.subversion}) via ${$window.location.href}.`
       );
-      $scope.$watch("version.text", function(newValue, oldValue) {
+      $scope.$watch("version.text", (newValue, oldValue) => {
         if (newValue !== oldValue) {
           LogService.info(
-            "MAAS version changed from '" +
-              oldValue +
-              "' to '" +
-              newValue +
-              "'; forcing reload."
+            `MAAS version changed from '${oldValue}' to '${newValue}'; forcing reload.`
           );
           $scope.reloadPage();
         }

--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -353,6 +353,10 @@ deferredBootstrapper.bootstrap({
     COMPLETED_INTRO: [
       "$http",
       $http => $http.get(`${CONFIG_API}&name=completed_intro`)
+    ],
+    SITE_NAME: [
+      "$http",
+      $http => $http.get(`${CONFIG_API}&name=maas_name`)
     ]
   }
 });

--- a/legacy/src/app/testing/setup.js
+++ b/legacy/src/app/testing/setup.js
@@ -27,6 +27,7 @@ beforeEach(function() {
   angular.mock.module(($provide) => {
     $provide.constant("VERSION", { version: "1", subversion: "2" });
     $provide.constant("COMPLETED_INTRO", true);
+    $provide.constant("SITE_NAME", "test");
   });
 });
 

--- a/legacy/src/index.html
+++ b/legacy/src/index.html
@@ -36,7 +36,6 @@
 -->
   <body
     class="has-sticky-footer"
-    data-ng-init="site='foo'"
     data-maas-version-reloader
     window-width
   >


### PR DESCRIPTION
## Done
Add `SITE_NAME` config value.

## QA
Load the app and open the console, the version reloader text (e.g. `Version reloader: Monitoring MAAS "kakariki" version 2.7.0 (8101-g.b3b43022d)`) should reflect your MAAS name.