### PR TITLE
Fix doc and release notes links in Footer

### DIFF
--- a/shared/src/components/Footer/Footer.js
+++ b/shared/src/components/Footer/Footer.js
@@ -2,10 +2,6 @@ import PropTypes from "prop-types";
 import React from "react";
 
 export const Footer = ({ debug, maasName, version }) => {
-  const docVersion = version
-    .split(".")
-    .slice(0, 2)
-    .join(".");
   return (
     <footer className="p-strip--light is-shallow p-footer">
       <div className="row">
@@ -25,7 +21,7 @@ export const Footer = ({ debug, maasName, version }) => {
           <ul className="p-inline-list--middot">
             <li className="p-inline-list__item">
               <a
-                href={`http://docs.ubuntu.com/maas/${docVersion}/en/release-notes`}
+                href={`https://maas.io/docs/release-notes`}
                 className="p-footer__link"
               >
                 View release notes
@@ -33,7 +29,7 @@ export const Footer = ({ debug, maasName, version }) => {
             </li>
             <li className="p-inline-list__item">
               <a
-                href={`https://docs.ubuntu.com/maas/${docVersion}/`}
+                href={`https://maas.io/docs/`}
                 className="p-footer__link"
               >
                 View documentation

--- a/shared/src/components/Footer/__snapshots__/Footer.test.js.snap
+++ b/shared/src/components/Footer/__snapshots__/Footer.test.js.snap
@@ -39,7 +39,7 @@ exports[`Footer renders 1`] = `
         >
           <a
             className="p-footer__link"
-            href="http://docs.ubuntu.com/maas/2.7/en/release-notes"
+            href="https://maas.io/docs/release-notes"
           >
             View release notes
           </a>
@@ -49,7 +49,7 @@ exports[`Footer renders 1`] = `
         >
           <a
             className="p-footer__link"
-            href="https://docs.ubuntu.com/maas/2.7/"
+            href="https://maas.io/docs/"
           >
             View documentation
           </a>


### PR DESCRIPTION
Done:
 * Point to maas.io/docs not docs.ubuntu.com
 * Point release notes at where they'll be

QA:
 * Click the docs link in the footer and see that you don't end up bouncing around from ubuntu.com