### PR TITLE
Set up real MAAS when running cypress in Circle CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,23 +6,48 @@ defaults: &defaults
 version: 2
 jobs:
   test-cypress:
-    docker:
-      - image: cypress/base:12.16.1
-        environment:
-          ## this enables colors in the output
-          TERM: xterm
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
       - checkout
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - yarn-{{ checksum "yarn.lock" }}
-      - run: yarn install --frozen-lockfile
-      - save_cache:
-          key: yarn-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache ## cache both yarn and Cypress!
-      - run: yarn test-cypress
+      - run:
+          name: Set environment variables
+          command: |
+            echo 'export IP_ADDRESS=$(hostname -I | cut -d" " -f1)' >> $BASH_ENV
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo ' [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Install system dependencies
+          command: |
+            sudo apt-get update && sudo apt-get install -y curl
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+            sudo apt-get update && sudo apt-get install --yes \
+            build-essential libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 \
+            libnss3 libxss1 libasound2 libxtst6 nodejs snapd \
+            software-properties-common xauth xvfb yarn
+      - run:
+          name: Install Node v12.14.1 LTS, node modules and verify cypress
+          command: |
+            nvm install v12.14.1
+            node -v
+            nvm alias default v12.14.1
+            yarn install
+            ./node_modules/.bin/cypress verify
+      - run:
+          name: Install and initialise edge MAAS snap
+          command: |
+            echo $IP_ADDRESS
+            sudo systemctl enable snapd
+            sudo snap install maas --channel=2.7/edge
+            sudo maas init --maas-url=http://$IP_ADDRESS:5240/MAAS --admin-username=admin --admin-password=test --admin-email=fake@email.com --mode all
+            sudo maas config
+      - run:
+          name: Set proxy url and start cypress tests
+          command: |
+            sed "1s/.*/MAAS_URL=\"http:\/\/$IP_ADDRESS:5240\/\"/" proxy/.env > proxy/.env.local
+            yarn test-cypress
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           command: |
             echo $IP_ADDRESS
             sudo systemctl enable snapd
-            sudo snap install maas --channel=2.7/edge
+            sudo snap install maas --channel=latest/edge
             sudo maas init --maas-url=http://$IP_ADDRESS:5240/MAAS --admin-username=admin --admin-password=test --admin-email=fake@email.com --mode all
             sudo maas config
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,23 @@ jobs:
             echo 'export IP_ADDRESS=$(hostname -I | cut -d" " -f1)' >> $BASH_ENV
             echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
             echo ' [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+            echo 'export POSTGRES_VERSION="10"' >> $BASH_ENV
+            echo 'export MAAS_DBNAME="maasdb"' >> $BASH_ENV
+            echo 'export MAAS_DBUSER="maas"' >> $BASH_ENV
+            echo 'export MAAS_DBPASS="maasdbpass"' >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: Install system dependencies
           command: |
-            sudo apt-get update && sudo apt-get install -y curl
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA 78BD65473CB3BD13
+            sudo apt-get update && sudo apt-get install -y curl ca-certificates gnupg
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+            curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+            sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
             sudo apt-get update && sudo apt-get install --yes \
             build-essential libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 \
-            libnss3 libxss1 libasound2 libxtst6 nodejs snapd \
+            libnss3 libxss1 libasound2 libxtst6 nodejs postgresql-$POSTGRES_VERSION snapd \
             software-properties-common xauth xvfb yarn
       - run:
           name: Install Node v12.14.1 LTS, node modules and verify cypress
@@ -36,11 +43,17 @@ jobs:
             yarn install
             ./node_modules/.bin/cypress verify
       - run:
-          name: Install and initialise edge MAAS snap
+          name: Install MAAS snap and set up postgres database
           command: |
-            echo $IP_ADDRESS
             sudo systemctl enable snapd
             sudo snap install maas --channel=latest/edge
+            sudo -iu postgres psql -c "CREATE USER \"$MAAS_DBUSER\" WITH ENCRYPTED PASSWORD '$MAAS_DBPASS'" >/dev/null
+            sudo -iu postgres createdb -O "$MAAS_DBUSER" "$MAAS_DBNAME" >/dev/null
+            pg_hba="/etc/postgresql/$POSTGRES_VERSION/main/pg_hba.conf"
+            sudo sh -c "echo grep -q '^host[[:space:]]\\+${MAAS_DBNAME}\\b' '$pg_hba' || printf 'host\t%s\t%s\t0/0\tmd5\n' '$MAAS_DBNAME' '$MAAS_DBUSER' >> '$pg_hba'"
+      - run:
+          name: Initialise MAAS
+          command: |
             sudo maas init \
               --maas-url=http://$IP_ADDRESS:5240/MAAS \
               --admin-username=admin \
@@ -48,9 +61,9 @@ jobs:
               --admin-email=fake@email.com \
               --mode region+rack \
               --database-host=localhost \
-              --database-name=maasdb \
-              --database-user=maas \
-              --database-pass=test
+              --database-name=$MAAS_DBNAME \
+              --database-user=$MAAS_DBUSER \
+              --database-pass=$MAAS_DBPASS
             sudo maas config
       - run:
           name: Set proxy url and start cypress tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,16 @@ jobs:
             echo $IP_ADDRESS
             sudo systemctl enable snapd
             sudo snap install maas --channel=latest/edge
-            sudo maas init --maas-url=http://$IP_ADDRESS:5240/MAAS --admin-username=admin --admin-password=test --admin-email=fake@email.com --mode all
+            sudo maas init \
+              --maas-url=http://$IP_ADDRESS:5240/MAAS \
+              --admin-username=admin \
+              --admin-password=test \
+              --admin-email=fake@email.com \
+              --mode region+rack \
+              --database-host=localhost \
+              --database-name=maasdb \
+              --database-user=maas \
+              --database-pass=test
             sudo maas config
       - run:
           name: Set proxy url and start cypress tests

--- a/proxy/cypress/integration/login/login.spec.js
+++ b/proxy/cypress/integration/login/login.spec.js
@@ -3,14 +3,6 @@ context("Login page", () => {
     cy.visit(`${Cypress.env("BASENAME")}${Cypress.env("REACT_BASENAME")}`);
   });
 
-  it("gets redirected correctly", () => {
-    cy.visit("/");
-    cy.location("pathname").should(
-      "eq",
-      `${Cypress.env("BASENAME")}${Cypress.env("REACT_BASENAME")}`
-    );
-  });
-
   it("is disabled by default", () => {
     cy.get("button").should("have.attr", "disabled", "disabled");
   });
@@ -32,5 +24,12 @@ context("Login page", () => {
     cy.get("input[name='username']").type("username");
     cy.get("input[name='password']").type("password");
     cy.get("button").should("not.have.attr", "disabled", "disabled");
+  });
+
+  it("displays an error notification if wrong credentials provided", () => {
+    cy.server();
+    cy.get("input[name='username']").type("username");
+    cy.get("input[name='password']").type("password{enter}");
+    cy.get(".p-notification--negative").should("exist");
   });
 });


### PR DESCRIPTION
## Done
- Set up basic, real MAAS using 2.7/edge snap when running cypress in Circle CI.
- Added a non-stubbed test that could only pass if a real MAAS was running (auth errors returned from api and displayed in UI)
- Removed Circle CI tests that have been migrated to GH actions

## QA
- Check that tests pass in Circle CI

Fixes #541