### PR TITLE
Reset add machine/chassis form if "add another" button used.

### DIFF
--- a/ui/src/app/base/components/FormikForm/FormikForm.js
+++ b/ui/src/app/base/components/FormikForm/FormikForm.js
@@ -17,6 +17,7 @@ const FormikForm = ({
   onSaveAnalytics = {},
   onSubmit,
   onValuesChanged,
+  resetOnSave,
   saving,
   saved,
   savedRedirect,
@@ -56,7 +57,9 @@ const FormikForm = ({
         allowAllEmpty={allowAllEmpty}
         buttons={buttons}
         errors={errors}
+        initialValues={initialValues}
         onValuesChanged={onValuesChanged}
+        resetOnSave={resetOnSave}
         saving={saving}
         saved={saved}
         secondarySubmit={secondarySubmit}
@@ -83,6 +86,7 @@ FormikForm.propTypes = {
   }),
   onSubmit: PropTypes.func.isRequired,
   onValuesChanged: PropTypes.func,
+  resetOnSave: PropTypes.bool,
   saving: PropTypes.bool,
   saved: PropTypes.bool,
   savedRedirect: PropTypes.string,

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
@@ -11,14 +11,16 @@ const FormikFormContent = ({
   buttons: Buttons = FormikFormButtons,
   children,
   errors,
+  initialValues,
   onValuesChanged,
+  resetOnSave,
   saving,
   saved,
   secondarySubmit,
   secondarySubmitLabel,
   submitLabel = "Save"
 }) => {
-  const { handleSubmit, submitForm, values } = useFormikContext();
+  const { handleSubmit, resetForm, submitForm, values } = useFormikContext();
   const formDisabled = useFormikFormDisabled(allowAllEmpty);
 
   useFormikErrors(errors);
@@ -26,6 +28,12 @@ const FormikFormContent = ({
   useEffect(() => {
     onValuesChanged && onValuesChanged(values);
   }, [values, onValuesChanged]);
+
+  useEffect(() => {
+    if (resetOnSave && saved) {
+      resetForm({ values: initialValues });
+    }
+  }, [initialValues, resetForm, resetOnSave, saved]);
 
   let nonFieldError;
   if (errors) {

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
@@ -41,7 +41,7 @@ export const AddChassisForm = () => {
   const machineSaving = useSelector(machineSelectors.saving);
 
   const [powerType, setPowerType] = useState("");
-  const [redirectOnSave, setRedirectOnSave] = useState(true);
+  const [resetOnSave, setResetOnSave] = useState(false);
   const [savingChassis, setSavingChassis] = useState(false);
 
   useEffect(() => {
@@ -49,10 +49,10 @@ export const AddChassisForm = () => {
   }, [dispatch]);
 
   useEffect(() => {
-    if (machineSaved && !redirectOnSave) {
-      setRedirectOnSave(true);
+    if (machineSaved && resetOnSave) {
+      setResetOnSave(false);
     }
-  }, [machineSaved, redirectOnSave]);
+  }, [machineSaved, resetOnSave]);
 
   useWindowTitle("Add chassis");
 
@@ -95,7 +95,7 @@ export const AddChassisForm = () => {
               power_type: ""
             }}
             onSaveAnalytics={{
-              action: redirectOnSave ? "Save" : "Save and add another",
+              action: resetOnSave ? "Save and add another" : "Save",
               category: "Chassis",
               label: "Add chassis form"
             }}
@@ -114,10 +114,11 @@ export const AddChassisForm = () => {
               );
               setPowerType(powerType);
             }}
+            resetOnSave={resetOnSave}
             saving={machineSaving}
             saved={machineSaved}
-            savedRedirect={redirectOnSave ? "/machines" : undefined}
-            secondarySubmit={() => setRedirectOnSave(false)}
+            savedRedirect={resetOnSave ? undefined : "/machines"}
+            secondarySubmit={() => setResetOnSave(true)}
             secondarySubmitLabel="Save and add another"
             submitLabel="Save chassis"
             validationSchema={ChassisSchema}

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -192,7 +192,7 @@ export const AddMachineForm = () => {
             submitLabel="Save machine"
             validationSchema={MachineSchema}
           >
-            <AddMachineFormFields />
+            <AddMachineFormFields saved={machineSaved} />
           </FormikForm>
         </FormCard>
       )}

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -77,7 +77,7 @@ export const AddMachineForm = () => {
   const zonesLoaded = useSelector(zoneSelectors.loaded);
 
   const [powerType, setPowerType] = useState("");
-  const [redirectOnSave, setRedirectOnSave] = useState(true);
+  const [resetOnSave, setResetOnSave] = useState(false);
   const [savingMachine, setSavingMachine] = useState(false);
 
   // Fetch all data required for the form.
@@ -92,10 +92,10 @@ export const AddMachineForm = () => {
   }, [dispatch]);
 
   useEffect(() => {
-    if (machineSaved && !redirectOnSave) {
-      setRedirectOnSave(true);
+    if (machineSaved && resetOnSave) {
+      setResetOnSave(false);
     }
-  }, [machineSaved, redirectOnSave]);
+  }, [machineSaved, resetOnSave]);
 
   useWindowTitle("Add machine");
 
@@ -154,7 +154,7 @@ export const AddMachineForm = () => {
               zone: (zones.length && zones[0].name) || ""
             }}
             onSaveAnalytics={{
-              action: redirectOnSave ? "Save" : "Save and add another",
+              action: resetOnSave ? "Save and add another" : "Save",
               category: "Machine",
               label: "Add machine form"
             }}
@@ -183,10 +183,11 @@ export const AddMachineForm = () => {
               );
               setPowerType(powerType);
             }}
