### PR TITLE
Add contextual menu

### DIFF
--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -1,0 +1,145 @@
+import { Button } from "@canonical/react-components";
+import classNames from "classnames";
+import nanoid from "nanoid";
+import PropTypes from "prop-types";
+import React, { useRef } from "react";
+import usePortal from "react-useportal";
+
+const getPositionStyle = (position, wrapper) => {
+  if (!wrapper || !wrapper.current) {
+    return undefined;
+  }
+
+  const dimensions = wrapper.current.getBoundingClientRect();
+  const { x, y, height, width } = dimensions;
+  let left = x + window.scrollX || 0;
+  let top = y + window.scrollY || 0;
+  let right = "auto";
+  top += height;
+
+  switch (position) {
+    case "center":
+      left += width / 2;
+      break;
+    case "left":
+      break;
+    case "right":
+      right = (window.innerWidth || 0) - left - width;
+      left = "auto";
+      break;
+    default:
+      break;
+  }
+
+  return { position: "absolute", left, right, top };
+};
+
+const generateLink = ({ children, className, ...props }, key) => (
+  <Button
+    className={classNames("p-contextual-menu__link", className)}
+    key={key}
+    {...props}
+  >
+    {children}
+  </Button>
+);
+
+const ContextualMenu = ({
+  className,
+  hasToggleIcon,
+  links,
+  position = "right",
+  toggleAppearance,
+  toggleLabel,
+  toggleLabelFirst = true
+}) => {
+  const id = useRef(nanoid());
+  const wrapper = useRef(null);
+  const hasToggle = hasToggleIcon || toggleLabel;
+  const { openPortal, closePortal, isOpen, Portal } = usePortal({
+    isOpen: !hasToggle
+  });
+  const positionStyle = getPositionStyle(position, wrapper);
+  const labelNode = toggleLabel ? <span>{toggleLabel}</span> : null;
+  const wrapperClass = classNames(
+    className,
+    ["p-contextual-menu", position === "right" ? null : position]
+      .filter(Boolean)
+      .join("--")
+  );
+  return (
+    <span className={wrapperClass} ref={wrapper}>
+      {hasToggle ? (
+        <Button
+          appearance={toggleAppearance}
+          aria-controls={id.current}
+          aria-expanded={isOpen ? "true" : "false"}
+          aria-haspopup="true"
+          className="p-contextual-menu__toggle"
+          hasIcon={hasToggleIcon}
+          onClick={evt => {
+            if (!isOpen) {
+              openPortal(evt);
+            } else {
+              closePortal(evt);
+            }
+          }}
+        >
+          {toggleLabelFirst ? labelNode : null}
+          {hasToggleIcon ? (
+            <i className="p-icon--contextual-menu p-contextual-menu__indicator"></i>
+          ) : null}
+          {toggleLabelFirst ? null : labelNode}
+        </Button>
+      ) : null}
+      {isOpen && (
+        <Portal>
+          <span className={wrapperClass} style={positionStyle}>
+            <span
+              className="p-contextual-menu__dropdown"
+              id={id.current}
+              aria-hidden={isOpen ? "false" : "true"}
+              aria-label="submenu"
+            >
+              {links.map((item, i) => {
+                if (Array.isArray(item)) {
+                  return (
+                    <span className="p-contextual-menu__group" key={i}>
+                      {item.map(generateLink)}
+                    </span>
+                  );
+                }
+                if (typeof item === "string") {
+                  return (
+                    <div className="p-contextual-menu__non-interactive" key={i}>
+                      {item}
+                    </div>
+                  );
+                }
+                return generateLink(item, i);
+              })}
+            </span>
+          </span>
+        </Portal>
+      )}
+    </span>
+  );
+};
+
+ContextualMenu.propTypes = {
+  className: PropTypes.string,
+  hasToggleIcon: PropTypes.bool,
+  links: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape(Button.propTypes),
+      PropTypes.arrayOf(PropTypes.shape(Button.propTypes))
+    ])
+  ).isRequired,
+  position: PropTypes.oneOf(["left", "center", "right"]),
+  toggleAppearance: PropTypes.string,
+  toggleLabel: PropTypes.string,
+  toggleLabelFirst: PropTypes.bool
+};
+
+export default ContextualMenu;

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.test.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.test.js
@@ -1,0 +1,162 @@
+import { mount } from "enzyme";
+import React from "react";
+
+import ContextualMenu from "./ContextualMenu";
+
+describe("ContextualMenu ", () => {
+  it("renders", () => {
+    const wrapper = mount(<ContextualMenu links={[]} />);
+    expect(wrapper.find("ContextualMenu")).toMatchSnapshot();
+  });
+
+  it("can be aligned to the right", () => {
+    const wrapper = mount(<ContextualMenu links={[]} position="right" />);
+    expect(wrapper.find(".p-contextual-menu").exists()).toBe(true);
+  });
+
+  it("can be aligned to the left", () => {
+    const wrapper = mount(<ContextualMenu links={[]} position="left" />);
+    expect(wrapper.find(".p-contextual-menu--left").exists()).toBe(true);
+  });
+
+  it("can be aligned to the center", () => {
+    const wrapper = mount(<ContextualMenu links={[]} position="center" />);
+    expect(wrapper.find(".p-contextual-menu--center").exists()).toBe(true);
+  });
+
+  it("can have a toggle button", () => {
+    const wrapper = mount(<ContextualMenu links={[]} toggleLabel="Toggle" />);
+    expect(wrapper.find("button.p-contextual-menu__toggle").exists()).toBe(
+      true
+    );
+  });
+
+  it("can have a toggle button with an icon", () => {
+    const wrapper = mount(<ContextualMenu hasToggleIcon links={[]} />);
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__toggle .p-contextual-menu__indicator")
+        .exists()
+    ).toBe(true);
+  });
+
+  it("can have a toggle button with an icon and text on the left", () => {
+    const wrapper = mount(
+      <ContextualMenu
+        hasToggleIcon
+        links={[]}
+        toggleLabel="Toggle"
+        toggleLabelFirst
+      />
+    );
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__toggle")
+        .children()
+        .at(0)
+        .text()
+    ).toBe("Toggle");
+  });
+
+  it("can have a toggle button with an icon and text on the right", () => {
+    const wrapper = mount(
+      <ContextualMenu
+        hasToggleIcon
+        links={[]}
+        toggleLabel="Toggle"
+        toggleLabelFirst={false}
+      />
+    );
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__toggle")
+        .children()
+        .at(1)
+        .text()
+    ).toBe("Toggle");
+  });
+
+  it("can have a toggle button with just text", () => {
+    const wrapper = mount(<ContextualMenu links={[]} toggleLabel="Toggle" />);
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__toggle .p-contextual-menu__indicator")
+        .exists()
+    ).toBe(false);
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__toggle")
+        .children()
+        .text()
+    ).toBe("Toggle");
+  });
+
+  it("can not have a toggle button", () => {
+    const wrapper = mount(<ContextualMenu links={[]} />);
+    expect(wrapper.find("button.p-contextual-menu__toggle").exists()).toBe(
+      false
+    );
+  });
+
+  it("can use the toggle button to display the menu", () => {
+    const wrapper = mount(<ContextualMenu links={[]} toggleLabel="Toggle" />);
+    expect(
+      wrapper.find("button.p-contextual-menu__toggle").prop("aria-expanded")
+    ).toBe("false");
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper.find("button.p-contextual-menu__toggle").prop("aria-expanded")
+    ).toBe("true");
+    expect(
+      wrapper.find(".p-contextual-menu__dropdown").prop("aria-hidden")
+    ).toBe("false");
+  });
+
+  it("be visible without a toggle button", () => {
+    const wrapper = mount(<ContextualMenu links={[]} />);
+    expect(
+      wrapper.find(".p-contextual-menu__dropdown").prop("aria-hidden")
+    ).toBe("false");
+  });
+
+  it("can display links", () => {
+    const wrapper = mount(<ContextualMenu links={[{ children: "Link1" }]} />);
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__link")
+        .children()
+        .text()
+    ).toBe("Link1");
+  });
+
+  it("can display links in groups", () => {
+    const wrapper = mount(<ContextualMenu links={[[{ children: "Link1" }]]} />);
+    expect(
+      wrapper
+        .find(".p-contextual-menu__group button.p-contextual-menu__link")
+        .children()
+        .text()
+    ).toBe("Link1");
+  });
+
+  it("can display a mix of links and groups", () => {
+    const wrapper = mount(
+      <ContextualMenu
+        links={[[{ children: "Link1" }], { children: "Link2" }]}
+      />
+    );
+    expect(
+      wrapper
+        .find(".p-contextual-menu__group button.p-contextual-menu__link")
+        .children()
+        .text()
+    ).toBe("Link1");
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__link")
+        .at(1)
+        .children()
+        .text()
+    ).toBe("Link2");
+  });
+});

