### PR TITLE
Improve perceived performance of machine list.

### DIFF
--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -2,7 +2,7 @@ import { __RouterContext as RouterContext } from "react-router";
 import { notificationTypes } from "@canonical/react-components";
 import { useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useFormikContext } from "formik";
 
 import { sendAnalyticsEvent } from "analytics";
@@ -155,4 +155,16 @@ export const useSendAnalytics = (
       sendAnalyticsEvent(eventCategory, eventAction, eventLabel);
     }
   }, [sendCondition, eventCategory, eventAction, eventLabel]);
+};
+
+/**
+ * Returns whether the component has undergone initial render,
+ * @returns {Boolean} rendered - Component has rendered.
+ */
+export const useHasRendered = () => {
+  const [rendered, setRendered] = useState(false);
+  useEffect(() => {
+    setRendered(true);
+  }, []);
+  return rendered;
 };

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -145,9 +145,9 @@ describe("MachineList", () => {
     };
   });
 
-  it("displays a loading component if machines are loading", () => {
+  it("displays a loading component if machines have not loaded", () => {
     const state = { ...initialState };
-    state.machine.loading = true;
+    state.machine.loaded = false;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>


### PR DESCRIPTION
## Done
- Added useComponentDidMount hook which runs a function exactly once after a component is initially rendered.
- Used useComponentDidMount hook to show a spinner in the machine list on first render. I think this makes the app feel faster because there's no delay between when you click and when the screen changes.
- Moved spinner to below the table headers to minimise "jumpiness".
- Fixed the logic for when to show a loading spinner. Originally it was shown while machines were loading, but that would mean nothing else would show while loading a lot of machines (e.g. >1000). It's now only shown if machines have not all loaded.

## QA
- Go to the machine list and click between the pools and machines tabs.
- Check that a loading spinner shows up every time you navigate to the machines tab, and there is no lag between pages switching.

## Fixes
Fixes #777 
