### PR TITLE
Add Tooltip component.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,7 @@
     "react-router-hash-link": "1.2.2",
     "react-router-prop-types": "1.0.4",
     "react-scripts": "3.2.0",
+    "react-useportal": "1.0.13",
     "reconnecting-websocket": "4.2.0",
     "reduce-reducers": "1.0.4",
     "redux": "4.0.4",

--- a/ui/src/app/base/components/Tooltip/Tooltip.js
+++ b/ui/src/app/base/components/Tooltip/Tooltip.js
@@ -1,0 +1,97 @@
+import PropTypes from "prop-types";
+import React, { useRef } from "react";
+import usePortal from "react-useportal";
+
+const getPositionStyle = (position, el) => {
+  if (!el || !el.current) {
+    return undefined;
+  }
+
+  const dimensions = el.current.getBoundingClientRect();
+  const { x, y, height, width } = dimensions;
+  let left = x + window.scrollX || 0;
+  let top = y + window.scrollY || 0;
+
+  switch (position) {
+    case "btm-center":
+      left += width / 2;
+      top += height;
+      break;
+    case "btm-left":
+      top += height;
+      break;
+    case "btm-right":
+      left += width;
+      top += height;
+      break;
+    case "left":
+      top += height / 2;
+      break;
+    case "right":
+      left += width;
+      top += height / 2;
+      break;
+    case "top-center":
+      left += width / 2;
+      break;
+    case "top-left":
+      break;
+    case "top-right":
+      left += width;
+      break;
+    default:
+      break;
+  }
+
+  return { position: "absolute", left, top };
+};
+
+const Tooltip = ({ children, message, position = "top-left" }) => {
+  const el = useRef(null);
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const positionStyle = getPositionStyle(position, el);
+
+  return (
+    <>
+      {message ? (
+        <span
+          onBlur={closePortal}
+          onFocus={openPortal}
+          onMouseOut={closePortal}
+          onMouseOver={openPortal}
+          ref={el}
+        >
+          {children}
+          {isOpen && (
+            <Portal>
+              <span className={`p-tooltip--${position}`} style={positionStyle}>
+                <span className="p-tooltip__message p-tooltip__message--portal">
+                  {message}
+                </span>
+              </span>
+            </Portal>
+          )}
+        </span>
+      ) : (
+        children
+      )}
+    </>
+  );
+};
+
+Tooltip.propTypes = {
+  children: PropTypes.node.isRequired,
+  message: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  position: PropTypes.oneOf([
+    "btm-center",
+    "btm-left",
+    "btm-right",
+    "left",
+    "right",
+    "top-center",
+    "top-left",
+    "top-right"
+  ])
+};
+
+export default Tooltip;

--- a/ui/src/app/base/components/Tooltip/Tooltip.test.js
+++ b/ui/src/app/base/components/Tooltip/Tooltip.test.js
@@ -1,0 +1,41 @@
+import { mount, shallow } from "enzyme";
+import React from "react";
+
+import Tooltip from "./Tooltip";
+
+describe("<Tooltip />", () => {
+  const body = document.querySelector("body");
+  const app = document.createElement("div");
+  app.setAttribute("id", "app");
+  body.appendChild(app);
+
+  // snapshot tests
+  it("renders and matches the snapshot", () => {
+    const component = shallow(<Tooltip message="text">Child</Tooltip>);
+    expect(component).toMatchSnapshot();
+  });
+
+  // unit tests
+  it("does not show tooltip message by default", () => {
+    const component = mount(<Tooltip message="text">Child</Tooltip>);
+    expect(component.exists(".p-tooltip__message--portal")).toEqual(false);
+  });
+
+  it("renders tooltip message when focused", () => {
+    const component = mount(<Tooltip message="text">Child</Tooltip>);
+    component.simulate("focus");
+    expect(component.find(".p-tooltip__message--portal").text()).toEqual(
+      "text"
+    );
+  });
+
+  it("gives the correct class name to the tooltip", () => {
+    const component = mount(
+      <Tooltip message="text" position="top-left">
+        Child
+      </Tooltip>
+    );
+    component.simulate("focus");
+    expect(component.exists(".p-tooltip--top-left")).toEqual(true);
+  });
+});

