### PR TITLE
LP: #1859032 - Fix bug where newly composed machine would not appear in KVM page.

### DIFF
--- a/legacy/src/app/controllers/pod_details.js
+++ b/legacy/src/app/controllers/pod_details.js
@@ -650,6 +650,18 @@ function PodDetailsController(
         }
       }
     });
+    $scope.$watch("pod.composed_machines_count", () => {
+      // Explicitly refresh machine list by changing search to return identical
+      // results when the number of machines in the pod changes. Symptom of
+      // problems with two-way data binding of machines and search string in the
+      // machine table.
+      if ($scope.loaded) {
+        $scope.machinesSearch = "pod:=" + $scope.pod.name;
+        setTimeout(() => {
+          $scope.machinesSearch = "pod-id:=" + $scope.pod.id;
+        }, 100);
+      }
+    });
     $scope.$watch("action.option", function(now, then) {
       // When the compose action is selected set the default
       // parameters.

--- a/legacy/src/app/directives/machines_table.js
+++ b/legacy/src/app/directives/machines_table.js
@@ -37,7 +37,8 @@ function maasMachinesTable(
       zones: "=",
       hideFailedTests: "<",
       metadata: "=",
-      truncate: "<"
+      displayLimit: "<",
+      defaultSort: "<"
     },
     template: machinesTableTmpl,
     link: function(scope) {
@@ -81,7 +82,7 @@ function maasMachinesTable(
     // Scope variables.
     $scope.table = {
       column: "fqdn",
-      predicate: "fqdn",
+      predicate: $scope.defaultSort || "fqdn",
       reverse: false,
       allViewableChecked: false,
       machines,
@@ -90,7 +91,7 @@ function maasMachinesTable(
       machineActions: GeneralManager.getData("machine_actions")
     };
 
-    $scope.DISPLAY_LIMIT = $scope.truncate ? 5 : 100;
+    $scope.DISPLAY_LIMIT = $scope.displayLimit || 5;
     $scope.displayLimits = {};
     const groupLabels = [
       "Failed",

--- a/legacy/src/app/directives/machines_table.js
+++ b/legacy/src/app/directives/machines_table.js
@@ -36,7 +36,8 @@ function maasMachinesTable(
       pools: "=",
       zones: "=",
       hideFailedTests: "<",
-      metadata: "="
+      metadata: "=",
+      truncate: "<"
     },
     template: machinesTableTmpl,
     link: function(scope) {
@@ -89,7 +90,7 @@ function maasMachinesTable(
       machineActions: GeneralManager.getData("machine_actions")
     };
 
-    $scope.DISPLAY_LIMIT = 5;
+    $scope.DISPLAY_LIMIT = $scope.truncate ? 5 : 100;
     $scope.displayLimits = {};
     const groupLabels = [
       "Failed",

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -828,7 +828,6 @@ sudo maas-rack register --url {$ tabs.controllers.registerUrl $} --secret {$ tab
             zones="zones"
             hide-failed-tests="tabs.machines.suppressFailedTestsChecked"
             metadata=tabs.machines.metadata
-            truncate="true"
         />
     </div>
 </div>

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -828,6 +828,7 @@ sudo maas-rack register --url {$ tabs.controllers.registerUrl $} --secret {$ tab
             zones="zones"
             hide-failed-tests="tabs.machines.suppressFailedTestsChecked"
             metadata=tabs.machines.metadata
+            truncate="true"
         />
     </div>
 </div>

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -364,11 +364,14 @@
                 <div class="row">
                     <div class="col-12">
                         <hr>
-                        <p maas-obj-hide-saving><maas-obj-errors></maas-obj-errors></p>
-                        <p maas-obj-show-saving><maas-obj-saving>Composing machine</maas-obj-saving></p>
-                        <div class="u-align--right u-no-margin--top" maas-obj-hide-saving>
-                            <button class="p-button--base" type="button" data-ng-click="cancelCompose()">Cancel</button>
-                            <button class="p-button--positive u-no-margin--top" maas-obj-save ng-disabled="!validateMachineCompose()" data-ng-click="sendAnalyticsEvent('KVM details', 'Submit form', 'KVM compose')">Compose machine</button>
+                        <div maas-obj-hide-saving><maas-obj-errors></maas-obj-errors></div>
+                        <div class="u-align--right" maas-obj-hide-saving>
+                            <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancelCompose()">Cancel</button>
+                            <button class="p-button--positive u-no-margin--bottom" maas-obj-save ng-disabled="!validateMachineCompose()" data-ng-click="sendAnalyticsEvent('KVM details', 'Submit form', 'KVM compose')">Compose machine</button>
+                        </div>
+                        <div class="u-align--right" maas-obj-show-saving>
+                            <button class="p-button--base u-no-margin--bottom" type="button" data-ng-disabled="true">Cancel</button>
+                            <button class="p-button--positive p-action-button is-indeterminate u-no-margin--bottom" ng-disabled="true">Composing machine...</button>
                         </div>
                     </div>
                 </div>

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -458,10 +458,11 @@
             <div class="row">
                 <div class="col-12" data-ng-if="pod.composed_machines_count">
                     <maas-machines-table
-                        search="machinesSearch"
+                        default-sort="'status'"
+                        display-limit="100"
                         hide-actions="true"
                         pools="pools"
-                        truncate="false"
+                        search="machinesSearch"
                         zones="zones"
                     />
                 </div>

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -461,6 +461,7 @@
                         search="machinesSearch"
                         hide-actions="true"
                         pools="pools"
+                        truncate="false"
                         zones="zones"
                     />
                 </div>


### PR DESCRIPTION
## Done
* Fixed bug where newly composed machine would not appear in KVM page. I'm not proud of the solution (at all) but I'm not terribly excited about rewriting big chunks of the machine list or pod details controllers. :(
* Improved action feedback of compose machine button

## QA
* Compose a machine in a KVM and check that the button becomes disabled with a spinner
* Check that the machine shows up automatically in the list below the pod summary.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1079

## Launchpad Issue
[lp#1859032](https://bugs.launchpad.net/maas/+bug/1859032)

## Screenshot
![0 0 0 0_8400_MAAS_ (5)](https://user-images.githubusercontent.com/25733845/72154953-3e431380-33b2-11ea-8977-8087157915f9.png)
