### PR TITLE
Migrate some reducers to createReducer.

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -11,14 +11,20 @@ Object {
     "saving": false,
   },
   "controller": Object {
+    "errors": Object {},
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "saved": false,
+    "saving": false,
   },
   "device": Object {
+    "errors": Object {},
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "saved": false,
+    "saving": false,
   },
   "dhcpsnippet": Object {
     "errors": Object {},
@@ -33,6 +39,8 @@ Object {
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "saved": false,
+    "saving": false,
   },
   "general": Object {
     "architectures": Object {
@@ -152,6 +160,8 @@ Object {
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "saved": false,
+    "saving": false,
   },
   "sshkey": Object {
     "errors": null,
@@ -174,15 +184,20 @@ Object {
     "authenticating": false,
   },
   "subnet": Object {
+    "errors": Object {},
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "saved": false,
+    "saving": false,
   },
   "tag": Object {
     "errors": Object {},
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "saved": false,
+    "saving": false,
   },
   "token": Object {
     "errors": null,
@@ -206,6 +221,8 @@ Object {
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "saved": false,
+    "saving": false,
   },
 }
 `;

--- a/ui/src/app/base/actions/domain/domain.js
+++ b/ui/src/app/base/actions/domain/domain.js
@@ -1,13 +1,5 @@
-const domain = {};
+import { createStandardActions } from "app/utils/redux";
 
-domain.fetch = () => {
-  return {
-    type: "FETCH_DOMAIN",
-    meta: {
-      model: "domain",
-      method: "list"
-    }
-  };
-};
+const domain = createStandardActions("domain");
 
 export default domain;

--- a/ui/src/app/base/actions/messages/messages.js
+++ b/ui/src/app/base/actions/messages/messages.js
@@ -1,3 +1,5 @@
+import { createAction } from "@reduxjs/toolkit";
+
 let messageId = 0;
 
 const getMessageId = () => {
@@ -7,9 +9,9 @@ const getMessageId = () => {
 
 const messages = {};
 
-messages.add = (message, type, status, temporary = true) => {
-  return {
-    type: "ADD_MESSAGE",
+messages.add = createAction(
+  "ADD_MESSAGE",
+  (message, type, status, temporary = true) => ({
     payload: {
       id: getMessageId(),
       message,
@@ -17,14 +19,9 @@ messages.add = (message, type, status, temporary = true) => {
       temporary,
       type
     }
-  };
-};
+  })
+);
 
-messages.remove = id => {
-  return {
-    type: "REMOVE_MESSAGE",
-    payload: id
-  };
-};
+messages.remove = createAction("REMOVE_MESSAGE");
 
 export default messages;

--- a/ui/src/app/base/actions/messages/messages.test.js
+++ b/ui/src/app/base/actions/messages/messages.test.js
@@ -1,11 +1,22 @@
 import messages from "./messages";
 
 describe("base actions", () => {
-  it("should handle adding a message", () => {
+  it("should handle adding a message and increment ids", () => {
     expect(messages.add("User added", "negative", "Error", true)).toEqual({
       type: "ADD_MESSAGE",
       payload: {
         id: 1,
+        message: "User added",
+        status: "Error",
+        temporary: true,
+        type: "negative"
+      }
+    });
+
+    expect(messages.add("User added", "negative", "Error", true)).toEqual({
+      type: "ADD_MESSAGE",
+      payload: {
+        id: 2,
         message: "User added",
         status: "Error",
         temporary: true,

--- a/ui/src/app/base/actions/status/status.js
+++ b/ui/src/app/base/actions/status/status.js
@@ -1,25 +1,33 @@
-const status = {};
+import { createAction } from "@reduxjs/toolkit";
 
-status.login = payload => ({
-  type: "LOGIN",
-  payload
-});
+const status = {
+  login: createAction("LOGIN"),
+  logout: createAction("LOGOUT"),
+  externalLogin: createAction("EXTERNAL_LOGIN"),
+  externalLoginURL: createAction("EXTERNAL_LOGIN_URL"),
+  checkAuthenticated: createAction("CHECK_AUTHENTICATED"),
+  websocketConnect: createAction("WEBSOCKET_CONNECT"),
+  websocketConnected: createAction("WEBSOCKET_CONNECTED"),
+  websocketDisconnected: createAction("WEBSOCKET_DISCONNECTED"),
+  websocketError: createAction("WEBSOCKET_ERROR")
+};
 
-status.logout = () => ({
-  type: "LOGOUT"
-});
-
-status.externalLogin = () => ({
-  type: "EXTERNAL_LOGIN"
-});
-
-status.externalLoginURL = payload => ({
-  type: "EXTERNAL_LOGIN_URL",
-  payload
-});
-
-status.checkAuthenticated = () => ({
-  type: "CHECK_AUTHENTICATED"
+// TODO: This should be generalised and moved to app/utils/redux once all actions types
+// have the same shape, unfortunately we currently have have some in the form
+// VERB_MODEL/VERB_MODEL_START and others simply in the form VERB/VERB_START
+// e.g. LOGIN should be STATUS_LOGIN
+// https://github.com/canonical-web-and-design/maas-ui/issues/785
+[
+  status.login,
+  status.logout,
+  status.externalLogin,
+  status.checkAuthenticated
+].forEach(method => {
+  ["start", "error", "success"].forEach(event => {
+    method[event] = createAction(
+      `${method.type.toUpperCase()}_${event.toUpperCase()}`
+    );
+  });
 });
 
 export default status;

--- a/ui/src/app/base/actions/status/status.test.js
+++ b/ui/src/app/base/actions/status/status.test.js
@@ -6,23 +6,31 @@ describe("status actions", () => {
       username: "koala",
       password: "gumtree"
     };
-    expect(status.login(payload)).toStrictEqual({ payload, type: "LOGIN" });
+    expect(status.login(payload)).toStrictEqual({
+      type: "LOGIN",
+      payload
+    });
   });
 
   it("should handle logging out", () => {
     expect(status.logout()).toStrictEqual({
-      type: "LOGOUT"
+      type: "LOGOUT",
+      payload: undefined
     });
   });
 
   it("should handle checking if the user is authenticated", () => {
     expect(status.checkAuthenticated()).toStrictEqual({
-      type: "CHECK_AUTHENTICATED"
+      type: "CHECK_AUTHENTICATED",
+      payload: undefined
     });
   });
 
   it("should handle external log in", () => {
-    expect(status.externalLogin()).toStrictEqual({ type: "EXTERNAL_LOGIN" });
+    expect(status.externalLogin()).toStrictEqual({
+      type: "EXTERNAL_LOGIN",
+      payload: undefined
+    });
   });
 
   it("should handle storing the external login URL", () => {
@@ -30,8 +38,8 @@ describe("status actions", () => {
       url: "http://login.example.com"
     };
     expect(status.externalLoginURL(payload)).toStrictEqual({
-      payload,
-      type: "EXTERNAL_LOGIN_URL"
+      type: "EXTERNAL_LOGIN_URL",
+      payload
     });
   });
 });

--- a/ui/src/app/base/actions/tag/tag.js
+++ b/ui/src/app/base/actions/tag/tag.js
@@ -1,13 +1,5 @@
-const tag = {};
+import { createStandardActions } from "app/utils/redux";
 
-tag.fetch = () => {
-  return {
-    type: "FETCH_TAG",
-    meta: {
-      model: "tag",
-      method: "list"
-    }
-  };
-};
+const tag = createStandardActions("tag");
 
 export default tag;

--- a/ui/src/app/base/actions/websocket/websocket.js
+++ b/ui/src/app/base/actions/websocket/websocket.js
@@ -1,9 +1,7 @@
+import { createAction } from "@reduxjs/toolkit";
+
 const websocket = {};
 
-websocket.connect = () => {
-  return {
-    type: "WEBSOCKET_CONNECT"
-  };
-};
+websocket.connect = createAction("WEBSOCKET_CONNECT");
 
 export default websocket;

--- a/ui/src/app/base/reducers/controller/controller.js
+++ b/ui/src/app/base/reducers/controller/controller.js
@@ -1,25 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const controller = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_CONTROLLER_START":
-        draft.loading = true;
-        break;
-      case "FETCH_CONTROLLER_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    items: [],
-    loaded: false,
-    loading: false
-  }
-);
+import { controller as controllerActions } from "app/base/actions";
+
+const controller = createStandardReducer(controllerActions);
 
 export default controller;

--- a/ui/src/app/base/reducers/controller/controller.test.js
+++ b/ui/src/app/base/reducers/controller/controller.test.js
@@ -3,9 +3,12 @@ import controller from "./controller";
 describe("controller reducer", () => {
   it("should return the initial state", () => {
     expect(controller(undefined, {})).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -15,9 +18,12 @@ describe("controller reducer", () => {
         type: "FETCH_CONTROLLER_START"
       })
     ).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -25,9 +31,12 @@ describe("controller reducer", () => {
     expect(
       controller(
         {
+          errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_CONTROLLER_SUCCESS",
@@ -38,12 +47,15 @@ describe("controller reducer", () => {
         }
       )
     ).toEqual({
+      errors: {},
       loading: false,
       loaded: true,
       items: [
         { id: 1, hostname: "rack" },
         { id: 2, hostname: "maas" }
-      ]
+      ],
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/base/reducers/device/device.js
+++ b/ui/src/app/base/reducers/device/device.js
@@ -1,25 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const device = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_DEVICE_START":
-        draft.loading = true;
-        break;
-      case "FETCH_DEVICE_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    items: [],
-    loaded: false,
-    loading: false
-  }
-);
+import { device as deviceActions } from "app/base/actions";
+
+const device = createStandardReducer(deviceActions);
 
 export default device;

--- a/ui/src/app/base/reducers/device/device.test.js
+++ b/ui/src/app/base/reducers/device/device.test.js
@@ -3,9 +3,12 @@ import device from "./device";
 describe("device reducer", () => {
   it("should return the initial state", () => {
     expect(device(undefined, {})).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -15,9 +18,12 @@ describe("device reducer", () => {
         type: "FETCH_DEVICE_START"
       })
     ).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -25,9 +31,12 @@ describe("device reducer", () => {
     expect(
       device(
         {
+          errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_DEVICE_SUCCESS",
@@ -38,12 +47,15 @@ describe("device reducer", () => {
         }
       )
     ).toEqual({
+      errors: {},
       loading: false,
       loaded: true,
       items: [
         { id: 1, hostname: "test1" },
         { id: 2, hostname: "test2" }
-      ]
+      ],
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/base/reducers/dhcpsnippet/dhcpsnippet.js
+++ b/ui/src/app/base/reducers/dhcpsnippet/dhcpsnippet.js
@@ -1,67 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const dhcpsnippet = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_DHCPSNIPPET_START":
-        draft.loading = true;
-        break;
-      case "FETCH_DHCPSNIPPET_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      case "UPDATE_DHCPSNIPPET_START":
-      case "CREATE_DHCPSNIPPET_START":
-      case "DELETE_DHCPSNIPPET_START":
-        draft.saved = false;
-        draft.saving = true;
-        break;
-      case "UPDATE_DHCPSNIPPET_ERROR":
-      case "CREATE_DHCPSNIPPET_ERROR":
-      case "DELETE_DHCPSNIPPET_ERROR":
-        draft.errors = action.error;
-        draft.saving = false;
-        break;
-      case "UPDATE_DHCPSNIPPET_SUCCESS":
-      case "CREATE_DHCPSNIPPET_SUCCESS":
-      case "DELETE_DHCPSNIPPET_SUCCESS":
-        draft.errors = {};
-        draft.saved = true;
-        draft.saving = false;
-        break;
-      case "UPDATE_DHCPSNIPPET_NOTIFY":
-        for (let i in draft.items) {
-          if (draft.items[i].id === action.payload.id) {
-            draft.items[i] = action.payload;
-            break;
-          }
-        }
-        break;
-      case "CREATE_DHCPSNIPPET_NOTIFY":
-        draft.items.push(action.payload);
-        break;
-      case "DELETE_DHCPSNIPPET_NOTIFY":
-        const index = draft.items.findIndex(item => item.id === action.payload);
-        draft.items.splice(index, 1);
-        break;
-      case "CLEANUP_DHCPSNIPPET":
-        draft.errors = {};
-        draft.saved = false;
-        draft.saving = false;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    errors: {},
-    items: [],
-    loaded: false,
-    loading: false,
-    saved: false,
-    saving: false
-  }
-);
+import { dhcpsnippet as dhcpSnippetActions } from "app/base/actions";
+
+const dhcpsnippet = createStandardReducer(dhcpSnippetActions);
 
 export default dhcpsnippet;

--- a/ui/src/app/base/reducers/domain/domain.js
+++ b/ui/src/app/base/reducers/domain/domain.js
@@ -1,38 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const domain = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_DOMAIN_START":
-        draft.loading = true;
-        break;
-      case "FETCH_DOMAIN_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      case "FETCH_DOMAIN_ERROR":
-        draft.errors = action.error;
-        draft.loading = false;
-        break;
-      case "UPDATE_DOMAIN_NOTIFY":
-        for (let i in draft.items) {
-          if (draft.items[i].id === action.payload.id) {
-            draft.items[i] = action.payload;
-            break;
-          }
-        }
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    errors: {},
-    items: [],
-    loaded: false,
-    loading: false
-  }
-);
+import { domain as domainActions } from "app/base/actions";
+
+const domain = createStandardReducer(domainActions);
 
 export default domain;

--- a/ui/src/app/base/reducers/domain/domain.test.js
+++ b/ui/src/app/base/reducers/domain/domain.test.js
@@ -6,7 +6,9 @@ describe("domain reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -19,7 +21,9 @@ describe("domain reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -30,7 +34,9 @@ describe("domain reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_DOMAIN_SUCCESS",
@@ -44,6 +50,9 @@ describe("domain reducer", () => {
       errors: {},
       loading: false,
       loaded: true,
+      saved: false,
+      saving: false,
+
       items: [
         { id: 1, name: "rack" },
         { id: 2, name: "maas" }
@@ -58,7 +67,9 @@ describe("domain reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: false
+          loading: false,
+          saved: false,
+          saving: false
         },
         {
           error: "Could not fetch domains",
@@ -69,7 +80,9 @@ describe("domain reducer", () => {
       errors: "Could not fetch domains",
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/base/reducers/messages/messages.js
+++ b/ui/src/app/base/reducers/messages/messages.js
@@ -1,22 +1,19 @@
-import produce from "immer";
+import { createReducer } from "@reduxjs/toolkit";
 
-const messages = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "ADD_MESSAGE":
-        draft.items.push(action.payload);
-        break;
-      case "REMOVE_MESSAGE":
-        const index = draft.items.findIndex(item => item.id === action.payload);
-        draft.items.splice(index, 1);
-        break;
-      default:
-        return draft;
-    }
+import { messages as messageActions } from "app/base/actions";
+
+const initialState = {
+  items: []
+};
+
+const messages = createReducer(initialState, {
+  [messageActions.add]: (state, action) => {
+    state.items.push(action.payload);
   },
-  {
-    items: []
+  [messageActions.remove]: (state, action) => {
+    const index = state.items.findIndex(item => item.id === action.payload);
+    state.items.splice(index, 1);
   }
-);
+});
 
 export default messages;

--- a/ui/src/app/base/reducers/resourcepool/resourcepool.js
+++ b/ui/src/app/base/reducers/resourcepool/resourcepool.js
@@ -1,71 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const resourcepool = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_RESOURCEPOOL_START":
-        draft.loading = true;
-        break;
-      case "FETCH_RESOURCEPOOL_ERROR":
-        draft.errors = action.error;
-        draft.loading = false;
-        break;
-      case "FETCH_RESOURCEPOOL_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      case "CREATE_RESOURCEPOOL_NOTIFY":
-        draft.items.push(action.payload);
-        break;
-      case "CREATE_RESOURCEPOOL_START":
-      case "UPDATE_RESOURCEPOOL_START":
-      case "DELETE_RESOURCEPOOL_START":
-        draft.saved = false;
-        draft.saving = true;
-        break;
-      case "CREATE_RESOURCEPOOL_ERROR":
-      case "UPDATE_RESOURCEPOOL_ERROR":
-      case "DELETE_RESOURCEPOOL_ERROR":
-        draft.errors = action.error;
-        draft.saving = false;
-        break;
-      case "CREATE_RESOURCEPOOL_SUCCESS":
-      case "UPDATE_RESOURCEPOOL_SUCCESS":
-      case "DELETE_RESOURCEPOOL_SUCCESS":
-        draft.errors = {};
-        draft.saved = true;
-        draft.saving = false;
-        break;
-      case "UPDATE_RESOURCEPOOL_NOTIFY":
-        for (let i in draft.items) {
-          if (draft.items[i].id === action.payload.id) {
-            draft.items[i] = action.payload;
-            break;
-          }
-        }
-        break;
-      case "DELETE_RESOURCEPOOL_NOTIFY":
-        const index = draft.items.findIndex(item => item.id === action.payload);
-        draft.items.splice(index, 1);
-        break;
-      case "CLEANUP_RESOURCEPOOL":
-        draft.errors = {};
-        draft.saved = false;
-        draft.saving = false;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    errors: {},
-    items: [],
-    loaded: false,
-    loading: false,
-    saved: false,
-    saving: false
-  }
-);
+import { resourcepool as poolActions } from "app/base/actions";
+
+const resourcepool = createStandardReducer(poolActions);
 
 export default resourcepool;

--- a/ui/src/app/base/reducers/service/service.js
+++ b/ui/src/app/base/reducers/service/service.js
@@ -1,30 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const service = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_SERVICE_START":
-        draft.loading = true;
-        break;
-      case "FETCH_SERVICE_ERROR":
-        draft.errors = action.error;
-        draft.loading = false;
-        break;
-      case "FETCH_SERVICE_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    errors: {},
-    items: [],
-    loaded: false,
-    loading: false
-  }
-);
+import { service as serviceActions } from "app/base/actions";
+
+const service = createStandardReducer(serviceActions);
 
 export default service;

--- a/ui/src/app/base/reducers/service/service.test.js
+++ b/ui/src/app/base/reducers/service/service.test.js
@@ -6,7 +6,9 @@ describe("service reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -19,7 +21,9 @@ describe("service reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -44,7 +48,9 @@ describe("service reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_SERVICE_SUCCESS",
@@ -55,7 +61,9 @@ describe("service reducer", () => {
       errors: {},
       items: payload,
       loading: false,
-      loaded: true
+      loaded: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -66,7 +74,9 @@ describe("service reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: false
+          loading: false,
+          saved: false,
+          saving: false
         },
         {
           error: "Could not fetch services",
@@ -77,7 +87,9 @@ describe("service reducer", () => {
       errors: "Could not fetch services",
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/base/reducers/subnet/subnet.js
+++ b/ui/src/app/base/reducers/subnet/subnet.js
@@ -1,25 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const subnet = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_SUBNET_START":
-        draft.loading = true;
-        break;
-      case "FETCH_SUBNET_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    items: [],
-    loaded: false,
-    loading: false
-  }
-);
+import { subnet as subnetActions } from "app/base/actions";
+
+const subnet = createStandardReducer(subnetActions);
 
 export default subnet;

--- a/ui/src/app/base/reducers/subnet/subnet.test.js
+++ b/ui/src/app/base/reducers/subnet/subnet.test.js
@@ -3,9 +3,12 @@ import subnet from "./subnet";
 describe("subnet reducer", () => {
   it("should return the initial state", () => {
     expect(subnet(undefined, {})).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -15,9 +18,38 @@ describe("subnet reducer", () => {
         type: "FETCH_SUBNET_START"
       })
     ).toEqual({
+      errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
+    });
+  });
+
+  it("should correctly reduce FETCH_SUBNET_ERROR", () => {
+    expect(
+      subnet(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          error: "Could not fetch subnets",
+          type: "FETCH_SUBNET_ERROR"
+        }
+      )
+    ).toEqual({
+      errors: "Could not fetch subnets",
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -25,9 +57,12 @@ describe("subnet reducer", () => {
     expect(
       subnet(
         {
+          errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_SUBNET_SUCCESS",
@@ -38,8 +73,11 @@ describe("subnet reducer", () => {
         }
       )
     ).toEqual({
+      errors: {},
       loading: false,
       loaded: true,
+      saved: false,
+      saving: false,
       items: [
         { id: 1, name: "10.0.0.99" },
         { id: 2, name: "test.maas" }

--- a/ui/src/app/base/reducers/tag/tag.js
+++ b/ui/src/app/base/reducers/tag/tag.js
@@ -1,30 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const tag = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_TAG_START":
-        draft.loading = true;
-        break;
-      case "FETCH_TAG_ERROR":
-        draft.errors = action.error;
-        draft.loading = false;
-        break;
-      case "FETCH_TAG_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    errors: {},
-    items: [],
-    loaded: false,
-    loading: false
-  }
-);
+import { tag as tagActions } from "app/base/actions";
+
+const tag = createStandardReducer(tagActions);
 
 export default tag;

--- a/ui/src/app/base/reducers/tag/tag.test.js
+++ b/ui/src/app/base/reducers/tag/tag.test.js
@@ -6,7 +6,9 @@ describe("tag reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -19,7 +21,9 @@ describe("tag reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -42,7 +46,9 @@ describe("tag reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_TAG_SUCCESS",
@@ -53,7 +59,9 @@ describe("tag reducer", () => {
       errors: {},
       items: payload,
       loading: false,
-      loaded: true
+      loaded: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -64,7 +72,9 @@ describe("tag reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: false
+          loading: false,
+          saved: false,
+          saving: false
         },
         {
           error: "Could not fetch tags",
@@ -75,7 +85,9 @@ describe("tag reducer", () => {
       errors: "Could not fetch tags",
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/base/reducers/user/user.js
+++ b/ui/src/app/base/reducers/user/user.js
@@ -1,68 +1,17 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const user = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_USER_START":
-        draft.loading = true;
-        break;
-      case "FETCH_USER_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      case "UPDATE_USER_START":
-      case "CREATE_USER_START":
-      case "DELETE_USER_START":
-        draft.saved = false;
-        draft.saving = true;
-        break;
-      case "UPDATE_USER_ERROR":
-      case "CREATE_USER_ERROR":
-      case "DELETE_USER_ERROR":
-        draft.errors = action.error;
-        draft.saving = false;
-        break;
-      case "UPDATE_USER_SUCCESS":
-      case "CREATE_USER_SUCCESS":
-      case "DELETE_USER_SUCCESS":
-        draft.errors = {};
-        draft.saved = true;
-        draft.saving = false;
-        break;
-      case "UPDATE_USER_NOTIFY":
-        for (let i in draft.items) {
-          if (draft.items[i].id === action.payload.id) {
-            draft.items[i] = action.payload;
-            break;
-          }
-        }
-        break;
-      case "CREATE_USER_NOTIFY":
-        draft.items.push(action.payload);
-        break;
-      case "DELETE_USER_NOTIFY":
-        const index = draft.items.findIndex(item => item.id === action.payload);
-        draft.items.splice(index, 1);
-        break;
-      case "CLEANUP_USER":
-        draft.errors = {};
-        draft.saved = false;
-        draft.saving = false;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    auth: {},
-    errors: {},
-    items: [],
-    loaded: false,
-    loading: false,
-    saved: false,
-    saving: false
-  }
-);
+import { user as userActions } from "app/base/actions";
+
+const initialState = {
+  auth: {},
+  errors: {},
+  items: [],
+  loaded: false,
+  loading: false,
+  saved: false,
+  saving: false
+};
+
+const user = createStandardReducer(userActions, initialState);
 
 export default user;

--- a/ui/src/app/base/reducers/user/user.test.js
+++ b/ui/src/app/base/reducers/user/user.test.js
@@ -13,6 +13,7 @@ describe("users reducer", () => {
     });
   });
 
+  // Fetch
   it("should correctly reduce FETCH_USER_START", () => {
     expect(
       user(undefined, {
@@ -63,33 +64,7 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce UPDATE_USER_START", () => {
-    expect(
-      user(
-        {
-          auth: {},
-          errors: {},
-          items: [],
-          loaded: false,
-          loading: false,
-          saved: true,
-          saving: false
-        },
-        {
-          type: "UPDATE_USER_START"
-        }
-      )
-    ).toEqual({
-      auth: {},
-      errors: {},
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: true
-    });
-  });
-
+  // Create
   it("should correctly reduce CREATE_USER_START", () => {
     expect(
       user(
@@ -117,7 +92,66 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce DELETE_USER_START", () => {
+  it("should correctly reduce CREATE_USER_ERROR", () => {
+    expect(
+      user(
+        {
+          auth: {},
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: { username: "Username already exists" },
+          type: "CREATE_USER_ERROR"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: { username: "Username already exists" },
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+  it("should correctly reduce CREATE_USER_NOTIFY", () => {
+    expect(
+      user(
+        {
+          auth: {},
+          errors: {},
+          items: [{ id: 1, username: "admin" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false
+        },
+        {
+          payload: { id: 2, username: "user1" },
+          type: "CREATE_USER_NOTIFY"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: {},
+      items: [
+        { id: 1, username: "admin" },
+        { id: 2, username: "user1" }
+      ],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  // Update
+  it("should correctly reduce UPDATE_USER_START", () => {
     expect(
       user(
         {
@@ -130,7 +164,7 @@ describe("users reducer", () => {
           saving: false
         },
         {
-          type: "DELETE_USER_START"
+          type: "UPDATE_USER_START"
         }
       )
     ).toEqual({
@@ -164,62 +198,6 @@ describe("users reducer", () => {
     ).toEqual({
       auth: {},
       errors: { username: "Username already exists" },
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false
-    });
-  });
-
-  it("should correctly reduce CREATE_USER_ERROR", () => {
-    expect(
-      user(
-        {
-          auth: {},
-          errors: {},
-          items: [],
-          loaded: false,
-          loading: false,
-          saved: false,
-          saving: true
-        },
-        {
-          error: { username: "Username already exists" },
-          type: "CREATE_USER_ERROR"
-        }
-      )
-    ).toEqual({
-      auth: {},
-      errors: { username: "Username already exists" },
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false
-    });
-  });
-
-  it("should correctly reduce DELETE_USER_ERROR", () => {
-    expect(
-      user(
-        {
-          auth: {},
-          errors: {},
-          items: [],
-          loaded: false,
-          loading: false,
-          saved: false,
-          saving: true
-        },
-        {
-          error: "Could not delete",
-          type: "DELETE_USER_ERROR"
-        }
-      )
-    ).toEqual({
-      auth: {},
-      errors: "Could not delete",
       items: [],
       loaded: false,
       loading: false,
@@ -265,30 +243,55 @@ describe("users reducer", () => {
     });
   });
 
-  it("should correctly reduce CREATE_USER_NOTIFY", () => {
+  // Delete
+  it("should correctly reduce DELETE_USER_START", () => {
     expect(
       user(
         {
           auth: {},
           errors: {},
-          items: [{ id: 1, username: "admin" }],
+          items: [],
           loaded: false,
           loading: false,
-          saved: false,
+          saved: true,
           saving: false
         },
         {
-          payload: { id: 2, username: "user1" },
-          type: "CREATE_USER_NOTIFY"
+          type: "DELETE_USER_START"
         }
       )
     ).toEqual({
       auth: {},
       errors: {},
-      items: [
-        { id: 1, username: "admin" },
-        { id: 2, username: "user1" }
-      ],
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: true
+    });
+  });
+
+  it("should correctly reduce DELETE_USER_ERROR", () => {
+    expect(
+      user(
+        {
+          auth: {},
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true
+        },
+        {
+          error: "Could not delete",
+          type: "DELETE_USER_ERROR"
+        }
+      )
+    ).toEqual({
+      auth: {},
+      errors: "Could not delete",
+      items: [],
       loaded: false,
       loading: false,
       saved: false,
@@ -327,6 +330,7 @@ describe("users reducer", () => {
     });
   });
 
+  // Cleanup
   it("should correctly reduce CLEANUP_USER", () => {
     expect(
       user(

--- a/ui/src/app/base/reducers/zone/zone.js
+++ b/ui/src/app/base/reducers/zone/zone.js
@@ -1,30 +1,7 @@
-import produce from "immer";
+import { createStandardReducer } from "app/utils/redux";
 
-const zone = produce(
-  (draft, action) => {
-    switch (action.type) {
-      case "FETCH_ZONE_START":
-        draft.loading = true;
-        break;
-      case "FETCH_ZONE_ERROR":
-        draft.errors = action.error;
-        draft.loading = false;
-        break;
-      case "FETCH_ZONE_SUCCESS":
-        draft.loading = false;
-        draft.loaded = true;
-        draft.items = action.payload;
-        break;
-      default:
-        return draft;
-    }
-  },
-  {
-    errors: {},
-    items: [],
-    loaded: false,
-    loading: false
-  }
-);
+import { zone as zoneActions } from "app/base/actions";
+
+const zone = createStandardReducer(zoneActions);
 
 export default zone;

--- a/ui/src/app/base/reducers/zone/zone.test.js
+++ b/ui/src/app/base/reducers/zone/zone.test.js
@@ -6,7 +6,9 @@ describe("zone reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 
@@ -19,7 +21,9 @@ describe("zone reducer", () => {
       errors: {},
       items: [],
       loaded: false,
-      loading: true
+      loading: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -42,7 +46,9 @@ describe("zone reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: true
+          loading: true,
+          saved: false,
+          saving: false
         },
         {
           type: "FETCH_ZONE_SUCCESS",
@@ -53,7 +59,9 @@ describe("zone reducer", () => {
       errors: {},
       items: payload,
       loading: false,
-      loaded: true
+      loaded: true,
+      saved: false,
+      saving: false
     });
   });
 
@@ -64,7 +72,9 @@ describe("zone reducer", () => {
           errors: {},
           items: [],
           loaded: false,
-          loading: false
+          loading: false,
+          saved: false,
+          saving: false
         },
         {
           error: "Could not fetch zones",
@@ -75,7 +85,9 @@ describe("zone reducer", () => {
       errors: "Could not fetch zones",
       items: [],
       loaded: false,
-      loading: false
+      loading: false,
+      saved: false,
+      saving: false
     });
   });
 });

--- a/ui/src/app/utils/redux.js
+++ b/ui/src/app/utils/redux.js
@@ -1,4 +1,4 @@
-import { createAction } from "@reduxjs/toolkit";
+import { createAction, createReducer } from "@reduxjs/toolkit";
 
 /**
  * Generates async actions for 'start', 'error' and 'success' events,
@@ -6,13 +6,15 @@ import { createAction } from "@reduxjs/toolkit";
  * @param {String} name - name of action
  * @param {Object} action - action creator object
  */
-const createAsyncActions = (name, action) => {
-  ["fetch", "create", "update", "delete"].forEach(type => {
-    ["start", "error", "success"].forEach(event => {
-      action[type][event] = createAction(
-        `${type.toUpperCase()}_${name.toUpperCase()}_${event.toUpperCase()}`
-      );
-    });
+export const createStandardAsyncActions = (name, action) => {
+  ["fetch", "create", "update", "delete"].forEach(method => {
+    if (action.hasOwnProperty(method)) {
+      ["start", "error", "success"].forEach(event => {
+        action[method][event] = createAction(
+          `${method.toUpperCase()}_${name.toUpperCase()}_${event.toUpperCase()}`
+        );
+      });
+    }
   });
   return action;
 };
@@ -39,6 +41,7 @@ export const createStandardActions = name => {
       params
     }
   }));
+  action.create.notify = createAction(`CREATE_${name.toUpperCase()}_NOTIFY`);
 
   action.update = createAction(`UPDATE_${name.toUpperCase()}`, params => ({
     meta: {
@@ -49,6 +52,7 @@ export const createStandardActions = name => {
       params
     }
   }));
+  action.update.notify = createAction(`UPDATE_${name.toUpperCase()}_NOTIFY`);
 
   action.delete = createAction(`DELETE_${name.toUpperCase()}`, id => ({
     meta: {
@@ -61,10 +65,97 @@ export const createStandardActions = name => {
       }
     }
   }));
+  action.delete.notify = createAction(`DELETE_${name.toUpperCase()}_NOTIFY`);
 
   action.cleanup = createAction(`CLEANUP_${name.toUpperCase()}`);
 
-  createAsyncActions(name, action);
+  createStandardAsyncActions(name, action);
 
   return action;
+};
+
+export const createStandardReducer = (
+  actions,
+  initialState = {
+    errors: {},
+    items: [],
+    loaded: false,
+    loading: false,
+    saved: false,
+    saving: false
+  }
+) => {
+  return createReducer(initialState, {
+    [actions.fetch.start]: state => {
+      state.loading = true;
+    },
+    [actions.fetch.error]: (state, action) => {
+      state.errors = action.error;
+      state.loading = false;
+    },
+    [actions.fetch.success]: (state, action) => {
+      state.loading = false;
+      state.loaded = true;
+      state.items = action.payload;
+    },
+    [actions.create.start]: state => {
+      state.saved = false;
+      state.saving = true;
+    },
+    [actions.create.error]: (state, action) => {
+      state.errors = action.error;
+      state.saving = false;
+    },
+    [actions.create.success]: state => {
+      state.errors = {};
+      state.saved = true;
+      state.saving = false;
+    },
+    [actions.create.notify]: (state, action) => {
+      state.items.push(action.payload);
+    },
+    [actions.update.start]: state => {
+      state.saved = false;
+      state.saving = true;
+    },
+    [actions.update.error]: (state, action) => {
+      state.errors = action.error;
+      state.saving = false;
+    },
+    [actions.update.success]: state => {
+      state.errors = {};
+      state.saved = true;
+      state.saving = false;
+    },
+    [actions.update.notify]: (state, action) => {
+      for (let i in state.items) {
+        if (state.items[i].id === action.payload.id) {
+          state.items[i] = action.payload;
+        }
+      }
+    },
+    [actions.delete.start]: state => {
+      state.saved = false;
+      state.saving = true;
+    },
+    [actions.delete.error]: (state, action) => {
+      state.errors = action.error;
+      state.saving = false;
+    },
+    [actions.delete.success]: state => {
+      state.errors = {};
+      state.saved = true;
+      state.saving = false;
+    },
+
+    [actions.delete.notify]: (state, action) => {
+      const index = state.items.findIndex(item => item.id === action.payload);
+      state.items.splice(index, 1);
+    },
+    [actions.cleanup]: state => {
+      state.errors = {};
+      state.saved = false;
+      state.saving = false;
+    }
+  });
 };

--- a/ui/src/app/utils/redux.test.js
+++ b/ui/src/app/utils/redux.test.js
@@ -1,4 +1,37 @@
-import { createStandardActions } from "./redux";
+import {
+  createStandardAsyncActions,
+  createStandardActions,
+  createStandardReducer
+} from "./redux";
+import { createAction } from "@reduxjs/toolkit";
+
+describe("createStandardAsyncAction", () => {
+  it("generates CRUD actions creators for start, error and success async events", () => {
+    const actions = {
+      fetch: createAction("FETCH_FOO"),
+      create: createAction("CREATE_FOO"),
+      update: createAction("UPDATE_FOO"),
+      delete: createAction("DELETE_FOO")
+    };
+
+    const actionsWithAsync = createStandardAsyncActions("foo", actions);
+
+    expect(actionsWithAsync.fetch.start()).toEqual({
+      payload: undefined,
+      type: "FETCH_FOO_START"
+    });
+
+    expect(actionsWithAsync.fetch.error()).toEqual({
+      payload: undefined,
+      type: "FETCH_FOO_ERROR"
+    });
+
+    expect(actionsWithAsync.fetch.success()).toEqual({
+      payload: undefined,
+      type: "FETCH_FOO_SUCCESS"
+    });
+  });
+});
 
 describe("createStandardActions", () => {
   it("defines a FETCH action", () => {
@@ -66,6 +99,387 @@ describe("createStandardActions", () => {
 
     expect(action.delete.success()).toEqual({
       type: "DELETE_FOO_SUCCESS"
+    });
+  });
+});
+
+describe("createStandardReducer", () => {
+  let actions;
+  let reducer;
+
+  beforeAll(() => {
+    actions = createStandardActions("foo");
+    reducer = createStandardReducer(actions);
+  });
+
+  it("should set initialState", () => {
+    expect(reducer(undefined, {})).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false
+    });
+  });
+
+  // fetch
+  describe("fetch", () => {
+    it("should set loading on fetch.start", () => {
+      expect(
+        reducer(undefined, {
+          type: "FETCH_FOO_START"
+        })
+      ).toEqual({
+        errors: {},
+        items: [],
+        loaded: false,
+        loading: true,
+        saved: false,
+        saving: false
+      });
+    });
+
+    it("should set errors and loading to false on fetch.error", () => {
+      expect(
+        reducer(undefined, {
+          error: { message: "Could not fetch foo" },
+          type: "FETCH_FOO_ERROR"
+        })
+      ).toEqual({
+        errors: { message: "Could not fetch foo" },
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
+    });
+
+    it("should correctly reduce FETCH_FOO_SUCCESS", () => {
+      expect(
+        reducer(undefined, {
+          type: "FETCH_FOO_SUCCESS",
+          payload: [
+            { id: 1, name: "foo" },
+            { id: 2, name: "bar" }
+          ]
+        })
+      ).toEqual({
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [
+          { id: 1, name: "foo" },
+          { id: 2, name: "bar" }
+        ],
+        saved: false,
+        saving: false
+      });
+    });
+  });
+
+  describe("create", () => {
+    it("should correctly reduce CREATE_FOO_START", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: true,
+            saving: false
+          },
+          {
+            type: "CREATE_FOO_START"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: true
+      });
+    });
+
+    it("should correctly reduce CREATE_FOO_ERROR", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: false,
+            saving: true
+          },
+          {
+            error: { name: "name already exists" },
+            type: "CREATE_FOO_ERROR"
+          }
+        )
+      ).toEqual({
+        errors: { name: "name already exists" },
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
+    });
+
+    it("should correctly reduce CREATE_FOO_SUCCESS", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: true,
+            saving: false
+          },
+          {
+            type: "CREATE_FOO_SUCCESS"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: true,
+        saving: false
+      });
+    });
+
+    it("should correctly reduce CREATE_FOO_NOTIFY", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [{ id: 1, name: "foo" }],
+            loaded: false,
+            loading: false,
+            saved: false,
+            saving: false
+          },
+          {
+            payload: { id: 2, name: "bar" },
+            type: "CREATE_FOO_NOTIFY"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [
+          { id: 1, name: "foo" },
+          { id: 2, name: "bar" }
+        ],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
+    });
+  });
+
+  describe("update", () => {
+    it("should correctly reduce UPDATE_FOO_START", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: true,
+            saving: false
+          },
+          {
+            type: "UPDATE_FOO_START"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: true
+      });
+    });
+
+    it("should correctly reduce UPDATE_FOO_ERROR", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: false,
+            saving: true
+          },
+          {
+            error: { name: "name already exists" },
+            type: "UPDATE_FOO_ERROR"
+          }
+        )
+      ).toEqual({
+        errors: { name: "name already exists" },
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
+    });
+
+    it("should correctly reduce UPDATE_FOO_NOTIFY", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [
+              { id: 1, name: "admin" },
+              { id: 2, name: "user1" }
+            ],
+            loaded: false,
+            loading: false,
+            saved: false,
+            saving: false
+          },
+          {
+            payload: {
+              id: 1,
+              name: "kangaroo"
+            },
+            type: "UPDATE_FOO_NOTIFY"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [
+          { id: 1, name: "kangaroo" },
+          { id: 2, name: "user1" }
+        ],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
+    });
+  });
+
+  describe("delete", () => {
+    it("should correctly reduce DELETE_FOO_START", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: true,
+            saving: false
+          },
+          {
+            type: "DELETE_FOO_START"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: true
+      });
+    });
+
+    it("should correctly reduce DELETE_FOO_ERROR", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: false,
+            saving: true
+          },
+          {
+            error: "Could not delete",
+            type: "DELETE_FOO_ERROR"
+          }
+        )
+      ).toEqual({
+        errors: "Could not delete",
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
+    });
+
+    it("should correctly reduce DELETE_FOO_NOTIFY", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [
+              { id: 1, name: "admin" },
+              { id: 2, name: "user1" }
+            ],
+            loaded: false,
+            loading: false,
+            saved: false,
+            saving: false
+          },
+          {
+            payload: 2,
+            type: "DELETE_FOO_NOTIFY"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [{ id: 1, name: "admin" }],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should correctly reduce CLEANUP_FOO", () => {
+      expect(
+        reducer(
+          {
+            errors: { name: "name already exists" },
+            items: [],
+            loaded: false,
+            loading: false,
+            saved: true,
+            saving: true
+          },
+          {
+            type: "CLEANUP_FOO"
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false
+      });
     });
   });
 });


### PR DESCRIPTION
## Done
* Migrate the majority of reducers with the same shape to redux-toolkit, generating 'standard' CRUD reducers using the `createStandardActions` utility.

## QA
* Ensure the app works as usual, without console errors.

## Fixes
Fixes canonical-web-and-design/MAAS-design#878

## Note
I've created [an additional card in the backlog](https://github.com/canonical-web-and-design/maas-ui/issues/801) with work that remains to fully complete the migration.
