### PR TITLE
Refactor HeaderStrip. Implement update selection functionality in machine list.

### DIFF
--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
@@ -1,0 +1,145 @@
+import { Button, Col, Row } from "@canonical/react-components";
+import pluralize from "pluralize";
+import PropTypes from "prop-types";
+import React, { useLayoutEffect, useEffect, useState } from "react";
+
+const getSubmitText = (action, count) => {
+  const machineString = `${count} ${pluralize("machine", count)}`;
+
+  switch (action.name) {
+    case "exit-rescue-mode":
+      return `Exit rescue mode for ${machineString}`;
+    case "abort":
+      return `Abort actions for ${machineString}`;
+    case "on":
+      return `Power on ${machineString}`;
+    case "off":
+      return `Power off ${machineString}`;
+    case "mark-broken":
+      return `Mark ${machineString} broken`;
+    case "mark-fixed":
+      return `Mark ${machineString} fixed`;
+    case "override-failed-testing":
+      return `Override failed tests for ${machineString}.`;
+    case "rescue-mode":
+      return `Enter rescue mode for ${machineString}`;
+    case "set-pool":
+      return `Set pool of ${machineString}`;
+    case "set-zone":
+      return `Set zone of ${machineString}`;
+    default:
+      return `${action.name.charAt(0).toUpperCase()}${action.name.slice(
+        1
+      )} ${machineString}`;
+  }
+};
+
+const getErrorSentence = (action, count) => {
+  const machineString = `${count} ${pluralize("machine", count)}`;
+
+  switch (action.name) {
+    case "exit-rescue-mode":
+      return `${machineString} cannot exit rescue mode`;
+    case "lock":
+      return `${machineString} cannot be locked`;
+    case "override-failed-testing":
+      return `Cannot override failed tests on ${machineString}.`;
+    case "rescue-mode":
+      return `${machineString} cannot be put in rescue mode`;
+    case "set-pool":
+      return `Cannot set pool of ${machineString}`;
+    case "set-zone":
+      return `Cannot set zone of ${machineString}`;
+    case "unlock":
+      return `${machineString} cannot be unlocked`;
+    default:
+      return `${machineString} cannot be ${action.sentence}`;
+  }
+};
+
+export const ActionFormWrapper = ({
+  selectedAction,
+  selectedMachines,
+  setSelectedAction,
+  setSelectedMachines
+}) => {
+  const [actionableMachines, setActionableMachines] = useState([]);
+  const actionDisabled = actionableMachines.length !== selectedMachines.length;
+
+  useLayoutEffect(() => {
+    if (selectedAction) {
+      const actionable = selectedMachines.filter(machine =>
+        machine.actions.includes(selectedAction.name)
+      );
+      setActionableMachines(actionable);
+    }
+  }, [selectedAction, selectedMachines]);
+
+  useEffect(() => {
+    if (selectedMachines.length === 0) {
+      setSelectedAction(null);
+    }
+  }, [selectedMachines, setSelectedAction]);
+
+  return (
+    <Row>
+      <hr />
+      <Col size="12">
+        {actionDisabled && (
+          <p data-test="machine-action-warning">
+            <i className="p-icon--warning" style={{ marginRight: ".5rem" }} />
+            <span>
+              {getErrorSentence(
+                selectedAction,
+                selectedMachines.length - actionableMachines.length
+              )}
+              . To proceed,{" "}
+              <Button
+                appearance="link"
+                data-test="select-actionable-machines"
+                inline
+                onClick={() => setSelectedMachines(actionableMachines)}
+              >
+                update your selection
+              </Button>
+              .
+            </span>
+          </p>
+        )}
+        {!actionDisabled && (
+          // TODO: Replace with form components for each action.
+          <div className="u-align--right">
+            <Button
+              appearance="neutral"
+              data-test="cancel-action"
+              onClick={() => setSelectedAction(null)}
+              style={{ marginBottom: ".4rem" }}
+            >
+              Cancel
+            </Button>
+            <Button
+              appearance={
+                selectedAction.name === "delete" ? "negative" : "positive"
+              }
+              style={{ marginBottom: ".4rem" }}
+              type="submit"
+            >
+              {getSubmitText(selectedAction, selectedMachines.length)}
+            </Button>
+          </div>
+        )}
+      </Col>
+    </Row>
+  );
+};
+
+ActionFormWrapper.propTypes = {
+  // TODO: PropType shapes for common props.
+  // https://github.com/canonical-web-and-design/maas-ui/issues/826
+  selectedAction: PropTypes.object,
+  selectedMachines: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
+  setSelectedMachines: PropTypes.func.isRequired
+};
+
+export default ActionFormWrapper;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.test.js
@@ -1,0 +1,54 @@
+import { mount } from "enzyme";
+import React from "react";
+
+import ActionFormWrapper from "./ActionFormWrapper";
+
+describe("ActionFormWrapper", () => {
+  it(`displays a warning if not all selected machines can perform selected
+  action`, () => {
+    const wrapper = mount(
+      <ActionFormWrapper
+        selectedAction={{ name: "commission" }}
+        selectedMachines={[{ actions: ["commission"] }, { actions: [] }]}
+        setSelectedAction={jest.fn()}
+        setSelectedMachines={jest.fn()}
+      />
+    );
+    expect(wrapper.find("[data-test='machine-action-warning']").exists()).toBe(
+      true
+    );
+  });
+
+  it("can set selected machines to those that can perform action", () => {
+    const selectedMachines = [{ actions: ["commission"] }, { actions: [] }];
+    const setSelectedMachines = jest.fn();
+    const wrapper = mount(
+      <ActionFormWrapper
+        selectedAction={{ name: "commission" }}
+        selectedMachines={selectedMachines}
+        setSelectedAction={jest.fn()}
+        setSelectedMachines={setSelectedMachines}
+      />
+    );
+    wrapper
+      .find('[data-test="select-actionable-machines"] button')
+      .simulate("click");
+
+    expect(setSelectedMachines).toHaveBeenCalledWith([selectedMachines[0]]);
+  });
+
+  it("can unset the selected action", () => {
+    const setSelectedAction = jest.fn();
+    const wrapper = mount(
+      <ActionFormWrapper
+        selectedAction={{ name: "commission" }}
+        selectedMachines={[{ actions: ["commission"] }]}
+        setSelectedAction={setSelectedAction}
+        setSelectedMachines={jest.fn()}
+      />
+    );
+    wrapper.find('[data-test="cancel-action"] button').simulate("click");
+
+    expect(setSelectedAction).toHaveBeenCalledWith(null);
+  });
+});

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ActionFormWrapper";

