### PR TITLE
LP: #1859623 - Sync network card in machine summary with region.

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -566,6 +566,9 @@ function NodeDetailsController(
 
       // Update the services when the services list is updated.
       $scope.$watch("node.service_ids", updateServices);
+
+      // Update the network card in summary when interfaces are updated.
+      $scope.$watch("node.interfaces", updateSummary);
     }
   }
 

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -591,7 +591,8 @@ describe("NodeDetailsController", function() {
       "node.pool.id",
       "node.power_type",
       "node.power_parameters",
-      "node.service_ids"
+      "node.service_ids",
+      "node.interfaces"
     ]);
     expect(watchCollections).toEqual([
       $scope.summary.architecture.options,


### PR DESCRIPTION
## Done
* Explicitly refresh summary page with with new data from the region by adding another watcher (AngularJS! :shakes fist:)

## QA
- Go to a Ready/Allocated machine's network tab
- Edit the name of an interface (or any other field that is also surfaced in the summary)
- Go back to the summary and check that it has updated
- Do the same with multiple browser tabs open, i.e. open the summary on one tab, edit an interface name on another, and check that the first tab automatically updates the name in the summary

## Fixes
Fixes #651 

## Launchpad Issue
lp#1859623
