### PR TITLE
Add Tooltip for machines with multiple spaces.

### DIFF
--- a/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
@@ -1,9 +1,9 @@
 import { useSelector } from "react-redux";
 import React from "react";
 import PropTypes from "prop-types";
-import Tooltip from "app/base/components/Tooltip";
 
 import ScriptStatus from "app/base/components/ScriptStatus";
+import Tooltip from "app/base/components/Tooltip";
 import { machine as machineSelectors } from "app/base/selectors";
 
 const CoresColumn = ({ systemId }) => {

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
@@ -2,25 +2,32 @@ import { useSelector } from "react-redux";
 import React from "react";
 import PropTypes from "prop-types";
 
+import Tooltip from "app/base/components/Tooltip";
 import { machine as machineSelectors } from "app/base/selectors";
+
+const getSpaces = machine => {
+  if (machine.spaces.length > 1) {
+    const sorted = [...machine.spaces].sort();
+    return (
+      <Tooltip position="btm-left" message={sorted.join("\n")}>
+        <span data-test="spaces">{`${machine.spaces.length} spaces`}</span>
+      </Tooltip>
+    );
+  }
+  return <span data-test="spaces">{machine.spaces[0]}</span>;
+};
 
 const ZoneColumn = ({ systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
-
-  const spaces =
-    machine.spaces.length > 1
-      ? `${machine.spaces.length} spaces`
-      : machine.spaces[0];
-
   return (
     <div className="p-double-row">
       <div className="p-double-row__primary-row u-truncate">
         <span data-test="zone">{machine.zone.name}</span>
       </div>
       <div className="p-double-row__secondary-row u-truncate">
-        <span data-test="spaces">{spaces}</span>
+        {getSpaces(machine)}
       </div>
     </div>
   );

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.test.js
@@ -77,7 +77,7 @@ describe("ZoneColumn", () => {
     expect(wrapper.find('[data-test="spaces"]').text()).toEqual("space1");
   });
 
-  it("displays spaces count", () => {
+  it("displays spaces count for multiple spaces", () => {
     state.machine.items[0].spaces = ["space1", "space2"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -91,5 +91,23 @@ describe("ZoneColumn", () => {
     );
 
     expect(wrapper.find('[data-test="spaces"]').text()).toEqual("2 spaces");
+  });
+
+  it("displays a sorted Tooltip for multiple spaces", () => {
+    state.machine.items[0].spaces = ["space2", "space1", "space3"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ZoneColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Tooltip").prop("message")).toEqual(
+      "space1\nspace2\nspace3"
+    );
   });
 });


### PR DESCRIPTION
## Done
Add Tooltip for machines with multiple spaces.

## QA
Ensure machines with multiple spaces have a tooltip over the `n spaces` count text. e.g. `comic-muskox-thing.maas` on karura.
