### PR TITLE
Add checkbox for selecting/unselecting all machines in list.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -58,8 +58,25 @@ const getSortValue = (machine, sortKey) => {
   }
 };
 
-const groupChecked = (group, selectedMachines) =>
-  group.machines.every(machine => selectedMachines.includes(machine));
+const getGroupSecondaryString = (machines, selectedMachines) => {
+  let string = `${machines.length} ${pluralize("machine", machines.length)}`;
+  const selectedCount = machines.reduce(
+    (sum, machine) => (selectedMachines.includes(machine) ? sum + 1 : sum),
+    0
+  );
+
+  if (selectedCount) {
+    if (selectedCount === machines.length) {
+      string = `${string} selected`;
+    } else {
+      string = `${string}, ${selectedCount} selected`;
+    }
+  }
+  return string;
+};
+
+const checkboxChecked = (machines, selectedMachines) =>
+  machines.every(machine => selectedMachines.includes(machine));
 
 const machineSort = currentSort => {
   const { key, direction } = currentSort;
@@ -327,22 +344,18 @@ const generateGroupRows = ({
                 data-test="group-cell"
                 primary={
                   <Input
-                    checked={groupChecked(group, selectedMachines)}
+                    checked={checkboxChecked(machines, selectedMachines)}
                     className="has-inline-label"
                     disabled={false}
                     id={label}
                     label={<strong>{label}</strong>}
-                    name={label}
                     onChange={() => handleGroupCheckbox(group)}
                     type="checkbox"
                     wrapperClassName="u-no-margin--bottom"
                   />
                 }
                 primaryTextClassName="u-nudge--checkbox"
-                secondary={`${machines.length} ${pluralize(
-                  "machine",
-                  machines.length
-                )}`}
+                secondary={getGroupSecondaryString(machines, selectedMachines)}
                 secondaryClassName="u-nudge--secondary-row"
               />
             )
@@ -461,7 +474,7 @@ const MachineList = () => {
 
   const handleGroupCheckbox = group => {
     let newSelectedMachines;
-    if (groupChecked(group, selectedMachines)) {
+    if (checkboxChecked(group.machines, selectedMachines)) {
       // Unselect all machines in the group if all selected
       newSelectedMachines = group.machines.reduce(
         (acc, machine) => {
@@ -485,6 +498,14 @@ const MachineList = () => {
       );
     }
     setSelectedMachines(newSelectedMachines);
+  };
+
+  const handleAllCheckbox = () => {
+    if (checkboxChecked(machines, selectedMachines)) {
+      setSelectedMachines([]);
+    } else {
+      setSelectedMachines(machines);
+    }
   };
 
   const rowProps = {
@@ -543,31 +564,44 @@ const MachineList = () => {
               headers={[
                 {
                   content: (
-                    <div className="u-nudge--checkbox">
-                      <TableHeader
-                        currentSort={currentSort}
-                        data-test="fqdn-header"
-                        onClick={() => {
-                          setShowMAC(false);
-                          updateSort("fqdn");
-                        }}
-                        sortKey="fqdn"
-                      >
-                        FQDN
-                      </TableHeader>
-                      &nbsp;<strong>|</strong>&nbsp;
-                      <TableHeader
-                        currentSort={currentSort}
-                        data-test="mac-header"
-                        onClick={() => {
-                          setShowMAC(true);
-                          updateSort("pxe_mac");
-                        }}
-                        sortKey="pxe_mac"
-                      >
-                        MAC
-                      </TableHeader>
-                      <TableHeader>IP</TableHeader>
+                    <div className="u-equal-height u-nudge--checkbox">
+                      <Input
+                        checked={checkboxChecked(machines, selectedMachines)}
+                        className="has-inline-label"
+                        data-test="all-machines-checkbox"
+                        disabled={false}
+                        id="all-machines-checkbox"
+                        label={" "}
+                        onChange={() => handleAllCheckbox()}
+                        type="checkbox"
+                        wrapperClassName="u-no-margin--bottom"
+                      />
+                      <div>
+                        <TableHeader
+                          currentSort={currentSort}
+                          data-test="fqdn-header"
+                          onClick={() => {
+                            setShowMAC(false);
+                            updateSort("fqdn");
+                          }}
+                          sortKey="fqdn"
+                        >
+                          FQDN
+                        </TableHeader>
+                        &nbsp;<strong>|</strong>&nbsp;
+                        <TableHeader
+                          currentSort={currentSort}
+                          data-test="mac-header"
+                          onClick={() => {
+                            setShowMAC(true);
+                            updateSort("pxe_mac");
+                          }}
+                          sortKey="pxe_mac"
+                        >
+                          MAC
+                        </TableHeader>
+                        <TableHeader>IP</TableHeader>
+                      </div>
                     </div>
                   )
                 },

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -535,7 +535,7 @@ describe("MachineList", () => {
   });
 
   it(`unchecks the group checkbox if at least one machine in group is not
-    selected`, () => {
+      selected`, () => {
     const state = { ...initialState };
     state.machine.items[1].status_code = nodeStatus.DEPLOYED;
     const store = mockStore(state);
@@ -566,5 +566,167 @@ describe("MachineList", () => {
     expect(
       wrapper.find("[data-test='group-cell'] input[checked=true]").length
     ).toBe(0);
+  });
+
+  it("can select all machines if at least one is unselected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Select a single machine
+    wrapper
+      .find("[data-test='name-column'] input")
+      .at(0)
+      .simulate("change", {
+        target: { name: state.machine.items[0].system_id }
+      });
+    expect(
+      wrapper.find("[data-test='name-column'] input[checked=true]").length
+    ).toBe(1);
+    expect(
+      wrapper.find("[data-test='all-machines-checkbox'] input[checked=true]")
+        .length
+    ).toBe(0);
+    // Check the all checkbox
+    wrapper
+      .find("[data-test='all-machines-checkbox'] input")
+      .at(0)
+      .simulate("change");
+    expect(
+      wrapper.find("[data-test='name-column'] input[checked=true]").length
+    ).toBe(2);
+    expect(
+      wrapper.find("[data-test='all-machines-checkbox'] input[checked=true]")
+        .length
+    ).toBe(1);
+  });
+
+  it("unselects all machines if all are selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Select both machines
+    wrapper
+      .find("[data-test='name-column'] input")
+      .at(0)
+      .simulate("change", {
+        target: { name: state.machine.items[0].system_id }
+      });
+    wrapper
+      .find("[data-test='name-column'] input")
+      .at(1)
+      .simulate("change", {
+        target: { name: state.machine.items[1].system_id }
+      });
+    expect(
+      wrapper.find("[data-test='name-column'] input[checked=true]").length
+    ).toBe(2);
+    expect(
+      wrapper.find("[data-test='all-machines-checkbox'] input[checked=true]")
+        .length
+    ).toBe(1);
+    // Check the all checkbox
+    wrapper
+      .find("[data-test='all-machines-checkbox'] input")
+      .at(0)
+      .simulate("change");
+    expect(
+      wrapper.find("[data-test='name-column'] input[checked=true]").length
+    ).toBe(0);
+    expect(
+      wrapper.find("[data-test='all-machines-checkbox'] input[checked=true]")
+        .length
+    ).toBe(0);
+  });
+
+  it(`unchecks the all checkbox if at least one machine is
+      not selected`, () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Select all machines
+    wrapper
+      .find("[data-test='all-machines-checkbox'] input")
+      .at(0)
+      .simulate("change");
+    expect(
+      wrapper.find("[data-test='all-machines-checkbox'] input[checked=true]")
+        .length
+    ).toBe(1);
+    // Unselect one machine
+    wrapper
+      .find("[data-test='name-column'] input")
+      .at(0)
+      .simulate("change");
+    expect(
+      wrapper.find("[data-test='all-machines-checkbox'] input[checked=true]")
+        .length
+    ).toBe(0);
+  });
+
+  it("displays correct selected string in group header", () => {
+    const state = { ...initialState };
+    state.machine.items[1].status_code = nodeStatus.DEPLOYED;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("[data-test='group-cell'] .p-double-row__secondary-row")
+        .at(0)
+        .text()
+    ).toEqual("2 machines");
+    // Select one machine
+    wrapper
+      .find("[data-test='name-column'] input")
+      .at(0)
+      .simulate("change");
+    expect(
+      wrapper
+        .find("[data-test='group-cell'] .p-double-row__secondary-row")
+        .at(0)
+        .text()
+    ).toEqual("2 machines, 1 selected");
+    // Select other machine
+    wrapper
+      .find("[data-test='name-column'] input")
+      .at(1)
+      .simulate("change");
+    expect(
+      wrapper
+        .find("[data-test='group-cell'] .p-double-row__secondary-row")
+        .at(0)
+        .text()
+    ).toEqual("2 machines selected");
   });
 });


### PR DESCRIPTION
## Done
- Added an "all machines" checkbox
- Added a selected count for each group

## QA
- Check that checking the checkbox in the table header selects all the machines in the list if at least one is not selected. Otherwise if all are selected, it unselects them all.
- Check that the number selected in the group header shows up correctly

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1739

## Screenshot
![0 0 0 0_8400_MAAS_r_machines (6)](https://user-images.githubusercontent.com/25733845/73953367-96f9c380-4900-11ea-90ba-f3328295934c.png)
