### PR TITLE
Rewrite Header component to utilise Vanilla subnav and remove hardcoded values.

### DIFF
--- a/legacy/src/scss/_patterns_navigation.scss
+++ b/legacy/src/scss/_patterns_navigation.scss
@@ -14,4 +14,14 @@
       display: none;
     }
   }
+
+  // This is fixed in Vanilla > 2.4.0, but is hardcoded here because we aren't
+  // committing to a full upgrade.
+  @media (max-width: $breakpoint-navigation-threshold) {
+    .p-navigation.is-dark .p-navigation__link > a::before {
+      background: hsl(0, 0%, 27%);
+      left: map-get($grid-gutter-widths, small);
+      right: map-get($grid-gutter-widths, small);
+    }
+  }
 }

--- a/legacy/src/scss/_patterns_navigation.scss
+++ b/legacy/src/scss/_patterns_navigation.scss
@@ -1,112 +1,17 @@
-//Local overrides to the navigation pattern
 @mixin maas-navigation {
-  $nav-threshold-small: 870px;
-  $nav-threshold-medium: 1070px;
+  $breakpoint-hardware-menu: 1200px;
 
-  .p-dropdown.active {
-    .p-navigation__toggle--open {
+  .hardware-menu {
+    display: none;
+
+    @media (min-width: $breakpoint-navigation-threshold) and (max-width: $breakpoint-hardware-menu) {
+      display: inherit;
+    }
+  }
+
+  .u-hide--hardware-menu-threshold {
+    @media (min-width: $breakpoint-navigation-threshold) and (max-width: $breakpoint-hardware-menu) {
       display: none;
-    }
-
-    .p-navigation__toggle--close {
-      @media (max-width: $breakpoint-navigation-threshold) {
-        display: inline-block;
-      }
-    }
-
-    .p-navigation__nav {
-      display: block;
-    }
-  }
-
-  .p-navigation {
-    &__banner {
-      @media (max-width: $breakpoint-navigation-threshold) {
-        overflow: hidden;
-        position: relative;
-      }
-    }
-
-    .p-navigation__links {
-      z-index: 6;
-
-      &--right {
-        @extend .p-navigation__links;
-
-        @media (min-width: $breakpoint-navigation-threshold) {
-          right: 0;
-        }
-      }
-
-      .p-navigation__link {
-        &:hover,
-        &:active {
-          background-color: $color-navigation-background--hover;
-        }
-
-        &.is-selected > a {
-          @media (min-width: $breakpoint-navigation-threshold) {
-            border-bottom-color: $color-brand;
-          }
-
-          @media (max-width: $breakpoint-navigation-threshold) {
-            border-bottom: 0;
-          }
-        }
-      }
-    }
-  }
-
-  .p-dropdown {
-    height: 3rem; //TODO ?variable
-
-    &__toggle {
-      background-color: $color-navigation-background;
-    }
-
-    .p-icon--chevron {
-      margin-bottom: -2px; //TODO: Use Vanilla variable / find better positioning solution
-      margin-left: 10px; //TODO: Use Vanilla variable
-    }
-
-    .active {
-      background-color: $color-navigation-background--hover;
-
-      .p-icon--chevron {
-        transform: rotate(180deg);
-      }
-    }
-  }
-
-  .p-navigation .p-navigation__links .p-dropdown__menu {
-    background-color: $color-navigation-background--hover;
-    margin: 0;
-    padding: 0;
-
-    .p-navigation__link {
-      border-left: 0;
-      width: 100%;
-      float: none;
-    }
-  }
-
-  .u-hide-nav-viewport {
-    &--large {
-      @media (min-width: $nav-threshold-medium + 1px) {
-        display: none !important;
-      }
-    }
-
-    &--medium {
-      @media (max-width: $nav-threshold-medium) and (min-width: $nav-threshold-small + 1px) {
-        display: none !important;
-      }
-    }
-
-    &--small {
-      @media (max-width: $nav-threshold-small) {
-        display: none !important;
-      }
     }
   }
 }

--- a/shared/src/components/Header/Header.test.js
+++ b/shared/src/components/Header/Header.test.js
@@ -56,7 +56,7 @@ describe("Header", () => {
       />
     );
     wrapper
-      .findWhere(n => n.name() === "a" && n.text() === "Logout")
+      .findWhere(n => n.name() === "a" && n.text() === "Log out")
       .last()
       .simulate("click", { preventDefault: jest.fn() });
     expect(logout).toHaveBeenCalled();
@@ -81,7 +81,7 @@ describe("Header", () => {
       wrapper.findWhere(n => n.name() === "a" && n.text() === "Skip").exists()
     ).toBe(true);
     expect(
-      wrapper.find(".p-navigation__links .p-navigation__link").exists()
+      wrapper.find(".p-navigation__links").at(0).props().children
     ).toBe(false);
   });
 });

