### PR TITLE
Add intro skip

### DIFF
--- a/legacy/src/app/bootstrap.js
+++ b/legacy/src/app/bootstrap.js
@@ -92,7 +92,14 @@ const bootstrapOverWebsocket = config => {
         break;
     }
     if (messagesReceived.length === 3) {
-      window.localStorage.setItem("maas-config", JSON.stringify(config));
+      // Only store the config once the MAAS has been set up. The intro pages
+      // refresh the window when each one completes, so we don't want the
+      // stored config to get out of sync (there is also little optimisation to
+      // be gained as the user won't be switching between the AngularJS and
+      // React clients during the intro flow).
+      if (config.completed_intro && config.current_user.completed_intro) {
+        window.localStorage.setItem("maas-config", JSON.stringify(config));
+      }
       bootstrapApp(config);
       webSocket.close();
     }

--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -342,16 +342,18 @@ function unhideRSDLinks() {
   rsdLinks.forEach(link => link.classList.remove("u-hide"));
 }
 
-const renderHeader = ($window, $http) => {
+const renderHeader = ($rootScope, $window, $http) => {
   const headerNode = document.querySelector("#header");
   if (!headerNode) {
     return;
   }
+  const { completed_intro, current_user } = $window.CONFIG;
   const debug = process.env.NODE_ENV === "development";
   ReactDOM.render(
     <Header
-      authUser={$window.CONFIG.current_user}
+      authUser={current_user}
       basename={process.env.BASENAME}
+      completedIntro={completed_intro && current_user.completed_intro}
       enableAnalytics={!debug && window.CONFIG.enable_analytics}
       location={window.location}
       logout={() => {
@@ -360,6 +362,11 @@ const renderHeader = ($window, $http) => {
         });
       }}
       newURLPrefix={process.env.REACT_BASENAME}
+      onSkip={() => {
+        // Call skip inside this function because skip won't exist when the
+        // header is first rendered.
+        $rootScope.skip();
+      }}
     />,
     headerNode
   );
@@ -383,7 +390,7 @@ const renderFooter = $window => {
 /* @ngInject */
 const displayTemplate = ($rootScope, $window, $http) => {
   $rootScope.site = window.CONFIG.maas_name;
-  renderHeader($window, $http);
+  renderHeader($rootScope, $window, $http);
   renderFooter($window);
 };
 

--- a/shared/src/components/Header/Header.js
+++ b/shared/src/components/Header/Header.js
@@ -14,11 +14,13 @@ const useVisible = initialValue => {
 export const Header = ({
   authUser,
   basename,
+  completedIntro,
   enableAnalytics,
   generateLocalLink,
   location,
   logout,
-  newURLPrefix
+  newURLPrefix,
+  onSkip
 }) => {
   const [hardwareVisible, toggleHardware] = useVisible(false);
   const [mobileMenuVisible, toggleMobileMenu] = useVisible(false);
@@ -198,26 +200,43 @@ export const Header = ({
                 <a href="#main-content">Jump to main content</a>
               </span>
               <ul className="p-navigation__links" role="menu">
-                <li
-                  role="menuitem"
-                  className="p-navigation__link p-dropdown u-hide-nav-viewport--large u-hide-nav-viewport--small p-dropdown__toggle"
-                >
-                  <a onClick={toggleHardware} href="#menu">
-                    Hardware <i className="p-icon--chevron"></i>
-                  </a>
-                  <ul
-                    className={classNames("p-dropdown__menu", {
-                      "u-hide": !hardwareVisible
-                    })}
-                  >
-                    {generateMenuItems(
-                      links.filter(item => item.inHardwareMenu)
-                    )}
-                  </ul>
-                </li>
-                {generateMenuItems(links, true, true)}
+                {completedIntro && (
+                  <>
+                    <li
+                      role="menuitem"
+                      className="p-navigation__link p-dropdown u-hide-nav-viewport--large u-hide-nav-viewport--small p-dropdown__toggle"
+                    >
+                      <a onClick={toggleHardware} href="#menu">
+                        Hardware <i className="p-icon--chevron"></i>
+                      </a>
+                      <ul
+                        className={classNames("p-dropdown__menu", {
+                          "u-hide": !hardwareVisible
+                        })}
+                      >
+                        {generateMenuItems(
+                          links.filter(item => item.inHardwareMenu)
+                        )}
+                      </ul>
+                    </li>
+                    {generateMenuItems(links, true, true)}
+                  </>
+                )}
               </ul>
               <ul className="p-navigation__links--right" role="menu">
+                {!completedIntro && (
+                  <li className="p-navigation__link" role="menuitem">
+                    <a
+                      href=""
+                      onClick={evt => {
+                        evt.preventDefault();
+                        onSkip();
+                      }}
+                    >
+                      Skip
+                    </a>
+                  </li>
+                )}
                 {generateLink("/account/prefs", authUser.username, false, true)}
                 <li className="p-navigation__link" role="menuitem">
                   <a
@@ -247,13 +266,15 @@ Header.propTypes = {
     username: PropTypes.string
   }),
   basename: PropTypes.string.isRequired,
+  completedIntro: PropTypes.bool,
   enableAnalytics: PropTypes.bool,
   generateLocalLink: PropTypes.func,
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired
   }).isRequired,
   logout: PropTypes.func.isRequired,
-  newURLPrefix: PropTypes.string
+  newURLPrefix: PropTypes.string,
+  onSkip: PropTypes.func
 };
 
 export default Header;

--- a/shared/src/components/Header/Header.test.js
+++ b/shared/src/components/Header/Header.test.js
@@ -16,6 +16,7 @@ describe("Header", () => {
           username: "koala"
         }}
         basename="/MAAS"
+        completedIntro={true}
         location={{
           pathname: "/"
         }}
@@ -59,5 +60,28 @@ describe("Header", () => {
       .last()
       .simulate("click", { preventDefault: jest.fn() });
     expect(logout).toHaveBeenCalled();
+  });
+
+  it("can show the intro flow state", () => {
+    const wrapper = shallow(
+      <Header
+        authUser={{
+          is_superuser: true,
+          username: "koala"
+        }}
+        basename="/MAAS"
+        completedIntro={false}
+        location={{
+          pathname: "/"
+        }}
+        logout={jest.fn()}
+      />
+    );
+    expect(
+      wrapper.findWhere(n => n.name() === "a" && n.text() === "Skip").exists()
+    ).toBe(true);
+    expect(
+      wrapper.find(".p-navigation__links .p-navigation__link").exists()
+    ).toBe(false);
   });
 });

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -33,7 +33,9 @@ export const App = () => {
   const authLoading = useSelector(authSelectors.loading);
   const version = useSelector(generalSelectors.version.get);
   const maasName = useSelector(configSelectors.maasName);
+  const completedIntro = useSelector(configSelectors.completedIntro);
   const dispatch = useDispatch();
+  const basename = process.env.REACT_APP_BASENAME;
   const debug = process.env.NODE_ENV === "development";
 
   useEffect(() => {
@@ -57,6 +59,14 @@ export const App = () => {
     }
   }, [dispatch, connected]);
 
+  // Explicitly check that completedIntro is false so that it doesn't redirect
+  // if the config isn't defined yet.
+  if (completedIntro === false) {
+    window.location = `${basename}/#/intro`;
+  } else if (authUser && !authUser.completed_intro) {
+    window.location = `${basename}/#/intro/user`;
+  }
+
   let content;
   if (authLoading || connecting || authenticating) {
     content = <Section title={<Loader text="Loading..." />} />;
@@ -79,6 +89,7 @@ export const App = () => {
       <Header
         authUser={authUser}
         basename={process.env.REACT_APP_BASENAME}
+        completedIntro={completedIntro && authUser.completed_intro}
         enableAnalytics={!debug && analyticsEnabled}
         generateLocalLink={(url, label, linkClass) => (
           <Link className={linkClass} to={url}>

--- a/ui/src/app/settings/selectors/config/config.js
+++ b/ui/src/app/settings/selectors/config/config.js
@@ -430,4 +430,14 @@ config.defaultDistroSeries = createSelector(
   configs => getValueFromName(configs, "default_distro_series")
 );
 
+/**
+ * Returns the MAAS config for whether the intro has been completed.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Whether the intro has been completed
+ */
+config.completedIntro = createSelector(
+  [config.all],
+  configs => getValueFromName(configs, "completed_intro")
+);
+
 export default config;

--- a/ui/src/app/settings/selectors/config/config.test.js
+++ b/ui/src/app/settings/selectors/config/config.test.js
@@ -441,4 +441,17 @@ describe("config selectors", () => {
       expect(config.defaultDistroSeries(state)).toBe("bionic");
     });
   });
+
+  describe("completedIntro", () => {
+    it("returns MAAS config for completed intro", () => {
+      const state = {
+        config: {
+          loading: false,
+          loaded: true,
+          items: [{ name: "completed_intro", value: true }]
+        }
+      };
+      expect(config.completedIntro(state)).toBe(true);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8438,7 +8438,7 @@ npm-bundled@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
   integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
 
-npm-package-json-lint@^4.0.3:
+npm-package-json-lint@4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/npm-package-json-lint/-/npm-package-json-lint-4.0.3.tgz#3f869195a238bd67c273c7ecb32b80a1e433a866"
   integrity sha512-cuvTR2l5dOjjlRR3a1CCp+mh2A2HyQRxydwdcYi0Z77NRlADpf7wF3Jf8XFLGZM7J6afXNRBofBjQ1UWFyOtKA==


### PR DESCRIPTION
Done:
- Display the intro skip link in the header. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/362.

QA:
- Log out of the UI.
- With a local maas, ssh into your maas mulitpass and cd to the maas dir.
- Run `make harness`
- Then inside the shell run:
```python
from maasserver.models import Config, UserProfile
Config.objects.filter(name='completed_intro').update(value=False)
UserProfile.objects.all().update(completed_intro=False)
```
- Reload the ui and log in.
- You should see the intro.
- Click Skip in the header and you should be taken to the second screen.
- Click Skip again and you should see the machine list.