### PR TITLE
WIP: Improve machine list sorting and grouping.

### DIFF
--- a/ui/src/app/base/components/TableHeader/TableHeader.js
+++ b/ui/src/app/base/components/TableHeader/TableHeader.js
@@ -1,0 +1,44 @@
+import { Button } from "@canonical/react-components";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const TableHeader = ({
+  children,
+  className,
+  currentSort,
+  onClick,
+  sortKey
+}) => {
+  if (!onClick) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <span className={className}>
+      <Button appearance="link" onClick={onClick}>
+        <span>{children}</span>
+        {currentSort && currentSort.key === sortKey && (
+          <i
+            className={classNames("p-icon--contextual-menu", {
+              "u-mirror--y": currentSort.direction === "ascending"
+            })}
+          />
+        )}
+      </Button>
+    </span>
+  );
+};
+
+TableHeader.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  currentSort: PropTypes.shape({
+    key: PropTypes.string,
+    direction: PropTypes.oneOf(["ascending", "descending", "none"])
+  }),
+  onClick: PropTypes.func,
+  sortKey: PropTypes.string
+};
+
+export default TableHeader;

--- a/ui/src/app/base/components/TableHeader/TableHeader.test.js
+++ b/ui/src/app/base/components/TableHeader/TableHeader.test.js
@@ -1,0 +1,58 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import TableHeader from "./TableHeader";
+
+describe("TableHeader ", () => {
+  it("renders a div if no onClick prop is present", () => {
+    const wrapper = shallow(<TableHeader>Text</TableHeader>);
+    expect(wrapper.find("Button").exists()).toBe(false);
+    expect(wrapper.find("div").exists()).toBe(true);
+  });
+
+  it("renders a Button if onClick prop is present", () => {
+    const mockFn = jest.fn();
+    const wrapper = shallow(<TableHeader onClick={mockFn}>Text</TableHeader>);
+    expect(wrapper.find("Button").exists()).toBe(true);
+
+    wrapper.find("Button").simulate("click");
+    expect(mockFn).toHaveBeenCalled();
+  });
+
+  it("renders a contextual icon if currentSort.key matches sortKey", () => {
+    const currentSort = {
+      key: "key",
+      direction: "descending"
+    };
+    const wrapper = shallow(
+      <TableHeader
+        currentSort={currentSort}
+        onClick={jest.fn()}
+        sortKey={"key"}
+      >
+        Text
+      </TableHeader>
+    );
+    expect(wrapper.find(".p-icon--contextual-menu").exists()).toBe(true);
+  });
+
+  it(`renders a flipped contextual icon if currentSort.key matches sortKey
+    and direction is ascending`, () => {
+    const currentSort = {
+      key: "key",
+      direction: "ascending"
+    };
+    const wrapper = shallow(
+      <TableHeader
+        currentSort={currentSort}
+        onClick={jest.fn()}
+        sortKey={"key"}
+      >
+        Text
+      </TableHeader>
+    );
+    expect(wrapper.find(".p-icon--contextual-menu.u-mirror--y").exists()).toBe(
+      true
+    );
+  });
+});

--- a/ui/src/app/base/components/TableHeader/index.js
+++ b/ui/src/app/base/components/TableHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TableHeader";

--- a/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.js
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.js
@@ -1,0 +1,52 @@
+import { Select } from "@canonical/react-components";
+import React from "react";
+import PropTypes from "prop-types";
+
+const groupOptions = [
+  {
+    value: "none",
+    label: "No grouping"
+  },
+  {
+    value: "owner",
+    label: "Group by owner"
+  },
+  {
+    value: "pool",
+    label: "Group by pool"
+  },
+  {
+    value: "power_state",
+    label: "Group by power state"
+  },
+  {
+    value: "status",
+    label: "Group by status"
+  },
+  {
+    value: "zone",
+    label: "Group by zone"
+  }
+];
+
+const GroupSelect = ({ grouping, setGrouping, setHiddenGroups }) => {
+  return (
+    <Select
+      defaultValue={grouping}
+      name="machine-groupings"
+      onChange={e => {
+        setGrouping(e.target.value);
+        setHiddenGroups([]);
+      }}
+      options={groupOptions}
+    />
+  );
+};
+
+GroupSelect.propTypes = {
+  grouping: PropTypes.string.isRequired,
+  setGrouping: PropTypes.func.isRequired,
+  setHiddenGroups: PropTypes.func.isRequired
+};
+
+export default GroupSelect;

--- a/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.test.js
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/GroupSelect.test.js
@@ -1,0 +1,33 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import GroupSelect from "./GroupSelect";
+
+describe("GroupSelect ", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <GroupSelect
+        grouping="none"
+        setGrouping={jest.fn()}
+        setHiddenGroups={jest.fn()}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("executes setGrouping and setHiddenGroups functions on change", () => {
+    const setGrouping = jest.fn();
+    const setHiddenGroups = jest.fn();
+    const wrapper = shallow(
+      <GroupSelect
+        grouping="none"
+        setGrouping={setGrouping}
+        setHiddenGroups={setHiddenGroups}
+      />
+    );
+    const mockEvent = { target: { value: "status" } };
+    wrapper.find("Select").simulate("change", mockEvent);
+    expect(setGrouping).toHaveBeenCalledWith(mockEvent.target.value);
+    expect(setHiddenGroups).toHaveBeenCalledWith([]);
+  });
+});

