### PR TITLE
LP: #1856772 - Fix install KVM checkbox.

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -102,21 +102,18 @@
                                             <div class="p-form__group">
                                                 <label class="p-form__label u-no-padding--top">Additional installs</label>
                                                 <div class="p-form__control" style="width: 70%">
-                                                    <input id="installKVM" type="checkbox" data-ng-model="deployOptions.installKVM" ng-disabled="!nodesManager.isModernUbuntu(osSelection)">
+                                                    <input id="installKVM" type="checkbox" data-ng-model="deployOptions.installKVM" ng-disabled="!nodesManager.canBeKvmHost(osSelection)">
                                                     <label for="installKVM" class="u-float--left" style="width: auto; margin-right: 1rem;">
                                                         Register as MAAS KVM host
                                                     </label>
-                                                    <span data-ng-if="!nodesManager.isModernUbuntu(osSelection)">
-                                                        <i class="p-icon--warning"></i>
-                                                        <strong>Warning:</strong> Ubuntu 18.04 is the minimum required. <a target="_blank"
-                                                        class="p-link--external"
-                                                        href="https://docs.maas.io/2.5/en/manage-pods-webui#add-a-kvm-host">Learn more</a>
-                                                    </span>
-                                                    <span data-ng-if="nodesManager.isModernUbuntu(osSelection)">
-                                                        <i class="p-icon--information">Information:</i>
-                                                        <a target="_blank" class="p-link--external"
-                                                            href="https://docs.maas.io/2.5/en/manage-pods-webui#add-a-kvm-host">Learn more</a>
-                                                    </span>
+                                                    <p class="u-sv-1 u-no-max-width" ng-if="!nodesManager.canBeKvmHost(osSelection)">
+                                                        <i class="p-icon--warning"></i>&nbsp;Ubuntu 18.04 is required to create a KVM host.
+                                                    </p>
+                                                    <p class="u-no-max-width u-no-margin--bottom">
+                                                        <a class="p-link--external" href="https://maas.io/docs/kvm-introduction" target="_blank">
+                                                            About MAAS KVM hosts
+                                                        </a>
+                                                    </p>
                                                 </div>
                                             </div>
                                         </div>

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -208,7 +208,7 @@
                                         <input
                                             id="installKVM"
                                             ng-disabled="!nodesManager.canBeKvmHost(tabs[tab].osSelection)"
-                                            ng-model="deployOptions.installKVM"
+                                            ng-model="tabs[tab].deployOptions.installKVM"
                                             type="checkbox"
                                         >
                                         <label class="u-no-margin--bottom" for="installKVM">Register as MAAS KVM host</label>


### PR DESCRIPTION
## Done
- Fixed install KVM checkbox in Deploy dropdown not working correctly. I think it was missed in one of the migrations from launchpad to github.

## QA
- In the machine list, open the Deploy action dropdown and check that the checkbox is disabled for all OSes that aren't 18.04 or 20.04.
- Check that the form actually sends the information to MAAS (add `console.log(extra)` to `legacy/src/app/factories/nodes.js` L32).
- Do the same on the machine details page.

## Fixes
Fixes #599.

## Launchpad Issue
lp#1856772.
