### PR TITLE
Fix spacing in table delete confirmations

### DIFF
--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
@@ -12,15 +12,23 @@ const TableDeleteConfirm = ({
   return (
     <Row>
       <Col size="7">
-        {message ||
-          `Are you sure you want to delete ${modelType} "${modelName}"?`}{" "}
-        <span className="u-text--light">
-          This action is permanent and can not be undone.
-        </span>
+        <p className="u-no-margin--bottom u-no-max-width">
+          {message ||
+            `Are you sure you want to delete ${modelType} "${modelName}"?`}{" "}
+          <span className="u-text--light">
+            This action is permanent and can not be undone.
+          </span>
+        </p>
       </Col>
       <Col size="3" className="u-align--right">
-        <Button onClick={onCancel}>Cancel</Button>
-        <Button appearance="negative" onClick={onConfirm}>
+        <Button className="u-no-margin--bottom" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          appearance="negative"
+          className="u-no-margin--bottom"
+          onClick={onConfirm}
+        >
           Delete
         </Button>
       </Col>

--- a/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
+++ b/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
@@ -5,25 +5,31 @@ exports[`TableDeleteConfirm renders 1`] = `
   <Col
     size="7"
   >
-    Are you sure you want to delete user "Cobba"?
-     
-    <span
-      className="u-text--light"
+    <p
+      className="u-no-margin--bottom u-no-max-width"
     >
-      This action is permanent and can not be undone.
-    </span>
+      Are you sure you want to delete user "Cobba"?
+       
+      <span
+        className="u-text--light"
+      >
+        This action is permanent and can not be undone.
+      </span>
+    </p>
   </Col>
   <Col
     className="u-align--right"
     size="3"
   >
     <Button
+      className="u-no-margin--bottom"
       onClick={[MockFunction]}
     >
       Cancel
     </Button>
     <Button
       appearance="negative"
+      className="u-no-margin--bottom"
       onClick={[MockFunction]}
     >
       Delete


### PR DESCRIPTION
## Done
- Fix the spacing in table delete confirmations. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/582.

## QA
- Upen a list in settings e.g. users
- Click delete on a row.
- The buttons and text should be centred vertically.