--- a/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.js
+++ b/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.js
@@ -1,0 +1,52 @@
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import { general as generalActions } from "app/base/actions";
+import { general as generalSelectors } from "app/base/selectors";
+import ContextualMenu from "app/base/components/ContextualMenu";
+
+const getAddHardwareLinks = navigationOptions => {
+  const links = [
+    {
+      children: "Machine",
+      element: Link,
+      to: "/machines/add"
+    },
+    {
+      children: "Chassis",
+      element: Link,
+      to: "/machines/chassis/add"
+    }
+  ];
+
+  return navigationOptions.rsd
+    ? links.concat({
+        children: "RSD",
+        element: "a",
+        href: `${process.env.REACT_APP_ANGULAR_BASENAME}/rsd`
+      })
+    : links;
+};
+
+export const AddHardwareMenu = () => {
+  const dispatch = useDispatch();
+  const navigationOptions = useSelector(generalSelectors.navigationOptions.get);
+
+  useEffect(() => {
+    dispatch(generalActions.fetchNavigationOptions());
+  }, [dispatch]);
+
+  return (
+    <ContextualMenu
+      data-test="add-hardware-dropdown"
+      hasToggleIcon
+      links={getAddHardwareLinks(navigationOptions)}
+      position="right"
+      toggleAppearance="neutral"
+      toggleLabel="Add hardware"
+    />
+  );
+};
+
+export default AddHardwareMenu;

--- a/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.test.js
@@ -1,0 +1,46 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import AddHardwareMenu from "./AddHardwareMenu";
+
+const mockStore = configureStore();
+
+describe("AddHardwareMenu", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      general: {
+        navigationOptions: {
+          data: {
+            rsd: false
+          }
+        }
+      }
+    };
+  });
+
+  it("displays RSD link if in navigation state", () => {
+    const state = { ...initialState };
+    state.general.navigationOptions.data.rsd = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddHardwareMenu />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="add-hardware-dropdown"]').props().links.length
+    ).toBe(3);
+    expect(
+      wrapper.find('[data-test="add-hardware-dropdown"]').props().links[2]
+        .children
+    ).toBe("RSD");
+  });
+});

--- a/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AddHardwareMenu";

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -1,106 +1,26 @@
 import { Button, Col, Loader, Row } from "@canonical/react-components";
 import pluralize from "pluralize";
-import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, Route, Switch } from "react-router-dom";
 
