### PR TITLE
Add machine searching

### DIFF
--- a/ui/src/app/base/selectors/machine/machine.js
+++ b/ui/src/app/base/selectors/machine/machine.js
@@ -1,3 +1,7 @@
+import { createSelector } from "reselect";
+
+import filterNodes from "app/machines/filter-nodes";
+
 const machine = {};
 
 /**
@@ -56,5 +60,29 @@ machine.getBySystemId = (state, id) =>
  * @returns {Object} Errors for machines.
  */
 machine.errors = state => state.machine.errors;
+
+/**
+ * Gets the search terms.
+ * @param {Object} state - The redux state.
+ * @param {Array} terms - The search terms.
+ * @returns {Array} The search terms.
+ */
+machine._getTerms = (state, terms) => terms;
+
+/**
+ * Get machines that match terms.
+ * @param {Object} state - The redux state.
+ * @param {String} terms - The terms to match against.
+ * @returns {Array} A filtered list of machines.
+ */
+machine.search = createSelector(
+  [machine.all, machine._getTerms],
+  (items, terms) => {
+    if (!terms) {
+      return items;
+    }
+    return filterNodes(items, terms);
+  }
+);
 
 export default machine;

--- a/ui/src/app/machines/filter-nodes.js
+++ b/ui/src/app/machines/filter-nodes.js
@@ -1,0 +1,179 @@
+import { getCurrentFilters } from "./search";
+
+// Helpers that convert the pseudo field on node to an actual
+// value from the node.
+const mappings = {
+  cpu: node => node.cpu_count,
+  cores: node => node.cpu_count,
+  ram: node => node.memory,
+  mac: node => [node.pxe_mac, ...node.extra_macs],
+  zone: node => node.zone.name,
+  pool: node => node.pool.name,
+  pod: node => node.pod && node.pod.name,
+  "pod-id": node => node.pod && node.pod.id,
+  power: node => node.power_state,
+  release: node =>
+    node.status_code === 6 || node.status_code === 9
+      ? node.osystem + "/" + node.distro_series
+      : "",
+  hostname: node => node.hostname,
+  vlan: node => node.vlan,
+  rack: node => node.observer_hostname,
+  subnet: node => node.subnet_cidr,
+  numa_nodes_count: ({ numa_nodes_count, numa_nodes }) => {
+    const count = numa_nodes_count || (numa_nodes && numa_nodes.length);
+    return `${count} node${count !== 1 ? "s" : ""}`;
+  },
+  sriov_support: ({ sriov_support, interfaces }) =>
+    sriov_support ||
+    (interfaces && interfaces.some(iface => iface.sriov_max_vf >= 1))
+      ? "Supported"
+      : "Not supported"
+};
+
+// Return true when lowercase value contains the already
+// lowercased lowerTerm.
+const _matches = (value, lowerTerm, exact) => {
+  if (typeof value === "number") {
+    if (exact) {
+      if (Number.isInteger(value)) {
+        return value === parseInt(lowerTerm, 10);
+      } else {
+        return value === parseFloat(lowerTerm);
+      }
+    } else {
+      if (Number.isInteger(value)) {
+        return value >= parseInt(lowerTerm, 10);
+      } else {
+        return value >= parseFloat(lowerTerm);
+      }
+    }
+  } else if (typeof value === "string") {
+    if (exact) {
+      return value.toLowerCase() === lowerTerm;
+    } else {
+      return value.toLowerCase().indexOf(lowerTerm) >= 0;
+    }
+  } else {
+    return value === lowerTerm;
+  }
+};
+
+// Return true if value matches lowerTerm, unless negate is true then
+// return false if matches.
+const matches = (value, lowerTerm, exact, negate) => {
+  const match = _matches(value, lowerTerm, exact);
+  return negate ? !match : match;
+};
+
+const filterNodes = (nodes, search) => {
+  if (
+    typeof nodes === "undefined" ||
+    typeof search === "undefined" ||
+    nodes.length === 0
+  ) {
+    return nodes;
+  }
+  const filters = getCurrentFilters(search);
+  Object.entries(filters).forEach(([attr, terms]) => {
+    if (terms.length === 0) {
+      // If this attribute has no associated terms then skip it.
+      return;
+    }
+    if (attr === "in") {
+      // "in:" is used to filter the nodes by those that are
+      // currently selected.
+      terms.forEach(term => {
+        const matched = [];
+        nodes.forEach(node => {
+          if (node.$selected && term.toLowerCase() === "selected") {
+            matched.push(node);
+          } else if (!node.$selected && term.toLowerCase() === "!selected") {
+            matched.push(node);
+          }
+        });
+        nodes = matched;
+      });
+    } else {
+      // Loop through each item and only select the matching.
+      const matched = [];
+      nodes.forEach(node => {
+        // Loop through the attributes to check. If this is for the
+        // generic "_" filter then check against all node attributes.
+        (attr === "_" ? Object.keys(node) : [attr]).some(key => {
+          // Mapping function for the attribute.
+          const mapFunc = mappings[key];
+          let value;
+          if (typeof mapFunc === "function") {
+            value = mapFunc(node);
+          } else if (node.hasOwnProperty(key)) {
+            value = node[key];
+          }
+
+          // Unable to get value for this node. So skip it.
+          if (typeof value === "undefined") {
+            return false;
+          }
+
+          return terms.some(term => {
+            term = term.toLowerCase();
+            let exact = false;
+            let negate = false;
+
+            // '!' at the beginning means the term is negated.
+            while (term.indexOf("!") === 0) {
+              negate = !negate;
+              term = term.substring(1);
+            }
+
+            // '=' at the beginning means to match exactly.
+            if (term.indexOf("=") === 0) {
+              exact = true;
+              term = term.substring(1);
+            }
+
+            // Allow '!' after the '=' as well.
+            while (term.indexOf("!") === 0) {
+              negate = !negate;
+              term = term.substring(1);
+            }
+
+            if (Array.isArray(value)) {
+              // If value is an array check if the
+              // term matches any value in the
+              // array. If negated, check whether no
+              // value in the array matches.
+              const match = value.some(v => {
+                if (matches(v, term, exact, false)) {
+                  return true;
+                }
+                return false;
+              });
+              if (negate) {
+                // Push to matched only if no value in the array matches term.
+                if (!match) {
+                  matched.push(node);
+                  return true;
+                }
+              } else if (match) {
+                matched.push(node);
+                return true;
+              }
+            } else {
+              // Standard value check that it matches the term.
+              if (matches(value, term, exact, negate)) {
+                matched.push(node);
+                return true;
+              }
+            }
+            return false;
+          });
+        });
+      });
+      nodes = matched;
+    }
+  });
+  return nodes;
+};
+
+export default filterNodes;

