### PR TITLE
Add extra macs fields to add machine form.

### DIFF
--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -155,7 +155,7 @@ export const AddMachineForm = () => {
               const params = {
                 architecture: values.architecture,
                 domain: domains.find(domain => domain.name === values.domain),
-                extra_macs: values.extra_macs,
+                extra_macs: values.extra_macs.filter(Boolean),
                 hostname: values.hostname,
                 min_hwe_kernel: values.min_hwe_kernel,
                 pool: resourcePools.find(pool => pool.name === values.pool),

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.test.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.test.js
@@ -259,4 +259,62 @@ describe("AddMachine", () => {
       }
     });
   });
+
+  it("correctly filters empty extra mac fields", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+        >
+          <AddMachineForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Submit the form with two extra macs, where one is an empty string
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          architecture: "amd64/generic",
+          domain: "maas",
+          extra_macs: ["12:12:12:12:12:12", ""],
+          hostname: "machine",
+          min_hwe_kernel: "ga-16.04",
+          pool: "default",
+          power_parameters: {},
+          power_type: "dummy",
+          pxe_mac: "11:11:11:11:11:11",
+          zone: "default"
+        })
+    );
+
+    // Expect the empty extra mac to be filtered out
+    expect(
+      store.getActions().find(action => action.type === "CREATE_MACHINE")
+    ).toStrictEqual({
+      type: "CREATE_MACHINE",
+      meta: {
+        method: "create",
+        model: "machine"
+      },
+      payload: {
+        params: {
+          architecture: "amd64/generic",
+          domain: state.domain.items[0],
+          extra_macs: ["12:12:12:12:12:12"],
+          hostname: "machine",
+          min_hwe_kernel: "ga-16.04",
+          pool: state.resourcepool.items[0],
+          power_parameters: {},
+          power_type: "dummy",
+          pxe_mac: "11:11:11:11:11:11",
+          zone: state.zone.items[0]
+        }
+      }
+    });
+  });
 });

--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
@@ -1,5 +1,5 @@
-import { Col, Row, Select } from "@canonical/react-components";
-import React from "react";
+import { Button, Col, Input, Row, Select } from "@canonical/react-components";
+import React, { useState } from "react";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
@@ -20,8 +20,10 @@ export const AddMachineFormFields = () => {
   const resourcePools = useSelector(resourcePoolSelectors.all);
   const zones = useSelector(zoneSelectors.all);
 
+  const [extraMACs, setExtraMACs] = useState([]);
+
   const formikProps = useFormikContext();
-  const { values } = formikProps;
+  const { setFieldValue, values } = formikProps;
 
   const architectureOptions = [
     {
@@ -124,6 +126,49 @@ export const AddMachineFormFields = () => {
           required
           type="text"
         />
+        {extraMACs.map((mac, i) => (
+          <div
+            className="p-input--closeable"
+            data-test={`extra-macs-${i}`}
+            key={`extra-macs-${i}`}
+          >
+            <Input
+              maxLength="17"
+              onChange={e => {
+                const newExtraMACs = [...extraMACs];
+                newExtraMACs[i] = e.target.value;
+                setExtraMACs(newExtraMACs);
+                setFieldValue("extra_macs", newExtraMACs);
+              }}
+              placeholder="00:00:00:00:00:00"
+              type="text"
+              value={mac}
+            />
+            <Button
+              className="p-close-input"
+              hasIcon
+              onClick={() => {
+                const newExtraMACs = extraMACs.filter((_, j) => j !== i);
+                setExtraMACs(newExtraMACs);
+                setFieldValue("extra_macs", newExtraMACs);
+              }}
+              type="button"
+            >
+              <i className="p-icon--close" />
+            </Button>
+          </div>
+        ))}
+        <div className="u-align--right">
+          <Button
+            data-test="add-extra-mac"
+            hasIcon
+            onClick={() => setExtraMACs([...extraMACs, ""])}
+            type="button"
+          >
+            <i className="p-icon--plus" />
+            <span>Add MAC address</span>
+          </Button>
+        </div>
       </Col>
       <Col size="5">
         <PowerTypeFields

--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.test.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.test.js
@@ -1,3 +1,4 @@
+import { act } from "react-dom/test-utils";
 import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
 import { MemoryRouter } from "react-router-dom";
@@ -92,5 +93,57 @@ describe("AddMachineFormFields", () => {
     expect(wrapper.find("Select[name='min_hwe_kernel']").props().value).toBe(
       "ga-18.04"
     );
+  });
+
+  it("can add extra mac address fields", async () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+        >
+          <AddMachineForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='extra-macs-0']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='extra-macs-1']").exists()).toBe(false);
+    await act(async () => {
+      wrapper.find("[data-test='add-extra-mac'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("[data-test='extra-macs-0']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='extra-macs-1']").exists()).toBe(false);
+    await act(async () => {
+      wrapper.find("[data-test='add-extra-mac'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("[data-test='extra-macs-0']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='extra-macs-1']").exists()).toBe(true);
+  });
+
+  it("can remove extra mac address fields", async () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+        >
+          <AddMachineForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    await act(async () => {
+      wrapper.find("[data-test='add-extra-mac'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("[data-test='extra-macs-0']").exists()).toBe(true);
+    await act(async () => {
+      wrapper.find("[data-test='extra-macs-0'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("[data-test='extra-macs-0']").exists()).toBe(false);
   });
 });

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -1,0 +1,10 @@
+.p-input--closeable {
+  position: relative;
+
+  .p-close-input {
+    margin: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+}

--- a/ui/src/scss/base.scss
+++ b/ui/src/scss/base.scss
@@ -4,6 +4,7 @@
 @import "./patterns_button";
 @import "./patterns_double-row";
 @import "./patterns_footer";
+@import "./patterns_forms";
 @import "./patterns_icons";
 @import "./patterns_navigation";
 @import "./patterns_notifications";


### PR DESCRIPTION
## Done
- Added extra macs button and extra macs fields to add machine form. Getting it to work with FormikField was tricky because of it being an optional field with variable size, so I've opted to instead build a more custom/imperative approach. I don't think this sort of pattern shows up anywhere else in MAAS.

## QA
- Go to /r/machines/add
- Check that you can add and remove extra MAC fields
- Submit the form with extra MACs
- Check that the network request includes an array of `extra_macs` and the machine is added successfully

## Fixes
Fixes #794 

## Screenshot
![0 0 0 0_8400_MAAS_r_machines_add (1)](https://user-images.githubusercontent.com/25733845/75049711-ecba9800-54ca-11ea-991e-7c53a43d160e.png)