-import {
-  general as generalActions,
-  machine as machineActions,
-  resourcepool as poolActions
-} from "app/base/actions";
-import {
-  general as generalSelectors,
-  machine as machineSelectors,
-  resourcepool as resourcePoolSelectors
-} from "app/base/selectors";
-import { useRouter } from "app/base/hooks";
-import ContextualMenu from "app/base/components/ContextualMenu";
-import Tabs from "app/base/components/Tabs";
-import Tooltip from "app/base/components/Tooltip";
+import { machine as machineActions } from "app/base/actions";
+import { machine as machineSelectors } from "app/base/selectors";
+import ActionFormWrapper from "./ActionFormWrapper";
+import AddHardwareMenu from "./AddHardwareMenu";
+import HeaderStripTabs from "./HeaderStripTabs";
+import TakeActionMenu from "./TakeActionMenu";
 
-const getAddHardwareLinks = navigationOptions => {
-  const links = [
-    {
-      children: "Machine",
-      element: Link,
-      to: "/machines/add"
-    },
-    {
-      children: "Chassis",
-      element: Link,
-      to: "/machines/chassis/add"
-    }
-  ];
-
-  return navigationOptions.rsd
-    ? links.concat({
-        children: "RSD",
-        element: "a",
-        href: `${process.env.REACT_APP_ANGULAR_BASENAME}/rsd`
-      })
-    : links;
-};
-
-const getTakeActionLinks = (actionOptions, machines) => {
-  const initGroups = [
-    { type: "lifecycle", items: [] },
-    { type: "power", items: [] },
-    { type: "testing", items: [] },
-    { type: "lock", items: [] },
-    { type: "misc", items: [] }
-  ];
-
-  const groupedLinks = actionOptions.reduce((groups, option) => {
-    const count = machines.reduce((sum, machine) => {
-      if (machine.actions.includes(option.name)) {
-        sum += 1;
-      }
-      return sum;
-    }, 0);
-
-    if (count > 0 || option.type === "lifecycle") {
-      const group = groups.find(group => group.type === option.type);
-      group.items.push({
-        children: (
-          <div className="u-flex-between">
-            <span data-test={`action-title-${option.name}`}>
-              {option.title}
-            </span>
-            {machines.length > 1 && (
-              <span
-                data-test={`action-count-${option.name}`}
-                style={{ marginLeft: ".5rem" }}
-              >
-                {count || ""}
-              </span>
-            )}
-          </div>
-        ),
-        disabled: count === 0,
-        onClick: () => null
-      });
-    }
-    return groups;
-  }, initGroups);
-
-  return groupedLinks.map(group => group.items);
-};
-
-export const HeaderStrip = ({ selectedMachines }) => {
+export const HeaderStrip = ({ selectedMachines, setSelectedMachines }) => {
   const dispatch = useDispatch();
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
-  const resourcePools = useSelector(resourcePoolSelectors.all);
-  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
-  const actionOptions = useSelector(generalSelectors.machineActions.get);
-  const navigationOptions = useSelector(generalSelectors.navigationOptions.get);
-  const { location } = useRouter();
+
+  const [selectedAction, setSelectedAction] = useState();
 
   useEffect(() => {
-    dispatch(generalActions.fetchMachineActions());
     dispatch(machineActions.fetch());
-    dispatch(poolActions.fetch());
   }, [dispatch]);
 
   return (
@@ -137,41 +57,23 @@ export const HeaderStrip = ({ selectedMachines }) => {
                     className="p-inline-list__item u-text--light"
                     data-test="selected-count"
                   >
-                    {`${selectedMachines.length} selected`}
+                    <span>{`${selectedMachines.length} selected`}</span>
+                    <span className="p-heading--four" />
                   </li>
                 )}
-                <li className="p-inline-list__item">
-                  <ContextualMenu
-                    data-test="add-hardware-dropdown"
-                    hasToggleIcon
-                    links={getAddHardwareLinks(navigationOptions)}
-                    position="right"
-                    toggleAppearance="neutral"
-                    toggleLabel="Add hardware"
-                  />
-                </li>
-                <li className="p-inline-list__item last-item">
-                  <Tooltip
-                    message={
-                      !selectedMachines.length &&
-                      "Select machines below to perform an action."
-                    }
-                    position="left"
-                  >
-                    <ContextualMenu
-                      data-test="take-action-dropdown"
-                      hasToggleIcon
-                      links={getTakeActionLinks(
-                        actionOptions,
-                        selectedMachines
-                      )}
-                      position="right"
-                      toggleAppearance="positive"
-                      toggleDisabled={!selectedMachines.length}
-                      toggleLabel="Take action"
-                    />
-                  </Tooltip>
-                </li>
+                {!selectedAction && (
+                  <>
+                    <li className="p-inline-list__item">
+                      <AddHardwareMenu />
+                    </li>
+                    <li className="p-inline-list__item last-item">
+                      <TakeActionMenu
+                        selectedMachines={selectedMachines}
+                        setSelectedAction={setSelectedAction}
+                      />
+                    </li>
+                  </>
+                )}
               </ul>
             </Route>
             <Route exact path="/pools">
@@ -182,34 +84,22 @@ export const HeaderStrip = ({ selectedMachines }) => {
           </Switch>
         </Col>
       </Row>
-      <Row>
-        <Col size="12">
-          <hr className="u-no-margin--bottom" />
-          <Tabs
-            data-test="machine-list-tabs"
-            links={[
-              {
-                active: location.pathname.startsWith("/machines"),
-                label: `${
-                  machinesLoaded ? `${machines.length} ` : ""
-                }${pluralize("Machine", machines.length)}`,
-                path: "/machines"
-              },
-              {
-                active: location.pathname.startsWith("/pool"),
-                label: `${
-                  resourcePoolsLoaded ? `${resourcePools.length} ` : ""
-                }${pluralize("Resource pool", resourcePools.length)}`,
-                path: "/pools"
-              }
-            ]}
-            listClassName="u-no-margin--bottom"
-            noBorder
-          />
-        </Col>
-      </Row>
+      {selectedAction && (
+        <ActionFormWrapper
+          selectedAction={selectedAction}
+          selectedMachines={selectedMachines}
+          setSelectedAction={setSelectedAction}
+          setSelectedMachines={setSelectedMachines}
+        />
+      )}
+      <HeaderStripTabs />
     </>
   );
+};
+
+HeaderStrip.propTypes = {
+  selectedMachines: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setSelectedMachines: PropTypes.func.isRequired
 };
 
 export default HeaderStrip;

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
@@ -115,7 +115,7 @@ describe("HeaderStrip", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <HeaderStrip selectedMachines={[]} />
+          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -131,65 +131,13 @@ describe("HeaderStrip", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <HeaderStrip selectedMachines={[]} />
+          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find('[data-test="machine-count"]').text()).toBe(
       "1 machine available"
     );
-  });
-
-  it("displays tabs with machine and resource pool counts if loaded", () => {
-    const state = { ...initialState };
-    state.machine.loaded = true;
-    state.resourcepool.loaded = true;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={[]} />
-        </MemoryRouter>
-      </Provider>
-    );
-    const tabs = wrapper.find('[data-test="machine-list-tabs"]');
-    expect(
-      tabs
-        .find("Link")
-        .at(0)
-        .text()
-    ).toBe("1 Machine");
-    expect(
-      tabs
-        .find("Link")
-        .at(1)
-        .text()
-    ).toBe("2 Resource pools");
-  });
-
-  it(`displays RSD link in add hardware dropdown if shown
-    in navigation`, () => {
-    const state = { ...initialState };
-    state.general.navigationOptions.data.rsd = true;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={[]} />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(
-      wrapper.find('[data-test="add-hardware-dropdown"]').props().links.length
-    ).toBe(3);
-    expect(
-      wrapper.find('[data-test="add-hardware-dropdown"]').props().links[2]
-        .children
-    ).toBe("RSD");
   });
 
   it("displays add hardware menu and not add pool when at machines route", () => {
@@ -200,7 +148,7 @@ describe("HeaderStrip", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <HeaderStrip selectedMachines={[]} />
+          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -217,7 +165,7 @@ describe("HeaderStrip", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <HeaderStrip selectedMachines={[]} />
+          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -225,227 +173,5 @@ describe("HeaderStrip", () => {
     expect(
       wrapper.find('Button[data-test="add-hardware-dropdown"]').length
     ).toBe(0);
-  });
-
-  it("disables take action menu if no are machines selected", () => {
-    const state = { ...initialState };
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={[]} />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(
-      wrapper.find('[data-test="take-action-dropdown"] button').props().disabled
-    ).toBe(true);
-  });
-
-  it(`enables take action menu and displays number of selected machines if
-    at least one selected`, () => {
-    const state = { ...initialState };
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={[state.machine.items[0]]} />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find('[data-test="selected-count"]').text()).toBe(
-      "1 selected"
-    );
-    expect(
-      wrapper.find('[data-test="take-action-dropdown"] button').props().disabled
-    ).toBe(false);
-  });
-
-  it(`displays all lifecycle actions in action menu, but disables buttons for
-    those in which selected machines cannot perform`, () => {
-    const state = { ...initialState };
-    state.general.machineActions.data = [
-      { name: "lifecycle1", title: "Lifecycle 1", type: "lifecycle" },
-      { name: "lifecycle2", title: "Lifecycle 2", type: "lifecycle" },
-      { name: "lifecycle3", title: "Lifecycle 3", type: "lifecycle" }
-    ];
-    // No machine can perform "lifecycle3" action
-    state.machine.items = [
-      { actions: ["lifecycle1", "lifecycle2"] },
-      { actions: ["lifecycle1"] },
-      { actions: ["other"] }
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={state.machine.items} />
-        </MemoryRouter>
-      </Provider>
-    );
-    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
-    expect(wrapper.find("button.p-contextual-menu__link").length).toBe(3);
-    expect(wrapper.find("[data-test='action-title-lifecycle1']").text()).toBe(
-      "Lifecycle 1"
-    );
-    expect(wrapper.find("[data-test='action-title-lifecycle2']").text()).toBe(
-      "Lifecycle 2"
-    );
-    expect(wrapper.find("[data-test='action-title-lifecycle3']").text()).toBe(
-      "Lifecycle 3"
-    );
-    // Lifecycle 3 action displays, but is disabled
-    expect(
-      wrapper
-        .find("button.p-contextual-menu__link")
-        .at(2)
-        .props().disabled
-    ).toBe(true);
-  });
-
-  it(`filters non-lifecycle actions from action menu if no selected machine
-    can perform the action`, () => {
-    const state = { ...initialState };
-    state.general.machineActions.data = [
-      { name: "on", title: "Power on...", type: "power" },
-      { name: "off", title: "Power off...", type: "power" },
-      { name: "house", title: "Power house...", type: "power" }
-    ];
-    // No machine can perform "house" action
-    state.machine.items = [
-      { actions: ["on", "off"] },
-      { actions: ["on"] },
-      { actions: ["off"] }
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={state.machine.items} />
-        </MemoryRouter>
-      </Provider>
-    );
-    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
-    expect(wrapper.find("button.p-contextual-menu__link").length).toBe(2);
-    expect(wrapper.find("[data-test='action-title-on']").text()).toBe(
-      "Power on..."
-    );
-    expect(wrapper.find("[data-test='action-title-off']").text()).toBe(
-      "Power off..."
-    );
-  });
-
-  it(`correctly calculates number of machines that can perform each action
-    in action menu`, () => {
-    const state = { ...initialState };
-    state.general.machineActions.data = [
-      { name: "commission", title: "Commission...", type: "lifecycle" },
-      { name: "release", title: "Release...", type: "lifecycle" },
-      { name: "deploy", title: "Deploy...", type: "lifecycle" }
-    ];
-    // 3 commission, 2 release, 1 deploy
-    state.machine.items = [
-      { actions: ["commission", "release", "deploy"] },
-      { actions: ["commission", "release"] },
-      { actions: ["commission"] }
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={state.machine.items} />
-        </MemoryRouter>
-      </Provider>
-    );
-    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
-    expect(wrapper.find("button.p-contextual-menu__link").length).toBe(3);
-    expect(wrapper.find("[data-test='action-count-commission']").text()).toBe(
-      "3"
-    );
-    expect(wrapper.find("[data-test='action-count-release']").text()).toBe("2");
-    expect(wrapper.find("[data-test='action-count-deploy']").text()).toBe("1");
-  });
-
-  it(`displays all actions a machine can take, without count, if only one
-  machine is selected`, () => {
-    const state = { ...initialState };
-    state.general.machineActions.data = [
-      { name: "action1", title: "Action 1", type: "power" },
-      { name: "action2", title: "Action 2", type: "power" }
-    ];
-    // No machine can perform "lifecycle3" action
-    state.machine.items = [{ actions: ["action1"] }];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={[state.machine.items[0]]} />
-        </MemoryRouter>
-      </Provider>
-    );
-    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
-    expect(wrapper.find("[data-test='action-title-action1']").text()).toBe(
-      "Action 1"
-    );
-    expect(wrapper.find("[data-test='action-count-action1']").exists()).toBe(
-      false
-    );
-  });
-
-  it("groups actions in action menu by type", () => {
-    const state = { ...initialState };
-    state.general.machineActions.data = [
-      { name: "commission", title: "Commission...", type: "lifecycle" },
-      { name: "on", title: "Power on...", type: "power" },
-      { name: "off", title: "Power on...", type: "power" },
-      { name: "test", title: "Test...", type: "testing" },
-      { name: "lock", title: "Lock...", type: "lock" },
-      { name: "set-pool", title: "Set pool...", type: "misc" },
-      { name: "set-zone", title: "Set zone...", type: "misc" },
-      { name: "delete", title: "Delete...", type: "misc" }
-    ];
-    state.machine.items = [
-      {
-        actions: [
-          "commission",
-          "on",
-          "off",
-          "test",
-          "lock",
-          "set-pool",
-          "set-zone",
-          "delete"
-        ]
-      }
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <HeaderStrip selectedMachines={state.machine.items} />
-        </MemoryRouter>
-      </Provider>
-    );
-    const links = wrapper.find('[data-test="take-action-dropdown"]').props()
-      .links;
-    expect(links[0].length).toBe(1);
-    expect(links[1].length).toBe(2);
-    expect(links[2].length).toBe(1);
-    expect(links[3].length).toBe(1);
-    expect(links[4].length).toBe(3);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/HeaderStripTabs.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/HeaderStripTabs.js
@@ -1,0 +1,61 @@
+import { Col, Row } from "@canonical/react-components";
+import pluralize from "pluralize";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import {
+  machine as machineActions,
+  resourcepool as poolActions
+} from "app/base/actions";
+import {
+  machine as machineSelectors,
+  resourcepool as resourcePoolSelectors
+} from "app/base/selectors";
+import { useRouter } from "app/base/hooks";
+import Tabs from "app/base/components/Tabs";
+
+export const HeaderStripTabs = () => {
+  const dispatch = useDispatch();
+  const machines = useSelector(machineSelectors.all);
+  const machinesLoaded = useSelector(machineSelectors.loaded);
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
+  const { location } = useRouter();
+
+  useEffect(() => {
+    dispatch(machineActions.fetch());
+    dispatch(poolActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Row>
+      <Col size="12">
+        <hr className="u-no-margin--bottom" />
+        <Tabs
+          data-test="machine-list-tabs"
+          links={[
+            {
+              active: location.pathname.startsWith("/machines"),
+              label: `${machinesLoaded ? `${machines.length} ` : ""}${pluralize(
+                "Machine",
+                machines.length
+              )}`,
+              path: "/machines"
+            },
+            {
+              active: location.pathname.startsWith("/pool"),
+              label: `${
+                resourcePoolsLoaded ? `${resourcePools.length} ` : ""
+              }${pluralize("Resource pool", resourcePools.length)}`,
+              path: "/pools"
+            }
+          ]}
+          listClassName="u-no-margin--bottom"
+          noBorder
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default HeaderStripTabs;

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/HeaderStripTabs.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/HeaderStripTabs.test.js
@@ -1,0 +1,54 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import HeaderStripTabs from "./HeaderStripTabs";
+
+const mockStore = configureStore();
+
+describe("HeaderStripTabs", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      machine: {
+        loaded: true,
+        items: [1]
+      },
+      resourcepool: {
+        loaded: true,
+        items: [1, 2]
+      }
+    };
+  });
+
+  it("displays tabs machine and resource pool counts if loaded", () => {
+    const state = { ...initialState };
+    state.machine.loaded = true;
+    state.resourcepool.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStripTabs />
+        </MemoryRouter>
+      </Provider>
+    );
+    const tabs = wrapper.find('[data-test="machine-list-tabs"]');
+    expect(
+      tabs
+        .find("Link")
+        .at(0)
+        .text()
+    ).toBe("1 Machine");
+    expect(
+      tabs
+        .find("Link")
+        .at(1)
+        .text()
+    ).toBe("2 Resource pools");
+  });
+});

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/index.js
@@ -1,0 +1,1 @@
+export { default } from "./HeaderStripTabs";

--- a/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/TakeActionMenu.js
+++ b/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/TakeActionMenu.js
@@ -1,0 +1,93 @@
+import PropTypes from "prop-types";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { general as generalActions } from "app/base/actions";
+import { general as generalSelectors } from "app/base/selectors";
+import ContextualMenu from "app/base/components/ContextualMenu";
+import Tooltip from "app/base/components/Tooltip";
+
+const getTakeActionLinks = (actionOptions, machines, setSelectedAction) => {
+  const initGroups = [
+    { type: "lifecycle", items: [] },
+    { type: "power", items: [] },
+    { type: "testing", items: [] },
+    { type: "lock", items: [] },
+    { type: "misc", items: [] }
+  ];
+
+  const groupedLinks = actionOptions.reduce((groups, option) => {
+    const count = machines.reduce((sum, machine) => {
+      if (machine.actions.includes(option.name)) {
+        sum += 1;
+      }
+      return sum;
+    }, 0);
+
+    if (count > 0 || option.type === "lifecycle") {
+      const group = groups.find(group => group.type === option.type);
+      group.items.push({
+        children: (
+          <div className="u-flex-between">
+            <span data-test={`action-title-${option.name}`}>
+              {option.title}
+            </span>
+            {machines.length > 1 && (
+              <span
+                data-test={`action-count-${option.name}`}
+                style={{ marginLeft: ".5rem" }}
+              >
+                {count || ""}
+              </span>
+            )}
+          </div>
+        ),
+        disabled: count === 0,
+        onClick: () => setSelectedAction(option)
+      });
+    }
+    return groups;
+  }, initGroups);
+
+  return groupedLinks.map(group => group.items);
+};
+
+export const TakeActionMenu = ({ selectedMachines, setSelectedAction }) => {
+  const dispatch = useDispatch();
+  const actionOptions = useSelector(generalSelectors.machineActions.get);
+
+  useEffect(() => {
+    dispatch(generalActions.fetchMachineActions());
+  }, [dispatch]);
+
+  return (
+    <Tooltip
+      message={
+        !selectedMachines.length &&
+        "Select machines below to perform an action."
+      }
+      position="left"
+    >
+      <ContextualMenu
+        data-test="take-action-dropdown"
+        hasToggleIcon
+        links={getTakeActionLinks(
+          actionOptions,
+          selectedMachines,
+          setSelectedAction
+        )}
+        position="right"
+        toggleAppearance="positive"
+        toggleDisabled={!selectedMachines.length}
+        toggleLabel="Take action"
+      />
+    </Tooltip>
+  );
+};
+
+TakeActionMenu.propTypes = {
+  selectedMachines: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setSelectedAction: PropTypes.func.isRequired
+};
+
+export default TakeActionMenu;

--- a/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/TakeActionMenu.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/TakeActionMenu.test.js
@@ -1,0 +1,288 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import TakeActionMenu from "./TakeActionMenu";
+
+const mockStore = configureStore();
+
+describe("TakeActionMenu", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      general: {
+        machineActions: {
+          data: [],
+          errors: {},
+          loaded: true,
+          loading: false
+        }
+      }
+    };
+  });
+
+  it("is disabled if no are machines selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu selectedMachines={[]} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="take-action-dropdown"] button').props().disabled
+    ).toBe(true);
+  });
+
+  it("is enabled if at least one machine selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const machines = [{ actions: ["lifecycle1", "lifecycle2"] }];
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu
+            selectedMachines={machines}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="take-action-dropdown"] button').props().disabled
+    ).toBe(false);
+  });
+
+  it(`displays all lifecycle actions in action menu, but disables buttons for
+    those in which selected machines cannot perform`, () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      { name: "lifecycle1", title: "Lifecycle 1", type: "lifecycle" },
+      { name: "lifecycle2", title: "Lifecycle 2", type: "lifecycle" },
+      { name: "lifecycle3", title: "Lifecycle 3", type: "lifecycle" }
+    ];
+    // No machine can perform "lifecycle3" action
+    const machines = [
+      { actions: ["lifecycle1", "lifecycle2"] },
+      { actions: ["lifecycle1"] },
+      { actions: ["other"] }
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu
+            selectedMachines={machines}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
+    expect(wrapper.find("button.p-contextual-menu__link").length).toBe(3);
+    expect(wrapper.find("[data-test='action-title-lifecycle1']").text()).toBe(
+      "Lifecycle 1"
+    );
+    expect(wrapper.find("[data-test='action-title-lifecycle2']").text()).toBe(
+      "Lifecycle 2"
+    );
+    expect(wrapper.find("[data-test='action-title-lifecycle3']").text()).toBe(
+      "Lifecycle 3"
+    );
+    // Lifecycle 3 action displays, but is disabled
+    expect(
+      wrapper
+        .find("button.p-contextual-menu__link")
+        .at(2)
+        .props().disabled
+    ).toBe(true);
+  });
+
+  it(`filters non-lifecycle actions if no selected machine can
+    perform the action`, () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      { name: "on", title: "Power on...", type: "power" },
+      { name: "off", title: "Power off...", type: "power" },
+      { name: "house", title: "Power house...", type: "power" }
+    ];
+    // No machine can perform "house" action
+    const machines = [
+      { actions: ["on", "off"] },
+      { actions: ["on"] },
+      { actions: ["off"] }
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu
+            selectedMachines={machines}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
+    expect(wrapper.find("button.p-contextual-menu__link").length).toBe(2);
+    expect(wrapper.find("[data-test='action-title-on']").text()).toBe(
+      "Power on..."
+    );
+    expect(wrapper.find("[data-test='action-title-off']").text()).toBe(
+      "Power off..."
+    );
+  });
+
+  it("correctly calculates number of machines that can perform each action", () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      { name: "commission", title: "Commission...", type: "lifecycle" },
+      { name: "release", title: "Release...", type: "lifecycle" },
+      { name: "deploy", title: "Deploy...", type: "lifecycle" }
+    ];
+    // 3 commission, 2 release, 1 deploy
+    const machines = [
+      { actions: ["commission", "release", "deploy"] },
+      { actions: ["commission", "release"] },
+      { actions: ["commission"] }
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu
+            selectedMachines={machines}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
+    expect(wrapper.find("button.p-contextual-menu__link").length).toBe(3);
+    expect(wrapper.find("[data-test='action-count-commission']").text()).toBe(
+      "3"
+    );
+    expect(wrapper.find("[data-test='action-count-release']").text()).toBe("2");
+    expect(wrapper.find("[data-test='action-count-deploy']").text()).toBe("1");
+  });
+
+  it(`displays all actions a machine can take, without count, if only one
+  machine is selected`, () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      { name: "action1", title: "Action 1", type: "power" },
+      { name: "action2", title: "Action 2", type: "power" }
+    ];
+    // No machine can perform "lifecycle3" action
+    const machines = [{ actions: ["action1"] }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu
+            selectedMachines={machines}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
+    expect(wrapper.find("[data-test='action-title-action1']").text()).toBe(
+      "Action 1"
+    );
+    expect(wrapper.find("[data-test='action-count-action1']").exists()).toBe(
+      false
+    );
+  });
+
+  it("groups actions by type", () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      { name: "commission", title: "Commission...", type: "lifecycle" },
+      { name: "on", title: "Power on...", type: "power" },
+      { name: "off", title: "Power on...", type: "power" },
+      { name: "test", title: "Test...", type: "testing" },
+      { name: "lock", title: "Lock...", type: "lock" },
+      { name: "set-pool", title: "Set pool...", type: "misc" },
+      { name: "set-zone", title: "Set zone...", type: "misc" },
+      { name: "delete", title: "Delete...", type: "misc" }
+    ];
+    const machines = [
+      {
+        actions: [
+          "commission",
+          "on",
+          "off",
+          "test",
+          "lock",
+          "set-pool",
+          "set-zone",
+          "delete"
+        ]
+      }
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu
+            selectedMachines={machines}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const links = wrapper.find('[data-test="take-action-dropdown"]').props()
+      .links;
+    expect(links[0].length).toBe(1);
+    expect(links[1].length).toBe(2);
+    expect(links[2].length).toBe(1);
+    expect(links[3].length).toBe(1);
+    expect(links[4].length).toBe(3);
+  });
+
+  it("fires setSelectedAction function on action button click", () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      { name: "commission", title: "Commission...", type: "lifecycle" }
+    ];
+    const machines = [{ actions: ["commission"] }];
+    const setSelectedAction = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu
+            selectedMachines={machines}
+            setSelectedAction={setSelectedAction}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
+    wrapper.find(".p-contextual-menu__link button").simulate("click");
+    expect(setSelectedAction).toHaveBeenCalledWith(
+      state.general.machineActions.data[0]
+    );
+  });
+});

