### PR TITLE
Fix console error when using the group by filter

### DIFF
--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -806,7 +806,7 @@ sudo maas-rack register --url {$ tabs.controllers.registerUrl $} --secret {$ tab
             </div>
         </div>
         <div class="col-small-4 col-medium-3 col-3">
-            <select data-ng-model="tabs.machines.groupByLabel" ng-init="tabs.machines.groupByLabel='status'" data-ng-change="sendAnalyticsEvent('Machines list', 'Group by: ' + tabs.machines.groupByLabel), 'Machines table'">
+            <select data-ng-model="tabs.machines.groupByLabel" ng-init="tabs.machines.groupByLabel='status'" data-ng-change="sendAnalyticsEvent('Machines list', 'Group by: ' + tabs.machines.groupByLabel, 'Machines table')">
                 <option value="status" selected="selected">Group by status</option>
                 <option value="owner">Group by owner</option>
                 <option value="none">No grouping</option>


### PR DESCRIPTION
## Done
Fix the syntax error that was causing a console error every time the group by filter in the machines listing page was used. Fixes: #458.

## QA
- On the machines listing page open your browsers dev tools and look at the console
- Use the group by filter and see that there are no related console errors