### PR TITLE
Refactor table actions into TableActions component.

### DIFF
--- a/ui/src/app/base/components/TableActions/TableActions.js
+++ b/ui/src/app/base/components/TableActions/TableActions.js
@@ -1,0 +1,60 @@
+import { Button } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import React from "react";
+
+import CopyButton from "app/base/components/CopyButton";
+import Tooltip from "app/base/components/Tooltip";
+
+const TableActions = ({
+  copyValue,
+  deleteDisabled,
+  deleteTooltip,
+  editDisabled,
+  editPath,
+  editTooltip,
+  onDelete
+}) => (
+  <div>
+    {copyValue && <CopyButton value={copyValue} />}
+    {editPath && (
+      <Tooltip message={editTooltip} position="left">
+        <Button
+          appearance="base"
+          className="is-dense u-table-cell-padding-overlap"
+          disabled={editDisabled}
+          element={Link}
+          hasIcon
+          to={editPath}
+        >
+          <i className="p-icon--edit">Edit</i>
+        </Button>
+      </Tooltip>
+    )}
+    {onDelete && (
+      <Tooltip message={deleteTooltip} position="left">
+        <Button
+          appearance="base"
+          className="is-dense u-table-cell-padding-overlap"
+          disabled={deleteDisabled}
+          hasIcon
+          onClick={() => onDelete()}
+        >
+          <i className="p-icon--delete">Delete</i>
+        </Button>
+      </Tooltip>
+    )}
+  </div>
+);
+
+TableActions.propTypes = {
+  copyValue: PropTypes.string,
+  deleteDisabled: PropTypes.bool,
+  deleteTooltip: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  editDisabled: PropTypes.bool,
+  editPath: PropTypes.string,
+  editTooltip: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  onDelete: PropTypes.func
+};
+
+export default TableActions;

