### PR TITLE
Add initial values when undefined for DnsForm and SyslogForm.

### DIFF
--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.js
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.js
@@ -50,9 +50,9 @@ const DnsForm = () => {
         {loaded && (
           <Formik
             initialValues={{
-              dnssec_validation: dnssecValidation,
-              dns_trusted_acl: dnsTrustedAcl,
-              upstream_dns: upstreamDns
+              dnssec_validation: dnssecValidation || "",
+              dns_trusted_acl: dnsTrustedAcl || "",
+              upstream_dns: upstreamDns || ""
             }}
             onSubmit={(values, { resetForm }) => {
               dispatch(updateConfig(values));

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.js
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.js
@@ -44,7 +44,7 @@ const SyslogForm = () => {
         {loaded && (
           <Formik
             initialValues={{
-              remote_syslog: remoteSyslog
+              remote_syslog: remoteSyslog || ""
             }}
             onSubmit={(values, { resetForm }) => {
               dispatch(updateConfig(values));


### PR DESCRIPTION
@Caleb-Ellis I wasn't able to find a console error on the Network Discovery form unfortunately, are you still able to replicate that?

## Done
Add empty string defaults for initial values

## QA
Visit DnsForm/SyslogForm/NetworkDisoverForm and ensure there are no console errors.