--- a/shared/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/shared/src/components/Header/__snapshots__/Header.test.js.snap
@@ -4,6 +4,7 @@ exports[`Header renders 1`] = `
 <Fragment>
   <header
     className="p-navigation is-dark"
+    id="navigation"
   >
     <div
       className="p-navigation__row row"
@@ -52,16 +53,14 @@ exports[`Header renders 1`] = `
         </div>
         <a
           className="p-navigation__toggle--open"
-          href="#menu"
           onClick={[Function]}
-          title="toggle menu"
+          title="Toggle menu"
         >
           Menu
         </a>
       </div>
       <nav
-        className="p-navigation__nav p-dropdown__menu"
-        role="menubar"
+        className="p-navigation__nav"
       >
         <span
           className="u-off-screen"
@@ -77,64 +76,52 @@ exports[`Header renders 1`] = `
           role="menu"
         >
           <li
-            className="p-navigation__link p-dropdown u-hide-nav-viewport--large u-hide-nav-viewport--small p-dropdown__toggle"
+            className="p-navigation__link p-subnav is-dark hardware-menu"
             role="menuitem"
           >
             <a
-              href="#menu"
               onClick={[Function]}
             >
-              Hardware 
-              <i
-                className="p-icon--chevron"
-              />
+              Hardware
             </a>
             <ul
-              className="p-dropdown__menu u-hide"
+              className="p-subnav__items"
             >
               <li
-                className="p-navigation__link"
-                key="/MAAS/#/machines"
-                role="menuitem"
+                key="/machines"
               >
                 <a
-                  className=""
+                  className="p-subnav__item"
                   href="/MAAS/#/machines"
                 >
                   Machines
                 </a>
               </li>
               <li
-                className="p-navigation__link"
-                key="/MAAS/#/devices"
-                role="menuitem"
+                key="/devices"
               >
                 <a
-                  className=""
+                  className="p-subnav__item"
                   href="/MAAS/#/devices"
                 >
                   Devices
                 </a>
               </li>
               <li
-                className="p-navigation__link"
-                key="/MAAS/#/controllers"
-                role="menuitem"
+                key="/controllers"
               >
                 <a
-                  className=""
+                  className="p-subnav__item"
                   href="/MAAS/#/controllers"
                 >
                   Controllers
                 </a>
               </li>
               <li
-                className="p-navigation__link"
-                key="/MAAS/#/kvm"
-                role="menuitem"
+                key="/kvm"
               >
                 <a
-                  className=""
+                  className="p-subnav__item"
                   href="/MAAS/#/kvm"
                 >
                   KVM
@@ -143,48 +130,44 @@ exports[`Header renders 1`] = `
             </ul>
           </li>
           <li
-            className="p-navigation__link u-hide-nav-viewport--medium"
-            key="/MAAS/#/machines"
+            className="p-navigation__link u-hide--hardware-menu-threshold"
+            key="/machines"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/machines"
             >
               Machines
             </a>
           </li>
           <li
-            className="p-navigation__link u-hide-nav-viewport--medium"
-            key="/MAAS/#/devices"
+            className="p-navigation__link u-hide--hardware-menu-threshold"
+            key="/devices"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/devices"
             >
               Devices
             </a>
           </li>
           <li
-            className="p-navigation__link u-hide-nav-viewport--medium"
-            key="/MAAS/#/controllers"
+            className="p-navigation__link u-hide--hardware-menu-threshold"
+            key="/controllers"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/controllers"
             >
               Controllers
             </a>
           </li>
           <li
-            className="p-navigation__link u-hide-nav-viewport--medium"
-            key="/MAAS/#/kvm"
+            className="p-navigation__link u-hide--hardware-menu-threshold"
+            key="/kvm"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/kvm"
             >
               KVM
@@ -192,11 +175,10 @@ exports[`Header renders 1`] = `
           </li>
           <li
             className="p-navigation__link"
-            key="/MAAS/#/images"
+            key="/images"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/images"
             >
               Images
@@ -204,11 +186,10 @@ exports[`Header renders 1`] = `
           </li>
           <li
             className="p-navigation__link"
