### PR TITLE
Add ErrorBoundaries around app sections.

### DIFF
--- a/ui/src/app/Routes.js
+++ b/ui/src/app/Routes.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 
+import ErrorBoundary from "app/base/components/ErrorBoundary";
 import Machines from "app/machines/views/Machines";
 import NotFound from "app/base/views/NotFound";
 import Preferences from "app/preferences/views/Preferences";
@@ -16,9 +17,30 @@ const Routes = () => (
         return null;
       }}
     />
-    <Route path="/settings" component={Settings} />
-    <Route path="/machines" component={Machines} />
-    <Route path="/account/prefs" component={Preferences} />
+    <Route
+      path="/settings"
+      render={() => (
+        <ErrorBoundary>
+          <Settings />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path="/machines"
+      render={() => (
+        <ErrorBoundary>
+          <Machines />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path="/account/prefs"
+      render={() => (
+        <ErrorBoundary>
+          <Preferences />
+        </ErrorBoundary>
+      )}
+    />
     <Route path="*" component={() => <NotFound includeSection />} />
   </Switch>
 );

--- a/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.js
+++ b/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.js
@@ -1,0 +1,33 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // XXX: Add Sentry logging here
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-notification--negative">
+          <p className="p-notification__response">
+            <span className="p-notification__status">Error:</span> An unexpected
+            error hs occurred, please try refreshing your browser window.
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.test.js
+++ b/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.test.js
@@ -1,0 +1,23 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import ErrorBoundary from "app/base/components/ErrorBoundary";
+
+
+describe("ErrorBoundary", () => {
+  it("should display an ErrorMessage if wrapped component throws", () => {
+    spyOn(console, "error"); // suppress traceback in test
+
+    const Component = () => null;
+    const wrapper = shallow(
+      <ErrorBoundary>
+        <Component />
+      </ErrorBoundary>
+    );
+    const error = new Error("kerblam");
+
+    wrapper.find(Component).simulateError(error);
+
+    expect(wrapper.state("hasError")).toEqual(true);
+  });
+});

--- a/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.test.js
+++ b/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.test.js
@@ -3,10 +3,9 @@ import React from "react";
 
 import ErrorBoundary from "app/base/components/ErrorBoundary";
 
-
 describe("ErrorBoundary", () => {
   it("should display an ErrorMessage if wrapped component throws", () => {
-    spyOn(console, "error"); // suppress traceback in test
+    jest.spyOn(console, "error"); // suppress traceback in test
 
     const Component = () => null;
     const wrapper = shallow(

--- a/ui/src/app/base/components/ErrorBoundary/index.js
+++ b/ui/src/app/base/components/ErrorBoundary/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ErrorBoundary";


### PR DESCRIPTION
## Done
Add React ErrorBoundary component, and wrap each app section. This is the first step towards implementing sentry reporting.

## QA
* Ensure the app still renders as expected.
* Deliberately break a component somewhere in the tree (e.g. drop `throw new Error('foo')` somewhere), and ensure the entire app doesn't crash and is still navigable. Be aware that the webpack devserver will fallback to displaying the full traceback, which you can close by clicking the 'X' in the top right.
