### PR TITLE
Add power menu to machine list

### DIFF
--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -53,6 +53,53 @@ machine.setZone = (systemId, zoneId) => {
   };
 };
 
+machine.turnOff = systemId => {
+  return {
+    type: "TURN_MACHINE_OFF",
+    meta: {
+      model: "machine",
+      method: "action"
+    },
+    payload: {
+      params: {
+        action: "off",
+        system_id: systemId
+      }
+    }
+  };
+};
+
+machine.turnOn = systemId => {
+  return {
+    type: "TURN_MACHINE_ON",
+    meta: {
+      model: "machine",
+      method: "action"
+    },
+    payload: {
+      params: {
+        action: "on",
+        system_id: systemId
+      }
+    }
+  };
+};
+
+machine.checkPower = systemId => {
+  return {
+    type: "CHECK_MACHINE_POWER",
+    meta: {
+      model: "machine",
+      method: "check_power"
+    },
+    payload: {
+      params: {
+        system_id: systemId
+      }
+    }
+  };
+};
+
 machine.cleanup = () => {
   return {
     type: "CLEANUP_MACHINE"

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -67,6 +67,53 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle turning on the machine", () => {
+    expect(machine.turnOn("abc123", 909)).toEqual({
+      type: "TURN_MACHINE_ON",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "on",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle turning off the machine", () => {
+    expect(machine.turnOff("abc123", 909)).toEqual({
+      type: "TURN_MACHINE_OFF",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "off",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle checking the machine power", () => {
+    expect(machine.checkPower("abc123", 909)).toEqual({
+      type: "CHECK_MACHINE_POWER",
+      meta: {
+        model: "machine",
+        method: "check_power"
+      },
+      payload: {
+        params: {
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
   it("can handle cleaning machines", () => {
     expect(machine.cleanup()).toEqual({
       type: "CLEANUP_MACHINE"

--- a/ui/src/app/base/components/DoubleRow/DoubleRow.js
+++ b/ui/src/app/base/components/DoubleRow/DoubleRow.js
@@ -9,6 +9,7 @@ const DoubleRow = ({
   icon,
   iconSpace,
   iconTitle,
+  menuClassName,
   menuLinks,
   menuTitle,
   onToggleMenu,
@@ -51,6 +52,7 @@ const DoubleRow = ({
           </div>
           {menuLinks ? (
             <TableMenu
+              className={menuClassName}
               links={menuLinks}
               title={menuTitle}
               onToggleMenu={onToggleMenu}
@@ -78,6 +80,7 @@ DoubleRow.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.node,
   iconSpace: PropTypes.bool,
+  menuClassName: PropTypes.string,
   menuLinks: TableMenu.propTypes.links,
   menuTitle: PropTypes.string,
   onToggleMenu: PropTypes.func,

--- a/ui/src/app/base/components/TableMenu/TableMenu.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.js
@@ -1,14 +1,15 @@
 import { Button } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import React from "react";
+import classNames from "classnames";
 
 import "./TableMenu.scss";
 import ContextualMenu from "app/base/components/ContextualMenu";
 
-const TableMenu = ({ links, title, onToggleMenu }) => {
+const TableMenu = ({ className, links, title, onToggleMenu }) => {
   return (
     <ContextualMenu
-      className="p-table-menu"
+      className={classNames("p-table-menu", className)}
       dropdownClassName="u-no-margin--top"
       hasToggleIcon
       links={[title, links]}
@@ -21,6 +22,7 @@ const TableMenu = ({ links, title, onToggleMenu }) => {
 };
 
 TableMenu.propTypes = {
+  className: PropTypes.string,
   links: PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
   onToggleMenu: PropTypes.func,
   title: PropTypes.string

--- a/ui/src/app/base/components/TableMenu/TableMenu.scss
+++ b/ui/src/app/base/components/TableMenu/TableMenu.scss
@@ -10,8 +10,21 @@
   text-transform: uppercase;
 }
 
+.p-table-menu .p-contextual-menu__dropdown {
+  .p-table-menu__icon-space,
+  [class*="p-icon"] {
+    margin-right: $sph-inner--small;
+  }
+}
+
 .p-table-menu__toggle {
   $icon-size: map-get($icon-sizes, default);
   line-height: $icon-size;
   padding: 0 $icon-size / 2;
+}
+
+.p-table-menu__icon-space {
+  $icon-space: map-get($icon-sizes, default);
+  display: inline-block;
+  width: $icon-space;
 }

--- a/ui/src/app/base/components/TableMenu/TableMenu.scss
+++ b/ui/src/app/base/components/TableMenu/TableMenu.scss
@@ -1,6 +1,8 @@
 @import "~vanilla-framework/scss/settings_colors";
 @import "~vanilla-framework/scss/settings_spacing";
 
+$icon-size: map-get($icon-sizes, default);
+
 .p-table-menu .p-contextual-menu__non-interactive {
   border-bottom: 1px solid $color-mid-light;
   color: $color-mid-dark;
@@ -8,6 +10,10 @@
   font-weight: 400;
   padding: $spv-inner--x-small $sph-inner--small;
   text-transform: uppercase;
+}
+
+.p-table-menu--hasIcon .p-contextual-menu__non-interactive {
+  padding-left: $icon-size + ($sph-inner--small * 2);
 }
 
 .p-table-menu .p-contextual-menu__dropdown {
@@ -18,7 +24,6 @@
 }
 
 .p-table-menu__toggle {
-  $icon-size: map-get($icon-sizes, default);
   line-height: $icon-size;
   padding: 0 $icon-size / 2;
 }

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -36,6 +36,13 @@ const machine = produce(
           }
         }
         break;
+      case "SET_MACHINE_POOL_ERROR":
+      case "SET_MACHINE_ZONE_ERROR":
+      case "TURN_MACHINE_OFF_ERROR":
+      case "TURN_MACHINE_ON_ERROR":
+      case "CHECK_MACHINE_POWER_ERROR":
+        draft.errors = action.error;
+        break;
       case "CLEANUP_MACHINE":
         draft.errors = {};
         draft.saved = false;

--- a/ui/src/app/base/reducers/machine/machine.test.js
+++ b/ui/src/app/base/reducers/machine/machine.test.js
@@ -199,4 +199,26 @@ describe("machine reducer", () => {
       saving: false
     });
   });
+
+  it("should correctly reduce CHECK_MACHINE_POWER_ERROR", () => {
+    expect(
+      machine(
+        {
+          errors: null,
+          items: [],
+          loaded: false,
+          loading: true
+        },
+        {
+          type: "CHECK_MACHINE_POWER_ERROR",
+          error: "Uh oh!"
+        }
+      )
+    ).toEqual({
+      errors: "Uh oh!",
+      loading: true,
+      loaded: false,
+      items: []
+    });
+  });
 });

--- a/ui/src/app/base/selectors/machine/machine.js
+++ b/ui/src/app/base/selectors/machine/machine.js
@@ -50,4 +50,11 @@ machine.errors = state => state.machine.errors;
 machine.getBySystemId = (state, id) =>
   state.machine.items.find(machine => machine.system_id === id);
 
+/**
+ * Returns machine errors.
+ * @param {Object} state - The redux state.
+ * @returns {Object} Errors for machines.
+ */
+machine.errors = state => state.machine.errors;
+
 export default machine;

--- a/ui/src/app/base/selectors/machine/machine.test.js
+++ b/ui/src/app/base/selectors/machine/machine.test.js
@@ -73,4 +73,15 @@ describe("machine selectors", () => {
       system_id: 909
     });
   });
+
+  it("can get the error state", () => {
+    const state = {
+      machine: {
+        errors: "Uh oh!",
+        items: [],
+        loaded: true
+      }
+    };
+    expect(machine.errors(state)).toEqual("Uh oh!");
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -416,6 +416,18 @@ const MachineList = () => {
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const machinesLoading = useSelector(machineSelectors.loading);
   const errors = useSelector(machineSelectors.errors);
+  let errorMessage;
+  if (errors) {
+    if (Array.isArray(errors)) {
+      errorMessage = errors.join(" ");
+    } else if (typeof errors === "object") {
+      errorMessage = Object.entries(errors)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(" ");
+    } else {
+      errorMessage = errors;
+    }
+  }
 
   const [currentSort, setCurrentSort] = useState({
     key: "fqdn",
@@ -552,7 +564,9 @@ const MachineList = () => {
           </Col>
         </Row>
       )}
-      {errors ? <Notification type="negative">{errors}</Notification> : null}
+      {errorMessage ? (
+        <Notification type="negative">{errorMessage}</Notification>
+      ) : null}
       {machinesLoaded && (
         <Row>
           <Col size={12}>

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -4,6 +4,7 @@ import {
   Input,
   Loader,
   MainTable,
+  Notification,
   Row,
   SearchBox,
   Select
@@ -414,6 +415,7 @@ const MachineList = () => {
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const machinesLoading = useSelector(machineSelectors.loading);
+  const errors = useSelector(machineSelectors.errors);
 
   const [currentSort, setCurrentSort] = useState({
     key: "fqdn",
@@ -550,6 +552,7 @@ const MachineList = () => {
           </Col>
         </Row>
       )}
+      {errors ? <Notification type="negative">{errors}</Notification> : null}
       {machinesLoaded && (
         <Row>
           <Col size={12}>

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -744,4 +744,57 @@ describe("MachineList", () => {
         .text()
     ).toEqual("2 machines selected");
   });
+
+  it("can display an error", () => {
+    const state = { ...initialState };
+    state.machine.errors = "Uh oh!";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
+    expect(wrapper.find("Notification").text()).toBe("Uh oh!");
+  });
+
+  it("can display a list of errors", () => {
+    const state = { ...initialState };
+    state.machine.errors = ["Uh oh!", "It broke"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
+    expect(wrapper.find("Notification").text()).toBe("Uh oh! It broke");
+  });
+
+  it("can display a collection of errors", () => {
+    const state = { ...initialState };
+    state.machine.errors = { machine: "Uh oh!", network: "It broke" };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
+    expect(wrapper.find("Notification").text()).toBe(
+      "machine: Uh oh! network: It broke"
+    );
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -28,11 +28,12 @@ describe("MachineList", () => {
         }
       },
       machine: {
-        errors: {},
+        errors: null,
         loading: false,
         loaded: true,
         items: [
           {
+            actions: [],
             architecture: "amd64/generic",
             cpu_count: 4,
             cpu_test_status: {
@@ -74,6 +75,7 @@ describe("MachineList", () => {
             zone: {}
           },
           {
+            actions: [],
             architecture: "amd64/generic",
             cpu_count: 2,
             cpu_test_status: {

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -66,7 +66,8 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
       ),
       onClick: () => {
         dispatch(machineActions.checkPower(systemId));
-        setUpdating(machine.power_state);
+        // Don't display the spinner when checking power as we can't reliably
+        // determine that the event has finished.
       }
     });
   }
@@ -88,16 +89,23 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
 
   return (
     <DoubleRow
-      icon={<i title={powerState} className={iconClass}></i>}
+      icon={
+        updating === null ? (
+          <i title={powerState} className={iconClass}></i>
+        ) : (
+          <Loader
+            className="u-no-margin u-no-padding--left u-no-padding--right"
+            inline
+          />
+        )
+      }
       iconSpace={true}
+      menuClassName={hasIcon ? "p-table-menu--hasIcon" : null}
       menuLinks={menuLinks}
       menuTitle="Take action:"
       onToggleMenu={onToggleMenu}
       primary={
         <div className="u-upper-case--first" data-test="power_state">
-          {updating !== null ? (
-            <Loader className="u-no-margin u-no-padding--left" inline />
-          ) : null}
           {powerState}
         </div>
       }

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.test.js
@@ -21,6 +21,7 @@ describe("PowerColumn", () => {
         loaded: true,
         items: [
           {
+            actions: [],
             system_id: "abc123",
             power_state: "on",
             power_type: "virsh"
@@ -75,5 +76,93 @@ describe("PowerColumn", () => {
     );
 
     expect(wrapper.find('[data-test="power_type"]').text()).toEqual("manual");
+  });
+
+  it("can show a menu item to turn a machine on", () => {
+    state.machine.items[0].actions = ["on"];
+    state.machine.items[0].power_state = "off";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-contextual-menu__link")
+        .at(0)
+        .text()
+    ).toEqual("Turn on");
+  });
+
+  it("can show a menu item to turn a machine off", () => {
+    state.machine.items[0].actions = ["off"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-contextual-menu__link")
+        .at(0)
+        .text()
+    ).toEqual("Turn off");
+  });
+
+  it("can show a menu item to check power", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-contextual-menu__link")
+        .at(0)
+        .text()
+    ).toEqual("Check power");
+  });
+
+  it("can show a message when there are no menu items", () => {
+    state.machine.items[0].power_state = "unknown";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-contextual-menu__link")
+        .at(1)
+        .text()
+    ).toEqual("No power actions available");
   });
 });

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -12,6 +12,17 @@ exports[`PowerColumn renders 1`] = `
       />
     }
     iconSpace={true}
+    menuLinks={
+      Array [
+        Object {
+          "children": <React.Fragment>
+            Check power
+          </React.Fragment>,
+          "onClick": [Function],
+        },
+      ]
+    }
+    menuTitle="Take action:"
     primary={
       <div
         className="u-upper-case--first"
@@ -57,6 +68,67 @@ exports[`PowerColumn renders 1`] = `
               on
             </div>
           </div>
+          <TableMenu
+            links={
+              Array [
+                Object {
+                  "children": <React.Fragment>
+                    Check power
+                  </React.Fragment>,
+                  "onClick": [Function],
+                },
+              ]
+            }
+            title="Take action:"
+          >
+            <ContextualMenu
+              className="p-table-menu"
+              dropdownClassName="u-no-margin--top"
+              hasToggleIcon={true}
+              links={
+                Array [
+                  "Take action:",
+                  Array [
+                    Object {
+                      "children": <React.Fragment>
+                        Check power
+                      </React.Fragment>,
+                      "onClick": [Function],
+                    },
+                  ],
+                ]
+              }
+              position="center"
+              toggleAppearance="base"
+              toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+            >
+              <span
+                className="p-table-menu p-contextual-menu--center"
+              >
+                <Button
+                  appearance="base"
+                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  hasIcon={true}
+                  onClick={[Function]}
+                >
+                  <button
+                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    onClick={[Function]}
+                  >
+                    <i
+                      className="p-icon--contextual-menu p-contextual-menu__indicator"
+                    />
+                  </button>
+                </Button>
+              </span>
+            </ContextualMenu>
+          </TableMenu>
         </div>
         <div
           className="p-double-row__secondary-row u-truncate"

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -12,6 +12,7 @@ exports[`PowerColumn renders 1`] = `
       />
     }
     iconSpace={true}
+    menuClassName={null}
     menuLinks={
       Array [
         Object {
@@ -69,6 +70,7 @@ exports[`PowerColumn renders 1`] = `
             </div>
           </div>
           <TableMenu
+            className={null}
             links={
               Array [
                 Object {


### PR DESCRIPTION
## Done
- Add the power menu to the machines in the machine list

## QA
- Visit /r/machines.
- In the power column you should see different actions depending on the current power state of the machine.

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-squad/issues/1723.