### PR TITLE
Disable modifying users when using external auth

### DIFF
--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 import { auth as authSelectors } from "app/base/selectors";
+import { status as statusSelectors } from "app/base/selectors";
 import { user as userSelectors } from "app/base/selectors";
 import { UserShape } from "app/base/proptypes";
 import FormikForm from "app/base/components/FormikForm";
@@ -60,6 +61,8 @@ export const UserForm = ({
   const saved = useSelector(userSelectors.saved);
   const userErrors = useSelector(userSelectors.errors);
   const authErrors = useSelector(authSelectors.errors);
+  const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
+  const formDisabled = !!externalAuthURL;
   let errors = userErrors;
   if (includeCurrentPassword) {
     errors = {
@@ -116,14 +119,21 @@ export const UserForm = ({
       }
     >
       <FormikField
+        disabled={formDisabled}
         name="username"
         help="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."
         label="Username"
         required={true}
         type="text"
       />
-      <FormikField name="fullName" label="Full name (optional)" type="text" />
       <FormikField
+        disabled={formDisabled}
+        name="fullName"
+        label="Full name (optional)"
+        type="text"
+      />
+      <FormikField
+        disabled={formDisabled}
         name="email"
         label="Email address"
         required={true}
@@ -131,6 +141,7 @@ export const UserForm = ({
       />
       {includeUserType && (
         <FormikField
+          disabled={formDisabled}
           name="isSuperuser"
           label="MAAS administrator"
           type="checkbox"
@@ -152,6 +163,7 @@ export const UserForm = ({
         <>
           {includeCurrentPassword && (
             <FormikField
+              disabled={formDisabled}
               name="old_password"
               label="Current password"
               required={true}
@@ -159,12 +171,14 @@ export const UserForm = ({
             />
           )}
           <FormikField
+            disabled={formDisabled}
             name="password"
             label={includeCurrentPassword ? "New password" : "Password"}
             required={true}
             type="password"
           />
           <FormikField
+            disabled={formDisabled}
             name="passwordConfirm"
             help="Enter the same password as before, for verification"
             label={

--- a/ui/src/app/base/components/UserForm/UserForm.test.js
+++ b/ui/src/app/base/components/UserForm/UserForm.test.js
@@ -23,6 +23,7 @@ describe("UserForm", () => {
       username: "admin"
     };
     state = {
+      status: {},
       user: {
         auth: {},
         errors: {},
@@ -175,5 +176,22 @@ describe("UserForm", () => {
       username: ["Username already exists"],
       password: ["Password too short"]
     });
+  });
+
+  it("disables fields when using external auth", () => {
+    state.status.externalAuthURL = "http://login.example.com";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
+        >
+          <UserForm onSave={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField[disabled=true]").length).toEqual(
+      wrapper.find("FormikField").length
+    );
   });
 });

--- a/ui/src/app/preferences/views/Details/Details.js
+++ b/ui/src/app/preferences/views/Details/Details.js
@@ -1,13 +1,14 @@
-import { Col, Row } from "@canonical/react-components";
+import { Col, Notification, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect, useState } from "react";
 
-import { auth as authActions } from "app/base/actions";
-import { auth as authSelectors } from "app/base/selectors";
-import { useAddMessage } from "app/base/hooks";
-import { user as userActions } from "app/base/actions";
-import { user as userSelectors } from "app/base/selectors";
-import { useWindowTitle } from "app/base/hooks";
+import { auth as authActions, user as userActions } from "app/base/actions";
+import {
+  auth as authSelectors,
+  user as userSelectors
+} from "app/base/selectors";
+import { useAddMessage, useWindowTitle } from "app/base/hooks";
+import { status as statusSelectors } from "app/base/selectors";
 import UserForm from "app/base/components/UserForm";
 
 export const Details = () => {
@@ -15,6 +16,7 @@ export const Details = () => {
   const authUser = useSelector(authSelectors.get);
   const usersSaved = useSelector(userSelectors.saved);
   const authUserSaved = useSelector(authSelectors.saved);
+  const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   const [passwordChanged, setPasswordChanged] = useState(false);
 
   const cleanup = () => {
@@ -39,31 +41,40 @@ export const Details = () => {
   }, [dispatch]);
 
   return (
-    <Row>
-      <Col size="4">
-        <UserForm
-          includeCurrentPassword
-          includeUserType={false}
-          onSave={(params, values, editing) => {
-            dispatch(userActions.update(params));
-            let passwordChanged =
-              values.old_password || values.password || values.passwordConfirm;
-            if (passwordChanged) {
-              passwordChanged = true;
-              dispatch(
-                authActions.changePassword({
-                  old_password: values.old_password,
-                  new_password1: values.password,
-                  new_password2: values.passwordConfirm
-                })
-              );
-            }
-            setPasswordChanged(passwordChanged);
-          }}
-          user={authUser}
-        />
-      </Col>
-    </Row>
+    <>
+      {externalAuthURL && (
+        <Notification type="information">
+          Users for this MAAS are managed using an external service
+        </Notification>
+      )}
+      <Row>
+        <Col size="4">
+          <UserForm
+            includeCurrentPassword
+            includeUserType={false}
+            onSave={(params, values, editing) => {
+              dispatch(userActions.update(params));
+              let passwordChanged =
+                values.old_password ||
+                values.password ||
+                values.passwordConfirm;
+              if (passwordChanged) {
+                passwordChanged = true;
+                dispatch(
+                  authActions.changePassword({
+                    old_password: values.old_password,
+                    new_password1: values.password,
+                    new_password2: values.passwordConfirm
+                  })
+                );
+              }
+              setPasswordChanged(passwordChanged);
+            }}
+            user={authUser}
+          />
+        </Col>
+      </Row>
+    </>
   );
 };
 

--- a/ui/src/app/preferences/views/Details/Details.test.js
+++ b/ui/src/app/preferences/views/Details/Details.test.js
@@ -17,6 +17,7 @@ describe("Details", () => {
       config: {
         items: []
       },
+      status: {},
       user: {
         auth: {
           saved: false,
@@ -196,5 +197,18 @@ describe("Details", () => {
     );
     const actions = store.getActions();
     expect(actions.some(action => action.type === "ADD_MESSAGE")).toBe(true);
+  });
+
+  it("shows a message when using external auth", () => {
+    state.status.externalAuthURL = "http://login.example.com";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <Details />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
   });
 });

--- a/ui/src/app/settings/components/Routes/Routes.js
+++ b/ui/src/app/settings/components/Routes/Routes.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Route, Redirect, Switch } from "react-router-dom";
+import { useSelector } from "react-redux";
 
+import { status as statusSelectors } from "app/base/selectors";
 import { useRouter } from "app/base/hooks";
 import Commissioning from "app/settings/views/Configuration/Commissioning";
 import Deploy from "app/settings/views/Configuration/Deploy";
@@ -33,6 +35,7 @@ import Windows from "app/settings/views/Images/Windows";
 
 const Routes = () => {
   const { match } = useRouter();
+  const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   return (
     <Switch>
       <Route
@@ -65,8 +68,16 @@ const Routes = () => {
         to={`${match.path}/configuration/general`}
       />
       <Route exact path={`${match.path}/users`} component={UsersList} />
-      <Route exact path={`${match.path}/users/add`} component={UserAdd} />
-      <Route exact path={`${match.path}/users/:id/edit`} component={UserEdit} />
+      {!externalAuthURL && (
+        <>
+          <Route exact path={`${match.path}/users/add`} component={UserAdd} />
+          <Route
+            exact
+            path={`${match.path}/users/:id/edit`}
+            component={UserEdit}
+          />
+        </>
+      )}
       <Route
         exact
         path={`${match.path}/license-keys`}

--- a/ui/src/app/settings/views/Settings.test.js
+++ b/ui/src/app/settings/views/Settings.test.js
@@ -21,6 +21,7 @@ describe("Settings", () => {
       messages: {
         items: []
       },
+      status: {},
       user: {
         auth: {
           user: {

--- a/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.js
+++ b/ui/src/app/settings/views/Users/UserEdit/UserEdit.test.js
@@ -16,6 +16,7 @@ describe("UserEdit", () => {
       config: {
         items: []
       },
+      status: {},
       user: {
         auth: {},
         errors: {},

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -17,6 +17,7 @@ describe("UserForm", () => {
       config: {
         items: []
       },
+      status: {},
       user: {
         auth: {},
         errors: {},

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.js
@@ -1,4 +1,4 @@
-import { Button } from "@canonical/react-components";
+import { Button, Notification } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 import { format, parse } from "date-fns";
 import { useDispatch, useSelector } from "react-redux";
@@ -12,6 +12,7 @@ import {
   user as userSelectors,
   auth as authSelectors
 } from "app/base/selectors";
+import { status as statusSelectors } from "app/base/selectors";
 import { useWindowTitle } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
@@ -125,6 +126,7 @@ const Users = () => {
   const loaded = useSelector(userSelectors.loaded);
   const authUser = useSelector(authSelectors.get);
   const saved = useSelector(userSelectors.saved);
+  const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   const dispatch = useDispatch();
 
   useWindowTitle("Users");
@@ -146,6 +148,14 @@ const Users = () => {
       dispatch(userActions.cleanup());
     };
   }, [dispatch]);
+
+  if (externalAuthURL) {
+    return (
+      <Notification type="information">
+        Users for this MAAS are managed using an external service
+      </Notification>
+    );
+  }
 
   return (
     <SettingsTable

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -37,6 +37,7 @@ describe("UsersList", () => {
       config: {
         items: []
       },
+      status: {},
       user: {
         auth: {
           user: users[0]
@@ -226,5 +227,21 @@ describe("UsersList", () => {
         .at(0)
         .text()
     ).toEqual("Kangaroo");
+  });
+
+  it("shows a message when using external auth", () => {
+    defaultStore.status.externalAuthURL = "http://login.example.com";
+    const store = mockStore(defaultStore);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
+        >
+          <UsersList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
+    expect(wrapper.find("MainTable").exists()).toBe(false);
   });
 });


### PR DESCRIPTION
Done:
- Disable user modification when using rbac. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/516.

QA:
- Set up a maas with rbac.
- View the list of users, you should see a message about external auth.
- View your profile details. The form should be disabled.