### PR TITLE
Remove dead link to UI setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ This is a mono repo for MAAS frontend projects.
 
 This is a React frontend. New work should be done here where possible.
 
-[UI setup instructions](ui/README.md)
-
 To view component docs run `./run exec --expose-port 6060 yarn docs`.
 
 # Adding a new project


### PR DESCRIPTION
The setup instructions of this app have been moved to the main README
and whilst the doc no longer exists, the link to it remains in the
README. This PR removes that link to avoid confusion for future
developers.