### PR TITLE
Fix alignment of add pool button

### DIFF
--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -45,10 +45,10 @@
                  data-ng-show="canCreateResourcePool()">
               <button class="p-button--neutral"
                       data-ng-click="tabs.pools.addPool()"
-                      data-ng-hide="tabs.pools.actionOption">Add pool</button>
+                      data-ng-if="!tabs.pools.actionOption">Add pool</button>
               <button class="p-button--neutral ng-hide"
                       data-ng-click="tabs.pools.cancelAddPool()"
-                      data-ng-show="tabs.pools.actionOption">Cancel add pool</button>
+                      data-ng-if="tabs.pools.actionOption">Cancel add pool</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Done
Conditionally render the sibling button to add pool rather than show/hide it to remove the extra right margin. Fixes: #467.

## QA
- Go to the resources tab on the machines listing page
- See that the "Add pool" button is aligned to the right of the container