--- a/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
+++ b/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContextualMenu  renders 1`] = `
+<ContextualMenu
+  links={Array []}
+>
+  <span
+    className="p-contextual-menu"
+  >
+    <Component>
+      <Portal
+        containerInfo={
+          <div>
+            <span
+              class="p-contextual-menu"
+            >
+              <span
+                aria-hidden="false"
+                aria-label="submenu"
+                class="p-contextual-menu__dropdown"
+                id="Uakgb_J5m9g-0JDMbcJqLJ"
+              />
+            </span>
+          </div>
+        }
+      >
+        <span
+          className="p-contextual-menu"
+        >
+          <span
+            aria-hidden="false"
+            aria-label="submenu"
+            className="p-contextual-menu__dropdown"
+            id="Uakgb_J5m9g-0JDMbcJqLJ"
+          />
+        </span>
+      </Portal>
+    </Component>
+  </span>
+</ContextualMenu>
+`;

--- a/ui/src/app/base/components/ContextualMenu/index.js
+++ b/ui/src/app/base/components/ContextualMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ContextualMenu";

--- a/ui/src/app/base/components/TableMenu/TableMenu.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.js
@@ -1,0 +1,25 @@
+import { Button } from "@canonical/react-components";
+import PropTypes from "prop-types";
+import React from "react";
+
+import "./TableMenu.scss";
+import ContextualMenu from "app/base/components/ContextualMenu";
+
+const TableMenu = ({ links, title }) => {
+  return (
+    <ContextualMenu
+      className="p-table-menu"
+      hasToggleIcon
+      links={[title, links]}
+      position="center"
+      toggleAppearance="base"
+    />
+  );
+};
+
+TableMenu.propTypes = {
+  links: PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
+  title: PropTypes.string
+};
+
+export default TableMenu;

--- a/ui/src/app/base/components/TableMenu/TableMenu.scss
+++ b/ui/src/app/base/components/TableMenu/TableMenu.scss
@@ -1,0 +1,11 @@
+@import "~vanilla-framework/scss/settings_colors";
+@import "~vanilla-framework/scss/settings_spacing";
+
+.p-table-menu .p-contextual-menu__non-interactive {
+  border-bottom: 1px solid $color-mid-light;
+  color: $color-mid-dark;
+  font-size: 0.75rem;
+  font-weight: 400;
+  padding: $spv-inner--x-small $sph-inner--small;
+  text-transform: uppercase;
+}

--- a/ui/src/app/base/components/TableMenu/TableMenu.test.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.test.js
@@ -1,0 +1,13 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import TableMenu from "./TableMenu";
+
+describe("TableMenu ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <TableMenu links={[{ children: "Item1" }]} title="Actions:" />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
+++ b/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableMenu  renders 1`] = `
+<ContextualMenu
+  className="p-table-menu"
+  hasToggleIcon={true}
+  links={
+    Array [
+      "Actions:",
+      Array [
+        Object {
+          "children": "Item1",
+        },
+      ],
+    ]
+  }
+  position="center"
+  toggleAppearance="base"
+/>
+`;

