### PR TITLE
Add status badge for CI workflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is repository contains sourcecode for the [MAAS](http://maas.io) web  front
 
 [![CircleCI](https://circleci.com/gh/canonical-web-and-design/maas-ui/tree/master.svg?style=svg)](https://circleci.com/gh/canonical-web-and-design/maas-ui/tree/master)
 
+![CI](https://github.com/canonical-web-and-design/maas-ui/workflows/CI/badge.svg)
+
 It is comprised of the following [yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/):
 
   - *legacy*: the angularjs maas client.


### PR DESCRIPTION
## Done
Add status badge for CI github action workflow.

## QA
* View the rich diff of the README, badge should be green.