### PR TITLE
Fix broken link to settings in storage tab

### DIFF
--- a/legacy/src/app/directives/nodedetails/storage_disks_partitions.js
+++ b/legacy/src/app/directives/nodedetails/storage_disks_partitions.js
@@ -2,7 +2,11 @@ import disksPartitionsTmpl from "../../partials/nodedetails/storage/disks-partit
 
 const storageDisksPartitions = () => ({
   restrict: "E",
-  template: disksPartitionsTmpl
+  template: disksPartitionsTmpl,
+  link: scope => {
+    scope.BASENAME = process.env.BASENAME;
+    scope.REACT_BASENAME = process.env.REACT_BASENAME;
+  }
 });
 
 export default storageDisksPartitions;

--- a/legacy/src/app/partials/nodedetails/storage/disks-partitions.html
+++ b/legacy/src/app/partials/nodedetails/storage/disks-partitions.html
@@ -1176,4 +1176,4 @@
 
 
 <p>Learn more about deploying <a href="https://docs.maas.io/en/installconfig-images" class="p-link--external" target="_blank">Windows</a></p>
-<p>Change the default layout in <a href="/MAAS/settings/storage/">Settings &rsaquo; Storage</a></p>
+<p>Change the default layout in <a href="{$ BASENAME $}{$ REACT_BASENAME $}/settings/storage">Settings &rsaquo; Storage</a></p>


### PR DESCRIPTION
## Done
Add the correct `href` value for the storage settings link in the storage tab of a machine details page. Fixes #389.

## QA
- Go to the storage tab on a machine details page
- Click the `Change the default layout in Settings › Storage` link
- See that you are taken to `/MAAS/r/settings/storage`