### PR TITLE
Add the status column actions to the machine list

### DIFF
--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -67,6 +67,47 @@ machine.acquire = systemId =>
 machine.release = systemId =>
   generateMachineAction("RELEASE_MACHINE", "release", systemId);
 
+machine.commission = systemId =>
+  generateMachineAction("COMMISSION_MACHINE", "commission", systemId);
+
+machine.deploy = systemId =>
+  generateMachineAction("DEPLOY_MACHINE", "deploy", systemId);
+
+machine.abort = systemId =>
+  generateMachineAction("ABORT_MACHINE", "abort", systemId);
+
+machine.test = systemId =>
+  generateMachineAction("TEST_MACHINE", "test", systemId);
+
+machine.rescueMode = systemId =>
+  generateMachineAction("MACHINE_RESCUE_MODE", "rescue-mode", systemId);
+
+machine.exitRescueMode = systemId =>
+  generateMachineAction(
+    "MACHINE_EXIT_RESCUE_MODE",
+    "exit-rescue-mode",
+    systemId
+  );
+
+machine.markBroken = systemId =>
+  generateMachineAction("MARK_MACHINE_BROKEN", "mark-broken", systemId);
+
+machine.markFixed = systemId =>
+  generateMachineAction("MARK_MACHINE_FIXED", "mark-fixed", systemId);
+
+machine.overrideFailedTesting = systemId =>
+  generateMachineAction(
+    "MACHINE_OVERRIDE_FAILED_TESTING",
+    "override-failed-testing",
+    systemId
+  );
+
+machine.lock = systemId =>
+  generateMachineAction("LOCK_MACHINE", "lock", systemId);
+
+machine.unlock = systemId =>
+  generateMachineAction("UNLOCK_MACHINE", "unlock", systemId);
+
 machine.cleanup = () => {
   return {
     type: "CLEANUP_MACHINE"

--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -15,7 +15,7 @@ machine.create = params => {
   };
 };
 
-const generateMachineAction = (type, action, systemId, extra) => ({
+const generateMachineAction = (type, action, systemId, extra = {}) => ({
   type,
   meta: {
     model: "machine",

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -77,6 +77,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "on",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -93,6 +94,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "off",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -124,6 +126,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "acquire",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -140,6 +143,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "release",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -156,6 +160,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "commission",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -172,6 +177,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "deploy",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -188,6 +194,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "abort",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -204,6 +211,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "test",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -220,6 +228,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "rescue-mode",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -236,6 +245,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "exit-rescue-mode",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -252,6 +262,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "mark-broken",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -268,6 +279,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "mark-fixed",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -284,6 +296,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "override-failed-testing",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -300,6 +313,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "lock",
+          extra: {},
           system_id: "abc123"
         }
       }
@@ -316,6 +330,7 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "unlock",
+          extra: {},
           system_id: "abc123"
         }
       }

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -146,6 +146,182 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle commissioning a machine", () => {
+    expect(machine.commission("abc123")).toEqual({
+      type: "COMMISSION_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "commission",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle deploying a machine", () => {
+    expect(machine.deploy("abc123")).toEqual({
+      type: "DEPLOY_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "deploy",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle aborting a machine", () => {
+    expect(machine.abort("abc123")).toEqual({
+      type: "ABORT_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "abort",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle testing a machine", () => {
+    expect(machine.test("abc123")).toEqual({
+      type: "TEST_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "test",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can putting a machine into rescue mode", () => {
+    expect(machine.rescueMode("abc123")).toEqual({
+      type: "MACHINE_RESCUE_MODE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "rescue-mode",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle making a machine exit rescue mode", () => {
+    expect(machine.exitRescueMode("abc123")).toEqual({
+      type: "MACHINE_EXIT_RESCUE_MODE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "exit-rescue-mode",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle marking a machine as broken", () => {
+    expect(machine.markBroken("abc123")).toEqual({
+      type: "MARK_MACHINE_BROKEN",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "mark-broken",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle marking a machine as fixed", () => {
+    expect(machine.markFixed("abc123")).toEqual({
+      type: "MARK_MACHINE_FIXED",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "mark-fixed",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle overriding failed testing on a machine", () => {
+    expect(machine.overrideFailedTesting("abc123")).toEqual({
+      type: "MACHINE_OVERRIDE_FAILED_TESTING",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "override-failed-testing",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle locking a machine", () => {
+    expect(machine.lock("abc123")).toEqual({
+      type: "LOCK_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "lock",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle unlocking a machine", () => {
+    expect(machine.unlock("abc123")).toEqual({
+      type: "UNLOCK_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "unlock",
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
   it("can handle cleaning machines", () => {
     expect(machine.cleanup()).toEqual({
       type: "CLEANUP_MACHINE"

--- a/ui/src/app/base/components/TableMenu/TableMenu.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.js
@@ -12,7 +12,7 @@ const TableMenu = ({ className, links, title, onToggleMenu }) => {
       className={classNames("p-table-menu", className)}
       dropdownClassName="u-no-margin--top"
       hasToggleIcon
-      links={[title, links]}
+      links={[title, ...links]}
       onToggleMenu={onToggleMenu}
       position="center"
       toggleAppearance="base"
@@ -23,7 +23,13 @@ const TableMenu = ({ className, links, title, onToggleMenu }) => {
 
 TableMenu.propTypes = {
   className: PropTypes.string,
-  links: PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
+  links: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape(Button.propTypes),
+      PropTypes.arrayOf(PropTypes.shape(Button.propTypes))
+    ])
+  ),
   onToggleMenu: PropTypes.func,
   title: PropTypes.string
 };

--- a/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
+++ b/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
@@ -8,11 +8,9 @@ exports[`TableMenu  renders 1`] = `
   links={
     Array [
       "Actions:",
-      Array [
-        Object {
-          "children": "Item1",
-        },
-      ],
+      Object {
+        "children": "Item1",
+      },
     ]
   }
   position="center"

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -38,6 +38,17 @@ const machine = produce(
         break;
       case "ACQUIRE_MACHINE_ERROR":
       case "RELEASE_MACHINE_ERROR":
+      case "COMMISSION_MACHINE_ERROR":
+      case "DEPLOY_MACHINE_ERROR":
+      case "ABORT_MACHINE_ERROR":
+      case "TEST_MACHINE_ERROR":
+      case "MACHINE_RESCUE_MODE_ERROR":
+      case "MACHINE_EXIT_RESCUE_MODE_ERROR":
+      case "MARK_MACHINE_BROKEN_ERROR":
+      case "MARK_MACHINE_FIXED_ERROR":
+      case "MACHINE_OVERRIDE_FAILED_TESTING_ERROR":
+      case "LOCK_MACHINE_ERROR":
+      case "UNLOCK_MACHINE_ERROR":
       case "SET_MACHINE_POOL_ERROR":
       case "SET_MACHINE_ZONE_ERROR":
       case "TURN_MACHINE_OFF_ERROR":

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -68,12 +68,10 @@ exports[`OwnerColumn renders 1`] = `
               links={
                 Array [
                   "Take action:",
-                  Array [
-                    Object {
-                      "children": "No owner actions available",
-                      "disabled": true,
-                    },
-                  ],
+                  Object {
+                    "children": "No owner actions available",
+                    "disabled": true,
+                  },
                 ]
               }
               position="center"

--- a/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -81,12 +81,10 @@ exports[`PoolColumn renders 1`] = `
               links={
                 Array [
                   "Change pool:",
-                  Array [
-                    Object {
-                      "children": "Backup",
-                      "onClick": [Function],
-                    },
-                  ],
+                  Object {
+                    "children": "Backup",
+                    "onClick": [Function],
+                  },
                 ]
               }
               position="center"

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -90,14 +90,12 @@ exports[`PowerColumn renders 1`] = `
               links={
                 Array [
                   "Take action:",
-                  Array [
-                    Object {
-                      "children": <React.Fragment>
-                        Check power
-                      </React.Fragment>,
-                      "onClick": [Function],
-                    },
-                  ],
+                  Object {
+                    "children": <React.Fragment>
+                      Check power
+                    </React.Fragment>,
+                    "onClick": [Function],
+                  },
                 ]
               }
               position="center"

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.test.js
@@ -34,6 +34,7 @@ describe("StatusColumn", () => {
       machine: {
         items: [
           {
+            actions: [],
             distro_series: "bionic",
             osystem: "ubuntu",
             status: "New",
@@ -224,5 +225,36 @@ describe("StatusColumn", () => {
       expect(wrapper.find(".p-icon--warning").exists()).toBe(true);
       expect(wrapper.find("Tooltip").exists()).toBe(true);
     });
+  });
+
+  it("can show a menu with all possible options", () => {
+    state.machine.items[0].actions = [
+      "abort",
+      "acquire",
+      "commission",
+      "deploy",
+      "exit-rescue-mode",
+      "lock",
+      "mark-broken",
+      "mark-fixed",
+      "override-failed-testing",
+      "release",
+      "rescue-mode",
+      "test",
+      "unlock"
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu so the elements get rendered.
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find(".p-contextual-menu__dropdown")).toMatchSnapshot();
   });
 });

--- a/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -1,5 +1,217 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StatusColumn can show a menu with all possible options 1`] = `
+<span
+  aria-hidden="false"
+  aria-label="submenu"
+  className="p-contextual-menu__dropdown u-no-margin--top"
+  id="Uakgb_J5m9g-0JDMbcJqLJ"
+>
+  <div
+    className="p-contextual-menu__non-interactive"
+    key="0"
+  >
+    Take action:
+  </div>
+  <span
+    className="p-contextual-menu__group"
+    key="1"
+  >
+    <Button
+      className="p-contextual-menu__link"
+      key="0"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        abort...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="1"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        acquire...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="2"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        commission...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="3"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        deploy...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="4"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        exit-rescue-mode...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="5"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        lock...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="6"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        mark-broken...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="7"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        mark-fixed...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="8"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        override-failed-testing...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="9"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        release...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="10"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        rescue-mode...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="11"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        test...
+      </button>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      key="12"
+      onClick={[Function]}
+    >
+      <button
+        className="p-button--neutral p-contextual-menu__link"
+        onClick={[Function]}
+      >
+        unlock...
+      </button>
+    </Button>
+  </span>
+  <span
+    className="p-contextual-menu__group"
+    key="2"
+  >
+    <Button
+      className="p-contextual-menu__link"
+      element="a"
+      href="/MAAS/#/machine/abc123?area=logs"
+      key="0"
+      onClick={null}
+    >
+      <a
+        className="p-button--neutral p-contextual-menu__link"
+        href="/MAAS/#/machine/abc123?area=logs"
+        onClick={null}
+      >
+        See logs
+      </a>
+    </Button>
+    <Button
+      className="p-contextual-menu__link"
+      element="a"
+      href="/MAAS/#/machine/abc123?area=events"
+      key="1"
+      onClick={null}
+    >
+      <a
+        className="p-button--neutral p-contextual-menu__link"
+        href="/MAAS/#/machine/abc123?area=events"
+        onClick={null}
+      >
+        See events
+      </a>
+    </Button>
+  </span>
+</span>
+`;
+
 exports[`StatusColumn renders 1`] = `
 <StatusColumn
   systemId="abc123"
@@ -7,6 +219,24 @@ exports[`StatusColumn renders 1`] = `
   <DoubleRow
     icon=""
     iconSpace={true}
+    menuLinks={
+      Array [
+        Array [],
+        Array [
+          Object {
+            "children": "See logs",
+            "element": "a",
+            "href": "/MAAS/#/machine/abc123?area=logs",
+          },
+          Object {
+            "children": "See events",
+            "element": "a",
+            "href": "/MAAS/#/machine/abc123?area=events",
+          },
+        ],
+      ]
+    }
+    menuTitle="Take action:"
     primary={
       <span
         data-test="status-text"
@@ -50,6 +280,79 @@ exports[`StatusColumn renders 1`] = `
               New
             </span>
           </div>
+          <TableMenu
+            links={
+              Array [
+                Array [],
+                Array [
+                  Object {
+                    "children": "See logs",
+                    "element": "a",
+                    "href": "/MAAS/#/machine/abc123?area=logs",
+                  },
+                  Object {
+                    "children": "See events",
+                    "element": "a",
+                    "href": "/MAAS/#/machine/abc123?area=events",
+                  },
+                ],
+              ]
+            }
+            title="Take action:"
+          >
+            <ContextualMenu
+              className="p-table-menu"
+              dropdownClassName="u-no-margin--top"
+              hasToggleIcon={true}
+              links={
+                Array [
+                  "Take action:",
+                  Array [],
+                  Array [
+                    Object {
+                      "children": "See logs",
+                      "element": "a",
+                      "href": "/MAAS/#/machine/abc123?area=logs",
+                    },
+                    Object {
+                      "children": "See events",
+                      "element": "a",
+                      "href": "/MAAS/#/machine/abc123?area=events",
+                    },
+                  ],
+                ]
+              }
+              position="center"
+              toggleAppearance="base"
+              toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+            >
+              <span
+                className="p-table-menu p-contextual-menu--center"
+              >
+                <Button
+                  appearance="base"
+                  aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  hasIcon={true}
+                  onClick={[Function]}
+                >
+                  <button
+                    aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    onClick={[Function]}
+                  >
+                    <i
+                      className="p-icon--contextual-menu p-contextual-menu__indicator"
+                    />
+                  </button>
+                </Button>
+              </span>
+            </ContextualMenu>
+          </TableMenu>
         </div>
         <div
           className="p-double-row__secondary-row u-truncate"

--- a/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -65,12 +65,10 @@ exports[`ZoneColumn renders 1`] = `
               links={
                 Array [
                   "Change AZ:",
-                  Array [
-                    Object {
-                      "children": "Backup",
-                      "onClick": [Function],
-                    },
-                  ],
+                  Object {
+                    "children": "Backup",
+                    "onClick": [Function],
+                  },
                 ]
               }
               position="center"


### PR DESCRIPTION
## Done
- Add the status column actions to the machine list.

## QA
- Visit /r/machines.
- In the status column you should get a menu of different actions depending on the state of the machine.

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-squad/issues/1722.
