### PR TITLE
Add double row component

### DIFF
--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -2,7 +2,7 @@ import { Button } from "@canonical/react-components";
 import classNames from "classnames";
 import nanoid from "nanoid";
 import PropTypes from "prop-types";
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import usePortal from "react-useportal";
 
 const getPositionStyle = (position, wrapper) => {
@@ -48,8 +48,10 @@ const ContextualMenu = ({
   className,
   hasToggleIcon,
   links,
+  onToggleMenu,
   position = "right",
   toggleAppearance,
+  toggleClassName,
   toggleLabel,
   toggleLabelFirst = true
 }) => {
@@ -67,6 +69,13 @@ const ContextualMenu = ({
       .filter(Boolean)
       .join("--")
   );
+
+  useEffect(() => {
+    onToggleMenu && onToggleMenu(isOpen);
+    // onToggleMenu is excluded from the useEffect deps as onToggleMenu gets
+    // redefined on a state update which causes an infinite loop here.
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <span className={wrapperClass} ref={wrapper}>
       {hasToggle ? (
@@ -75,7 +84,7 @@ const ContextualMenu = ({
           aria-controls={id.current}
           aria-expanded={isOpen ? "true" : "false"}
           aria-haspopup="true"
-          className="p-contextual-menu__toggle"
+          className={classNames("p-contextual-menu__toggle", toggleClassName)}
           hasIcon={hasToggleIcon}
           onClick={evt => {
             if (!isOpen) {
@@ -136,8 +145,10 @@ ContextualMenu.propTypes = {
       PropTypes.arrayOf(PropTypes.shape(Button.propTypes))
     ])
   ).isRequired,
+  onToggleMenu: PropTypes.func,
   position: PropTypes.oneOf(["left", "center", "right"]),
   toggleAppearance: PropTypes.string,
+  toggleClassName: PropTypes.string,
   toggleLabel: PropTypes.string,
   toggleLabelFirst: PropTypes.bool
 };

--- a/ui/src/app/base/components/DoubleRow/DoubleRow.js
+++ b/ui/src/app/base/components/DoubleRow/DoubleRow.js
@@ -7,6 +7,7 @@ import TableMenu from "app/base/components/TableMenu";
 const DoubleRow = ({
   className,
   icon,
+  iconSpace,
   iconTitle,
   menuLinks,
   menuTitle,
@@ -18,45 +19,51 @@ const DoubleRow = ({
   secondaryAriaLabel,
   secondaryClassName
 }) => {
+  const hasIcon = icon || iconSpace;
   return (
     <div
       className={classNames(
         {
-          "p-double-row": !icon,
-          "p-double-row--with-icon": icon
+          "p-double-row": !hasIcon,
+          "p-double-row--with-icon": hasIcon
         },
         className
       )}
     >
-      {icon ? <div className="p-double-row__icon">{icon}</div> : null}
-      <div
-        className={classNames(
-          "p-double-row__primary-row u-truncate",
-          primaryClassName
-        )}
-        aria-label={primaryAriaLabel}
-      >
-        {primary}
-      </div>
-      {menuLinks ? (
-        <TableMenu
-          links={menuLinks}
-          title={menuTitle}
-          onToggleMenu={onToggleMenu}
-        />
-      ) : null}
-      {secondary ? (
-        <div
-          className={classNames(
-            "p-double-row__secondary-row",
-            "u-truncate",
-            secondaryClassName
-          )}
-          aria-label={secondaryAriaLabel}
-        >
-          {secondary}
+      {hasIcon ? (
+        <div className="p-double-row__icon">
+          {icon || <div className="p-double-row__icon-space"></div>}
         </div>
       ) : null}
+      <div className="p-double-row__rows-container">
+        <div
+          className={classNames("p-double-row__primary-row", primaryClassName)}
+          aria-label={primaryAriaLabel}
+        >
+          <div className="p-double-row__primary-row-text u-truncate">
+            {primary}
+          </div>
+          {menuLinks ? (
+            <TableMenu
+              links={menuLinks}
+              title={menuTitle}
+              onToggleMenu={onToggleMenu}
+            />
+          ) : null}
+        </div>
+        {secondary ? (
+          <div
+            className={classNames(
+              "p-double-row__secondary-row",
+              "u-truncate",
+              secondaryClassName
+            )}
+            aria-label={secondaryAriaLabel}
+          >
+            {secondary}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 };
@@ -64,6 +71,7 @@ const DoubleRow = ({
 DoubleRow.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.node,
+  iconSpace: PropTypes.bool,
   menuLinks: TableMenu.propTypes.links,
   menuTitle: PropTypes.string,
   onToggleMenu: PropTypes.func,

--- a/ui/src/app/base/components/DoubleRow/DoubleRow.js
+++ b/ui/src/app/base/components/DoubleRow/DoubleRow.js
@@ -1,0 +1,78 @@
+import PropTypes from "prop-types";
+import React from "react";
+import classNames from "classnames";
+
+import TableMenu from "app/base/components/TableMenu";
+
+const DoubleRow = ({
+  className,
+  icon,
+  iconTitle,
+  menuLinks,
+  menuTitle,
+  onToggleMenu,
+  primary,
+  primaryAriaLabel,
+  primaryClassName,
+  secondary,
+  secondaryAriaLabel,
+  secondaryClassName
+}) => {
+  return (
+    <div
+      className={classNames(
+        {
+          "p-double-row": !icon,
+          "p-double-row--with-icon": icon
+        },
+        className
+      )}
+    >
+      {icon ? <div className="p-double-row__icon">{icon}</div> : null}
+      <div
+        className={classNames(
+          "p-double-row__primary-row u-truncate",
+          primaryClassName
+        )}
+        aria-label={primaryAriaLabel}
+      >
+        {primary}
+      </div>
+      {menuLinks ? (
+        <TableMenu
+          links={menuLinks}
+          title={menuTitle}
+          onToggleMenu={onToggleMenu}
+        />
+      ) : null}
+      {secondary ? (
+        <div
+          className={classNames(
+            "p-double-row__secondary-row",
+            "u-truncate",
+            secondaryClassName
+          )}
+          aria-label={secondaryAriaLabel}
+        >
+          {secondary}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+DoubleRow.propTypes = {
+  className: PropTypes.string,
+  icon: PropTypes.node,
+  menuLinks: TableMenu.propTypes.links,
+  menuTitle: PropTypes.string,
+  onToggleMenu: PropTypes.func,
+  primary: PropTypes.node,
+  primaryAriaLabel: PropTypes.string,
+  primaryClassName: PropTypes.string,
+  secondary: PropTypes.node,
+  secondaryAriaLabel: PropTypes.string,
+  secondaryClassName: PropTypes.string
+};
+
+export default DoubleRow;

--- a/ui/src/app/base/components/DoubleRow/DoubleRow.test.js
+++ b/ui/src/app/base/components/DoubleRow/DoubleRow.test.js
@@ -1,0 +1,42 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import DoubleRow from "./DoubleRow";
+
+describe("DoubleRow ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <DoubleRow primary="Top row" secondary="Bottom row" />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can render without a secondary row", () => {
+    const wrapper = shallow(<DoubleRow primary="Top row" />);
+    expect(wrapper.find(".p-double-row__secondary-row").exists()).toBe(false);
+  });
+
+  it("can display an icon", () => {
+    const wrapper = shallow(
+      <DoubleRow
+        icon={<i classname="p-icon"></i>}
+        primary="Top row"
+        secondary="Bottom row"
+      />
+    );
+    expect(wrapper.find(".p-double-row--with-icon").exists()).toBe(true);
+    expect(wrapper.find(".p-double-row__icon").exists()).toBe(true);
+  });
+
+  it("can have a menu", () => {
+    const wrapper = shallow(
+      <DoubleRow
+        menuLinks={[{ children: "Link1" }, { children: "Link2" }]}
+        menuTitle="Take action:"
+        primary="Top row"
+        secondary="Bottom row"
+      />
+    );
+    expect(wrapper.find("TableMenu").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/DoubleRow/DoubleRow.test.js
+++ b/ui/src/app/base/components/DoubleRow/DoubleRow.test.js
@@ -28,6 +28,14 @@ describe("DoubleRow ", () => {
     expect(wrapper.find(".p-double-row__icon").exists()).toBe(true);
   });
 
+  it("can display the space for an icon", () => {
+    const wrapper = shallow(
+      <DoubleRow iconSpace={true} primary="Top row" secondary="Bottom row" />
+    );
+    expect(wrapper.find(".p-double-row--with-icon").exists()).toBe(true);
+    expect(wrapper.find(".p-double-row__icon").exists()).toBe(true);
+  });
+
   it("can have a menu", () => {
     const wrapper = shallow(
       <DoubleRow

--- a/ui/src/app/base/components/DoubleRow/__snapshots__/DoubleRow.test.js.snap
+++ b/ui/src/app/base/components/DoubleRow/__snapshots__/DoubleRow.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DoubleRow  renders 1`] = `
+<div
+  className="p-double-row"
+>
+  <div
+    className="p-double-row__primary-row u-truncate"
+  >
+    Top row
+  </div>
+  <div
+    className="p-double-row__secondary-row u-truncate"
+  >
+    Bottom row
+  </div>
+</div>
+`;

--- a/ui/src/app/base/components/DoubleRow/__snapshots__/DoubleRow.test.js.snap
+++ b/ui/src/app/base/components/DoubleRow/__snapshots__/DoubleRow.test.js.snap
@@ -5,14 +5,22 @@ exports[`DoubleRow  renders 1`] = `
   className="p-double-row"
 >
   <div
-    className="p-double-row__primary-row u-truncate"
+    className="p-double-row__rows-container"
   >
-    Top row
-  </div>
-  <div
-    className="p-double-row__secondary-row u-truncate"
-  >
-    Bottom row
+    <div
+      className="p-double-row__primary-row"
+    >
+      <div
+        className="p-double-row__primary-row-text u-truncate"
+      >
+        Top row
+      </div>
+    </div>
+    <div
+      className="p-double-row__secondary-row u-truncate"
+    >
+      Bottom row
+    </div>
   </div>
 </div>
 `;

--- a/ui/src/app/base/components/DoubleRow/index.js
+++ b/ui/src/app/base/components/DoubleRow/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DoubleRow";

--- a/ui/src/app/base/components/TableMenu/TableMenu.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.js
@@ -5,20 +5,23 @@ import React from "react";
 import "./TableMenu.scss";
 import ContextualMenu from "app/base/components/ContextualMenu";
 
-const TableMenu = ({ links, title }) => {
+const TableMenu = ({ links, title, onToggleMenu }) => {
   return (
     <ContextualMenu
       className="p-table-menu"
       hasToggleIcon
       links={[title, links]}
+      onToggleMenu={onToggleMenu}
       position="center"
       toggleAppearance="base"
+      toggleClassName="u-no-margin--bottom p-table-menu__toggle"
     />
   );
 };
 
 TableMenu.propTypes = {
   links: PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
+  onToggleMenu: PropTypes.func,
   title: PropTypes.string
 };
 

--- a/ui/src/app/base/components/TableMenu/TableMenu.scss
+++ b/ui/src/app/base/components/TableMenu/TableMenu.scss
@@ -9,3 +9,9 @@
   padding: $spv-inner--x-small $sph-inner--small;
   text-transform: uppercase;
 }
+
+.p-table-menu__toggle {
+  $icon-size: map-get($icon-sizes, default);
+  line-height: $icon-size;
+  padding: 0 $icon-size / 2;
+}

--- a/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
+++ b/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
@@ -16,5 +16,6 @@ exports[`TableMenu  renders 1`] = `
   }
   position="center"
   toggleAppearance="base"
+  toggleClassName="u-no-margin--bottom p-table-menu__toggle"
 />
 `;

--- a/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
@@ -30,6 +30,7 @@ const CoresColumn = ({ onToggleMenu, systemId }) => {
         </ScriptStatus>
       }
       primaryAriaLabel="Cores"
+      primaryClassName="u-align--right"
       secondary={
         <Tooltip position="btm-left" message={machine.architecture}>
           <span data-test="arch">{formatShortArch(machine.architecture)}</span>

--- a/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/CoresColumn.js
@@ -2,11 +2,12 @@ import { useSelector } from "react-redux";
 import React from "react";
 import PropTypes from "prop-types";
 
+import DoubleRow from "app/base/components/DoubleRow";
 import ScriptStatus from "app/base/components/ScriptStatus";
 import Tooltip from "app/base/components/Tooltip";
 import { machine as machineSelectors } from "app/base/selectors";
 
-const CoresColumn = ({ systemId }) => {
+const CoresColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -15,8 +16,10 @@ const CoresColumn = ({ systemId }) => {
     arch.includes("/generic") ? arch.split("/")[0] : arch;
 
   return (
-    <div className="p-double-row u-align--right">
-      <div className="p-double-row__primary-row u-truncate" aria-label="Cores">
+    <DoubleRow
+      className="u-align--right"
+      onToggleMenu={onToggleMenu}
+      primary={
         <ScriptStatus
           data-test="cores"
           hidePassedIcon
@@ -25,20 +28,20 @@ const CoresColumn = ({ systemId }) => {
         >
           {machine.cpu_count}
         </ScriptStatus>
-      </div>
-      <div
-        className="p-double-row__secondary-row u-truncate"
-        aria-label="Architecture"
-      >
+      }
+      primaryAriaLabel="Cores"
+      secondary={
         <Tooltip position="btm-left" message={machine.architecture}>
           <span data-test="arch">{formatShortArch(machine.architecture)}</span>
         </Tooltip>
-      </div>
-    </div>
+      }
+      secondaryAriaLabel="Architecture"
+    />
   );
 };
 
 CoresColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
@@ -4,13 +4,9 @@ exports[`CoresColumn renders 1`] = `
 <CoresColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row u-align--right"
-  >
-    <div
-      aria-label="Cores"
-      className="p-double-row__primary-row u-truncate"
-    >
+  <DoubleRow
+    className="u-align--right"
+    primary={
       <ScriptStatus
         data-test="cores"
         hidePassedIcon={true}
@@ -21,34 +17,70 @@ exports[`CoresColumn renders 1`] = `
         }
         tooltipPosition="top-right"
       >
-        <i
-          className="p-icon--running is-inline"
-        />
         4
       </ScriptStatus>
-    </div>
-    <div
-      aria-label="Architecture"
-      className="p-double-row__secondary-row u-truncate"
-    >
+    }
+    primaryAriaLabel="Cores"
+    secondary={
       <Tooltip
         message="amd64/generic"
         position="btm-left"
       >
         <span
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
+          data-test="arch"
         >
-          <span
-            data-test="arch"
-          >
-            amd64
-          </span>
+          amd64
         </span>
       </Tooltip>
+    }
+    secondaryAriaLabel="Architecture"
+  >
+    <div
+      className="p-double-row u-align--right"
+    >
+      <div
+        aria-label="Cores"
+        className="p-double-row__primary-row u-truncate"
+      >
+        <ScriptStatus
+          data-test="cores"
+          hidePassedIcon={true}
+          scriptType={
+            Object {
+              "status": 1,
+            }
+          }
+          tooltipPosition="top-right"
+        >
+          <i
+            className="p-icon--running is-inline"
+          />
+          4
+        </ScriptStatus>
+      </div>
+      <div
+        aria-label="Architecture"
+        className="p-double-row__secondary-row u-truncate"
+      >
+        <Tooltip
+          message="amd64/generic"
+          position="btm-left"
+        >
+          <span
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <span
+              data-test="arch"
+            >
+              amd64
+            </span>
+          </span>
+        </Tooltip>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </CoresColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/CoresColumn/__snapshots__/CoresColumn.test.js.snap
@@ -21,6 +21,7 @@ exports[`CoresColumn renders 1`] = `
       </ScriptStatus>
     }
     primaryAriaLabel="Cores"
+    primaryClassName="u-align--right"
     secondary={
       <Tooltip
         message="amd64/generic"
@@ -39,46 +40,54 @@ exports[`CoresColumn renders 1`] = `
       className="p-double-row u-align--right"
     >
       <div
-        aria-label="Cores"
-        className="p-double-row__primary-row u-truncate"
+        className="p-double-row__rows-container"
       >
-        <ScriptStatus
-          data-test="cores"
-          hidePassedIcon={true}
-          scriptType={
-            Object {
-              "status": 1,
-            }
-          }
-          tooltipPosition="top-right"
+        <div
+          aria-label="Cores"
+          className="p-double-row__primary-row u-align--right"
         >
-          <i
-            className="p-icon--running is-inline"
-          />
-          4
-        </ScriptStatus>
-      </div>
-      <div
-        aria-label="Architecture"
-        className="p-double-row__secondary-row u-truncate"
-      >
-        <Tooltip
-          message="amd64/generic"
-          position="btm-left"
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <ScriptStatus
+              data-test="cores"
+              hidePassedIcon={true}
+              scriptType={
+                Object {
+                  "status": 1,
+                }
+              }
+              tooltipPosition="top-right"
+            >
+              <i
+                className="p-icon--running is-inline"
+              />
+              4
+            </ScriptStatus>
+          </div>
+        </div>
+        <div
+          aria-label="Architecture"
+          className="p-double-row__secondary-row u-truncate"
         >
-          <span
-            onBlur={[Function]}
-            onFocus={[Function]}
-            onMouseOut={[Function]}
-            onMouseOver={[Function]}
+          <Tooltip
+            message="amd64/generic"
+            position="btm-left"
           >
             <span
-              data-test="arch"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
             >
-              amd64
+              <span
+                data-test="arch"
+              >
+                amd64
+              </span>
             </span>
-          </span>
-        </Tooltip>
+          </Tooltip>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/DisksColumn/DisksColumn.js
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/DisksColumn.js
@@ -3,16 +3,18 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { machine as machineSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 import ScriptStatus from "app/base/components/ScriptStatus";
 
-const DisksColumn = ({ systemId }) => {
+const DisksColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
 
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-align--right u-truncate">
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={
         <ScriptStatus
           data-test="disks"
           hidePassedIcon
@@ -21,12 +23,14 @@ const DisksColumn = ({ systemId }) => {
         >
           {machine.physical_disk_count}
         </ScriptStatus>
-      </div>
-    </div>
+      }
+      primaryClassName="u-align--right"
+    />
   );
 };
 
 DisksColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
@@ -25,20 +25,28 @@ exports[`DisksColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        className="p-double-row__primary-row u-truncate u-align--right"
+        className="p-double-row__rows-container"
       >
-        <ScriptStatus
-          data-test="disks"
-          hidePassedIcon={true}
-          scriptType={
-            Object {
-              "status": 2,
-            }
-          }
-          tooltipPosition="top-right"
+        <div
+          className="p-double-row__primary-row u-align--right"
         >
-          1
-        </ScriptStatus>
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <ScriptStatus
+              data-test="disks"
+              hidePassedIcon={true}
+              scriptType={
+                Object {
+                  "status": 2,
+                }
+              }
+              tooltipPosition="top-right"
+            >
+              1
+            </ScriptStatus>
+          </div>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/DisksColumn/__snapshots__/DisksColumn.test.js.snap
@@ -4,12 +4,8 @@ exports[`DisksColumn renders 1`] = `
 <DisksColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
-  >
-    <div
-      className="p-double-row__primary-row u-align--right u-truncate"
-    >
+  <DoubleRow
+    primary={
       <ScriptStatus
         data-test="disks"
         hidePassedIcon={true}
@@ -22,7 +18,29 @@ exports[`DisksColumn renders 1`] = `
       >
         1
       </ScriptStatus>
+    }
+    primaryClassName="u-align--right"
+  >
+    <div
+      className="p-double-row"
+    >
+      <div
+        className="p-double-row__primary-row u-truncate u-align--right"
+      >
+        <ScriptStatus
+          data-test="disks"
+          hidePassedIcon={true}
+          scriptType={
+            Object {
+              "status": 2,
+            }
+          }
+          tooltipPosition="top-right"
+        >
+          1
+        </ScriptStatus>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </DisksColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/FabricColumn/FabricColumn.js
+++ b/ui/src/app/machines/views/MachineList/FabricColumn/FabricColumn.js
@@ -2,10 +2,11 @@ import { useSelector } from "react-redux";
 import React from "react";
 import PropTypes from "prop-types";
 
+import DoubleRow from "app/base/components/DoubleRow";
 import ScriptStatus from "app/base/components/ScriptStatus";
 import { machine as machineSelectors } from "app/base/selectors";
 
-const FabricColumn = ({ systemId }) => {
+const FabricColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -15,8 +16,9 @@ const FabricColumn = ({ systemId }) => {
   const vlan = machine.vlan && machine.vlan.name ? machine.vlan.name : "";
 
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-truncate" aria-label="Fabric">
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={
         <ScriptStatus
           data-test="fabric"
           hidePassedIcon
@@ -26,15 +28,16 @@ const FabricColumn = ({ systemId }) => {
         >
           {fabric}
         </ScriptStatus>
-      </div>
-      <div className="p-double-row__secondary-row u-truncate" aria-label="VLAN">
-        <span data-test="vlan">{vlan}</span>
-      </div>
-    </div>
+      }
+      primaryAriaLabel="Fabric"
+      secondary={<span data-test="vlan">{vlan}</span>}
+      secondaryAriaLabel="VLAN"
+    />
   );
 };
 
 FabricColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/FabricColumn/__snapshots__/FabricColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/FabricColumn/__snapshots__/FabricColumn.test.js.snap
@@ -4,13 +4,8 @@ exports[`FabricColumn renders 1`] = `
 <FabricColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
-  >
-    <div
-      aria-label="Fabric"
-      className="p-double-row__primary-row u-truncate"
-    >
+  <DoubleRow
+    primary={
       <ScriptStatus
         data-test="fabric"
         hideNotRunIcon={true}
@@ -22,22 +17,54 @@ exports[`FabricColumn renders 1`] = `
         }
         tooltipPosition="top-right"
       >
-        <i
-          className="p-icon--running is-inline"
-        />
         fabric-0
       </ScriptStatus>
-    </div>
-    <div
-      aria-label="VLAN"
-      className="p-double-row__secondary-row u-truncate"
-    >
+    }
+    primaryAriaLabel="Fabric"
+    secondary={
       <span
         data-test="vlan"
       >
         Default VLAN
       </span>
+    }
+    secondaryAriaLabel="VLAN"
+  >
+    <div
+      className="p-double-row"
+    >
+      <div
+        aria-label="Fabric"
+        className="p-double-row__primary-row u-truncate"
+      >
+        <ScriptStatus
+          data-test="fabric"
+          hideNotRunIcon={true}
+          hidePassedIcon={true}
+          scriptType={
+            Object {
+              "status": 1,
+            }
+          }
+          tooltipPosition="top-right"
+        >
+          <i
+            className="p-icon--running is-inline"
+          />
+          fabric-0
+        </ScriptStatus>
+      </div>
+      <div
+        aria-label="VLAN"
+        className="p-double-row__secondary-row u-truncate"
+      >
+        <span
+          data-test="vlan"
+        >
+          Default VLAN
+        </span>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </FabricColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/FabricColumn/__snapshots__/FabricColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/FabricColumn/__snapshots__/FabricColumn.test.js.snap
@@ -34,35 +34,43 @@ exports[`FabricColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        aria-label="Fabric"
-        className="p-double-row__primary-row u-truncate"
+        className="p-double-row__rows-container"
       >
-        <ScriptStatus
-          data-test="fabric"
-          hideNotRunIcon={true}
-          hidePassedIcon={true}
-          scriptType={
-            Object {
-              "status": 1,
-            }
-          }
-          tooltipPosition="top-right"
+        <div
+          aria-label="Fabric"
+          className="p-double-row__primary-row"
         >
-          <i
-            className="p-icon--running is-inline"
-          />
-          fabric-0
-        </ScriptStatus>
-      </div>
-      <div
-        aria-label="VLAN"
-        className="p-double-row__secondary-row u-truncate"
-      >
-        <span
-          data-test="vlan"
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <ScriptStatus
+              data-test="fabric"
+              hideNotRunIcon={true}
+              hidePassedIcon={true}
+              scriptType={
+                Object {
+                  "status": 1,
+                }
+              }
+              tooltipPosition="top-right"
+            >
+              <i
+                className="p-icon--running is-inline"
+              />
+              fabric-0
+            </ScriptStatus>
+          </div>
+        </div>
+        <div
+          aria-label="VLAN"
+          className="p-double-row__secondary-row u-truncate"
         >
-          Default VLAN
-        </span>
+          <span
+            data-test="vlan"
+          >
+            Default VLAN
+          </span>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -72,7 +72,13 @@ const getSortValue = (machine, currentSort) => {
   }
 };
 
-const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
+const generateRows = (
+  rows,
+  hiddenGroups,
+  setHiddenGroups,
+  activeRow,
+  setActiveRow
+) =>
   rows.map(row => {
     if (row.isGroup) {
       const sortData = {
@@ -128,41 +134,86 @@ const generateRows = (rows, hiddenGroups, setHiddenGroups) =>
         sortData
       };
     }
+    const isActive = activeRow === row.system_id;
+    const onToggleMenu = open => {
+      if (open && !activeRow) {
+        setActiveRow(row.system_id);
+      } else if (!open || (open && activeRow)) {
+        setActiveRow(null);
+      }
+    };
     return {
-      className: "machine-list__machine",
+      className: classNames("machine-list__machine", {
+        "machine-list__machine--active": isActive
+      }),
       columns: [
         {
-          content: <NameColumn showMAC={false} systemId={row.system_id} />
+          content: (
+            <NameColumn
+              onToggleMenu={onToggleMenu}
+              showMAC={false}
+              systemId={row.system_id}
+            />
+          )
         },
         {
-          content: <PowerColumn systemId={row.system_id} />
+          content: (
+            <PowerColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+          )
         },
         {
-          content: <StatusColumn systemId={row.system_id} />
+          content: (
+            <StatusColumn
+              onToggleMenu={onToggleMenu}
+              systemId={row.system_id}
+            />
+          )
         },
         {
-          content: <OwnerColumn systemId={row.system_id} />
+          content: (
+            <OwnerColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+          )
         },
         {
-          content: <PoolColumn systemId={row.system_id} />
+          content: (
+            <PoolColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+          )
         },
         {
-          content: <ZoneColumn systemId={row.system_id} />
+          content: (
+            <ZoneColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+          )
         },
         {
-          content: <FabricColumn systemId={row.system_id} />
+          content: (
+            <FabricColumn
+              onToggleMenu={onToggleMenu}
+              systemId={row.system_id}
+            />
+          )
         },
         {
-          content: <CoresColumn systemId={row.system_id} />
+          content: (
+            <CoresColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+          )
         },
         {
-          content: <RamColumn systemId={row.system_id} />
+          content: (
+            <RamColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+          )
         },
         {
-          content: <DisksColumn systemId={row.system_id} />
+          content: (
+            <DisksColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+          )
         },
         {
-          content: <StorageColumn systemId={row.system_id} />
+          content: (
+            <StorageColumn
+              onToggleMenu={onToggleMenu}
+              systemId={row.system_id}
+            />
+          )
         }
       ],
       sortData: {
@@ -186,6 +237,7 @@ const MachineList = () => {
   const dispatch = useDispatch();
   const [currentSort, setSort] = useState(defaultSort);
   const [hiddenGroups, setHiddenGroups] = useState([]);
+  const [activeRow, setActiveRow] = useState(null);
   const lastSort = useRef(defaultSort);
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
@@ -318,7 +370,13 @@ const MachineList = () => {
             ]}
             onUpdateSort={updateSort}
             paginate={150}
-            rows={generateRows(rows, hiddenGroups, setHiddenGroups)}
+            rows={generateRows(
+              rows,
+              hiddenGroups,
+              setHiddenGroups,
+              activeRow,
+              setActiveRow
+            )}
             sortable
           />
         )}

--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -1,4 +1,5 @@
 @import "~vanilla-framework/scss/settings_spacing";
+@import "~vanilla-framework/scss/settings_colors";
 @import "~vanilla-framework/scss/base_forms-tick-elements";
 @import "./machine-list-breakpoint-widths";
 
@@ -6,6 +7,19 @@ $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spaci
 
 .machine-list--grouped .machine-list__machine td:first-child {
   padding-left: $grouped-machines-indentation;
+}
+
+.machine-list__machine .p-table-menu {
+  display: none;
+}
+
+.machine-list__machine:hover,
+.machine-list__machine--active {
+  background-color: $color-x-light;
+
+  .p-table-menu {
+    display: block;
+  }
 }
 
 .machine-list__group-toggle {

--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -19,6 +19,16 @@ $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spaci
 
   .p-table-menu {
     display: block;
+
+    .p-table-menu__toggle {
+      opacity: 0.25;
+    }
+  }
+
+  .p-table-menu .p-table-menu__toggle:focus,
+  .p-table-menu .p-table-menu__toggle:active,
+  td:hover .p-table-menu .p-table-menu__toggle {
+    opacity: 1;
   }
 }
 

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
@@ -3,9 +3,10 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { machine as machineSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 import Tooltip from "app/base/components/Tooltip";
 
-const generateFQDN = (machine, machineURL) => {
+const generateFQDN = (machine, machineURL, onToggleMenu) => {
   const name = (
     <a href={machineURL} title={machine.fqdn}>
       <strong>
@@ -32,11 +33,7 @@ const generateFQDN = (machine, machineURL) => {
     }
   });
   if (ipAddresses.length === 0) {
-    return (
-      <div className="p-double-row">
-        <div className="p-double-row__primary-row u-truncate">{name}</div>
-      </div>
-    );
+    return <DoubleRow onToggleMenu={onToggleMenu} primary={name} />;
   }
   let ipAddressesLine = (
     <span data-test="ip-addresses">
@@ -66,41 +63,44 @@ const generateFQDN = (machine, machineURL) => {
   }
 
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-truncate">{name}</div>
-      <div className="p-double-row__secondary-row u-truncate">
-        {ipAddressesLine}
-      </div>
-    </div>
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={name}
+      secondary={ipAddressesLine}
+    />
   );
 };
 
-const generateMAC = (machine, machineURL) => {
+const generateMAC = (machine, machineURL, onToggleMenu) => {
   return (
-    <div className="p-double-row">
-      <div className="p-doouble-row__primary-row u-truncate">
-        <a href={machineURL} title={machine.pxe_mac_vendor}>
-          {machine.pxe_mac}
-        </a>{" "}
-        {machine.extra_macs && machine.extra_macs.length > 0 ? (
-          <a href={machineURL}>(+{machine.extra_macs.length})</a>
-        ) : null}
-      </div>
-    </div>
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={
+        <>
+          <a href={machineURL} title={machine.pxe_mac_vendor}>
+            {machine.pxe_mac}
+          </a>{" "}
+          {machine.extra_macs && machine.extra_macs.length > 0 ? (
+            <a href={machineURL}>(+{machine.extra_macs.length})</a>
+          ) : null}
+        </>
+      }
+    />
   );
 };
 
-const NameColumn = ({ showMAC, systemId }) => {
+const NameColumn = ({ onToggleMenu, showMAC, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
   const machineURL = `${process.env.REACT_APP_ANGULAR_BASENAME}/${machine.link_type}/${machine.system_id}`;
   return showMAC
-    ? generateMAC(machine, machineURL)
-    : generateFQDN(machine, machineURL);
+    ? generateMAC(machine, machineURL, onToggleMenu)
+    : generateFQDN(machine, machineURL, onToggleMenu);
 };
 
 NameColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   showMAC: PropTypes.bool,
   systemId: PropTypes.string.isRequired
 };

--- a/ui/src/app/machines/views/MachineList/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -23,19 +23,27 @@ exports[`NameColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        className="p-double-row__primary-row u-truncate"
+        className="p-double-row__rows-container"
       >
-        <a
-          href="/#/undefined/abc123"
+        <div
+          className="p-double-row__primary-row"
         >
-          <strong>
-            koala
-          </strong>
-          <small>
-            .
-            example
-          </small>
-        </a>
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <a
+              href="/#/undefined/abc123"
+            >
+              <strong>
+                koala
+              </strong>
+              <small>
+                .
+                example
+              </small>
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -4,12 +4,8 @@ exports[`NameColumn renders 1`] = `
 <NameColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
-  >
-    <div
-      className="p-double-row__primary-row u-truncate"
-    >
+  <DoubleRow
+    primary={
       <a
         href="/#/undefined/abc123"
       >
@@ -21,7 +17,27 @@ exports[`NameColumn renders 1`] = `
           example
         </small>
       </a>
+    }
+  >
+    <div
+      className="p-double-row"
+    >
+      <div
+        className="p-double-row__primary-row u-truncate"
+      >
+        <a
+          href="/#/undefined/abc123"
+        >
+          <strong>
+            koala
+          </strong>
+          <small>
+            .
+            example
+          </small>
+        </a>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </NameColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -3,9 +3,9 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { machine as machineSelectors } from "app/base/selectors";
-import TableMenu from "app/base/components/TableMenu";
+import DoubleRow from "app/base/components/DoubleRow";
 
-const OwnerColumn = ({ systemId }) => {
+const OwnerColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -14,24 +14,22 @@ const OwnerColumn = ({ systemId }) => {
   const tags = machine.tags ? machine.tags.join(", ") : "";
 
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-truncate">
-        <span data-test="owner">{owner}</span>
-        <TableMenu
-          links={[{ children: "Link1" }, { children: "Link2" }]}
-          title="Take action:"
-        />
-      </div>
-      <div className="p-double-row__secondary-row u-truncate">
+    <DoubleRow
+      menuLinks={[{ children: "Link1" }, { children: "Link2" }]}
+      menuTitle="Take action:"
+      onToggleMenu={onToggleMenu}
+      primary={<span data-test="owner">{owner}</span>}
+      secondary={
         <span title={tags} data-test="tags">
           {tags}
         </span>
-      </div>
-    </div>
+      }
+    />
   );
 };
 
 OwnerColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -4,17 +4,46 @@ exports[`OwnerColumn renders 1`] = `
 <OwnerColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
-  >
-    <div
-      className="p-double-row__primary-row u-truncate"
-    >
+  <DoubleRow
+    menuLinks={
+      Array [
+        Object {
+          "children": "Link1",
+        },
+        Object {
+          "children": "Link2",
+        },
+      ]
+    }
+    menuTitle="Take action:"
+    primary={
       <span
         data-test="owner"
       >
         admin
       </span>
+    }
+    secondary={
+      <span
+        data-test="tags"
+        title=""
+      >
+        
+      </span>
+    }
+  >
+    <div
+      className="p-double-row"
+    >
+      <div
+        className="p-double-row__primary-row u-truncate"
+      >
+        <span
+          data-test="owner"
+        >
+          admin
+        </span>
+      </div>
       <TableMenu
         links={
           Array [
@@ -46,6 +75,7 @@ exports[`OwnerColumn renders 1`] = `
           }
           position="center"
           toggleAppearance="base"
+          toggleClassName="u-no-margin--bottom p-table-menu__toggle"
         >
           <span
             className="p-table-menu p-contextual-menu--center"
@@ -55,7 +85,7 @@ exports[`OwnerColumn renders 1`] = `
               aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
               aria-expanded="false"
               aria-haspopup="true"
-              className="p-contextual-menu__toggle"
+              className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
               hasIcon={true}
               onClick={[Function]}
             >
@@ -63,7 +93,7 @@ exports[`OwnerColumn renders 1`] = `
                 aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
                 aria-expanded="false"
                 aria-haspopup="true"
-                className="p-button--base has-icon p-contextual-menu__toggle"
+                className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                 onClick={[Function]}
               >
                 <i
@@ -74,15 +104,15 @@ exports[`OwnerColumn renders 1`] = `
           </span>
         </ContextualMenu>
       </TableMenu>
+      <div
+        className="p-double-row__secondary-row u-truncate"
+      >
+        <span
+          data-test="tags"
+          title=""
+        />
+      </div>
     </div>
-    <div
-      className="p-double-row__secondary-row u-truncate"
-    >
-      <span
-        data-test="tags"
-        title=""
-      />
-    </div>
-  </div>
+  </DoubleRow>
 </OwnerColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -36,33 +36,22 @@ exports[`OwnerColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        className="p-double-row__primary-row u-truncate"
+        className="p-double-row__rows-container"
       >
-        <span
-          data-test="owner"
+        <div
+          className="p-double-row__primary-row"
         >
-          admin
-        </span>
-      </div>
-      <TableMenu
-        links={
-          Array [
-            Object {
-              "children": "Link1",
-            },
-            Object {
-              "children": "Link2",
-            },
-          ]
-        }
-        title="Take action:"
-      >
-        <ContextualMenu
-          className="p-table-menu"
-          hasToggleIcon={true}
-          links={
-            Array [
-              "Take action:",
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <span
+              data-test="owner"
+            >
+              admin
+            </span>
+          </div>
+          <TableMenu
+            links={
               Array [
                 Object {
                   "children": "Link1",
@@ -70,47 +59,66 @@ exports[`OwnerColumn renders 1`] = `
                 Object {
                   "children": "Link2",
                 },
-              ],
-            ]
-          }
-          position="center"
-          toggleAppearance="base"
-          toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+              ]
+            }
+            title="Take action:"
+          >
+            <ContextualMenu
+              className="p-table-menu"
+              hasToggleIcon={true}
+              links={
+                Array [
+                  "Take action:",
+                  Array [
+                    Object {
+                      "children": "Link1",
+                    },
+                    Object {
+                      "children": "Link2",
+                    },
+                  ],
+                ]
+              }
+              position="center"
+              toggleAppearance="base"
+              toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+            >
+              <span
+                className="p-table-menu p-contextual-menu--center"
+              >
+                <Button
+                  appearance="base"
+                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  hasIcon={true}
+                  onClick={[Function]}
+                >
+                  <button
+                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    onClick={[Function]}
+                  >
+                    <i
+                      className="p-icon--contextual-menu p-contextual-menu__indicator"
+                    />
+                  </button>
+                </Button>
+              </span>
+            </ContextualMenu>
+          </TableMenu>
+        </div>
+        <div
+          className="p-double-row__secondary-row u-truncate"
         >
           <span
-            className="p-table-menu p-contextual-menu--center"
-          >
-            <Button
-              appearance="base"
-              aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
-              aria-expanded="false"
-              aria-haspopup="true"
-              className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
-              hasIcon={true}
-              onClick={[Function]}
-            >
-              <button
-                aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
-                aria-expanded="false"
-                aria-haspopup="true"
-                className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
-                onClick={[Function]}
-              >
-                <i
-                  className="p-icon--contextual-menu p-contextual-menu__indicator"
-                />
-              </button>
-            </Button>
-          </span>
-        </ContextualMenu>
-      </TableMenu>
-      <div
-        className="p-double-row__secondary-row u-truncate"
-      >
-        <span
-          data-test="tags"
-          title=""
-        />
+            data-test="tags"
+            title=""
+          />
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/PoolColumn/PoolColumn.js
+++ b/ui/src/app/machines/views/MachineList/PoolColumn/PoolColumn.js
@@ -3,31 +3,36 @@ import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 
 import { machine as machineSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 
-const PoolColumn = ({ systemId }) => {
+const PoolColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
 
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-truncate" aria-label="Pool">
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={
         <span data-test="pool">
           <a className="p-link--soft" href="#/pools" title={machine.pool.name}>
             {machine.pool.name}
           </a>
         </span>
-      </div>
-      <div className="p-double-row__secondary-row u-truncate" aria-label="Note">
+      }
+      primaryAriaLabel="Pool"
+      secondary={
         <span title={machine.description} data-test="note">
           {machine.description}
         </span>
-      </div>
-    </div>
+      }
+      secondaryAriaLabel="Note"
+    />
   );
 };
 
 PoolColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -4,13 +4,8 @@ exports[`PoolColumn renders 1`] = `
 <PoolColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
-  >
-    <div
-      aria-label="Pool"
-      className="p-double-row__primary-row u-truncate"
-    >
+  <DoubleRow
+    primary={
       <span
         data-test="pool"
       >
@@ -22,18 +17,49 @@ exports[`PoolColumn renders 1`] = `
           default
         </a>
       </span>
-    </div>
-    <div
-      aria-label="Note"
-      className="p-double-row__secondary-row u-truncate"
-    >
+    }
+    primaryAriaLabel="Pool"
+    secondary={
       <span
         data-test="note"
         title="Firmware old"
       >
         Firmware old
       </span>
+    }
+    secondaryAriaLabel="Note"
+  >
+    <div
+      className="p-double-row"
+    >
+      <div
+        aria-label="Pool"
+        className="p-double-row__primary-row u-truncate"
+      >
+        <span
+          data-test="pool"
+        >
+          <a
+            className="p-link--soft"
+            href="#/pools"
+            title="default"
+          >
+            default
+          </a>
+        </span>
+      </div>
+      <div
+        aria-label="Note"
+        className="p-double-row__secondary-row u-truncate"
+      >
+        <span
+          data-test="note"
+          title="Firmware old"
+        >
+          Firmware old
+        </span>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </PoolColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -33,31 +33,39 @@ exports[`PoolColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        aria-label="Pool"
-        className="p-double-row__primary-row u-truncate"
+        className="p-double-row__rows-container"
       >
-        <span
-          data-test="pool"
+        <div
+          aria-label="Pool"
+          className="p-double-row__primary-row"
         >
-          <a
-            className="p-link--soft"
-            href="#/pools"
-            title="default"
+          <div
+            className="p-double-row__primary-row-text u-truncate"
           >
-            default
-          </a>
-        </span>
-      </div>
-      <div
-        aria-label="Note"
-        className="p-double-row__secondary-row u-truncate"
-      >
-        <span
-          data-test="note"
-          title="Firmware old"
+            <span
+              data-test="pool"
+            >
+              <a
+                className="p-link--soft"
+                href="#/pools"
+                title="default"
+              >
+                default
+              </a>
+            </span>
+          </div>
+        </div>
+        <div
+          aria-label="Note"
+          className="p-double-row__secondary-row u-truncate"
         >
-          Firmware old
-        </span>
+          <span
+            data-test="note"
+            title="Firmware old"
+          >
+            Firmware old
+          </span>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -4,8 +4,9 @@ import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 
 import { machine as machineSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 
-const PowerColumn = ({ systemId }) => {
+const PowerColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -18,23 +19,23 @@ const PowerColumn = ({ systemId }) => {
   });
 
   return (
-    <div className="p-double-row--with-icon">
-      <div className="p-double-row__icon">
-        <i title={machine.power_state} className={iconClass}></i>
-      </div>
-      <div className="p-double-row__primary-row u-upper-case--first u-truncate">
-        <span data-test="power_state">{machine.power_state}</span>
-      </div>
-      <div className="p-double-row__secondary-row u-upper-case--first u-truncate">
+    <DoubleRow
+      icon={<i title={machine.power_state} className={iconClass}></i>}
+      onToggleMenu={onToggleMenu}
+      primary={<span data-test="power_state">{machine.power_state}</span>}
+      primaryClassName="u-upper-case--first"
+      secondary={
         <span title={machine.power_type} data-test="power_type">
           {machine.power_type}
         </span>
-      </div>
-    </div>
+      }
+      secondaryClassName="u-upper-case--first"
+    />
   );
 };
 
 PowerColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -21,6 +21,7 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
   return (
     <DoubleRow
       icon={<i title={machine.power_state} className={iconClass}></i>}
+      iconSpace={true}
       onToggleMenu={onToggleMenu}
       primary={<span data-test="power_state">{machine.power_state}</span>}
       primaryClassName="u-upper-case--first"

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -11,6 +11,7 @@ exports[`PowerColumn renders 1`] = `
         title="on"
       />
     }
+    iconSpace={true}
     primary={
       <span
         data-test="power_state"
@@ -41,23 +42,31 @@ exports[`PowerColumn renders 1`] = `
         />
       </div>
       <div
-        className="p-double-row__primary-row u-truncate u-upper-case--first"
+        className="p-double-row__rows-container"
       >
-        <span
-          data-test="power_state"
+        <div
+          className="p-double-row__primary-row u-upper-case--first"
         >
-          on
-        </span>
-      </div>
-      <div
-        className="p-double-row__secondary-row u-truncate u-upper-case--first"
-      >
-        <span
-          data-test="power_type"
-          title="virsh"
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <span
+              data-test="power_state"
+            >
+              on
+            </span>
+          </div>
+        </div>
+        <div
+          className="p-double-row__secondary-row u-truncate u-upper-case--first"
         >
-          virsh
-        </span>
+          <span
+            data-test="power_type"
+            title="virsh"
+          >
+            virsh
+          </span>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -4,36 +4,62 @@ exports[`PowerColumn renders 1`] = `
 <PowerColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row--with-icon"
-  >
-    <div
-      className="p-double-row__icon"
-    >
+  <DoubleRow
+    icon={
       <i
         className="p-icon--power-on"
         title="on"
       />
-    </div>
-    <div
-      className="p-double-row__primary-row u-upper-case--first u-truncate"
-    >
+    }
+    primary={
       <span
         data-test="power_state"
       >
         on
       </span>
-    </div>
-    <div
-      className="p-double-row__secondary-row u-upper-case--first u-truncate"
-    >
+    }
+    primaryClassName="u-upper-case--first"
+    secondary={
       <span
         data-test="power_type"
         title="virsh"
       >
         virsh
       </span>
+    }
+    secondaryClassName="u-upper-case--first"
+  >
+    <div
+      className="p-double-row--with-icon"
+    >
+      <div
+        className="p-double-row__icon"
+      >
+        <i
+          className="p-icon--power-on"
+          title="on"
+        />
+      </div>
+      <div
+        className="p-double-row__primary-row u-truncate u-upper-case--first"
+      >
+        <span
+          data-test="power_state"
+        >
+          on
+        </span>
+      </div>
+      <div
+        className="p-double-row__secondary-row u-truncate u-upper-case--first"
+      >
+        <span
+          data-test="power_type"
+          title="virsh"
+        >
+          virsh
+        </span>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </PowerColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/RamColumn/RamColumn.js
+++ b/ui/src/app/machines/views/MachineList/RamColumn/RamColumn.js
@@ -3,16 +3,18 @@ import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 
 import { machine as machineSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 import ScriptStatus from "app/base/components/ScriptStatus";
 
-const RamColumn = ({ systemId }) => {
+const RamColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
 
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-align--right u-truncate">
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={
         <ScriptStatus
           hidePassedIcon
           scriptType={machine.memory_test_status}
@@ -21,12 +23,14 @@ const RamColumn = ({ systemId }) => {
           <span data-test="memory">{machine.memory}</span>&nbsp;
           <small className="u-text--light">GiB</small>
         </ScriptStatus>
-      </div>
-    </div>
+      }
+      primaryClassName="u-align--right"
+    />
   );
 };
 
 RamColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/RamColumn/__snapshots__/RamColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/RamColumn/__snapshots__/RamColumn.test.js.snap
@@ -34,29 +34,37 @@ exports[`RamColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        className="p-double-row__primary-row u-truncate u-align--right"
+        className="p-double-row__rows-container"
       >
-        <ScriptStatus
-          hidePassedIcon={true}
-          scriptType={
-            Object {
-              "status": 2,
-            }
-          }
-          tooltipPosition="top-right"
+        <div
+          className="p-double-row__primary-row u-align--right"
         >
-          <span
-            data-test="memory"
+          <div
+            className="p-double-row__primary-row-text u-truncate"
           >
-            8
-          </span>
-           
-          <small
-            className="u-text--light"
-          >
-            GiB
-          </small>
-        </ScriptStatus>
+            <ScriptStatus
+              hidePassedIcon={true}
+              scriptType={
+                Object {
+                  "status": 2,
+                }
+              }
+              tooltipPosition="top-right"
+            >
+              <span
+                data-test="memory"
+              >
+                8
+              </span>
+               
+              <small
+                className="u-text--light"
+              >
+                GiB
+              </small>
+            </ScriptStatus>
+          </div>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/RamColumn/__snapshots__/RamColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/RamColumn/__snapshots__/RamColumn.test.js.snap
@@ -4,12 +4,8 @@ exports[`RamColumn renders 1`] = `
 <RamColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
-  >
-    <div
-      className="p-double-row__primary-row u-align--right u-truncate"
-    >
+  <DoubleRow
+    primary={
       <ScriptStatus
         hidePassedIcon={true}
         scriptType={
@@ -31,7 +27,38 @@ exports[`RamColumn renders 1`] = `
           GiB
         </small>
       </ScriptStatus>
+    }
+    primaryClassName="u-align--right"
+  >
+    <div
+      className="p-double-row"
+    >
+      <div
+        className="p-double-row__primary-row u-truncate u-align--right"
+      >
+        <ScriptStatus
+          hidePassedIcon={true}
+          scriptType={
+            Object {
+              "status": 2,
+            }
+          }
+          tooltipPosition="top-right"
+        >
+          <span
+            data-test="memory"
+          >
+            8
+          </span>
+           
+          <small
+            className="u-text--light"
+          >
+            GiB
+          </small>
+        </ScriptStatus>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </RamColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
@@ -8,6 +8,7 @@ import {
   machine as machineSelectors
 } from "app/base/selectors";
 import { nodeStatus, scriptStatus } from "app/base/enum";
+import DoubleRow from "app/base/components/DoubleRow";
 import Tooltip from "app/base/components/Tooltip";
 
 // Node statuses for which the failed test warning is not shown.
@@ -97,7 +98,7 @@ const getStatusIcon = machine => {
   return "";
 };
 
-const StatusColumn = ({ systemId }) => {
+const StatusColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -106,27 +107,28 @@ const StatusColumn = ({ systemId }) => {
   );
 
   return (
-    <div className="p-double-row--with-icon">
-      <div className="p-double-row__icon">{getStatusIcon(machine)}</div>
-      <div
-        className="p-double-row__primary-row u-truncate"
-        data-test="status-text"
-        title={getStatusText(machine, osReleases)}
-      >
-        {getStatusText(machine, osReleases)}
-      </div>
-      <div
-        className="p-double-row__secondary-row u-truncate"
-        data-test="progress-text"
-        title={getProgressText(machine)}
-      >
-        {getProgressText(machine)}
-      </div>
-    </div>
+    <DoubleRow
+      icon={getStatusIcon(machine)}
+      onToggleMenu={onToggleMenu}
+      primary={
+        <span
+          data-test="status-text"
+          title={getStatusText(machine, osReleases)}
+        >
+          {getStatusText(machine, osReleases)}
+        </span>
+      }
+      secondary={
+        <span data-test="progress-text" title={getProgressText(machine)}>
+          {getProgressText(machine)}
+        </span>
+      }
+    />
   );
 };
 
 StatusColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
@@ -109,6 +109,7 @@ const StatusColumn = ({ onToggleMenu, systemId }) => {
   return (
     <DoubleRow
       icon={getStatusIcon(machine)}
+      iconSpace={true}
       onToggleMenu={onToggleMenu}
       primary={
         <span

--- a/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -4,24 +4,47 @@ exports[`StatusColumn renders 1`] = `
 <StatusColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row--with-icon"
+  <DoubleRow
+    icon=""
+    primary={
+      <span
+        data-test="status-text"
+        title="New"
+      >
+        New
+      </span>
+    }
+    secondary={
+      <span
+        data-test="progress-text"
+        title=""
+      >
+        
+      </span>
+    }
   >
     <div
-      className="p-double-row__icon"
-    />
-    <div
-      className="p-double-row__primary-row u-truncate"
-      data-test="status-text"
-      title="New"
+      className="p-double-row"
     >
-      New
+      <div
+        className="p-double-row__primary-row u-truncate"
+      >
+        <span
+          data-test="status-text"
+          title="New"
+        >
+          New
+        </span>
+      </div>
+      <div
+        className="p-double-row__secondary-row u-truncate"
+      >
+        <span
+          data-test="progress-text"
+          title=""
+        />
+      </div>
     </div>
-    <div
-      className="p-double-row__secondary-row u-truncate"
-      data-test="progress-text"
-      title=""
-    />
-  </div>
+  </DoubleRow>
 </StatusColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -6,6 +6,7 @@ exports[`StatusColumn renders 1`] = `
 >
   <DoubleRow
     icon=""
+    iconSpace={true}
     primary={
       <span
         data-test="status-text"
@@ -24,25 +25,40 @@ exports[`StatusColumn renders 1`] = `
     }
   >
     <div
-      className="p-double-row"
+      className="p-double-row--with-icon"
     >
       <div
-        className="p-double-row__primary-row u-truncate"
+        className="p-double-row__icon"
       >
-        <span
-          data-test="status-text"
-          title="New"
-        >
-          New
-        </span>
+        <div
+          className="p-double-row__icon-space"
+        />
       </div>
       <div
-        className="p-double-row__secondary-row u-truncate"
+        className="p-double-row__rows-container"
       >
-        <span
-          data-test="progress-text"
-          title=""
-        />
+        <div
+          className="p-double-row__primary-row"
+        >
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <span
+              data-test="status-text"
+              title="New"
+            >
+              New
+            </span>
+          </div>
+        </div>
+        <div
+          className="p-double-row__secondary-row u-truncate"
+        >
+          <span
+            data-test="progress-text"
+            title=""
+          />
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/StorageColumn/StorageColumn.js
+++ b/ui/src/app/machines/views/MachineList/StorageColumn/StorageColumn.js
@@ -4,26 +4,32 @@ import PropTypes from "prop-types";
 
 import { machine as machineSelectors } from "app/base/selectors";
 import { formatBytes } from "app/utils";
+import DoubleRow from "app/base/components/DoubleRow";
 
-const StorageColumn = ({ systemId }) => {
+const StorageColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
   const formattedStorage = formatBytes(machine.storage, "GB");
 
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-align--right u-truncate">
-        <span data-test="storage-value">{formattedStorage.value}</span>&nbsp;
-        <small className="u-text--light" data-test="storage-unit">
-          {formattedStorage.unit}
-        </small>
-      </div>
-    </div>
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={
+        <>
+          <span data-test="storage-value">{formattedStorage.value}</span>&nbsp;
+          <small className="u-text--light" data-test="storage-unit">
+            {formattedStorage.unit}
+          </small>
+        </>
+      }
+      primaryClassName="u-align--right"
+    />
   );
 };
 
 StorageColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/StorageColumn/__snapshots__/StorageColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StorageColumn/__snapshots__/StorageColumn.test.js.snap
@@ -4,25 +4,45 @@ exports[`StorageColumn renders 1`] = `
 <StorageColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
+  <DoubleRow
+    primary={
+      <React.Fragment>
+        <span
+          data-test="storage-value"
+        >
+          8
+        </span>
+         
+        <small
+          className="u-text--light"
+          data-test="storage-unit"
+        >
+          GB
+        </small>
+      </React.Fragment>
+    }
+    primaryClassName="u-align--right"
   >
     <div
-      className="p-double-row__primary-row u-align--right u-truncate"
+      className="p-double-row"
     >
-      <span
-        data-test="storage-value"
+      <div
+        className="p-double-row__primary-row u-truncate u-align--right"
       >
-        8
-      </span>
-       
-      <small
-        className="u-text--light"
-        data-test="storage-unit"
-      >
-        GB
-      </small>
+        <span
+          data-test="storage-value"
+        >
+          8
+        </span>
+         
+        <small
+          className="u-text--light"
+          data-test="storage-unit"
+        >
+          GB
+        </small>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </StorageColumn>
 `;

--- a/ui/src/app/machines/views/MachineList/StorageColumn/__snapshots__/StorageColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StorageColumn/__snapshots__/StorageColumn.test.js.snap
@@ -27,20 +27,28 @@ exports[`StorageColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        className="p-double-row__primary-row u-truncate u-align--right"
+        className="p-double-row__rows-container"
       >
-        <span
-          data-test="storage-value"
+        <div
+          className="p-double-row__primary-row u-align--right"
         >
-          8
-        </span>
-         
-        <small
-          className="u-text--light"
-          data-test="storage-unit"
-        >
-          GB
-        </small>
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <span
+              data-test="storage-value"
+            >
+              8
+            </span>
+             
+            <small
+              className="u-text--light"
+              data-test="storage-unit"
+            >
+              GB
+            </small>
+          </div>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/ZoneColumn.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 
 import Tooltip from "app/base/components/Tooltip";
 import { machine as machineSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 
 const getSpaces = machine => {
   if (machine.spaces.length > 1) {
@@ -17,23 +18,21 @@ const getSpaces = machine => {
   return <span data-test="spaces">{machine.spaces[0]}</span>;
 };
 
-const ZoneColumn = ({ systemId }) => {
+const ZoneColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
   return (
-    <div className="p-double-row">
-      <div className="p-double-row__primary-row u-truncate">
-        <span data-test="zone">{machine.zone.name}</span>
-      </div>
-      <div className="p-double-row__secondary-row u-truncate">
-        {getSpaces(machine)}
-      </div>
-    </div>
+    <DoubleRow
+      onToggleMenu={onToggleMenu}
+      primary={<span data-test="zone">{machine.zone.name}</span>}
+      secondary={getSpaces(machine)}
+    />
   );
 };
 
 ZoneColumn.propTypes = {
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired
 };
 

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -24,22 +24,30 @@ exports[`ZoneColumn renders 1`] = `
       className="p-double-row"
     >
       <div
-        className="p-double-row__primary-row u-truncate"
+        className="p-double-row__rows-container"
       >
-        <span
-          data-test="zone"
+        <div
+          className="p-double-row__primary-row"
         >
-          zone-north
-        </span>
-      </div>
-      <div
-        className="p-double-row__secondary-row u-truncate"
-      >
-        <span
-          data-test="spaces"
+          <div
+            className="p-double-row__primary-row-text u-truncate"
+          >
+            <span
+              data-test="zone"
+            >
+              zone-north
+            </span>
+          </div>
+        </div>
+        <div
+          className="p-double-row__secondary-row u-truncate"
         >
-          management
-        </span>
+          <span
+            data-test="spaces"
+          >
+            management
+          </span>
+        </div>
       </div>
     </div>
   </DoubleRow>

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -4,27 +4,44 @@ exports[`ZoneColumn renders 1`] = `
 <ZoneColumn
   systemId="abc123"
 >
-  <div
-    className="p-double-row"
-  >
-    <div
-      className="p-double-row__primary-row u-truncate"
-    >
+  <DoubleRow
+    primary={
       <span
         data-test="zone"
       >
         zone-north
       </span>
-    </div>
-    <div
-      className="p-double-row__secondary-row u-truncate"
-    >
+    }
+    secondary={
       <span
         data-test="spaces"
       >
         management
       </span>
+    }
+  >
+    <div
+      className="p-double-row"
+    >
+      <div
+        className="p-double-row__primary-row u-truncate"
+      >
+        <span
+          data-test="zone"
+        >
+          zone-north
+        </span>
+      </div>
+      <div
+        className="p-double-row__secondary-row u-truncate"
+      >
+        <span
+          data-test="spaces"
+        >
+          management
+        </span>
+      </div>
     </div>
-  </div>
+  </DoubleRow>
 </ZoneColumn>
 `;

--- a/ui/src/scss/_patterns_double-row.scss
+++ b/ui/src/scss/_patterns_double-row.scss
@@ -2,16 +2,18 @@
   $icon-space: map-get($icon-sizes, default) + $sph-inner--small;
 
   .p-double-row {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid:
+      [row1-start] "primary-row menu" auto [row1-end]
+      [row2-start] "secondary-row menu" auto [row2-end] / auto auto;
   }
 
   .p-double-row--with-icon {
     display: grid;
     grid:
-      [row1-start] "icon primary-row" auto [row1-end]
-      [row2-start] "icon secondary-row" auto [row2-end] /
-      $icon-space auto;
+      [row1-start] "icon primary-row menu" auto [row1-end]
+      [row2-start] "icon secondary-row menu" auto [row2-end] /
+      $icon-space auto auto;
   }
 
   .p-double-row__icon {
@@ -30,5 +32,9 @@
 
   .p-double-row__icon-space {
     padding-left: $icon-space;
+  }
+
+  .p-double-row .p-table-menu {
+    grid-area: menu;
   }
 }

--- a/ui/src/scss/_patterns_double-row.scss
+++ b/ui/src/scss/_patterns_double-row.scss
@@ -1,40 +1,40 @@
 @mixin maas-double-row {
-  $icon-space: map-get($icon-sizes, default) + $sph-inner--small;
+  $icon-space: map-get($icon-sizes, default);
 
+  .p-double-row--with-icon,
   .p-double-row {
-    display: grid;
-    grid:
-      [row1-start] "primary-row menu" auto [row1-end]
-      [row2-start] "secondary-row menu" auto [row2-end] / auto auto;
+    display: flex;
+    flex-direction: row;
   }
 
-  .p-double-row--with-icon {
-    display: grid;
-    grid:
-      [row1-start] "icon primary-row menu" auto [row1-end]
-      [row2-start] "icon secondary-row menu" auto [row2-end] /
-      $icon-space auto auto;
+  .p-double-row--with-icon .p-double-row__rows-container {
+    width: calc(100% - #{$icon-space + $sph-inner--small});
+  }
+
+  .p-double-row__rows-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
   }
 
   .p-double-row__icon {
-    grid-area: icon;
+    padding-right: $sph-inner--small;
   }
 
   .p-double-row__primary-row {
-    grid-area: primary-row;
+    display: flex;
   }
 
   .p-double-row__secondary-row {
     @extend %small-text;
     color: $color-mid-dark;
-    grid-area: secondary-row;
   }
 
   .p-double-row__icon-space {
-    padding-left: $icon-space;
+    width: $icon-space;
   }
 
-  .p-double-row .p-table-menu {
-    grid-area: menu;
+  [class*="p-double-row"] .p-table-menu {
+    margin-left: $sph-inner--small / 2;
   }
 }


### PR DESCRIPTION
## Done
- Replace double row elements with a component.
- Use the double row component to display a contextual menu.

## QA
- Visit /r/machines.
- Hover rows, the menu icon should appear next to the owner.
- Clicking the menu icon should display the menu and keep the row highlighted.

## Fixes
Fixes https://github.com/canonical-web-and-design/MAAS-squad/issues/1797.