### PR TITLE
Add machines accordion

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -1,3 +1,12 @@
-.machine-list__group {
-  background-color: white;
+.machine-list--grouped .machine-list__machine td:first-child {
+  padding-left: 2rem;
+}
+
+.machine-list__group-toggle {
+  text-align: right;
+  vertical-align: middle;
+}
+
+.machine-list__group-toggle-button {
+  display: inline-block;
 }

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -49,7 +49,6 @@ describe("MachineList", () => {
 
   it("includes groups", () => {
     const state = { ...initialState };
-    state.machine.loading = true;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -64,7 +63,29 @@ describe("MachineList", () => {
       wrapper
         .find(".machine-list__group td")
         .at(0)
+        .find("strong")
         .text()
     ).toBe("Releasing");
+  });
+
+  it("can filter groups", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("tr.machine-list__machine").length).toBe(1);
+    // Click the button to toggle the group.
+    wrapper
+      .find(".machine-list__group button")
+      .at(0)
+      .simulate("click");
+    expect(wrapper.find("tr.machine-list__machine").length).toBe(0);
   });
 });


### PR DESCRIPTION
Done:
- Allow hiding of machine groups. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/491.

QA:
- View /MAAS/r/machines.
- Click the "-" in a group header, it should hide the machines for that group.
- Click the "+" that group should appear again.