### PR TITLE
Build "Save and add another" secondary submit in hardware forms.

### DIFF
--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
@@ -1,15 +1,19 @@
 import { ActionButton, Button } from "@canonical/react-components";
-import { useRouter } from "app/base/hooks";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { useRouter } from "app/base/hooks";
+
 export const FormCardButtons = ({
-  actionDisabled,
-  actionLabel,
-  actionLoading,
-  actionSuccess
+  loading,
+  secondarySubmit,
+  secondarySubmitLabel,
+  submitDisabled,
+  submitLabel,
+  success
 }) => {
   const { history } = useRouter();
+
   return (
     <div className="form-card__buttons">
       <Button
@@ -20,25 +24,39 @@ export const FormCardButtons = ({
       >
         Cancel
       </Button>
+      {secondarySubmit && secondarySubmitLabel && (
+        <Button
+          appearance="neutral"
+          className="u-no-margin--bottom"
+          data-test="secondary-submit"
+          disabled={submitDisabled}
+          onClick={secondarySubmit}
+          type="button"
+        >
+          {secondarySubmitLabel}
+        </Button>
+      )}
       <ActionButton
         appearance="positive"
         className="u-no-margin--bottom"
-        disabled={actionDisabled}
-        loading={actionLoading}
-        success={actionSuccess}
+        disabled={submitDisabled}
+        loading={loading}
+        success={success}
         type="submit"
       >
-        {actionLabel}
+        {submitLabel}
       </ActionButton>
     </div>
   );
 };
 
 FormCardButtons.propTypes = {
-  actionDisabled: PropTypes.bool,
-  actionLabel: PropTypes.string.isRequired,
-  actionLoading: PropTypes.bool,
-  actionSuccess: PropTypes.bool
+  loading: PropTypes.bool,
+  secondarySubmit: PropTypes.func,
+  secondarySubmitLabel: PropTypes.string,
+  submitDisabled: PropTypes.bool,
+  submitLabel: PropTypes.string.isRequired,
+  success: PropTypes.bool
 };
 
 export default FormCardButtons;

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.js
@@ -8,9 +8,27 @@ describe("FormCardButtons ", () => {
   it("renders", () => {
     const wrapper = mount(
       <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-        <FormCardButtons actionLabel="Save user" />
+        <FormCardButtons submitLabel="Save user" />
       </MemoryRouter>
     );
     expect(wrapper.find("FormCardButtons")).toMatchSnapshot();
+  });
+
+  it("can perform a secondary submit action if function and label provided", () => {
+    const secondarySubmit = jest.fn();
+    const wrapper = mount(
+      <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+        <FormCardButtons
+          submitLabel="Save user"
+          secondarySubmit={secondarySubmit}
+          secondarySubmitLabel="Save and add another"
+        />
+      </MemoryRouter>
+    );
+    expect(wrapper.find("[data-test='secondary-submit'] button").text()).toBe(
+      "Save and add another"
+    );
+    wrapper.find("[data-test='secondary-submit'] button").simulate("click");
+    expect(secondarySubmit).toHaveBeenCalled();
   });
 });

--- a/ui/src/app/base/components/FormCardButtons/__snapshots__/FormCardButtons.test.js.snap
+++ b/ui/src/app/base/components/FormCardButtons/__snapshots__/FormCardButtons.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FormCardButtons  renders 1`] = `
 <FormCardButtons
-  actionLabel="Save user"
+  submitLabel="Save user"
 >
   <div
     className="form-card__buttons"

--- a/ui/src/app/base/components/FormikForm/FormikForm.js
+++ b/ui/src/app/base/components/FormikForm/FormikForm.js
@@ -20,6 +20,8 @@ const FormikForm = ({
   saving,
   saved,
   savedRedirect,
+  secondarySubmit,
+  secondarySubmitLabel,
   submitLabel,
   validationSchema,
   ...props
@@ -57,6 +59,8 @@ const FormikForm = ({
         onValuesChanged={onValuesChanged}
         saving={saving}
         saved={saved}
+        secondarySubmit={secondarySubmit}
+        secondarySubmitLabel={secondarySubmitLabel}
         submitLabel={submitLabel}
       >
         {children}
@@ -82,6 +86,8 @@ FormikForm.propTypes = {
   saving: PropTypes.bool,
   saved: PropTypes.bool,
   savedRedirect: PropTypes.string,
+  secondarySubmit: PropTypes.func,
+  secondarySubmitLabel: PropTypes.string,
   submitLabel: PropTypes.string,
   validationSchema: PropTypes.object.isRequired
 };

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
@@ -3,32 +3,32 @@ import PropTypes from "prop-types";
 import React from "react";
 
 export const FormikFormButtons = ({
-  actionDisabled,
-  actionLabel,
-  actionLoading,
-  actionSuccess
+  loading,
+  submitDisabled,
+  submitLabel,
+  success
 }) => {
   return (
     <div>
       <ActionButton
         appearance="positive"
         className="u-no-margin--bottom"
-        disabled={actionDisabled}
-        loading={actionLoading}
-        success={actionSuccess}
+        disabled={submitDisabled}
+        loading={loading}
+        success={success}
         type="submit"
       >
-        {actionLabel}
+        {submitLabel}
       </ActionButton>
     </div>
   );
 };
 
 FormikFormButtons.propTypes = {
-  actionDisabled: PropTypes.bool,
-  actionLabel: PropTypes.string.isRequired,
-  actionLoading: PropTypes.bool,
-  actionSuccess: PropTypes.bool
+  loading: PropTypes.bool,
+  submitDisabled: PropTypes.bool,
+  submitLabel: PropTypes.string.isRequired,
+  success: PropTypes.bool
 };
 
 export default FormikFormButtons;

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.js
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.js
@@ -5,7 +5,7 @@ import FormikFormButtons from "./FormikFormButtons";
 
 describe("FormikFormButtons ", () => {
   it("renders", () => {
-    const wrapper = shallow(<FormikFormButtons actionLabel="Save user" />);
+    const wrapper = shallow(<FormikFormButtons submitLabel="Save user" />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
@@ -14,9 +14,11 @@ const FormikFormContent = ({
   onValuesChanged,
   saving,
   saved,
+  secondarySubmit,
+  secondarySubmitLabel,
   submitLabel = "Save"
 }) => {
-  const { handleSubmit, values } = useFormikContext();
+  const { handleSubmit, submitForm, values } = useFormikContext();
   const formDisabled = useFormikFormDisabled(allowAllEmpty);
 
   useFormikErrors(errors);
@@ -43,10 +45,19 @@ const FormikFormContent = ({
       )}
       <div>{children}</div>
       <Buttons
-        actionDisabled={saving || formDisabled}
-        actionLabel={submitLabel}
-        actionLoading={saving}
-        actionSuccess={saved}
+        loading={saving}
+        secondarySubmit={
+          secondarySubmit
+            ? () => {
+                secondarySubmit();
+                submitForm();
+              }
+            : undefined
+        }
+        secondarySubmitLabel={secondarySubmitLabel}
+        submitDisabled={saving || formDisabled}
+        submitLabel={submitLabel}
+        success={saved}
       />
     </Form>
   );
@@ -60,6 +71,8 @@ FormikFormContent.propTypes = {
   onValuesChanged: PropTypes.func,
   saving: PropTypes.bool,
   saved: PropTypes.bool,
+  secondarySubmit: PropTypes.func,
+  secondarySubmitLabel: PropTypes.string,
   submitLabel: PropTypes.string
 };
 

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
@@ -41,11 +41,18 @@ export const AddChassisForm = () => {
   const machineSaving = useSelector(machineSelectors.saving);
 
   const [powerType, setPowerType] = useState("");
+  const [redirectOnSave, setRedirectOnSave] = useState(true);
   const [savingChassis, setSavingChassis] = useState(false);
 
   useEffect(() => {
     dispatch(domainActions.fetch());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (machineSaved && !redirectOnSave) {
+      setRedirectOnSave(true);
+    }
+  }, [machineSaved, redirectOnSave]);
 
   useWindowTitle("Add chassis");
 
@@ -88,7 +95,7 @@ export const AddChassisForm = () => {
               power_type: ""
             }}
             onSaveAnalytics={{
-              action: "Save",
+              action: redirectOnSave ? "Save" : "Save and add another",
               category: "Chassis",
               label: "Add chassis form"
             }}
@@ -109,7 +116,9 @@ export const AddChassisForm = () => {
             }}
             saving={machineSaving}
             saved={machineSaved}
-            savedRedirect="/machines"
+            savedRedirect={redirectOnSave ? "/machines" : undefined}
+            secondarySubmit={() => setRedirectOnSave(false)}
+            secondarySubmitLabel="Save and add another"
             submitLabel="Save chassis"
             validationSchema={ChassisSchema}
           >

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -76,8 +76,9 @@ export const AddMachineForm = () => {
   const zones = useSelector(zoneSelectors.all);
   const zonesLoaded = useSelector(zoneSelectors.loaded);
 
-  const [savingMachine, setSavingMachine] = useState(false);
   const [powerType, setPowerType] = useState("");
+  const [redirectOnSave, setRedirectOnSave] = useState(true);
+  const [savingMachine, setSavingMachine] = useState(false);
 
   // Fetch all data required for the form.
   useEffect(() => {
@@ -89,6 +90,12 @@ export const AddMachineForm = () => {
     dispatch(resourcePoolActions.fetch());
     dispatch(zoneActions.fetch());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (machineSaved && !redirectOnSave) {
+      setRedirectOnSave(true);
+    }
+  }, [machineSaved, redirectOnSave]);
 
   useWindowTitle("Add machine");
 
@@ -147,7 +154,7 @@ export const AddMachineForm = () => {
               zone: (zones.length && zones[0].name) || ""
             }}
             onSaveAnalytics={{
-              action: "Save",
+              action: redirectOnSave ? "Save" : "Save and add another",
               category: "Machine",
               label: "Add machine form"
             }}
@@ -178,7 +185,9 @@ export const AddMachineForm = () => {
             }}
             saving={machineSaving}
             saved={machineSaved}
-            savedRedirect="/machines"
+            savedRedirect={redirectOnSave ? "/machines" : undefined}
+            secondarySubmit={() => setRedirectOnSave(false)}
+            secondarySubmitLabel="Save and add another"
             submitLabel="Save machine"
             validationSchema={MachineSchema}
           >


### PR DESCRIPTION
## Done
- Add secondary submit props to FormCardButtons to allow another way to submit a form.
- In this case the the secondary submit is the same as the normal one, but the default "redirect on save" behaviour is prevented.

## QA
- Go to `/MAAS/r/machines/add` and fill the form in correctly.
- Click "Save and add another" and check that the new machine is added into state, a notification confirms it, and you are not redirected to the machine list.
- Fill in the form again and click "Save machine".
- Check that you are redirected to the machine list, as before.
- Do the same with the "Add chassis" form (`/MAAS/r/machines/chassis/add`)

## Fixes
Fixes #795 

## Screenshot

![0 0 0 0_8400_MAAS_r_machines (17)](https://user-images.githubusercontent.com/25733845/75273983-358f8b00-5802-11ea-9fb3-aad957ef6612.png)
