### PR TITLE
Add viewport meta tag

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>MAAS</title>
     <link rel="shortcut icon" href="%PUBLIC_URL%/maas-favicon-32px.png" />
   </head>


### PR DESCRIPTION
## Done
Add the viewport meta tag so the app responds to the viewport width of mobile browsers rather than defaulting to the desktop view. Fixes: #451.

## QA
- Go to any page of the app
- Open the browser developer tools and [emulate a mobile device](https://developers.google.com/web/tools/chrome-devtools/device-mode)
- See that the mobile view is displayed