### PR TITLE
Reset user preference form values on submit.

### DIFF
--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -86,7 +86,7 @@ export const UserForm = ({
       buttons={buttons}
       errors={errors}
       initialValues={initialValues}
-      onSubmit={values => {
+      onSubmit={(values, { resetForm }) => {
         const [firstName, ...lastNameParts] = values.fullName.split(" ");
         const params = {
           email: values.email,
@@ -103,6 +103,7 @@ export const UserForm = ({
           params.id = user.id;
         }
         onSave(params, values, editing);
+        resetForm({ values });
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/base/components/UserForm/UserForm.test.js
+++ b/ui/src/app/base/components/UserForm/UserForm.test.js
@@ -51,6 +51,7 @@ describe("UserForm", () => {
   it("can handle saving", () => {
     const store = mockStore(state);
     const onSave = jest.fn();
+    const resetForm = jest.fn();
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
@@ -62,14 +63,17 @@ describe("UserForm", () => {
       wrapper
         .find("Formik")
         .props()
-        .onSubmit({
-          isSuperuser: true,
-          email: "test@example.com",
-          fullName: "Miss Wallaby",
-          password: "test1234",
-          passwordConfirm: "test1234",
-          username: "admin"
-        })
+        .onSubmit(
+          {
+            isSuperuser: true,
+            email: "test@example.com",
+            fullName: "Miss Wallaby",
+            password: "test1234",
+            passwordConfirm: "test1234",
+            username: "admin"
+          },
+          { resetForm }
+        )
     );
     expect(onSave.mock.calls[0][0]).toEqual({
       email: "test@example.com",
@@ -81,6 +85,7 @@ describe("UserForm", () => {
       password2: "test1234",
       username: "admin"
     });
+    expect(resetForm).toHaveBeenCalled();
   });
 
   it("hides the password fields when editing", () => {


### PR DESCRIPTION
## Done
- Call Formik resetForm after UserPreferences form submit

## QA
- Go to user prefs page
- Change username and check that the nav updates, a notification appears, and the button becomes disabled whenever the text input matches the current username

Fixes #474