### PR TITLE
Show or hide RSD nav

### DIFF
--- a/legacy/src/app/bootstrap.js
+++ b/legacy/src/app/bootstrap.js
@@ -94,7 +94,7 @@ const bootstrapOverWebsocket = () => {
         messagesReceived.push(3);
         break;
 
-      // general.version
+      // general.navigation_options
       case 4:
         config.navigation_options = msg.result;
         messagesReceived.push(4);

--- a/legacy/src/app/bootstrap.js
+++ b/legacy/src/app/bootstrap.js
@@ -93,8 +93,14 @@ const bootstrapOverWebsocket = () => {
         config.version = msg.result;
         messagesReceived.push(3);
         break;
+
+      // general.version
+      case 4:
+        config.navigation_options = msg.result;
+        messagesReceived.push(4);
+        break;
     }
-    if (messagesReceived.length === 3) {
+    if (messagesReceived.length === 4) {
       // Only store the config once the MAAS has been set up. The intro pages
       // refresh the window when each one completes, so we don't want the
       // stored config to get out of sync (there is also little optimisation to
@@ -112,6 +118,7 @@ const bootstrapOverWebsocket = () => {
     sendMsg(1, "user.auth_user");
     sendMsg(2, "config.list");
     sendMsg(3, "general.version");
+    sendMsg(4, "general.navigation_options");
   };
 };
 

--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -354,7 +354,9 @@ const renderHeader = ($rootScope, $window, $http) => {
     <Header
       authUser={current_user}
       basename={process.env.BASENAME}
-      completedIntro={completed_intro && current_user && current_user.completed_intro}
+      completedIntro={
+        completed_intro && current_user && current_user.completed_intro
+      }
       enableAnalytics={!debug && window.CONFIG.enable_analytics}
       location={window.location}
       logout={() => {
@@ -368,6 +370,7 @@ const renderHeader = ($rootScope, $window, $http) => {
         // header is first rendered.
         $rootScope.skip();
       }}
+      showRSD={window.CONFIG.navigation_options.rsd}
     />,
     headerNode
   );

--- a/shared/src/components/Header/Header.js
+++ b/shared/src/components/Header/Header.js
@@ -20,7 +20,8 @@ export const Header = ({
   location,
   logout,
   newURLPrefix,
-  onSkip
+  onSkip,
+  showRSD
 }) => {
   const [hardwareVisible, toggleHardware] = useVisible(false);
   const [mobileMenuVisible, toggleMobileMenu] = useVisible(false);
@@ -52,6 +53,7 @@ export const Header = ({
       url: "/kvm"
     },
     {
+      hidden: !showRSD,
       inHardwareMenu: true,
       isLegacy: true,
       label: "RSD",
@@ -83,9 +85,13 @@ export const Header = ({
       label: "Settings",
       url: "/settings"
     }
-  ].filter(
-    ({ adminOnly }) => !adminOnly || (authUser && authUser.is_superuser)
-  );
+  ]
+    // Remove the admin only items if the user is not an admin.
+    .filter(
+      ({ adminOnly }) => !adminOnly || (authUser && authUser.is_superuser)
+    )
+    // Remove the hidden items.
+    .filter(({ hidden }) => !hidden);
 
   const generateLegacyURL = url => `${basename}/#${url}`;
 
@@ -274,7 +280,8 @@ Header.propTypes = {
   }).isRequired,
   logout: PropTypes.func.isRequired,
   newURLPrefix: PropTypes.string,
-  onSkip: PropTypes.func
+  onSkip: PropTypes.func,
+  showRSD: PropTypes.bool
 };
 
 export default Header;

--- a/shared/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/shared/src/components/Header/__snapshots__/Header.test.js.snap
@@ -140,18 +140,6 @@ exports[`Header renders 1`] = `
                   KVM
                 </a>
               </li>
-              <li
-                className="p-navigation__link"
-                key="/MAAS/#/rsd"
-                role="menuitem"
-              >
-                <a
-                  className=""
-                  href="/MAAS/#/rsd"
-                >
-                  RSD
-                </a>
-              </li>
             </ul>
           </li>
           <li
@@ -200,18 +188,6 @@ exports[`Header renders 1`] = `
               href="/MAAS/#/kvm"
             >
               KVM
-            </a>
-          </li>
-          <li
-            className="p-navigation__link u-hide-nav-viewport--medium"
-            key="/MAAS/#/rsd"
-            role="menuitem"
-          >
-            <a
-              className="p-dropdown__item"
-              href="/MAAS/#/rsd"
-            >
-              RSD
             </a>
           </li>
           <li

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -30,6 +30,7 @@ export const App = () => {
   const connectionError = useSelector(status.error);
   const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const authLoading = useSelector(authSelectors.loading);
+  const navigationOptions = useSelector(generalSelectors.navigationOptions.get);
   const version = useSelector(generalSelectors.version.get);
   const maasName = useSelector(configSelectors.maasName);
   const completedIntro = useSelector(configSelectors.completedIntro);
@@ -52,6 +53,7 @@ export const App = () => {
     if (connected) {
       dispatch(authActions.fetch());
       dispatch(generalActions.fetchVersion());
+      dispatch(generalActions.fetchNavigationOptions());
       // Fetch the config at the top so we can access the MAAS name for the
       // window title.
       dispatch(configActions.fetch());
@@ -99,6 +101,7 @@ export const App = () => {
         logout={() => {
           dispatch(statusActions.logout());
         }}
+        showRSD={navigationOptions.rsd}
       />
       {content}
       {maasName && version && (

--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -223,4 +223,17 @@ describe("App", () => {
     );
     expect(wrapper.find("Login").exists()).toBe(true);
   });
+
+  it("can show the RSD link", () => {
+    state.general.navigationOptions.data.rsd = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
+          <App />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Header").prop("showRSD")).toBe(true);
+  });
 });

--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -236,4 +236,17 @@ describe("App", () => {
     );
     expect(wrapper.find("Header").prop("showRSD")).toBe(true);
   });
+
+  it("can hide the RSD link", () => {
+    state.general.navigationOptions.data.rsd = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
+          <App />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Header").prop("showRSD")).toBe(false);
+  });
 });


### PR DESCRIPTION
Done:
- Only display the RSD tab when enabled. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/382.

QA:
- Run the UI, you probably won't have the RSD option in your header.
- Fake the showRSD option in App.js or entry.js (unless you have a MAAS with RSD).