### PR TITLE
Fix button link active state colour

### DIFF
--- a/legacy/src/scss/_patterns_button.scss
+++ b/legacy/src/scss/_patterns_button.scss
@@ -75,6 +75,11 @@ $vanilla-2-icon-button-side-padding: $sph-inner--small * 1.5;
     &:visited {
       color: $color-link;
     }
+
+    // Override inherited button style from Vanilla
+    &:active {
+      background-color: inherit !important;
+    }
   }
 
   [class*="p-button"] [class^="p-icon"],


### PR DESCRIPTION
## Done
Overridden Vanilla button styles for button links which are in both active and hover states to remove the grey background. Fixes #462.

## QA
- Go to the machine summary page
- Click on one of the test links e.g. "Test CPU..."
- See that as you click the background remains the same colour