### PR TITLE
LP: #1859626 - Show information icon for audit events.

### DIFF
--- a/legacy/src/scss/_patterns_icons.scss
+++ b/legacy/src/scss/_patterns_icons.scss
@@ -246,6 +246,10 @@
       background-image: url("data:image/svg+xml,%3Csvg id='Disconnect_2' data-name='Disconnect 2' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%23c7162b%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M6.1 13.52l2.71-2.71-3.58-3.58L2.51 10l-.47 2.11-1.61 1.58a1.36 1.36 0 001.92 1.92L4 14l2.11-.47zM15.59 2.36A1.35 1.35 0 0013.68.45l-1.63 1.62-2.05.46-2.78 2.71 3.58 3.58 2.7-2.71L14 4zM13.01 9.48h2.98v1h-2.98z'/%3E%3Cpath class='cls-1' transform='rotate(-45.01 13.332 13.315)' d='M12.83 11.83h1v2.98h-1z'/%3E%3Cpath class='cls-1' d='M9.49 13.03h1v2.98h-1zM.02 5.53H3v1H.02z'/%3E%3Cpath class='cls-1' transform='rotate(-45 2.663 2.687)' d='M2.17 1.2h1v2.98h-1z'/%3E%3Cpath class='cls-1' d='M5.51 0h1v2.98h-1z'/%3E%3C/svg%3E");
       background-size: 100% 100%;
     }
+
+    &--audit {
+      @extend .p-icon--information;
+    }
   }
 
   .p-icon--power-error {


### PR DESCRIPTION
## Done
* Create `.p-icon--audit` class, which is identical to `.p-icon--information`.

## QA
* Go to the event tab of a machine and check that all rows have an icon.

## Fixes
Fixes #653 .

## Launchpad Issue
lp#1859626

## Screenshot
![screenshot_1](https://user-images.githubusercontent.com/25733845/72361099-34424d00-36f1-11ea-9541-19e234f7be06.png)