--- a/ui/src/app/machines/filter-nodes.test.js
+++ b/ui/src/app/machines/filter-nodes.test.js
@@ -1,0 +1,410 @@
+import filterNodes from "./filter-nodes";
+
+describe("filterNodes", () => {
+  it("matches using standard filter", () => {
+    const matchingNode = {
+      hostname: "name"
+    };
+    const otherNode = {
+      hostname: "other"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "nam")).toEqual([matchingNode]);
+  });
+
+  it("doesn't return duplicates using standard filter", () => {
+    const matchingNode = {
+      hostname: "name",
+      pod: {
+        name: "name"
+      }
+    };
+    const otherNode = {
+      hostname: "other"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "nam am")).toEqual([matchingNode]);
+  });
+
+  it("matches selected", () => {
+    const matchingNode = {
+      $selected: true
+    };
+    const otherNode = {
+      $selected: false
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "in:selected")).toEqual([matchingNode]);
+  });
+
+  it("matches selected uppercase", () => {
+    const matchingNode = {
+      $selected: true
+    };
+    const otherNode = {
+      $selected: false
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "in:Selected")).toEqual([matchingNode]);
+  });
+
+  it("matches selected uppercase in brackets", () => {
+    const matchingNode = {
+      $selected: true
+    };
+    const otherNode = {
+      $selected: false
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "in:(Selected)")).toEqual([matchingNode]);
+  });
+
+  it("matches non-selected", () => {
+    const matchingNode = {
+      $selected: false
+    };
+    const otherNode = {
+      $selected: true
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "in:!selected")).toEqual([matchingNode]);
+  });
+
+  it("matches non-selected uppercase", () => {
+    const matchingNode = {
+      $selected: false
+    };
+    const otherNode = {
+      $selected: true
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "in:!Selected")).toEqual([matchingNode]);
+  });
+
+  it("matches non-selected uppercase in brackets", () => {
+    const matchingNode = {
+      $selected: false
+    };
+    const otherNode = {
+      $selected: true
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "in:(!Selected)")).toEqual([matchingNode]);
+  });
+
+  it("matches on attribute", () => {
+    const matchingNode = {
+      hostname: "name"
+    };
+    const otherNode = {
+      hostname: "other"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "hostname:name")).toEqual([matchingNode]);
+  });
+
+  it("matches with contains on attribute", () => {
+    const matchingNode = {
+      hostname: "name"
+    };
+    const otherNode = {
+      hostname: "other"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "hostname:na")).toEqual([matchingNode]);
+  });
+
+  it("matches on negating attribute", () => {
+    const matchingNode = {
+      hostname: "name"
+    };
+    const otherNode = {
+      hostname: "other"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "hostname:!other")).toEqual([matchingNode]);
+  });
+
+  it("matches on exact attribute", () => {
+    const matchingNode = {
+      hostname: "other"
+    };
+    const otherNode = {
+      hostname: "other2"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "hostname:=other")).toEqual([matchingNode]);
+  });
+
+  it("matches on array", () => {
+    const matchingNode = {
+      hostnames: ["name", "first"]
+    };
+    const otherNode = {
+      hostnames: ["other", "second"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "hostnames:first")).toEqual([matchingNode]);
+  });
+
+  it("matches integer values", () => {
+    const matchingNode = {
+      count: 4
+    };
+    const otherNode = {
+      count: 2
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "count:3")).toEqual([matchingNode]);
+  });
+
+  it("matches float values", () => {
+    const matchingNode = {
+      count: 2.2
+    };
+    const otherNode = {
+      count: 1.1
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "count:1.5")).toEqual([matchingNode]);
+  });
+
+  it("matches using cpu mapping function", () => {
+    const matchingNode = {
+      cpu_count: 4
+    };
+    const otherNode = {
+      cpu_count: 2
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "cpu:3")).toEqual([matchingNode]);
+  });
+
+  it("matches using cores mapping function", () => {
+    const matchingNode = {
+      cpu_count: 4
+    };
+    const otherNode = {
+      cpu_count: 2
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "cores:3")).toEqual([matchingNode]);
+  });
+
+  it("matches using ram mapping function", () => {
+    const matchingNode = {
+      memory: 2048
+    };
+    const otherNode = {
+      memory: 1024
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "ram:2000")).toEqual([matchingNode]);
+  });
+
+  it("matches using mac mapping function", () => {
+    const matchingNode = {
+      pxe_mac: "00:11:22:33:44:55",
+      extra_macs: ["aa:bb:cc:dd:ee:ff"]
+    };
+    const otherNode = {
+      pxe_mac: "66:11:22:33:44:55",
+      extra_macs: ["00:bb:cc:dd:ee:ff"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "mac:aa:bb:cc:dd:ee:ff")).toEqual([matchingNode]);
+  });
+
+  it("matches using zone mapping function", () => {
+    const matchingNode = {
+      zone: {
+        name: "first"
+      }
+    };
+    const otherNode = {
+      zone: {
+        name: "second"
+      }
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "zone:first")).toEqual([matchingNode]);
+  });
+
+  it("matches using pool mapping function", () => {
+    const matchingNode = {
+      pool: {
+        name: "pool1"
+      }
+    };
+    const otherNode = {
+      pool: {
+        name: "pool2"
+      }
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "pool:pool1")).toEqual([matchingNode]);
+  });
+
+  it("matches using pod mapping function", () => {
+    const matchingNode = {
+      pod: {
+        name: "pod1"
+      }
+    };
+    const otherNode = {
+      pod: {
+        name: "pod2"
+      }
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "pod:pod1")).toEqual([matchingNode]);
+  });
+
+  it("matches using pod-id mapping function", () => {
+    const matchingNode = {
+      pod: {
+        name: "pod1",
+        id: 1
+      }
+    };
+    const otherNode = {
+      pod: {
+        name: "pod2",
+        id: 2
+      }
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "pod-id:=1")).toEqual([matchingNode]);
+  });
+
+  it("matches using power mapping function", () => {
+    const matchingNode = {
+      power_state: "on"
+    };
+    const otherNode = {
+      power_state: "off"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "power:on")).toEqual([matchingNode]);
+  });
+
+  it("matches accumulate", () => {
+    const matchingNode = {
+      power_state: "on",
+      zone: {
+        name: "first"
+      }
+    };
+    const otherNode = {
+      power_state: "on",
+      zone: {
+        name: "second"
+      }
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "power:on zone:first")).toEqual([matchingNode]);
+  });
+
+  it("matches a tag", () => {
+    const matchingNode = {
+      tags: ["first", "second"]
+    };
+    const otherNode = {
+      tags: ["second", "third"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "tags:first")).toEqual([matchingNode]);
+  });
+
+  it("matches a negated tag", () => {
+    const matchingNode = {
+      tags: ["first", "second"]
+    };
+    const otherNode = {
+      tags: ["second", "third"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "tags:!third")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "tags:!(third)")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "tags:(!third)")).toEqual([matchingNode]);
+  });
+
+  it("matches a double negated tag", () => {
+    const matchingNode = {
+      tags: ["first", "second"]
+    };
+    const otherNode = {
+      tags: ["second", "third"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "tags:!!first")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "tags:!(!first)")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "tags:(!!first)")).toEqual([matchingNode]);
+  });
+
+  it("matches a direct and a negated tag", () => {
+    const matchingNode = {
+      tags: ["first", "second"]
+    };
+    const otherNode = {
+      tags: ["second", "third"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "tags:(first,!third)")).toEqual([matchingNode]);
+  });
+
+  it("matches an exact direct and a negated tag", () => {
+    const matchingNode = {
+      tags: ["first", "second"]
+    };
+    const otherNode = {
+      tags: ["first1", "third"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "tags:(=first,!third)")).toEqual([matchingNode]);
+  });
+
+  it("matches two negated tags", () => {
+    const matchingNode = {
+      tags: ["first", "second"]
+    };
+    const otherNode = {
+      tags: ["second", "third"]
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "tags:(!second,!third)")).toEqual([matchingNode]);
+  });
+
+  it("matches using release mapping function", () => {
+    const deployingNode = {
+      status_code: 9,
+      osystem: "ubuntu",
+      distro_series: "xenial"
+    };
+    const deployedNode = {
+      status_code: 6,
+      osystem: "ubuntu",
+      distro_series: "xenial"
+    };
+    const allocatedNode = {
+      status_code: 5,
+      osystem: "ubuntu",
+      distro_series: "xenial"
+    };
+    const deployedOtherNode = {
+      status_code: 6,
+      osystem: "ubuntu",
+      distro_series: "trusty"
+    };
+    const nodes = [
+      deployingNode,
+      deployedNode,
+      allocatedNode,
+      deployedOtherNode
+    ];
+    expect(filterNodes(nodes, "release:ubuntu/xenial")).toEqual([
+      deployingNode,
+      deployedNode
+    ]);
+  });
+});

