### PR TITLE
Configure production build

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "NODE_ENV=production webpack --mode production --config webpack.config.js",
+    "build": "webpack -p --config webpack.config.js",
     "build-dev": "NODE_ENV=development webpack --config webpack.config.js",
     "clean": "rm -rf node_modules dist",
+    "clean-build": "rm -rf dist",
     "lint": "eslint ./src/app/",
     "prettier": "prettier --write 'src/**/*.{js,scss}' '!**/build.scss' '!**/*-min.js'",
     "prettier-check": "prettier --check 'src/**/*.{js,scss}' '!**/build.scss' '!**/*-min.js'",

--- a/legacy/src/app/partials/directives/script-runtime.html
+++ b/legacy/src/app/partials/directives/script-runtime.html
@@ -1,4 +1,4 @@
-<span data-ng-if="(scriptStatus === 1 || scriptStatus === 7) && estimatedRunTime !== 'Unknown'" + '">{{counter}} of ~{{estimatedRunTime}}</span>
-<span data-ng-if="(scriptStatus === 1 || scriptStatus === 7) && estimatedRunTime == 'Unknown'" + '">{{counter}}</span>
-<span data-ng-if="scriptStatus === 0 && estimatedRunTime !== 'Unknown'" + '">~{{estimatedRunTime}}</span>
+<span data-ng-if="(scriptStatus === 1 || scriptStatus === 7) && estimatedRunTime !== 'Unknown'">{{counter}} of ~{{estimatedRunTime}}</span>
+<span data-ng-if="(scriptStatus === 1 || scriptStatus === 7) && estimatedRunTime == 'Unknown'">{{counter}}</span>
+<span data-ng-if="scriptStatus === 0 && estimatedRunTime !== 'Unknown'">~{{estimatedRunTime}}</span>
 <span data-ng-if="scriptStatus !== 0 && scriptStatus !== 1 && scriptStatus !== 7">{{runTime}}</span>

--- a/legacy/webpack.config.js
+++ b/legacy/webpack.config.js
@@ -1,8 +1,9 @@
 const webpack = require("webpack");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const TerserJSPlugin = require("terser-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-var HtmlWebpackPlugin = require("html-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 const DotenvFlow = require("dotenv-flow-webpack");
 
@@ -10,9 +11,12 @@ module.exports = {
   entry: {
     maas: ["babel-polyfill", "macaroon-bakery", "./src/app/entry.js"]
   },
+  optimization: {
+    minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})]
+  },
   output: {
     path: path.resolve(__dirname, "./dist"),
-    filename: "[name]-min.js",
+    filename: "[name].[hash].bundle.js",
     publicPath: "/MAAS/"
   },
   mode: "development",
@@ -37,7 +41,14 @@ module.exports = {
       },
       {
         test: /\.html$/,
-        use: ["html-loader"]
+        use: {
+          loader: "html-loader",
+          options: {
+            ignoreCustomFragments: [/\{\$.*?\$}/, /\{\{.*?\}\}/],
+            removeComments: true,
+            collapseWhitespace: true
+          }
+        }
       },
       {
         test: /\.(sa|sc|c)ss$/,
@@ -63,17 +74,13 @@ module.exports = {
       }
     ]
   },
-  optimization: {
-    minimizer: [new OptimizeCSSAssetsPlugin({})]
-  },
   plugins: [
     new CopyWebpackPlugin([
       { from: path.resolve(__dirname, "./src/assets"), to: "assets" }
     ]),
     new MiniCssExtractPlugin({
       // This file is relative to output.path above.
-      filename: "build.css",
-      chunkFilename: "[id].css"
+      filename: "[name].[hash].css"
     }),
     new HtmlWebpackPlugin({
       template: "./src/index.html",


### PR DESCRIPTION
## Done
* Configure production build with html, css and js optimisation and hashed assets.
* Configured html-loader to ignore angularjs template tags (e.g. `{$ foo $}` and `{{ bar }}`).
* Fixed a template bug in _script-runtime.html_ which was breaking the minification parser.

## QA
* Run `yarn clean-build`
* Run `yarn build`, ensure assets are correctly output to `./dist` and minified.