### PR TITLE
Fix default icon appearing in select elements

### DIFF
--- a/ui/src/app/base/components/FormikField/FormikField.js
+++ b/ui/src/app/base/components/FormikField/FormikField.js
@@ -7,17 +7,15 @@ import nanoid from "nanoid";
 const FormikField = ({
   component: Component = Input,
   name,
-  type = "text",
   value,
   ...props
 }) => {
   const id = useRef(nanoid());
-  const [field, meta] = useField({ name, type, value });
+  const [field, meta] = useField({ name, type: props.type, value });
   return (
     <Component
       error={meta.touched ? meta.error : null}
       id={id.current}
-      type={type}
       {...field}
       {...props}
     />
@@ -27,7 +25,6 @@ const FormikField = ({
 FormikField.propTypes = {
   component: PropTypes.func,
   name: PropTypes.string.isRequired,
-  type: PropTypes.string,
   value: PropTypes.string
 };
 


### PR DESCRIPTION
## Done
- Don't pass type to fields that don't need it.

## QA
- Visit /MAAS/r/settings/configuration/commissioning.
- The selects should now show the default browser icon as seen in https://github.com/canonical-web-and-design/maas-ui/issues/617.
- Have a poke around other forms, all should look normal.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/617.
