### PR TITLE
Add disconnected icon

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -876,7 +876,7 @@
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
                                                 <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
                                                     aria-describedby="not-connected-tooltip">
-                                                    <i class="p-icon--error"></i>
+                                                    <i class="p-icon--disconnected"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
                                                 <span class="p-tooltip--top-left"
@@ -1198,7 +1198,7 @@
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
                                                 <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
                                                     aria-describedby="not-connected-tooltip">
-                                                    <i class="p-icon--error"></i>
+                                                    <i class="p-icon--disconnected"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
                                                 <span class="p-tooltip--top-left"
@@ -1330,7 +1330,7 @@
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
                                                 <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
                                                     aria-describedby="not-connected-tooltip">
-                                                    <i class="p-icon--error"></i>
+                                                    <i class="p-icon--disconnected"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
                                                 <span class="p-tooltip--top-left"
@@ -2597,7 +2597,7 @@
                                         <span ng-if="!isBond(interface) && !isBridge(interface)">
                                             <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
                                                 aria-describedby="not-connected-tooltip">
-                                                <i class="p-icon--error"></i>
+                                                <i class="p-icon--disconnected"></i>
                                                 <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                             </span>
                                             <span class="p-tooltip--top-left"
@@ -2986,7 +2986,7 @@
                                                 class="p-tooltip--top-left"
                                                 ng-if="!member.link_connected"
                                             >
-                                                <i class="p-icon--error"></i>
+                                                <i class="p-icon--disconnected"></i>
                                                 <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                             </span>
                                             <span

--- a/legacy/src/scss/_patterns_icons.scss
+++ b/legacy/src/scss/_patterns_icons.scss
@@ -240,6 +240,12 @@
       background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8' standalone='no'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' width='16px' version='1.1' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 16 16'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Etimed out%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg id='Page-1' fill-rule='evenodd' fill='none'%3E%3Cg id='smoke-testing-status' transform='translate%28-62 -206%29'%3E%3Cg id='timed-out' transform='translate%2850 191%29'%3E%3Cg transform='translate%2812 15%29'%3E%3Crect id='rect4970' y='0.00002' x='0' height='16' width='16'/%3E%3Ccircle id='circle4972' stroke-width='1.5' cy='8' stroke='%23E95420' cx='8' r='7.25'/%3E%3Cpolyline id='path839' stroke='%23E95420' stroke-width='2' points='11.8 11.8 7.9999 8 7.9999 3'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
       background-size: 100% 100%;
     }
+
+    &--disconnected {
+      @extend %icon;
+      background-image: url("data:image/svg+xml,%3Csvg id='Disconnect_2' data-name='Disconnect 2' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%23c7162b%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M6.1 13.52l2.71-2.71-3.58-3.58L2.51 10l-.47 2.11-1.61 1.58a1.36 1.36 0 001.92 1.92L4 14l2.11-.47zM15.59 2.36A1.35 1.35 0 0013.68.45l-1.63 1.62-2.05.46-2.78 2.71 3.58 3.58 2.7-2.71L14 4zM13.01 9.48h2.98v1h-2.98z'/%3E%3Cpath class='cls-1' transform='rotate(-45.01 13.332 13.315)' d='M12.83 11.83h1v2.98h-1z'/%3E%3Cpath class='cls-1' d='M9.49 13.03h1v2.98h-1zM.02 5.53H3v1H.02z'/%3E%3Cpath class='cls-1' transform='rotate(-45 2.663 2.687)' d='M2.17 1.2h1v2.98h-1z'/%3E%3Cpath class='cls-1' d='M5.51 0h1v2.98h-1z'/%3E%3C/svg%3E");
+      background-size: 100% 100%;
+    }
   }
 
   .p-icon--power-error {


### PR DESCRIPTION
## Done
Add icon for disconnected state and replace instances of error icon with disconnected icon when interface is disconnected.

## QA
- Go to the network tab
- If no interfaces are disconnected mark one as disconnected
- You should see the new disconnected icon instead of a white cross inside a red circle