### PR TITLE
Clear Redux state on log out.

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -1,0 +1,202 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rootReducer should reset app to initial state on LOGOUT_SUCCESS, except status which
+    resets to authenticating = false 1`] = `
+Object {
+  "config": Object {
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "controller": Object {
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "device": Object {
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "dhcpsnippet": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "general": Object {
+    "architectures": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "componentsToDisable": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "defaultMinHweKernel": Object {
+      "data": "",
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "hweKernels": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "knownArchitectures": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "machineActions": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "navigationOptions": Object {
+      "data": Object {},
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "osInfo": Object {
+      "data": Object {},
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "pocketsToDisable": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "powerTypes": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+    "version": Object {
+      "data": "",
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
+  },
+  "licensekeys": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "machine": Object {
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "messages": Object {
+    "items": Array [],
+  },
+  "packagerepository": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "resourcepool": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "router": Object {
+    "action": undefined,
+    "location": Object {
+      "query": Object {},
+    },
+  },
+  "scripts": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "service": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "sshkey": Object {
+    "errors": null,
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "sslkey": Object {
+    "errors": null,
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "status": Object {
+    "authenticated": false,
+    "authenticating": false,
+  },
+  "subnet": Object {
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "tag": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+  "token": Object {
+    "errors": null,
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "user": Object {
+    "auth": Object {},
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
+  "zone": Object {
+    "errors": Object {},
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+  },
+}
+`;

--- a/ui/src/app/base/reducers/auth/auth.js
+++ b/ui/src/app/base/reducers/auth/auth.js
@@ -31,7 +31,7 @@ const auth = produce(
       case "UPDATE_USER_NOTIFY":
         // Check to see whether the auth user has been updated and if so
         // update the stored auth user.
-        if (draft.auth.user.id === action.payload.id) {
+        if (draft.auth.user && draft.auth.user.id === action.payload.id) {
           draft.auth.user = action.payload;
         }
         break;

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -24,7 +24,7 @@ import {
 import { config } from "./app/settings/reducers";
 import { token, sshkey, sslkey } from "./app/preferences/reducers";
 
-export default history =>
+const createAppReducer = history =>
   combineReducers({
     config,
     controller,
@@ -48,3 +48,17 @@ export default history =>
     user: reduceReducers(user, auth),
     zone
   });
+
+const createRootReducer = history => (state, action) => {
+  if (action.type === "LOGOUT_SUCCESS") {
+    return createAppReducer(history)(
+      // Status reducer defaults to authenticating = true to stop login screen
+      // flashing. It's overwritten here otherwise app is stuck loading.
+      { status: { authenticating: false } },
+      action
+    );
+  }
+  return createAppReducer(history)(state, action);
+};
+
+export default createRootReducer;

--- a/ui/src/root-reducer.test.js
+++ b/ui/src/root-reducer.test.js
@@ -1,0 +1,16 @@
+import createRootReducer from "./root-reducer";
+
+describe("rootReducer", () => {
+  it(`should reset app to initial state on LOGOUT_SUCCESS, except status which
+    resets to authenticating = false`, () => {
+    const initialState = {
+      status: { authenticating: true }
+    };
+    const newState = createRootReducer({})(initialState, {
+      type: "LOGOUT_SUCCESS"
+    });
+
+    expect(newState.status.authenticating).toBe(false);
+    expect(newState).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Done
- Set initial state for each reducer on LOGOUT_SUCCESS. Exceptions are auth and status which were causing authentication issues when cleared.

## QA
- Log in as an admin and go to the machine list.
- Log out and check that the header is cleared.
- Log in as a user while the url is still at the machine list.
- Check that the list of machines changes.
- Log out and check Redux Devtools that on LOGOUT_SUCCESS the state for everything reset.

## Fixes
Fixes #629 