--- a/ui/src/app/base/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/ui/src/app/base/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tooltip /> renders and matches the snapshot 1`] = `
+<Fragment>
+  <span
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+  >
+    Child
+  </span>
+</Fragment>
+`;

--- a/ui/src/app/base/components/Tooltip/index.js
+++ b/ui/src/app/base/components/Tooltip/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Tooltip";

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyFormFields/SSHKeyFormFields.js
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyFormFields/SSHKeyFormFields.js
@@ -3,6 +3,7 @@ import { useFormikContext } from "formik";
 import React from "react";
 
 import FormikField from "app/base/components/FormikField";
+import Tooltip from "app/base/components/Tooltip";
 
 export const SSHKeyFormFields = () => {
   const { values } = useFormikContext();
@@ -40,14 +41,12 @@ export const SSHKeyFormFields = () => {
               label={
                 <>
                   Public key{" "}
-                  <span className="p-tooltip">
+                  <Tooltip
+                    position="btm-left"
+                    message={`Begins with 'ssh-rsa', 'ssh-dss', 'ssh-ed25519',\n 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', or\n 'ecdsa-sha2-nistp521`}
+                  >
                     <i className="p-icon--help"></i>
-                    <span className="p-tooltip__message" role="tooltip">
-                      Begins with 'ssh-rsa', 'ssh-dss', 'ssh-ed25519',
-                      'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', or
-                      'ecdsa-sha2-nistp521'
-                    </span>
-                  </span>
+                  </Tooltip>
                 </>
               }
               style={{ minHeight: "10rem" }}

--- a/ui/src/app/settings/components/SettingsTable/SettingsTable.js
+++ b/ui/src/app/settings/components/SettingsTable/SettingsTable.js
@@ -10,6 +10,7 @@ import {
   MainTable,
   SearchBox
 } from "@canonical/react-components";
+import Tooltip from "app/base/components/Tooltip";
 
 export const SettingsTable = ({
   buttons,
@@ -37,12 +38,11 @@ export const SettingsTable = ({
         )}
         {buttons.map(({ label, url, disabled = false, tooltip }) =>
           tooltip ? (
-            <span key={url} className="p-tooltip p-tooltip--left">
+            <Tooltip key={url} position="left" message={tooltip}>
               <Button element={Link} to={url} disabled={disabled}>
                 {label}
               </Button>
-              <span className="p-tooltip__message">{tooltip}</span>
-            </span>
+            </Tooltip>
           ) : (
             <Button element={Link} to={url} key={url} disabled={disabled}>
               {label}

--- a/ui/src/app/settings/components/SettingsTable/SettingsTable.test.js
+++ b/ui/src/app/settings/components/SettingsTable/SettingsTable.test.js
@@ -83,7 +83,7 @@ it("can render a disabled button ", () => {
   expect(wrapper.find("Button").props().disabled).toBe(true);
 });
 
-it("can show render a button with a tooltip", () => {
+it("can render a button with a tooltip", () => {
   const tooltip = "Add a user to MAAS";
   const wrapper = shallow(
     <SettingsTable
@@ -95,5 +95,5 @@ it("can show render a button with a tooltip", () => {
     </SettingsTable>
   );
 
-  expect(wrapper.find("span.p-tooltip__message").text()).toEqual(tooltip);
+  expect(wrapper.find("Tooltip").props().message).toEqual(tooltip);
 });

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
@@ -118,19 +118,16 @@ const generateRows = (
               >
                 <i className="p-icon--edit">Edit</i>
               </Button>
-
-              <span className="p-tooltip p-tooltip--left">
-                <Button
-                  appearance="base"
-                  className="is-small u-justify-table-icon"
-                  onClick={() => {
-                    setExpandedId(dhcpsnippet.id);
-                    setExpandedType("delete");
-                  }}
-                >
-                  <i className="p-icon--delete">Delete</i>
-                </Button>
-              </span>
+              <Button
+                appearance="base"
+                className="is-small u-justify-table-icon"
+                onClick={() => {
+                  setExpandedId(dhcpsnippet.id);
+                  setExpandedType("delete");
+                }}
+              >
+                <i className="p-icon--delete">Delete</i>
+              </Button>
             </>
           ),
           className: "u-align--right u-align-icons--top"

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
@@ -11,6 +11,7 @@ import { useAddMessage } from "app/base/hooks";
 import { useWindowTitle } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+import Tooltip from "app/base/components/Tooltip";
 
 const generateRepositoryRows = (
   dispatch,
@@ -46,7 +47,10 @@ const generateRepositoryRows = (
               >
                 <i className="p-icon--edit">Edit</i>
               </Button>
-              <span className="p-tooltip p-tooltip--left">
+              <Tooltip
+                position="left"
+                message={repo.default && "Default repos cannot be deleted."}
+              >
                 <Button
                   appearance="base"
                   className="is-small u-justify-table-icon"
@@ -55,12 +59,7 @@ const generateRepositoryRows = (
                 >
                   <i className="p-icon--delete">Delete</i>
                 </Button>
-                {repo.default && (
-                  <span className="p-tooltip__message">
-                    Default repos cannot be deleted.
-                  </span>
-                )}
-              </span>
+              </Tooltip>
             </>
           ),
           className: "u-align--right u-align-icons--top"

--- a/ui/src/app/settings/views/Scripts/ScriptsList.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsList.js
@@ -12,6 +12,7 @@ import SettingsTable from "app/settings/components/SettingsTable";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import { scripts as scriptActions } from "app/base/actions";
 import { scripts as scriptSelectors } from "app/base/selectors";
+import Tooltip from "app/base/components/Tooltip";
 
 const generateRows = (
   scripts,
@@ -80,26 +81,22 @@ const generateRows = (
         { content: uploadedOn },
         {
           content: (
-            <>
-              <span className="p-tooltip p-tooltip--left">
-                <Button
-                  appearance="base"
-                  disabled={script.default}
-                  className="is-small u-justify-table-icon"
-                  onClick={() => {
-                    setExpandedId(script.id);
-                    setExpandedType("delete");
-                  }}
-                >
-                  <i className="p-icon--delete">Delete</i>
-                </Button>
-                {script.default && (
-                  <span className="p-tooltip__message">
-                    Default scripts cannot be deleted.
-                  </span>
-                )}
-              </span>
-            </>
+            <Tooltip
+              position="left"
+              message={script.default && "Default scripts cannot be deleted."}
+            >
+              <Button
+                appearance="base"
+                disabled={script.default}
+                className="is-small u-justify-table-icon"
+                onClick={() => {
+                  setExpandedId(script.id);
+                  setExpandedType("delete");
+                }}
+              >
+                <i className="p-icon--delete">Delete</i>
+              </Button>
+            </Tooltip>
           ),
           className: "u-align--right u-align-icons--top"
         }

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.js
@@ -15,6 +15,7 @@ import {
 import { useWindowTitle } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+import Tooltip from "app/base/components/Tooltip";
 
 const generateUserRows = (
   users,
@@ -71,8 +72,10 @@ const generateUserRows = (
               >
                 <i className="p-icon--edit">Edit</i>
               </Button>
-
-              <span className="p-tooltip p-tooltip--left">
+              <Tooltip
+                position="left"
+                message={isAuthUser && "You cannot delete your own user."}
+              >
                 <Button
                   appearance="base"
                   className="is-small u-justify-table-icon"
@@ -81,12 +84,7 @@ const generateUserRows = (
                 >
                   <i className="p-icon--delete">Delete</i>
                 </Button>
-                {isAuthUser && (
-                  <span className="p-tooltip__message">
-                    You cannot delete your own user.
-                  </span>
-                )}
-              </span>
+              </Tooltip>
             </>
           ),
           className: "u-align--right u-align-icons--top"

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -45,3 +45,9 @@ td > .p-tooltip {
   .p-table-multi-header__link.is-active::after {
   @include vf-icon-chevron;
 }
+
+// 27-11-2019 Caleb: Tooltips cannot be used with React Portals.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2672
+.p-tooltip__message--portal {
+  display: inline;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10655,6 +10655,13 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.16.2"
 
+react-useportal@1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/react-useportal/-/react-useportal-1.0.13.tgz#abfc29f8128756cd7382bff7c81a4f446b792199"
+  integrity sha512-83KpNTXUIHnRVTLeMberIblCtssvRSKCPnG/xT9NW60gDYfU13pQBNQKCVUF8MBK+7LnCQ/ZrOuXl8Mp+iXdXA==
+  dependencies:
+    use-ssr "^1.0.19"
+
 react@16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
@@ -12662,6 +12669,11 @@ url@0.11.0, url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-ssr@^1.0.19:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.21.tgz#cb3921f62396adfdce22d1ac784fe1c12cb57923"
+  integrity sha512-4LaUeTJsYZQPLldNO7fUEvTu7+ehb1iBs9FlWEIGzx5pmdaDodBHU+M+OKbr/kl/4TnLPnzrmP5KJbEVEAT6Hw==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
## Done
- Added a Tooltip component and replaced all instances of `<span className="p-tooltip">` with it.
- Note there's a weird issue where the tooltip doesn't show when hovering over the *padding* of a disabled button, but it works when hovering over the text/icon. I know it has something to do with disabled buttons disabling all events... but why only the padding?!?

## QA
- Check tooltips still work
  - /settings/users delete self
  - /settings/license-keys button
  - /settings/scripts/testing
  - /settings/repositories
  - /account/prefs/ssh-keys/add SSH upload

Fixes #497 