### PR TITLE
Add menu to change zones

### DIFF
--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -29,4 +29,23 @@ machine.setPool = (systemId, poolId) => {
   };
 };
 
+machine.setZone = (systemId, zoneId) => {
+  return {
+    type: "SET_MACHINE_ZONE",
+    meta: {
+      model: "machine",
+      method: "action"
+    },
+    payload: {
+      params: {
+        action: "set-zone",
+        extra: {
+          zone_id: zoneId
+        },
+        system_id: systemId
+      }
+    }
+  };
+};
+
 export default machine;

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -29,4 +29,23 @@ describe("machine actions", () => {
       }
     });
   });
+
+  it("can handle setting the zone", () => {
+    expect(machine.setZone("abc123", 909)).toEqual({
+      type: "SET_MACHINE_ZONE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "set-zone",
+          extra: {
+            zone_id: 909
+          },
+          system_id: "abc123"
+        }
+      }
+    });
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -128,6 +128,19 @@ describe("MachineList", () => {
             name: "Backup"
           }
         ]
+      },
+      zone: {
+        loaded: true,
+        items: [
+          {
+            id: 0,
+            name: "default"
+          },
+          {
+            id: 1,
+            name: "Backup"
+          }
+        ]
       }
     };
   });

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -5,6 +5,15 @@ exports[`ZoneColumn renders 1`] = `
   systemId="abc123"
 >
   <DoubleRow
+    menuLinks={
+      Array [
+        Object {
+          "children": "Backup",
+          "onClick": [Function],
+        },
+      ]
+    }
+    menuTitle="Change AZ:"
     primary={
       <span
         data-test="zone"
@@ -38,6 +47,62 @@ exports[`ZoneColumn renders 1`] = `
               zone-north
             </span>
           </div>
+          <TableMenu
+            links={
+              Array [
+                Object {
+                  "children": "Backup",
+                  "onClick": [Function],
+                },
+              ]
+            }
+            title="Change AZ:"
+          >
+            <ContextualMenu
+              className="p-table-menu"
+              hasToggleIcon={true}
+              links={
+                Array [
+                  "Change AZ:",
+                  Array [
+                    Object {
+                      "children": "Backup",
+                      "onClick": [Function],
+                    },
+                  ],
+                ]
+              }
+              position="center"
+              toggleAppearance="base"
+              toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+            >
+              <span
+                className="p-table-menu p-contextual-menu--center"
+              >
+                <Button
+                  appearance="base"
+                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  hasIcon={true}
+                  onClick={[Function]}
+                >
+                  <button
+                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    onClick={[Function]}
+                  >
+                    <i
+                      className="p-icon--contextual-menu p-contextual-menu__indicator"
+                    />
+                  </button>
+                </Button>
+              </span>
+            </ContextualMenu>
+          </TableMenu>
         </div>
         <div
           className="p-double-row__secondary-row u-truncate"

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -77,6 +77,19 @@ describe("Machines", () => {
       resourcepool: {
         loaded: false,
         items: [1, 2]
+      },
+      zone: {
+        loaded: true,
+        items: [
+          {
+            id: 0,
+            name: "default"
+          },
+          {
+            id: 1,
+            name: "Backup"
+          }
+        ]
       }
     };
   });


### PR DESCRIPTION
## Done
- Add a menu to the zone column of the machine list to change the zone.

## QA
- Load /r/machines.
- Change the zone using the context menu.
- You should see a spinner and then the zone should change.

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-squad/issues/1719.