### PR TITLE
Fix contextual menu position

### DIFF
--- a/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
+++ b/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
@@ -26,6 +26,7 @@ exports[`ContextualMenu  renders 1`] = `
       >
         <span
           className="p-contextual-menu"
+          style={null}
         >
           <span
             aria-hidden="false"

--- a/ui/src/app/base/components/TableMenu/TableMenu.scss
+++ b/ui/src/app/base/components/TableMenu/TableMenu.scss
@@ -10,6 +10,10 @@
   text-transform: uppercase;
 }
 
+.p-table-menu .p-contextual-menu__dropdown {
+  margin-top: 0;
+}
+
 .p-table-menu__toggle {
   $icon-size: map-get($icon-sizes, default);
   line-height: $icon-size;


### PR DESCRIPTION
## Done
- Only calculate styles when the toggle element is visible.

## QA
- Visit /r/machines.
- Click on a contextual menu a bunch of times, it should always appear in the same place (never in the top left of the page).

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-ui/issues/714.