### PR TITLE
LP: #1859849 - Fix "Create bond" button being unresponsive.

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -780,11 +780,27 @@
                     <div class="row" data-ng-if="!isController && !isDevice"
                         data-ng-hide="isAllNetworkingDisabled() || isShowingCreateBond() || isShowingCreatePhysical()">
                         <div class="col-8">
-                            <button class="p-button--neutral" data-ng-disabled="selectedMode !== null"
-                                data-ng-click="showCreatePhysical(); sendAnalyticsEvent('Machine details', 'Add interface', 'Network tab')">Add interface</button>
-                            <button class="p-button--neutral" data-ng-disabled="!canCreateBond(); sendAnalyticsEvent('Machine details', 'Create bond', 'Network tab')" data-ng-click="showCreateBond()">Create bond</button>
-                            <button class="p-button--neutral" data-ng-disabled="!canCreateBridge()"
-                                data-ng-click="showCreateBridge(); sendAnalyticsEvent('Machine details', 'Create bridge', 'Network tab')">Create bridge</button>
+                            <button
+                                class="p-button--neutral"
+                                data-ng-click="showCreatePhysical(); sendAnalyticsEvent('Machine details', 'Add interface', 'Network tab')"
+                                data-ng-disabled="selectedMode !== null"
+                            >
+                                Add interface
+                            </button>
+                            <button
+                                class="p-button--neutral"
+                                data-ng-click="showCreateBond(); sendAnalyticsEvent('Machine details', 'Create bond', 'Network tab')"
+                                data-ng-disabled="!canCreateBond()"
+                            >
+                                Create bond
+                            </button>
+                            <button
+                                class="p-button--neutral"
+                                data-ng-disabled="!canCreateBridge()"
+                                data-ng-click="showCreateBridge(); sendAnalyticsEvent('Machine details', 'Create bridge', 'Network tab')"
+                            >
+                                Create bridge
+                            </button>
                         </div>
                         <div class="col-4 u-align--right">
                             <button class="p-button--neutral"


### PR DESCRIPTION
## Done
- Moved Create bond button GA event from `ng-disabled` attribute to correct `ng-click` attribute

## QA
- Go to the network tab of a machine
- Select two interfaces on the same VLAN and check that the "Create bond" button enables
- Check that you can actually create a bond

## Fixes
Fixes #680 

## Launchpad Issue
lp#1859849
