### PR TITLE
Remove warning icon and tooltip if no tests have been run.

### DIFF
--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
@@ -7,7 +7,6 @@ import Tooltip from "app/base/components/Tooltip";
 const ScriptStatus = ({
   children,
   hidePassedIcon = false,
-  hideNotRunIcon = false,
   scriptType,
   tooltipPosition
 }) => {
@@ -64,20 +63,6 @@ const ScriptStatus = ({
           <i className="p-icon--pending is-inline" />
           {children}
         </>
-      );
-    }
-
-    case scriptStatus.NONE: {
-      return hideNotRunIcon ? (
-        children
-      ) : (
-        <Tooltip
-          message="Machine has not run any tests of this type."
-          position={tooltipPosition}
-        >
-          <i className="p-icon--warning is-inline" />
-          {children}
-        </Tooltip>
       );
     }
 

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.js
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.js
@@ -33,16 +33,6 @@ describe("ScriptStatus ", () => {
     expect(wrapper.find(".p-icon--success").exists()).toBe(false);
   });
 
-  it(`does not display an icon if no scripts have run and
-    and hideNotRunIcon is true`, () => {
-    const wrapper = shallow(
-      <ScriptStatus hideNotRunIcon scriptType={{ status: scriptStatus.NONE }}>
-        Tests have not run.
-      </ScriptStatus>
-    );
-    expect(wrapper.find(".p-icon--warning").exists()).toBe(false);
-  });
-
   it("displays an error icon and tooltip if scripts have failed", () => {
     const wrapper = shallow(
       <ScriptStatus scriptType={{ status: scriptStatus.FAILED }}>
@@ -79,15 +69,5 @@ describe("ScriptStatus ", () => {
       </ScriptStatus>
     );
     expect(wrapper.find(".p-icon--running").exists()).toBe(true);
-  });
-
-  it("displays a warning icon and tooltip if scripts have not been run", () => {
-    const wrapper = shallow(
-      <ScriptStatus scriptType={{ status: scriptStatus.NONE }}>
-        Some or all tests are running
-      </ScriptStatus>
-    );
-    expect(wrapper.find(".p-icon--warning").exists()).toBe(true);
-    expect(wrapper.find("Tooltip").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
@@ -20,7 +20,6 @@ const CoresColumn = ({ systemId }) => {
         <ScriptStatus
           data-test="cores"
           hidePassedIcon
-          hideNotRunIcon
           scriptType={machine.cpu_test_status}
           tooltipPosition="top-right"
         >

--- a/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
@@ -13,7 +13,6 @@ exports[`CoresColumn renders 1`] = `
     >
       <ScriptStatus
         data-test="cores"
-        hideNotRunIcon={true}
         hidePassedIcon={true}
         scriptType={
           Object {


### PR DESCRIPTION
## Done
- Removed the warning icon and tooltip for the None case

## QA
- See there are no warning icons in the new machine list for machines that have not run tests

## Fixes
Fixes #665 
