### PR TITLE
Add CopyWebpackPlugin and serve assets correctly in dev.

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -22,6 +22,7 @@
     "babel-jest": "24.9.0",
     "babel-loader": "8.0.6",
     "babel-plugin-angularjs-annotate": "0.10.0",
+    "copy-webpack-plugin": "^5.0.4",
     "css-loader": "3.2.0",
     "dotenv-flow-webpack": "1.0.0",
     "enzyme": "3.10.0",

--- a/legacy/src/index.html
+++ b/legacy/src/index.html
@@ -23,9 +23,7 @@
     {% endif %}
 -->
 
-    <!--
-    <link rel="shortcut icon" href="{{ STATIC_URL }}assets/images/icons/maas-favicon-32px.png">
-        -->
+    <link rel="shortcut icon" href="assets/images/icons/maas-favicon-32px.png">
 
     <!--
     {% include "maasserver/css-conf.html" %}

--- a/legacy/src/scss/_settings.scss
+++ b/legacy/src/scss/_settings.scss
@@ -11,6 +11,6 @@ $breakpoint-x-large: 1300px;
 $breakpoint-navigation-threshold: 870px;
 $increase-font-size-on-larger-screens: false;
 
-$assets-path: "/MAAS/static/assets/fonts/";
+$assets-path: "assets/fonts/";
 
 $multi: 1;

--- a/legacy/webpack.config.js
+++ b/legacy/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require("webpack");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 var HtmlWebpackPlugin = require("html-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
@@ -16,7 +17,7 @@ module.exports = {
   },
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "/src"),
+    contentBase: path.resolve(__dirname, "./src"),
     host: "0.0.0.0",
     compress: true,
     public: "0.0.0.0:8400",
@@ -66,9 +67,12 @@ module.exports = {
     minimizer: [new OptimizeCSSAssetsPlugin({})]
   },
   plugins: [
+    new CopyWebpackPlugin([
+      { from: path.resolve(__dirname, "./src/assets"), to: "assets" }
+    ]),
     new MiniCssExtractPlugin({
       // This file is relative to output.path above.
-      filename: "dist/build.css",
+      filename: "build.css",
       chunkFilename: "[id].css"
     }),
     new HtmlWebpackPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2557,6 +2557,26 @@ cacache@^10.0.4:
     unique-filename "^1.1.0"
     y18n "^4.0.0"
 
+cacache@^11.3.3:
+  version "11.3.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.3.tgz#8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc"
+  integrity sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
+  dependencies:
+    bluebird "^3.5.5"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.4"
+    graceful-fs "^4.1.15"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.3"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
 cacache@^12.0.2:
   version "12.0.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
@@ -3204,6 +3224,24 @@ copy-webpack-plugin@^4.6.0:
     minimatch "^3.0.4"
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
+
+copy-webpack-plugin@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.4.tgz#c78126f604e24f194c6ec2f43a64e232b5d43655"
+  integrity sha512-YBuYGpSzoCHSSDGyHy6VJ7SHojKp6WHT4D7ItcQFNAYx2hrwkMe56e97xfVR0/ovDuMTrMffXUiltvQljtAGeg==
+  dependencies:
+    cacache "^11.3.3"
+    find-cache-dir "^2.1.0"
+    glob-parent "^3.1.0"
+    globby "^7.1.1"
+    is-glob "^4.0.1"
+    loader-utils "^1.2.3"
+    minimatch "^3.0.4"
+    normalize-path "^3.0.0"
+    p-limit "^2.2.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
+    webpack-log "^2.0.0"
 
 core-js-compat@^3.1.1:
   version "3.3.3"
@@ -7322,7 +7360,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.5, lodash@~4.17.10:
+lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8437,7 +8475,7 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
   integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==


### PR DESCRIPTION
## Done
* Add CopyWebpackPlugin to ensure static assets are served correctly by webpack-dev-server, and output correctly to `./dist` on build.
* Correct `build.css` path.

## QA
* Run the app, fonts and images should no longer 404.
* run `yarn build`, assets should be output correctly to `./dist`.