### PR TITLE
LP: #1832176 - Fix release-options directive not adopting defaults correctly

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -77,7 +77,9 @@ function NodeDetailsController(
   };
   $scope.commissioningSelection = [];
   $scope.testSelection = [];
-  $scope.releaseOptions = {};
+  $scope.release = {
+    options: {}
+  };
   $scope.checkingPower = false;
   $scope.devices = [];
   $scope.fabrics = FabricsManager.getItems();
@@ -944,9 +946,9 @@ function NodeDetailsController(
       extra.script_input = scriptInput;
     } else if ($scope.action.option.name === "release") {
       // Set the release options.
-      extra.erase = $scope.releaseOptions.erase;
-      extra.secure_erase = $scope.releaseOptions.secureErase;
-      extra.quick_erase = $scope.releaseOptions.quickErase;
+      extra.erase = $scope.release.options.enableDiskErasing;
+      extra.secure_erase = $scope.release.options.secureErase;
+      extra.quick_erase = $scope.release.options.quickErase;
     } else if (
       $scope.action.option.name === "delete" &&
       $scope.type_name === "controller" &&

--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -1011,7 +1011,7 @@ function NodesListController(
       extra.script_input = scriptInput;
     } else if (tab.actionOption.name === "release") {
       // Set the release options.
-      extra.erase = tab.releaseOptions.erase;
+      extra.erase = tab.releaseOptions.enableDiskErasing;
       extra.secure_erase = tab.releaseOptions.secureErase;
       extra.quick_erase = tab.releaseOptions.quickErase;
     } else if (

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -248,7 +248,7 @@ describe("NodeDetailsController", function() {
       updateFirmware: false,
       configureHBA: false
     });
-    expect($scope.releaseOptions).toEqual({});
+    expect($scope.release).toEqual({ options: {} });
     expect($scope.checkingPower).toBe(false);
     expect($scope.devices).toEqual([]);
     expect($scope.services).toEqual({});
@@ -1303,9 +1303,9 @@ describe("NodeDetailsController", function() {
       };
       var secureErase = makeName("secureErase");
       var quickErase = makeName("quickErase");
-      $scope.releaseOptions.erase = true;
-      $scope.releaseOptions.secureErase = secureErase;
-      $scope.releaseOptions.quickErase = quickErase;
+      $scope.release.options.enableDiskErasing = true;
+      $scope.release.options.secureErase = secureErase;
+      $scope.release.options.quickErase = quickErase;
       $scope.actionGo();
       expect(MachinesManager.performAction).toHaveBeenCalledWith(
         node,

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -1762,7 +1762,7 @@ describe("NodesListController", function() {
         var quickErase = makeName("quickErase");
         $scope.tabs.machines.actionOption = { name: "release" };
         $scope.tabs.machines.selectedItems = [object];
-        $scope.tabs.machines.releaseOptions.erase = true;
+        $scope.tabs.machines.releaseOptions.enableDiskErasing = true;
         $scope.tabs.machines.releaseOptions.secureErase = secureErase;
         $scope.tabs.machines.releaseOptions.quickErase = quickErase;
         $scope.actionGo("machines");

--- a/legacy/src/app/partials/directives/release-options.html
+++ b/legacy/src/app/partials/directives/release-options.html
@@ -1,27 +1,40 @@
-<label class="p-form__label">Choose your image</label>
-<div class="p-form__control">
-  <select
-    name="os"
-    data-ng-model="ngModel.osystem"
-    data-ng-change="selectedOSChanged()"
-    data-ng-disabled="maasOsSelect.osystems.length <= 1"
-    data-ng-options="os[0] as os[1] disable when installKVMSelectedAndNotUbuntu(os) for os in maasOsSelect.osystems"
-  >
-  </select>
-  <select
-    name="release"
-    data-ng-model="ngModel.release"
-    data-ng-change="selectedReleaseChanged()"
-    data-ng-disabled="maasOsSelect.releases.length <= 1"
-    data-ng-options="release[0] as release[1] disable when osOutdated(release, deployOptions) for release in releases"
-  >
-  </select>
-  <select
-    name="hwe_kernel"
-    data-ng-model="ngModel.hwe_kernel"
-    data-ng-show="hwe_kernels.length"
-    data-ng-options="hwe_kernel[0] as hwe_kernel[1] for hwe_kernel in hwe_kernels"
-  >
-    <option value="">Default kernel</option>
-  </select>
+<div ng-if="loading">
+  <i class="p-icon--spinner u-animation--spin" />
+  &nbsp;Loading...
 </div>
+<ul class="p-inline-list--settings u-no-margin--left" ng-if="!loading">
+  <li class="p-inline-list__item">
+    <input
+      id="enableDiskErasing"
+      ng-change="onEraseChange()"
+      ng-disabled="globalOptions.enableDiskErasing"
+      ng-model="localOptions.enableDiskErasing"
+      type="checkbox"
+    />
+    <label for="enableDiskErasing">
+      Erase disks before releasing
+    </label>
+  </li>
+  <li class="p-inline-list__item">
+    <input
+      id="secureErase"
+      ng-disabled="!localOptions.enableDiskErasing"
+      ng-model="localOptions.secureErase"
+      type="checkbox"
+    />
+    <label for="secureErase">
+      Use secure erase
+    </label>
+  </li>
+  <li class="p-inline-list__item">
+    <input
+      id="quickErase"
+      ng-disabled="!localOptions.enableDiskErasing"
+      ng-model="localOptions.quickErase"
+      type="checkbox"
+    />
+    <label for="quickErase">
+      Use quick erase (not secure)
+    </label>
+  </li>
+</ul>

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -127,7 +127,7 @@
                         <div class="row">
                             <div class="col-12 u-no-margin--left" data-ng-show="action.option.name === 'deploy' || action.option.name === 'release'">
                                 <div data-ng-if="action.option.name === 'release'" class="u-no-margin--top">
-                                    <div data-maas-release-options="releaseOptions"></div>
+                                    <maas-release-options local-options="release.options"></maas-release-options>
                                 </div>
                             </div>
                         </div>

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -228,7 +228,7 @@
                             </div>
                             <div ng-if="tabs[tab].actionOption.name === 'release'">
                                 <div class="row">
-                                    <div data-maas-release-options="tabs[tab].releaseOptions"></div>
+                                    <maas-release-options local-options="tabs[tab].releaseOptions"></maas-release-options>
                                 </div>
                             </div>
                             <div class="row">


### PR DESCRIPTION
## Done
- Moved inline markup in release-options directive to its own partial.
- Renamed a few variables to be clearer (maasReleaseOptions => localOptions, erase => enableDiskErasing).
- Config is now explicitly loaded on directive render. Previously, it was assumed that the config had already been loaded, so refreshing on the node details page would return incorrect config values (i.e. nothing). This also means that a spinner will display when the release dropdown is opened.
- Also fixed a bug where `extra` parameters weren't actually getting passed to the websocket handler. LOL

## QA
- Select multiple machines and choose Release from the action menu, and check that the checkboxes correctly reflect what's set in Settings > Storage. Note that if "Enable disk erasing" is set to true in Settings, the checkbox in the dropdown is disabled and permanently checked **by design** due to the way the `release_or_erase` method works in the backend. This took me a liiiittle while to realise that it wasn't a bug that disks were always erased even when the dropdown checkbox suggested otherwise >_>
- Check that running Release actually does what it's supposed to do, e.g. if erase is not selected the node goes straight to "Releasing..." state. If it is selected, the node goes to "Disk erasing..." state.
- Do the same in the node details page.

## Fixes
Fixes #562.

## Launchpad Issue
lp#1832176.
