### PR TITLE
Add machine list owner actions

### DIFF
--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -15,75 +15,36 @@ machine.create = params => {
   };
 };
 
-machine.setPool = (systemId, poolId) => {
-  return {
-    type: "SET_MACHINE_POOL",
-    meta: {
-      model: "machine",
-      method: "action"
-    },
-    payload: {
-      params: {
-        action: "set-pool",
-        extra: {
-          pool_id: poolId
-        },
-        system_id: systemId
-      }
+const generateMachineAction = (type, action, systemId, extra) => ({
+  type,
+  meta: {
+    model: "machine",
+    method: "action"
+  },
+  payload: {
+    params: {
+      action,
+      extra,
+      system_id: systemId
     }
-  };
-};
+  }
+});
 
-machine.setZone = (systemId, zoneId) => {
-  return {
-    type: "SET_MACHINE_ZONE",
-    meta: {
-      model: "machine",
-      method: "action"
-    },
-    payload: {
-      params: {
-        action: "set-zone",
-        extra: {
-          zone_id: zoneId
-        },
-        system_id: systemId
-      }
-    }
-  };
-};
+machine.setPool = (systemId, poolId) =>
+  generateMachineAction("SET_MACHINE_POOL", "set-pool", systemId, {
+    pool_id: poolId
+  });
 
-machine.turnOff = systemId => {
-  return {
-    type: "TURN_MACHINE_OFF",
-    meta: {
-      model: "machine",
-      method: "action"
-    },
-    payload: {
-      params: {
-        action: "off",
-        system_id: systemId
-      }
-    }
-  };
-};
+machine.setZone = (systemId, zoneId) =>
+  generateMachineAction("SET_MACHINE_ZONE", "set-zone", systemId, {
+    zone_id: zoneId
+  });
 
-machine.turnOn = systemId => {
-  return {
-    type: "TURN_MACHINE_ON",
-    meta: {
-      model: "machine",
-      method: "action"
-    },
-    payload: {
-      params: {
-        action: "on",
-        system_id: systemId
-      }
-    }
-  };
-};
+machine.turnOff = systemId =>
+  generateMachineAction("TURN_MACHINE_OFF", "off", systemId);
+
+machine.turnOn = systemId =>
+  generateMachineAction("TURN_MACHINE_ON", "on", systemId);
 
 machine.checkPower = systemId => {
   return {
@@ -99,6 +60,12 @@ machine.checkPower = systemId => {
     }
   };
 };
+
+machine.acquire = systemId =>
+  generateMachineAction("ACQUIRE_MACHINE", "acquire", systemId);
+
+machine.release = systemId =>
+  generateMachineAction("RELEASE_MACHINE", "release", systemId);
 
 machine.cleanup = () => {
   return {

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -68,7 +68,7 @@ describe("machine actions", () => {
   });
 
   it("can handle turning on the machine", () => {
-    expect(machine.turnOn("abc123", 909)).toEqual({
+    expect(machine.turnOn("abc123")).toEqual({
       type: "TURN_MACHINE_ON",
       meta: {
         model: "machine",
@@ -84,7 +84,7 @@ describe("machine actions", () => {
   });
 
   it("can handle turning off the machine", () => {
-    expect(machine.turnOff("abc123", 909)).toEqual({
+    expect(machine.turnOff("abc123")).toEqual({
       type: "TURN_MACHINE_OFF",
       meta: {
         model: "machine",
@@ -100,7 +100,7 @@ describe("machine actions", () => {
   });
 
   it("can handle checking the machine power", () => {
-    expect(machine.checkPower("abc123", 909)).toEqual({
+    expect(machine.checkPower("abc123")).toEqual({
       type: "CHECK_MACHINE_POWER",
       meta: {
         model: "machine",
@@ -108,6 +108,38 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle acquiring a machine", () => {
+    expect(machine.acquire("abc123")).toEqual({
+      type: "ACQUIRE_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "acquire",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle releasing a machine", () => {
+    expect(machine.release("abc123")).toEqual({
+      type: "RELEASE_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "release",
           system_id: "abc123"
         }
       }

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -36,6 +36,8 @@ const machine = produce(
           }
         }
         break;
+      case "ACQUIRE_MACHINE_ERROR":
+      case "RELEASE_MACHINE_ERROR":
       case "SET_MACHINE_POOL_ERROR":
       case "SET_MACHINE_ZONE_ERROR":
       case "TURN_MACHINE_OFF_ERROR":

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -1,24 +1,68 @@
-import { useSelector } from "react-redux";
-import React from "react";
+import { Loader } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
+import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
 
 const OwnerColumn = ({ onToggleMenu, systemId }) => {
+  const dispatch = useDispatch();
+  const [updating, setUpdating] = useState(null);
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
 
   const owner = machine.owner ? machine.owner : "-";
   const tags = machine.tags ? machine.tags.join(", ") : "";
+  const hasAcquireAction = machine.actions.includes("acquire");
+  const hasReleaseAction = machine.actions.includes("release");
+  let menuLinks = [];
+  if (hasAcquireAction) {
+    menuLinks.push({
+      children: "Acquire...",
+      onClick: () => {
+        dispatch(machineActions.acquire(systemId));
+        setUpdating(machine.status);
+      }
+    });
+  }
+  if (hasReleaseAction) {
+    menuLinks.push({
+      children: "Release...",
+      onClick: () => {
+        dispatch(machineActions.release(systemId));
+        setUpdating(machine.status);
+      }
+    });
+  }
+  if (!hasAcquireAction && !hasReleaseAction) {
+    menuLinks.push({
+      children: "No owner actions available",
+      disabled: true
+    });
+  }
+
+  useEffect(() => {
+    if (updating !== null && machine.status !== updating) {
+      setUpdating(null);
+    }
+  }, [updating, machine.status]);
 
   return (
     <DoubleRow
-      menuLinks={[{ children: "Link1" }, { children: "Link2" }]}
+      menuLinks={menuLinks}
       menuTitle="Take action:"
       onToggleMenu={onToggleMenu}
-      primary={<span data-test="owner">{owner}</span>}
+      primary={
+        <>
+          {updating === null ? null : (
+            <Loader className="u-no-margin u-no-padding--left" inline />
+          )}
+          <span data-test="owner">{owner}</span>
+        </>
+      }
       secondary={
         <span title={tags} data-test="tags">
           {tags}

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.test.js
@@ -21,6 +21,7 @@ describe("OwnerColumn", () => {
         loaded: true,
         items: [
           {
+            actions: [],
             system_id: "abc123",
             owner: "admin",
             tags: []
@@ -75,5 +76,70 @@ describe("OwnerColumn", () => {
     );
 
     expect(wrapper.find('[data-test="tags"]').text()).toEqual("minty, aloof");
+  });
+
+  it("can show a menu item to acquire a machine", () => {
+    state.machine.items[0].actions = ["acquire"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OwnerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-contextual-menu__link")
+        .at(0)
+        .text()
+    ).toEqual("Acquire...");
+  });
+
+  it("can show a menu item to release a machine", () => {
+    state.machine.items[0].actions = ["release"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OwnerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-contextual-menu__link")
+        .at(0)
+        .text()
+    ).toEqual("Release...");
+  });
+
+  it("can show a message when there are no menu items", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OwnerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-contextual-menu__link")
+        .at(1)
+        .text()
+    ).toEqual("No owner actions available");
   });
 });

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -8,20 +8,20 @@ exports[`OwnerColumn renders 1`] = `
     menuLinks={
       Array [
         Object {
-          "children": "Link1",
-        },
-        Object {
-          "children": "Link2",
+          "children": "No owner actions available",
+          "disabled": true,
         },
       ]
     }
     menuTitle="Take action:"
     primary={
-      <span
-        data-test="owner"
-      >
-        admin
-      </span>
+      <React.Fragment>
+        <span
+          data-test="owner"
+        >
+          admin
+        </span>
+      </React.Fragment>
     }
     secondary={
       <span
@@ -54,10 +54,8 @@ exports[`OwnerColumn renders 1`] = `
             links={
               Array [
                 Object {
-                  "children": "Link1",
-                },
-                Object {
-                  "children": "Link2",
+                  "children": "No owner actions available",
+                  "disabled": true,
                 },
               ]
             }
@@ -72,10 +70,8 @@ exports[`OwnerColumn renders 1`] = `
                   "Take action:",
                   Array [
                     Object {
-                      "children": "Link1",
-                    },
-                    Object {
-                      "children": "Link2",
+                      "children": "No owner actions available",
+                      "disabled": true,
                     },
                   ],
                 ]


### PR DESCRIPTION
## Done
- Add actions for owners in the machine list.
- Clean up generation of machine actions.

## QA
- Visit /r/machines.
- Click on the menu for an owner column.
- You should be able to perform different actions.

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-squad/issues/1721.
