### PR TITLE
Use 'build' instead of 'dist' for legacy build dir for consistency.

### DIFF
--- a/legacy/.gitignore
+++ b/legacy/.gitignore
@@ -13,7 +13,7 @@ yarn.lock
 /coverage
 
 # production
-/dist
+/build
 
 # misc
 *.swp

--- a/legacy/package.json
+++ b/legacy/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "webpack -p --config webpack.config.js",
     "build-dev": "NODE_ENV=development webpack --config webpack.config.js",
-    "clean": "rm -rf node_modules dist",
-    "clean-build": "rm -rf dist",
+    "clean": "rm -rf node_modules build",
+    "clean-build": "rm -rf build",
     "lint": "eslint ./src/app/",
     "prettier": "prettier --write 'src/**/*.{js,scss}' '!**/build.scss' '!**/*-min.js'",
     "prettier-check": "prettier --check 'src/**/*.{js,scss}' '!**/build.scss' '!**/*-min.js'",

--- a/legacy/webpack.config.js
+++ b/legacy/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
     minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})]
   },
   output: {
-    path: path.resolve(__dirname, "./dist"),
+    path: path.resolve(__dirname, "./build"),
     filename: "[name].[hash].bundle.js",
     publicPath: "/MAAS/"
   },


### PR DESCRIPTION
## Done
CRA (and hence `ui`) outputs to `./build` by default. To make the projects consistent, we should also build to `./build` in legacy instead of `./dist`.

## QA
`cd legacy;yarn build` - production build should output to `./build`.