### PR TITLE
LP: #1859630 - Fix invalid markup and styling in ipranges partial.

### DIFF
--- a/legacy/src/app/partials/ipranges.html
+++ b/legacy/src/app/partials/ipranges.html
@@ -10,34 +10,32 @@
 </div>
 
 <div class="row">
-    <table class="p-table-expanding">
+    <table class="p-table--ipranges p-table-expanding">
         <thead>
             <tr>
-                <th class="col-2">Start IP Address</th>
-                <th class="col-2">End IP Address</th>
-                <th class="col-1">Owner</th>
-                <th class="col-1">Type</th>
-                <th class="col-3">Comment</th>
-                <th class="col-3">
-                    <span class="u-float--right">Actions</span>
-                </th>
+                <th>Start IP Address</th>
+                <th>End IP Address</th>
+                <th>Owner</th>
+                <th>Type</th>
+                <th>Comment</th>
+                <th class="u-align--right">Actions</th>
             </tr>
         </thead>
         <tbody>
             <tr data-ng-repeat="iprange in (subnetIPRanges = ipranges | filterBySubnetOrVlan:subnet:vlan) | orderBy:ipRangeSort"
                 data-ng-class="{ 'is-active': isIPRangeInEditMode(iprange) || isIPRangeInDeleteMode(iprange)}">
-                <td class="col-2" aria-label="Start IP Address">{$ iprange.start_ip $}</td>
-                <td class="col-2" aria-label="End IP Address">{$ iprange.end_ip $}</td>
-                <td class="col-1" aria-label="Owner">{$ iprange.type == "dynamic" ? "MAAS" : iprange.user $}</td>
-                <td class="col-1" aria-label="Type">{$ iprange.type == "dynamic" ? "Dynamic" : "Reserved" $}</td>
-                <td class="col-3" aria-label="Comment">{$ iprange.type == "dynamic" ? "Dynamic" : iprange.comment $}</td>
-                <td class="col-3">
+                <td aria-label="Start IP Address">{$ iprange.start_ip $}</td>
+                <td aria-label="End IP Address">{$ iprange.end_ip $}</td>
+                <td aria-label="Owner">{$ iprange.type == "dynamic" ? "MAAS" : iprange.user $}</td>
+                <td aria-label="Type">{$ iprange.type == "dynamic" ? "Dynamic" : "Reserved" $}</td>
+                <td aria-label="Comment">{$ iprange.type == "dynamic" ? "Dynamic" : iprange.comment $}</td>
+                <td>
                     <div class="u-align--right" data-ng-if="!isIPRangeInDeleteMode(iprange) && !isIPRangeInEditMode(iprange)">
-                        <button class="p-button--base is-small u-no-padding--top u-no-padding--bottom" aria-label="Edit reserved range"
+                        <button class="p-button--base p-button--icon" aria-label="Edit reserved range"
                             data-ng-click="toggleMenu(); ipRangeToggleEditMode(iprange)">
                             <i class="p-icon--edit">Edit</i>
                         </button>
-                        <button class="p-button--base is-small u-no-padding--top u-no-padding--bottom" aria-label="Remove range"
+                        <button class="p-button--base p-button--icon" aria-label="Remove range"
                             data-ng-click="toggleMenu(); ipRangeEnterDeleteMode(iprange)">
                             <i class="p-icon--delete">Remove</i>
                         </button>
@@ -77,11 +75,9 @@
                             </div>
                         </div>
                         <div class="row" data-ng-if="iprange.type === 'dynamic'">
-                            <div class="p-form__group">
-                                <label class="col-2 col-medium-2 p-form__group-label" for="purpose">Purpose</label>
-                                <div class="p-form__group-input col-4 col-medium-3">
-                                    <input type="text" id="purpose" value="Dynamic" disabled>
-                                </div>
+                            <label class="col-2 col-medium-2 p-form__group-label" for="purpose">Purpose</label>
+                            <div class="p-form__group-input col-4 col-medium-3">
+                                <input type="text" id="purpose" value="Dynamic" disabled>
                             </div>
                         </div>
                         <div class="row u-no-margin--top">
@@ -91,14 +87,12 @@
                             <div class="col-6">
                                 <maas-obj-errors></maas-obj-errors>
                             </div>
