### PR TITLE
Remove extra spacing inside expanding rows

### DIFF
--- a/ui/src/app/settings/views/Scripts/ScriptsList.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsList.js
@@ -121,7 +121,7 @@ const generateRows = (
         ) : (
           <Row>
             <Col size="10">
-              <Code>{scriptSrc}</Code>
+              <Code className="u-no-margin--bottom">{scriptSrc}</Code>
             </Col>
           </Row>
         )),

--- a/ui/src/scss/_patterns_table.scss
+++ b/ui/src/scss/_patterns_table.scss
@@ -1,7 +1,7 @@
 .p-table-expanding--light .p-table-expanding__panel {
   border-top: 1px solid $color-mid-light;
-  margin: 0.5rem 0.5rem 0 0.5rem;
-  padding-top: 0.5rem;
+  margin: 0 $sp-small $sp-small $sp-small;
+  padding: $sp-small 0 0 0;
 }
 
 .p-table-expanding--light .p-table__row.is-active {


### PR DESCRIPTION
Done:
- Align the spacing inside expanding rows with the Vanilla pattern. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/401.

QA:
- View the scripts list in settings and expand a script
- The code block should not have extra space around it, as seen in: https://github.com/canonical-web-and-design/maas-ui/issues/401.