### PR TITLE
LP: #1850850 - Only show power error notification if node is in error state.

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -1296,7 +1296,8 @@ function NodeDetailsController(
   $scope.getPowerEventError = function() {
     if (
       !angular.isObject($scope.node) ||
-      !angular.isArray($scope.node.events)
+      !angular.isArray($scope.node.events) ||
+      $scope.node.power_state !== "error"
     ) {
       return;
     }

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -2250,8 +2250,21 @@ describe("NodeDetailsController", function() {
       evt.type.level = "warning";
       evt.type.description = "Failed to query node's BMC";
       $scope.node = node;
+      node.power_state = "error";
       $scope.node.events = [makeEvent(), evt];
       expect($scope.getPowerEventError()).toBe(evt);
+    });
+
+    it(`returns nothing if there is a power event error, but the node
+      is not currently in a power error state`, function() {
+      makeController();
+      var evt = makeEvent();
+      evt.type.level = "warning";
+      evt.type.description = "Failed to query node's BMC";
+      $scope.node = node;
+      node.power_state = "on";
+      $scope.node.events = [makeEvent(), evt];
+      expect($scope.getPowerEventError()).toBe();
     });
 
     it("returns nothing if there is no power event error", function() {
@@ -2263,6 +2276,7 @@ describe("NodeDetailsController", function() {
       evt_error.type.level = "warning";
       evt_error.type.description = "Failed to query node's BMC";
       $scope.node = node;
+      node.power_state = "error";
       $scope.node.events = [makeEvent(), evt_info, evt_error];
       expect($scope.getPowerEventError()).toBe();
     });
@@ -2275,6 +2289,7 @@ describe("NodeDetailsController", function() {
       evt.type.level = "warning";
       evt.type.description = "Failed to query node's BMC";
       $scope.node = node;
+      node.power_state = "error";
       $scope.node.events = [evt];
       expect($scope.hasPowerEventError()).toBe(true);
     });
@@ -2282,6 +2297,7 @@ describe("NodeDetailsController", function() {
     it("returns false if last event is not an error", function() {
       makeController();
       $scope.node = node;
+      node.power_state = "error";
       $scope.node.events = [makeEvent()];
       expect($scope.hasPowerEventError()).toBe(false);
     });
@@ -2301,6 +2317,7 @@ describe("NodeDetailsController", function() {
       evt.type.level = "warning";
       evt.type.description = "Failed to query node's BMC";
       $scope.node = node;
+      node.power_state = "error";
       $scope.node.events = [evt];
       expect($scope.getPowerEventErrorText()).toBe(evt.description);
     });


### PR DESCRIPTION
## Done
- Added a conditional to the `getPowerEventError()` function so that it only returns if the node is currently in a power error state.

## QA
- Go to Machine details > Configuration, change the power configuration to be wrong and click "Save changes".
- Check that an error shows up at the top of the section, e.g. "Error:Failed to get domain: blah".
- Fix the power configuration and save again
- Check that the notification disappears.

## Fixes
Fixes #652 

## Launchpad Issue
lp#1850850
