### PR TITLE
Disable CRA sourcemaps

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "start": "react-scripts start",
     "serve": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
     "postbuild": "mkdir -p dist && tar -C build -czvf dist/maas-ui-v$npm_package_version.tar.gz .",
     "test": "react-scripts test",


### PR DESCRIPTION
Done:
- Disable the sourcemaps for the production CRA build. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/423

Sizes go from:
3.7M	build/ui
To:
904K	build/ui

QA:
- `yarn build-all`
- There should be no sourcemaps inside build/ui/...