### PR TITLE
MAAS name in window title

### DIFF
--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -380,6 +380,7 @@ const renderFooter = $window => {
 
 /* @ngInject */
 const displayTemplate = ($rootScope, $window, $http) => {
+  $rootScope.site = window.CONFIG.maas_name;
   renderHeader($window, $http);
   renderFooter($window);
 };

--- a/legacy/src/index.html
+++ b/legacy/src/index.html
@@ -13,7 +13,7 @@
       <meta http-equiv="X-UA-Compatible" content="IE=8" />
     <![endif]-->
 
-    <title data-ng-bind="title + ' | ' + ' MAAS'"></title>
+    <title data-ng-bind="title + ' | ' + site + ' MAAS'">Loading MAAS...</title>
     <!--
     {% if global_options.enable_analytics %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -38,7 +38,10 @@
 -->
   <body class="has-sticky-footer" data-maas-version-reloader window-width>
     <div id="header"></div>
-    <header ng-loading class="p-strip--light is-shallow u-no-padding--bottom page-header">
+    <header
+      ng-loading
+      class="p-strip--light is-shallow u-no-padding--bottom page-header"
+    >
       <div class="row">
         <h1 class="page-header__title">Loading MAAS...</h1>
       </div>


### PR DESCRIPTION
Done:
- Display the maas name in the window title for the legacy app. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/348.

QA:
- Load a legacy page. The window title should include the maas name (e.g. Machines | [maas name] MAAS).