### PR TITLE
Update setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ From the root of the MAAS UI project run:
 ./run
 ```
 
-From here you should be able to view the project at &lt;your-local-maas-ip>:8000
+From here you should be able to view the project at &lt;your-local-maas-ip>:8400/MAAS/


### PR DESCRIPTION
The app now runs on port 8400 and also has no redirect to it's root URL
but the instructions in the README don't reflect this. This PR updates
the instructions in the README.