### PR TITLE
Add support for serverside notifications in UI.

### DIFF
--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -93,6 +93,9 @@ describe("App", () => {
       messages: {
         items: []
       },
+      notification: {
+        items: []
+      },
       status: {},
       user: {
         auth: {

--- a/ui/src/app/base/actions/notification/notification.js
+++ b/ui/src/app/base/actions/notification/notification.js
@@ -16,4 +16,6 @@ notification.delete = createAction(`DELETE_NOTIFICATION`, id => ({
   }
 }));
 
+notification.delete.notify = createAction(`DELETE_NOTIFICATION_NOTIFY`);
+
 export default notification;

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.js
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.js
@@ -1,0 +1,110 @@
+import classNames from "classnames";
+import pluralize from "pluralize";
+import PropTypes from "prop-types";
+import React from "react";
+import { useDispatch } from "react-redux";
+import { Button } from "@canonical/react-components";
+
+import { capitaliseFirst } from "app/utils";
+import { useVisible } from "app/base/hooks";
+import NotificationGroupMessage from "app/base/components/NotificationGroupMessage";
+import { notification as notificationActions } from "app/base/actions";
+
+export const notificationTypes = {
+  CAUTION: "caution",
+  INFORMATION: "information",
+  NEGATIVE: "negative",
+  POSITIVE: "positive"
+};
+
+const dismissAll = (notifications, dispatch) => {
+  notifications.forEach(notification => {
+    dismiss(notification.id, dispatch);
+  });
+};
+
+const dismiss = (id, dispatch) => {
+  dispatch(notificationActions.delete(id));
+};
+
+const NotificationGroup = ({ notifications, type }) => {
+  const dispatch = useDispatch();
+  const [groupOpen, toggleGroup] = useVisible(false);
+
+  const notificationCount =
+    type === "information"
+      ? `${notifications.length} Other messages`
+      : `${notifications.length} ${pluralize(
+          capitaliseFirst(notifications[0].category, notifications.length)
+        )}`;
+
+  return (
+    <div className="row p-notification--group">
+      <div className={`p-notification--${type}`}>
+        <div className="p-notification__toggle">
+          {notifications.length > 1 ? (
+            <p className="p-notification__response">
+              <Button
+                appearance="link"
+                onClick={toggleGroup}
+                className="u-no-margin u-no-padding"
+                aria-label={`${notifications.length} ${type}, click to open messages.`}
+              >
+                <span
+                  className="p-notification__status"
+                  data-test="notification-count"
+                >
+                  {notificationCount}
+                </span>
+                <small>
+                  <i
+                    className={classNames({
+                      "p-icon--collapse": groupOpen,
+                      "p-icon--expand": !groupOpen
+                    })}
+                  ></i>
+                </small>
+              </Button>
+              <Button
+                appearance="link"
+                className="p-notification__action u-no-margin u-no-padding"
+                onClick={() => dismissAll(notifications, dispatch)}
+              >
+                Dismiss all
+              </Button>
+            </p>
+          ) : (
+            <NotificationGroupMessage
+              message={notifications[0].message}
+              id={notifications[0].id}
+              action="Dismiss"
+              actionHandler={dismiss}
+            />
+          )}
+        </div>
+        {groupOpen && notifications.length > 1 && (
+          <ul className="p-list--divided u-no-margin--bottom">
+            {notifications.map(notification => (
+              <li key={notification.id} className="p-list__item">
+                <NotificationGroupMessage
+                  message={notification.message}
+                  id={notification.id}
+                  action="Dismiss"
+                  actionHandler={dismiss}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+NotificationGroup.propTypes = {
+  notifications: PropTypes.arrayOf(PropTypes.object).isRequired,
+  type: PropTypes.oneOf(["caution", "negative", "positive", "information"])
+    .isRequired
+};
+
+export default NotificationGroup;

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.js
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.js
@@ -1,0 +1,149 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import NotificationGroup from "./NotificationGroup";
+
+const mockStore = configureStore();
+
+describe("NotificationGroup", () => {
+  let state;
+  beforeEach(() => {
+    state = {};
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const notifications = [
+      { id: 1, category: "error", message: "an error occurred" },
+      { id: 2, category: "error", message: "an error occurred" }
+    ];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    expect(wrapper.find("NotificationGroup")).toMatchSnapshot();
+  });
+
+  it("displays a single notification by default", () => {
+    const store = mockStore(state);
+    const notifications = [
+      { id: 1, category: "error", message: "an error occurred" }
+    ];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("span[data-test='notification-message']").text()
+    ).toEqual("an error occurred");
+  });
+
+  it("hides multiple notifications by default", () => {
+    const store = mockStore(state);
+    const notifications = [
+      { id: 1, category: "error", message: "an error occurred" },
+      { id: 2, category: "error", message: "an error occurred" }
+    ];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("span[data-test='notification-message']").exists()
+    ).toBe(false);
+  });
+
+  it("displays a count for multiple notifications", () => {
+    const store = mockStore(state);
+    const notifications = [
+      { id: 1, category: "error", message: "an error occurred" },
+      { id: 2, category: "error", message: "an error occurred" }
+    ];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    expect(wrapper.find("span[data-test='notification-count']").text()).toEqual(
+      "2 Errors"
+    );
+  });
+
+  it("can dismiss multiple notifications", () => {
+    const store = mockStore(state);
+    const notifications = [
+      { id: 1, category: "error", message: "an error occurred" },
+      { id: 2, category: "error", message: "an error occurred" }
+    ];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    wrapper
+      .find("Button")
+      .at(1)
+      .simulate("click");
+
+    expect(store.getActions().length).toEqual(2);
+    expect(store.getActions()[0].type).toEqual("DELETE_NOTIFICATION");
+    expect(store.getActions()[1].type).toEqual("DELETE_NOTIFICATION");
+  });
+
+  it("can dismiss a single notification", () => {
+    const store = mockStore(state);
+    const notifications = [
+      { id: 1, category: "error", message: "an error occurred" }
+    ];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    wrapper.find("button[data-test='action-link']").simulate("click");
+
+    expect(store.getActions().length).toEqual(1);
+    expect(store.getActions()[0].type).toEqual("DELETE_NOTIFICATION");
+  });
+
+  it("can toggle multiple notifications", () => {
+    const store = mockStore(state);
+    const notifications = [
+      { id: 1, category: "error", message: "an error occurred" },
+      { id: 2, category: "error", message: "an error occurred" },
+      { id: 3, category: "error", message: "an error occurred" }
+    ];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    expect(wrapper.find("NotificationGroupMessage").length).toEqual(0);
+
+    wrapper
+      .find("Button")
+      .at(0)
+      .simulate("click");
+
+    expect(wrapper.find("NotificationGroupMessage").length).toEqual(3);
+  });
+});

--- a/ui/src/app/base/components/NotificationGroup/__snapshots__/NotificationGroup.test.js.snap
+++ b/ui/src/app/base/components/NotificationGroup/__snapshots__/NotificationGroup.test.js.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationGroup renders 1`] = `
+<NotificationGroup
+  notifications={
+    Array [
+      Object {
+        "category": "error",
+        "id": 1,
+        "message": "an error occurred",
+      },
+      Object {
+        "category": "error",
+        "id": 2,
+        "message": "an error occurred",
+      },
+    ]
+  }
+  type="negative"
+>
+  <div
+    className="row p-notification--group"
+  >
+    <div
+      className="p-notification--negative"
+    >
+      <div
+        className="p-notification__toggle"
+      >
+        <p
+          className="p-notification__response"
+        >
+          <Button
+            appearance="link"
+            aria-label="2 negative, click to open messages."
+            className="u-no-margin u-no-padding"
+            onClick={[Function]}
+          >
+            <button
+              aria-label="2 negative, click to open messages."
+              className="p-button--link u-no-margin u-no-padding"
+              onClick={[Function]}
+            >
+              <span
+                className="p-notification__status"
+                data-test="notification-count"
+              >
+                2 Errors
+              </span>
+              <small>
+                <i
+                  className="p-icon--expand"
+                />
+              </small>
+            </button>
+          </Button>
+          <Button
+            appearance="link"
+            className="p-notification__action u-no-margin u-no-padding"
+            onClick={[Function]}
+          >
+            <button
+              className="p-button--link p-notification__action u-no-margin u-no-padding"
+              onClick={[Function]}
+            >
+              Dismiss all
+            </button>
+          </Button>
+        </p>
+      </div>
+    </div>
+  </div>
+</NotificationGroup>
+`;

--- a/ui/src/app/base/components/NotificationGroup/index.js
+++ b/ui/src/app/base/components/NotificationGroup/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NotificationGroup";

--- a/ui/src/app/base/components/NotificationGroupMessage/NotificationGroupMessage.js
+++ b/ui/src/app/base/components/NotificationGroupMessage/NotificationGroupMessage.js
@@ -1,0 +1,36 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useDispatch } from "react-redux";
+import { Button } from "@canonical/react-components";
+
+const NotificationGroupMessage = ({ message, id, action, actionHandler }) => {
+  const dispatch = useDispatch();
+  return (
+    <p className="p-notification__response">
+      <span
+        className="p-notification__status"
+        data-test="notification-message"
+        dangerouslySetInnerHTML={{ __html: message }}
+      ></span>
+      {action && (
+        <Button
+          appearance="link"
+          data-test="action-link"
+          className="p-notification__action"
+          onClick={() => actionHandler(id, dispatch)}
+        >
+          {action}
+        </Button>
+      )}
+    </p>
+  );
+};
+
+NotificationGroupMessage.propTypes = {
+  message: PropTypes.string.isRequired,
+  id: PropTypes.number,
+  action: PropTypes.string,
+  actionHandler: PropTypes.func
+};
+
+export default NotificationGroupMessage;

--- a/ui/src/app/base/components/NotificationGroupMessage/NotificationGroupMessage.test.js
+++ b/ui/src/app/base/components/NotificationGroupMessage/NotificationGroupMessage.test.js
@@ -1,0 +1,57 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import NotificationGroupMessage from "./NotificationGroupMessage";
+
+const mockStore = configureStore();
+
+describe("NotificationGroupMessage", () => {
+  let state;
+  beforeEach(() => {
+    state = {};
+  });
+
+  it("renders a message", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroupMessage message="Hello there" />
+      </Provider>
+    );
+
+    expect(wrapper.find("NotificationGroupMessage").text()).toContain(
+      "Hello there"
+    );
+  });
+
+  it("optionally renders an action", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroupMessage message="A message" action="delete" />
+      </Provider>
+    );
+    expect(wrapper.find("NotificationGroupMessage").text()).toContain("delete");
+  });
+
+  it("can call a callback", () => {
+    const callback = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroupMessage
+          message="A message"
+          action="delete"
+          id={1}
+          actionHandler={callback}
+        />
+      </Provider>
+    );
+
+    wrapper.find("button[data-test='action-link']").simulate("click");
+
+    expect(callback).toHaveBeenCalledWith(1, expect.anything());
+  });
+});

--- a/ui/src/app/base/components/NotificationGroupMessage/index.js
+++ b/ui/src/app/base/components/NotificationGroupMessage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NotificationGroupMessage";

--- a/ui/src/app/base/components/NotificationList/NotificationList.js
+++ b/ui/src/app/base/components/NotificationList/NotificationList.js
@@ -1,4 +1,5 @@
 import { Notification } from "@canonical/react-components";
+
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect } from "react";
 
@@ -6,7 +7,11 @@ import {
   messages as messageActions,
   notification as notificationActions
 } from "app/base/actions";
-import { messages as messageSelectors } from "app/base/selectors";
+import {
+  messages as messageSelectors,
+  notification as notificationSelectors
+} from "app/base/selectors";
+import NotificationGroup from "app/base/components/NotificationGroup";
 
 const generateMessages = (messages, dispatch) =>
   messages.map(({ id, message, status, temporary, type }) => (
@@ -23,13 +28,51 @@ const generateMessages = (messages, dispatch) =>
 
 const NotificationList = ({ children, sidebar, title }) => {
   const messages = useSelector(messageSelectors.all);
+
+  const notifications = {
+    warnings: {
+      items: useSelector(notificationSelectors.warnings),
+      type: "caution"
+    },
+    errors: {
+      items: useSelector(notificationSelectors.errors),
+      type: "negative"
+    },
+    success: {
+      items: useSelector(notificationSelectors.success),
+      type: "positive"
+    },
+    info: {
+      items: useSelector(notificationSelectors.info),
+      type: "information"
+    }
+  };
+
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(notificationActions.fetch());
   }, [dispatch]);
 
-  return <>{generateMessages(messages, dispatch)}</>;
+  return (
+    <>
+      {Object.keys(notifications).map(group => {
+        const type = notifications[group].type;
+        if (notifications[group].items.length > 0) {
+          return (
+            <NotificationGroup
+              key={type}
+              type={type}
+              notifications={notifications[group].items}
+            />
+          );
+        }
+        return null;
+      })}
+
+      {generateMessages(messages, dispatch)}
+    </>
+  );
 };
 
 export default NotificationList;

--- a/ui/src/app/base/components/NotificationList/NotificationList.js
+++ b/ui/src/app/base/components/NotificationList/NotificationList.js
@@ -1,5 +1,4 @@
 import { Notification } from "@canonical/react-components";
-
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect } from "react";
 
@@ -7,11 +6,11 @@ import {
   messages as messageActions,
   notification as notificationActions
 } from "app/base/actions";
+import NotificationGroup from "app/base/components/NotificationGroup";
 import {
   messages as messageSelectors,
   notification as notificationSelectors
 } from "app/base/selectors";
-import NotificationGroup from "app/base/components/NotificationGroup";
 
 const generateMessages = (messages, dispatch) =>
   messages.map(({ id, message, status, temporary, type }) => (

--- a/ui/src/app/base/components/NotificationList/NotificationList.test.js
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.js
@@ -12,7 +12,16 @@ describe("NotificationList", () => {
 
   beforeEach(() => {
     state = {
-      messages: { items: [{ id: 1, message: "User deleted" }] }
+      messages: { items: [{ id: 1, message: "User deleted" }] },
+      notification: {
+        items: [
+          {
+            id: 1,
+            category: "error",
+            message: "an error"
+          }
+        ]
+      }
     };
   });
 
@@ -24,6 +33,24 @@ describe("NotificationList", () => {
       </Provider>
     );
     expect(wrapper.find("NotificationList")).toMatchSnapshot();
+  });
+
+  it("can hide a message", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationList title="Settings">content</NotificationList>
+      </Provider>
+    );
+    wrapper
+      .find("Notification")
+      .props()
+      .close();
+
+    expect(store.getActions()[1]).toEqual({
+      type: "REMOVE_MESSAGE",
+      payload: 1
+    });
   });
 
   it("fetches notifications", () => {
@@ -39,21 +66,20 @@ describe("NotificationList", () => {
     ).toBe(true);
   });
 
-  it("can hide a notification", () => {
+  it("displays a NotificationGroup for notifications", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <NotificationList title="Settings">content</NotificationList>
       </Provider>
     );
-    wrapper
-      .find("Notification")
-      .props()
-      .close();
 
-    expect(store.getActions()[1]).toEqual({
-      type: "REMOVE_MESSAGE",
-      payload: 1
+    const notificationGroup = wrapper.find("NotificationGroup");
+
+    expect(notificationGroup.exists()).toBe(true);
+    expect(notificationGroup.props()).toEqual({
+      type: "negative",
+      notifications: [{ id: 1, category: "error", message: "an error" }]
     });
   });
 });

--- a/ui/src/app/base/components/NotificationList/__snapshots__/NotificationList.test.js.snap
+++ b/ui/src/app/base/components/NotificationList/__snapshots__/NotificationList.test.js.snap
@@ -2,6 +2,66 @@
 
 exports[`NotificationList renders a list of messages 1`] = `
 <NotificationList>
+  <NotificationGroup
+    key="negative"
+    notifications={
+      Array [
+        Object {
+          "category": "error",
+          "id": 1,
+          "message": "an error",
+        },
+      ]
+    }
+    type="negative"
+  >
+    <div
+      className="row p-notification--group"
+    >
+      <div
+        className="p-notification--negative"
+      >
+        <div
+          className="p-notification__toggle"
+        >
+          <NotificationGroupMessage
+            action="Dismiss"
+            actionHandler={[Function]}
+            id={1}
+            message="an error"
+          >
+            <p
+              className="p-notification__response"
+            >
+              <span
+                className="p-notification__status"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "an error",
+                  }
+                }
+                data-test="notification-message"
+              />
+              <Button
+                appearance="link"
+                className="p-notification__action"
+                data-test="action-link"
+                onClick={[Function]}
+              >
+                <button
+                  className="p-button--link p-notification__action"
+                  data-test="action-link"
+                  onClick={[Function]}
+                >
+                  Dismiss
+                </button>
+              </Button>
+            </p>
+          </NotificationGroupMessage>
+        </div>
+      </div>
+    </div>
+  </NotificationGroup>
   <Notification
     close={[Function]}
     key="1"

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -212,7 +212,7 @@ export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
     ];
   }
   return actionLinks;
-}
+};
 
 /**
  * Simple hook for visibility toggles.

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -2,7 +2,7 @@ import { __RouterContext as RouterContext } from "react-router";
 import { notificationTypes } from "@canonical/react-components";
 import { useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useEffect, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useFormikContext } from "formik";
 
 import { sendAnalyticsEvent } from "analytics";
@@ -160,7 +160,6 @@ export const useSendAnalytics = (
   }, [sendCondition, eventCategory, eventAction, eventLabel]);
 };
 
-//
 const actionMethodOverrides = new Map([
   ["exit-rescue-mode", "exitRescueMode"],
   ["mark-broken", "markBroken"],
@@ -213,4 +212,17 @@ export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
     ];
   }
   return actionLinks;
+}
+
+/**
+ * Simple hook for visibility toggles.
+ * @param {Bool} initialValue - initial toggle value.
+ */
+export const useVisible = initialValue => {
+  const [value, setValue] = useState(initialValue);
+  const toggleValue = evt => {
+    evt.preventDefault();
+    setValue(!value);
+  };
+  return [value, toggleValue];
 };

--- a/ui/src/app/base/selectors/index.js
+++ b/ui/src/app/base/selectors/index.js
@@ -7,6 +7,7 @@ export { default as general } from "./general";
 export { default as licensekeys } from "./licensekeys";
 export { default as machine } from "./machine";
 export { default as messages } from "./messages";
+export { default as notification } from "./notification";
 export { default as packagerepository } from "./packagerepository";
 export { default as resourcepool } from "./resourcepool";
 export { default as scripts } from "./scripts";

--- a/ui/src/app/base/selectors/notification/index.js
+++ b/ui/src/app/base/selectors/notification/index.js
@@ -1,0 +1,1 @@
+export { default } from "./notification";

--- a/ui/src/app/base/selectors/notification/notification.js
+++ b/ui/src/app/base/selectors/notification/notification.js
@@ -1,0 +1,72 @@
+const notification = {};
+
+/**
+ * Returns all notifications.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all notifications.
+ */
+notification.all = state => state.notification.items;
+
+/**
+ * Whether notifications are loading.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Notifications are loading.
+ */
+notification.loading = state => state.notification.loading;
+
+/**
+ * Whether notifications have been loaded.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Notifications have loaded.
+ */
+notification.loaded = state => state.notification.loaded;
+
+/**
+ * Returns a notification for the given id.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A notification.
+ */
+notification.getById = (state, id) =>
+  state.notification.items.find(notification => notification.id === id);
+
+/**
+ * Returns notifications of type 'warning'
+ * @param {Object} state - The redux state.
+ * @returns {Array} A notification.
+ */
+notification.warnings = state =>
+  state.notification.items.filter(
+    notification => notification.category === "warning"
+  );
+
+/**
+ * Returns notifications of type 'error'
+ * @param {Object} state - The redux state.
+ * @returns {Array} A notification.
+ */
+notification.errors = state =>
+  state.notification.items.filter(
+    notification => notification.category === "error"
+  );
+
+/**
+ * Returns notifications of type 'success'
+ * @param {Object} state - The redux state.
+ * @returns {Array} A notification.
+ */
+notification.success = state =>
+  state.notification.items.filter(
+    notification => notification.category === "success"
+  );
+
+/**
+ * Returns notifications of type 'info'
+ * @param {Object} state - The redux state.
+ * @returns {Array} A notification.
+ */
+notification.info = state =>
+  state.notification.items.filter(
+    notification => notification.category === "info"
+  );
+
+export default notification;

--- a/ui/src/app/base/selectors/notification/notification.test.js
+++ b/ui/src/app/base/selectors/notification/notification.test.js
@@ -1,0 +1,56 @@
+import notification from "./notification";
+
+describe("notification selectors", () => {
+  it("can get all items", () => {
+    const state = {
+      notification: {
+        items: [{ name: "maas.test" }]
+      }
+    };
+    expect(notification.all(state)).toEqual([{ name: "maas.test" }]);
+  });
+
+  it("can get the loading state", () => {
+    const state = {
+      notification: {
+        loading: true,
+        items: []
+      }
+    };
+    expect(notification.loading(state)).toEqual(true);
+  });
+
+  it("can get the loaded state", () => {
+    const state = {
+      notification: {
+        loaded: true,
+        items: []
+      }
+    };
+    expect(notification.loaded(state)).toEqual(true);
+  });
+
+  it("can get a notification by id", () => {
+    const state = {
+      notification: {
+        items: [
+          {
+            message: "Something terrible occurred",
+            category: "error",
+            id: 808
+          },
+          {
+            message: "Something rather good happened",
+            category: "info",
+            id: 909
+          }
+        ]
+      }
+    };
+    expect(notification.getById(state, 909)).toStrictEqual({
+      message: "Something rather good happened",
+      category: "info",
+      id: 909
+    });
+  });
+});

--- a/ui/src/app/base/views/NotFound/NotFound.test.js
+++ b/ui/src/app/base/views/NotFound/NotFound.test.js
@@ -18,6 +18,9 @@ describe("NotFound ", () => {
       },
       messages: {
         items: []
+      },
+      notification: {
+        items: []
       }
     };
   });

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -154,6 +154,9 @@ describe("Machines", () => {
           }
         ]
       },
