### PR TITLE
LP: #1859087 - Add required indicator for Power type field.

### DIFF
--- a/legacy/src/app/directives/power_parameters.js
+++ b/legacy/src/app/directives/power_parameters.js
@@ -6,7 +6,7 @@
 
 const powerParametersTmpl = `<div class="p-form__group row">
     <label for="power-type"
-        class="p-form__label col-2"
+        class="p-form__label col-2 is-required"
         data-ng-class="{'is-disabled': !ngModel.editing }">
         Power type
     </label>


### PR DESCRIPTION
## Done
* Added the little red asterisk to the "Power type" field in the power parameters form

## QA
* Add a machine from the machine list and check that the form enables only when the required fields are filled in (MAC address and Power type)

## Fixes
Fixes #659

## Launchpad Issue
lp#1859087

## Screenshot
![screenshot_2](https://user-images.githubusercontent.com/25733845/72363152-a36d7080-36f4-11ea-99fd-787937c0c57c.png)