--- a/ui/src/app/base/components/TableActions/TableActions.test.js
+++ b/ui/src/app/base/components/TableActions/TableActions.test.js
@@ -1,0 +1,70 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import TableActions from "./TableActions";
+
+describe("TableActions ", () => {
+  it("renders a copy button if copy value provided", () => {
+    const wrapper = shallow(<TableActions copyValue="foo" />);
+    expect(wrapper.find("CopyButton").exists()).toBe(true);
+  });
+
+  it("renders an edit link if edit path provided", () => {
+    const wrapper = shallow(<TableActions editPath="/bar" />);
+    expect(wrapper.find("Button").props().to).toBe("/bar");
+  });
+
+  it("renders a delete button if delete function provided", () => {
+    const onDelete = jest.fn();
+    const wrapper = shallow(<TableActions onDelete={onDelete} />);
+    expect(wrapper.find("Button .p-icon--delete").exists()).toBe(true);
+    wrapper.find("Button").simulate("click");
+    expect(onDelete).toHaveBeenCalled();
+  });
+
+  it("correctly renders tooltips", () => {
+    const wrapper = shallow(
+      <TableActions
+        deleteTooltip="delete tooltip"
+        editPath="/bar"
+        editTooltip="edit tooltip"
+        onDelete={jest.fn()}
+      />
+    );
+    expect(
+      wrapper
+        .find("Tooltip")
+        .at(0)
+        .props().message
+    ).toBe("edit tooltip");
+    expect(
+      wrapper
+        .find("Tooltip")
+        .at(1)
+        .props().message
+    ).toBe("delete tooltip");
+  });
+
+  it("correctly disables buttons", () => {
+    const wrapper = shallow(
+      <TableActions
+        deleteDisabled
+        editDisabled
+        editPath="/bar"
+        onDelete={jest.fn()}
+      />
+    );
+    expect(
+      wrapper
+        .find("Button")
+        .at(0)
+        .props().disabled
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("Button")
+        .at(1)
+        .props().disabled
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/TableActions/index.js
+++ b/ui/src/app/base/components/TableActions/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TableActions";

--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 const TableDeleteConfirm = ({
+  sidebar = true,
   message,
   modelName,
   modelType,
@@ -11,7 +12,7 @@ const TableDeleteConfirm = ({
 }) => {
   return (
     <Row>
-      <Col size="7">
+      <Col size={sidebar ? "7" : "9"}>
         <p className="u-no-margin--bottom u-no-max-width">
           {message ||
             `Are you sure you want to delete ${modelType} "${modelName}"?`}{" "}

--- a/ui/src/app/pools/views/Pools.js
+++ b/ui/src/app/pools/views/Pools.js
@@ -1,16 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  Button,
-  Col,
-  Link,
-  Loader,
-  MainTable,
-  Row
-} from "@canonical/react-components";
+import { Col, Loader, MainTable, Row } from "@canonical/react-components";
 
+import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
-import Tooltip from "app/base/components/Tooltip";
 import {
   machine as machineActions,
   resourcepool as resourcePoolActions
@@ -42,36 +35,17 @@ const generateRows = (rows, expandedId, setExpandedId, dispatch, setDeleting) =>
         },
         {
           content: (
-            <>
-              <Button
-                appearance="base"
-                element={Link}
-                hasIcon
-                to={`/pools/${row.id}/edit`}
-                className="is-dense u-table-cell-padding-overlap"
-                disabled={!row.permissions.includes("edit")}
-              >
-                <i className="p-icon--edit">Edit</i>
-              </Button>
-              <Tooltip
-                position="left"
-                message={
-                  row.is_default && "The default pool may not be deleted."
-                }
-              >
-                <Button
-                  appearance="base"
-                  className="is-dense u-table-cell-padding-overlap"
-                  hasIcon
-                  disabled={
-                    !row.permissions.includes("delete") || row.is_default
-                  }
-                  onClick={() => setExpandedId(row.id)}
-                >
-                  <i className="p-icon--delete">Delete</i>
-                </Button>
-              </Tooltip>
-            </>
+            <TableActions
+              deleteDisabled={
+                !row.permissions.includes("delete") || row.is_default
+              }
+              deleteTooltip={
+                row.is_default && "The default pool may not be deleted."
+              }
+              editDisabled={!row.permissions.includes("edit")}
+              editPath={`/pools/${row.id}/edit`}
+              onDelete={() => setExpandedId(row.id)}
+            />
           ),
           className: "u-align--right"
         }
@@ -87,6 +61,7 @@ const generateRows = (rows, expandedId, setExpandedId, dispatch, setDeleting) =>
             setDeleting(row.name);
             setExpandedId();
           }}
+          sidebar={false}
         />
       ),
       key: row.name,

--- a/ui/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.js
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.js
@@ -1,5 +1,4 @@
-import { Button, Notification } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect, useState } from "react";
 
@@ -8,8 +7,8 @@ import { token as tokenActions } from "app/preferences/actions";
 import { token as tokenSelectors } from "app/preferences/selectors";
 import { useAddMessage } from "app/base/hooks";
 import { useWindowTitle } from "app/base/hooks";
-import CopyButton from "app/base/components/CopyButton";
 import SettingsTable from "app/settings/components/SettingsTable";
+import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 const generateRows = (
@@ -35,28 +34,11 @@ const generateRows = (
         },
         {
           content: (
-            <>
-              <CopyButton value={token} />
-              <Button
-                appearance="base"
-                className="is-dense u-table-cell-padding-overlap"
-                element={Link}
-                hasIcon
-                to={`/account/prefs/api-keys/${id}/edit`}
-              >
-                <i className="p-icon--edit">Edit</i>
-              </Button>
-              <Button
-                appearance="base"
-                hasIcon
-                className="is-dense u-table-cell-padding-overlap"
-                onClick={() => {
-                  setExpandedId(id);
-                }}
-              >
-                <i className="p-icon--delete">Delete</i>
-              </Button>
-            </>
+            <TableActions
+              copyValue={token}
+              editPath={`/account/prefs/api-keys/${id}/edit`}
+              onDelete={() => setExpandedId(id)}
+            />
           ),
           className: "u-align--right"
         }

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.js
@@ -1,4 +1,4 @@
-import { Button, Notification } from "@canonical/react-components";
+import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect, useState } from "react";
 
@@ -7,8 +7,8 @@ import { sslkey as sslkeyActions } from "app/preferences/actions";
 import { sslkey as sslkeySelectors } from "app/preferences/selectors";
 import { useAddMessage } from "app/base/hooks";
 import { useWindowTitle } from "app/base/hooks";
-import CopyButton from "app/base/components/CopyButton";
 import SettingsTable from "app/settings/components/SettingsTable";
+import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 const generateRows = (
@@ -30,19 +30,7 @@ const generateRows = (
         },
         {
           content: (
-            <>
-              <CopyButton value={key} />
-              <Button
-                appearance="base"
-                className="is-dense u-table-cell-padding-overlap"
-                hasIcon
-                onClick={() => {
-                  setExpandedId(id);
-                }}
-              >
-                <i className="p-icon--delete">Delete</i>
-              </Button>
-            </>
+            <TableActions copyValue={key} onDelete={() => setExpandedId(id)} />
           ),
           className: "u-align--right"
         }

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
@@ -1,6 +1,5 @@
-import { Button, Code, Col, Row } from "@canonical/react-components";
+import { Code, Col, Row } from "@canonical/react-components";
 import { format, parse } from "date-fns";
-import { Link } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { useWindowTitle } from "app/base/hooks";
 import React, { useEffect, useState } from "react";
@@ -24,6 +23,7 @@ import { useAddMessage } from "app/base/hooks";
 import ColumnToggle from "app/base/components/ColumnToggle";
 import DhcpTarget from "app/settings/views/Dhcp/DhcpTarget";
 import SettingsTable from "app/settings/components/SettingsTable";
+import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 const getTargetName = (
@@ -109,28 +109,13 @@ const generateRows = (
         { content: updated },
         {
           content: (
-            <>
-              <Button
-                appearance="base"
-                element={Link}
-                to={`/settings/dhcp/${dhcpsnippet.id}/edit`}
-                className="is-dense u-table-cell-padding-overlap"
-                hasIcon
-              >
-                <i className="p-icon--edit">Edit</i>
-              </Button>
-              <Button
-                appearance="base"
-                className="is-dense u-table-cell-padding-overlap"
-                hasIcon
-                onClick={() => {
-                  setExpandedId(dhcpsnippet.id);
-                  setExpandedType("delete");
-                }}
-              >
-                <i className="p-icon--delete">Delete</i>
-              </Button>
-            </>
+            <TableActions
+              editPath={`/settings/dhcp/${dhcpsnippet.id}/edit`}
+              onDelete={() => {
+                setExpandedId(dhcpsnippet.id);
+                setExpandedType("delete");
+              }}
+            />
           ),
           className: "u-align--right"
         }

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.js
@@ -1,5 +1,3 @@
-import { Button } from "@canonical/react-components";
-import { Link } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect, useState } from "react";
 
@@ -7,6 +5,7 @@ import "./LicenseKeyList.scss";
 import { useAddMessage } from "app/base/hooks";
 import { useWindowTitle } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
+import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 import { licensekeys as licenseKeysActions } from "app/base/actions";
@@ -36,27 +35,10 @@ const generateRows = (
         },
         {
           content: (
-            <>
-              <Button
-                appearance="base"
-                element={Link}
-                to={`/settings/license-keys/${licenseKey.osystem}/${licenseKey.distro_series}/edit`}
-                className="is-dense u-table-cell-padding-overlap"
-                hasIcon
-              >
-                <i className="p-icon--edit">Edit</i>
-              </Button>
-              <Button
-                appearance="base"
-                className="is-dense u-table-cell-padding-overlap"
-                hasIcon
-                onClick={() => {
-                  setExpandedId(licenseKey.license_key);
-                }}
-              >
-                <i className="p-icon--delete">Delete</i>
-              </Button>
-            </>
+            <TableActions
+              editPath={`/settings/license-keys/${licenseKey.osystem}/${licenseKey.distro_series}/edit`}
+              onDelete={() => setExpandedId(licenseKey.license_key)}
+            />
           ),
           className: "u-align--right"
         }

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.js
@@ -1,5 +1,3 @@
-import { Button } from "@canonical/react-components";
-import { Link } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect, useState } from "react";
 
@@ -10,8 +8,8 @@ import { getRepoDisplayName } from "../utils";
 import { useAddMessage } from "app/base/hooks";
 import { useWindowTitle } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
+import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
-import Tooltip from "app/base/components/Tooltip";
 
 const generateRepositoryRows = (
   dispatch,
@@ -38,31 +36,12 @@ const generateRepositoryRows = (
         },
         {
           content: (
-            <>
-              <Button
-                appearance="base"
-                element={Link}
-                to={`/settings/repositories/edit/${type}/${repo.id}`}
-                className="is-dense u-table-cell-padding-overlap"
-                hasIcon
-              >
-                <i className="p-icon--edit">Edit</i>
-              </Button>
-              <Tooltip
-                position="left"
-                message={repo.default && "Default repos cannot be deleted."}
-              >
-                <Button
-                  appearance="base"
-                  className="is-dense u-table-cell-padding-overlap"
-                  hasIcon
-                  onClick={() => setExpandedId(repo.id)}
-                  disabled={repo.default}
-                >
-                  <i className="p-icon--delete">Delete</i>
-                </Button>
-              </Tooltip>
-            </>
+            <TableActions
+              deleteDisabled={repo.default}
+              deleteTooltip={repo.default && "Default repos cannot be deleted."}
+              editPath={`/settings/repositories/edit/${type}/${repo.id}`}
+              onDelete={() => setExpandedId(repo.id)}
+            />
           ),
           className: "u-align--right"
         }

--- a/ui/src/app/settings/views/Scripts/ScriptsList.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsList.js
@@ -1,4 +1,4 @@
-import { Button, Code, Col, Row } from "@canonical/react-components";
+import { Code, Col, Row } from "@canonical/react-components";
 import { format, parse } from "date-fns";
 import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
@@ -7,12 +7,12 @@ import React, { useEffect, useState } from "react";
 import "./ScriptsList.scss";
 import { useAddMessage } from "app/base/hooks";
 import { useWindowTitle } from "app/base/hooks";
-import ColumnToggle from "app/base/components/ColumnToggle";
-import SettingsTable from "app/settings/components/SettingsTable";
-import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import { scripts as scriptActions } from "app/base/actions";
 import { scripts as scriptSelectors } from "app/base/selectors";
-import Tooltip from "app/base/components/Tooltip";
+import ColumnToggle from "app/base/components/ColumnToggle";
+import SettingsTable from "app/settings/components/SettingsTable";
+import TableActions from "app/base/components/TableActions";
+import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 
 const generateRows = (
   scripts,
@@ -81,23 +81,16 @@ const generateRows = (
         { content: uploadedOn },
         {
           content: (
-            <Tooltip
-              position="left"
-              message={script.default && "Default scripts cannot be deleted."}
-            >
-              <Button
-                appearance="base"
-                disabled={script.default}
-                className="is-dense u-table-cell-padding-overlap"
-                hasIcon
-                onClick={() => {
-                  setExpandedId(script.id);
-                  setExpandedType("delete");
-                }}
-              >
-                <i className="p-icon--delete">Delete</i>
-              </Button>
-            </Tooltip>
+            <TableActions
+              deleteDisabled={script.default}
+              deleteTooltip={
+                script.default && "Default scripts cannot be deleted."
+              }
+              onDelete={() => {
+                setExpandedId(script.id);
+                setExpandedType("delete");
+              }}
+            />
           ),
           className: "u-align--right"
         }

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.js
@@ -1,5 +1,4 @@
-import { Button, Notification } from "@canonical/react-components";
-import { Link } from "react-router-dom";
+import { Notification } from "@canonical/react-components";
 import { format, parse } from "date-fns";
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect, useState } from "react";
@@ -14,9 +13,9 @@ import {
 import { status as statusSelectors } from "app/base/selectors";
 import { useWindowTitle } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
+import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import TableHeader from "app/base/components/TableHeader";
-import Tooltip from "app/base/components/Tooltip";
 
 const generateUserRows = (
   users,
@@ -58,35 +57,16 @@ const generateUserRows = (
         },
         {
           content: (
-            <>
-              <Button
-                appearance="base"
-                element={Link}
-                hasIcon
-                to={
-                  isAuthUser
-                    ? "/account/prefs/details"
-                    : `/settings/users/${user.id}/edit`
-                }
-                className="is-dense u-table-cell-padding-overlap"
-              >
-                <i className="p-icon--edit">Edit</i>
-              </Button>
-              <Tooltip
-                position="left"
-                message={isAuthUser && "You cannot delete your own user."}
-              >
-                <Button
-                  appearance="base"
-                  className="is-dense u-table-cell-padding-overlap"
-                  hasIcon
-                  onClick={() => setExpandedId(user.id)}
-                  disabled={isAuthUser}
-                >
-                  <i className="p-icon--delete">Delete</i>
-                </Button>
-              </Tooltip>
-            </>
+            <TableActions
+              deleteDisabled={isAuthUser}
+              deleteTooltip={isAuthUser && "You cannot delete your own user."}
+              editPath={
+                isAuthUser
+                  ? "/account/prefs/details"
+                  : `/settings/users/${user.id}/edit`
+              }
+              onDelete={() => setExpandedId(user.id)}
+            />
           ),
           className: "u-align--right"
         }

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.scss
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.scss
@@ -39,7 +39,6 @@ $grid-size: 0.1 / 3;
 
   // Actions
   &:nth-child(8) {
-    align-items: center;
     flex: $grid-size * 3 0 0;
   }
 }


### PR DESCRIPTION
## Done
- Pulled out the common edit/delete/copy JSX from some tables into new TableActions component.

## QA
- Check that the following tables still work as intended (i.e clicking delete button opens delete panel, clicking edit button redirects to edit page, clicking copy button copies to clipboard):
   - Settings: Users, licence keys, scripts, DHCP snippets and package repos
   - User prefs: API keys, SSH keys and SSL keys 
   - Machines: Pools list

## Fixes
Fixes #770 
