### PR TITLE
Remove password length restriction for users.

### DIFF
--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -17,7 +17,7 @@ const schemaFields = {
     .required("Email is required"),
   fullName: Yup.string(),
   is_superuser: Yup.boolean(),
-  password: Yup.string().min(8, "Passwords must be 8 characters or more"),
+  password: Yup.string(),
   passwordConfirm: Yup.string().oneOf(
     [Yup.ref("password")],
     "Passwords must be the same"


### PR DESCRIPTION
## Done
* Removed password length restriction for users

## QA
* Check that you can create and log in as a user with a 1 character password, like with the api

## Fixes
Fixes #865 
