### PR TITLE
Build 'Add hardware' dropdown.

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -78,7 +78,11 @@ export const App = () => {
         title={
           <>
             <span className="p-heading--four"></span>
-            <Loader inline text="Loading..." />
+            <Loader
+              className="u-no-padding u-no-margin"
+              inline
+              text="Loading..."
+            />
           </>
         }
       />

--- a/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
+++ b/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
@@ -26,7 +26,6 @@ exports[`ContextualMenu  renders 1`] = `
       >
         <span
           className="p-contextual-menu"
-          style={null}
         >
           <span
             aria-hidden="false"

--- a/ui/src/app/base/components/FormCard/FormCard.js
+++ b/ui/src/app/base/components/FormCard/FormCard.js
@@ -4,7 +4,7 @@ import React from "react";
 
 import "./FormCard.scss";
 
-export const FormCard = ({ children, stacked, title }) => {
+export const FormCard = ({ children, sidebar = true, stacked, title }) => {
   const titleNode = <h4 className="form-card__title">{title}</h4>;
   const content = stacked ? (
     <>
@@ -14,7 +14,7 @@ export const FormCard = ({ children, stacked, title }) => {
   ) : (
     <Row>
       <Col size="2">{titleNode}</Col>
-      <Col size="8">{children}</Col>
+      <Col size={sidebar ? "8" : "10"}>{children}</Col>
     </Row>
   );
   return (

--- a/ui/src/app/base/components/FormCard/FormCard.test.js
+++ b/ui/src/app/base/components/FormCard/FormCard.test.js
@@ -13,4 +13,23 @@ describe("FormCard ", () => {
     const wrapper = shallow(<FormCard stacked title="Add user" />);
     expect(wrapper.find("Col").exists()).toBe(false);
   });
+
+  it("decreases col size if sidebar is present", () => {
+    const withoutSidebar = shallow(
+      <FormCard sidebar={false} title="Add user" />
+    );
+    const withSidebar = shallow(<FormCard sidebar title="Add user" />);
+    expect(
+      withoutSidebar
+        .find("Col")
+        .at(1)
+        .props().size
+    ).toBe("10");
+    expect(
+      withSidebar
+        .find("Col")
+        .at(1)
+        .props().size
+    ).toBe("8");
+  });
 });

--- a/ui/src/app/base/components/TableMenu/TableMenu.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.js
@@ -9,6 +9,7 @@ const TableMenu = ({ links, title, onToggleMenu }) => {
   return (
     <ContextualMenu
       className="p-table-menu"
+      dropdownClassName="u-no-margin--top"
       hasToggleIcon
       links={[title, links]}
       onToggleMenu={onToggleMenu}

--- a/ui/src/app/base/components/TableMenu/TableMenu.scss
+++ b/ui/src/app/base/components/TableMenu/TableMenu.scss
@@ -10,10 +10,6 @@
   text-transform: uppercase;
 }
 
-.p-table-menu .p-contextual-menu__dropdown {
-  margin-top: 0;
-}
-
 .p-table-menu__toggle {
   $icon-size: map-get($icon-sizes, default);
   line-height: $icon-size;

--- a/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
+++ b/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
@@ -3,6 +3,7 @@
 exports[`TableMenu  renders 1`] = `
 <ContextualMenu
   className="p-table-menu"
+  dropdownClassName="u-no-margin--top"
   hasToggleIcon={true}
   links={
     Array [

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -1,0 +1,132 @@
+import { Button, Col, Loader, Row } from "@canonical/react-components";
+import pluralize from "pluralize";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, Route, Switch } from "react-router-dom";
+
+import {
+  machine as machineActions,
+  resourcepool as poolActions
+} from "app/base/actions";
+import {
+  general as generalSelectors,
+  machine as machineSelectors,
+  resourcepool as resourcePoolSelectors
+} from "app/base/selectors";
+import { useRouter } from "app/base/hooks";
+import ContextualMenu from "app/base/components/ContextualMenu";
+import Tabs from "app/base/components/Tabs";
+
+const getAddHardwareLinks = navigationOptions => {
+  const links = [
+    {
+      children: "Machine",
+      element: Link,
+      to: "/machines/add"
+    },
+    {
+      children: "Chassis",
+      element: Link,
+      to: "/machines/chassis/add"
+    }
+  ];
+
+  return navigationOptions.rsd
+    ? links.concat({
+        children: "RSD",
+        element: "a",
+        href: `${process.env.REACT_APP_ANGULAR_BASENAME}/rsd`
+      })
+    : links;
+};
+
+export const HeaderStrip = () => {
+  const dispatch = useDispatch();
+  const machines = useSelector(machineSelectors.all);
+  const machinesLoaded = useSelector(machineSelectors.loaded);
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
+  const navigationOptions = useSelector(generalSelectors.navigationOptions.get);
+  const { location } = useRouter();
+
+  useEffect(() => {
+    dispatch(poolActions.fetch());
+    dispatch(machineActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <>
+      <Row>
+        <Col size="10">
+          <ul className="p-inline-list">
+            <li className="p-inline-list__item p-heading--four">Machines</li>
+            {machinesLoaded ? (
+              <li
+                className="p-inline-list__item u-text--light"
+                data-test="machine-count"
+              >
+                {`${machines.length} ${pluralize(
+                  "machine",
+                  machines.length
+                )} available`}
+              </li>
+            ) : (
+              <Loader
+                className="u-no-padding u-no-margin"
+                inline
+                text="Loading..."
+              />
+            )}
+          </ul>
+        </Col>
+        <Col size="2" className="u-align--right">
+          <Switch>
+            <Route exact path="/machines">
+              <ContextualMenu
+                data-test="add-hardware-dropdown"
+                hasToggleIcon
+                links={getAddHardwareLinks(navigationOptions)}
+                position="right"
+                toggleAppearance="neutral"
+                toggleLabel="Add hardware"
+              />
+            </Route>
+            <Route exact path="/pools">
+              <Button data-test="add-pool" element={Link} to="/pools/add">
+                Add pool
+              </Button>
+            </Route>
+          </Switch>
+        </Col>
+      </Row>
+      <Row>
+        <Col size="12">
+          <hr className="u-no-margin--bottom" />
+          <Tabs
+            data-test="machine-list-tabs"
+            links={[
+              {
+                active: location.pathname.startsWith("/machines"),
+                label: `${
+                  machinesLoaded ? `${machines.length} ` : ""
+                }${pluralize("Machine", machines.length)}`,
+                path: "/machines"
+              },
+              {
+                active: location.pathname.startsWith("/pool"),
+                label: `${
+                  resourcePoolsLoaded ? `${resourcePools.length} ` : ""
+                }${pluralize("Resource pool", resourcePools.length)}`,
+                path: "/pools"
+              }
+            ]}
+            listClassName="u-no-margin--bottom"
+            noBorder
+          />
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default HeaderStrip;

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
@@ -1,0 +1,222 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import { nodeStatus, scriptStatus } from "app/base/enum";
+import HeaderStrip from "./HeaderStrip";
+
+const mockStore = configureStore();
+
+describe("HeaderStrip", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      config: {
+        items: []
+      },
+      general: {
+        osInfo: {
+          data: {
+            osystems: [["ubuntu", "Ubuntu"]],
+            releases: [["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"']]
+          },
+          errors: {},
+          loaded: true,
+          loading: false
+        },
+        navigationOptions: {
+          data: {
+            rsd: false
+          }
+        }
+      },
+      messages: {
+        items: []
+      },
+      machine: {
+        loaded: false,
+        items: [
+          {
+            architecture: "amd64/generic",
+            cpu_count: 4,
+            cpu_test_status: {
+              status: scriptStatus.RUNNING
+            },
+            distro_series: "bionic",
+            domain: {
+              name: "example"
+            },
+            extra_macs: [],
+            hostname: "koala",
+            ip_addresses: [],
+            memory: 8,
+            memory_test_status: {
+              status: scriptStatus.PASSED
+            },
+            network_test_status: {
+              status: scriptStatus.PASSED
+            },
+            osystem: "ubuntu",
+            permissions: ["edit", "delete"],
+            physical_disk_count: 1,
+            pool: {},
+            pxe_mac: "00:11:22:33:44:55",
+            spaces: [],
+            status: "Releasing",
+            status_code: nodeStatus.RELEASING,
+            status_message: "",
+            storage: 8,
+            storage_test_status: {
+              status: scriptStatus.PASSED
+            },
+            testing_status: {
+              status: scriptStatus.PASSED
+            },
+            system_id: "abc123",
+            zone: {}
+          }
+        ]
+      },
+      resourcepool: {
+        loaded: false,
+        items: [1, 2]
+      },
+      zone: {
+        loaded: true,
+        items: [
+          {
+            id: 0,
+            name: "default"
+          },
+          {
+            id: 1,
+            name: "Backup"
+          }
+        ]
+      }
+    };
+  });
+
+  it("displays a loader if machines have not loaded", () => {
+    const state = { ...initialState };
+    state.machine.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("displays a machine count if machines have loaded", () => {
+    const state = { ...initialState };
+    state.machine.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="machine-count"]').text()).toBe(
+      "1 machine available"
+    );
+  });
+
+  it("displays tabs with machine and resource pool counts if loaded", () => {
+    const state = { ...initialState };
+    state.machine.loaded = true;
+    state.resourcepool.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip />
+        </MemoryRouter>
+      </Provider>
+    );
+    const tabs = wrapper.find('[data-test="machine-list-tabs"]');
+    expect(
+      tabs
+        .find("Link")
+        .at(0)
+        .text()
+    ).toBe("1 Machine");
+    expect(
+      tabs
+        .find("Link")
+        .at(1)
+        .text()
+    ).toBe("2 Resource pools");
+  });
+
+  it(`displays RSD link in add hardware dropdown if shown
+    in navigation`, () => {
+    const state = { ...initialState };
+    state.general.navigationOptions.data.rsd = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="add-hardware-dropdown"]').props().links.length
+    ).toBe(3);
+    expect(
+      wrapper.find('[data-test="add-hardware-dropdown"]').props().links[2]
+        .children
+    ).toBe("RSD");
+  });
+
+  it("displays add hardware menu and not add pool when at machines route", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('ContextualMenu[data-test="add-hardware-dropdown"]').length
+    ).toBe(1);
+    expect(wrapper.find('Button[data-test="add-pool"]').length).toBe(0);
+  });
+
+  it(`displays add pool button and not hardware dropdown when
+    at pools route`, () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+          <HeaderStrip />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('Button[data-test="add-pool"]').length).toBe(1);
+    expect(
+      wrapper.find('Button[data-test="add-hardware-dropdown"]').length
+    ).toBe(0);
+  });
+});

