### PR TITLE
Use localStorage for persisting config.

### DIFF
--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -353,6 +353,7 @@ const renderHeader = ($window, $http) => {
       basename={process.env.BASENAME}
       location={window.location}
       logout={() => {
+        window.localStorage.removeItem("maas-config");
         $http.post(LOGOUT_API).then(() => {
           $window.location.href = process.env.BASENAME;
         });

--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -353,7 +353,6 @@ const renderHeader = ($window, $http) => {
       basename={process.env.BASENAME}
       location={window.location}
       logout={() => {
-        window.localStorage.removeItem("maas-config");
         $http.post(LOGOUT_API).then(() => {
           $window.location.href = process.env.BASENAME;
         });

--- a/shared/src/components/Header/Header.js
+++ b/shared/src/components/Header/Header.js
@@ -208,6 +208,7 @@ export const Header = ({
                   href=""
                   onClick={evt => {
                     evt.preventDefault();
+                    localStorage.removeItem("maas-config");
                     logout();
                   }}
                 >


### PR DESCRIPTION
## Done
* Persist config to localStorage after fetching from websocket.
* On load, if config is available from localStorage, fetch from there rather than over network.
* Clear config from localStorage on logout.

## QA
1. Load app, config should be persisted to localStorage.
2. Refresh app, config should be loaded from localStorage (you can confirm this by checking that no websocket messages are sent with method `config.list`).
3. Logout, config should be removed from localStorage.