### PR TITLE
Fix broken link in subnets detail page

### DIFF
--- a/legacy/src/app/partials/ipranges.html
+++ b/legacy/src/app/partials/ipranges.html
@@ -150,4 +150,4 @@
     </table>
 </div>
 
-<p class="u-no-margin--bottom"><a class="p-link--external" href="https://maas.io/docs/{$ MAAS_VERSION_NUMBER $}/en/installconfig-network-ipranges" target="_blank">About IP ranges</a></p>
+<p class="u-no-margin--bottom"><a class="p-link--external" href="https://maas.io/docs/ip-ranges" target="_blank">About IP ranges</a></p>


### PR DESCRIPTION
## Done
Update the docs link for IP ranges in the subnets detail page. Fixes #1635.

## QA
- Go to a subnets detail page
- Click the `About IP ranges` link
- See that you are taken to https://maas.io/docs/ip-ranges in a new tab