### PR TITLE
Disable Add License key button if no valid OSes.

### DIFF
--- a/ui/src/app/settings/components/SettingsTable/SettingsTable.js
+++ b/ui/src/app/settings/components/SettingsTable/SettingsTable.js
@@ -35,11 +35,20 @@ export const SettingsTable = ({
         ) : (
           <div className="p-table-actions__space-left"></div>
         )}
-        {buttons.map(({ label, url }) => (
-          <Button element={Link} to={url} key={url}>
-            {label}
-          </Button>
-        ))}
+        {buttons.map(({ label, url, disabled = false, tooltip }) =>
+          tooltip ? (
+            <span key={url} className="p-tooltip p-tooltip--left">
+              <Button element={Link} to={url} disabled={disabled}>
+                {label}
+              </Button>
+              <span className="p-tooltip__message">{tooltip}</span>
+            </span>
+          ) : (
+            <Button element={Link} to={url} key={url} disabled={disabled}>
+              {label}
+            </Button>
+          )
+        )}
       </div>
       {loading && (
         <div className="settings-table__loader">
@@ -67,7 +76,9 @@ SettingsTable.propTypes = {
   buttons: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired
+      url: PropTypes.string.isRequired,
+      disabled: PropTypes.bool,
+      tooltip: PropTypes.string
     })
   ).isRequired,
   defaultSort: PropTypes.string,

--- a/ui/src/app/settings/components/SettingsTable/SettingsTable.test.js
+++ b/ui/src/app/settings/components/SettingsTable/SettingsTable.test.js
@@ -63,7 +63,37 @@ describe("SettingsTable", () => {
         <span>Content</span>
       </SettingsTable>
     );
+
     expect(wrapper.find(".p-table-actions__space-left").exists()).toBe(true);
     expect(wrapper.find("SearchBox").exists()).toBe(false);
   });
+});
+
+it("can render a disabled button ", () => {
+  const wrapper = shallow(
+    <SettingsTable
+      buttons={[{ label: "Add User", url: "/foo", disabled: true }]}
+      loaded={false}
+      loading={true}
+    >
+      <span>Content</span>
+    </SettingsTable>
+  );
+
+  expect(wrapper.find("Button").props().disabled).toBe(true);
+});
+
+it("can show render a button with a tooltip", () => {
+  const tooltip = "Add a user to MAAS";
+  const wrapper = shallow(
+    <SettingsTable
+      buttons={[{ label: "Add User", url: "/foo", tooltip }]}
+      loaded={false}
+      loading={true}
+    >
+      <span>Content</span>
+    </SettingsTable>
+  );
+
+  expect(wrapper.find("span.p-tooltip__message").text()).toEqual(tooltip);
 });

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
@@ -10,6 +10,7 @@ import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 import { licensekeys as licenseKeysActions } from "app/base/actions";
 import { licensekeys as licenseKeysSelectors } from "app/base/selectors";
+import { general as generalSelectors } from "app/base/selectors";
 
 const generateRows = (
   licenseKeys,
@@ -86,6 +87,7 @@ const LicenseKeyList = () => {
 
   const licenseKeysLoading = useSelector(licenseKeysSelectors.loading);
   const licenseKeysLoaded = useSelector(licenseKeysSelectors.loaded);
+  const osystems = useSelector(generalSelectors.osInfo.getLicensedOsystems);
   const hasErrors = useSelector(licenseKeysSelectors.hasErrors);
   const errors = useSelector(licenseKeysSelectors.errors);
   const saved = useSelector(licenseKeysSelectors.saved);
@@ -123,10 +125,20 @@ const LicenseKeyList = () => {
     dispatch(licenseKeysActions.fetch());
   }, [dispatch]);
 
+  const addBtnDisabled = osystems.length === 0;
+  const tooltip = addBtnDisabled
+    ? "No available licensed operating systems."
+    : null;
+
   return (
     <SettingsTable
       buttons={[
-        { label: "Add license key", url: "/settings/license-keys/add" }
+        {
+          label: "Add license key",
+          url: "/settings/license-keys/add",
+          disabled: addBtnDisabled,
+          tooltip
+        }
       ]}
       headers={[
         {

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.js
@@ -15,6 +15,19 @@ describe("LicenseKeyList", () => {
       config: {
         items: []
       },
+      general: {
+        osInfo: {
+          loaded: true,
+          loading: false,
+          data: {
+            osystems: [["ubuntu", "Ubuntu"], ["windows", "Windows"]],
+            releases: [
+              ["ubuntu/bionic", "Ubuntu 18.04 LTS 'Bionic Beaver'"],
+              ["windows/win2012*", "Windows Server 2012"]
+            ]
+          }
+        }
+      },
       licensekeys: {
         loading: false,
         loaded: true,


### PR DESCRIPTION
## Done
Disable "Add License key" button if no valid licensed operating systems are synced.

## QA
* Delete any licensed images should you have one (e.g. a fake Windows server image)
* Visit the license key page in settings. The add button should be disabled and display a tooltip.

fixes #397 