### PR TITLE
Send script_input when commissioning machines

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -870,6 +870,32 @@ function NodeDetailsController(
         // Tell the region not to run any tests.
         extra.testing_scripts.push("none");
       }
+
+      const testingScriptsWithUrlParam = $scope.testSelection.filter(test => {
+        const paramsWithUrl = [];
+        for (let key in test.parameters) {
+          if (test.parameters[key].type === "url") {
+            paramsWithUrl.push(test.parameters[key]);
+          }
+        }
+        return paramsWithUrl.length;
+      });
+
+      testingScriptsWithUrlParam.forEach(test => {
+        let urlValue;
+        for (let key in test.parameters) {
+          if (test.parameters[key].type === "url") {
+            urlValue =
+              test.parameters[key].value || test.parameters[key].default;
+            break;
+          }
+        }
+        scriptInput[test.name] = {
+          url: urlValue
+        };
+      });
+
+      extra.script_input = scriptInput;
     } else if ($scope.action.option.name === "test") {
       if (
         $scope.node.status_code === 6 &&

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -1238,6 +1238,7 @@ describe("NodeDetailsController", function() {
         "commission",
         {
           enable_ssh: true,
+          script_input: {},
           skip_bmc_config: false,
           skip_networking: false,
           skip_storage: false,


### PR DESCRIPTION
In relation to: https://bugs.launchpad.net/maas/+bug/1853568

## Done
Added the `script_input` parameter to the data sent when commissioning a machine and running the `internet-connectivity` test script

## QA
The simplest way to see this works is to `console.log` the `params` parameter in `callMethod` in the `region.js` file from the legacy app.

- Go to a machine in "New" or "Ready" state
- Select "Commission" from the "Take action" menu
- Select the `internet-connectivity` script
- Commission the machine and see the output in the browser console has a `extra.script_input` property e.g. https://pastebin.canonical.com/p/YNst3xs3Vz/