### PR TITLE
Machine actions hook

### DIFF
--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -8,6 +8,7 @@ import { useFormikContext } from "formik";
 import { sendAnalyticsEvent } from "analytics";
 import { config as configSelectors } from "app/settings/selectors";
 import { general as generalSelectors } from "app/base/selectors";
+import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import { messages } from "app/base/actions";
 import { simpleObjectEquality } from "app/settings/utils";
@@ -177,7 +178,9 @@ const actionMethodOverrides = new Map([
  */
 export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
   const dispatch = useDispatch();
-  const machineActions = useSelector(generalSelectors.machineActions.get);
+  const generalMachineActions = useSelector(
+    generalSelectors.machineActions.get
+  );
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -185,7 +188,7 @@ export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
   actions.forEach(action => {
     if (machine.actions.includes(action)) {
       let actionLabel = action;
-      machineActions.forEach(machineAction => {
+      generalMachineActions.forEach(machineAction => {
         if (machineAction.name === action) {
           actionLabel = machineAction.title;
         }
@@ -195,7 +198,7 @@ export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
         children: actionLabel,
         onClick: () => {
           const actionMethod = actionMethodOverrides.get(action) || action;
-          dispatch(actionMethod(systemId));
+          dispatch(machineActions[actionMethod](systemId));
           onClick && onClick();
         }
       });

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.js
@@ -1,14 +1,13 @@
 import { Loader } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
-import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
+import { useMachineActions } from "app/base/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 
 const OwnerColumn = ({ onToggleMenu, systemId }) => {
-  const dispatch = useDispatch();
   const [updating, setUpdating] = useState(null);
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
@@ -16,33 +15,15 @@ const OwnerColumn = ({ onToggleMenu, systemId }) => {
 
   const owner = machine.owner ? machine.owner : "-";
   const tags = machine.tags ? machine.tags.join(", ") : "";
-  const hasAcquireAction = machine.actions.includes("acquire");
-  const hasReleaseAction = machine.actions.includes("release");
-  let menuLinks = [];
-  if (hasAcquireAction) {
-    menuLinks.push({
-      children: "Acquire...",
-      onClick: () => {
-        dispatch(machineActions.acquire(systemId));
-        setUpdating(machine.status);
-      }
-    });
-  }
-  if (hasReleaseAction) {
-    menuLinks.push({
-      children: "Release...",
-      onClick: () => {
-        dispatch(machineActions.release(systemId));
-        setUpdating(machine.status);
-      }
-    });
-  }
-  if (!hasAcquireAction && !hasReleaseAction) {
-    menuLinks.push({
-      children: "No owner actions available",
-      disabled: true
-    });
-  }
+
+  const menuLinks = useMachineActions(
+    systemId,
+    ["acquire", "release"],
+    "No owner actions available",
+    () => {
+      setUpdating(machine.status);
+    }
+  );
 
   useEffect(() => {
     if (updating !== null && machine.status !== updating) {

--- a/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/OwnerColumn/OwnerColumn.test.js
@@ -15,6 +15,14 @@ describe("OwnerColumn", () => {
       config: {
         items: []
       },
+      general: {
+        machineActions: {
+          data: [
+            { name: "acquire", title: "Acquire..." },
+            { name: "release", title: "Release..." }
+          ]
+        }
+      },
       machine: {
         errors: {},
         loading: false,

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.js
@@ -1,14 +1,14 @@
 import { Loader } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import React from "react";
 import PropTypes from "prop-types";
 
-import { machine as machineActions } from "app/base/actions";
 import {
   general as generalSelectors,
   machine as machineSelectors
 } from "app/base/selectors";
 import { nodeStatus, scriptStatus } from "app/base/enum";
+import { useMachineActions } from "app/base/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 import Tooltip from "app/base/components/Tooltip";
 
@@ -100,40 +100,28 @@ const getStatusIcon = machine => {
 };
 
 const StatusColumn = ({ onToggleMenu, systemId }) => {
-  const dispatch = useDispatch();
   const machine = useSelector(state =>
     machineSelectors.getBySystemId(state, systemId)
   );
   const osReleases = useSelector(state =>
     generalSelectors.osInfo.getOsReleases(state, machine.osystem)
   );
-  let actionLinks = [];
-  const actionTypes = new Map([
-    ["abort", null],
-    ["acquire", null],
-    ["commission", null],
-    ["deploy", null],
-    ["exit-rescue-mode", "exitRescueMode"],
-    ["lock", null],
-    ["mark-broken", "markBroken"],
-    ["mark-fixed", "markFixed"],
-    ["override-failed-testing", "overrideFailedTesting"],
-    ["release", null],
-    ["rescue-mode", "rescueMode"],
-    ["test", null],
-    ["unlock", null]
+
+  const actionLinks = useMachineActions(systemId, [
+    "abort",
+    "acquire",
+    "commission",
+    "deploy",
+    "exit-rescue-mode",
+    "lock",
+    "mark-broken",
+    "mark-fixed",
+    "override-failed-testing",
+    "release",
+    "rescue-mode",
+    "test",
+    "unlock"
   ]);
-  Array.from(actionTypes.keys()).forEach(action => {
-    if (machine.actions.includes(action)) {
-      actionLinks.push({
-        children: `${action}...`,
-        onClick: () => {
-          const actionMethod = actionTypes.get(action) || action;
-          dispatch(machineActions[actionMethod](systemId));
-        }
-      });
-    }
-  });
 
   const menuLinks = [
     actionLinks,

--- a/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/StatusColumn.test.js
@@ -14,6 +14,9 @@ describe("StatusColumn", () => {
   beforeEach(() => {
     state = {
       general: {
+        machineActions: {
+          data: []
+        },
         osInfo: {
           data: {
             osystems: [

--- a/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -26,7 +26,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        abort...
+        abort
       </button>
     </Button>
     <Button
@@ -38,7 +38,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        acquire...
+        acquire
       </button>
     </Button>
     <Button
@@ -50,7 +50,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        commission...
+        commission
       </button>
     </Button>
     <Button
@@ -62,7 +62,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        deploy...
+        deploy
       </button>
     </Button>
     <Button
@@ -74,7 +74,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        exit-rescue-mode...
+        exit-rescue-mode
       </button>
     </Button>
     <Button
@@ -86,7 +86,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        lock...
+        lock
       </button>
     </Button>
     <Button
@@ -98,7 +98,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        mark-broken...
+        mark-broken
       </button>
     </Button>
     <Button
@@ -110,7 +110,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        mark-fixed...
+        mark-fixed
       </button>
     </Button>
     <Button
@@ -122,7 +122,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        override-failed-testing...
+        override-failed-testing
       </button>
     </Button>
     <Button
@@ -134,7 +134,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        release...
+        release
       </button>
     </Button>
     <Button
@@ -146,7 +146,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        rescue-mode...
+        rescue-mode
       </button>
     </Button>
     <Button
@@ -158,7 +158,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        test...
+        test
       </button>
     </Button>
     <Button
@@ -170,7 +170,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
         className="p-button--neutral p-contextual-menu__link"
         onClick={[Function]}
       >
-        unlock...
+        unlock
       </button>
     </Button>
   </span>


### PR DESCRIPTION
## Done
- Generate the machine actions using a generic hook.
- Replace action labels with the values from the API.

## QA
- Load /r/machines.
- Check that the owner and power columns display the actions as before and display nice text labels.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/793.
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/811.