### PR TITLE
Add status column to new machine listing.

### DIFF
--- a/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
@@ -16,7 +16,7 @@ const CoresColumn = ({ systemId }) => {
 
   return (
     <div className="p-double-row u-align--right">
-      <div className="p-double-row__primary-row" aria-label="Cores">
+      <div className="p-double-row__primary-row u-truncate" aria-label="Cores">
         <ScriptStatus
           data-test="cores"
           hidePassedIcon
@@ -27,7 +27,7 @@ const CoresColumn = ({ systemId }) => {
         </ScriptStatus>
       </div>
       <div
-        className="p-double-row__secondary-row u-truncate-text"
+        className="p-double-row__secondary-row u-truncate"
         aria-label="Architecture"
       >
         <Tooltip position="btm-left" message={machine.architecture}>

--- a/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
@@ -9,7 +9,7 @@ exports[`CoresColumn renders 1`] = `
   >
     <div
       aria-label="Cores"
-      className="p-double-row__primary-row"
+      className="p-double-row__primary-row u-truncate"
     >
       <ScriptStatus
         data-test="cores"
@@ -29,7 +29,7 @@ exports[`CoresColumn renders 1`] = `
     </div>
     <div
       aria-label="Architecture"
-      className="p-double-row__secondary-row u-truncate-text"
+      className="p-double-row__secondary-row u-truncate"
     >
       <Tooltip
         message="amd64/generic"

--- a/ui/src/app/machines/views/MachineList/DisksColumn/DisksColumn.js
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/DisksColumn.js
@@ -12,7 +12,7 @@ const DisksColumn = ({ systemId }) => {
 
   return (
     <div className="p-double-row">
-      <div className="p-double-row__primary-row u-align--right">
+      <div className="p-double-row__primary-row u-align--right u-truncate">
         <ScriptStatus
           data-test="disks"
           hidePassedIcon

--- a/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
@@ -8,7 +8,7 @@ exports[`DisksColumn renders 1`] = `
     className="p-double-row"
   >
     <div
-      className="p-double-row__primary-row u-align--right"
+      className="p-double-row__primary-row u-align--right u-truncate"
     >
       <ScriptStatus
         data-test="disks"

--- a/ui/src/app/machines/views/MachineList/FabricColumn/FabricColumn.js
+++ b/ui/src/app/machines/views/MachineList/FabricColumn/FabricColumn.js
@@ -16,7 +16,7 @@ const FabricColumn = ({ systemId }) => {
 
   return (
     <div className="p-double-row">
-      <div className="p-double-row__primary-row" aria-label="Fabric">
+      <div className="p-double-row__primary-row u-truncate" aria-label="Fabric">
         <ScriptStatus
           data-test="fabric"
           hidePassedIcon
@@ -27,10 +27,7 @@ const FabricColumn = ({ systemId }) => {
           {fabric}
         </ScriptStatus>
       </div>
-      <div
-        className="p-double-row__secondary-row u-truncate-text"
-        aria-label="VLAN"
-      >
+      <div className="p-double-row__secondary-row u-truncate" aria-label="VLAN">
         <span data-test="vlan">{vlan}</span>
       </div>
     </div>

--- a/ui/src/app/machines/views/MachineList/FabricColumn/__snapshots__/FabricColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/FabricColumn/__snapshots__/FabricColumn.test.js.snap
@@ -9,7 +9,7 @@ exports[`FabricColumn renders 1`] = `
   >
     <div
       aria-label="Fabric"
-      className="p-double-row__primary-row"
+      className="p-double-row__primary-row u-truncate"
     >
       <ScriptStatus
         data-test="fabric"
@@ -30,7 +30,7 @@ exports[`FabricColumn renders 1`] = `
     </div>
     <div
       aria-label="VLAN"
-      className="p-double-row__secondary-row u-truncate-text"
+      className="p-double-row__secondary-row u-truncate"
     >
       <span
         data-test="vlan"

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -32,6 +32,7 @@ import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
 import PoolColumn from "./PoolColumn";
 import PowerColumn from "./PowerColumn";
+import StatusColumn from "./StatusColumn";
 import ZoneColumn from "./ZoneColumn";
 
 const normaliseStatus = (statusCode, status) => {
@@ -136,7 +137,7 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
           content: <PowerColumn systemId={row.system_id} />
         },
         {
-          content: row.status
+          content: <StatusColumn systemId={row.system_id} />
         },
         {
           content: <OwnerColumn systemId={row.system_id} />
@@ -274,7 +275,9 @@ const MachineList = () => {
                 sortKey: "power_state"
               },
               {
-                content: "Status",
+                content: (
+                  <span className="p-double-row__icon-space">Status</span>
+                ),
                 sortKey: "normalisedStatus"
               },
               {

--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -22,4 +22,9 @@ $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spaci
   &:nth-child(1) {
     width: 20%;
   }
+
+  // Status:
+  &:nth-child(3) {
+    width: 20%;
+  }
 }

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import MachineList from "./MachineList";
+import { nodeStatus, scriptStatus } from "app/base/enum";
 
 const mockStore = configureStore();
 
@@ -15,6 +16,17 @@ describe("MachineList", () => {
       config: {
         items: []
       },
+      general: {
+        osInfo: {
+          data: {
+            osystems: [["ubuntu", "Ubuntu"]],
+            releases: [["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"']]
+          },
+          errors: {},
+          loaded: true,
+          loading: false
+        }
+      },
       machine: {
         errors: {},
         loading: false,
@@ -22,26 +34,33 @@ describe("MachineList", () => {
         items: [
           {
             architecture: "amd64/generic",
+            cpu_count: 4,
+            cpu_test_status: {
+              status: scriptStatus.RUNNING
+            },
+            distro_series: "bionic",
             domain: {
               name: "example"
             },
-            cpu_count: 4,
             extra_macs: [],
             hostname: "koala",
             ip_addresses: [],
             network_test_status: {
-              status: 2
+              status: scriptStatus.PASSED
             },
+            osystem: "ubuntu",
             physical_disk_count: 1,
             pool: {},
             pxe_mac: "00:11:22:33:44:55",
             spaces: [],
             status: "Releasing",
-            cpu_test_status: {
-              status: 1
-            },
+            status_code: nodeStatus.RELEASING,
+            status_message: "",
             storage_test_status: {
-              status: 2
+              status: scriptStatus.PASSED
+            },
+            testing_status: {
+              status: scriptStatus.PASSED
             },
             system_id: "abc123",
             zone: {}

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
@@ -63,22 +63,26 @@ const generateFQDN = (machine, machineURL) => {
 
   return (
     <div className="p-double-row">
-      <div className="p-double-row__primary-row">{name}</div>
-      <div className="p-double-row__secondary-row">{ipAddressesLine}</div>
+      <div className="p-double-row__primary-row u-truncate">{name}</div>
+      <div className="p-double-row__secondary-row u-truncate">
+        {ipAddressesLine}
+      </div>
     </div>
   );
 };
 
 const generateMAC = (machine, machineURL) => {
   return (
-    <>
-      <a href={machineURL} title={machine.pxe_mac_vendor}>
-        {machine.pxe_mac}
-      </a>{" "}
-      {machine.extra_macs && machine.extra_macs.length > 0 ? (
-        <a href={machineURL}>(+{machine.extra_macs.length})</a>
-      ) : null}
-    </>
+    <div className="p-double-row">
+      <div className="p-doouble-row__primary-row u-truncate">
+        <a href={machineURL} title={machine.pxe_mac_vendor}>
+          {machine.pxe_mac}
+        </a>{" "}
+        {machine.extra_macs && machine.extra_macs.length > 0 ? (
+          <a href={machineURL}>(+{machine.extra_macs.length})</a>
+        ) : null}
+      </div>
+    </div>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -14,10 +14,10 @@ const OwnerColumn = ({ systemId }) => {
 
   return (
     <div className="p-double-row">
-      <div className="p-double-row__primary-row">
+      <div className="p-double-row__primary-row u-truncate">
         <span data-test="owner">{owner}</span>
       </div>
-      <div className="p-double-row__secondary-row u-truncate-text">
+      <div className="p-double-row__secondary-row u-truncate">
         <span title={tags} data-test="tags">
           {tags}
         </span>

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -8,7 +8,7 @@ exports[`OwnerColumn renders 1`] = `
     className="p-double-row"
   >
     <div
-      className="p-double-row__primary-row"
+      className="p-double-row__primary-row u-truncate"
     >
       <span
         data-test="owner"
@@ -17,7 +17,7 @@ exports[`OwnerColumn renders 1`] = `
       </span>
     </div>
     <div
-      className="p-double-row__secondary-row u-truncate-text"
+      className="p-double-row__secondary-row u-truncate"
     >
       <span
         data-test="tags"

--- a/ui/src/app/machines/views/MachineList/PoolColumn/PoolColumn.js
+++ b/ui/src/app/machines/views/MachineList/PoolColumn/PoolColumn.js
@@ -10,23 +10,20 @@ const PoolColumn = ({ systemId }) => {
   );
 
   return (
-    <>
-      <div className="p-double-row__primary-row" aria-label="Pool">
+    <div className="p-double-row">
+      <div className="p-double-row__primary-row u-truncate" aria-label="Pool">
         <span data-test="pool">
           <a className="p-link--soft" href="#/pools" title={machine.pool.name}>
             {machine.pool.name}
           </a>
         </span>
       </div>
-      <div
-        className="p-double-row__secondary-row u-truncate-text"
-        aria-label="Note"
-      >
+      <div className="p-double-row__secondary-row u-truncate" aria-label="Note">
         <span title={machine.description} data-test="note">
           {machine.description}
         </span>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -5,31 +5,35 @@ exports[`PoolColumn renders 1`] = `
   systemId="abc123"
 >
   <div
-    aria-label="Pool"
-    className="p-double-row__primary-row"
+    className="p-double-row"
   >
-    <span
-      data-test="pool"
+    <div
+      aria-label="Pool"
+      className="p-double-row__primary-row u-truncate"
     >
-      <a
-        className="p-link--soft"
-        href="#/pools"
-        title="default"
+      <span
+        data-test="pool"
       >
-        default
-      </a>
-    </span>
-  </div>
-  <div
-    aria-label="Note"
-    className="p-double-row__secondary-row u-truncate-text"
-  >
-    <span
-      data-test="note"
-      title="Firmware old"
+        <a
+          className="p-link--soft"
+          href="#/pools"
+          title="default"
+        >
+          default
+        </a>
+      </span>
+    </div>
+    <div
+      aria-label="Note"
+      className="p-double-row__secondary-row u-truncate"
     >
-      Firmware old
-    </span>
+      <span
+        data-test="note"
+        title="Firmware old"
+      >
+        Firmware old
+      </span>
+    </div>
   </div>
 </PoolColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -22,10 +22,10 @@ const PowerColumn = ({ systemId }) => {
       <div className="p-double-row__icon">
         <i title={machine.power_state} className={iconClass}></i>
       </div>
-      <div className="p-double-row__primary-row u-upper-case--first">
+      <div className="p-double-row__primary-row u-upper-case--first u-truncate">
         <span data-test="power_state">{machine.power_state}</span>
       </div>
-      <div className="p-double-row__secondary-row u-upper-case--first u-truncate-text">
+      <div className="p-double-row__secondary-row u-upper-case--first u-truncate">
         <span title={machine.power_type} data-test="power_type">
           {machine.power_type}
         </span>

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -16,7 +16,7 @@ exports[`PowerColumn renders 1`] = `
       />
     </div>
     <div
-      className="p-double-row__primary-row u-upper-case--first"
+      className="p-double-row__primary-row u-upper-case--first u-truncate"
     >
       <span
         data-test="power_state"
@@ -25,7 +25,7 @@ exports[`PowerColumn renders 1`] = `
       </span>
     </div>
     <div
-      className="p-double-row__secondary-row u-upper-case--first u-truncate-text"
+      className="p-double-row__secondary-row u-upper-case--first u-truncate"
     >
       <span
         data-test="power_type"

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
@@ -1,0 +1,131 @@
+import { useSelector } from "react-redux";
+import React from "react";
+import PropTypes from "prop-types";
+
+import {
+  general as generalSelectors,
+  machine as machineSelectors
+} from "app/base/selectors";
+import { nodeStatus, scriptStatus } from "app/base/enum";
+import Tooltip from "app/base/components/Tooltip";
+
+// Node statuses for which the failed test warning is not shown.
+const hideFailedTestWarningStatuses = [
+  nodeStatus.COMMISSIONING,
+  nodeStatus.FAILED_COMMISSIONING,
+  nodeStatus.FAILED_TESTING,
+  nodeStatus.NEW,
+  nodeStatus.TESTING
+];
+
+// Node statuses for which the OS + release is made human-readable.
+const formattedReleaseStatuses = [nodeStatus.DEPLOYED, nodeStatus.DEPLOYING];
+
+// Node statuses that are temporary.
+const transientStatuses = [
+  nodeStatus.COMMISSIONING,
+  nodeStatus.DEPLOYING,
+  nodeStatus.DISK_ERASING,
+  nodeStatus.ENTERING_RESCUE_MODE,
+  nodeStatus.EXITING_RESCUE_MODE,
+  nodeStatus.RELEASING,
+  nodeStatus.TESTING
+];
+
+// Script statuses associated with failure.
+const failedScriptStatuses = [
+  scriptStatus.DEGRADED,
+  scriptStatus.FAILED,
+  scriptStatus.FAILED_APPLYING_NETCONF,
+  scriptStatus.FAILED_INSTALLING,
+  scriptStatus.TIMEDOUT
+];
+
+const getStatusText = (machine, osReleases) => {
+  if (formattedReleaseStatuses.includes(machine.status_code)) {
+    const machineRelease = osReleases.find(
+      release => release.value === machine.distro_series
+    );
+
+    if (machineRelease) {
+      let releaseTitle;
+      if (machine.osystem === "ubuntu") {
+        releaseTitle = machineRelease.label.split('"')[0].trim();
+      } else {
+        releaseTitle = machineRelease.label;
+      }
+
+      if (machine.status_code === nodeStatus.DEPLOYING) {
+        return `Deploying ${releaseTitle}`;
+      }
+      return releaseTitle;
+    }
+  }
+  return machine.status;
+};
+
+const getProgressText = machine => {
+  if (transientStatuses.includes(machine.status_code)) {
+    return machine.status_message;
+  }
+  return "";
+};
+
+const getStatusIcon = machine => {
+  if (transientStatuses.includes(machine.status_code)) {
+    return (
+      <i
+        className="p-icon--spinner u-animation--spin"
+        data-test="status-icon"
+      />
+    );
+  } else if (
+    failedScriptStatuses.includes(machine.testing_status.status) &&
+    !hideFailedTestWarningStatuses.includes(machine.status_code)
+  ) {
+    return (
+      <Tooltip
+        message="Machine has failed tests; use with caution."
+        position="top-left"
+      >
+        <i className="p-icon--warning" data-test="status-icon" />
+      </Tooltip>
+    );
+  }
+  return "";
+};
+
+const StatusColumn = ({ systemId }) => {
+  const machine = useSelector(state =>
+    machineSelectors.getBySystemId(state, systemId)
+  );
+  const osReleases = useSelector(state =>
+    generalSelectors.osInfo.getOsReleases(state, machine.osystem)
+  );
+
+  return (
+    <div className="p-double-row--with-icon">
+      <div className="p-double-row__icon">{getStatusIcon(machine)}</div>
+      <div
+        className="p-double-row__primary-row u-truncate-text"
+        data-test="status-text"
+        title={getStatusText(machine, osReleases)}
+      >
+        {getStatusText(machine, osReleases)}
+      </div>
+      <div
+        className="p-double-row__secondary-row u-truncate-text"
+        data-test="progress-text"
+        title={getProgressText(machine)}
+      >
+        {getProgressText(machine)}
+      </div>
+    </div>
+  );
+};
+
+StatusColumn.propTypes = {
+  systemId: PropTypes.string.isRequired
+};
+
+export default StatusColumn;

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
@@ -1,3 +1,4 @@
+import { Loader } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import React from "react";
 import PropTypes from "prop-types";
@@ -74,9 +75,10 @@ const getProgressText = machine => {
 const getStatusIcon = machine => {
   if (transientStatuses.includes(machine.status_code)) {
     return (
-      <i
-        className="p-icon--spinner u-animation--spin"
+      <Loader
+        className="u-no-margin u-no-padding"
         data-test="status-icon"
+        inline
       />
     );
   } else if (
@@ -107,14 +109,14 @@ const StatusColumn = ({ systemId }) => {
     <div className="p-double-row--with-icon">
       <div className="p-double-row__icon">{getStatusIcon(machine)}</div>
       <div
-        className="p-double-row__primary-row u-truncate-text"
+        className="p-double-row__primary-row u-truncate"
         data-test="status-text"
         title={getStatusText(machine, osReleases)}
       >
         {getStatusText(machine, osReleases)}
       </div>
       <div
-        className="p-double-row__secondary-row u-truncate-text"
+        className="p-double-row__secondary-row u-truncate"
         data-test="progress-text"
         title={getProgressText(machine)}
       >

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.test.js
@@ -1,0 +1,228 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import { nodeStatus, scriptStatus } from "app/base/enum";
+import StatusColumn from "./StatusColumn";
+
+const mockStore = configureStore();
+
+describe("StatusColumn", () => {
+  let state;
+  beforeEach(() => {
+    state = {
+      general: {
+        osInfo: {
+          data: {
+            osystems: [
+              ["centos", "CentOS"],
+              ["ubuntu", "Ubuntu"]
+            ],
+            releases: [
+              ["centos/centos70", "CentOS 7"],
+              ["ubuntu/xenial", 'Ubuntu 16.04 LTS "Xenial Xerus"'],
+              ["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"']
+            ]
+          },
+          errors: {},
+          loaded: true,
+          loading: false
+        }
+      },
+      machine: {
+        items: [
+          {
+            distro_series: "bionic",
+            osystem: "ubuntu",
+            status: "New",
+            status_code: 0,
+            status_message: "",
+            testing_status: {
+              status: scriptStatus.NONE
+            },
+            system_id: "abc123"
+          }
+        ],
+        errors: {},
+        loaded: true,
+        loading: false
+      }
+    };
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("StatusColumn")).toMatchSnapshot();
+  });
+
+  describe("status text", () => {
+    it("displays the machine's status if not deploying or deployed", () => {
+      state.machine.items[0].status = "New";
+      state.machine.items[0].status_code = nodeStatus.NEW;
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-text']").text()).toBe("New");
+    });
+
+    it("displays the short-form of Ubuntu release if deployed", () => {
+      state.machine.items[0].status = "Deployed";
+      state.machine.items[0].status_code = nodeStatus.DEPLOYED;
+      state.machine.items[0].osystem = "ubuntu";
+      state.machine.items[0].distro_series = "bionic";
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-text']").text()).toBe(
+        "Ubuntu 18.04 LTS"
+      );
+    });
+
+    it("displays the full OS and release if non-Ubuntu deployed", () => {
+      state.machine.items[0].status = "Deployed";
+      state.machine.items[0].status_code = nodeStatus.DEPLOYED;
+      state.machine.items[0].osystem = "centos";
+      state.machine.items[0].distro_series = "centos70";
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-text']").text()).toBe("CentOS 7");
+    });
+
+    it("displays 'Deploying OS release' if machine is deploying", () => {
+      state.machine.items[0].status = "Deploying";
+      state.machine.items[0].status_code = nodeStatus.DEPLOYING;
+      state.machine.items[0].osystem = "ubuntu";
+      state.machine.items[0].distro_series = "bionic";
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-text']").text()).toBe(
+        "Deploying Ubuntu 18.04 LTS"
+      );
+    });
+  });
+
+  describe("progress text", () => {
+    it("displays the machine's status_message if in a transient state", () => {
+      state.machine.items[0].status = "Testing";
+      state.machine.items[0].status_code = nodeStatus.TESTING;
+      state.machine.items[0].status_message = "2 of 6 tests complete";
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='progress-text']").text()).toBe(
+        "2 of 6 tests complete"
+      );
+    });
+
+    it(`does not display the machine's status_message if
+      not in a transient state`, () => {
+      state.machine.items[0].status = "Allocated";
+      state.machine.items[0].status_code = nodeStatus.ALLOCATED;
+      state.machine.items[0].status_message = "This machine is allocated";
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='progress-text']").text()).toBe("");
+    });
+  });
+
+  describe("status icon", () => {
+    it("shows a spinner if machine is in a transient state", () => {
+      state.machine.items[0].status = "Commissioning";
+      state.machine.items[0].status_code = nodeStatus.COMMISSIONING;
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find(".p-icon--spinner").exists()).toBe(true);
+    });
+
+    it(`shows a warning and tooltip if machine has failed tests and is not in a
+      state where the warning should be hidden`, () => {
+      state.machine.items[0].status = "Allocated";
+      state.machine.items[0].status_code = nodeStatus.ALLOCATED;
+      state.machine.items[0].testing_status.status = scriptStatus.FAILED;
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find(".p-icon--warning").exists()).toBe(true);
+      expect(wrapper.find("Tooltip").exists()).toBe(true);
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StatusColumn renders 1`] = `
+<StatusColumn
+  systemId="abc123"
+>
+  <div
+    className="p-double-row--with-icon"
+  >
+    <div
+      className="p-double-row__icon"
+    />
+    <div
+      className="p-double-row__primary-row u-truncate-text"
+      data-test="status-text"
+      title="New"
+    >
+      New
+    </div>
+    <div
+      className="p-double-row__secondary-row u-truncate-text"
+      data-test="progress-text"
+      title=""
+    />
+  </div>
+</StatusColumn>
+`;

--- a/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -11,14 +11,14 @@ exports[`StatusColumn renders 1`] = `
       className="p-double-row__icon"
     />
     <div
-      className="p-double-row__primary-row u-truncate-text"
+      className="p-double-row__primary-row u-truncate"
       data-test="status-text"
       title="New"
     >
       New
     </div>
     <div
-      className="p-double-row__secondary-row u-truncate-text"
+      className="p-double-row__secondary-row u-truncate"
       data-test="progress-text"
       title=""
     />

--- a/ui/src/app/machines/views/MachineList/StatusColumn/index.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/index.js
@@ -1,0 +1,1 @@
+export { default } from "./StatusColumn";

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
@@ -16,10 +16,10 @@ const ZoneColumn = ({ systemId }) => {
 
   return (
     <div className="p-double-row">
-      <div className="p-double-row__primary-row">
+      <div className="p-double-row__primary-row u-truncate">
         <span data-test="zone">{machine.zone.name}</span>
       </div>
-      <div className="p-double-row__secondary-row u-truncate-text">
+      <div className="p-double-row__secondary-row u-truncate">
         <span data-test="spaces">{spaces}</span>
       </div>
     </div>

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -8,7 +8,7 @@ exports[`ZoneColumn renders 1`] = `
     className="p-double-row"
   >
     <div
-      className="p-double-row__primary-row"
+      className="p-double-row__primary-row u-truncate"
     >
       <span
         data-test="zone"
@@ -17,7 +17,7 @@ exports[`ZoneColumn renders 1`] = `
       </span>
     </div>
     <div
-      className="p-double-row__secondary-row u-truncate-text"
+      className="p-double-row__secondary-row u-truncate"
     >
       <span
         data-test="spaces"

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -37,12 +37,6 @@ body {
   color: $color-mid-dark;
 }
 
-.u-truncate-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .p-modal {
   // The modal needs to be above the header nav items.
   z-index: 10;


### PR DESCRIPTION
## Done
- Added StatusColumn component that handles the logic of what shows up in the status cell.

## QA
- Check that a machine that is deployed just shows the OS + release (only the number + LTS if an Ubuntu release e.g. Ubuntu 18.04 LTS instead of Ubuntu 18.04 LTS Bionic Beaver)
- Check that a machine that is deploying shows `Deploying ${OS + release}`
- Check that if a machine has failed tests and is not new, commissioning or testing, a warning icon and tooltip shows
- Check that when a machine is in a transient state (e.g. deploying), progress text is shown below the status and a spinner shows

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1756

