### PR TITLE
Fix the display of the chevron

### DIFF
--- a/ui/src/app/base/components/ColumnToggle/ColumnToggle.scss
+++ b/ui/src/app/base/components/ColumnToggle/ColumnToggle.scss
@@ -5,11 +5,9 @@
 td:not(.p-table-expanding__panel) [class*="p-button"].column-toggle,
 .column-toggle {
   align-items: center;
-  align-self: flex-start;
   color: $color-dark;
+  display: flex;
   justify-content: space-between;
-  margin: 0;
-  padding: 0;
   width: 100%;
 
   &::after {


### PR DESCRIPTION
## Done
- Make the chevron appear in the row toggle. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/581.

## QA
- View testing scripts in settings.
- The script name column cells should show chevrons.