--- a/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from "./TakeActionMenu";

--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -17,7 +17,12 @@ const Machines = () => {
   return (
     <Section
       headerClassName="u-no-padding--bottom"
-      title={<HeaderStrip selectedMachines={selectedMachines} />}
+      title={
+        <HeaderStrip
+          selectedMachines={selectedMachines}
+          setSelectedMachines={setSelectedMachines}
+        />
+      }
     >
       <Switch>
         <Route exact path="/machines">


### PR DESCRIPTION
## Done
- Split HeaderStrip into smaller components because it was starting to get large. Now it consists of:
  - AddHardwareMenu
  - TakeActionMenu
  - HeaderStripTabs
  - ActionFormWrapper (which is bare bones right now, but will house the individual form components for each action type) 
- Built the "update your selection" functionality from the angular machine list, which filters selected machines to only those that can perform the selected action.

## QA
- Select a bunch of machines.
- Open the take action menu and pick an action that not all machines can perform.
- Check that a warning shows up that asks you to update your selection.
- Click the "update your selection" link and check that the selected machines are filtered to those that can perform the action.
- Check that the submit label is formatted nicely for each action.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1793

## Screenshots
### Select action that can't be performed by all selected machines
![0 0 0 0_8400_MAAS_r_machines (14)](https://user-images.githubusercontent.com/25733845/74955980-b6671500-5405-11ea-8898-73d5ecedfca5.png)

### Error message
![0 0 0 0_8400_MAAS_r_machines (15)](https://user-images.githubusercontent.com/25733845/74955987-b9fa9c00-5405-11ea-8426-2c3ec28d268a.png)

### All machines can perform action
![0 0 0 0_8400_MAAS_r_machines (16)](https://user-images.githubusercontent.com/25733845/74955993-bc5cf600-5405-11ea-9f87-cecc0449047c.png)