--- a/ui/src/app/machines/components/HeaderStrip/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/index.js
@@ -1,0 +1,1 @@
+export { default } from "./HeaderStrip";

--- a/ui/src/app/machines/components/Routes/Routes.js
+++ b/ui/src/app/machines/components/Routes/Routes.js
@@ -1,20 +1,22 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 
+import AddMachine from "app/machines/views/AddMachine";
+import AddChassis from "app/machines/views/AddChassis";
 import MachineList from "app/machines/views/MachineList";
 import NotFound from "app/base/views/NotFound";
-import Pools from "app/pools/views/Pools";
 import PoolAdd from "app/pools/views/PoolAdd";
+import Pools from "app/pools/views/Pools";
 
-const Routes = () => {
-  return (
-    <Switch>
-      <Route exact path="/machines" component={MachineList} />
-      <Route exact path="/pools" component={Pools} />
-      <Route exact path="/pools/add" component={PoolAdd} />
-      <Route path="*" component={NotFound} />
-    </Switch>
-  );
-};
+const Routes = () => (
+  <Switch>
+    <Route exact path="/machines" component={MachineList} />
+    <Route exact path="/machines/add" component={AddMachine} />
+    <Route exact path="/machines/chassis/add" component={AddChassis} />
+    <Route exact path="/pools" component={Pools} />
+    <Route exact path="/pools/add" component={PoolAdd} />
+    <Route path="*" component={NotFound} />
+  </Switch>
+);
 
 export default Routes;