-            key="/MAAS/#/domains"
+            key="/domains"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/domains"
             >
               DNS
@@ -216,11 +197,10 @@ exports[`Header renders 1`] = `
           </li>
           <li
             className="p-navigation__link"
-            key="/MAAS/#/zones"
+            key="/zones"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/zones"
             >
               AZs
@@ -228,11 +208,10 @@ exports[`Header renders 1`] = `
           </li>
           <li
             className="p-navigation__link"
-            key="/MAAS/#/networks?by=fabric"
+            key="/networks?by=fabric"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/MAAS/#/networks?by=fabric"
             >
               Subnets
@@ -244,7 +223,6 @@ exports[`Header renders 1`] = `
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/settings"
             >
               Settings
@@ -252,16 +230,14 @@ exports[`Header renders 1`] = `
           </li>
         </ul>
         <ul
-          className="p-navigation__links--right"
+          className="p-navigation__links"
           role="menu"
         >
           <li
             className="p-navigation__link"
-            key="/account/prefs"
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
               href="/account/prefs"
             >
               koala
@@ -272,11 +248,9 @@ exports[`Header renders 1`] = `
             role="menuitem"
           >
             <a
-              className="p-dropdown__item"
-              href=""
               onClick={[Function]}
             >
-              Logout
+              Log out
             </a>
           </li>
         </ul>

--- a/ui/src/app/base/components/ColumnToggle/ColumnToggle.scss
+++ b/ui/src/app/base/components/ColumnToggle/ColumnToggle.scss
@@ -2,40 +2,24 @@
 @import "~vanilla-framework/scss/settings_colors";
 @import "~vanilla-framework/scss/patterns_icons";
 
-%heading-icon {
-  @include vf-icon-chevron;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 100%;
-  content: "";
-  display: block;
-  flex: 0 0 $sp-medium;
-  height: 0.4rem;
-  margin-top: $sp-small;
-  margin-left: $sp-x-small;
-  vertical-align: middle;
-}
-
 td:not(.p-table-expanding__panel) [class*="p-button"].column-toggle,
 .column-toggle {
+  align-items: center;
   align-self: flex-start;
   color: $color-dark;
+  justify-content: space-between;
   margin: 0;
   padding: 0;
   width: 100%;
-  display: flex;
-}
 
-.column-toggle__name {
-  flex: 1 1 auto;
-}
+  &::after {
+    @include vf-icon-chevron;
+    @include vf-icon-size($default-icon-size);
+    content: "";
+  }
 
-.column-toggle::after {
-  @extend %heading-icon;
-}
-
-.column-toggle.is-active::after {
-  @extend %heading-icon;
-  -webkit-transform: rotate(180deg);
-  transform: rotate(180deg);
+  &.is-active::after {
+    -webkit-transform: rotate(180deg);
+    transform: rotate(180deg);
+  }
 }

--- a/ui/src/app/base/components/FormCard/FormCard.js
+++ b/ui/src/app/base/components/FormCard/FormCard.js
@@ -18,7 +18,7 @@ export const FormCard = ({ children, stacked, title }) => {
     </Row>
   );
   return (
-    <Card highlighted={true} className="card-form">
+    <Card highlighted={true} className="form-card">
       {content}
     </Card>
   );

--- a/ui/src/app/base/components/FormCard/FormCard.scss
+++ b/ui/src/app/base/components/FormCard/FormCard.scss
@@ -5,23 +5,15 @@
 
 @include vf-b-placeholders;
 
-.form-card {
-  margin-top: 0.5rem;
-}
-
-.form-card__title {
-  word-break: break-word;
-}
-
 .form-card__buttons {
-  border-top: 1px solid $color-mid-light;
-  margin-top: 1rem;
-  padding-top: 1rem;
-  text-align: right;
+  border-top: $border;
+  display: flex;
+  justify-content: flex-end;
+  padding-top: $spv-inner--large;
 }
 
 .form-card__help {
   @extend %small-text;
   color: $color-mid-dark;
-  margin-top: $sp-x-small;
+  margin-top: $spv-inner--x-small;
 }

--- a/ui/src/app/base/components/FormCard/__snapshots__/FormCard.test.js.snap
+++ b/ui/src/app/base/components/FormCard/__snapshots__/FormCard.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FormCard  renders 1`] = `
 <Card
-  className="card-form"
+  className="form-card"
   highlighted={true}
 >
   <Row>

--- a/ui/src/app/base/components/Section/Section.js
+++ b/ui/src/app/base/components/Section/Section.js
@@ -8,14 +8,14 @@ import NotificationList from "app/base/components/NotificationList";
 const Section = ({ children, sidebar, title }) => {
   return (
     <div className="section">
-      <Strip element="header" className="section__header">
+      <Strip className="section__header" element="header" shallow>
         <h1 className="p-heading--four u-no-margin--bottom">{title}</h1>
       </Strip>
       <Strip
         element="main"
-        className="u-no-padding"
-        rowClassName="u-equal-height section__content-wrapper"
         includeCol={false}
+        rowClassName="u-equal-height section__content-wrapper"
+        shallow
       >
         {sidebar && (
           <Col element="aside" size="2" className="section__sidebar">

--- a/ui/src/app/base/components/Section/Section.scss
+++ b/ui/src/app/base/components/Section/Section.scss
@@ -7,31 +7,10 @@
 .section {
   display: grid;
   grid-template-rows: auto 1fr;
-  min-height: calc(100% - 3rem);
+  height: auto;
 }
 
 .section__header {
   @extend %vf-has-box-shadow;
-  // Display the shadow above the content.
-  z-index: 1;
-}
-
-.section__header.p-strip {
   background-color: #fff;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-}
-
-.section__sidebar,
-.section__content {
-  padding-top: 1em;
-  padding-bottom: 1em;
-}
-
-.section__sidebar {
-  height: 100%;
-}
-
-.section__content-wrapper {
-  height: 100%;
 }

--- a/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
+++ b/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
@@ -7,6 +7,7 @@ exports[`Section renders 1`] = `
   <Strip
     className="section__header"
     element="header"
