### PR TITLE
Add disks column to new machine listing.

### DIFF
--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
@@ -1,0 +1,108 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { scriptStatus } from "app/base/enum";
+import Tooltip from "app/base/components/Tooltip";
+
+const ScriptStatus = ({
+  children,
+  hidePassedIcon = false,
+  scriptType,
+  tooltipPosition
+}) => {
+  switch (scriptType.status) {
+    case scriptStatus.PASSED: {
+      return hidePassedIcon ? (
+        children
+      ) : (
+        <>
+          <i className="p-icon--success is-inline" />
+          {children}
+        </>
+      );
+    }
+
+    case scriptStatus.DEGRADED:
+    case scriptStatus.FAILED:
+    case scriptStatus.FAILED_APPLYING_NETCONF:
+    case scriptStatus.FAILED_INSTALLING: {
+      return (
+        <Tooltip message="Machine has failed tests." position={tooltipPosition}>
+          <i className="p-icon--error is-inline" />
+          {children}
+        </Tooltip>
+      );
+    }
+
+    case scriptStatus.TIMEDOUT: {
+      return (
+        <Tooltip
+          message="Machine has tests that have timed out."
+          position={tooltipPosition}
+        >
+          <i className="p-icon--timed-out is-inline" />
+          {children}
+        </Tooltip>
+      );
+    }
+
+    case scriptStatus.APPLYING_NETCONF:
+    case scriptStatus.INSTALLING:
+    case scriptStatus.RUNNING: {
+      return (
+        <>
+          <i className="p-icon--running is-inline" />
+          {children}
+        </>
+      );
+    }
+
+    case scriptStatus.PENDING: {
+      return (
+        <>
+          <i className="p-icon--pending is-inline" />
+          {children}
+        </>
+      );
+    }
+
+    case scriptStatus.NONE: {
+      return (
+        <Tooltip
+          message="Machine has not run any tests of this type."
+          position={tooltipPosition}
+        >
+          <i className="p-icon--warning is-inline" />
+          {children}
+        </Tooltip>
+      );
+    }
+
+    default:
+      return children;
+  }
+};
+
+ScriptStatus.propTypes = {
+  children: PropTypes.node.isRequired,
+  hidePassedIcon: PropTypes.bool,
+  scriptType: PropTypes.shape({
+    status: PropTypes.number,
+    pending: PropTypes.number,
+    running: PropTypes.number,
+    passed: PropTypes.number,
+    failed: PropTypes.number
+  }).isRequired,
+  tooltipPosition: PropTypes.oneOf([
+    "btm-center",
+    "btm-left",
+    "btm-right",
+    "left",
+    "right",
+    "top-center",
+    "top-left",
+    "top-right"
+  ])
+};
+
+export default ScriptStatus;

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.js
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.js
@@ -1,0 +1,83 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import { scriptStatus } from "app/base/enum";
+import ScriptStatus from "./ScriptStatus";
+
+describe("ScriptStatus ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <ScriptStatus scriptType={{ status: scriptStatus.PASSED }}>
+        All tests have passed
+      </ScriptStatus>
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("displays a success icon if scripts passed", () => {
+    const wrapper = shallow(
+      <ScriptStatus scriptType={{ status: scriptStatus.PASSED }}>
+        All tests have passed
+      </ScriptStatus>
+    );
+    expect(wrapper.find(".p-icon--success").exists()).toBe(true);
+  });
+
+  it(`does not display a success icon if scripts passed
+    and hidePassedIcon is false`, () => {
+    const wrapper = shallow(
+      <ScriptStatus hidePassedIcon scriptType={{ status: scriptStatus.PASSED }}>
+        All tests have passed
+      </ScriptStatus>
+    );
+    expect(wrapper.find(".p-icon--success").exists()).toBe(false);
+  });
+
+  it("displays an error icon and tooltip if scripts have failed", () => {
+    const wrapper = shallow(
+      <ScriptStatus scriptType={{ status: scriptStatus.FAILED }}>
+        Some or all tests have failed
+      </ScriptStatus>
+    );
+    expect(wrapper.find(".p-icon--error").exists()).toBe(true);
+    expect(wrapper.find("Tooltip").exists()).toBe(true);
+  });
+
+  it("displays a timed out icon and tooltip if scripts have timed out", () => {
+    const wrapper = shallow(
+      <ScriptStatus scriptType={{ status: scriptStatus.TIMEDOUT }}>
+        Some or all tests have timed out
+      </ScriptStatus>
+    );
+    expect(wrapper.find(".p-icon--timed-out").exists()).toBe(true);
+    expect(wrapper.find("Tooltip").exists()).toBe(true);
+  });
+
+  it("displays a pending icon if scripts are pending", () => {
+    const wrapper = shallow(
+      <ScriptStatus scriptType={{ status: scriptStatus.PENDING }}>
+        Some or all tests are pending
+      </ScriptStatus>
+    );
+    expect(wrapper.find(".p-icon--pending").exists()).toBe(true);
+  });
+
+  it("displays a running icon if scripts are running", () => {
+    const wrapper = shallow(
+      <ScriptStatus scriptType={{ status: scriptStatus.RUNNING }}>
+        Some or all tests are running
+      </ScriptStatus>
+    );
+    expect(wrapper.find(".p-icon--running").exists()).toBe(true);
+  });
+
+  it("displays a warning icon and tooltip if scripts have not been run", () => {
+    const wrapper = shallow(
+      <ScriptStatus scriptType={{ status: scriptStatus.NONE }}>
+        Some or all tests are running
+      </ScriptStatus>
+    );
+    expect(wrapper.find(".p-icon--warning").exists()).toBe(true);
+    expect(wrapper.find("Tooltip").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/ScriptStatus/__snapshots__/ScriptStatus.test.js.snap
+++ b/ui/src/app/base/components/ScriptStatus/__snapshots__/ScriptStatus.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScriptStatus  renders 1`] = `
+<Fragment>
+  <i
+    className="p-icon--success is-inline"
+  />
+  All tests have passed
+</Fragment>
+`;

--- a/ui/src/app/base/components/ScriptStatus/index.js
+++ b/ui/src/app/base/components/ScriptStatus/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ScriptStatus";

--- a/ui/src/app/base/enum.js
+++ b/ui/src/app/base/enum.js
@@ -49,3 +49,19 @@ export const nodeStatus = {
   // Testing has failed
   FAILED_TESTING: 22
 };
+
+export const scriptStatus = {
+  NONE: -1,
+  PENDING: 0,
+  RUNNING: 1,
+  PASSED: 2,
+  FAILED: 3,
+  TIMEDOUT: 4,
+  ABORTED: 5,
+  DEGRADED: 6,
+  INSTALLING: 7,
+  FAILED_INSTALLING: 8,
+  SKIPPED: 9,
+  APPLYING_NETCONF: 10,
+  FAILED_APPLYING_NETCONF: 11
+};

--- a/ui/src/app/machines/views/MachineList/DisksColumn/DisksColumn.js
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/DisksColumn.js
@@ -1,0 +1,33 @@
+import { useSelector } from "react-redux";
+import React from "react";
+import PropTypes from "prop-types";
+
+import { machine as machineSelectors } from "app/base/selectors";
+import ScriptStatus from "app/base/components/ScriptStatus";
+
+const DisksColumn = ({ systemId }) => {
+  const machine = useSelector(state =>
+    machineSelectors.getBySystemId(state, systemId)
+  );
+
+  return (
+    <div className="p-double-row">
+      <div className="p-double-row__primary-row u-align--right">
+        <ScriptStatus
+          data-test="disks"
+          hidePassedIcon
+          scriptType={machine.storage_test_status}
+          tooltipPosition="top-right"
+        >
+          {machine.physical_disk_count}
+        </ScriptStatus>
+      </div>
+    </div>
+  );
+};
+
+DisksColumn.propTypes = {
+  systemId: PropTypes.string.isRequired
+};
+
+export default DisksColumn;

--- a/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DisksColumn renders 1`] = `
+<DisksColumn
+  systemId="abc123"
+>
+  <div
+    className="p-double-row"
+  >
+    <div
+      className="p-double-row__primary-row u-align--right"
+    >
+      <ScriptStatus
+        data-test="disks"
+        hidePassedIcon={true}
+        scriptType={
+          Object {
+            "status": 2,
+          }
+        }
+        tooltipPosition="top-right"
+      >
+        1
+      </ScriptStatus>
+    </div>
+  </div>
+</DisksColumn>
+`;

--- a/ui/src/app/machines/views/MachineList/DisksColumn/index.js
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DisksColumn";

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -25,6 +25,7 @@ import { machine as machineSelectors } from "app/base/selectors";
 import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import { formatGigabytes, formatGigabits } from "app/utils";
+import DisksColumn from "./DisksColumn";
 import FabricColumn from "./FabricColumn";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
@@ -157,8 +158,7 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
           className: "u-align--right"
         },
         {
-          content: row.physical_disk_count,
-          className: "u-align--right"
+          content: <DisksColumn systemId={row.system_id} />
         },
         {
           content: formatGigabytes(row.storage),
@@ -268,7 +268,9 @@ const MachineList = () => {
                 sortKey: "name"
               },
               {
-                content: "Power",
+                content: (
+                  <span className="p-double-row__icon-space">Power</span>
+                ),
                 sortKey: "power_state"
               },
               {

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
@@ -35,12 +35,10 @@ const generateFQDN = (machine, machineURL) => {
     return name;
   }
   let ipAddressesLine = (
-    <div>
-      <small className="u-text--light">
-        {bootIP || ipAddresses[0]}
-        {ipAddresses.length > 1 ? ` (+${ipAddresses.length - 1})` : null}
-      </small>
-    </div>
+    <span data-test="ip-addresses">
+      {bootIP || ipAddresses[0]}
+      {ipAddresses.length > 1 ? ` (+${ipAddresses.length - 1})` : null}
+    </span>
   );
 
   if (ipAddresses.length > 1) {
@@ -62,11 +60,12 @@ const generateFQDN = (machine, machineURL) => {
       </Tooltip>
     );
   }
+
   return (
-    <>
-      {name}
-      {ipAddressesLine}
-    </>
+    <div className="p-double-row">
+      <div className="p-double-row__primary-row">{name}</div>
+      <div className="p-double-row__secondary-row">{ipAddressesLine}</div>
+    </div>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.test.js
@@ -93,8 +93,8 @@ describe("NameColumn", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("div").text()).toBe("127.0.0.1");
-    // Doesn't show toolip.
+    expect(wrapper.find('[data-test="ip-addresses"]').text()).toBe("127.0.0.1");
+    // Doesn't show tooltip.
     expect(wrapper.find("Tooltip").exists()).toBe(false);
   });
 
@@ -113,7 +113,9 @@ describe("NameColumn", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("div").text()).toBe("127.0.0.1 (+1)");
+    expect(wrapper.find('[data-test="ip-addresses"]').text()).toBe(
+      "127.0.0.1 (+1)"
+    );
     // Shows a tooltip.
     expect(wrapper.find("Tooltip").exists()).toBe(true);
   });
@@ -130,7 +132,9 @@ describe("NameColumn", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("div").text()).toBe("127.0.0.1 (PXE)");
+    expect(wrapper.find('[data-test="ip-addresses"]').text()).toBe(
+      "127.0.0.1 (PXE)"
+    );
   });
 
   it("doesn't show duplicate ip addresses", () => {
@@ -148,7 +152,7 @@ describe("NameColumn", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("div").text()).toBe("127.0.0.1");
+    expect(wrapper.find('[data-test="ip-addresses"]').text()).toBe("127.0.0.1");
     // Doesn't show toolip.
     expect(wrapper.find("Tooltip").exists()).toBe(false);
   });

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -13,7 +13,7 @@ const OwnerColumn = ({ systemId }) => {
   const tags = machine.tags ? machine.tags.join(", ") : "";
 
   return (
-    <>
+    <div className="p-double-row">
       <div className="p-double-row__primary-row">
         <span data-test="owner">{owner}</span>
       </div>
@@ -22,7 +22,7 @@ const OwnerColumn = ({ systemId }) => {
           {tags}
         </span>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -5,21 +5,25 @@ exports[`OwnerColumn renders 1`] = `
   systemId="abc123"
 >
   <div
-    className="p-double-row__primary-row"
+    className="p-double-row"
   >
-    <span
-      data-test="owner"
+    <div
+      className="p-double-row__primary-row"
     >
-      admin
-    </span>
-  </div>
-  <div
-    className="p-double-row__secondary-row u-truncate-text"
-  >
-    <span
-      data-test="tags"
-      title=""
-    />
+      <span
+        data-test="owner"
+      >
+        admin
+      </span>
+    </div>
+    <div
+      className="p-double-row__secondary-row u-truncate-text"
+    >
+      <span
+        data-test="tags"
+        title=""
+      />
+    </div>
   </div>
 </OwnerColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
@@ -15,14 +15,14 @@ const ZoneColumn = ({ systemId }) => {
       : machine.spaces[0];
 
   return (
-    <>
+    <div className="p-double-row">
       <div className="p-double-row__primary-row">
         <span data-test="zone">{machine.zone.name}</span>
       </div>
       <div className="p-double-row__secondary-row u-truncate-text">
         <span data-test="spaces">{spaces}</span>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -5,22 +5,26 @@ exports[`ZoneColumn renders 1`] = `
   systemId="abc123"
 >
   <div
-    className="p-double-row__primary-row"
+    className="p-double-row"
   >
-    <span
-      data-test="zone"
+    <div
+      className="p-double-row__primary-row"
     >
-      zone-north
-    </span>
-  </div>
-  <div
-    className="p-double-row__secondary-row u-truncate-text"
-  >
-    <span
-      data-test="spaces"
+      <span
+        data-test="zone"
+      >
+        zone-north
+      </span>
+    </div>
+    <div
+      className="p-double-row__secondary-row u-truncate-text"
     >
-      management
-    </span>
+      <span
+        data-test="spaces"
+      >
+        management
+      </span>
+    </div>
   </div>
 </ZoneColumn>
 `;

--- a/ui/src/scss/_patterns_icons.scss
+++ b/ui/src/scss/_patterns_icons.scss
@@ -1,7 +1,28 @@
+
+@import "~vanilla-framework/scss/settings_spacing";
+
 @mixin maas-icon-edit($color) {
   background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg width='22' height='22' viewBox='0 0 22 22' xmlns='http://www.w3.org/2000/svg'%3e%3ctitle%3eedit%3c/title%3e%3cg fill='"+vf-url-friendly-color(
       $color
     )+"' fill-rule='evenodd'%3e%3cpath d='M17 15h5v1h-5zm-3 3h8v1h-8zm-3 3h11v1H11zm5.75-21L3.47 13.517S.956 17.465 0 21.987v.004l.002.004V22c4.532-.955 8.48-3.472 8.48-3.472L22 5.25 16.75 0zM4.51 14.555L7.454 17.5c-.2.114-2.99 2.064-5.544 2.602V20.093l-.002-.003c.537-2.546 2.485-5.334 2.602-5.537v.002z'/%3e%3cpath d='M2.234 18l1.85 1.85L1 21'/%3e%3c/g%3e%3c/svg%3e");
+}
+
+@mixin maas-icon-locked($color) {
+  background-image: url("data:image/svg+xml,%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cdefs%3E%3Cpath d='M8,3e-05 C5.7926,3e-05 4,1.79263 4,4.00003 L4,7.00003 L2,7.00003 L2,15.99953 L14,15.99953 L14,7.00003 L12,7.00003 L12,4.00003 C12,1.79263 10.207,3e-05 8,3e-05 L8,0 L8,3e-05 Z M8,1.00003 C9.6706,1.00003 11,2.32933 11,4.00003 L11,7.00003 L5,7.00003 L5,4.00003 C5,2.32933 6.3293,1.00003 8,1.00003 Z M9,9.50003 L9,13.99953 L7,13.99953 L7,9.99953 L9,9.50003 L9,9.50003 Z' id='padlock-icon'%3E%3C/path%3E%3C/defs%3E%3Cg id='padlock-16'%3E%3Cuse id='lock-icon' fill='"+vf-url-friendly-color(
+      $color
+    )+"' fill-rule='nonzero' xlink:href='%23padlock-icon'%3E%3C/use%3E%3C/g%3E%3C/svg%3E%0A");
+}
+
+@mixin maas-icon-power($color) {
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%2215%22%20width%3D%2214%22%3E%3Cpath%20d%3D%22M11.04%202.323l-.324%202.268a5.017%205.017%200%200%201%201.352%203.426c0%202.787-2.274%205.056-5.068%205.056s-5.067-2.269-5.067-5.056a5.02%205.02%200%200%201%201.351-3.426L2.96%202.323A6.935%206.935%200%200%200%200%208.017C0%2011.868%203.14%2015%207%2015s7-3.132%207-6.983a6.933%206.933%200%200%200-2.96-5.694zM6%200h2v7H6V0z%22%20fill%3D%22"+vf-url-friendly-color(
+      $color
+    )+"%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E");
+}
+
+@mixin maas-icon-unknown($color) {
+  background-image: url("data:image/svg+xml,%0A%3Csvg width='7px' height='12px' viewBox='0 0 7 12' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 50.2 %2855047%29 - http://www.bohemiancoding.com/sketch --%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='prototype--tables' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='207-group-selection' transform='translate%28-333.000000, -143.000000%29'%3E%3Cg id='Group' transform='translate%28333.000000, 141.000000%29'%3E%3Crect id='Rectangle' x='0' y='0' width='16' height='16'%3E%3C/rect%3E%3Cpath d='M2.79224377,3.71191136 C2.40443019,3.71191136 2.03324277,3.7590023 1.67867036,3.8531856 C1.32409795,3.94736889 0.952910526,4.09972194 0.565096953,4.31024931 L0,2.76454294 C0.409974349,2.53185479 0.878113712,2.34626108 1.40443213,2.20775623 C1.93075055,2.06925139 2.47091136,2 3.02493075,2 C3.68975402,2 4.23822499,2.09141183 4.67036011,2.27423823 C5.10249524,2.45706463 5.44598211,2.68697922 5.70083102,2.96398892 C5.95567994,3.24099861 6.13296349,3.54570471 6.23268698,3.87811634 C6.33241047,4.21052798 6.38227147,4.5318544 6.38227147,4.84210526 C6.38227147,5.21883845 6.31302008,5.55678521 6.17451524,5.85595568 C6.03601039,6.15512615 5.8614969,6.43213169 5.65096953,6.68698061 C5.44044216,6.94182953 5.21329762,7.18282435 4.96952909,7.4099723 C4.72576055,7.63712025 4.49861601,7.8698049 4.28808864,8.10803324 C4.07756127,8.34626158 3.90304778,8.59833662 3.76454294,8.86426593 C3.62603809,9.13019524 3.5567867,9.42936122 3.5567867,9.76177285 L3.5567867,9.95290859 C3.5567867,10.0249311 3.56232681,10.0941825 3.5734072,10.1606648 L1.84487535,10.1606648 C1.82271457,10.0498609 1.80609424,9.93074856 1.79501385,9.8033241 C1.78393346,9.67589964 1.77839335,9.55678726 1.77839335,9.44598338 C1.77839335,9.08033058 1.83933457,8.75346404 1.96121884,8.46537396 C2.0831031,8.17728388 2.2382262,7.91135856 2.4265928,7.66759003 C2.61495939,7.4238215 2.81717343,7.19667695 3.033241,6.98614958 C3.24930856,6.77562222 3.4515226,6.56509801 3.6398892,6.35457064 C3.82825579,6.14404327 3.98337889,5.92797895 4.10526316,5.70637119 C4.22714742,5.48476343 4.28808864,5.24099856 4.28808864,4.97506925 C4.28808864,4.60941645 4.16343615,4.30748042 3.91412742,4.06925208 C3.6648187,3.83102374 3.29086122,3.71191136 2.79224377,3.71191136 Z M4.08864266,12.6869806 C4.08864266,13.0747942 3.96122011,13.3905805 3.70637119,13.634349 C3.45152227,13.8781176 3.13573596,14 2.75900277,14 C2.39334997,14 2.08033371,13.8781176 1.8199446,13.634349 C1.55955548,13.3905805 1.42936288,13.0747942 1.42936288,12.6869806 C1.42936288,12.299167 1.55955548,11.9806107 1.8199446,11.7313019 C2.08033371,11.4819932 2.39334997,11.3573407 2.75900277,11.3573407 C3.13573596,11.3573407 3.45152227,11.4819932 3.70637119,11.7313019 C3.96122011,11.9806107 4.08864266,12.299167 4.08864266,12.6869806 Z' id='%3F' fill='"+vf-url-friendly-color(
+      $color
+    )+"'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }
 
 .p-icon--edit {
@@ -11,15 +32,12 @@
 
 .p-icon--locked {
   @extend %icon;
-  background-image: url("data:image/svg+xml,%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3Cdefs%3E%3Cpath d='M8,3e-05 C5.7926,3e-05 4,1.79263 4,4.00003 L4,7.00003 L2,7.00003 L2,15.99953 L14,15.99953 L14,7.00003 L12,7.00003 L12,4.00003 C12,1.79263 10.207,3e-05 8,3e-05 L8,0 L8,3e-05 Z M8,1.00003 C9.6706,1.00003 11,2.32933 11,4.00003 L11,7.00003 L5,7.00003 L5,4.00003 C5,2.32933 6.3293,1.00003 8,1.00003 Z M9,9.50003 L9,13.99953 L7,13.99953 L7,9.99953 L9,9.50003 L9,9.50003 Z' id='padlock-icon'%3E%3C/path%3E%3C/defs%3E%3Cg id='padlock-16'%3E%3Cuse id='lock-icon' fill='"+vf-url-friendly-color(
-      $color-mid-dark
-    )+"' fill-rule='nonzero' xlink:href='%23padlock-icon'%3E%3C/use%3E%3C/g%3E%3C/svg%3E%0A");
+  @include maas-icon-power($color-mid-dark);
 }
 
-@mixin maas-icon-power($color) {
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%2215%22%20width%3D%2214%22%3E%3Cpath%20d%3D%22M11.04%202.323l-.324%202.268a5.017%205.017%200%200%201%201.352%203.426c0%202.787-2.274%205.056-5.068%205.056s-5.067-2.269-5.067-5.056a5.02%205.02%200%200%201%201.351-3.426L2.96%202.323A6.935%206.935%200%200%200%200%208.017C0%2011.868%203.14%2015%207%2015s7-3.132%207-6.983a6.933%206.933%200%200%200-2.96-5.694zM6%200h2v7H6V0z%22%20fill%3D%22"+vf-url-friendly-color(
-      $color
-    )+"%22%20fill-rule%3D%22evenodd%22%2F%3E%3C%2Fsvg%3E");
+.p-icon--pending {
+  @extend %icon;
+  background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Epending%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='smoke-testing-status' transform='translate%28-62.000000, -112.000000%29'%3E%3Cg id='pending' transform='translate%2850.000000, 97.000000%29'%3E%3Cg transform='translate%2812.000000, 15.000000%29'%3E%3Crect id='rect4970' x='0' y='1.99999999e-05' width='16' height='16'%3E%3C/rect%3E%3Ccircle id='circle4972' stroke='%23F99B11' stroke-width='1.5' cx='8' cy='8.00002' r='7.2500086'%3E%3C/circle%3E%3Crect id='rect4980' fill='%23F99B11' fill-rule='nonzero' x='7' y='7.00002' width='2' height='2'%3E%3C/rect%3E%3Crect id='rect4982' fill='%23F99B11' fill-rule='nonzero' x='10' y='7.00002' width='2' height='2'%3E%3C/rect%3E%3Crect id='rect4984' fill='%23F99B11' fill-rule='nonzero' x='4' y='7.00002' width='2' height='2'%3E%3C/rect%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }
 
 .p-icon--power-error {
@@ -39,6 +57,20 @@
 
 .p-icon--power-unknown {
   @extend %icon;
-  background-image: url("data:image/svg+xml,%0A%3Csvg width='7px' height='12px' viewBox='0 0 7 12' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 50.2 %2855047%29 - http://www.bohemiancoding.com/sketch --%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='prototype--tables' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='207-group-selection' transform='translate%28-333.000000, -143.000000%29'%3E%3Cg id='Group' transform='translate%28333.000000, 141.000000%29'%3E%3Crect id='Rectangle' x='0' y='0' width='16' height='16'%3E%3C/rect%3E%3Cpath d='M2.79224377,3.71191136 C2.40443019,3.71191136 2.03324277,3.7590023 1.67867036,3.8531856 C1.32409795,3.94736889 0.952910526,4.09972194 0.565096953,4.31024931 L0,2.76454294 C0.409974349,2.53185479 0.878113712,2.34626108 1.40443213,2.20775623 C1.93075055,2.06925139 2.47091136,2 3.02493075,2 C3.68975402,2 4.23822499,2.09141183 4.67036011,2.27423823 C5.10249524,2.45706463 5.44598211,2.68697922 5.70083102,2.96398892 C5.95567994,3.24099861 6.13296349,3.54570471 6.23268698,3.87811634 C6.33241047,4.21052798 6.38227147,4.5318544 6.38227147,4.84210526 C6.38227147,5.21883845 6.31302008,5.55678521 6.17451524,5.85595568 C6.03601039,6.15512615 5.8614969,6.43213169 5.65096953,6.68698061 C5.44044216,6.94182953 5.21329762,7.18282435 4.96952909,7.4099723 C4.72576055,7.63712025 4.49861601,7.8698049 4.28808864,8.10803324 C4.07756127,8.34626158 3.90304778,8.59833662 3.76454294,8.86426593 C3.62603809,9.13019524 3.5567867,9.42936122 3.5567867,9.76177285 L3.5567867,9.95290859 C3.5567867,10.0249311 3.56232681,10.0941825 3.5734072,10.1606648 L1.84487535,10.1606648 C1.82271457,10.0498609 1.80609424,9.93074856 1.79501385,9.8033241 C1.78393346,9.67589964 1.77839335,9.55678726 1.77839335,9.44598338 C1.77839335,9.08033058 1.83933457,8.75346404 1.96121884,8.46537396 C2.0831031,8.17728388 2.2382262,7.91135856 2.4265928,7.66759003 C2.61495939,7.4238215 2.81717343,7.19667695 3.033241,6.98614958 C3.24930856,6.77562222 3.4515226,6.56509801 3.6398892,6.35457064 C3.82825579,6.14404327 3.98337889,5.92797895 4.10526316,5.70637119 C4.22714742,5.48476343 4.28808864,5.24099856 4.28808864,4.97506925 C4.28808864,4.60941645 4.16343615,4.30748042 3.91412742,4.06925208 C3.6648187,3.83102374 3.29086122,3.71191136 2.79224377,3.71191136 Z M4.08864266,12.6869806 C4.08864266,13.0747942 3.96122011,13.3905805 3.70637119,13.634349 C3.45152227,13.8781176 3.13573596,14 2.75900277,14 C2.39334997,14 2.08033371,13.8781176 1.8199446,13.634349 C1.55955548,13.3905805 1.42936288,13.0747942 1.42936288,12.6869806 C1.42936288,12.299167 1.55955548,11.9806107 1.8199446,11.7313019 C2.08033371,11.4819932 2.39334997,11.3573407 2.75900277,11.3573407 C3.13573596,11.3573407 3.45152227,11.4819932 3.70637119,11.7313019 C3.96122011,11.9806107 4.08864266,12.299167 4.08864266,12.6869806 Z' id='%3F' fill='%23CDCDCD'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  @include maas-icon-unknown($color-mid-dark);
 }
 
+.p-icon--running {
+  @extend %icon;
+  background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Erunning%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='smoke-testing-status' transform='translate%28-62.000000, -159.000000%29'%3E%3Cg id='running' transform='translate%2850.000000, 144.000000%29'%3E%3Cg transform='translate%2812.000000, 15.000000%29'%3E%3Crect id='rect6425' x='9.99999997e-06' y='9.99999989e-06' width='16' height='16'%3E%3C/rect%3E%3Ccircle id='circle6427' stroke='%230E8420' stroke-width='1.5' fill='%230E8420' fill-rule='nonzero' cx='8.00001' cy='8.00001' r='7.2500086'%3E%3C/circle%3E%3Cpolygon id='path6429' fill='%23FFFFFF' fill-rule='nonzero' points='6.00002 12.00001 6.00002 4.00001 12.00002 8.00001'%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+}
+
+.p-icon--timed-out {
+  @extend %icon;
+  background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8' standalone='no'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' width='16px' version='1.1' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 16 16'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Etimed out%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg id='Page-1' fill-rule='evenodd' fill='none'%3E%3Cg id='smoke-testing-status' transform='translate%28-62 -206%29'%3E%3Cg id='timed-out' transform='translate%2850 191%29'%3E%3Cg transform='translate%2812 15%29'%3E%3Crect id='rect4970' y='0.00002' x='0' height='16' width='16'/%3E%3Ccircle id='circle4972' stroke-width='1.5' cy='8' stroke='%23E95420' cx='8' r='7.25'/%3E%3Cpolyline id='path839' stroke='%23E95420' stroke-width='2' points='11.8 11.8 7.9999 8 7.9999 3'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
+}
+
+[class*='p-icon--'].is-inline {
+  margin-right: $sph-inner--small;
+  top: 0;
+}


### PR DESCRIPTION
## Done
- Added disks column which shows `machine.physical_disk_count`.
- Copied over scriptStatus enum from legacy which just lists out the different statuses a script can be in (failed, passed, running etc).
- Added ScriptStatus component that generates an icon and tooltip given a certain script type's status (e.g. storage tests have failed = return error icon and tooltip "Machine has failed tests", cpu tests are pending = return pending icon without tooltip, etc).
- Added icons for pending, running and timed out tests.
- Small css and markup fixes for other columns.

## QA
- Check that the disks column correctly displays the physical_disk_count of the machine
- Check that icons and tooltips display for machines that have storage tests that have failed/timed out/pending/running/no tests

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1763

## Screenshot
![screenshot](https://user-images.githubusercontent.com/25733845/72270768-f4626380-3625-11ea-8676-4f1daa107bab.png)

