### PR TITLE
Link to legacy machine listing by default.

### DIFF
--- a/ui/src/app/base/components/Header/Header.js
+++ b/ui/src/app/base/components/Header/Header.js
@@ -110,13 +110,9 @@ export const Header = () => {
                     "u-hide": !hardwareVisible
                   })}
                 >
-                  {generateLocalLink(
-                    location,
-                    "/machines",
-                    "Machines",
-                    false,
-                    false
-                  )}
+                  <li className="p-navigation__link" role="menuitem">
+                    <a href={generateURL("#/machines")}>Machines</a>
+                  </li>
                   <li className="p-navigation__link" role="menuitem">
                     <a href={generateURL("#/devices")}>Devices</a>
                   </li>
@@ -133,7 +129,9 @@ export const Header = () => {
                   </li>
                 </ul>
               </li>
-              {generateLocalLink(location, "/machines", "Machines", true, true)}
+              <li className="p-navigation__link" role="menuitem">
+                <a href={generateURL("#/machines")}>Machines</a>
+              </li>
               <li
                 className="p-navigation__link u-hide-nav-viewport--medium"
                 role="menuitem"

--- a/ui/src/app/base/components/Header/__snapshots__/Header.test.js.snap
+++ b/ui/src/app/base/components/Header/__snapshots__/Header.test.js.snap
@@ -96,24 +96,11 @@ exports[`Header renders 1`] = `
                 className="p-navigation__link"
                 role="menuitem"
               >
-                <Link
-                  className=""
-                  to="/machines"
+                <a
+                  href="/MAAS/#/machines"
                 >
-                  <LinkAnchor
-                    className=""
-                    href="/machines"
-                    navigate={[Function]}
-                  >
-                    <a
-                      className=""
-                      href="/machines"
-                      onClick={[Function]}
-                    >
-                      Machines
-                    </a>
-                  </LinkAnchor>
-                </Link>
+                  Machines
+                </a>
               </li>
               <li
                 className="p-navigation__link"
@@ -148,27 +135,14 @@ exports[`Header renders 1`] = `
             </ul>
           </li>
           <li
-            className="p-navigation__link u-hide-nav-viewport--medium"
+            className="p-navigation__link"
             role="menuitem"
           >
-            <Link
-              className="p-dropdown__item"
-              to="/machines"
+            <a
+              href="/MAAS/#/machines"
             >
-              <LinkAnchor
-                className="p-dropdown__item"
-                href="/machines"
-                navigate={[Function]}
-              >
-                <a
-                  className="p-dropdown__item"
-                  href="/machines"
-                  onClick={[Function]}
-                >
-                  Machines
-                </a>
-              </LinkAnchor>
-            </Link>
+              Machines
+            </a>
           </li>
           <li
             className="p-navigation__link u-hide-nav-viewport--medium"


### PR DESCRIPTION
## Done
Link to the legacy machine listing be default in the header. The react machine listing is still available from `/MAAS/r/machines`.

## QA
Load the app, the heading should link to the angularjs machine listing.

fixes #327 