### PR TITLE
Remove leftover jQuery reference in add-chassis http request.

### DIFF
--- a/legacy/src/app/controllers/add_hardware.js
+++ b/legacy/src/app/controllers/add_hardware.js
@@ -634,12 +634,14 @@ function AddHardwareController(
     if (params.chassis_type === "powerkvm" || params.chassis_type === "virsh") {
       delete params.username;
     }
+
+    const urlParams = new URLSearchParams(Object.entries(params));
     // Add the chassis. For now we use the API as the websocket doesn't
     // support probe and enlist.
     $http({
       method: "POST",
       url: "api/2.0/machines/?op=add_chassis",
-      data: $.param(params),
+      data: urlParams.toString(),
       headers: {
         "Content-Type": "application/x-www-form-urlencoded"
       }

--- a/legacy/src/app/controllers/tests/test_add_hardware.js
+++ b/legacy/src/app/controllers/tests/test_add_hardware.js
@@ -714,10 +714,12 @@ describe("AddHardwareController", function() {
       var parameters = $scope.chassis.power.parameters;
       parameters.chassis_type = $scope.chassis.power.type.name;
       parameters.domain = $scope.chassis.domain.name;
+
+      const urlParams = new URLSearchParams(Object.entries(parameters));
       expect($http).toHaveBeenCalledWith({
         method: "POST",
         url: "api/2.0/machines/?op=add_chassis",
-        data: $.param(parameters),
+        data: urlParams.toString(),
         headers: {
           "Content-Type": "application/x-www-form-urlencoded"
         }


### PR DESCRIPTION
## Done
- Replaced leftover jQuery reference in legacy add-chassis http request with native javascript version.

## QA
- Go to `/MAAS/#/machines` > Click `Add hardware` > Click `Chassis`
- Fill in the form with a virsh power type (PowerKVM/Virsh)
- Submit the form and check that the network request has a 200 response code.

## Fixes
Fixes #842 

## Launchpad Issue
[lp#1864809](https://bugs.launchpad.net/maas/+bug/1864809)
