### PR TITLE
Remove machine shadow

### DIFF
--- a/legacy/src/scss/tables/_patterns_table-machines.scss
+++ b/legacy/src/scss/tables/_patterns_table-machines.scss
@@ -173,7 +173,6 @@
     .p-table--machines tbody &:hover,
     .p-table--machines tbody &:focus-within {
       background-color: $color-x-light;
-      box-shadow: 0 1px 3px 0 transparentize($color-dark, 0.8);
 
       .p-table-menu__toggle {
         display: inline-block;


### PR DESCRIPTION
Done:
- Remove hover shadow from machines table. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/398.

QA:
- View the list of machines (you may need to update your MAAS).
- Hover over a machine, you should see white background, but no shadow.