### PR TITLE
Implement machine list grouping and sorting with double row headers

### DIFF
--- a/ui/src/app/base/components/TableHeader/TableHeader.js
+++ b/ui/src/app/base/components/TableHeader/TableHeader.js
@@ -1,0 +1,42 @@
+import { Button } from "@canonical/react-components";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const TableHeader = ({
+  children,
+  className,
+  currentSort,
+  onClick,
+  sortKey
+}) => {
+  if (!onClick) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <Button appearance="link" className={className} onClick={onClick}>
+      <span>{children}</span>
+      {currentSort && currentSort.key === sortKey && (
+        <i
+          className={classNames("p-icon--contextual-menu", {
+            "u-mirror--y": currentSort.direction === "ascending"
+          })}
+        />
+      )}
+    </Button>
+  );
+};
+
+TableHeader.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  currentSort: PropTypes.shape({
+    key: PropTypes.string,
+    direction: PropTypes.oneOf(["ascending", "descending", "none"])
+  }),
+  onClick: PropTypes.func,
+  sortKey: PropTypes.string
+};
+
+export default TableHeader;

--- a/ui/src/app/base/components/TableHeader/TableHeader.test.js
+++ b/ui/src/app/base/components/TableHeader/TableHeader.test.js
@@ -1,0 +1,58 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import TableHeader from "./TableHeader";
+
+describe("TableHeader ", () => {
+  it("renders a div if no onClick prop is present", () => {
+    const wrapper = shallow(<TableHeader>Text</TableHeader>);
+    expect(wrapper.find("Button").exists()).toBe(false);
+    expect(wrapper.find("div").exists()).toBe(true);
+  });
+
+  it("renders a Button if onClick prop is present", () => {
+    const mockFn = jest.fn();
+    const wrapper = shallow(<TableHeader onClick={mockFn}>Text</TableHeader>);
+    expect(wrapper.find("Button").exists()).toBe(true);
+
+    wrapper.find("Button").simulate("click");
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  it("renders a contextual icon if currentSort.key matches sortKey", () => {
+    const currentSort = {
+      key: "key",
+      direction: "descending"
+    };
+    const wrapper = shallow(
+      <TableHeader
+        currentSort={currentSort}
+        onClick={jest.fn()}
+        sortKey={"key"}
+      >
+        Text
+      </TableHeader>
+    );
+    expect(wrapper.find(".p-icon--contextual-menu").exists()).toBe(true);
+  });
+
+  it(`renders a flipped contextual icon if currentSort.key matches sortKey
+    and direction is ascending`, () => {
+    const currentSort = {
+      key: "key",
+      direction: "ascending"
+    };
+    const wrapper = shallow(
+      <TableHeader
+        currentSort={currentSort}
+        onClick={jest.fn()}
+        sortKey={"key"}
+      >
+        Text
+      </TableHeader>
+    );
+    expect(wrapper.find(".p-icon--contextual-menu.u-mirror--y").exists()).toBe(
+      true
+    );
+  });
+});

--- a/ui/src/app/base/components/TableHeader/index.js
+++ b/ui/src/app/base/components/TableHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TableHeader";

--- a/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.js
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.js
@@ -1,0 +1,52 @@
+import { Select } from "@canonical/react-components";
+import React from "react";
+import PropTypes from "prop-types";
+
+const groupOptions = [
+  {
+    value: "none",
+    label: "No grouping"
+  },
+  {
+    value: "owner",
+    label: "Group by owner"
+  },
+  {
+    value: "pool",
+    label: "Group by pool"
+  },
+  {
+    value: "power_state",
+    label: "Group by power state"
+  },
+  {
+    value: "status",
+    label: "Group by status"
+  },
+  {
+    value: "zone",
+    label: "Group by zone"
+  }
+];
+
+const GroupSelect = ({ grouping, setGrouping, setHiddenGroups }) => {
+  return (
+    <Select
+      defaultValue={grouping}
+      name="machine-groupings"
+      onChange={e => {
+        setGrouping(e.target.value);
+        setHiddenGroups([]);
+      }}
+      options={groupOptions}
+    />
+  );
+};
+
+GroupSelect.propTypes = {
+  grouping: PropTypes.string.isRequired,
+  setGrouping: PropTypes.func.isRequired,
+  setHiddenGroups: PropTypes.func.isRequired
+};
+
+export default GroupSelect;

--- a/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.test.js
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.test.js
@@ -1,0 +1,33 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import GroupSelect from "./GroupSelect";
+
+describe("GroupSelect ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <GroupSelect
+        grouping="none"
+        setGrouping={jest.fn()}
+        setHiddenGroups={jest.fn()}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("executes setGrouping and setHiddenGroups functions on change", () => {
+    const setGrouping = jest.fn();
+    const setHiddenGroups = jest.fn();
+    const wrapper = shallow(
+      <GroupSelect
+        grouping="none"
+        setGrouping={setGrouping}
+        setHiddenGroups={setHiddenGroups}
+      />
+    );
+    const mockEvent = { target: { value: "status" } };
+    wrapper.find("Select").simulate("change", mockEvent);
+    expect(setGrouping).toHaveBeenCalledWith(mockEvent.target.value);
+    expect(setHiddenGroups).toHaveBeenCalledWith([]);
+  });
+});

--- a/ui/src/app/machines/views/MachineList/GroupSelect/__snapshots__/GroupSelect.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/__snapshots__/GroupSelect.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GroupSelect  renders 1`] = `
+<Select
+  defaultValue="none"
+  name="machine-groupings"
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "label": "No grouping",
+        "value": "none",
+      },
+      Object {
+        "label": "Group by owner",
+        "value": "owner",
+      },
+      Object {
+        "label": "Group by pool",
+        "value": "pool",
+      },
+      Object {
+        "label": "Group by power state",
+        "value": "power_state",
+      },
+      Object {
+        "label": "Group by status",
+        "value": "status",
+      },
+      Object {
+        "label": "Group by zone",
+        "value": "zone",
+      },
+    ]
+  }
+/>
+`;

--- a/ui/src/app/machines/views/MachineList/GroupSelect/index.js
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/index.js
@@ -1,0 +1,1 @@
+export { default } from "./GroupSelect";

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -3,11 +3,13 @@ import {
   Col,
   Loader,
   MainTable,
-  Row
+  Row,
+  SearchBox,
+  Select
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import classNames from "classnames";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import pluralize from "pluralize";
 
 import "./MachineList.scss";
@@ -21,12 +23,14 @@ import {
   user as userActions,
   zone as zoneActions
 } from "app/base/actions";
+import { groupAsMap, simpleSortByKey } from "app/utils";
 import { machine as machineSelectors } from "app/base/selectors";
 import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
 import FabricColumn from "./FabricColumn";
+import GroupSelect from "./GroupSelect";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
 import PoolColumn from "./PoolColumn";
@@ -34,106 +38,53 @@ import PowerColumn from "./PowerColumn";
 import RamColumn from "./RamColumn";
 import StatusColumn from "./StatusColumn";
 import StorageColumn from "./StorageColumn";
+import TableHeader from "app/base/components/TableHeader";
 import ZoneColumn from "./ZoneColumn";
 
-const normaliseStatus = (statusCode, status) => {
-  switch (statusCode) {
-    case nodeStatus.FAILED_COMMISSIONING:
-    case nodeStatus.FAILED_DEPLOYMENT:
-    case nodeStatus.FAILED_RELEASING:
-    case nodeStatus.FAILED_DISK_ERASING:
-    case nodeStatus.FAILED_ENTERING_RESCUE_MODE:
-    case nodeStatus.FAILED_EXITING_RESCUE_MODE:
-    case nodeStatus.FAILED_TESTING:
-      return "Failed";
-    case nodeStatus.RESCUE_MODE:
-    case nodeStatus.ENTERING_RESCUE_MODE:
-    case nodeStatus.EXITING_RESCUE_MODE:
-      return "Rescue mode";
-    case nodeStatus.RELEASING:
-    case nodeStatus.DISK_ERASING:
-      return "Releasing";
-    case nodeStatus.RETIRED:
-    case nodeStatus.MISSING:
-    case nodeStatus.RESERVED:
-      return "Other";
-    default:
-      return status;
-  }
-};
-
-const getSortValue = (machine, currentSort) => {
-  switch (currentSort) {
+const getSortValue = (machine, sortKey) => {
+  switch (sortKey) {
     case "domain":
+      return machine.domain && machine.domain.name;
+    case "pool":
+      return machine.pool && machine.pool.name;
     case "zone":
-      return machine[currentSort].name;
+      return machine.zone && machine.zone.name;
+    case "fabric":
+      return machine.vlan && machine.vlan.fabric_name;
     default:
-      return machine[currentSort];
+      return machine[sortKey];
   }
 };
 
-const generateRows = (
-  rows,
-  hiddenGroups,
-  setHiddenGroups,
-  activeRow,
-  setActiveRow
-) =>
-  rows.map(row => {
-    if (row.isGroup) {
-      const sortData = {
-        [row.sortKey]: row.label
-      };
-      const collapsed = hiddenGroups.includes(row.label);
-      return {
-        className: "machine-list__group",
-        columns: [
-          {
-            content: (
-              <>
-                <strong>{row.label}</strong>
-                <div className="u-text--light">{`
-                ${row.count} ${pluralize("machine", row.count)}`}</div>
-              </>
-            )
-          },
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {},
-          {
-            className: "machine-list__group-toggle",
-            content: (
-              <Button
-                appearance="base"
-                className="machine-list__group-toggle-button"
-                onClick={() => {
-                  if (collapsed) {
-                    setHiddenGroups(
-                      hiddenGroups.filter(group => group !== row.label)
-                    );
-                  } else {
-                    setHiddenGroups(hiddenGroups.concat([row.label]));
-                  }
-                }}
-              >
-                {collapsed ? (
-                  <i className="p-icon--plus">Show</i>
-                ) : (
-                  <i className="p-icon--minus">Hide</i>
-                )}
-              </Button>
-            )
-          }
-        ],
-        sortData
-      };
+const machineSort = currentSort => {
+  const { key, direction } = currentSort;
+
+  return function(a, b) {
+    const sortA = getSortValue(a, key);
+    const sortB = getSortValue(b, key);
+
+    if (direction === "none") {
+      return 0;
     }
+    if (sortA < sortB) {
+      return direction === "descending" ? -1 : 1;
+    }
+    if (sortA > sortB) {
+      return direction === "descending" ? 1 : -1;
+    }
+    return 0;
+  };
+};
+
+const generateRows = ({
+  activeRow,
+  currentSort,
+  machines,
+  setActiveRow,
+  showMAC
+}) => {
+  const sortedMachines = [...machines].sort(machineSort(currentSort));
+  return sortedMachines.map(row => {
     const isActive = activeRow === row.system_id;
     const onToggleMenu = open => {
       if (open && !activeRow) {
@@ -142,6 +93,7 @@ const generateRows = (
         setActiveRow(null);
       }
     };
+
     return {
       className: classNames("machine-list__machine", {
         "machine-list__machine--active": isActive
@@ -151,7 +103,7 @@ const generateRows = (
           content: (
             <NameColumn
               onToggleMenu={onToggleMenu}
-              showMAC={false}
+              showMAC={showMAC}
               systemId={row.system_id}
             />
           )
@@ -215,70 +167,222 @@ const generateRows = (
             />
           )
         }
-      ],
-      sortData: {
-        cores: row.cpu_count,
-        disks: row.physical_disk_count,
-        domain: row.domain.name,
-        name: row.fqdn,
-        owner: row.owner,
-        pool: row.pool.name,
-        power: row.power_state,
-        ram: row.memory,
-        normalisedStatus: row.normalisedStatus,
-        storage: row.storage,
-        zone: row.zone.name
-      }
+      ]
     };
   });
+};
+
+const generateGroups = ({
+  activeRow,
+  currentSort,
+  grouping,
+  hiddenGroups,
+  machines,
+  setActiveRow,
+  setHiddenGroups,
+  showMAC
+}) => {
+  let groups = [];
+  let rows = [];
+
+  if (grouping === "owner") {
+    const groupMap = groupAsMap(machines, machine => machine.owner);
+    groups = Array.from(groupMap)
+      .map(([label, machines]) => ({ label: label || "No owner", machines }))
+      .sort(simpleSortByKey("label"));
+  }
+
+  if (grouping === "pool") {
+    const groupMap = groupAsMap(machines, machine => machine.pool.name);
+    groups = Array.from(groupMap)
+      .map(([label, machines]) => ({ label: label || "No pool", machines }))
+      .sort(simpleSortByKey("label"));
+  }
+
+  if (grouping === "power_state") {
+    const groupMap = groupAsMap(machines, machine => machine.power_state);
+    groups = [
+      {
+        label: "Error",
+        machines: groupMap.get("error") || []
+      },
+      {
+        label: "Off",
+        machines: groupMap.get("off") || []
+      },
+      {
+        label: "On",
+        machines: groupMap.get("on") || []
+      },
+      {
+        label: "Unknown",
+        machines: groupMap.get("unknown") || []
+      }
+    ].filter(group => group.machines.length);
+  }
+
+  if (grouping === "status") {
+    const groupMap = groupAsMap(machines, machine => machine.status_code);
+    groups = [
+      {
+        label: "Failed",
+        machines: [
+          ...(groupMap.get(nodeStatus.FAILED_COMMISSIONING) || []),
+          ...(groupMap.get(nodeStatus.FAILED_DEPLOYMENT) || []),
+          ...(groupMap.get(nodeStatus.FAILED_DISK_ERASING) || []),
+          ...(groupMap.get(nodeStatus.FAILED_ENTERING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.FAILED_EXITING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.FAILED_RELEASING) || []),
+          ...(groupMap.get(nodeStatus.FAILED_TESTING) || [])
+        ]
+      },
+      {
+        label: "New",
+        machines: groupMap.get(nodeStatus.NEW) || []
+      },
+      {
+        label: "Commissioning",
+        machines: groupMap.get(nodeStatus.COMMISSIONING) || []
+      },
+      {
+        label: "Testing",
+        machines: groupMap.get(nodeStatus.TESTING) || []
+      },
+      {
+        label: "Ready",
+        machines: groupMap.get(nodeStatus.READY) || []
+      },
+      {
+        label: "Allocated",
+        machines: groupMap.get(nodeStatus.ALLOCATED) || []
+      },
+      {
+        label: "Deploying",
+        machines: groupMap.get(nodeStatus.DEPLOYING) || []
+      },
+      {
+        label: "Deployed",
+        machines: groupMap.get(nodeStatus.DEPLOYED) || []
+      },
+      {
+        label: "Rescue mode",
+        machines: [
+          ...(groupMap.get(nodeStatus.ENTERING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.EXITING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.RESCUE_MODE) || [])
+        ]
+      },
+      {
+        label: "Releasing",
+        machines: [
+          ...(groupMap.get(nodeStatus.DISK_ERASING) || []),
+          ...(groupMap.get(nodeStatus.RELEASING) || [])
+        ]
+      },
+      {
+        label: "Broken",
+        machines: groupMap.get(nodeStatus.BROKEN) || []
+      },
+      {
+        label: "Other",
+        machines: [
+          ...(groupMap.get(nodeStatus.MISSING) || []),
+          ...(groupMap.get(nodeStatus.RESERVED) || []),
+          ...(groupMap.get(nodeStatus.RETIRED) || [])
+        ]
+      }
+    ].filter(group => group.machines.length);
+  }
+
+  if (grouping === "zone") {
+    const groupMap = groupAsMap(machines, machine => machine.zone.name);
+    groups = Array.from(groupMap)
+      .map(([label, machines]) => ({ label: label || "No zone", machines }))
+      .sort(simpleSortByKey("label"));
+  }
+
+  groups.forEach(group => {
+    const { label, machines } = group;
+    const collapsed = hiddenGroups.includes(label);
+    rows.push({
+      className: "machine-list__group",
+      columns: [
+        {
+          content: (
+            <>
+              <strong>{label}</strong>
+              <div className="u-text--light">{`
+              ${machines.length} ${pluralize(
+                "machine",
+                machines.length
+              )}`}</div>
+            </>
+          )
+        },
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {
+          className: "machine-list__group-toggle",
+          content: (
+            <Button
+              appearance="base"
+              className="machine-list__group-toggle-button"
+              onClick={() => {
+                if (collapsed) {
+                  setHiddenGroups(
+                    hiddenGroups.filter(group => group !== label)
+                  );
+                } else {
+                  setHiddenGroups(hiddenGroups.concat([label]));
+                }
+              }}
+            >
+              {collapsed ? (
+                <i className="p-icon--plus">Show</i>
+              ) : (
+                <i className="p-icon--minus">Hide</i>
+              )}
+            </Button>
+          )
+        }
+      ]
+    });
+    const visibleMachines = collapsed ? [] : machines;
+    rows = rows.concat(
+      generateRows({
+        activeRow,
+        currentSort,
+        machines: visibleMachines,
+        setActiveRow,
+        showMAC
+      })
+    );
+  });
+  return rows;
+};
 
 const MachineList = () => {
-  const defaultSort = "normalisedStatus";
   const dispatch = useDispatch();
-  const [currentSort, setSort] = useState(defaultSort);
+
+  const [currentSort, setCurrentSort] = useState({
+    key: "fqdn",
+    direction: "descending"
+  });
+  const [grouping, setGrouping] = useState("status");
   const [hiddenGroups, setHiddenGroups] = useState([]);
   const [activeRow, setActiveRow] = useState(null);
-  const lastSort = useRef(defaultSort);
+  const [showMAC, setShowMAC] = useState(false);
+
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const machinesLoading = useSelector(machineSelectors.loading);
-  const normalisedMachines = machines.map(machine => ({
-    ...machine,
-    normalisedStatus: normaliseStatus(machine.status_code, machine.status)
-  }));
-  const groupKeys = ["normalisedStatus", "domain", "zone"];
-  let groups = [];
-  const grouped = groupKeys.includes(currentSort);
-  if (grouped) {
-    const labels = {};
-    normalisedMachines.forEach(machine => {
-      const sortKey = getSortValue(machine, currentSort);
-      if (labels[sortKey]) {
-        labels[sortKey].count += 1;
-      } else {
-        labels[sortKey] = {
-          count: 1,
-          isGroup: true,
-          label: sortKey,
-          sortKey: currentSort
-        };
-      }
-    });
-    groups = Object.keys(labels).map(label => labels[label]);
-  }
-  const visibleMachines = normalisedMachines.filter(machine => {
-    return !hiddenGroups.includes(getSortValue(machine, currentSort));
-  });
-  const rows = groups.concat(visibleMachines);
-
-  const updateSort = newSort => {
-    // Reset the hidden groups if the sort changes.
-    if (newSort !== lastSort.current) {
-      setHiddenGroups([]);
-      lastSort.current = newSort;
-    }
-    setSort(newSort);
-  };
 
   useWindowTitle("Machines");
 
@@ -299,89 +403,265 @@ const MachineList = () => {
     dispatch(zoneActions.fetch());
   }, [dispatch, machinesLoaded]);
 
+  // Update sort parameters depending on whether the same sort key was clicked.
+  const updateSort = newSortKey => {
+    const { key, direction } = currentSort;
+
+    if (newSortKey === key) {
+      if (direction === "ascending") {
+        setCurrentSort({ key: "", direction: "none" });
+      } else {
+        setCurrentSort({ key, direction: "ascending" });
+      }
+    } else {
+      setCurrentSort({ key: newSortKey, direction: "descending" });
+    }
+  };
+
   return (
-    <Row>
-      <Col size={12}>
-        {machinesLoading && (
-          <div className="u-align--center">
-            <Loader text="Loading..." />
-          </div>
-        )}
-        {machinesLoaded && (
-          <MainTable
-            className={classNames("p-table-expanding--light", "machine-list", {
-              "machine-list--grouped": grouped
-            })}
-            defaultSort={defaultSort}
-            defaultSortDirection="ascending"
-            headers={[
+    <>
+      <Row>
+        <Col size={3}>
+          <Select
+            name="machineFilters"
+            defaultValue=""
+            options={[
               {
-                content: "FQDN | MAC",
-                sortKey: "name"
-              },
-              {
-                content: (
-                  <span className="p-double-row__icon-space">Power</span>
-                ),
-                sortKey: "power_state"
-              },
-              {
-                content: (
-                  <span className="p-double-row__icon-space">Status</span>
-                ),
-                sortKey: "normalisedStatus"
-              },
-              {
-                content: "Owner",
-                sortKey: "owner"
-              },
-              {
-                content: "Pool",
-                sortkey: "pool.name"
-              },
-              {
-                content: "Zone",
-                sortKey: "zone"
-              },
-              {
-                content: "Fabric",
-                sortKey: "vlan.fabric_name"
-              },
-              {
-                content: "Cores",
-                sortKey: "cpu_count",
-                className: "u-align--right"
-              },
-              {
-                content: "RAM",
-                sortKey: "memory",
-                className: "u-align--right"
-              },
-              {
-                content: "Disks",
-                sortKey: "physical_disk_count",
-                className: "u-align--right"
-              },
-              {
-                content: "Storage",
-                sortKey: "storage",
-                className: "u-align--right"
+                value: "",
+                disabled: "disabled",
+                label: "Filters"
               }
             ]}
-            onUpdateSort={updateSort}
-            paginate={150}
-            rows={generateRows(
-              rows,
-              hiddenGroups,
-              setHiddenGroups,
-              activeRow,
-              setActiveRow
-            )}
-            sortable
           />
-        )}
-      </Col>
-    </Row>
+        </Col>
+        <Col size={6}>
+          <SearchBox onChange={() => null} />
+        </Col>
+        <Col size={3}>
+          <GroupSelect
+            grouping={grouping}
+            setGrouping={setGrouping}
+            setHiddenGroups={setHiddenGroups}
+          />
+        </Col>
+      </Row>
+      {machinesLoading && (
+        <Row>
+          <Col className="u-align--center" size={12}>
+            <Loader text="Loading..." />
+          </Col>
+        </Row>
+      )}
+      {machinesLoaded && (
+        <Row>
+          <Col size={12}>
+            <MainTable
+              className={classNames(
+                "p-table-expanding--light",
+                "machine-list",
+                {
+                  "machine-list--grouped": grouping !== "none"
+                }
+              )}
+              headers={[
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="fqdn-header"
+                        onClick={() => {
+                          setShowMAC(false);
+                          updateSort("fqdn");
+                        }}
+                        sortKey="fqdn"
+                      >
+                        FQDN
+                      </TableHeader>
+                      &nbsp;<strong>|</strong>&nbsp;
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="mac-header"
+                        onClick={() => {
+                          setShowMAC(true);
+                          updateSort("pxe_mac");
+                        }}
+                        sortKey="pxe_mac"
+                      >
+                        MAC
+                      </TableHeader>
+                      <TableHeader>IP</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <TableHeader
+                      className="p-double-row__header-spacer"
+                      currentSort={currentSort}
+                      data-test="power-header"
+                      onClick={() => updateSort("power_state")}
+                      sortKey="power_state"
+                    >
+                      Power
+                    </TableHeader>
+                  )
+                },
+                {
+                  content: (
+                    <TableHeader
+                      className="p-double-row__header-spacer"
+                      currentSort={currentSort}
+                      data-test="status-header"
+                      onClick={() => updateSort("status")}
+                      sortKey="status"
+                    >
+                      Status
+                    </TableHeader>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="owner-header"
+                        onClick={() => updateSort("owner")}
+                        sortKey="owner"
+                      >
+                        Owner
+                      </TableHeader>
+                      <TableHeader>Tags</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="pool-header"
+                        onClick={() => updateSort("pool")}
+                        sortKey="pool"
+                      >
+                        Pool
+                      </TableHeader>
+                      <TableHeader>Note</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="zone-header"
+                        onClick={() => updateSort("zone")}
+                        sortKey="zone"
+                      >
+                        Zone
+                      </TableHeader>
+                      <TableHeader>Spaces</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="fabric-header"
+                        onClick={() => updateSort("fabric")}
+                        sortKey="fabric"
+                      >
+                        Fabric
+                      </TableHeader>
+                      <TableHeader>VLAN</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="cores-header"
+                        onClick={() => updateSort("cpu_count")}
+                        sortKey="cpu_count"
+                      >
+                        Cores
+                      </TableHeader>
+                      <TableHeader>Arch</TableHeader>
+                    </>
+                  ),
+                  className: "u-align--right"
+                },
+                {
+                  content: (
+                    <TableHeader
+                      currentSort={currentSort}
+                      data-test="memory-header"
+                      onClick={() => updateSort("memory")}
+                      sortKey="memory"
+                    >
+                      RAM
+                    </TableHeader>
+                  ),
+                  className: "u-align--right"
+                },
+                {
+                  content: (
+                    <TableHeader
+                      currentSort={currentSort}
+                      data-test="disks-header"
+                      onClick={() => updateSort("physical_disk_count")}
+                      sortKey="physical_disk_count"
+                    >
+                      Disks
+                    </TableHeader>
+                  ),
+                  className: "u-align--right"
+                },
+                {
+                  content: (
+                    <TableHeader
+                      currentSort={currentSort}
+                      data-test="storage-header"
+                      onClick={() => updateSort("storage")}
+                      sortKey="storage"
+                    >
+                      Storage
+                    </TableHeader>
+                  ),
+                  className: "u-align--right"
+                }
+              ]}
+              paginate={150}
+              rows={
+                grouping === "none"
+                  ? generateRows({
+                      activeRow,
+                      currentSort,
+                      machines,
+                      setActiveRow,
+                      showMAC
+                    })
+                  : generateGroups({
+                      activeRow,
+                      currentSort,
+                      grouping,
+                      hiddenGroups,
+                      machines,
+                      setActiveRow,
+                      setHiddenGroups,
+                      showMAC
+                    })
+              }
+            />
+          </Col>
+        </Row>
+      )}
+    </>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -45,11 +45,11 @@ $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spaci
 .machine-list th {
   // FQDN/MAC
   &:nth-child(1) {
-    @include breakpoint-widths(45%, 36%, 26%, 24%, 20%);
+    @include breakpoint-widths(45%, 35%, 26%, 24%, 20%);
   }
   // Power
   &:nth-child(2) {
-    @include breakpoint-widths(23%, 16%, 12%, 10%, 8%);
+    @include breakpoint-widths(23%, 15%, 12%, 10%, 8%);
   }
   // Status
   &:nth-child(3) {
@@ -65,26 +65,26 @@ $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spaci
   }
   // Zone
   &:nth-child(6) {
-    @include breakpoint-widths(0, 0, 0, 9%, 9%);
+    @include breakpoint-widths(0, 0, 0, 9%, 7%);
   }
   // Fabric
   &:nth-child(7) {
-    @include breakpoint-widths(0, 0, 0, 0, 8%);
+    @include breakpoint-widths(0, 0, 0, 0, 7%);
   }
   // Cores
   &:nth-child(8) {
-    @include breakpoint-widths(0, 0, 8%, 6%, 5%);
+    @include breakpoint-widths(0, 0, 8%, 6%, 6%);
   }
   // RAM
   &:nth-child(9) {
-    @include breakpoint-widths(0, 0, 9%, 7%, 7%);
+    @include breakpoint-widths(0, 0, 9%, 8%, 7%);
   }
   // Disks
   &:nth-child(10) {
-    @include breakpoint-widths(0, 0, 8%, 6%, 5%);
+    @include breakpoint-widths(0, 0, 8%, 6%, 6%);
   }
   // Storage
   &:nth-child(11) {
-    @include breakpoint-widths(0, 0, 10%, 8%, 6%);
+    @include breakpoint-widths(0, 0, 9%, 8%, 6%);
   }
 }

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -43,6 +43,7 @@ describe("MachineList", () => {
               name: "example"
             },
             extra_macs: [],
+            fqdn: "koala.example",
             hostname: "koala",
             ip_addresses: [],
             memory: 8,
@@ -53,12 +54,13 @@ describe("MachineList", () => {
               status: scriptStatus.PASSED
             },
             osystem: "ubuntu",
+            owner: "admin",
             physical_disk_count: 1,
             pool: {},
             pxe_mac: "00:11:22:33:44:55",
             spaces: [],
-            status: "Releasing",
-            status_code: nodeStatus.RELEASING,
+            status: "Deployed",
+            status_code: nodeStatus.DEPLOYED,
             status_message: "",
             storage: 8,
             storage_test_status: {
@@ -68,6 +70,46 @@ describe("MachineList", () => {
               status: scriptStatus.PASSED
             },
             system_id: "abc123",
+            zone: {}
+          },
+          {
+            architecture: "amd64/generic",
+            cpu_count: 2,
+            cpu_test_status: {
+              status: scriptStatus.FAILED
+            },
+            distro_series: "xenial",
+            domain: {
+              name: "example"
+            },
+            extra_macs: [],
+            fqdn: "other.example",
+            hostname: "other",
+            ip_addresses: [],
+            memory: 6,
+            memory_test_status: {
+              status: scriptStatus.FAILED
+            },
+            network_test_status: {
+              status: scriptStatus.FAILED
+            },
+            osystem: "ubuntu",
+            owner: "user",
+            physical_disk_count: 2,
+            pool: {},
+            pxe_mac: "66:77:88:99:00:11",
+            spaces: [],
+            status: "Releasing",
+            status_code: nodeStatus.RELEASING,
+            status_message: "",
+            storage: 16,
+            storage_test_status: {
+              status: scriptStatus.FAILED
+            },
+            testing_status: {
+              status: scriptStatus.FAILED
+            },
+            system_id: "def456",
             zone: {}
           }
         ]
@@ -103,10 +145,18 @@ describe("MachineList", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(
       wrapper
-        .find(".machine-list__group td")
+        .find(".machine-list__group")
         .at(0)
+        .find("strong")
+        .text()
+    ).toBe("Deployed");
+    expect(
+      wrapper
+        .find(".machine-list__group")
+        .at(2)
         .find("strong")
         .text()
     ).toBe("Releasing");
@@ -124,12 +174,232 @@ describe("MachineList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("tr.machine-list__machine").length).toBe(1);
+
+    expect(wrapper.find("tr.machine-list__machine").length).toBe(2);
     // Click the button to toggle the group.
     wrapper
       .find(".machine-list__group button")
       .at(0)
       .simulate("click");
-    expect(wrapper.find("tr.machine-list__machine").length).toBe(0);
+    expect(wrapper.find("tr.machine-list__machine").length).toBe(1);
+  });
+
+  it("can change groups", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find(".machine-list__group")
+        .at(0)
+        .find("strong")
+        .text()
+    ).toBe("Deployed");
+    // Change grouping to owner
+    wrapper
+      .find('Select[name="machine-groupings"]')
+      .find("select")
+      .simulate("change", { target: { value: "owner" } });
+    expect(
+      wrapper
+        .find(".machine-list__group")
+        .at(0)
+        .find("strong")
+        .text()
+    ).toBe("admin");
+  });
+
+  it("can change machines to display PXE MAC instead of FQDN", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const firstMachine = state.machine.items[0];
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
+    // Click the MAC table header
+    wrapper
+      .find('[data-test="mac-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.pxe_mac);
+  });
+
+  it("updates sort on header click", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // First machine has more cores than second machine
+    const [firstMachine, secondMachine] = [
+      state.machine.items[0],
+      state.machine.items[1]
+    ];
+
+    // Change grouping to none
+    wrapper
+      .find('Select[name="machine-groupings"]')
+      .find("select")
+      .simulate("change", { target: { value: "none" } });
+    expect(
+      wrapper
+        .find('[data-test="cores-header"]')
+        .find("i")
+        .exists()
+    ).toBe(false);
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
+    // Click the cores table header
+    wrapper
+      .find('[data-test="cores-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="cores-header"]')
+        .find("i")
+        .exists()
+    ).toBe(true);
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(secondMachine.fqdn);
+  });
+
+  it("updates sort direction on multiple header clicks", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    const [firstMachine, secondMachine] = [
+      state.machine.items[0],
+      state.machine.items[1]
+    ];
+
+    // Change grouping to none
+    wrapper
+      .find('Select[name="machine-groupings"]')
+      .find("select")
+      .simulate("change", { target: { value: "none" } });
+
+    // Click the status table header
+    wrapper
+      .find('[data-test="status-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="status-header"]')
+        .find("i")
+        .exists()
+    ).toBe(true);
+    expect(
+      wrapper
+        .find('[data-test="status-header"]')
+        .find("i")
+        .props().className
+    ).toBe("p-icon--contextual-menu");
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
+
+    // Click the status table header again to reverse sort order
+    wrapper
+      .find('[data-test="status-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="status-header"]')
+        .find("i")
+        .props().className
+    ).toBe("p-icon--contextual-menu u-mirror--y");
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(secondMachine.fqdn);
+
+    // Click the FQDN table header again to return to no sort
+    wrapper
+      .find('[data-test="status-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="status-header"]')
+        .find("i")
+        .exists()
+    ).toBe(false);
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
   });
 });

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
@@ -79,9 +79,9 @@ const generateMAC = (machine, machineURL, onToggleMenu) => {
         <>
           <a href={machineURL} title={machine.pxe_mac_vendor}>
             {machine.pxe_mac}
-          </a>{" "}
+          </a>
           {machine.extra_macs && machine.extra_macs.length > 0 ? (
-            <a href={machineURL}>(+{machine.extra_macs.length})</a>
+            <a href={machineURL}> (+{machine.extra_macs.length})</a>
           ) : null}
         </>
       }

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.test.js
@@ -189,7 +189,7 @@ describe("NameColumn", () => {
         .find("a")
         .at(1)
         .text()
-    ).toEqual("(+1)");
+    ).toEqual(" (+1)");
   });
 
   it("can render a machine with minimal data", () => {

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -23,14 +23,20 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
       icon={<i title={machine.power_state} className={iconClass}></i>}
       iconSpace={true}
       onToggleMenu={onToggleMenu}
-      primary={<span data-test="power_state">{machine.power_state}</span>}
-      primaryClassName="u-upper-case--first"
-      secondary={
-        <span title={machine.power_type} data-test="power_type">
-          {machine.power_type}
-        </span>
+      primary={
+        <div className="u-upper-case--first" data-test="power_state">
+          {machine.power_state}
+        </div>
       }
-      secondaryClassName="u-upper-case--first"
+      secondary={
+        <div
+          className="u-upper-case--first"
+          title={machine.power_type}
+          data-test="power_type"
+        >
+          {machine.power_type}
+        </div>
+      }
     />
   );
 };

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -13,22 +13,22 @@ exports[`PowerColumn renders 1`] = `
     }
     iconSpace={true}
     primary={
-      <span
+      <div
+        className="u-upper-case--first"
         data-test="power_state"
       >
         on
-      </span>
+      </div>
     }