+      notification: {
+        items: []
+      },
       resourcepool: {
         items: []
       },

--- a/ui/src/app/preferences/views/Preferences.test.js
+++ b/ui/src/app/preferences/views/Preferences.test.js
@@ -16,6 +16,9 @@ describe("Preferences", () => {
       },
       messages: {
         items: []
+      },
+      notification: {
+        items: []
       }
     });
     const wrapper = mount(

--- a/ui/src/app/settings/views/Settings.test.js
+++ b/ui/src/app/settings/views/Settings.test.js
@@ -21,6 +21,9 @@ describe("Settings", () => {
       messages: {
         items: []
       },
+      notification: {
+        items: []
+      },
       status: {},
       user: {
         auth: {

--- a/ui/src/app/utils/capitaliseFirst.js
+++ b/ui/src/app/utils/capitaliseFirst.js
@@ -1,0 +1,6 @@
+/**
+ * Capitalises the first character of a string.
+ * @param {String} text
+ */
+export const capitaliseFirst = ([firstLetter, ...rest]) =>
+  [firstLetter.toLocaleUpperCase(), ...rest].join("");

--- a/ui/src/app/utils/capitaliseFirst.test.js
+++ b/ui/src/app/utils/capitaliseFirst.test.js
@@ -1,0 +1,7 @@
+import { capitaliseFirst } from "./capitaliseFirst";
+
+describe("capitaliseFirst", () => {
+  it("correctly capitalises the first letter of a string", () => {
+    expect(capitaliseFirst("foo bar")).toEqual("Foo bar");
+  });
+});

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -1,3 +1,4 @@
 export { formatBytes } from "./formatBytes";
 export { groupAsMap } from "./groupAsMap";
 export { simpleSortByKey } from "./simpleSortByKey";
+export { capitaliseFirst } from "./capitaliseFirst";

--- a/ui/src/scss/_patterns_notifications.scss
+++ b/ui/src/scss/_patterns_notifications.scss
@@ -1,0 +1,37 @@
+@mixin maas-p-notifications {
+  @include maas-notification;
+  @include maas-notification-group;
+  @include maas-notification-subtle;
+}
+
+@mixin maas-notification-group {
+  .p-notification--group {
+    > [class^="p-notification"] {
+      flex-direction: column;
+    }
+
+    .p-list--divided {
+      margin-top: $sp-small;
+      border-top: 1px dotted $color-mid-light;
+    }
+  }
+}
+
+@mixin maas-notification {
+  .p-notification {
+    &__response {
+      max-width: none;
+    }
+  }
+}
+
+@mixin maas-notification-subtle {
+  [class*="p-notification"].is-subtle {
+    background: transparent;
+    box-shadow: none;
+
+    &::before {
+      height: 0;
+    }
+  }
+}

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -6,12 +6,14 @@
 @import "./patterns_footer";
 @import "./patterns_icons";
 @import "./patterns_navigation";
+@import "./patterns_notifications";
 @import "./patterns_table";
 @import "./patterns_table-actions";
 
 @include maas-navigation;
 @include maas-p-sticky-footer;
 @include maas-double-row;
+@include maas-p-notifications;
 
 html {
   height: 100%;


### PR DESCRIPTION
## Done
* Add `NotificationGroup` and `NotificationGroupMessage` components for displaying and dismissing serverside notifications.

Note, this is *only* for serverside notifications. Messages generated by the app itself are still handled the same way. If we're going to consolidate our approach for these, it probably needs some UX discussion, as there are some tricky things to consider like - how do timeouts work in the context of a NotificationGroup? My gut feeling is that ephemeral messages like "You successfully added a user", should be handled differently from these serverside notifications. Perhaps what we already have makes the most sense. Something to consider perhaps @lilyvidenova 

## QA
* Add a single notification of any type.
* Ensure this displays without a toggle button, a "Dismiss all" button or a notification count.
* Ensure the notification can be dismissed.
* Add multiple notifications of any type.
* Ensure these display *with* a toggle, "Dismiss All" button, and notification count.
* Ensure the notification count is correct.
* Ensure the notification visibilty can be toggled.
* Ensure clicking "Dismiss All" removes all notifications of that type.

### Creating notifications for QA
A bit awkward sorry. If you have a method for creating these from the UI, by all means do that.

* Run MAAS from `make start`
* Run `make harness`
* import factories with `from maasserver.testing.factory import factory`
* create a bunch of notifications with `factory.make_Notification(admins=True)`

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1735 canonical-web-and-design/MAAS-squad#1737

## Screenshot
![image](https://user-images.githubusercontent.com/130286/74985870-3b513d80-549d-11ea-84b0-2c05b76186f6.png)