--- a/ui/src/app/machines/views/AddChassis/AddChassis.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassis.js
@@ -1,0 +1,30 @@
+import { Button } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import React from "react";
+
+import FormCard from "app/base/components/FormCard";
+
+export const AddChassis = () => (
+  <FormCard sidebar={false} title="Add chassis">
+    <hr />
+    <div className="u-align--right">
+      <Button
+        appearance="base"
+        className="u-no-margin--bottom"
+        element={Link}
+        style={{ marginRight: "1rem" }}
+        to="/machines"
+      >
+        Cancel
+      </Button>
+      <Button appearance="neutral" className="u-no-margin--bottom" disabled>
+        Save and add another
+      </Button>
+      <Button appearance="positive" className="u-no-margin--bottom" disabled>
+        Save chassis
+      </Button>
+    </div>
+  </FormCard>
+);
+
+export default AddChassis;

--- a/ui/src/app/machines/views/AddChassis/AddChassis.test.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassis.test.js
@@ -1,0 +1,11 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import AddChassis from "./AddChassis";
+
+describe("AddChassis", () => {
+  it("renders", () => {
+    const wrapper = shallow(<AddChassis />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/machines/views/AddChassis/__snapshots__/AddChassis.test.js.snap
+++ b/ui/src/app/machines/views/AddChassis/__snapshots__/AddChassis.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddChassis renders 1`] = `
+<FormCard
+  sidebar={false}
+  title="Add chassis"
+>
+  <hr />
+  <div
+    className="u-align--right"
+  >
+    <Button
+      appearance="base"
+      className="u-no-margin--bottom"
+      element={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "displayName": "Link",
+          "propTypes": Object {
+            "innerRef": [Function],
+            "onClick": [Function],
+            "replace": [Function],
+            "target": [Function],
+            "to": [Function],
+          },
+          "render": [Function],
+        }
+      }
+      style={
+        Object {
+          "marginRight": "1rem",
+        }
+      }
+      to="/machines"
+    >
+      Cancel
+    </Button>
+    <Button
+      appearance="neutral"
+      className="u-no-margin--bottom"
+      disabled={true}
+    >
+      Save and add another
+    </Button>
+    <Button
+      appearance="positive"
+      className="u-no-margin--bottom"
+      disabled={true}
+    >
+      Save chassis
+    </Button>
+  </div>
+</FormCard>
+`;

--- a/ui/src/app/machines/views/AddChassis/index.js
+++ b/ui/src/app/machines/views/AddChassis/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AddChassis";

--- a/ui/src/app/machines/views/AddMachine/AddMachine.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachine.js
@@ -1,0 +1,30 @@
+import { Button } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import React from "react";
+
+import FormCard from "app/base/components/FormCard";
+
+export const AddMachine = () => (
+  <FormCard sidebar={false} title="Add machine">
+    <hr />
+    <div className="u-align--right">
+      <Button
+        appearance="base"
+        className="u-no-margin--bottom"
+        element={Link}
+        style={{ marginRight: "1rem" }}
+        to="/machines"
+      >
+        Cancel
+      </Button>
+      <Button appearance="neutral" className="u-no-margin--bottom" disabled>
+        Save and add another
+      </Button>
+      <Button appearance="positive" className="u-no-margin--bottom" disabled>
+        Save machine
+      </Button>
+    </div>
+  </FormCard>
+);
+
+export default AddMachine;

--- a/ui/src/app/machines/views/AddMachine/AddMachine.test.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachine.test.js
@@ -1,0 +1,11 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import AddMachine from "./AddMachine";
+
+describe("AddMachine", () => {
+  it("renders", () => {
+    const wrapper = shallow(<AddMachine />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/machines/views/AddMachine/__snapshots__/AddMachine.test.js.snap
+++ b/ui/src/app/machines/views/AddMachine/__snapshots__/AddMachine.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddMachine renders 1`] = `
+<FormCard
+  sidebar={false}
+  title="Add machine"
+>
+  <hr />
+  <div
+    className="u-align--right"
+  >
+    <Button
+      appearance="base"
+      className="u-no-margin--bottom"
+      element={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "displayName": "Link",
+          "propTypes": Object {
+            "innerRef": [Function],
+            "onClick": [Function],
+            "replace": [Function],
+            "target": [Function],
+            "to": [Function],
+          },
+          "render": [Function],
+        }
+      }
+      style={
+        Object {
+          "marginRight": "1rem",
+        }
+      }
+      to="/machines"
+    >
+      Cancel
+    </Button>
+    <Button
+      appearance="neutral"
+      className="u-no-margin--bottom"
+      disabled={true}
+    >
+      Save and add another
+    </Button>
+    <Button
+      appearance="positive"
+      className="u-no-margin--bottom"
+      disabled={true}
+    >
+      Save machine
+    </Button>
+  </div>
+</FormCard>
+`;

--- a/ui/src/app/machines/views/AddMachine/index.js
+++ b/ui/src/app/machines/views/AddMachine/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AddMachine";

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -65,6 +65,7 @@ exports[`OwnerColumn renders 1`] = `
           >
             <ContextualMenu
               className="p-table-menu"
+              dropdownClassName="u-no-margin--top"
               hasToggleIcon={true}
               links={
                 Array [

--- a/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -76,6 +76,7 @@ exports[`PoolColumn renders 1`] = `
           >
             <ContextualMenu
               className="p-table-menu"
+              dropdownClassName="u-no-margin--top"
               hasToggleIcon={true}
               links={
                 Array [

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -60,6 +60,7 @@ exports[`ZoneColumn renders 1`] = `
           >
             <ContextualMenu
               className="p-table-menu"
+              dropdownClassName="u-no-margin--top"
               hasToggleIcon={true}
               links={
                 Array [

--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -1,89 +1,13 @@
-import { Button, Row, Col, Loader } from "@canonical/react-components";
-import pluralize from "pluralize";
 import React from "react";
-import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
 
-import { useRouter } from "app/base/hooks";
-import {
-  machine as machineSelectors,
-  resourcepool as resourcePoolSelectors
-} from "app/base/selectors";
+import HeaderStrip from "app/machines/components/HeaderStrip";
 import Routes from "app/machines/components/Routes";
 import Section from "app/base/components/Section";
-import Tabs from "app/base/components/Tabs";
 
-const Machines = () => {
-  const machines = useSelector(machineSelectors.all);
-  const machinesLoaded = useSelector(machineSelectors.loaded);
-  const resourcePools = useSelector(resourcePoolSelectors.all);
-  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
-  const { location } = useRouter();
-
-  return (
-    <Section
-      headerClassName="u-no-padding--bottom"
-      title={
-        <>
-          <Row>
-            <Col size={10}>
-              <ul className="p-inline-list">
-                <li className="p-inline-list__item p-heading--four">
-                  Machines
-                </li>
-                {machinesLoaded ? (
-                  <li
-                    className="p-inline-list__item u-text--light"
-                    data-test="machine-count"
-                  >
-                    {`${machines.length} ${pluralize(
-                      "machine",
-                      machines.length
-                    )} available`}
-                  </li>
-                ) : (
-                  <Loader inline text="Loading..." />
-                )}
-              </ul>
-            </Col>
-            <Col size={2} className="u-align--right">
-              {location.pathname === "/pools" && (
-                <div>
-                  <Button element={Link} to="/pools/add" key="/pools/add">
-                    Add Pool
-                  </Button>
-                </div>
-              )}
-            </Col>
-          </Row>
-          <hr className="u-no-margin--bottom" />
-          <Tabs
-            data-test="machine-list-tabs"
-            links={[
-              {
-                active: location.pathname === "/machines",
-                label: `${
-                  machinesLoaded ? `${machines.length} ` : ""
-                }${pluralize("Machine", machines.length)}`,
-                path: "/machines"
-              },
-              {
-                active: location.pathname === "/pools",
-                label: `${
-                  resourcePoolsLoaded ? `${resourcePools.length} ` : ""
-                }${pluralize("Resource pool", resourcePools.length)}`,
-                path: "/pools"
-              }
-            ]}
-            listClassName="u-no-margin--bottom"
-            noBorder
-          />
-        </>
-      }
-    >
-      <Routes />
-    </Section>
-  );
-};
+const Machines = () => (
+  <Section headerClassName="u-no-padding--bottom" title={<HeaderStrip />}>
+    <Routes />
+  </Section>
+);
 
 export default Machines;

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -4,7 +4,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import { nodeStatus, scriptStatus } from "app/base/enum";
 import Machines from "./Machines";
 
 const mockStore = configureStore();
@@ -17,86 +16,24 @@ describe("Machines", () => {
         items: []
       },
       general: {
-        osInfo: {
-          data: {
-            osystems: [["ubuntu", "Ubuntu"]],
-            releases: [["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"']]
-          },
-          errors: {},
-          loaded: true,
-          loading: false
+        navigationOptions: {
+          data: {}
         }
       },
       messages: {
         items: []
       },
       machine: {
-        loaded: false,
-        items: [
-          {
-            architecture: "amd64/generic",
-            cpu_count: 4,
-            cpu_test_status: {
-              status: scriptStatus.RUNNING
-            },
-            distro_series: "bionic",
-            domain: {
-              name: "example"
-            },
-            extra_macs: [],
-            hostname: "koala",
-            ip_addresses: [],
-            memory: 8,
-            memory_test_status: {
-              status: scriptStatus.PASSED
-            },
-            network_test_status: {
-              status: scriptStatus.PASSED
-            },
-            osystem: "ubuntu",
-            permissions: ["edit", "delete"],
-            physical_disk_count: 1,
-            pool: {},
-            pxe_mac: "00:11:22:33:44:55",
-            spaces: [],
-            status: "Releasing",
-            status_code: nodeStatus.RELEASING,
-            status_message: "",
-            storage: 8,
-            storage_test_status: {
-              status: scriptStatus.PASSED
-            },
-            testing_status: {
-              status: scriptStatus.PASSED
-            },
-            system_id: "abc123",
-            zone: {}
-          }
-        ]
+        items: []
       },
       resourcepool: {
-        loaded: false,
-        items: [1, 2]
-      },
-      zone: {
-        loaded: true,
-        items: [
-          {
-            id: 0,
-            name: "default"
-          },
-          {
-            id: 1,
-            name: "Backup"
-          }
-        ]
+        items: []
       }
     };
   });
 
-  it("displays a loader if machines have not loaded", () => {
+  it("correctly routes to machine list", () => {
     const state = { ...initialState };
-    state.machine.loaded = false;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -107,53 +44,81 @@ describe("Machines", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Loader").exists()).toBe(true);
+    expect(wrapper.find("MachineList").length).toBe(1);
   });
 
-  it("displays a machine count if machines have loaded", () => {
+  it("correctly routes to add machine form", () => {
     const state = { ...initialState };
-    state.machine.loaded = true;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
           <Machines />
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find('[data-test="machine-count"]').text()).toBe(
-      "1 machine available"
-    );
+    expect(wrapper.find("AddMachine").length).toBe(1);
   });
 
-  it("displays tabs with machine and resource pool counts if loaded", () => {
+  it("correctly routes to add chassis form", () => {
     const state = { ...initialState };
-    state.machine.loaded = true;
-    state.resourcepool.loaded = true;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          initialEntries={[
+            { pathname: "/machines/chassis/add", key: "testKey" }
+          ]}
         >
           <Machines />
         </MemoryRouter>
       </Provider>
     );
-    const tabs = wrapper.find('[data-test="machine-list-tabs"]');
-    expect(
-      tabs
-        .find("Link")
-        .at(0)
-        .text()
-    ).toBe("1 Machine");
-    expect(
-      tabs
-        .find("Link")
-        .at(1)
-        .text()
-    ).toBe("2 Resource pools");
+    expect(wrapper.find("AddChassis").length).toBe(1);
+  });
+
+  it("correctly routes to pools tab", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Pools").length).toBe(1);
+  });
+
+  it("correctly routes to add pool form", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/pools/add", key: "testKey" }]}
+        >
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("PoolAdd").length).toBe(1);
+  });
+
+  it("correctly routes to not found component if url does not match", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/qwerty", key: "testKey" }]}
+        >
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("NotFound").length).toBe(1);
   });
 });

--- a/ui/src/app/pools/views/PoolForm/PoolForm.js
+++ b/ui/src/app/pools/views/PoolForm/PoolForm.js
@@ -1,11 +1,8 @@
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
-import {
-  machine as machineActions,
-  resourcepool as poolActions
-} from "app/base/actions";
+import { resourcepool as poolActions } from "app/base/actions";
 import { resourcepool as poolSelectors } from "app/base/selectors";
 import { useAddMessage } from "app/base/hooks";
 import { useWindowTitle } from "app/base/hooks";
@@ -37,13 +34,8 @@ export const PoolForm = () => {
     setSaving
   );
 
-  useEffect(() => {
-    dispatch(poolActions.fetch());
-    dispatch(machineActions.fetch());
-  }, [dispatch]);
-
   return (
-    <FormCard title={title}>
+    <FormCard sidebar={false} title={title}>
       <FormikForm
         buttons={FormCardButtons}
         errors={errors}

--- a/ui/src/app/pools/views/PoolForm/PoolForm.test.js
+++ b/ui/src/app/pools/views/PoolForm/PoolForm.test.js
@@ -66,7 +66,7 @@ describe("PoolForm", () => {
       </Provider>
     );
     wrapper.unmount();
-    expect(store.getActions()[2]).toEqual({
+    expect(store.getActions()[0]).toEqual({
       type: "CLEANUP_RESOURCEPOOL"
     });
   });
@@ -106,7 +106,7 @@ describe("PoolForm", () => {
           {}
         )
     );
-    expect(store.getActions()[2]).toEqual({
+    expect(store.getActions()[0]).toEqual({
       type: "CREATE_RESOURCEPOOL",
       payload: {
         params: {

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -54,4 +54,8 @@ body {
 
 a:visited {
   color: $color-link;
+
+  &.p-contextual-menu__link {
+    color: $color-dark;
+  }
 }


### PR DESCRIPTION
## Done
- Refactored `Machines.js`, basically just by extracting out `HeaderStrip` into a separate component.
- Built "Add hardware" dropdown in machine list.
- Added placeholder `AddMachine` and `AddChassis` form components.
- Changed how `ContextualMenu` calculates position - @huwshimi not sure why but before I changed it the dropdown would only render after opening the dropdown twice? Some sort of weird race condition with the `useEffects`.... anyway it seems to work now.
- Tidied up spacing for some Loaders.

## QA
- Check that there is an "Add hardware" dropdown in the top-right of the machine list.
- Check that it is not there in the pools tab.
- Check that you are redirected to the Add machine and Add chassis forms when you click the links.
- Check that going to `/machines/cyw` takes you to an error page

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1728

## Screenshot
![0 0 0 0_8400_MAAS_r_machines (7)](https://user-images.githubusercontent.com/25733845/74057475-507d9500-49e4-11ea-88be-e9446386f86c.png)