-    primaryClassName="u-upper-case--first"
     secondary={
-      <span
+      <div
+        className="u-upper-case--first"
         data-test="power_type"
         title="virsh"
       >
         virsh
-      </span>
+      </div>
     }
-    secondaryClassName="u-upper-case--first"
   >
     <div
       className="p-double-row--with-icon"
@@ -45,27 +45,29 @@ exports[`PowerColumn renders 1`] = `
         className="p-double-row__rows-container"
       >
         <div
-          className="p-double-row__primary-row u-upper-case--first"
+          className="p-double-row__primary-row"
         >
           <div
             className="p-double-row__primary-row-text u-truncate"
           >
-            <span
+            <div
+              className="u-upper-case--first"
               data-test="power_state"
             >
               on
-            </span>
+            </div>
           </div>
         </div>
         <div
-          className="p-double-row__secondary-row u-truncate u-upper-case--first"
+          className="p-double-row__secondary-row u-truncate"
         >
-          <span
+          <div
+            className="u-upper-case--first"
             data-test="power_type"
             title="virsh"
           >
             virsh
-          </span>
+          </div>
         </div>
       </div>
     </div>

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -209,20 +209,20 @@ describe("UsersList", () => {
     expect(
       wrapper
         .find("TableRow")
-        .at(2)
+        .at(1)
         .find("TableCell")
         .at(0)
         .text()
-    ).toEqual("user1");
+    ).toEqual("admin");
     // Click on the header toggle.
     wrapper
-      .find(".p-table-multi-header__link")
-      .at(2)
+      .find('[data-test="real-name-header"]')
+      .find("button")
       .simulate("click");
     expect(
       wrapper
         .find("TableRow")
-        .at(2)
+        .at(1)
         .find("TableCell")
         .at(0)
         .text()

--- a/ui/src/app/utils/groupAsMap.js
+++ b/ui/src/app/utils/groupAsMap.js
@@ -1,0 +1,21 @@
+/**
+ * Group an array of objects by a key getter function into an ES6 Map.
+ *
+ * @param {array{}} arr - the array of objects to group
+ * @param {function} keyGetter - the key getter function to group by, e.g item => item.name
+ * @returns {Map} grouped Map
+ */
+
+export const groupAsMap = (arr, keyGetter) => {
+  const map = new Map();
+  arr.forEach(item => {
+    const key = keyGetter(item);
+    const collection = map.get(key);
+    if (!collection) {
+      map.set(key, [item]);
+    } else {
+      collection.push(item);
+    }
+  });
+  return map;
+};

--- a/ui/src/app/utils/groupAsMap.test.js
+++ b/ui/src/app/utils/groupAsMap.test.js
@@ -1,0 +1,40 @@
+import { groupAsMap } from "./groupAsMap";
+
+describe("groupAsMap", () => {
+  it("correctly groups a list of objects by given key getter function", () => {
+    const arr = [
+      { name: "Alice", age: 25, height: 165 },
+      { name: "Bob", age: 40, height: 165 },
+      { name: "Chris", age: 25, height: 165 }
+    ];
+    const groupedByName = groupAsMap(arr, person => person.name);
+    const groupedByAge = groupAsMap(arr, person => person.age);
+    const groupedByHeight = groupAsMap(arr, person => person.height);
+
+    expect(Array.from(groupedByName)).toEqual([
+      ["Alice", [{ name: "Alice", age: 25, height: 165 }]],
+      ["Bob", [{ name: "Bob", age: 40, height: 165 }]],
+      ["Chris", [{ name: "Chris", age: 25, height: 165 }]]
+    ]);
+    expect(Array.from(groupedByAge)).toEqual([
+      [
+        25,
+        [
+          { name: "Alice", age: 25, height: 165 },
+          { name: "Chris", age: 25, height: 165 }
+        ]
+      ],
+      [40, [{ name: "Bob", age: 40, height: 165 }]]
+    ]);
+    expect(Array.from(groupedByHeight)).toEqual([
+      [
+        165,
+        [
+          { name: "Alice", age: 25, height: 165 },
+          { name: "Bob", age: 40, height: 165 },
+          { name: "Chris", age: 25, height: 165 }
+        ]
+      ]
+    ]);
+  });
+});

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -1,1 +1,3 @@
 export { formatBytes } from "./formatBytes";
+export { groupAsMap } from "./groupAsMap";
+export { simpleSortByKey } from "./simpleSortByKey";

--- a/ui/src/app/utils/simpleSortByKey.js
+++ b/ui/src/app/utils/simpleSortByKey.js
@@ -1,0 +1,14 @@
+/**
+ * Simple sort objects by key value.
+ *
+ * @param {string} key - the key of the objects to sort by
+ * @returns {function} sort function
+ */
+
+export const simpleSortByKey = attr => {
+  return function(a, b) {
+    if (a[attr] > b[attr]) return 1;
+    if (a[attr] < b[attr]) return -1;
+    return 0;
+  };
+};

--- a/ui/src/app/utils/simpleSortByKey.test.js
+++ b/ui/src/app/utils/simpleSortByKey.test.js
@@ -1,0 +1,22 @@
+import { simpleSortByKey } from "./simpleSortByKey";
+
+describe("simpleSortByKey", () => {
+  it("correctly sorts objects by key", () => {
+    const arr = [
+      { name: "Bob", age: 30 },
+      { name: "Chris", age: 20 },
+      { name: "Alice", age: 25 }
+    ];
+
+    expect(arr.sort(simpleSortByKey("name"))).toEqual([
+      { name: "Alice", age: 25 },
+      { name: "Bob", age: 30 },
+      { name: "Chris", age: 20 }
+    ]);
+    expect(arr.sort(simpleSortByKey("age"))).toEqual([
+      { name: "Chris", age: 20 },
+      { name: "Alice", age: 25 },
+      { name: "Bob", age: 30 }
+    ]);
+  });
+});

--- a/ui/src/scss/_patterns_double-row.scss
+++ b/ui/src/scss/_patterns_double-row.scss
@@ -34,6 +34,10 @@
     width: $icon-space;
   }
 
+  .p-double-row__header-spacer{
+    padding-left: $icon-space + $sph-inner--small;
+  }
+
   [class*="p-double-row"] .p-table-menu {
     margin-left: $sph-inner--small / 2;
   }

--- a/ui/src/scss/_patterns_table.scss
+++ b/ui/src/scss/_patterns_table.scss
@@ -8,43 +8,6 @@
   background-color: $color-x-light;
 }
 
-.p-table--sortable th[role="columnheader"][aria-sort].p-table-multi-header {
-  &::after {
-    display: none;
-  }
-
-  &[aria-sort]:hover {
-    color: $color-mid-dark;
-    text-decoration: none;
-  }
-}
-
-.p-table-multi-header .p-table-multi-header__link {
-  color: $color-mid-dark;
-
-  &:hover {
-    color: $color-link;
-  }
-}
-
-.p-table-multi-header[aria-sort="descending"],
-.p-table-multi-header[aria-sort="ascending"] {
-  .p-table-multi-header__link.is-active::after {
-    @extend %heading-icon;
-  }
-}
-
-.p-table-multi-header[aria-sort="descending"]
-  .p-table-multi-header__link.is-active::after {
-  -webkit-transform: rotate(180deg);
-  transform: rotate(180deg);
-}
-
-.p-table-multi-header__spacer {
-  margin-left: $sp-x-small;
-  margin-right: $sp-x-small;
-}
-
 .p-table-sub-cols {
   flex-direction: column;
 }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -4,6 +4,11 @@
  * {Link to relevant GitHub issue}
  */
 
+@import "~vanilla-framework/scss/settings_colors";
+@import "~vanilla-framework/scss/settings_spacing";
+@import "~vanilla-framework/scss/patterns_icons";
+@import "~vanilla-framework/scss/global_functions";
+
 // 19-08-2019 Caleb: Form submit button too close to input when $multi = 1
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2497
 .p-form__group:last-child {
@@ -20,4 +25,37 @@
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2672
 .p-tooltip__message--portal {
   display: inline;
+}
+
+// 28-01-2020 Caleb: Increase density of table headers
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2501
+%table-header-typography {
+  color: $color-mid-dark;
+  font-size: pow($ms-ratio, -2) * 1rem;
+  font-weight: 400;
+  line-height: 1rem;
+}
+thead th {
+  @extend %table-header-typography;
+  padding-bottom: .35rem;
+
+  .p-button--link {
+    @extend %table-header-typography;
+    &:hover {
+      color: $color-link;
+    }
+    &:active {
+      background-color: transparent !important;
+    }
+    &:focus {
+      color: $color-link;
+      outline: 0;
+      text-decoration: underline;
+    }
+  }
+
+  .p-icon--contextual-menu {
+    @include vf-icon-size(.875rem);
+    margin-left: $sp-x-small;
+  }
 }

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -37,6 +37,10 @@ body {
   color: $color-mid-dark;
 }
 
+.u-mirror--y {
+  transform: rotate(180deg);
+}
+
 .p-modal {
   // The modal needs to be above the header nav items.
   z-index: 10;
@@ -46,4 +50,8 @@ body {
 
 .u-upper-case--first:first-letter {
   text-transform: capitalize;
+}
+
+a:visited {
+  color: $color-link;
 }


### PR DESCRIPTION
## Done
- Added a TableHeader component which allows table headers to be clickable to run their own sort functions. Used in MachineList and UserList in settings. This required a bit of custom work to override the default MainTable sort behaviour, so I'm not sure this work should be upstreamed to the component library (if ever). I think once the UX of a generic table between products is finalised we can settle on an implementation, but for now this implements what's in the current angular version.
- Added a GroupSelect component that implements grouping as in the current angular version, plus added options for pool, power state and zone.
- Added placeholder filter dropdown and searchbox.
- Refactored MachineList to better separate grouping, sorting and row generation functions.
- Clicking the FQDN | MAC headers now change the first cell content.
- Drive by styling fixes:
  - Dense table headers (should be released in Vanilla soon)
  - Table cell/header spacing
  - Ensure table widths add up to 100% (oops)

## QA
- Check that you can change the leftmost column to MAC or FQDN.
- Check that clicking the table headers changes the sort parameter, and can be cycled between ascending, descending and none. Check that sorting works for all column headers, including FQDN and MAC.
- Check that you can change the grouping of machines, and that changing the sort changes the order of machines within each group (not the groups themselves)
- Check that the Settings > Users table still sorts as expected.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1744
Fixes canonical-web-and-design/MAAS-squad#1745
Fixes canonical-web-and-design/MAAS-squad#1746

## Screenshot
![0 0 0 0_8400_MAAS_r_machines (1)](https://user-images.githubusercontent.com/25733845/73351878-392a0380-4290-11ea-8501-e13cac32dd60.png)

