### PR TITLE
Add config from USERS API.

### DIFF
--- a/legacy/src/app/routes.js
+++ b/legacy/src/app/routes.js
@@ -18,7 +18,7 @@ import vlanDetailsTmpl from "./partials/vlan-details.html";
 import zoneDetailsTmpl from "./partials/zone-details.html";
 import zonesListTmpl from "./partials/zones-list.html";
 
-const configureRoutes = ($routeProvider, MAAS_config) => {
+const configureRoutes = $routeProvider => {
   let routes;
   routes = $routeProvider
     .when("/intro", {
@@ -178,15 +178,12 @@ const configureRoutes = ($routeProvider, MAAS_config) => {
     .when("/pools", {
       template: nodesListTmpl,
       controller: "NodesListController"
-    });
-
-  if (MAAS_config.superuser) {
-    // Only superuser's can access the dashboard at the moment.
-    routes = routes.when("/dashboard", {
+    })
+    .when("/dashboard", {
       template: dashboardTmpl,
       controller: "DashboardController"
     });
-  }
+
   routes.otherwise({
     redirectTo: "/machines"
   });

--- a/legacy/src/app/testing/setup.js
+++ b/legacy/src/app/testing/setup.js
@@ -28,6 +28,7 @@ beforeEach(function() {
     $provide.constant("VERSION", { version: "1", subversion: "2" });
     $provide.constant("COMPLETED_INTRO", true);
     $provide.constant("SITE_NAME", "test");
+    $provide.constant("CURRENT_USER", {username: "testuser", _userprofile_cache: {}});
   });
 });
 


### PR DESCRIPTION
## Done
Add `CURRENT_USER` config var from the `/users` API.

## QA
Ensure /dashboard is accessible to superusers, but not regular users.
Ensure a new regular user gets redirected to intro/user