--- a/ui/src/app/machines/views/MachineList/GroupSelect/__snapshots__/GroupSelect.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/__snapshots__/GroupSelect.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GroupSelect  renders 1`] = `
+<Select
+  defaultValue="none"
+  name="machine-groupings"
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "label": "No grouping",
+        "value": "none",
+      },
+      Object {
+        "label": "Group by owner",
+        "value": "owner",
+      },
+      Object {
+        "label": "Group by pool",
+        "value": "pool",
+      },
+      Object {
+        "label": "Group by power state",
+        "value": "power_state",
+      },
+      Object {
+        "label": "Group by status",
+        "value": "status",
+      },
+      Object {
+        "label": "Group by zone",
+        "value": "zone",
+      },
+    ]
+  }
+/>
+`;

--- a/ui/src/app/machines/views/MachineList/GroupSelect/index.js
+++ b/ui/src/app/machines/views/MachineList/GroupSelect/index.js
@@ -1,0 +1,1 @@
+export { default } from "./GroupSelect";

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -3,7 +3,9 @@ import {
   Col,
   Loader,
   MainTable,
-  Row
+  Row,
+  SearchBox,
+  Select
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import classNames from "classnames";
@@ -24,10 +26,10 @@ import {
 import { machine as machineSelectors } from "app/base/selectors";
 import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
-import TableHeader from "app/base/components/TableHeader";
 import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
 import FabricColumn from "./FabricColumn";
+import GroupSelect from "./GroupSelect";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
 import PoolColumn from "./PoolColumn";
@@ -35,33 +37,8 @@ import PowerColumn from "./PowerColumn";
 import RamColumn from "./RamColumn";
 import StatusColumn from "./StatusColumn";
 import StorageColumn from "./StorageColumn";
+import TableHeader from "app/base/components/TableHeader";
 import ZoneColumn from "./ZoneColumn";
-
-const normaliseStatus = (statusCode, status) => {
-  switch (statusCode) {
-    case nodeStatus.FAILED_COMMISSIONING:
-    case nodeStatus.FAILED_DEPLOYMENT:
-    case nodeStatus.FAILED_RELEASING:
-    case nodeStatus.FAILED_DISK_ERASING:
-    case nodeStatus.FAILED_ENTERING_RESCUE_MODE:
-    case nodeStatus.FAILED_EXITING_RESCUE_MODE:
-    case nodeStatus.FAILED_TESTING:
-      return "Failed";
-    case nodeStatus.RESCUE_MODE:
-    case nodeStatus.ENTERING_RESCUE_MODE:
-    case nodeStatus.EXITING_RESCUE_MODE:
-      return "Rescue mode";
-    case nodeStatus.RELEASING:
-    case nodeStatus.DISK_ERASING:
-      return "Releasing";
-    case nodeStatus.RETIRED:
-    case nodeStatus.MISSING:
-    case nodeStatus.RESERVED:
-      return "Other";
-    default:
-      return status;
-  }
-};
 
 const getSortValue = (machine, currentSort) => {
   switch (currentSort) {
@@ -69,13 +46,58 @@ const getSortValue = (machine, currentSort) => {
     case "pool":
     case "zone":
       return machine[currentSort].name;
+    case "fabric":
+      return machine.vlan && machine.vlan.fabric_name;
     default:
       return machine[currentSort];
   }
 };
 
-const generateRows = ({ rows, showMAC }) => {
-  return rows.map(row => {
+const simpleSort = attr => {
+  return function(a, b) {
+    if (a[attr] > b[attr]) return 1;
+    if (a[attr] < b[attr]) return -1;
+    return 0;
+  };
+};
+
+const machineSort = currentSort => {
+  const { key, direction } = currentSort;
+
+  return function(a, b) {
+    const sortA = getSortValue(a, key);
+    const sortB = getSortValue(b, key);
+
+    if (direction === "none") {
+      return 0;
+    }
+    if (sortA < sortB) {
+      return direction === "descending" ? -1 : 1;
+    }
+    if (sortA > sortB) {
+      return direction === "descending" ? 1 : -1;
+    }
+    return 0;
+  };
+};
+
+const groupBy = (list, keyGetter) => {
+  const map = new Map();
+  list.forEach(item => {
+    const key = keyGetter(item);
+    const collection = map.get(key);
+    if (!collection) {
+      map.set(key, [item]);
+    } else {
+      collection.push(item);
+    }
+  });
+  return map;
+};
+
+const generateRows = ({ currentSort, machines, showMAC }) => {
+  const sortedMachines = [...machines].sort(machineSort(currentSort));
+  return sortedMachines.map(row => {
     return {
       className: "machine-list__machine",
       columns: [
@@ -117,10 +139,135 @@ const generateRows = ({ rows, showMAC }) => {
   });
 };
 
-const generateGroups = ({ groups, hiddenGroups, setHiddenGroups, showMAC }) => {
+const generateGroups = ({
+  currentSort,
+  grouping,
+  hiddenGroups,
+  machines,
+  setHiddenGroups,
+  showMAC
+}) => {
+  let groups = [];
   let rows = [];
+
+  if (grouping === "owner") {
+    const groupMap = groupBy(machines, machine => machine.owner);
+    groups = Array.from(groupMap)
+      .map(([label, machines]) => ({ label: label || "No owner", machines }))
+      .sort(simpleSort("label"));
+  }
+
+  if (grouping === "pool") {
+    const groupMap = groupBy(machines, machine => machine.pool.name);
+    groups = Array.from(groupMap)
+      .map(([label, machines]) => ({ label: label || "No pool", machines }))
+      .sort(simpleSort("label"));
+  }
+
+  if (grouping === "power_state") {
+    const groupMap = groupBy(machines, machine => machine.power_state);
+    groups = [
+      {
+        label: "Error",
+        machines: groupMap.get("error") || []
+      },
+      {
+        label: "Off",
+        machines: groupMap.get("off") || []
+      },
+      {
+        label: "On",
+        machines: groupMap.get("on") || []
+      },
+      {
+        label: "Unknown",
+        machines: groupMap.get("unknown") || []
+      }
+    ].filter(group => group.machines.length);
+  }
+
+  if (grouping === "status") {
+    const groupMap = groupBy(machines, machine => machine.status_code);
+    groups = [
+      {
+        label: "Failed",
+        machines: [
+          ...(groupMap.get(nodeStatus.FAILED_COMMISSIONING) || []),
+          ...(groupMap.get(nodeStatus.FAILED_DEPLOYMENT) || []),
+          ...(groupMap.get(nodeStatus.FAILED_DISK_ERASING) || []),
+          ...(groupMap.get(nodeStatus.FAILED_ENTERING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.FAILED_EXITING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.FAILED_RELEASING) || []),
+          ...(groupMap.get(nodeStatus.FAILED_TESTING) || [])
+        ]
+      },
+      {
+        label: "New",
+        machines: groupMap.get(nodeStatus.NEW) || []
+      },
+      {
+        label: "Commissioning",
+        machines: groupMap.get(nodeStatus.COMMISSIONING) || []
+      },
+      {
+        label: "Testing",
+        machines: groupMap.get(nodeStatus.TESTING) || []
+      },
+      {
+        label: "Ready",
+        machines: groupMap.get(nodeStatus.READY) || []
+      },
+      {
+        label: "Allocated",
+        machines: groupMap.get(nodeStatus.ALLOCATED) || []
+      },
+      {
+        label: "Deploying",
+        machines: groupMap.get(nodeStatus.DEPLOYING) || []
+      },
+      {
+        label: "Deployed",
+        machines: groupMap.get(nodeStatus.DEPLOYED) || []
+      },
+      {
+        label: "Rescue mode",
+        machines: [
+          ...(groupMap.get(nodeStatus.ENTERING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.EXITING_RESCUE_MODE) || []),
+          ...(groupMap.get(nodeStatus.RESCUE_MODE) || [])
+        ]
+      },
+      {
+        label: "Releasing",
+        machines: [
+          ...(groupMap.get(nodeStatus.DISK_ERASING) || []),
+          ...(groupMap.get(nodeStatus.RELEASING) || [])
+        ]
+      },
+      {
+        label: "Broken",
+        machines: groupMap.get(nodeStatus.BROKEN) || []
+      },
+      {
+        label: "Other",
+        machines: [
+          ...(groupMap.get(nodeStatus.MISSING) || []),
+          ...(groupMap.get(nodeStatus.RESERVED) || []),
+          ...(groupMap.get(nodeStatus.RETIRED) || [])
+        ]
+      }
+    ].filter(group => group.machines.length);
+  }
+
+  if (grouping === "zone") {
+    const groupMap = groupBy(machines, machine => machine.zone.name);
+    groups = Array.from(groupMap)
+      .map(([label, machines]) => ({ label: label || "No zone", machines }))
+      .sort(simpleSort("label"));
+  }
+
   groups.forEach(group => {
-    const { items, label, sortKey } = group;
+    const { label, machines } = group;
     const collapsed = hiddenGroups.includes(label);
     rows.push({
       className: "machine-list__group",
@@ -130,7 +277,10 @@ const generateGroups = ({ groups, hiddenGroups, setHiddenGroups, showMAC }) => {
             <>
               <strong>{label}</strong>
               <div className="u-text--light">{`
