### PR TITLE
LP: #1811107 - Explicitly wait for authUser to load before loading users.

### DIFF
--- a/legacy/.babelrc
+++ b/legacy/.babelrc
@@ -1,5 +1,15 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ],
+    "@babel/preset-react"
+  ],
   "plugins": [
     ["angularjs-annotate", { "explicitOnly": true }],
     "@babel/plugin-proposal-class-properties"

--- a/legacy/src/app/factories/users.js
+++ b/legacy/src/app/factories/users.js
@@ -91,15 +91,15 @@ function UsersManager(Manager, RegionConnection, ErrorService) {
     }
   };
 
-  UsersManager.prototype.loadItems = function() {
+  UsersManager.prototype.loadItems = async function() {
     // Load the auth user when all the items are loaded as well.
-    this._loadAuthUser();
+    await this._loadAuthUser();
     return Manager.prototype.loadItems.call(this);
   };
 
-  UsersManager.prototype.reloadItems = function() {
+  UsersManager.prototype.reloadItems = async function() {
     // Load the auth user when all the items are reloaded as well.
-    this._loadAuthUser();
+    await this._loadAuthUser();
     return Manager.prototype.reloadItems.call(this);
   };
 


### PR DESCRIPTION
## Done
* Turned UsersManager.loadItems and UsersManager.reloadItems into async functions that explicitly wait for authUser to load before loading users.
* Made legacy tests compatible with async/await.

## QA
* Create a new user, log in as them and go to the SSH keys intro page
* Refresh several times and check that there are never any console errors (the original issue was a race condition that occurred roughly 1 in 4 times for me)

## Fixes
Fixes canonical-web-and-design/MAAS-design#829 .

## Launchpad Issue
[lp#1811107](https://bugs.launchpad.net/maas/+bug/1811107)
