### PR TITLE
Fix change password link spacing

### DIFF
--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -137,14 +137,16 @@ export const UserForm = ({
         />
       )}
       {editing && !passwordVisible && (
-        <Link
-          onClick={event => {
-            event.preventDefault();
-            showPassword(!passwordVisible);
-          }}
-        >
-          Change password&hellip;
-        </Link>
+        <div className="p-form__group">
+          <Link
+            onClick={event => {
+              event.preventDefault();
+              showPassword(!passwordVisible);
+            }}
+          >
+            Change password&hellip;
+          </Link>
+        </div>
       )}
       {passwordVisible && (
         <>

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -6,7 +6,7 @@
 
 // 19-08-2019 Caleb: Form submit button too close to input when $multi = 1
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2497
-.p-form__group:last-of-type {
+.p-form__group:last-child {
   margin-bottom: $spv-outer--medium;
 }
 


### PR DESCRIPTION
## Done
Wrap the change password link in a `p-form__group` to give the correct margin between it and the button. Fixes #480.

## Screenshot
https://usercontent.irccloud-cdn.com/file/dVj4bw93/user_form.png

## QA
- Go to the user preferences page
- See that the gap between "Change password" and the "Save" button matches the screenshot