### PR TITLE
Add machine count to heading strip.

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -75,10 +75,10 @@ export const App = () => {
     content = (
       <Section
         title={
-          <Loader
-            className="u-align--left u-no-padding--left"
-            text="Loading..."
-          />
+          <>
+            <span className="p-heading--four"></span>
+            <Loader inline text="Loading..." />
+          </>
         }
       />
     );

--- a/ui/src/app/base/components/Section/Section.js
+++ b/ui/src/app/base/components/Section/Section.js
@@ -9,7 +9,11 @@ const Section = ({ children, sidebar, title }) => {
   return (
     <div className="section">
       <Strip className="section__header" element="header" shallow>
-        <h1 className="p-heading--four u-no-margin--bottom">{title}</h1>
+        {typeof title === "string" ? (
+          <h1 className="p-heading--four u-no-margin--bottom">{title}</h1>
+        ) : (
+          title
+        )}
       </Strip>
       <Strip
         element="main"
@@ -34,7 +38,7 @@ const Section = ({ children, sidebar, title }) => {
 Section.propTypes = {
   children: PropTypes.node,
   sidebar: PropTypes.node,
-  title: PropTypes.node.isRequired
+  title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired
 };
 
 export default Section;

--- a/ui/src/app/base/components/Section/Section.test.js
+++ b/ui/src/app/base/components/Section/Section.test.js
@@ -24,4 +24,13 @@ describe("Section", () => {
         .includes("col-10")
     ).toBe(false);
   });
+
+  it("can render a node as a title", () => {
+    const wrapper = shallow(
+      <Section title={<span data-test="test">Node title</span>}>
+        content
+      </Section>
+    );
+    expect(wrapper.find('[data-test="test"]').text()).toEqual("Node title");
+  });
 });

--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -1,12 +1,40 @@
+import { Loader } from "@canonical/react-components";
+import pluralize from "pluralize";
 import React from "react";
+import { useSelector } from "react-redux";
 
+import { machine as machineSelectors } from "app/base/selectors";
 import Routes from "app/machines/components/Routes";
 import Section from "app/base/components/Section";
 
-const Machines = () => (
-  <Section title="Machines">
-    <Routes />
-  </Section>
-);
+const Machines = () => {
+  const machines = useSelector(machineSelectors.all);
+  const machinesLoaded = useSelector(machineSelectors.loaded);
+
+  return (
+    <Section
+      title={
+        <ul className="p-inline-list u-no-margin--bottom">
+          <li className="p-inline-list__item p-heading--four">Machines</li>
+          {machinesLoaded ? (
+            <li
+              className="p-inline-list__item u-text--light"
+              data-test="machine-count"
+            >
+              {`${machines.length} ${pluralize(
+                "machine",
+                machines.length
+              )} available`}
+            </li>
+          ) : (
+            <Loader inline text="Loading..." />
+          )}
+        </ul>
+      }
+    >
+      <Routes />
+    </Section>
+  );
+};
 
 export default Machines;

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -1,12 +1,61 @@
-import { shallow } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 import React from "react";
 
 import Machines from "./Machines";
 
+const mockStore = configureStore();
+
 describe("Machines", () => {
-  it("renders", () => {
-    const wrapper = shallow(<Machines />);
-    expect(wrapper.find("Section").exists());
-    expect(wrapper.find("Section").prop("title")).toEqual("Machines");
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      config: {
+        items: []
+      },
+      messages: {
+        items: []
+      },
+      machine: {
+        loaded: false,
+        items: [1, 2]
+      }
+    };
+  });
+
+  it("displays a loader if machines have not loaded", () => {
+    const state = { ...initialState };
+    state.machine.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("displays a machine count if machines have loaded", () => {
+    const state = { ...initialState };
+    state.machine.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="machine-count"]').text()).toBe(
+      "2 machines available"
+    );
   });
 });


### PR DESCRIPTION
## Done
- Added machine count to heading strip if machines have loaded, otherwise a spinner shows.
- Added a placeholder heading to the App.js Section title so that the heading strip wouldn't jump in size once auth user is loaded.

## QA
- Open the new machine list and check that a spinner shows while machines are loading
- Check that the heading strip maintains the same height while user loading > machines loading > machines loaded
- Check that a machine count shows when all the machines have loaded

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1725.
