### PR TITLE
Remove machine/pool counts until fully loaded.

### DIFF
--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -16,6 +16,7 @@ const Machines = () => {
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const resourcePools = useSelector(resourcePoolSelectors.all);
+  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
   const { location } = useRouter();
 
   return (
@@ -45,18 +46,16 @@ const Machines = () => {
             links={[
               {
                 active: location.pathname === "/machines",
-                label: `${machines.length} ${pluralize(
-                  "Machine",
-                  machines.length
-                )}`,
+                label: `${
+                  machinesLoaded ? `${machines.length} ` : ""
+                }${pluralize("Machine", machines.length)}`,
                 path: "/machines"
               },
               {
                 active: location.pathname === "/pools",
-                label: `${resourcePools.length} ${pluralize(
-                  "Resource pool",
-                  resourcePools.length
-                )}`,
+                label: `${
+                  resourcePoolsLoaded ? `${resourcePools.length} ` : ""
+                }${pluralize("Resource pool", resourcePools.length)}`,
                 path: "/pools"
               }
             ]}

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -114,9 +114,10 @@ describe("Machines", () => {
     );
   });
 
-  it("displays tabs with machine and resource pool counts", () => {
+  it("displays tabs with machine and resource pool counts if loaded", () => {
     const state = { ...initialState };
     state.machine.loaded = true;
+    state.resourcepool.loaded = true;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>


### PR DESCRIPTION
## Done
- Removed machine and resource pool counts from tab strip until they have loaded

## QA
- Go to the machine list and check that the tabs says "Machines" and "Resource pools" until they have loaded, at which point they say "X Machines" and "X Resource pools"

## Fixes
Fixes #725 
