### PR TITLE
Change root element height to min height

### DIFF
--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -18,7 +18,7 @@ body {
 }
 
 #root {
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .p-icon--chevron {


### PR DESCRIPTION
The background colour doesn't extend beyond 100vh so when the content
exceeds that height the background changes from grey to white. By
changing the height to min-height this issue is mitigated. Fixes #331 

## QA
Go to the settings section and pick a tab with content that exceeds the height of the page. See that as you scroll beyond the viewport that the grey background extends to the bottom of the page.