### PR TITLE
Set ActionButton dimensions on loading state transition.

### DIFF
--- a/ui/src/app/base/components/ActionButton/ActionButton.js
+++ b/ui/src/app/base/components/ActionButton/ActionButton.js
@@ -17,23 +17,22 @@ const ActionButton = ({
   success,
   ...props
 }) => {
-  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState();
+  const [width, setWidth] = useState();
   const [showLoader, setShowLoader] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const ref = useRef(null);
-
-  // Store default button width
-  useEffect(() => {
-    if (ref.current && ref.current.getBoundingClientRect().width) {
-      setWidth(ref.current.getBoundingClientRect().width);
-    }
-  }, [children]);
 
   // Set up loader timer
   useEffect(() => {
     let loaderTimeout;
 
     if (loading) {
+      // Explicitly set button dimensions
+      if (ref.current && !!ref.current.getBoundingClientRect()) {
+        setHeight(ref.current.getBoundingClientRect().height);
+        setWidth(ref.current.getBoundingClientRect().width);
+      }
       setShowLoader(true);
     }
 
@@ -56,6 +55,8 @@ const ActionButton = ({
 
     if (showSuccess) {
       successTimeout = setTimeout(() => {
+        setHeight();
+        setWidth();
         setShowSuccess(false);
       }, SUCCESS_DURATION);
     }
@@ -89,7 +90,14 @@ const ActionButton = ({
       className={buttonClasses}
       disabled={disabled}
       ref={ref}
-      style={width ? { width: `${width}px` } : undefined}
+      style={
+        height && width
+          ? {
+              height: `${height}px`,
+              width: `${width}px`
+            }
+          : undefined
+      }
       {...props}
     >
       {showLoader || showSuccess ? <i className={iconClasses} /> : children}


### PR DESCRIPTION
## Done
- Updated ActionButton so that it explicitly sets width *and* height when transitioning to loading, instead of just width on mount. This means that if for some reason the content of the button changes it will actually be the correct height/width as according to Vanilla and will only store the dimensions for the loading => success phase.

## QA
- Go to any Settings form, make changes and save. Check that the button dimensions stay consistent.
- Open the inspector and change the button text to something else. Save again and check that the dimensions are consistent.