### PR TITLE
Add owner/tags column to machine listing.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -26,6 +26,10 @@ import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import { formatGigabytes, formatGigabits } from "app/utils";
 import NameColumn from "./NameColumn";
+<<<<<<< HEAD
+=======
+import OwnerColumn from "./OwnerColumn";
+>>>>>>> Add owner/tags column to machine listing.
 import PowerColumn from "./PowerColumn";
 
 const getFabricColValue = vlan => {
@@ -141,7 +145,8 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
           content: row.status
         },
         {
-          content: row.owner
+          content: <OwnerColumn systemId={row.system_id} />,
+          className: "p-table__col--owner p-double-row"
         },
         {
           content: row.pool.name

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -26,10 +26,7 @@ import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import { formatGigabytes, formatGigabits } from "app/utils";
 import NameColumn from "./NameColumn";
-<<<<<<< HEAD
-=======
 import OwnerColumn from "./OwnerColumn";
->>>>>>> Add owner/tags column to machine listing.
 import PowerColumn from "./PowerColumn";
 
 const getFabricColValue = vlan => {
@@ -145,8 +142,7 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
           content: row.status
         },
         {
-          content: <OwnerColumn systemId={row.system_id} />,
-          className: "p-table__col--owner p-double-row"
+          content: <OwnerColumn systemId={row.system_id} />
         },
         {
           content: row.pool.name

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -1,0 +1,35 @@
+import { useSelector } from "react-redux";
+import React from "react";
+import PropTypes from "prop-types";
+
+import { machine as machineSelectors } from "app/base/selectors";
+
+const OwnerColumn = ({ systemId }) => {
+  const machine = useSelector(state =>
+    machineSelectors.getBySystemId(state, systemId)
+  );
+
+  const owner = machine.owner ? machine.owner : "-";
+  const tags = machine.tags ? machine.tags.join(", ") : "";
+
+  return (
+    <>
+      <div className="p-double-row__rows-container--icon">
+        <div className="p-double-row__main-row">
+          <span data-test="owner">{owner}</span>
+        </div>
+        <div className="p-double-row__muted-row">
+          <span className="u-text-overflow" title={tags} data-test="tags">
+            {tags}
+          </span>
+        </div>
+      </div>
+    </>
+  );
+};
+
+OwnerColumn.propTypes = {
+  systemId: PropTypes.string.isRequired
+};
+
+export default OwnerColumn;

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -17,8 +17,8 @@ const OwnerColumn = ({ systemId }) => {
       <div className="p-double-row__primary-row">
         <span data-test="owner">{owner}</span>
       </div>
-      <div className="p-double-row__secondary-row">
-        <span className="u-text-overflow" title={tags} data-test="tags">
+      <div className="p-double-row__secondary-row u-truncate-text">
+        <span title={tags} data-test="tags">
           {tags}
         </span>
       </div>

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -14,15 +14,13 @@ const OwnerColumn = ({ systemId }) => {
 
   return (
     <>
-      <div className="p-double-row__rows-container--icon">
-        <div className="p-double-row__main-row">
-          <span data-test="owner">{owner}</span>
-        </div>
-        <div className="p-double-row__muted-row">
-          <span className="u-text-overflow" title={tags} data-test="tags">
-            {tags}
-          </span>
-        </div>
+      <div className="p-double-row__primary-row">
+        <span data-test="owner">{owner}</span>
+      </div>
+      <div className="p-double-row__secondary-row">
+        <span className="u-text-overflow" title={tags} data-test="tags">
+          {tags}
+        </span>
       </div>
     </>
   );

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.test.js
@@ -1,0 +1,79 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import OwnerColumn from "./OwnerColumn";
+
+const mockStore = configureStore();
+
+describe("OwnerColumn", () => {
+  let state;
+  beforeEach(() => {
+    state = {
+      config: {
+        items: []
+      },
+      machine: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            system_id: "abc123",
+            owner: "admin",
+            tags: []
+          }
+        ]
+      }
+    };
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OwnerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("OwnerColumn")).toMatchSnapshot();
+  });
+
+  it("displays owner", () => {
+    state.machine.items[0].owner = "user1";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OwnerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find('[data-test="owner"]').text()).toEqual("user1");
+  });
+
+  it("displays tags", () => {
+    state.machine.items[0].tags = ["minty", "aloof"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OwnerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find('[data-test="tags"]').text()).toEqual("minty, aloof");
+  });
+});

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -14,10 +14,9 @@ exports[`OwnerColumn renders 1`] = `
     </span>
   </div>
   <div
-    className="p-double-row__secondary-row"
+    className="p-double-row__secondary-row u-truncate-text"
   >
     <span
-      className="u-text-overflow"
       data-test="tags"
       title=""
     />

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OwnerColumn renders 1`] = `
+<OwnerColumn
+  systemId="abc123"
+>
+  <div
+    className="p-double-row__rows-container--icon"
+  >
+    <div
+      className="p-double-row__main-row"
+    >
+      <span
+        data-test="owner"
+      >
+        admin
+      </span>
+    </div>
+    <div
+      className="p-double-row__muted-row"
+    >
+      <span
+        className="u-text-overflow"
+        data-test="tags"
+        title=""
+      />
+    </div>
+  </div>
+</OwnerColumn>
+`;

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -5,26 +5,22 @@ exports[`OwnerColumn renders 1`] = `
   systemId="abc123"
 >
   <div
-    className="p-double-row__rows-container--icon"
+    className="p-double-row__primary-row"
   >
-    <div
-      className="p-double-row__main-row"
+    <span
+      data-test="owner"
     >
-      <span
-        data-test="owner"
-      >
-        admin
-      </span>
-    </div>
-    <div
-      className="p-double-row__muted-row"
-    >
-      <span
-        className="u-text-overflow"
-        data-test="tags"
-        title=""
-      />
-    </div>
+      admin
+    </span>
+  </div>
+  <div
+    className="p-double-row__secondary-row"
+  >
+    <span
+      className="u-text-overflow"
+      data-test="tags"
+      title=""
+    />
   </div>
 </OwnerColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/index.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/index.js
@@ -1,0 +1,1 @@
+export { default } from "./OwnerColumn";

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -24,9 +24,8 @@ const PowerColumn = ({ systemId }) => {
       <div className="p-double-row__primary-row u-upper-case--first">
         <span data-test="power_state">{machine.power_state}</span>
       </div>
-      <div className="p-double-row__secondary-row u-upper-case--first">
+      <div className="p-double-row__secondary-row u-upper-case--first u-truncate-text">
         <span
-          className="u-text-overflow"
           title={machine.power_type}
           data-test="power_type"
         >

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -25,10 +25,7 @@ const PowerColumn = ({ systemId }) => {
         <span data-test="power_state">{machine.power_state}</span>
       </div>
       <div className="p-double-row__secondary-row u-upper-case--first u-truncate-text">
-        <span
-          title={machine.power_type}
-          data-test="power_type"
-        >
+        <span title={machine.power_type} data-test="power_type">
           {machine.power_type}
         </span>
       </div>

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -25,10 +25,9 @@ exports[`PowerColumn renders 1`] = `
       </span>
     </div>
     <div
-      className="p-double-row__secondary-row u-upper-case--first"
+      className="p-double-row__secondary-row u-upper-case--first u-truncate-text"
     >
       <span
-        className="u-text-overflow"
         data-test="power_type"
         title="virsh"
       >

--- a/ui/src/scss/_patterns_double-row.scss
+++ b/ui/src/scss/_patterns_double-row.scss
@@ -25,6 +25,7 @@
   .p-double-row__secondary-row {
     @extend %small-text;
     color: $color-mid-dark;
+    grid-area: secondary-row;
   }
 
   .p-double-row__icon-space {

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -37,6 +37,12 @@ body {
   color: $color-mid-dark;
 }
 
+.u-truncate-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .p-modal {
   // The modal needs to be above the header nav items.
   z-index: 10;


### PR DESCRIPTION
## Done
Add owner/tags column to machine listing.

## QA
* ensure owner displays correctly.
* ensure tags display correctly (add tags from machine details | configuration).

## Note
This branch is based on #631 and will need to be rebased once that lands.