### PR TITLE
Fix side nav spacing

### DIFF
--- a/ui/src/app/base/components/SideNav/SideNav.scss
+++ b/ui/src/app/base/components/SideNav/SideNav.scss
@@ -13,8 +13,8 @@
 
 .side-nav__list {
   @extend %vf-clearfix;
-  margin-bottom: $spv-inner--small;
-  margin-top: -$spv-inner--x-small;
+  margin: -$spv-inner--x-small 0 $spv-inner--small;
+  padding: 0;
 
   &__item {
     @extend %vf-list-item;


### PR DESCRIPTION
Done:
- Correct left spacing of the side nav. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/395. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/391.

QA
- Load the settings.
- Check that the left nav is directly below the Settings title.
- Reduce the size of the screen, the left nav should never overlap the main content.
