### PR TITLE
Truncate the power text

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineList.scss
+++ b/ui/src/app/machines/views/MachineList/MachineList.scss
@@ -43,11 +43,11 @@
   }
   // Power
   &:nth-child(2) {
-    @include breakpoint-widths(23%, 15%, 12%, 10%, 8%);
+    @include breakpoint-widths(25%, 17%, 14%, 12%, 10%);
   }
   // Status
   &:nth-child(3) {
-    @include breakpoint-widths(32%, 30%, 20%, 20%, 17%);
+    @include breakpoint-widths(30%, 28%, 18%, 18%, 15%);
   }
   // Owner
   &:nth-child(4) {

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -105,7 +105,7 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
       menuTitle="Take action:"
       onToggleMenu={onToggleMenu}
       primary={
-        <div className="u-upper-case--first" data-test="power_state">
+        <div className="u-upper-case--first u-truncate" data-test="power_state">
           {powerState}
         </div>
       }

--- a/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -26,7 +26,7 @@ exports[`PowerColumn renders 1`] = `
     menuTitle="Take action:"
     primary={
       <div
-        className="u-upper-case--first"
+        className="u-upper-case--first u-truncate"
         data-test="power_state"
       >
         on
@@ -63,7 +63,7 @@ exports[`PowerColumn renders 1`] = `
             className="p-double-row__primary-row-text u-truncate"
           >
             <div
-              className="u-upper-case--first"
+              className="u-upper-case--first u-truncate"
               data-test="power_state"
             >
               on


### PR DESCRIPTION
## Done
- Correctly truncate the power text for small screens or when the action icon is visible.

## QA
- Open /r/machines.
- Reduce the size of your screen a bit until some of the power statuses don't have room. They should truncate with an ellipsis.
- Hover of the statuses, the menu chevron should appear and the statuses should further truncate.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/809.

## Screenshots

<img width="147" alt="Screen Shot 2020-02-20 at 10 42 03 am" src="https://user-images.githubusercontent.com/361637/74887142-370a1f00-53ce-11ea-924c-616d81645424.png">
