### PR TITLE
LP: #1859426 - Group multiple errors from machine list in notifications section.

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -484,6 +484,18 @@ function NodesListController(
 
   // Add error to action progress and group error messages by nodes.
   function addErrorToActionProgress(tab, error, node) {
+    const authUser = UsersManager.getAuthUser();
+    if (angular.isObject(authUser) && node) {
+      const name = node.hostname || "node";
+      NotificationsManager.createItem({
+        message: `Unable to perform action on ${name}: ${error}`,
+        category: "error",
+        user: authUser.id
+      });
+    } else {
+      $log.error(error);
+    }
+
     var progress = $scope.tabs[tab].actionProgress;
     progress.completed += 1;
     var nodes = progress.errors[error];

--- a/legacy/src/app/directives/notifications.js
+++ b/legacy/src/app/directives/notifications.js
@@ -4,120 +4,7 @@
  * Notifications.
  */
 
-/* @ngInject */
-export function cacheNotifications($templateCache) {
-  // Inject notifications.html into the template cache.
-  $templateCache.put(
-    "directive/templates/notifications.html",
-    [
-      '<div class="" data-ng-repeat="category in categories"',
-      ' data-ng-init="notifications = categoryNotifications[category]">',
-      // 1 notification.
-      '<span class="row" data-ng-if="notifications.length == 1">',
-      '<ul class="p-list" data-ng-class="{\'is-open\': shown}">',
-      '<li data-ng-repeat="notification in notifications"',
-      ' class="p-notification"',
-      ' data-ng-class="categoryClasses[notification.category]">',
-      '<p class="p-notification__response">',
-      '<span data-ng-bind-html="notification.message"></span> ',
-      '<a class="p-notification__action"',
-      ' data-ng-click="dismiss(notification)">Dismiss</a>',
-      "</p>",
-      "</li>",
-      "</ul>",
-      "</span>",
-      // 2 or more notifications.
-      '<div class="row p-notification--group" ',
-      'data-ng-if="notifications.length >= 2"',
-      ' data-ng-init="shown = false">',
-      '<div data-ng-class="categoryClasses[notifications[0].category]">',
-      '<a aria-label="{$ notifications.length $} ',
-      '{$ categoryTitles[category] $}, click to open messages."',
-      ' maas-enter="shown = !shown"',
-      ' class="p-notification__toggle"',
-      ' data-ng-click="shown = !shown">',
-      '<p class="p-notification__response">',
-      '<span class="p-notification__status"',
-      ' data-count="{$ notifications.length $}"',
-      " data-ng-bind=\"notifications.length + ' ' + ",
-      'categoryTitles[category]"></span>',
-      "<small>",
-      "<i data-ng-class=\"{ 'p-icon--expand': !shown,",
-      " 'p-icon--collapse': shown }\"></i></small>",
-      "</p>",
-      "</a>",
-      '<ul class="p-list--divided u-no-margin--bottom" ',
-      "data-ng-class=\"{'u-hide': !shown}\">",
-      '<li data-ng-repeat="notification in notifications"',
-      ' class="p-list__item">',
-      '<p class="p-notification__response">',
-      '<span data-ng-bind-html="notification.message">',
-      "</span> ",
-      '<a class="p-notification__action"',
-      ' data-ng-click="dismiss(notification)">Dismiss</a>',
-      "</p>",
-      "</li>",
-      "</ul>",
-      "</div>",
-      "</div>",
-      "</div>"
-    ].join("")
-  );
-}
-
-const NotificationsTmpl = [
-  '<div class="" data-ng-repeat="category in categories"',
-      ' data-ng-init="notifications = categoryNotifications[category]">',
-      // 1 notification.
-      '<span class="row" data-ng-if="notifications.length == 1">',
-      '<ul class="p-list" data-ng-class="{\'is-open\': shown}">',
-      '<li data-ng-repeat="notification in notifications"',
-      ' class="p-notification"',
-      ' data-ng-class="categoryClasses[notification.category]">',
-      '<p class="p-notification__response">',
-      '<span data-ng-bind-html="notification.message"></span> ',
-      '<a class="p-notification__action"',
-      ' data-ng-click="dismiss(notification)">Dismiss</a>',
-      "</p>",
-      "</li>",
-      "</ul>",
-      "</span>",
-      // 2 or more notifications.
-      '<div class="row p-notification--group" ',
-      'data-ng-if="notifications.length >= 2"',
-      ' data-ng-init="shown = false">',
-      '<div data-ng-class="categoryClasses[notifications[0].category]">',
-      '<a aria-label="{$ notifications.length $} ',
-      '{$ categoryTitles[category] $}, click to open messages."',
-      ' maas-enter="shown = !shown"',
-      ' class="p-notification__toggle"',
-      ' data-ng-click="shown = !shown">',
-      '<p class="p-notification__response">',
-      '<span class="p-notification__status"',
-      ' data-count="{$ notifications.length $}"',
-      " data-ng-bind=\"notifications.length + ' ' + ",
-      'categoryTitles[category]"></span>',
-      "<small>",
-      "<i data-ng-class=\"{ 'p-icon--expand': !shown,",
-      " 'p-icon--collapse': shown }\"></i></small>",
-      "</p>",
-      "</a>",
-      '<ul class="p-list--divided u-no-margin--bottom" ',
-      "data-ng-class=\"{'u-hide': !shown}\">",
-      '<li data-ng-repeat="notification in notifications"',
-      ' class="p-list__item">',
-      '<p class="p-notification__response">',
-      '<span data-ng-bind-html="notification.message">',
-      "</span> ",
-      '<a class="p-notification__action"',
-      ' data-ng-click="dismiss(notification)">Dismiss</a>',
-      "</p>",
-      "</li>",
-      "</ul>",
-      "</div>",
-      "</div>",
-      "</div>"
-].join("");
+import NotificationsTmpl from "../partials/nodelist/notifications.html";
 
 /* @ngInject */
 export function maasNotifications(NotificationsManager, ManagerHelperService) {
@@ -150,6 +37,15 @@ export function maasNotifications(NotificationsManager, ManagerHelperService) {
         warning: [],
         success: [],
         info: []
+      };
+
+      scope.dismissCategory = category => {
+        const categoryNotifications = scope.notifications.filter(
+          notification => notification.category === category
+        );
+        categoryNotifications.forEach(notification => {
+          scope.dismiss(notification);
+        });
       };
 
       scope.$watchCollection("notifications", function() {

--- a/legacy/src/app/directives/tests/test_notifications.js
+++ b/legacy/src/app/directives/tests/test_notifications.js
@@ -119,6 +119,19 @@ describe("maasNotifications", function() {
       expect(dismiss).toHaveBeenCalledWith(notification);
     });
 
+    it("dismisses all in category when dismiss all link is clicked", () => {
+      const notifications = [
+        ...exampleNotifications,
+        exampleAdditionalNotification
+      ];
+      theNotificationsManager._items = notifications;
+      const dismiss = spyOn(theNotificationsManager, "dismiss");
+      const directive = compileDirective();
+      directive.find('[data-test="dismiss-all"]').click();
+      expect(dismiss).toHaveBeenCalledWith(notifications[2]);
+      expect(dismiss).toHaveBeenCalledWith(notifications[3]);
+    });
+
     it("adjusts class according to category", function() {
       theNotificationsManager._items = exampleNotifications;
       var directive = compileDirective();
@@ -142,57 +155,18 @@ describe("maasNotifications", function() {
       ]);
     });
 
-    it("adjusts class according to number in category", function() {
-      // Get the message from a notification object.
-      var getMessage = function(ntfn) {
-        return ntfn.message;
-      };
-      // Is the notification object an "info" notification.
-      var isInfo = function(ntfn) {
-        return ntfn.category === "info";
-      };
-      // Find message texts rendered into the DOM.
-      var findRenderedMessages = function() {
-        return directive
-          .find("div > span > ul > li > p > span:nth-child(1)")
-          .map(function() {
-            return $(this).text();
-          })
-          .get();
-      };
-      // Find grouped message texts rendered into the DOM.
-      var findRenderedGroupedMessages = function() {
-        return directive
-          .find("div > div > ul > li > p > span:nth-child(1)")
-          .map(function() {
-            return $(this).text();
-          })
-          .get();
-      };
+    it("groups messages if there are two in the same category", () => {
+      theNotificationsManager._items = exampleNotifications;
+      const directive = compileDirective();
+      expect(
+        directive.find('[data-test="multiple-notifications"]').length
+      ).toBe(0);
 
-      theNotificationsManager._items = angular.copy(exampleNotifications);
-      var directive = compileDirective();
-
-      // At first there is only one message per category.
-      var messagesExpected1 = exampleNotifications.map(getMessage);
-      expect(findRenderedMessages()).toEqual(messagesExpected1);
-
-      // Now we add an additional "info" message.
       theNotificationsManager._items.push(exampleAdditionalNotification);
       $scope.$digest();
-
-      // A category title can now be found at the point where we
-      // previously found the "info" message.
-      var messagesExpected2 = angular.copy(messagesExpected1);
-      messagesExpected2.splice(messagesExpected2.length - 1, 1);
-      expect(findRenderedMessages()).toEqual(messagesExpected2);
-
-      // The "info" messages are now grouped.
-      var groupedMessagesExpected = exampleNotifications
-        .filter(isInfo)
-        .map(getMessage)
-        .concat([exampleAdditionalNotification.message]);
-      expect(findRenderedGroupedMessages()).toEqual(groupedMessagesExpected);
+      expect(
+        directive.find('[data-test="multiple-notifications"]').length
+      ).toBe(1);
     });
 
     it("sanitizes messages", function() {

--- a/legacy/src/app/partials/nodelist/notifications.html
+++ b/legacy/src/app/partials/nodelist/notifications.html
@@ -1,0 +1,69 @@
+<div
+  ng-init="notifications = categoryNotifications[category]"
+  ng-repeat="category in categories"
+>
+  <span
+    class="row"
+    data-test="single-notification"
+    ng-if="notifications.length == 1"
+  >
+    <ul class="p-list" ng-class="{ 'is-open' : shown }">
+      <li
+        class="p-notification"
+        ng-class="categoryClasses[notification.category]"
+        ng-repeat="notification in notifications"
+      >
+        <p class="p-notification__response">
+          <span ng-bind-html="notification.message"></span>
+          <a class="p-notification__action" ng-click="dismiss(notification)">
+            Dismiss
+          </a>
+        </p>
+      </li>
+    </ul>
+  </span>
+  <div
+    class="row p-notification--group"
+    data-test="multiple-notifications"
+    ng-if="notifications.length >= 2"
+    ng-init="shown = false"
+  >
+    <div ng-class="categoryClasses[notifications[0].category]">
+      <div class="p-notification__toggle">
+        <p class="p-notification__response">
+          <a
+            aria-label="{$ notifications.length $} {$ categoryTitles[category] $}, click to open messages."
+            maas-enter="shown = !shown"
+            ng-click="shown = !shown"
+          >
+            <span
+              class="p-notification__status"
+              count="{$ notifications.length $}"
+              ng-bind="notifications.length + ' ' + categoryTitles[category]"
+            ></span>
+            <small>
+              <i ng-class="{ 'p-icon--expand': !shown, 'p-icon--collapse': shown }"></i>
+            </small>
+          </a>&nbsp;&nbsp;
+          <a data-test="dismiss-all" ng-click="dismissCategory(category)">Dismiss all</a>
+        </p>
+      </div>
+      <ul
+        class="p-list--divided u-no-margin--bottom"
+        ng-if="shown"
+      >
+        <li class="p-list__item" ng-repeat="notification in notifications">
+          <p class="p-notification__response">
+            <span ng-bind-html="notification.message"></span>&nbsp;&nbsp;
+            <a
+              class="p-notification__action"
+              ng-click="dismiss(notification)"
+            >
+              Dismiss
+            </a>
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -447,11 +447,6 @@
                         {$ tabs[tab].actionProgress.completed $} of {$ tabs[tab].actionProgress.total $}
                         nodes are transitioning to {$ tabs[tab].actionOption.sentence $}.
                     </p>
-                    <div class="p-notification--negative" data-ng-repeat="(error, machines) in tabs[tab].actionProgress.errors">
-                        <p class="p-notification__response">
-                            {$ getHardwareTestErrorText(error, tab) $}
-                        </p>
-                    </div>
                 </div>
             </section>
         </div>


### PR DESCRIPTION
## Done
- Create notifications for each error when multiple machines have actions performed on them, instead of having them (very) temporarily displayed in the transition dropdown.
- Moved the notifications template to its own partial.
- Added a "Dismiss all" link to notification groups, which dismisses all notifications of a particular category (error, warning, info).

## QA
- Select multiple machines and perform an ILLEGAL ACTION on them (on karura there are a bunch of broken machines - try to mark them as fixed)
- Check that you get an error notification for each failure
- Check that you can dismiss notifications individually
- Check that "Dismiss all" works properly

## Fixes
Fixes #647 

## Launchpad Issue
lp#1859426
