### PR TITLE
Stop Add MAC button submitting form prematurely in Add Machine form.

### DIFF
--- a/legacy/src/app/partials/nodelist/add-machine.html
+++ b/legacy/src/app/partials/nodelist/add-machine.html
@@ -90,11 +90,10 @@
             </div>
           </div>
           <div class="p-form__group row" data-ng-repeat="mac in machine.macs">
-            <label for="mac-address" class="p-form__label is-required col-2"
-              ><span data-ng-hide="mac !== machine.macs[0]">MAC Address</span
-              >&nbsp;</label
-            >
-            <div class="p-form__control p-search-box col-4">
+            <label for="mac-address" class="p-form__label col-2" ng-class="{ 'is-required': mac === machine.macs[0] }">
+              <span data-ng-if="mac === machine.macs[0]">MAC Address</span>&nbsp;
+            </label>
+            <div class="col-4 p-form__control p-search-box u-no-margin--bottom">
               <input
                 type="text"
                 id="mac-address"
@@ -119,7 +118,7 @@
             </div>
           </div>
           <div class="p-form__group u-align--right">
-            <button class="p-button--neutral" data-ng-click="addMac()">
+            <button class="p-button--neutral" data-ng-click="addMac()" type="button">
               + Add MAC Address
             </button>
           </div>


### PR DESCRIPTION
## Done
- Explicitly give "Add MAC Address" button an attribute of `type="button"` so it doesn't submit the form on click.

## QA
- Open Add Machine dropdown.
- Choose a power type that has some required fields.
- Add another MAC address and see that a browser tooltip doesn't appear below the first required power parameter.