--- a/ui/src/app/base/components/TableMenu/index.js
+++ b/ui/src/app/base/components/TableMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TableMenu";

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -3,6 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { machine as machineSelectors } from "app/base/selectors";
+import TableMenu from "app/base/components/TableMenu";
 
 const OwnerColumn = ({ systemId }) => {
   const machine = useSelector(state =>
@@ -16,6 +17,10 @@ const OwnerColumn = ({ systemId }) => {
     <div className="p-double-row">
       <div className="p-double-row__primary-row u-truncate">
         <span data-test="owner">{owner}</span>
+        <TableMenu
+          links={[{ children: "Link1" }, { children: "Link2" }]}
+          title="Take action:"
+        />
       </div>
       <div className="p-double-row__secondary-row u-truncate">
         <span title={tags} data-test="tags">

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -15,6 +15,65 @@ exports[`OwnerColumn renders 1`] = `
       >
         admin
       </span>
+      <TableMenu
+        links={
+          Array [
+            Object {
+              "children": "Link1",
+            },
+            Object {
+              "children": "Link2",
+            },
+          ]
+        }
+        title="Take action:"
+      >
+        <ContextualMenu
+          className="p-table-menu"
+          hasToggleIcon={true}
+          links={
+            Array [
+              "Take action:",
+              Array [
+                Object {
+                  "children": "Link1",
+                },
+                Object {
+                  "children": "Link2",
+                },
+              ],
+            ]
+          }
+          position="center"
+          toggleAppearance="base"
+        >
+          <span
+            className="p-table-menu p-contextual-menu--center"
+          >
+            <Button
+              appearance="base"
+              aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+              aria-expanded="false"
+              aria-haspopup="true"
+              className="p-contextual-menu__toggle"
+              hasIcon={true}
+              onClick={[Function]}
+            >
+              <button
+                aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                aria-expanded="false"
+                aria-haspopup="true"
+                className="p-button--base has-icon p-contextual-menu__toggle"
+                onClick={[Function]}
+              >
+                <i
+                  className="p-icon--contextual-menu p-contextual-menu__indicator"
+                />
+              </button>
+            </Button>
+          </span>
+        </ContextualMenu>
+      </TableMenu>
     </div>
     <div
       className="p-double-row__secondary-row u-truncate"


### PR DESCRIPTION
## Done
- Add a Vanilla contextual menu component.
- Add a table menu component.

## QA
- View /r/machines
- In the owner column you should see a contextual menu (this will be updated to appear on hover in a followup).

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-squad/issues/1724.