### PR TITLE
Improve helptext for settings analytics checkbox.

### DIFF
--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.js
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.js
@@ -51,9 +51,10 @@ const GeneralForm = () => {
         required={true}
       />
       <FormikField
-        label="Send anonymous data to help us improve MAAS"
+        label="Enable analytics to shape improvements to user experience"
         type="checkbox"
         name="enable_analytics"
+        help="The analytics used in MAAS are Google Analytics and Sentry Error Tracking."
       />
     </FormikForm>
   );


### PR DESCRIPTION
## Done
* Changed text for analytics textbox to "Enable analytics to shape improvements to user experience" with helptext of "The analytics used in MAAS are Google Analytics and Sentry Error Tracking."

## QA
none

## Fixes
Fixes #828  .

## Screenshot
![image](https://user-images.githubusercontent.com/130286/75208751-70cd9200-57e1-11ea-88ea-e76d5a44fed7.png)
