### PR TITLE
Fix bug where admins could no longer be added.

### DIFF
--- a/ui/src/app/settings/views/Users/UserForm/UserForm.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.js
@@ -32,6 +32,7 @@ export const UserForm = ({ user }) => {
       <BaseUserForm
         buttons={FormCardButtons}
         cleanup={userActions.cleanup}
+        includeUserType
         submitLabel="Save user"
         onSaveAnalytics={{
           action: "Saved",

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -191,4 +191,18 @@ describe("UserForm", () => {
     expect(actions.some(action => action.type === "CLEANUP_USER")).toBe(true);
     expect(actions.some(action => action.type === "ADD_MESSAGE")).toBe(true);
   });
+
+  it("displays a checkbox for making the user a MAAS admin", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <UserForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("FormikField[label='MAAS administrator']").exists()
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Done
* You can now add admins/edit a user to be an admin

## QA
* Check that the MAAS administrator checkbox shows on user add/edit forms if you are logged in as an admin
* Check that it doesn't show up in the user preferences page

## Fixes
Fixes #626 