### PR TITLE
Scroll a section into view when toggled

### DIFF
--- a/ui/src/app/base/components/ColumnToggle/ColumnToggle.js
+++ b/ui/src/app/base/components/ColumnToggle/ColumnToggle.js
@@ -1,28 +1,42 @@
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useRef } from "react";
 
 import "./ColumnToggle.scss";
 
-const ColumnToggle = ({ isExpanded, label, onClose, onOpen }) => (
-  <Button
-    appearance="link"
-    className={classNames("column-toggle", {
-      "is-active": isExpanded
-    })}
-    inline
-    onClick={() => {
-      if (isExpanded) {
-        onClose();
-      } else {
-        onOpen();
-      }
-    }}
-  >
-    <span className="column-toggle__name">{label}</span>
-  </Button>
-);
+const ColumnToggle = ({ isExpanded, label, onClose, onOpen }) => {
+  const buttonNode = useRef(null);
+  return (
+    <Button
+      appearance="link"
+      className={classNames("column-toggle", {
+        "is-active": isExpanded
+      })}
+      inline
+      onClick={() => {
+        if (isExpanded) {
+          onClose();
+        } else {
+          onOpen();
+          // Delay the scroll check until the toggle is complete.
+          window.requestAnimationFrame(() => {
+            const { top } = buttonNode.current.getBoundingClientRect();
+            // When a section opens check that it does not get moved off screen,
+            // and if it does, scroll it into view.
+            if (window.scrollY + top < window.scrollY) {
+              window.scrollTo(0, window.scrollY + top);
+            }
+          });
+        }
+      }}
+    >
+      <span className="column-toggle__name" ref={buttonNode}>
+        {label}
+      </span>
+    </Button>
+  );
+};
 
 ColumnToggle.propTypes = {
   isExpanded: PropTypes.bool,

--- a/ui/src/app/base/components/ColumnToggle/ColumnToggle.test.js
+++ b/ui/src/app/base/components/ColumnToggle/ColumnToggle.test.js
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import React from "react";
 
 import ColumnToggle from "./ColumnToggle";
@@ -42,5 +42,50 @@ describe("ColumnToggle ", () => {
     );
     wrapper.simulate("click");
     expect(onOpen).toHaveBeenCalled();
+  });
+
+  describe("scroll ", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation(cb => cb());
+      window.scrollTo = jest.fn();
+      window.scrollY = 100;
+    });
+
+    afterEach(() => {
+      window.requestAnimationFrame.mockRestore();
+      window.scrollTo.mockRestore();
+      window.scrollY = 0;
+    });
+
+    it("can scroll to a toggle", () => {
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({ top: -20 }));
+      const wrapper = mount(
+        <ColumnToggle
+          isExpanded={false}
+          label="maas.local"
+          onClose={jest.fn()}
+          onOpen={jest.fn()}
+        />
+      );
+      wrapper.simulate("click");
+      expect(window.scrollTo).toHaveBeenCalled();
+      expect(window.scrollTo.mock.calls[0][1]).toBe(80);
+    });
+
+    it("does not scroll if the toggle is visible", () => {
+      Element.prototype.getBoundingClientRect = jest.fn(() => ({ top: 20 }));
+      const wrapper = mount(
+        <ColumnToggle
+          isExpanded={false}
+          label="maas.local"
+          onClose={jest.fn()}
+          onOpen={jest.fn()}
+        />
+      );
+      wrapper.simulate("click");
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Done:
- When a row is toggled open then scroll it into view if it collapses a section above it. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/402.

QA:
- Open the settings scripts section (you need to have some scripts).
- Open a really long script.
- Scroll down and toggle open a script.
- You should get scrolled to the top of that script.