### PR TITLE
Fix broken links in network tab

### DIFF
--- a/legacy/src/app/directives/dhcp_snippets_table.js
+++ b/legacy/src/app/directives/dhcp_snippets_table.js
@@ -17,7 +17,11 @@ function maasDhcpSnippetsTable($window) {
       hideAllSnippetsLink: "="
     },
     template: dhcpSnippetsTableTmpl,
-    controller: DHCPSnippetsTableController
+    controller: DHCPSnippetsTableController,
+    link: scope => {
+      scope.BASENAME = process.env.BASENAME;
+      scope.REACT_BASENAME = process.env.REACT_BASENAME;
+    }
   };
 }
 

--- a/legacy/src/app/partials/dhcp-snippets-table.html
+++ b/legacy/src/app/partials/dhcp-snippets-table.html
@@ -192,11 +192,11 @@
 </div>
 <ul class="p-inline-list--middot">
   <li class="p-inline-list__item" data-ng-if="!hideAllSnippetsLink">
-    <a href="/#/settings/dhcp">All snippets: Settings > DHCP snippets</a>
+    <a href="{$ BASENAME $}{$ REACT_BASENAME $}/settings/dhcp">All snippets: Settings > DHCP snippets</a>
   </li>
   <li class="p-inline-list__item">
     <a class="p-link--external"
-      href="https://maas.io/docs/{$ MAAS_VERSION_NUMBER $}/en/installconfig-network-dhcp#dhcp-snippets"
+      href="https://maas.io/docs/dhcp"
       target="_blank">About DHCP snippets</a>
   </li>
 </ul>


### PR DESCRIPTION
## Done
Add correct `href` values for the links to DHCP snippet settings and DHCP snippets docs on the network tab of a machine detail page. Fixes #396 and #392.

## QA
- Go to `/MAAS/#/machines`
- Go to the detail page of a machine that has DHCP snippets (on Karura `actual-swine.maas` qualifies)
- Go to the network tab of the machine
- Click the `About DHCP snippets` link and see that you are taken to https://maas.io/docs/dhcp in a new tab
- Click the `All snippets: Settings > DHCP snippets` link and see that you are taken to  `/MAAS/r/settings/dhcp`