### PR TITLE
Fix console error when editing resource pool

### DIFF
--- a/legacy/src/app/directives/maas_obj_form.js
+++ b/legacy/src/app/directives/maas_obj_form.js
@@ -132,7 +132,11 @@ export function maasObjForm(JSONService) {
     // Watch for changes on the value of the object.
     var self = this;
     this.scope.$watch("obj." + key, function() {
-      if (angular.isObject(self.obj) && !self.fields[key].editing) {
+      if (
+        angular.isObject(self.obj) &&
+        angular.isObject(self.fields[key]) &&
+        !self.fields[key].editing
+      ) {
         self.fields[key].scope.updateValue(self.obj[key]);
       }
     });


### PR DESCRIPTION
## Done
Added a check for the fields key in the MAAS form directive which was causing an error to be shown in the console. Fixes: #457

## QA
- Go to the resource pools tab on the machines listing page
- Open your browser dev tools and make sure the console is visible
- Try editing the pools in the list and see that no error is thrown and displayed in the browser console