### PR TITLE
Use the new chevron icon

### DIFF
--- a/ui/src/app/base/components/ColumnToggle/ColumnToggle.scss
+++ b/ui/src/app/base/components/ColumnToggle/ColumnToggle.scss
@@ -1,13 +1,12 @@
 @import "~vanilla-framework/scss/settings_spacing";
 @import "~vanilla-framework/scss/settings_colors";
+@import "~vanilla-framework/scss/patterns_icons";
 
 %heading-icon {
-  background: {
-    image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='4' width='10' viewBox='0 0 10 4'%3E%3Cpath d='M3.637 3.138c-.518-.365-1.052-.778-1.6-1.238C1.486 1.44.946.948.414.423.273.283.135.14 0 0h1.54c.305.29.62.57.948.846.138.116.277.23.417.34.163.13.328.257.495.38.085.062.17.123.257.184.397.282.935.626 1.315.848h.054c.38-.222.918-.566 1.315-.848.4-.28.79-.583 1.17-.904C7.837.57 8.153.29 8.457 0h1.54c-.134.14-.272.282-.414.422C9.05.948 8.51 1.442 7.963 1.9c-.55.46-1.084.873-1.602 1.238S5.39 3.79 5 4c-.39-.21-.845-.497-1.363-.862z' fill='%23888' fill-rule='evenodd'/%3E%3C/svg%3E");
-    position: center;
-    repeat: no-repeat;
-    size: 100%;
-  }
+  @include vf-icon-chevron;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 100%;
   content: "";
   display: block;
   flex: 0 0 $sp-medium;

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -37,3 +37,14 @@ td > .p-tooltip {
 [class*="p-notification"] .p-icon--close {
   margin-top: 0.75rem;
 }
+
+// 11-11-2019 Huw: The table sort icon uses old chevron.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2634
+.p-table--sortable th[role="columnheader"][aria-sort="ascending"]::after,
+.p-table--sortable th[role="columnheader"][aria-sort="descending"]::after,
+.p-table-multi-header[aria-sort="descending"]
+  .p-table-multi-header__link.is-active::after,
+.p-table-multi-header[aria-sort="ascending"]
+  .p-table-multi-header__link.is-active::after {
+  @include vf-icon-chevron;
+}


### PR DESCRIPTION
Done:
- Update the column toggles to use the new chevron. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/400.
- Override the table sort to use the new chevron. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/390.

QA:
- View the scripts list in settings.
- Check that the toggle row chevrons look like:
<img width="206" alt="Screenshot 2019-11-05 at 11 30 14" src="https://user-images.githubusercontent.com/2741678/68204367-b7dc1100-ffbf-11e9-89f8-ef3c171946b6.png">
- Sort the table by clicking on a header label, the sort chevron should be the same.