+    shallow={true}
   >
     <h1
       className="p-heading--four u-no-margin--bottom"
@@ -15,10 +16,10 @@ exports[`Section renders 1`] = `
     </h1>
   </Strip>
   <Strip
-    className="u-no-padding"
     element="main"
     includeCol={false}
     rowClassName="u-equal-height section__content-wrapper"
+    shallow={true}
   >
     <Col
       className="section__sidebar"

--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -1,5 +1,10 @@
+@import "~vanilla-framework/scss/settings_spacing";
+@import "~vanilla-framework/scss/base_forms-tick-elements";
+
+$grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spacing
+
 .machine-list--grouped .machine-list__machine td:first-child {
-  padding-left: 2rem;
+  padding-left: $grouped-machines-indentation;
 }
 
 .machine-list__group-toggle {

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.scss
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.scss
@@ -1,6 +1,8 @@
 @import "~vanilla-framework/scss/settings_font";
 
+$textarea-min-height: 25rem;
+
 .ssl-key-form-fields__key {
   font-family: unquote($font-monospace);
-  min-height: 25rem;
+  min-height: $textarea-min-height;
 }

--- a/ui/src/scss/_patterns_navigation.scss
+++ b/ui/src/scss/_patterns_navigation.scss
@@ -1,112 +1,18 @@
 //Local overrides to the navigation pattern
 @mixin maas-navigation {
-  $nav-threshold-small: 870px;
-  $nav-threshold-medium: 1070px;
+  $breakpoint-hardware-menu: 1200px;
 
-  .p-dropdown.active {
-    .p-navigation__toggle--open {
+  .hardware-menu {
+    display: none;
+
+    @media (min-width: $breakpoint-navigation-threshold) and (max-width: $breakpoint-hardware-menu) {
+      display: inherit;
+    }
+  }
+
+  .u-hide--hardware-menu-threshold {
+    @media (min-width: $breakpoint-navigation-threshold) and (max-width: $breakpoint-hardware-menu) {
       display: none;
-    }
-
-    .p-navigation__toggle--close {
-      @media (max-width: $breakpoint-navigation-threshold) {
-        display: inline-block;
-      }
-    }
-
-    .p-navigation__nav {
-      display: block;
-    }
-  }
-
-  .p-navigation {
-    &__banner {
-      @media (max-width: $breakpoint-navigation-threshold) {
-        overflow: hidden;
-        position: relative;
-      }
-    }
-
-    .p-navigation__links {
-      z-index: 6;
-
-      &--right {
-        @extend .p-navigation__links;
-
-        @media (min-width: $breakpoint-navigation-threshold) {
-          right: 0;
-        }
-      }
-
-      .p-navigation__link {
-        &:hover,
-        &:active {
-          background-color: $color-navigation-background--hover;
-        }
-
-        &.is-selected > a {
-          @media (min-width: $breakpoint-navigation-threshold) {
-            border-bottom-color: $color-brand;
-          }
-
-          @media (max-width: $breakpoint-navigation-threshold) {
-            border-bottom: 0;
-          }
-        }
-      }
-    }
-  }
-
-  .p-dropdown {
-    height: 3rem; //TODO ?variable
-
-    &__toggle {
-      background-color: $color-navigation-background;
-    }
-
-    .p-icon--chevron {
-      margin-bottom: -2px; //TODO: Use Vanilla variable / find better positioning solution
-      margin-left: 10px; //TODO: Use Vanilla variable
-    }
-
-    .active {
-      background-color: $color-navigation-background--hover;
-
-      .p-icon--chevron {
-        transform: rotate(180deg);
-      }
-    }
-  }
-
-  .p-navigation .p-navigation__links .p-dropdown__menu {
-    background-color: $color-navigation-background--hover;
-    margin: 0;
-    padding: 0;
-
-    .p-navigation__link {
-      border-left: 0;
-      width: 100%;
-      float: none;
-    }
-  }
-
-  .u-hide-nav-viewport {
-    &--large {
-      @media (min-width: $nav-threshold-medium + 1px) {
-        display: none !important;
-      }
-    }
-
-    &--medium {
-      @media (max-width: $nav-threshold-medium) and (min-width: $nav-threshold-small + 1px) {
-        display: none !important;
-      }
-    }
-
-    &--small {
-      @media (max-width: $nav-threshold-small) {
-        display: none !important;
-      }
     }
   }
 }

--- a/ui/src/scss/_patterns_table-actions.scss
+++ b/ui/src/scss/_patterns_table-actions.scss
@@ -1,7 +1,7 @@
 @media screen and (min-width: $breakpoint-x-small) {
   .p-table-actions {
     display: flex;
-    margin-bottom: 1rem;
+    margin-bottom: $spv-inner--scaleable;
   }
 
   .p-table-actions__space-left,
@@ -14,7 +14,7 @@
     margin: 0;
 
     &:first-of-type {
-      margin-left: 1rem;
+      margin-left: $sph-inner;
     }
   }
 }

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -43,7 +43,7 @@ body {
 
 .p-form-validation__message [class*="p-icon--"] {
   @extend %icon;
-  @include vf-icon-size(0.875rem);
+  @include vf-icon-size(#{map-get($font-sizes, small)}rem);
 }
 
 .u-text--light {


### PR DESCRIPTION
## Done
- Adopted Vanilla subnav in `Header` component, and added some simple MAAS-specific utilities to show/hide it. Note that because the Vanilla versions are different, there are subtle differences in the Angular and React headers, particularly on mobile view.
- Rewrote sections of the `Header` component to work with the different markup structure of the Vanilla subnav - now internal functions are generally a bit smaller and more modular, e.g. `generateLink()` only ever returns an `<a>` and never an `<li>`, the hardware menu is generated separate to the rest of the links, etc.
- Removed all instances of hardcoded scss values with Vanilla variables (except in the vanilla-overrides file - these should be short-lived anyway).
- Trimmed custom scss.

## QA
- In both the React and Angular parts of the app:
  - Check that all the links go to the right places
  - Check that the hardware menu dropdown appears between 870 - 1200px, and it works correctly
  - Check that the mobile dropdown appears below 870px and works correctly
- Check that the first time login works correctly with "Skip" (you can test on karura by adding a new user and logging in as them)
- Do a general check of the React stuff and see that everything is still styled properly.

## Screenshots
### Desktop
![0 0 0 0_8400_MAAS_r_settings](https://user-images.githubusercontent.com/25733845/70153229-e75d6680-16ae-11ea-85d3-02fa1497e361.png)


### Tablet
![0 0 0 0_8400_MAAS_r_settings (1)](https://user-images.githubusercontent.com/25733845/70153235-e9bfc080-16ae-11ea-8c30-e59ccac243fd.png)


### Mobile
![0 0 0 0_8400_MAAS_r_settings (2)](https://user-images.githubusercontent.com/25733845/70153240-ec221a80-16ae-11ea-9da4-e02007f394f7.png)


Fixes #121 