### PR TITLE
Remove instances of first_name param in user objects.

### DIFF
--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -100,7 +100,6 @@ describe("App", () => {
           user: {
             completed_intro: true,
             email: "test@example.com",
-            first_name: "",
             global_permissions: ["machine_create"],
             id: 1,
             is_superuser: true,

--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -70,7 +70,9 @@ export const UserForm = ({
   let initialValues = {
     isSuperuser: user ? user.is_superuser : false,
     email: user ? user.email : "",
-    fullName: user ? `${user.first_name} ${user.last_name}` : "",
+    // first_name is not exposed by the websocket, so only last_name is used.
+    // https://bugs.launchpad.net/maas/+bug/1853579
+    fullName: user ? user.last_name : "",
     password: "",
     passwordConfirm: "",
     username: user ? user.username : ""
@@ -87,12 +89,10 @@ export const UserForm = ({
       errors={errors}
       initialValues={initialValues}
       onSubmit={(values, { resetForm }) => {
-        const [firstName, ...lastNameParts] = values.fullName.split(" ");
         const params = {
           email: values.email,
-          first_name: firstName,
           is_superuser: values.isSuperuser,
-          last_name: lastNameParts.join(" "),
+          last_name: values.fullName,
           username: values.username
         };
         if (values.password) {

--- a/ui/src/app/base/components/UserForm/UserForm.test.js
+++ b/ui/src/app/base/components/UserForm/UserForm.test.js
@@ -15,10 +15,9 @@ describe("UserForm", () => {
   beforeEach(() => {
     user = {
       email: "old@example.com",
-      first_name: "Miss",
       id: 808,
       is_superuser: true,
-      last_name: "Wallaby",
+      last_name: "Miss Wallaby",
       password1: "test1234",
       password2: "test1234",
       username: "admin"
@@ -77,10 +76,9 @@ describe("UserForm", () => {
     );
     expect(onSave.mock.calls[0][0]).toEqual({
       email: "test@example.com",
-      first_name: "Miss",
       id: 808,
       is_superuser: true,
-      last_name: "Wallaby",
+      last_name: "Miss Wallaby",
       password1: "test1234",
       password2: "test1234",
       username: "admin"

--- a/ui/src/app/base/proptypes.js
+++ b/ui/src/app/base/proptypes.js
@@ -2,7 +2,6 @@ import PropTypes from "prop-types";
 
 export const UserShape = PropTypes.shape({
   email: PropTypes.string.isRequired,
-  first_name: PropTypes.string,
   global_permissions: PropTypes.arrayOf(PropTypes.string),
   id: PropTypes.number.isRequired,
   is_local: PropTypes.bool,

--- a/ui/src/app/base/selectors/user/user.js
+++ b/ui/src/app/base/selectors/user/user.js
@@ -24,7 +24,6 @@ user.search = (state, term) => {
     user =>
       user.username.includes(term) ||
       user.email.includes(term) ||
-      user.first_name.includes(term) ||
       user.last_name.includes(term)
   );
 };

--- a/ui/src/app/base/selectors/user/user.test.js
+++ b/ui/src/app/base/selectors/user/user.test.js
@@ -83,31 +83,21 @@ describe("users selectors", () => {
           {
             username: "admin",
             email: "test@example.com",
-            first_name: "",
             last_name: ""
           },
           {
             username: "me",
             email: "minnie@example.com",
-            first_name: "",
             last_name: ""
           },
           {
             username: "richie",
             email: "richie@example.com",
-            first_name: "",
-            last_name: ""
-          },
-          {
-            username: "boris",
-            email: "boris@example.com",
-            first_name: "mine",
             last_name: ""
           },
           {
             username: "adam",
             email: "adam@example.com",
-            first_name: "",
             last_name: "minichiello"
           }
         ]
@@ -118,28 +108,18 @@ describe("users selectors", () => {
       {
         username: "admin",
         email: "test@example.com",
-        first_name: "",
         last_name: ""
       },
       // Matches email:
       {
         username: "me",
         email: "minnie@example.com",
-        first_name: "",
-        last_name: ""
-      },
-      // Matches first name:
-      {
-        username: "boris",
-        email: "boris@example.com",
-        first_name: "mine",
         last_name: ""
       },
       // Matches last name:
       {
         username: "adam",
         email: "adam@example.com",
-        first_name: "",
         last_name: "minichiello"
       }
     ]);

--- a/ui/src/app/preferences/views/Details/Details.test.js
+++ b/ui/src/app/preferences/views/Details/Details.test.js
@@ -22,7 +22,6 @@ describe("Details", () => {
           saved: false,
           user: {
             email: "test@example.com",
-            first_name: "",
             global_permissions: ["machine_create"],
             id: 1,
             is_superuser: true,
@@ -78,10 +77,9 @@ describe("Details", () => {
           <Details
             user={{
               email: "old@example.com",
-              first_name: "Miss",
               id: 808,
               is_superuser: true,
-              last_name: "Wallaby",
+              last_name: "Miss Wallaby",
               password1: "test1234",
               password2: "test1234",
               username: "admin"
@@ -135,10 +133,9 @@ describe("Details", () => {
           <Details
             user={{
               email: "old@example.com",
-              first_name: "Miss",
               id: 808,
               is_superuser: true,
-              last_name: "Wallaby",
+              last_name: "Miss Wallaby",
               password1: "test1234",
               password2: "test1234",
               username: "admin"

--- a/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.js
+++ b/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.js
@@ -24,7 +24,6 @@ describe("UserEdit", () => {
         items: [
           {
             email: "admin@example.com",
-            first_name: "",
             global_permissions: ["machine_create"],
             id: 1,
             is_superuser: true,
@@ -34,7 +33,6 @@ describe("UserEdit", () => {
           },
           {
             email: "user@example.com",
-            first_name: "",
             global_permissions: ["machine_create"],
             id: 2,
             is_superuser: false,

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -79,10 +79,9 @@ describe("UserForm", () => {
           <UserForm
             user={{
               email: "old@example.com",
-              first_name: "Miss",
               id: 808,
               is_superuser: true,
-              last_name: "Wallaby",
+              last_name: "Miss Wallaby",
               password1: "test1234",
               password2: "test1234",
               username: "admin"

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.js
@@ -35,9 +35,7 @@ const generateUserRows = (
           "yyyy-LL-dd H:mm"
         )
       : "Never";
-    const fullName =
-      (user.first_name || user.last_name) &&
-      [user.first_name, user.last_name].filter(Boolean).join(" ");
+    const fullName = user.last_name;
     return {
       className: expanded ? "p-table__row is-active" : null,
       columns: [

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -16,21 +16,19 @@ describe("UsersList", () => {
     users = [
       {
         email: "admin@example.com",
-        first_name: "Kangaroo",
         global_permissions: ["machine_create"],
         id: 1,
         is_superuser: true,
-        last_name: "",
+        last_name: "Kangaroo",
         sshkeys_count: 0,
         username: "admin"
       },
       {
         email: "user@example.com",
-        first_name: "Koala",
         global_permissions: ["machine_create"],
         id: 2,
         is_superuser: false,
-        last_name: "",
+        last_name: "Koala",
         sshkeys_count: 0,
         username: "user1"
       }


### PR DESCRIPTION
## Done
- Removed references to `first_name` param from ui code. As of [this MP](https://code.launchpad.net/~blake-rouse/maas/+git/maas/+merge/375892), `first_name` will no longer be sent through the websocket, so a user's full name is essentially just the `last_name`.

## QA
- Go to user prefs and check that the first and last name saves correctly.
- Do the same with add and editing users from the user list in settings.
- Verify in Redux state the only `last_name` is getting updated.

Fixes #476 