+            resetOnSave={resetOnSave}
             saving={machineSaving}
             saved={machineSaved}
-            savedRedirect={redirectOnSave ? "/machines" : undefined}
-            secondarySubmit={() => setRedirectOnSave(false)}
+            savedRedirect={resetOnSave ? undefined : "/machines"}
+            secondarySubmit={() => setResetOnSave(true)}
             secondarySubmitLabel="Save and add another"
             submitLabel="Save machine"
             validationSchema={MachineSchema}

--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
@@ -1,5 +1,5 @@
 import { Button, Col, Input, Row, Select } from "@canonical/react-components";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
@@ -12,7 +12,7 @@ import {
 import FormikField from "app/base/components/FormikField";
 import PowerTypeFields from "app/machines/components/PowerTypeFields";
 
-export const AddMachineFormFields = () => {
+export const AddMachineFormFields = ({ saved }) => {
   const architectures = useSelector(generalSelectors.architectures.get);
   const domains = useSelector(domainSelectors.all);
   const hweKernels = useSelector(generalSelectors.hweKernels.get);
@@ -24,6 +24,12 @@ export const AddMachineFormFields = () => {
 
   const formikProps = useFormikContext();
   const { setFieldValue, values } = formikProps;
+
+  useEffect(() => {
+    if (saved) {
+      setExtraMACs([]);
+    }
+  }, [saved]);
 
   const architectureOptions = [
     {


### PR DESCRIPTION
## Done
- Reset add machine/chassis form if user successfully submits with the "Save and add another" button.
- Reworded some FormikForm props from `redirectOnSave` to `resetOnSave` (and consequently reversed logic). Seems a bit clearer for me to highlight resetting a form than handling redirects in the form logic.

## QA
- Go to `/MAAS/r/machines/add`
- Fill in the fields and add a machine using the "Save and add another" button.
- Check the form resets on successful submit and a notification confirms the machine is added.
- Add another machine using values that will return an error from the backend (i.e. duplicate hostname/MAC, unknown virsh address, etc.)
- Submit the form with "Save and add another"
- Check that an error notification shows up and the form does not get reset.
- Do the same at `/MAAS/r/machines/chassis/add`

## Fixes
Fixes #844 
