### PR TITLE
Display required indicators when adding machine from machine list.

### DIFF
--- a/legacy/src/app/controllers/add_hardware.js
+++ b/legacy/src/app/controllers/add_hardware.js
@@ -368,18 +368,15 @@ function AddHardwareController(
   }
 
   // Validate that all the parameters are there for the given power type.
-  function powerParametersHasError(power_type, parameters) {
-    var i;
-    for (i = 0; i < power_type.fields.length; i++) {
-      var field = power_type.fields[i];
-      var value = parameters[field.name];
+  function powerParametersHasError(power) {
+    const { parameters, type } = power;
+    const fields = type.fields || [];
+    return fields.some(field => {
       if (field.required) {
-        if (angular.isUndefined(value) || value === "") {
-          return true;
-        }
+        return !parameters[field.name];
       }
-    }
-    return false;
+      return false;
+    });
   }
 
   // Called by the parent scope when this controller is viewable.
@@ -511,6 +508,12 @@ function AddHardwareController(
       return in_error;
     }
 
+    // Required power parameters fields not filled in.
+    const powerParametersError = powerParametersHasError($scope.machine.power);
+    if (powerParametersError) {
+      return true;
+    }
+
     // Make sure none of the mac addresses are in error. The first one
     // cannot be blank the remaining are allowed to be empty.
     if (
@@ -538,10 +541,7 @@ function AddHardwareController(
     if (in_error) {
       return in_error;
     }
-    return powerParametersHasError(
-      $scope.chassis.power.type,
-      $scope.chassis.power.parameters
-    );
+    return powerParametersHasError($scope.chassis.power);
   };
 
   // Called when the cancel button is pressed.

--- a/legacy/src/app/controllers/tests/test_add_hardware.js
+++ b/legacy/src/app/controllers/tests/test_add_hardware.js
@@ -450,6 +450,21 @@ describe("AddHardwareController", function() {
       expect($scope.machineHasError()).toBe(true);
     });
 
+    it("returns true if a required field is empty", () => {
+      makeControllerWithMachine();
+      $scope.machine.zone = {};
+      $scope.machine.architecture = makeName("arch");
+      $scope.machine.macs[0].mac = "00:11:22:33:44:55";
+      $scope.machine.macs[0].error = false;
+      $scope.machine.power.type = {
+        fields: [{ name: "field", required: true }]
+      };
+      $scope.machine.power.parameters = {
+        field: null
+      };
+      expect($scope.machineHasError()).toBe(true);
+    });
+
     it("returns false if all is correct", function() {
       makeControllerWithMachine();
       $scope.machine.zone = {};

--- a/legacy/src/app/directives/power_parameters.js
+++ b/legacy/src/app/directives/power_parameters.js
@@ -29,7 +29,10 @@ const powerParametersTmpl = `<div class="p-form__group row">
         && (field.scope !== 'bmc' || !ngModel.in_pod)">
     <label for="{$ field.name $}"
         class="p-form__label col-2"
-        data-ng-class="{'is-disabled': !ngModel.editing }">
+        data-ng-class="{
+          'is-disabled': !ngModel.editing,
+          'is-required': field.required
+        }">
         {$ field.label $}
     </label>
     <div class="p-form__control col-4">

--- a/legacy/src/app/partials/nodelist/add-machine.html
+++ b/legacy/src/app/partials/nodelist/add-machine.html
@@ -90,7 +90,7 @@
             </div>
           </div>
           <div class="p-form__group row" data-ng-repeat="mac in machine.macs">
-            <label for="mac-address" class="p-form__label col-2"
+            <label for="mac-address" class="p-form__label is-required col-2"
               ><span data-ng-hide="mac !== machine.macs[0]">MAC Address</span
               >&nbsp;</label
             >


### PR DESCRIPTION
## Done
- Show required asterisks in "Add machine" dropdown
- Disable save button if one of the required fields is missing

## QA
- Add a machine from the machine list
- Check that MAC address is required
- Change the power type and check that required fields show up correctly
- Check the submit button is disabled if some of the required fields are not filled in

Fixes #454 