### PR TITLE
Display a spinner when checking power

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -117,6 +117,7 @@ Object {
     "loading": false,
   },
   "machine": Object {
+    "awaitingUpdate": false,
     "errors": Object {},
     "items": Array [],
     "loaded": false,

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -35,6 +35,14 @@ const machine = produce(
             break;
           }
         }
+        draft.awaitingUpdate = false;
+        break;
+      case "CHECK_MACHINE_POWER_START":
+        draft.awaitingUpdate = true;
+        break;
+      case "CHECK_MACHINE_POWER_ERROR":
+        draft.awaitingUpdate = false;
+        draft.errors = action.error;
         break;
       case "ACQUIRE_MACHINE_ERROR":
       case "RELEASE_MACHINE_ERROR":
@@ -53,7 +61,6 @@ const machine = produce(
       case "SET_MACHINE_ZONE_ERROR":
       case "TURN_MACHINE_OFF_ERROR":
       case "TURN_MACHINE_ON_ERROR":
-      case "CHECK_MACHINE_POWER_ERROR":
         draft.errors = action.error;
         break;
       case "CLEANUP_MACHINE":
@@ -66,6 +73,7 @@ const machine = produce(
     }
   },
   {
+    awaitingUpdate: false,
     errors: {},
     items: [],
     loaded: false,

--- a/ui/src/app/base/reducers/machine/machine.test.js
+++ b/ui/src/app/base/reducers/machine/machine.test.js
@@ -3,6 +3,7 @@ import machine from "./machine";
 describe("machine reducer", () => {
   it("should return the initial state", () => {
     expect(machine(undefined, {})).toEqual({
+      awaitingUpdate: false,
       errors: {},
       items: [],
       loaded: false,
@@ -18,6 +19,7 @@ describe("machine reducer", () => {
         type: "FETCH_MACHINE_START"
       })
     ).toEqual({
+      awaitingUpdate: false,
       errors: {},
       items: [],
       loaded: false,
@@ -169,6 +171,7 @@ describe("machine reducer", () => {
     expect(
       machine(
         {
+          awaitingUpdate: true,
           errors: {},
           items: [
             { id: 1, hostname: "node1" },
@@ -188,6 +191,7 @@ describe("machine reducer", () => {
         }
       )
     ).toEqual({
+      awaitingUpdate: false,
       errors: {},
       items: [
         { id: 1, hostname: "node1v2" },
@@ -215,6 +219,7 @@ describe("machine reducer", () => {
         }
       )
     ).toEqual({
+      awaitingUpdate: false,
       errors: "Uh oh!",
       loading: true,
       loaded: false,

--- a/ui/src/app/base/selectors/machine/machine.js
+++ b/ui/src/app/base/selectors/machine/machine.js
@@ -57,4 +57,11 @@ machine.getBySystemId = (state, id) =>
  */
 machine.errors = state => state.machine.errors;
 
+/**
+ * Whether machines are awaiting update.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} Machines awaiting update state.
+ */
+machine.awaitingUpdate = state => state.machine.awaitingUpdate;
+
 export default machine;

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.test.js
@@ -1,3 +1,4 @@
+import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
@@ -164,5 +165,74 @@ describe("PowerColumn", () => {
         .at(1)
         .text()
     ).toEqual("No power actions available");
+  });
+
+  it("shows a spinner when turning a machine on", () => {
+    state.machine.items[0].actions = ["on"];
+    state.machine.items[0].power_state = "off";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(false);
+    act(() => {
+      wrapper
+        .find("DoubleRow")
+        .prop("menuLinks")[0]
+        .onClick();
+    });
+    wrapper.update();
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("shows a spinner when turning a machine off", () => {
+    state.machine.items[0].actions = ["off"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(false);
+    act(() => {
+      wrapper
+        .find("DoubleRow")
+        .prop("menuLinks")[0]
+        .onClick();
+    });
+    wrapper.update();
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("shows a spinner when checking power", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Loader").exists()).toBe(false);
+    act(() => {
+      wrapper
+        .find("DoubleRow")
+        .prop("menuLinks")[0]
+        .onClick();
+    });
+    wrapper.update();
+    expect(wrapper.find("Loader").exists()).toBe(true);
   });
 });


### PR DESCRIPTION
## Done
- Track state when waiting for a machine update.
- Display a spinner when awaiting a machine update.
Note: this may see the spinner prematurely stop as a machine update may be received from other actions. This issue is tracked here: https://github.com/canonical-web-and-design/maas-ui/issues/781.

## QA
- Load /r/machines.
- Click 'Check power' in the power menu.
- You should see a spinner.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/813.