-                            <div class="col-6">
-                                <span class="u-float--right">
-                                    <button class="p-button--base" type="button" data-ng-click="ipRangeToggleEditMode(iprange)">Cancel</button>
-                                    <button class="p-button--positive u-no-margin--top" maas-obj-save>Save</button>
-                                </span>
+                            <div class="col-6 u-align--right">
+                                <button class="p-button--base" type="button" data-ng-click="ipRangeToggleEditMode(iprange)">Cancel</button>
+                                <button class="p-button--positive u-no-margin--top" maas-obj-save>Save</button>
                             </div>
-                        </maas-obj-form>
-                    </div>
+                        </div>
+                    </maas-obj-form>
                 </td>
             </tr>
             <tr data-ng-if="subnetIPRanges.length === 0 && !newRange">
@@ -136,11 +130,9 @@
                             <div class="col-6">
                                 <maas-obj-errors></maas-obj-errors>
                             </div>
-                            <div class="col-6">
-                                <div class="u-align--right">
-                                    <button class="p-button--base" type="button" data-ng-click="cancelAddRange()">Cancel</button>
-                                    <button class="p-button--positive u-no-margin--top" maas-obj-save>Reserve</button>
-                                </div>
+                            <div class="col-6 u-align--right">
+                                <button class="p-button--base" type="button" data-ng-click="cancelAddRange()">Cancel</button>
+                                <button class="p-button--positive u-no-margin--top" maas-obj-save>Reserve</button>
                             </div>
                         </div>
                     </maas-obj-form>

--- a/legacy/src/scss/_patterns_button.scss
+++ b/legacy/src/scss/_patterns_button.scss
@@ -34,12 +34,8 @@ $vanilla-2-icon-button-side-padding: $sph-inner--small * 1.5;
   }
 
   .p-button--icon {
-    input + & {
-      margin-left: $sph-outer;
-    }
-
-    @extend %p-button--min-margin-bottom;
-    padding: $spv-inner--small $sph-inner--small;
+    margin: 0 !important;
+    padding: 0 #{$sph-inner--small / 2} !important;
   }
 
   .p-button--close {

--- a/legacy/src/scss/_tables.scss
+++ b/legacy/src/scss/_tables.scss
@@ -7,6 +7,7 @@
 @import "tables/patterns_table-expanding";
 @import "tables/patters_table-fabrics";
 @import "tables/patterns_table-images";
+@import "tables/patterns_table-ipranges";
 @import "tables/patterns_table-machines";
 @import "tables/patterns_table-network-discovery";
 @import "tables/patterns_table-network-summary";
@@ -29,6 +30,7 @@
 @include maas-table-expanding;
 @include maas-table-fabrics;
 @include maas-table-images;
+@include maas-table-ipranges;
 @include maas-table-machines;
 @include maas-table-network-discovery;
 @include maas-table-network-summary;

--- a/legacy/src/scss/tables/_patterns_table-ipranges.scss
+++ b/legacy/src/scss/tables/_patterns_table-ipranges.scss
@@ -1,0 +1,37 @@
+@mixin maas-table-ipranges {
+  .p-table--ipranges {
+    th:nth-child(1),
+    td:nth-child(1) {
+      width: 25%;
+    }
+
+    th:nth-child(2),
+    td:nth-child(2) {
+      width: 25%;
+    }
+
+    th:nth-child(3),
+    td:nth-child(3) {
+      width: 13%;
+    }
+
+    th:nth-child(4),
+    td:nth-child(4) {
+      width: 13%;
+    }
+
+    th:nth-child(5),
+    td:nth-child(5) {
+      width: 12%;
+    }
+
+    th:nth-child(6),
+    td:nth-child(6) {
+      width: 12%;
+    }
+
+    .p-table-expanding__panel {
+      width: 100%;
+    }
+  }
+}


### PR DESCRIPTION
## Done
- Fixed invalid markup in ipranges partial. In development the markup was automagically fixed, but not when running the built files.
- Minor styling fixes (column widths, align buttons right, align form fields)

## QA
- Go to the Subnets page and choose a VLAN that has less than 100% available IPs
- Add a valid reserved range (dynamic or not) and see that it gets added properly
- Check that the add and edit forms no longer want you to gouge your eyes out

## Fixes
Fixes #656 

## Launchpad Issue
lp#1859630

## Screenshot
![0 0 0 0_8400_MAAS_ (6)](https://user-images.githubusercontent.com/25733845/72538815-a98f5880-387e-11ea-8738-30ddfcf2277c.png)

