### PR TITLE
Replace uuid with nanoid for generated form element ids.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "formik": "2.0.7",
     "http-proxy-middleware": "0.20.0",
     "immer": "5.0.1",
+    "nanoid": "2.1.7",
     "path-parse": "1.0.6",
     "pluralize": "8.0.0",
     "prop-types": "15.7.2",
@@ -31,7 +32,6 @@
     "redux-devtools-extension": "2.13.8",
     "redux-saga": "1.1.3",
     "reselect": "4.0.0",
-    "uuid": "3.3.3",
     "vanilla-framework": "2.5.0",
     "yup": "0.27.0"
   },

--- a/ui/src/app/base/components/FormikField/FormikField.js
+++ b/ui/src/app/base/components/FormikField/FormikField.js
@@ -2,7 +2,7 @@ import { Input } from "@canonical/react-components";
 import { useField } from "formik";
 import PropTypes from "prop-types";
 import React, { useRef } from "react";
-import uuidv4 from "uuid/v4";
+import nanoid from "nanoid";
 
 const FormikField = ({
   component: Component = Input,
@@ -11,7 +11,7 @@ const FormikField = ({
   value,
   ...props
 }) => {
-  const id = useRef(uuidv4());
+  const id = useRef(nanoid());
   const [field, meta] = useField({ name, type, value });
   return (
     <Component

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -3,6 +3,4 @@ import Adapter from "enzyme-adapter-react-16";
 
 Enzyme.configure({ adapter: new Adapter() });
 
-jest.mock("nanoid", () =>
-  jest.fn(() => "Uakgb_J5m9g-0JDMbcJqLJ")
-);
+jest.mock("nanoid", () => jest.fn(() => "Uakgb_J5m9g-0JDMbcJqLJ"));

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -3,6 +3,6 @@ import Adapter from "enzyme-adapter-react-16";
 
 Enzyme.configure({ adapter: new Adapter() });
 
-jest.mock("uuid/v4", () =>
-  jest.fn(() => "00000000-0000-0000-0000-000000000000")
+jest.mock("nanoid", () =>
+  jest.fn(() => "Uakgb_J5m9g-0JDMbcJqLJ")
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8866,7 +8866,7 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nanoid@^2.1.7:
+nanoid@2.1.7:
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.7.tgz#d775e3e7c6470bbaaae3da9a647a80e228e0abf7"
   integrity sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8866,6 +8866,11 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.7.tgz#d775e3e7c6470bbaaae3da9a647a80e228e0abf7"
+  integrity sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -13184,7 +13189,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@3.3.3, uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==


### PR DESCRIPTION
## Done
Replace `uuid/v4` with `nanoid` for a modest bundle size saving (~3x smaller).

## QA
* Inspect some form elements, they should have unique ids.

## Fixes
Fixes #527 
