### PR TITLE
Fix form button spacing Vanilla override.

### DIFF
--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
@@ -6,11 +6,10 @@ export const FormikFormButtons = ({
   actionDisabled,
   actionLabel,
   actionLoading,
-  actionSuccess,
-  showCancel
+  actionSuccess
 }) => {
   return (
-    <div style={{ marginTop: "1rem" }}>
+    <div>
       <ActionButton
         appearance="positive"
         className="u-no-margin--bottom"

--- a/ui/src/app/base/components/FormikFormButtons/__snapshots__/FormikFormButtons.test.js.snap
+++ b/ui/src/app/base/components/FormikFormButtons/__snapshots__/FormikFormButtons.test.js.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormikFormButtons  renders 1`] = `
-<div
-  style={
-    Object {
-      "marginTop": "1rem",
-    }
-  }
->
+<div>
   <ActionButton
     appearance="positive"
     className="u-no-margin--bottom"

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
@@ -40,7 +40,7 @@ const FormikFormContent = ({
           {nonFieldError}
         </Notification>
       )}
-      {children}
+      <div>{children}</div>
       <Buttons
         actionDisabled={saving || formDisabled}
         actionLabel={submitLabel}

--- a/ui/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.js
+++ b/ui/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.js
@@ -8,10 +8,10 @@ const ProxyFormFields = () => {
 
   return (
     <>
-      <label>
+      <p>
         HTTP proxy used by MAAS to download images, and by provisioned machines
         for APT and YUM packages.
-      </label>
+      </p>
       <FormikField
         name="proxyType"
         value="noProxy"

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -6,9 +6,6 @@
 
 // 19-08-2019 Caleb: Form submit button too close to input when $multi = 1
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2497
-.p-form__control:last-of-type {
-  margin-bottom: $spv-outer--small;
-}
 .p-form__group:last-of-type {
   margin-bottom: $spv-outer--medium;
 }


### PR DESCRIPTION
## Done
- Wrap form fields in a parent div, so the resultant markup of a FormikForm becomes:
``` html
<form>
    <div>
        ...form fields...
    </div>
    <div>
        ...buttons...
    </div>
</form>
```
This makes it possible to apply `:last-of-type` to the last form field in which to apply `margin-bottom`.

![screenshot_27](https://user-images.githubusercontent.com/25733845/68772885-ddee5a80-062a-11ea-8441-17e2cdb2321e.png)


Fixes #464, fixes #465