-              ${items.length} ${pluralize("machine", items.length)}`}</div>
+              ${machines.length} ${pluralize(
+                "machine",
+                machines.length
+              )}`}</div>
             </>
           )
         },
@@ -169,83 +319,28 @@ const generateGroups = ({ groups, hiddenGroups, setHiddenGroups, showMAC }) => {
         }
       ]
     });
-    const visibleItems = items
-      .filter(machine => {
-        return !hiddenGroups.includes(getSortValue(machine, sortKey));
-      })
-      .sort((a, b) => (a.hostname > b.hostname ? 1 : -1));
-    rows = rows.concat(generateRows({ rows: visibleItems, showMAC }));
+    const visibleMachines = collapsed ? [] : machines;
+    rows = rows.concat(
+      generateRows({ currentSort, machines: visibleMachines, showMAC })
+    );
   });
   return rows;
-};
-
-const machineSort = currentSort => {
-  const { key, direction } = currentSort;
-
-  return function(a, b) {
-    const sortA = getSortValue(a, key);
-    const sortB = getSortValue(b, key);
-
-    if (direction === "none") {
-      return 0;
-    }
-    if (sortA < sortB) {
-      return direction === "descending" ? -1 : 1;
-    }
-    if (sortA > sortB) {
-      return direction === "descending" ? 1 : -1;
-    }
-    return 0;
-  };
 };
 
 const MachineList = () => {
   const dispatch = useDispatch();
 
   const [currentSort, setCurrentSort] = useState({
-    key: "normalisedStatus",
+    key: "fqdn",
     direction: "descending"
   });
+  const [grouping, setGrouping] = useState("status");
   const [hiddenGroups, setHiddenGroups] = useState([]);
   const [showMAC, setShowMAC] = useState(false);
 
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const machinesLoading = useSelector(machineSelectors.loading);
-
-  const normalisedMachines = machines.map(machine => ({
-    ...machine,
-    normalisedStatus: normaliseStatus(machine.status_code, machine.status)
-  }));
-  const visibleMachines = normalisedMachines.filter(machine => {
-    return !hiddenGroups.includes(getSortValue(machine, currentSort));
-  });
-  const sortedMachines = visibleMachines.sort(machineSort(currentSort));
-
-  const groupKeys = [
-    "domain",
-    "normalisedStatus",
-    "owner",
-    "pool",
-    "power_state",
-    "zone"
-  ];
-  const groups =
-    groupKeys.includes(currentSort.key) &&
-    sortedMachines.reduce((acc, machine) => {
-      const sortKey = getSortValue(machine, currentSort.key);
-      const group = acc.find(group => group.label === sortKey);
-      if (group) {
-        group.items.push(machine);
-      } else {
-        acc.push({
-          label: sortKey,
-          sortKey: currentSort.key,
-          items: [machine]
-        });
-      }
-      return acc;
-    }, []);
 
   useWindowTitle("Machines");
 
@@ -278,211 +373,245 @@ const MachineList = () => {
       }
     } else {
       setCurrentSort({ key: newSortKey, direction: "descending" });
-      setHiddenGroups([]);
     }
   };
 
   return (
-    <Row>
-      <Col size={12}>
-        {machinesLoading && (
-          <div className="u-align--center">
-            <Loader text="Loading..." />
-          </div>
-        )}
-        {machinesLoaded && (
-          <MainTable
-            className={classNames("p-table-expanding--light", "machine-list", {
-              "machine-list--grouped": groups
-            })}
-            headers={[
+    <>
+      <Row>
+        <Col size={3}>
+          <Select
+            name="machineFilters"
+            defaultValue=""
+            options={[
               {
-                content: (
-                  <>
-                    <TableHeader
-                      currentSort={currentSort}
-                      data-test="fqdn-header"
-                      onClick={() => {
-                        setShowMAC(false);
-                        updateSort("fqdn");
-                      }}
-                      sortKey="fqdn"
-                    >
-                      FQDN
-                    </TableHeader>
-                    &nbsp;<strong>|</strong>&nbsp;
-                    <TableHeader
-                      currentSort={currentSort}
-                      data-test="mac-header"
-                      onClick={() => {
-                        setShowMAC(true);
-                        updateSort("pxe_mac");
-                      }}
-                      sortKey="pxe_mac"
-                    >
-                      MAC
-                    </TableHeader>
-                    <TableHeader>IP</TableHeader>
-                  </>
-                )
-              },
-              {
-                content: (
-                  <TableHeader
-                    className="p-double-row__icon-space"
-                    currentSort={currentSort}
-                    data-test="power-header"
-                    onClick={() => updateSort("power_state")}
-                    sortKey="power_state"
-                  >
-                    Power
-                  </TableHeader>
-                )
-              },
-              {
-                content: (
-                  <TableHeader
-                    className="p-double-row__icon-space"
-                    currentSort={currentSort}
-                    data-test="status-header"
-                    onClick={() => updateSort("normalisedStatus")}
-                    sortKey="normalisedStatus"
-                  >
-                    Status
-                  </TableHeader>
-                )
-              },
-              {
-                content: (
-                  <>
-                    <TableHeader
-                      currentSort={currentSort}
-                      data-test="owner-header"
-                      onClick={() => updateSort("owner")}
-                      sortKey="owner"
-                    >
-                      Owner
-                    </TableHeader>
-                    <TableHeader>Tags</TableHeader>
-                  </>
-                )
-              },
-              {
-                content: (
-                  <>
-                    <TableHeader
-                      currentSort={currentSort}
-                      data-test="pool-header"
-                      onClick={() => updateSort("pool")}
-                      sortKey="pool"
-                    >
-                      Pool
-                    </TableHeader>
-                    <TableHeader>Note</TableHeader>
-                  </>
-                )
-              },
-              {
-                content: (
-                  <>
-                    <TableHeader
-                      currentSort={currentSort}
-                      data-test="zone-header"
-                      onClick={() => updateSort("zone")}
-                      sortKey="zone"
-                    >
-                      Zone
-                    </TableHeader>
-                    <TableHeader>Spaces</TableHeader>
-                  </>
-                )
-              },
-              {
-                content: (
-                  <>
-                    <TableHeader
-                      currentSort={currentSort}
-                      data-test="fabric-header"
-                      onClick={() => updateSort("fabric")}
-                      sortKey="fabric"
-                    >
-                      Fabric
-                    </TableHeader>
-                    <TableHeader>VLAN</TableHeader>
-                  </>
-                )
-              },
-              {
-                content: (
-                  <>
-                    <TableHeader
-                      currentSort={currentSort}
-                      data-test="cores-header"
-                      onClick={() => updateSort("cpu_count")}
-                      sortKey="cpu_count"
-                    >
-                      Cores
-                    </TableHeader>
-                    <TableHeader>Arch</TableHeader>
-                  </>
-                ),
-                className: "u-align--right"
-              },
-              {
-                content: (
-                  <TableHeader
-                    currentSort={currentSort}
-                    data-test="memory-header"
-                    onClick={() => updateSort("memory")}
-                    sortKey="memory"
-                  >
-                    RAM
-                  </TableHeader>
-                ),
-                className: "u-align--right"
-              },
-              {
-                content: (
-                  <TableHeader
-                    currentSort={currentSort}
-                    data-test="disks-header"
-                    onClick={() => updateSort("physical_disk_count")}
-                    sortKey="physical_disk_count"
-                  >
-                    Disks
-                  </TableHeader>
-                ),
-                className: "u-align--right"
-              },
-              {
-                content: (
-                  <TableHeader
-                    currentSort={currentSort}
-                    data-test="storage-header"
-                    onClick={() => updateSort("storage")}
-                    sortKey="storage"
-                  >
-                    Storage
-                  </TableHeader>
-                ),
-                className: "u-align--right"
+                value: "",
+                disabled: "disabled",
+                label: "Filters"
               }
             ]}
-            paginate={150}
-            rows={
-              groups
-                ? generateGroups({
-                    groups,
-                    hiddenGroups,
-                    setHiddenGroups,
-                    showMAC
-                  })
-                : generateRows({ rows: visibleMachines, showMAC })
-            }
           />
-        )}
-      </Col>
-    </Row>
+        </Col>
+        <Col size={6}>
+          <SearchBox onChange={() => null} />
+        </Col>
+        <Col size={3}>
+          <GroupSelect
+            grouping={grouping}
+            setGrouping={setGrouping}
+            setHiddenGroups={setHiddenGroups}
+          />
+        </Col>
+      </Row>
+      {machinesLoading && (
+        <Row>
+          <Col className="u-align--center" size={12}>
+            <Loader text="Loading..." />
+          </Col>
+        </Row>
+      )}
+      {machinesLoaded && (
+        <Row>
+          <Col size={12}>
+            <MainTable
+              className={classNames(
+                "p-table-expanding--light",
+                "machine-list",
+                {
+                  "machine-list--grouped": grouping !== "none"
+                }
+              )}
+              headers={[
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="fqdn-header"
+                        onClick={() => {
+                          setShowMAC(false);
+                          updateSort("fqdn");
+                        }}
+                        sortKey="fqdn"
+                      >
+                        FQDN
+                      </TableHeader>
+                      &nbsp;<strong>|</strong>&nbsp;
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="mac-header"
+                        onClick={() => {
+                          setShowMAC(true);
+                          updateSort("pxe_mac");
+                        }}
+                        sortKey="pxe_mac"
+                      >
+                        MAC
+                      </TableHeader>
+                      <TableHeader>IP</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <TableHeader
+                      className="p-double-row__icon-space"
+                      currentSort={currentSort}
+                      data-test="power-header"
+                      onClick={() => updateSort("power_state")}
+                      sortKey="power_state"
+                    >
+                      Power
+                    </TableHeader>
+                  )
+                },
+                {
+                  content: (
+                    <TableHeader
+                      className="p-double-row__icon-space"
+                      currentSort={currentSort}
+                      data-test="status-header"
+                      onClick={() => updateSort("status")}
+                      sortKey="status"
+                    >
+                      Status
+                    </TableHeader>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="owner-header"
+                        onClick={() => updateSort("owner")}
+                        sortKey="owner"
+                      >
+                        Owner
+                      </TableHeader>
+                      <TableHeader>Tags</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="pool-header"
+                        onClick={() => updateSort("pool")}
+                        sortKey="pool"
+                      >
+                        Pool
+                      </TableHeader>
+                      <TableHeader>Note</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="zone-header"
+                        onClick={() => updateSort("zone")}
+                        sortKey="zone"
+                      >
+                        Zone
+                      </TableHeader>
+                      <TableHeader>Spaces</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="fabric-header"
+                        onClick={() => updateSort("fabric")}
+                        sortKey="fabric"
+                      >
+                        Fabric
+                      </TableHeader>
+                      <TableHeader>VLAN</TableHeader>
+                    </>
+                  )
+                },
+                {
+                  content: (
+                    <>
+                      <TableHeader
+                        currentSort={currentSort}
+                        data-test="cores-header"
+                        onClick={() => updateSort("cpu_count")}
+                        sortKey="cpu_count"
+                      >
+                        Cores
+                      </TableHeader>
+                      <TableHeader>Arch</TableHeader>
+                    </>
+                  ),
+                  className: "u-align--right"
+                },
+                {
+                  content: (
+                    <TableHeader
+                      currentSort={currentSort}
+                      data-test="memory-header"
+                      onClick={() => updateSort("memory")}
+                      sortKey="memory"
+                    >
+                      RAM
+                    </TableHeader>
+                  ),
+                  className: "u-align--right"
+                },
+                {
+                  content: (
+                    <TableHeader
+                      currentSort={currentSort}
+                      data-test="disks-header"
+                      onClick={() => updateSort("physical_disk_count")}
+                      sortKey="physical_disk_count"
+                    >
+                      Disks
+                    </TableHeader>
+                  ),
+                  className: "u-align--right"
+                },
+                {
+                  content: (
+                    <TableHeader
+                      currentSort={currentSort}
+                      data-test="storage-header"
+                      onClick={() => updateSort("storage")}
+                      sortKey="storage"
+                    >
+                      Storage
+                    </TableHeader>
+                  ),
+                  className: "u-align--right"
+                }
+              ]}
+              paginate={150}
+              rows={
+                grouping === "none"
+                  ? generateRows({ currentSort, machines, showMAC })
+                  : generateGroups({
+                      currentSort,
+                      grouping,
+                      hiddenGroups,
+                      machines,
+                      setHiddenGroups,
+                      showMAC
+                    })
+              }
+            />
+          </Col>
+        </Row>
+      )}
+    </>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -1,5 +1,6 @@
-@import "~vanilla-framework/scss/settings_spacing";
 @import "~vanilla-framework/scss/base_forms-tick-elements";
+@import "~vanilla-framework/scss/settings_colors";
+@import "~vanilla-framework/scss/settings_spacing";
 @import "./machine-list-breakpoint-widths";
 
 $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spacing
@@ -21,11 +22,11 @@ $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spaci
 .machine-list th {
   // FQDN/MAC
   &:nth-child(1) {
-    @include breakpoint-widths(45%, 36%, 26%, 24%, 20%);
+    @include breakpoint-widths(45%, 35%, 26%, 24%, 20%);
   }
   // Power
   &:nth-child(2) {
-    @include breakpoint-widths(23%, 16%, 12%, 10%, 8%);
+    @include breakpoint-widths(23%, 15%, 12%, 10%, 8%);
   }
   // Status
   &:nth-child(3) {
@@ -41,26 +42,26 @@ $grouped-machines-indentation: $box-size + $sph-inner; // Checkbox + label spaci
   }
   // Zone
   &:nth-child(6) {
-    @include breakpoint-widths(0, 0, 0, 9%, 9%);
+    @include breakpoint-widths(0, 0, 0, 9%, 7%);
   }
   // Fabric
   &:nth-child(7) {
-    @include breakpoint-widths(0, 0, 0, 0, 8%);
+    @include breakpoint-widths(0, 0, 0, 0, 7%);
   }
   // Cores
   &:nth-child(8) {
-    @include breakpoint-widths(0, 0, 8%, 6%, 5%);
+    @include breakpoint-widths(0, 0, 8%, 6%, 6%);
   }
   // RAM
   &:nth-child(9) {
-    @include breakpoint-widths(0, 0, 9%, 7%, 7%);
+    @include breakpoint-widths(0, 0, 9%, 8%, 7%);
   }
   // Disks
   &:nth-child(10) {
-    @include breakpoint-widths(0, 0, 8%, 6%, 5%);
+    @include breakpoint-widths(0, 0, 8%, 6%, 6%);
   }
   // Storage
   &:nth-child(11) {
-    @include breakpoint-widths(0, 0, 10%, 8%, 6%);
+    @include breakpoint-widths(0, 0, 9%, 8%, 6%);
   }
 }

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -54,6 +54,7 @@ describe("MachineList", () => {
               status: scriptStatus.PASSED
             },
             osystem: "ubuntu",
+            owner: "admin",
             physical_disk_count: 1,
             pool: {},
             pxe_mac: "00:11:22:33:44:55",
@@ -93,6 +94,7 @@ describe("MachineList", () => {
               status: scriptStatus.FAILED
             },
             osystem: "ubuntu",
+            owner: "user",
             physical_disk_count: 2,
             pool: {},
             pxe_mac: "66:77:88:99:00:11",
@@ -182,6 +184,40 @@ describe("MachineList", () => {
     expect(wrapper.find("tr.machine-list__machine").length).toBe(1);
   });
 
+  it("can change groups", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find(".machine-list__group")
+        .at(0)
+        .find("strong")
+        .text()
+    ).toBe("Deployed");
+    // Change grouping to owner
+    wrapper
+      .find('Select[name="machine-groupings"]')
+      .find("select")
+      .simulate("change", { target: { value: "owner" } });
+    expect(
+      wrapper
+        .find(".machine-list__group")
+        .at(0)
+        .find("strong")
+        .text()
+    ).toBe("admin");
+  });
+
   it("can change machines to display PXE MAC instead of FQDN", () => {
     const state = { ...initialState };
     const store = mockStore(state);
@@ -219,33 +255,6 @@ describe("MachineList", () => {
     ).toEqual(firstMachine.pxe_mac);
   });
 
-  it("is sorted by status by default", () => {
-    const state = { ...initialState };
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <MachineList />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(
-      wrapper
-        .find('[data-test="fqdn-header"]')
-        .find("i")
-        .exists()
-    ).toBe(false);
-    expect(
-      wrapper
-        .find('[data-test="status-header"]')
-        .find("i")
-        .exists()
-    ).toBe(true);
-  });
-
   it("updates sort on header click", () => {
     const state = { ...initialState };
     const store = mockStore(state);
@@ -264,6 +273,11 @@ describe("MachineList", () => {
       state.machine.items[1]
     ];
 
+    // Change grouping to none
+    wrapper
+      .find('Select[name="machine-groupings"]')
+      .find("select")
+      .simulate("change", { target: { value: "none" } });
     expect(
       wrapper
         .find('[data-test="cores-header"]')
@@ -278,7 +292,7 @@ describe("MachineList", () => {
         .at(0)
         .text()
     ).toEqual(firstMachine.fqdn);
-    // Click the FQDN table header
+    // Click the cores table header
     wrapper
       .find('[data-test="cores-header"]')
       .find("button")
@@ -316,20 +330,26 @@ describe("MachineList", () => {
       state.machine.items[1]
     ];
 
-    // Click the FQDN table header
+    // Change grouping to none
     wrapper
-      .find('[data-test="fqdn-header"]')
+      .find('Select[name="machine-groupings"]')
+      .find("select")
+      .simulate("change", { target: { value: "none" } });
+
+    // Click the status table header
+    wrapper
+      .find('[data-test="status-header"]')
       .find("button")
       .simulate("click");
     expect(
       wrapper
-        .find('[data-test="fqdn-header"]')
+        .find('[data-test="status-header"]')
         .find("i")
         .exists()
     ).toBe(true);
     expect(
       wrapper
-        .find('[data-test="fqdn-header"]')
+        .find('[data-test="status-header"]')
         .find("i")
         .props().className
     ).toBe("p-icon--contextual-menu");
@@ -342,14 +362,14 @@ describe("MachineList", () => {
         .text()
     ).toEqual(firstMachine.fqdn);
 
-    // Click the FQDN table header again to reverse sort order
+    // Click the status table header again to reverse sort order
     wrapper
-      .find('[data-test="fqdn-header"]')
+      .find('[data-test="status-header"]')
       .find("button")
       .simulate("click");
     expect(
       wrapper
-        .find('[data-test="fqdn-header"]')
+        .find('[data-test="status-header"]')
         .find("i")
         .props().className
     ).toBe("p-icon--contextual-menu u-mirror--y");
@@ -364,12 +384,12 @@ describe("MachineList", () => {
 
     // Click the FQDN table header again to return to no sort
     wrapper
-      .find('[data-test="fqdn-header"]')
+      .find('[data-test="status-header"]')
       .find("button")
       .simulate("click");
     expect(
       wrapper
-        .find('[data-test="fqdn-header"]')
+        .find('[data-test="status-header"]')
         .find("i")
         .exists()
     ).toBe(false);

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -43,6 +43,7 @@ describe("MachineList", () => {
               name: "example"
             },
             extra_macs: [],
+            fqdn: "koala.example",
             hostname: "koala",
             ip_addresses: [],
             memory: 8,
@@ -57,8 +58,8 @@ describe("MachineList", () => {
             pool: {},
             pxe_mac: "00:11:22:33:44:55",
             spaces: [],
-            status: "Releasing",
-            status_code: nodeStatus.RELEASING,
+            status: "Deployed",
+            status_code: nodeStatus.DEPLOYED,
             status_message: "",
             storage: 8,
             storage_test_status: {
@@ -68,6 +69,45 @@ describe("MachineList", () => {
               status: scriptStatus.PASSED
             },
             system_id: "abc123",
+            zone: {}
+          },
+          {
+            architecture: "amd64/generic",
+            cpu_count: 2,
+            cpu_test_status: {
+              status: scriptStatus.FAILED
+            },
+            distro_series: "xenial",
+            domain: {
+              name: "example"
+            },
+            extra_macs: [],
+            fqdn: "other.example",
+            hostname: "other",
+            ip_addresses: [],
+            memory: 6,
+            memory_test_status: {
+              status: scriptStatus.FAILED
+            },
+            network_test_status: {
+              status: scriptStatus.FAILED
+            },
+            osystem: "ubuntu",
+            physical_disk_count: 2,
+            pool: {},
+            pxe_mac: "66:77:88:99:00:11",
+            spaces: [],
+            status: "Releasing",
+            status_code: nodeStatus.RELEASING,
+            status_message: "",
+            storage: 16,
+            storage_test_status: {
+              status: scriptStatus.FAILED
+            },
+            testing_status: {
+              status: scriptStatus.FAILED
+            },
+            system_id: "def456",
             zone: {}
           }
         ]
@@ -103,10 +143,18 @@ describe("MachineList", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(
       wrapper
-        .find(".machine-list__group td")
+        .find(".machine-list__group")
         .at(0)
+        .find("strong")
+        .text()
+    ).toBe("Deployed");
+    expect(
+      wrapper
+        .find(".machine-list__group")
+        .at(2)
         .find("strong")
         .text()
     ).toBe("Releasing");
@@ -124,12 +172,214 @@ describe("MachineList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("tr.machine-list__machine").length).toBe(1);
+
+    expect(wrapper.find("tr.machine-list__machine").length).toBe(2);
     // Click the button to toggle the group.
     wrapper
       .find(".machine-list__group button")
       .at(0)
       .simulate("click");
-    expect(wrapper.find("tr.machine-list__machine").length).toBe(0);
+    expect(wrapper.find("tr.machine-list__machine").length).toBe(1);
+  });
+
+  it("can change machines to display PXE MAC instead of FQDN", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const firstMachine = state.machine.items[0];
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
+    // Click the MAC table header
+    wrapper
+      .find('[data-test="mac-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.pxe_mac);
+  });
+
+  it("is sorted by status by default", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find('[data-test="fqdn-header"]')
+        .find("i")
+        .exists()
+    ).toBe(false);
+    expect(
+      wrapper
+        .find('[data-test="status-header"]')
+        .find("i")
+        .exists()
+    ).toBe(true);
+  });
+
+  it("updates sort on header click", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // First machine has more cores than second machine
+    const [firstMachine, secondMachine] = [
+      state.machine.items[0],
+      state.machine.items[1]
+    ];
+
+    expect(
+      wrapper
+        .find('[data-test="cores-header"]')
+        .find("i")
+        .exists()
+    ).toBe(false);
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
+    // Click the FQDN table header
+    wrapper
+      .find('[data-test="cores-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="cores-header"]')
+        .find("i")
+        .exists()
+    ).toBe(true);
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(secondMachine.fqdn);
+  });
+
+  it("updates sort direction on multiple header clicks", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    const [firstMachine, secondMachine] = [
+      state.machine.items[0],
+      state.machine.items[1]
+    ];
+
+    // Click the FQDN table header
+    wrapper
+      .find('[data-test="fqdn-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="fqdn-header"]')
+        .find("i")
+        .exists()
+    ).toBe(true);
+    expect(
+      wrapper
+        .find('[data-test="fqdn-header"]')
+        .find("i")
+        .props().className
+    ).toBe("p-icon--contextual-menu");
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
+
+    // Click the FQDN table header again to reverse sort order
+    wrapper
+      .find('[data-test="fqdn-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="fqdn-header"]')
+        .find("i")
+        .props().className
+    ).toBe("p-icon--contextual-menu u-mirror--y");
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(secondMachine.fqdn);
+
+    // Click the FQDN table header again to return to no sort
+    wrapper
+      .find('[data-test="fqdn-header"]')
+      .find("button")
+      .simulate("click");
+    expect(
+      wrapper
+        .find('[data-test="fqdn-header"]')
+        .find("i")
+        .exists()
+    ).toBe(false);
+    expect(
+      wrapper
+        .find(".machine-list__machine")
+        .at(0)
+        .find("TableCell")
+        .at(0)
+        .text()
+    ).toEqual(firstMachine.fqdn);
   });
 });

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.js
@@ -81,9 +81,9 @@ const generateMAC = (machine, machineURL) => {
       <div className="p-doouble-row__primary-row u-truncate">
         <a href={machineURL} title={machine.pxe_mac_vendor}>
           {machine.pxe_mac}
-        </a>{" "}
+        </a>
         {machine.extra_macs && machine.extra_macs.length > 0 ? (
-          <a href={machineURL}>(+{machine.extra_macs.length})</a>
+          <a href={machineURL}> (+{machine.extra_macs.length})</a>
         ) : null}
       </div>
     </div>

--- a/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/NameColumn/NameColumn.test.js
@@ -189,7 +189,7 @@ describe("NameColumn", () => {
         .find("a")
         .at(1)
         .text()
-    ).toEqual("(+1)");
+    ).toEqual(" (+1)");
   });
 
   it("can render a machine with minimal data", () => {

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -209,20 +209,20 @@ describe("UsersList", () => {
     expect(
       wrapper
         .find("TableRow")
-        .at(2)
+        .at(1)
         .find("TableCell")
         .at(0)
         .text()
-    ).toEqual("user1");
+    ).toEqual("admin");
     // Click on the header toggle.
     wrapper
-      .find(".p-table-multi-header__link")
-      .at(2)
+      .find('[data-test="real-name-header"]')
+      .find("button")
       .simulate("click");
     expect(
       wrapper
         .find("TableRow")
-        .at(2)
+        .at(1)
         .find("TableCell")
         .at(0)
         .text()

--- a/ui/src/scss/_patterns_table.scss
+++ b/ui/src/scss/_patterns_table.scss
@@ -8,43 +8,6 @@
   background-color: $color-x-light;
 }
 
-.p-table--sortable th[role="columnheader"][aria-sort].p-table-multi-header {
-  &::after {
-    display: none;
-  }
-
-  &[aria-sort]:hover {
-    color: $color-mid-dark;
-    text-decoration: none;
-  }
-}
-
-.p-table-multi-header .p-table-multi-header__link {
-  color: $color-mid-dark;
-
-  &:hover {
-    color: $color-link;
-  }
-}
-
-.p-table-multi-header[aria-sort="descending"],
-.p-table-multi-header[aria-sort="ascending"] {
-  .p-table-multi-header__link.is-active::after {
-    @extend %heading-icon;
-  }
-}
-
-.p-table-multi-header[aria-sort="descending"]
-  .p-table-multi-header__link.is-active::after {
-  -webkit-transform: rotate(180deg);
-  transform: rotate(180deg);
-}
-
-.p-table-multi-header__spacer {
-  margin-left: $sp-x-small;
-  margin-right: $sp-x-small;
-}
-
 .p-table-sub-cols {
   flex-direction: column;
 }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -4,6 +4,11 @@
  * {Link to relevant GitHub issue}
  */
 
+@import "~vanilla-framework/scss/settings_colors";
+@import "~vanilla-framework/scss/settings_spacing";
+@import "~vanilla-framework/scss/patterns_icons";
+@import "~vanilla-framework/scss/global_functions";
+
 // 19-08-2019 Caleb: Form submit button too close to input when $multi = 1
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2497
 .p-form__group:last-child {
@@ -20,4 +25,37 @@
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/2672
 .p-tooltip__message--portal {
   display: inline;
+}
+
+// 28-01-2020 Caleb: Increase density of table headers
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/2501
+%table-header-typography {
+  color: $color-mid-dark;
+  font-size: pow($ms-ratio, -2) * 1rem;
+  font-weight: 400;
+  line-height: 1rem;
+}
+thead th {
+  @extend %table-header-typography;
+  padding-bottom: .35rem;
+
+  .p-button--link {
+    @extend %table-header-typography;
+    &:hover {
+      color: $color-link;
+    }
+    &:active {
+      background-color: transparent !important;
+    }
+    &:focus {
+      color: $color-link;
+      outline: 0;
+      text-decoration: underline;
+    }
+  }
+
+  .p-icon--contextual-menu {
+    @include vf-icon-size(.875rem);
+    margin-left: $sp-x-small;
+  }
 }

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -37,6 +37,10 @@ body {
   color: $color-mid-dark;
 }
 
+.u-mirror--y {
+  transform: rotate(180deg);
+}
+
 .p-modal {
   // The modal needs to be above the header nav items.
   z-index: 10;

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -51,3 +51,7 @@ body {
 .u-upper-case--first:first-letter {
   text-transform: capitalize;
 }
+
+a:visited {
+  color: $color-link;
+}


### PR DESCRIPTION
## #700 prerequisite

## Done
- Copied over some grouping code from the angular machine list, which orders groups in specific ways (mostly with status)
- Added a GroupSelect component, which is simply a select that lets you choose the grouping

## QA
- Check that the machine list is sorted by status by default, where failed machines show up first
- Check that you can change the grouping using the right select
- Check that you can sort within groups by clicking the table headers

