### PR TITLE
Send analytics events when forms are saved.

### DIFF
--- a/ui/src/analytics.js
+++ b/ui/src/analytics.js
@@ -1,0 +1,5 @@
+export const sendAnalyticsEvent = (eventCategory, eventAction, eventLabel) => {
+  if (window.ga && eventCategory && eventAction && eventLabel) {
+    window.ga("send", "event", eventCategory, eventAction, eventLabel);
+  }
+};

--- a/ui/src/app/base/components/FormikForm/FormikForm.js
+++ b/ui/src/app/base/components/FormikForm/FormikForm.js
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
 
+import { useSendAnalytics } from "app/base/hooks";
 import FormikFormContent from "app/base/components/FormikFormContent";
 
 const FormikForm = ({
@@ -13,6 +14,7 @@ const FormikForm = ({
   children,
   errors,
   initialValues,
+  onSaveAnalytics = {},
   onSubmit,
   onValuesChanged,
   saving,
@@ -23,6 +25,13 @@ const FormikForm = ({
   ...props
 }) => {
   const dispatch = useDispatch();
+
+  useSendAnalytics(
+    saved,
+    onSaveAnalytics.category,
+    onSaveAnalytics.action,
+    onSaveAnalytics.label
+  );
 
   useEffect(() => {
     return () => {
@@ -63,6 +72,11 @@ FormikForm.propTypes = {
   children: PropTypes.node.isRequired,
   errors: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   initialValues: PropTypes.object.isRequired,
+  onSaveAnalytics: PropTypes.shape({
+    category: PropTypes.string,
+    action: PropTypes.string,
+    label: PropTypes.string
+  }),
   onSubmit: PropTypes.func.isRequired,
   onValuesChanged: PropTypes.func,
   saving: PropTypes.bool,

--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -48,10 +48,13 @@ const NoPasswordUserSchema = Yup.object().shape(schemaFields);
 
 export const UserForm = ({
   buttons,
+  cleanup,
   includeCurrentPassword,
   includeUserType,
   onSave,
+  onSaveAnalytics,
   onUpdateFields,
+  savedRedirect,
   submitLabel,
   user
 }) => {
@@ -89,8 +92,10 @@ export const UserForm = ({
   return (
     <FormikForm
       buttons={buttons}
+      cleanup={cleanup}
       errors={errors}
       initialValues={initialValues}
+      onSaveAnalytics={onSaveAnalytics}
       onSubmit={(values, { resetForm }) => {
         const params = {
           email: values.email,
@@ -114,6 +119,7 @@ export const UserForm = ({
       onValuesChanged={values => {
         onUpdateFields && onUpdateFields(values);
       }}
+      savedRedirect={savedRedirect}
       validationSchema={
         editing && !passwordVisible ? NoPasswordUserSchema : fullSchema
       }
@@ -197,10 +203,17 @@ export const UserForm = ({
 
 UserForm.propTypes = {
   buttons: PropTypes.func,
+  cleanup: PropTypes.func,
   includeCurrentPassword: PropTypes.bool,
   includeUserType: PropTypes.bool,
   onSave: PropTypes.func.isRequired,
+  onSaveAnalytics: PropTypes.shape({
+    category: PropTypes.string,
+    action: PropTypes.string,
+    label: PropTypes.string
+  }),
   onUpdateFields: PropTypes.func,
+  savedRedirect: PropTypes.string,
   submitLabel: PropTypes.string,
   user: UserShape
 };

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useRef } from "react";
 import { useFormikContext } from "formik";
 
+import { sendAnalyticsEvent } from "analytics";
 import { config as configSelectors } from "app/settings/selectors";
 import { messages } from "app/base/actions";
 import { simpleObjectEquality } from "app/settings/utils";
@@ -134,4 +135,24 @@ export const useWindowTitle = title => {
   useEffect(() => {
     document.title = `${titlePart}${maasNamePart}MAAS`;
   }, [maasNamePart, titlePart]);
+};
+
+/**
+ * Send an analytics event.
+ * @param {String} sendCondition - Whether the analytics event should be sent.
+ * @param {String} eventCategory - The analytics category.
+ * @param {String} eventAction - The analytics action.
+ * @param {String} eventLabel - The analytics label.
+ */
+export const useSendAnalytics = (
+  sendCondition,
+  eventCategory,
+  eventAction,
+  eventLabel
+) => {
+  useEffect(() => {
+    if (sendCondition && eventCategory && eventAction && eventLabel) {
+      sendAnalyticsEvent(eventCategory, eventAction, eventLabel);
+    }
+  }, [sendCondition, eventCategory, eventAction, eventLabel]);
 };

--- a/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.js
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.js
@@ -46,6 +46,11 @@ export const APIKeyForm = ({ token }) => {
         initialValues={{
           name: token ? token.consumer.name : ""
         }}
+        onSaveAnalytics={{
+          action: "Saved",
+          category: "API keys preferences",
+          label: "Generate API key form"
+        }}
         onSubmit={values => {
           if (editing) {
             dispatch(

--- a/ui/src/app/preferences/views/Details/Details.js
+++ b/ui/src/app/preferences/views/Details/Details.js
@@ -1,6 +1,6 @@
 import { Col, Notification, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { auth as authActions, user as userActions } from "app/base/actions";
 import {
@@ -32,14 +32,6 @@ export const Details = () => {
     "Your details were updated successfully"
   );
 
-  useEffect(() => {
-    return () => {
-      // Clean up saved and error states on unmount.
-      dispatch(authActions.cleanup());
-      dispatch(userActions.cleanup());
-    };
-  }, [dispatch]);
-
   return (
     <>
       {externalAuthURL && (
@@ -50,8 +42,14 @@ export const Details = () => {
       <Row>
         <Col size="4">
           <UserForm
+            cleanup={cleanup}
             includeCurrentPassword
             includeUserType={false}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Details preferences",
+              label: "Details form"
+            }}
             onSave={(params, values, editing) => {
               dispatch(userActions.update(params));
               let passwordChanged =

--- a/ui/src/app/preferences/views/Details/Details.test.js
+++ b/ui/src/app/preferences/views/Details/Details.test.js
@@ -105,25 +105,25 @@ describe("Details", () => {
           {}
         )
     );
-    expect(store.getActions()).toEqual([
-      {
-        type: "UPDATE_USER",
-        payload: {
-          params: {
-            isSuperuser: true,
-            email: "test@example.com",
-            fullName: "Miss Wallaby",
-            password: "test1234",
-            passwordConfirm: "test1234",
-            username: "admin"
-          }
-        },
-        meta: {
-          model: "user",
-          method: "update"
+    expect(
+      store.getActions().find(({ type }) => type === "UPDATE_USER")
+    ).toEqual({
+      type: "UPDATE_USER",
+      payload: {
+        params: {
+          isSuperuser: true,
+          email: "test@example.com",
+          fullName: "Miss Wallaby",
+          password: "test1234",
+          passwordConfirm: "test1234",
+          username: "admin"
         }
+      },
+      meta: {
+        model: "user",
+        method: "update"
       }
-    ]);
+    });
   });
 
   it("can change the password", () => {

--- a/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.js
+++ b/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.js
@@ -40,6 +40,11 @@ export const AddSSHKey = () => {
         cleanup={sshkeyActions.cleanup}
         errors={errors}
         initialValues={{ auth_id: "", protocol: "", key: "" }}
+        onSaveAnalytics={{
+          action: "Saved",
+          category: "SSH keys preferences",
+          label: "Import SSH key form"
+        }}
         onSubmit={values => {
           if (values.key && values.key !== "") {
             dispatch(sshkeyActions.create(values));

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.js
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.js
@@ -34,6 +34,11 @@ export const AddSSLKey = () => {
         cleanup={sslkeyActions.cleanup}
         errors={errors}
         initialValues={{ key: "" }}
+        onSaveAnalytics={{
+          action: "Saved",
+          category: "SSL keys preferences",
+          label: "Add SSL key form"
+        }}
         onSubmit={values => {
           dispatch(sslkeyActions.create(values));
         }}

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.js
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.js
@@ -29,6 +29,11 @@ const CommissioningForm = () => {
         commissioning_distro_series: commissioningDistroSeries,
         default_min_hwe_kernel: defaultMinKernelVersion
       }}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Configuration settings",
+        label: "Commissioning form"
+      }}
       onSubmit={(values, { resetForm }) => {
         dispatch(configActions.update(values));
         resetForm({ values });

--- a/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.js
+++ b/ui/src/app/settings/views/Configuration/DeployForm/DeployForm.js
@@ -28,6 +28,11 @@ const DeployForm = () => {
         default_osystem: defaultOSystem,
         default_distro_series: defaultDistroSeries
       }}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Configuration settings",
+        label: "Deploy form"
+      }}
       onSubmit={(values, { resetForm }) => {
         dispatch(updateConfig(values));
         resetForm({ values });

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.js
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.js
@@ -4,6 +4,7 @@ import * as Yup from "yup";
 
 import { config as configActions } from "app/settings/actions";
 import { config as configSelectors } from "app/settings/selectors";
+import { sendAnalyticsEvent } from "analytics";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 
@@ -25,7 +26,17 @@ const GeneralForm = () => {
         maas_name: maasName,
         enable_analytics: analyticsEnabled
       }}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Configuration settings",
+        label: "General form"
+      }}
       onSubmit={(values, { resetForm }) => {
+        sendAnalyticsEvent(
+          "General configuration settings",
+          values.enable_analytics ? "Turned on" : "Turned off",
+          "Enable Google Analytics"
+        );
         dispatch(configActions.update(values));
         resetForm({ values });
       }}

--- a/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.js
+++ b/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.js
@@ -25,6 +25,11 @@ const KernelParametersForm = () => {
       initialValues={{
         kernel_opts: kernelParams
       }}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Configuration settings",
+        label: "Kernel parameters form"
+      }}
       onSubmit={(values, { resetForm }) => {
         dispatch(updateConfig(values));
         resetForm({ values });

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
@@ -88,6 +88,11 @@ export const DhcpForm = ({ dhcpSnippet }) => {
           type: dhcpSnippet ? type : "",
           value: dhcpSnippet ? dhcpSnippet.value : ""
         }}
+        onSaveAnalytics={{
+          action: "Saved",
+          category: "DHCP snippet settings",
+          label: `${editing ? "Edit" : "Add"} form`
+        }}
         onSubmit={values => {
           const params = {
             description: values.description,

--- a/ui/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.js
+++ b/ui/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.js
@@ -27,6 +27,11 @@ const ThirdPartyDriversForm = () => {
       initialValues={{
         enable_third_party_drivers: thirdPartyDriversEnabled
       }}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Images settings",
+        label: "Ubuntu form"
+      }}
       onSubmit={(values, { resetForm }) => {
         dispatch(updateConfig(values));
         resetForm({ values });

--- a/ui/src/app/settings/views/Images/VMWareForm/VMWareForm.js
+++ b/ui/src/app/settings/views/Images/VMWareForm/VMWareForm.js
@@ -34,6 +34,11 @@ const VMWareForm = () => {
         vcenter_password: vCenterPassword,
         vcenter_datacenter: vCenterDatacenter
       }}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Images settings",
+        label: "VMware form"
+      }}
       onSubmit={(values, { resetForm }) => {
         dispatch(updateConfig(values));
         resetForm({ values });

--- a/ui/src/app/settings/views/Images/WindowsForm/WindowsForm.js
+++ b/ui/src/app/settings/views/Images/WindowsForm/WindowsForm.js
@@ -25,6 +25,11 @@ const WindowsForm = () => {
       initialValues={{
         windows_kms_host: windowsKmsHost
       }}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Images settings",
+        label: "Windows form"
+      }}
       onSubmit={(values, { resetForm }) => {
         dispatch(updateConfig(values));
         resetForm({ values });

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
@@ -70,6 +70,11 @@ export const LicenseKeyForm = ({ licenseKey }) => {
               : releases[osystems[0][0]][0].value,
             license_key: licenseKey ? licenseKey.license_key : ""
           }}
+          onSaveAnalytics={{
+            action: "Saved",
+            category: "License keys settings",
+            label: `${title} form`
+          }}
           onSubmit={values => {
             const params = {
               osystem: values.osystem,

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.js
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.js
@@ -50,6 +50,11 @@ const DnsForm = () => {
               dns_trusted_acl: dnsTrustedAcl || "",
               upstream_dns: upstreamDns || ""
             }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Network settings",
+              label: "DNS form"
+            }}
             onSubmit={(values, { resetForm }) => {
               dispatch(updateConfig(values));
               resetForm({ values });

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.js
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.js
@@ -52,6 +52,11 @@ const NetworkDiscoveryForm = () => {
               active_discovery_interval: activeDiscoveryInterval,
               network_discovery: networkDiscovery
             }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Network settings",
+              label: "Network discovery form"
+            }}
             onSubmit={(values, { resetForm }) => {
               dispatch(updateConfig(values));
               resetForm({ values });

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.js
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.js
@@ -44,6 +44,11 @@ const NtpForm = () => {
               ntp_external_only: ntpExternalOnly,
               ntp_servers: ntpServers
             }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Network settings",
+              label: "NTP form"
+            }}
             onSubmit={(values, { resetForm }) => {
               dispatch(updateConfig(values));
               resetForm({ values });

--- a/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.js
+++ b/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.js
@@ -49,6 +49,11 @@ const ProxyForm = () => {
               httpProxy: httpProxy || "",
               proxyType
             }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Network settings",
+              label: "Proxy form"
+            }}
             onSubmit={(values, { resetForm }) => {
               const { httpProxy, proxyType } = values;
 

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.js
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.js
@@ -41,6 +41,11 @@ const SyslogForm = () => {
             initialValues={{
               remote_syslog: remoteSyslog || ""
             }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Network settings",
+              label: "Syslog form"
+            }}
             onSubmit={(values, { resetForm }) => {
               dispatch(updateConfig(values));
               resetForm({ values });

--- a/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.js
+++ b/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.js
@@ -124,6 +124,11 @@ export const RepositoryForm = ({ type, repository }) => {
             cleanup={repositoryActions.cleanup}
             errors={errors}
             initialValues={initialValues}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Package repos settings",
+              label: `${title} form`
+            }}
             onSubmit={values => {
               const params = {
                 arches: values.arches,

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.js
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.js
@@ -52,6 +52,11 @@ const StorageForm = () => {
               disk_erase_with_secure_erase: diskEraseWithSecure,
               enable_disk_erasing_on_release: enableDiskErasing
             }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Storage settings",
+              label: "Storage form"
+            }}
             onSubmit={(values, { resetForm }) => {
               dispatch(updateConfig(values));
               resetForm({ values });

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.js
@@ -1,6 +1,5 @@
-import { Redirect } from "react-router";
 import { useDispatch, useSelector } from "react-redux";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { user as userActions } from "app/base/actions";
 import { user as userSelectors } from "app/base/selectors";
@@ -28,23 +27,17 @@ export const UserForm = ({ user }) => {
     setSaving
   );
 
-  useEffect(() => {
-    return () => {
-      // Clean up saved and error states on unmount.
-      dispatch(userActions.cleanup());
-    };
-  }, [dispatch]);
-
-  if (saved) {
-    // The user was successfully created/updated so redirect to the user list.
-    return <Redirect to="/settings/users" />;
-  }
-
   return (
     <FormCard title={title}>
       <BaseUserForm
         buttons={FormCardButtons}
+        cleanup={userActions.cleanup}
         submitLabel="Save user"
+        onSaveAnalytics={{
+          action: "Saved",
+          category: "Users settings",
+          label: `${editing ? "Edit" : "Add"} user form`
+        }}
         onSave={(params, values, editing) => {
           if (editing) {
             dispatch(userActions.update(params));
@@ -56,6 +49,7 @@ export const UserForm = ({ user }) => {
         onUpdateFields={values => {
           setName(values.username);
         }}
+        savedRedirect="/settings/users"
         user={user}
       />
     </FormCard>


### PR DESCRIPTION
## Done
- Send events when forms are saved in settings and preferences.
- Send an event when the GA checkbox is changed.

## QA
- This one's a bit tricky to QA, you could add something like: `console.log("send event", eventCategory, eventAction, eventLabel);` in analytics.js and then check that you get events when saving forms and changing whether GA is checked in the General settings.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/566.
