### PR TITLE
Group machines when sorting

### DIFF
--- a/ui/src/app/base/enum.js
+++ b/ui/src/app/base/enum.js
@@ -1,0 +1,51 @@
+export const nodeStatus = {
+  // The node has been created and has a system ID assigned to it.
+  NEW: 0,
+  // Testing and other commissioning steps are taking place.
+  COMMISSIONING: 1,
+  // The commissioning step failed.
+  FAILED_COMMISSIONING: 2,
+  // The node can't be contacted.
+  MISSING: 3,
+  // The node is in the general pool ready to be deployed.
+  READY: 4,
+  // The node is ready for named deployment.
+  RESERVED: 5,
+  // The node has booted into the operating system of its owner's choice
+  // and is ready for use.
+  DEPLOYED: 6,
+  // The node has been removed from service manually until an admin
+  // overrides the retirement.
+  RETIRED: 7,
+  // The node is broken: a step in the node lifecycle failed.
+  // More details can be found in the node's event log.
+  BROKEN: 8,
+  // The node is being installed.
+  DEPLOYING: 9,
+  // The node has been allocated to a user and is ready for deployment.
+  ALLOCATED: 10,
+  // The deployment of the node failed.
+  FAILED_DEPLOYMENT: 11,
+  // The node is powering down after a release request.
+  RELEASING: 12,
+  // The releasing of the node failed.
+  FAILED_RELEASING: 13,
+  // The node is erasing its disks.
+  DISK_ERASING: 14,
+  // The node failed to erase its disks.
+  FAILED_DISK_ERASING: 15,
+  // The node is in rescue mode.
+  RESCUE_MODE: 16,
+  // The node is entering rescue mode.
+  ENTERING_RESCUE_MODE: 17,
+  // The node failed to enter rescue mode.
+  FAILED_ENTERING_RESCUE_MODE: 18,
+  // The node is exiting rescue mode.
+  EXITING_RESCUE_MODE: 19,
+  // The node failed to exit rescue mode.
+  FAILED_EXITING_RESCUE_MODE: 20,
+  // Running tests on Node
+  TESTING: 21,
+  // Testing has failed
+  FAILED_TESTING: 22
+};

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -1,7 +1,8 @@
 import { Col, Loader, MainTable, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
+import "./MachineList.scss";
 import {
   general as generalActions,
   machine as machineActions,
@@ -13,34 +14,122 @@ import {
   zone as zoneActions
 } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
+import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 
+const normaliseStatus = (statusCode, status) => {
+  switch (statusCode) {
+    case nodeStatus.FAILED_COMMISSIONING:
+    case nodeStatus.FAILED_DEPLOYMENT:
+    case nodeStatus.FAILED_RELEASING:
+    case nodeStatus.FAILED_DISK_ERASING:
+    case nodeStatus.FAILED_ENTERING_RESCUE_MODE:
+    case nodeStatus.FAILED_EXITING_RESCUE_MODE:
+    case nodeStatus.FAILED_TESTING:
+      return "Failed";
+    case nodeStatus.RESCUE_MODE:
+    case nodeStatus.ENTERING_RESCUE_MODE:
+    case nodeStatus.EXITING_RESCUE_MODE:
+      return "Rescue mode";
+    case nodeStatus.RELEASING:
+    case nodeStatus.DISK_ERASING:
+      return "Releasing";
+    case nodeStatus.RETIRED:
+    case nodeStatus.MISSING:
+    case nodeStatus.RESERVED:
+      return "Other";
+    default:
+      return status;
+  }
+};
+
 const generateRows = machines =>
-  machines.map(machine => ({
-    columns: [
-      {
-        content: machine.fqdn
-      }
-    ],
-    sortData: {
-      name: machine.fqdn,
-      power: machine.power_state,
-      status: machine.status,
-      owner: machine.owner,
-      pool: machine.pool.name,
-      zone: machine.zone.name,
-      cores: machine.cpu_count,
-      ram: machine.memory,
-      disks: machine.physical_disk_count,
-      storage: machine.storage
+  machines.map(machine => {
+    if (machine.isGroup) {
+      const sortData = {
+        [machine.sortKey]: machine.label
+      };
+      return {
+        className: "machine-list__group",
+        columns: [
+          {
+            content: machine.label
+          },
+          {},
+          {},
+          {}
+        ],
+        sortData
+      };
     }
-  }));
+    return {
+      columns: [
+        {
+          content: machine.fqdn
+        },
+        {
+          content: machine.status
+        },
+        {
+          content: machine.domain.name
+        },
+        {
+          content: machine.zone.name
+        }
+      ],
+      sortData: {
+        cores: machine.cpu_count,
+        disks: machine.physical_disk_count,
+        domain: machine.domain.name,
+        name: machine.fqdn,
+        owner: machine.owner,
+        pool: machine.pool.name,
+        power: machine.power_state,
+        ram: machine.memory,
+        normalisedStatus: machine.normalisedStatus,
+        storage: machine.storage,
+        zone: machine.zone.name
+      }
+    };
+  });
 
 const MachineList = () => {
   const dispatch = useDispatch();
+  const [currentSort, setSort] = useState("normalisedStatus");
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const machinesLoading = useSelector(machineSelectors.loading);
+  machines.forEach(machine => {
+    machine.normalisedStatus = normaliseStatus(
+      machine.status_code,
+      machine.status
+    );
+  });
+  const groupKeys = ["normalisedStatus", "domain", "zone"];
+  let groups = [];
+  if (groupKeys.includes(currentSort)) {
+    const labels = [];
+    machines.forEach(machine => {
+      let sortKey;
+      switch (currentSort) {
+        case "domain":
+        case "zone":
+          sortKey = machine[currentSort].name;
+          break;
+        default:
+          sortKey = machine[currentSort];
+      }
+      if (!labels.includes(sortKey)) {
+        labels.push(sortKey);
+      }
+    });
+    groups = labels.map(label => ({
+      label,
+      isGroup: true,
+      sortKey: currentSort
+    }));
+  }
+  const rows = groups.concat(machines);
 
   useWindowTitle("Machines");
 
@@ -71,17 +160,30 @@ const MachineList = () => {
         )}
         {machinesLoaded && (
           <MainTable
-            className="p-table-expanding--light"
-            defaultSort="status"
+            className="p-table-expanding--light machine-list"
+            defaultSort="normalisedStatus"
             defaultSortDirection="ascending"
             headers={[
               {
                 content: "FQDN",
                 sortKey: "name"
+              },
+              {
+                content: "Status",
+                sortKey: "normalisedStatus"
+              },
+              {
+                content: "Domain",
+                sortKey: "domain"
+              },
+              {
+                content: "Zone",
+                sortKey: "zone"
               }
             ]}
+            onUpdateSort={setSort}
             paginate={150}
-            rows={generateRows(machines)}
+            rows={generateRows(rows)}
             sortable
           />
         )}

--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -1,0 +1,3 @@
+.machine-list__group {
+  background-color: white;
+}

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -19,7 +19,14 @@ describe("MachineList", () => {
         errors: {},
         loading: false,
         loaded: true,
-        items: []
+        items: [
+          {
+            domain: {},
+            pool: {},
+            status: "Releasing",
+            zone: {}
+          }
+        ]
       }
     };
   });
@@ -38,5 +45,26 @@ describe("MachineList", () => {
       </Provider>
     );
     expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("includes groups", () => {
+    const state = { ...initialState };
+    state.machine.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find(".machine-list__group td")
+        .at(0)
+        .text()
+    ).toBe("Releasing");
   });
 });


### PR DESCRIPTION
Done:
- Group machines on the machine list by the selected sort. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/485.

QA:
- View a MAAS with lots of machines (or import some json e.g. https://github.com/huwshimi/maas-ui/blob/99bc5a61170fc377dfa578f5ab7a503b72a0fa90/ui/src/app/settings/views/Machines/MachineList/data.json)
- Click on the different table headers to sort the list.
- The machines should be grouped by the selected sort (or have no grouping for 'name').