### PR TITLE
Add remaining config

### DIFF
--- a/legacy/src/app/bootstrap.js
+++ b/legacy/src/app/bootstrap.js
@@ -40,7 +40,8 @@ const buildUrl = () => {
   return url;
 };
 
-const bootstrapOverWebsocket = config => {
+const bootstrapOverWebsocket = () => {
+  let config = {};
   const webSocket = new WebSocket(buildUrl());
 
   const sendMsg = (id, method) => {
@@ -70,6 +71,8 @@ const bootstrapOverWebsocket = config => {
         const requiredConfigKeys = [
           "completed_intro",
           "maas_name",
+          "maas_url",
+          "rpc_shared_secret",
           "uuid",
           "enable_analytics"
         ];
@@ -117,19 +120,11 @@ const bootstrapOverWebsocket = config => {
  * then manually bootstrap angularjs app.
  */
 const bootstrap = () => {
-  let CONFIG = {
-    register_url: "foo", // https://bugs.launchpad.net/maas/+bug/1850246
-    register_secret: "bar" // https://bugs.launchpad.net/maas/+bug/1850246
-  };
-
   const savedConfig = window.localStorage.getItem("maas-config");
   if (savedConfig) {
-    // Once register_url and register_secret are fetched from the
-    // ws API, merging here will no longer be necessary.
-    const mergedConfig = { ...CONFIG, ...JSON.parse(savedConfig) };
-    bootstrapApp(mergedConfig);
+    bootstrapApp(JSON.parse(savedConfig));
   } else {
-    bootstrapOverWebsocket(CONFIG);
+    bootstrapOverWebsocket();
   }
 };
 

--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -273,8 +273,8 @@ function NodesListController(
   $scope.tabs.controllers.newPool = {};
   $scope.tabs.controllers.syncStatuses = {};
   $scope.tabs.controllers.addController = false;
-  $scope.tabs.controllers.registerUrl = $window.CONFIG.register_url;
-  $scope.tabs.controllers.registerSecret = $window.CONFIG.register_secret;
+  $scope.tabs.controllers.registerUrl = $window.CONFIG.maas_url;
+  $scope.tabs.controllers.registerSecret = $window.CONFIG.rpc_shared_secret;
 
   // Switch tab.
   $scope.tabs.switches = {};

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -454,8 +454,8 @@ describe("NodesListController", function() {
           registerUrl = makeName("url");
           registerSecret = makeName("secret");
           window.CONFIG = {
-            register_url: registerUrl,
-            register_secret: registerSecret
+            maas_url: registerUrl,
+            rpc_shared_secret: registerSecret
           };
         }
 


### PR DESCRIPTION
Done:
- Add config for controller registration. Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/1618.

QA:
- Log out and back in.
- Visit /MAAS/#/controllers
- Click "Add rack controller"
- Check that the instructions contain a url and secret e.g. `sudo maas-rack register --url http://192.168.1.14:5240/MAAS --secret 96449773da9d65df0f926e4c1068799b`