### PR TITLE
Fix validation that passwords are the same

### DIFF
--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -34,14 +34,16 @@ const schemaFields = {
 const UserSchema = Yup.object().shape({
   ...schemaFields,
   password: schemaFields.password.required("Password is required"),
-  passwordConfirm: schemaFields.password.required("Password is required")
+  passwordConfirm: schemaFields.passwordConfirm.required("Password is required")
 });
 
 const CurrentPasswordUserSchema = Yup.object().shape({
   ...schemaFields,
   old_password: Yup.string().required("Your current password is required"),
   password: schemaFields.password.required("A new password is required"),
-  passwordConfirm: schemaFields.password.required("Confirm your new password")
+  passwordConfirm: schemaFields.passwordConfirm.required(
+    "Confirm your new password"
+  )
 });
 
 const NoPasswordUserSchema = Yup.object().shape(schemaFields);


### PR DESCRIPTION
## Done
- Correctly validate that passwords match in user forms. Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/579.

## QA
- Open the user list and click 'Add user'.
- Enter different passowords in the two password fields.
- You should see an error about passwords needing to match.