### PR TITLE
Fix styles for autocomplete list

### DIFF
--- a/legacy/src/scss/_patterns_tag-input.scss
+++ b/legacy/src/scss/_patterns_tag-input.scss
@@ -29,6 +29,8 @@
         min-width: 160px;
         width: 100%;
         box-sizing: border-box;
+        list-style: none;
+        padding-left: 0;
 
         .suggestion-item {
           float: left;
@@ -130,6 +132,8 @@
         word-wrap: break-word;
 
         .remove-button {
+          @extend %icon;
+          @include vf-icon-close($color-mid-dark);
           border-bottom: 0;
         }
       }


### PR DESCRIPTION
## Done
Remove default list styles from autocomplete list. Fixes #381

## QA
- On the machine list page select all the machines
- Select all machines that can be tagged (tip: select all machines, select tag from the take action menu and update your selection)
- When entering tags into the tag input see that the suggestion list doesn't have the default bulleted list style