--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -1,0 +1,124 @@
+// Holds all stored filters.
+const storedFilters = {};
+
+// Return a new empty filter;
+export const getEmptyFilter = () => ({ _: [] });
+
+// Return all of the currently active filters for the given search.
+export const getCurrentFilters = search => {
+  const filters = getEmptyFilter();
+  if (!search) {
+    return filters;
+  }
+  const terms = search.split(" ");
+  let processingFilter;
+  terms.forEach(term => {
+    if (processingFilter) {
+      const filter = filters[processingFilter];
+      // A previous term had a space in it. This may contain multiple comma
+      // separated terms, the first of which will be part of the last term to
+      // be added to the filter.
+      term.split(",").forEach((termItem, i) => {
+        termItem = termItem.replace(")", "");
+        if (i === 0) {
+          // If this is the first term it is part of the last term to be added.
+          filter[filter.length - 1] += ` ${termItem}`;
+        } else {
+          // This is a new term.
+          filter.push(termItem);
+        }
+      });
+      // If the term contains the ending ')' then it's the last in the group.
+      if (term.includes(")")) {
+        processingFilter = null;
+      }
+    } else if (term.includes(":")) {
+      // This is a filter for a specific property.
+      let [filter, values: ""] = term.split(":");
+      // Remove the starting '(' and ending ')'.
+      values = values.replace("(", "").replace(")", "");
+      if (!values) {
+        // This filter has no values so skip it.
+        return;
+      }
+      // Add the values to the filter.
+      filters[filter] = values.split(",");
+      if (term.includes("(") && !term.includes(")")) {
+        // Contains a starting '(' but not an ending ')' so the next term in the
+        // array is part of the current filter.
+        processingFilter = filter;
+      }
+    } else {
+      // Term is not part of a previous '(..)' span so add it to the generic
+      // filters.
+      filters._.push(term);
+    }
+  });
+  // If the filter has finished looping over the terms without
+  // closing the current filter then it is malformed.
+  if (processingFilter) {
+    return null;
+  }
+  return filters;
+};
+
+// Convert "filters" into a search string.
+export const filtersToString = filters => {
+  let search = filters._.length > 0 ? `${filters._.join(" ")}` : "";
+  Object.entries(filters).forEach(([type, terms]) => {
+    // Skip empty and skip "_" as it gets appended at the
+    // beginning of the search.
+    if (terms.length === 0 || type === "_") {
+      return;
+    }
+    search += ` ${type}:(${terms.join(",")})`;
+  });
+  return search.trim();
+};
+
+// Return the index of the value in the type for the filter.
+const _getFilterValueIndex = (filters, type, value) => {
+  const values = filters[type];
+  if (!values) {
+    return -1;
+  }
+  const lowerValues = values.map(value => value.toLowerCase());
+  return lowerValues.indexOf(value.toLowerCase());
+};
+
+// Whether the type and value are in the filters.
+export const isFilterActive = (filters, type, value, exact = false) => {
+  const values = filters[type];
+  if (!values) {
+    return false;
+  }
+  if (exact) {
+    value = `=${value}`;
+  }
+  return _getFilterValueIndex(filters, type, value) !== -1;
+};
+
+// Toggles a filter on or off based on type and value.
+export const toggleFilter = (filters, type, value, exact) => {
+  if (typeof filters[type] === "undefined") {
+    filters[type] = [];
+  }
+  if (exact) {
+    value = "=" + value;
+  }
+  const idx = _getFilterValueIndex(filters, type, value);
+  if (idx === -1) {
+    filters[type].push(value);
+  } else {
+    filters[type].splice(idx, 1);
+  }
+  return filters;
+};
+
+// Store a filter for later.
+export const storeFilters = (name, filters) => {
+  storedFilters[name] = filters;
+};
+
+// Retrieve a stored filter.
+export const retrieveFilters = name => storedFilters[name];

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -1,0 +1,259 @@
+import {
+  filtersToString,
+  getCurrentFilters,
+  getEmptyFilter,
+  isFilterActive,
+  retrieveFilters,
+  storeFilters,
+  toggleFilter
+} from "./search";
+
+describe("SearchService", () => {
+  const scenarios = [
+    {
+      input: "",
+      filters: {
+        _: []
+      }
+    },
+    {
+      input: "moon",
+      filters: {
+        _: ["moon"]
+      }
+    },
+    {
+      input: "moon status:(new)",
+      filters: {
+        _: ["moon"],
+        status: ["new"]
+      }
+    },
+    {
+      input: "moon status:(new,deployed)",
+      filters: {
+        _: ["moon"],
+        status: ["new", "deployed"]
+      }
+    },
+    {
+      input: "moon status:(new,failed disk erasing)",
+      filters: {
+        _: ["moon"],
+        status: ["new", "failed disk erasing"]
+      }
+    },
+    {
+      input: "moon status:(new,failed disk erasing,pending)",
+      filters: {
+        _: ["moon"],
+        status: ["new", "failed disk erasing", "pending"]
+      }
+    },
+    {
+      input: "moon status:new,deployed",
+      output: "moon status:(new,deployed)",
+      filters: {
+        _: ["moon"],
+        status: ["new", "deployed"]
+      }
+    },
+    {
+      input: "moon status:new,failed disk erasing",
+      output: "moon disk erasing status:(new,failed)",
+      filters: {
+        _: ["moon", "disk", "erasing"],
+        status: ["new", "failed"]
+      }
+    },
+    {
+      input: "moon status:(new,failed disk erasing",
+      filters: null
+    },
+    {
+      input: "moon status:(",
+      output: "moon",
+      filters: {
+        _: ["moon"]
+      }
+    },
+    {
+      input: "moon status:",
+      output: "moon",
+      filters: {
+        _: ["moon"]
+      }
+    }
+  ];
+
+  scenarios.forEach(scenario => {
+    describe("input:" + scenario.input, () => {
+      it("getCurrentFilters", () => {
+        expect(getCurrentFilters(scenario.input)).toEqual(scenario.filters);
+      });
+
+      it("filtersToString", () => {
+        // Skip the ones with filters equal to null.
+        if (!scenario.filters) {
+          return;
+        }
+
+        expect(filtersToString(scenario.filters)).toEqual(
+          scenario.output || scenario.input
+        );
+      });
+    });
+  });
+
+  describe("isFilterActive", () => {
+    it("returns false if type not in filter", () => {
+      expect(isFilterActive({}, "type", "invalid")).toBe(false);
+    });
+
+    it("returns false if value not in type", () => {
+      expect(
+        isFilterActive(
+          {
+            type: ["not"]
+          },
+          "type",
+          "invalid"
+        )
+      ).toBe(false);
+    });
+
+    it("returns true if value in type", () => {
+      expect(
+        isFilterActive(
+          {
+            type: ["valid"]
+          },
+          "type",
+          "valid"
+        )
+      ).toBe(true);
+    });
+
+    it("returns false if exact value not in type", () => {
+      expect(
+        isFilterActive(
+          {
+            type: ["valid"]
+          },
+          "type",
+          "valid",
+          true
+        )
+      ).toBe(false);
+    });
+
+    it("returns true if exact value in type", () => {
+      expect(
+        isFilterActive(
+          {
+            type: ["=valid"]
+          },
+          "type",
+          "valid",
+          true
+        )
+      ).toBe(true);
+    });
+
+    it("returns true if lowercase value in type", () => {
+      expect(
+        isFilterActive(
+          {
+            type: ["=Valid"]
+          },
+          "type",
+          "valid",
+          true
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("toggleFilter", () => {
+    it("adds type to filters", () => {
+      expect(toggleFilter({}, "type", "value")).toEqual({
+        type: ["value"]
+      });
+    });
+
+    it("adds value to type in filters", () => {
+      const filters = {
+        type: ["exists"]
+      };
+      expect(toggleFilter(filters, "type", "value")).toEqual({
+        type: ["exists", "value"]
+      });
+    });
+
+    it("removes value to type in filters", () => {
+      const filters = {
+        type: ["exists", "value"]
+      };
+      expect(toggleFilter(filters, "type", "value")).toEqual({
+        type: ["exists"]
+      });
+    });
+
+    it("adds exact value to type in filters", () => {
+      const filters = {
+        type: ["exists"]
+      };
+      expect(toggleFilter(filters, "type", "value", true)).toEqual({
+        type: ["exists", "=value"]
+      });
+    });
+
+    it("removes exact value to type in filters", () => {
+      const filters = {
+        type: ["exists", "value", "=value"]
+      };
+      expect(toggleFilter(filters, "type", "value", true)).toEqual({
+        type: ["exists", "value"]
+      });
+    });
+
+    it("removes lowercase value to type in filters", () => {
+      const filters = {
+        type: ["exists", "=Value"]
+      };
+      expect(toggleFilter(filters, "type", "value", true)).toEqual({
+        type: ["exists"]
+      });
+    });
+  });
+
+  describe("getEmptyFilter", () => {
+    it("includes _ empty list", () => {
+      expect(getEmptyFilter()).toEqual({ _: [] });
+    });
+
+    it("returns different object on each call", () => {
+      const one = getEmptyFilter();
+      const two = getEmptyFilter();
+      expect(one).not.toBe(two);
+    });
+  });
+
+  describe("storeFilters/retrieveFilters", () => {
+    it("stores and retrieves the same object", () => {
+      let i;
+      const names = [];
+      const objects = [];
+      for (i = 0; i < 3; i++) {
+        names.push(`name_${i}`);
+        objects.push({});
+      }
+      names.forEach((name, idx) => {
+        storeFilters(name, objects[idx]);
+      });
+      names.forEach((name, idx) => {
+        expect(retrieveFilters(name)).toBe(objects[idx]);
+      });
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -514,4 +514,24 @@ describe("MachineList", () => {
       "machine: Uh oh! network: It broke"
     );
   });
+
+  it("displays a message if there are no search results", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList selectedMachines={[]} setSelectedMachines={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("input[type='search']")
+      .simulate("change", { target: { value: "test" } });
+    expect(wrapper.find("Strip span").text()).toBe(
+      "No machines match the search criteria."
+    );
+  });
 });


### PR DESCRIPTION
## Done
- Ported search utilities from the angular client. Includes bug fixes, additional tests, es6ificiation and cleanupification.

## QA
- Visit /r/machines.
- Search using the search box. You should be able to free search against the machine attributes and also specify specific values e.g. hostname:cow.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1488.
