### PR TITLE
Pluralise machine counts in machines table

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "http-proxy-middleware": "0.20.0",
     "immer": "5.0.0",
     "path-parse": "1.0.6",
+    "pluralize": "^8.0.0",
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
     "http-proxy-middleware": "0.20.0",
     "immer": "5.0.0",
     "path-parse": "1.0.6",
-    "pluralize": "^8.0.0",
+    "pluralize": "8.0.0",
     "prop-types": "15.7.2",
     "react": "16.12.0",
     "react-dom": "16.12.0",

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -75,7 +75,8 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
             content: (
               <>
                 <strong>{row.label}</strong>
-                <div className="u-text--light">{`${row.count} ${pluralize("machine", row.count)}`}</div>
+                <div className="u-text--light">{`
+                ${row.count} ${pluralize("machine", row.count)}`}</div>
               </>
             )
           },

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -60,6 +60,14 @@ const getSortValue = (machine, currentSort) => {
   }
 };
 
+const pluraliseMachineCount = count => {
+  if (count === 1) {
+    return `${count} machine`;
+  }
+
+  return `${count} machines`;
+};
+
 const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
   rows.map(row => {
     if (row.isGroup) {
@@ -74,7 +82,7 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
             content: (
               <>
                 <strong>{row.label}</strong>
-                <div className="u-text--light">{row.count} machines</div>
+                <div className="u-text--light">{pluraliseMachineCount(row.count)}</div>
               </>
             )
           },

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -8,6 +8,7 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
+import pluralize from "pluralize";
 
 import "./MachineList.scss";
 import {
@@ -60,14 +61,6 @@ const getSortValue = (machine, currentSort) => {
   }
 };
 
-const pluraliseMachineCount = count => {
-  if (count === 1) {
-    return `${count} machine`;
-  }
-
-  return `${count} machines`;
-};
-
 const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
   rows.map(row => {
     if (row.isGroup) {
@@ -82,7 +75,7 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
             content: (
               <>
                 <strong>{row.label}</strong>
-                <div className="u-text--light">{pluraliseMachineCount(row.count)}</div>
+                <div className="u-text--light">{`${row.count} ${pluralize("machine", row.count)}`}</div>
               </>
             )
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9436,6 +9436,11 @@ plur@^3.1.1:
   dependencies:
     irregular-plurals "^2.0.0"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9436,7 +9436,7 @@ plur@^3.1.1:
   dependencies:
     irregular-plurals "^2.0.0"
 
-pluralize@^8.0.0:
+pluralize@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==


### PR DESCRIPTION
## Done
Pluralise machine counts in the machines table e.g. "1 machine" instead of "1 machines". Fixes #479.

## QA
- Go to the machines listing
- See that each group that has multiple machines has a pluralised count e.g. "5 machines"
- See that each group that has only one machine has a singular count e.g. "1 machine"