### PR TITLE
Add filter accordion UI

### DIFF
--- a/legacy/src/app/partials/nodelist/nodes-list-filter.html
+++ b/legacy/src/app/partials/nodelist/nodes-list-filter.html
@@ -35,7 +35,7 @@
                   ng-class="{ 'is-active': isFilterActive(option.name, entry.name, currentPage) }"
                 >
                   {$ formatFilterLabel(entry, option) $}
-                </a>
+                </button>
               </li>
             </ul>
           </div>

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.test.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.test.js
@@ -180,6 +180,16 @@ describe("ContextualMenu ", () => {
     ).toBe("Link2");
   });
 
+  it("can supply content instead of links", () => {
+    const wrapper = mount(
+      <ContextualMenu
+        dropdownContent={<span className="content">content</span>}
+      />
+    );
+    expect(wrapper.find(".content").exists()).toBe(true);
+    expect(wrapper.find("button.p-contextual-menu__link").exists()).toBe(false);
+  });
+
   it("closes the menu when clicking on an item", () => {
     const wrapper = mount(
       <ContextualMenu links={[{ onClick: jest.fn() }]} toggleLabel="Toggle" />

--- a/ui/src/app/machines/filter-nodes.js
+++ b/ui/src/app/machines/filter-nodes.js
@@ -1,35 +1,5 @@
 import { getCurrentFilters } from "./search";
-
-// Helpers that convert the pseudo field on node to an actual
-// value from the node.
-const mappings = {
-  cpu: node => node.cpu_count,
-  cores: node => node.cpu_count,
-  ram: node => node.memory,
-  mac: node => [node.pxe_mac, ...node.extra_macs],
-  zone: node => node.zone.name,
-  pool: node => node.pool.name,
-  pod: node => node.pod && node.pod.name,
-  "pod-id": node => node.pod && node.pod.id,
-  power: node => node.power_state,
-  release: node =>
-    node.status_code === 6 || node.status_code === 9
-      ? node.osystem + "/" + node.distro_series
-      : "",
-  hostname: node => node.hostname,
-  vlan: node => node.vlan,
-  rack: node => node.observer_hostname,
-  subnet: node => node.subnet_cidr,
-  numa_nodes_count: ({ numa_nodes_count, numa_nodes }) => {
-    const count = numa_nodes_count || (numa_nodes && numa_nodes.length);
-    return `${count} node${count !== 1 ? "s" : ""}`;
-  },
-  sriov_support: ({ sriov_support, interfaces }) =>
-    sriov_support ||
-    (interfaces && interfaces.some(iface => iface.sriov_max_vf >= 1))
-      ? "Supported"
-      : "Not supported"
-};
+import { getMachineValue } from "app/utils";
 
 // Return true when lowercase value contains the already
 // lowercased lowerTerm.
@@ -101,15 +71,7 @@ const filterNodes = (nodes, search) => {
         // Loop through the attributes to check. If this is for the
         // generic "_" filter then check against all node attributes.
         (attr === "_" ? Object.keys(node) : [attr]).some(key => {
-          // Mapping function for the attribute.
-          const mapFunc = mappings[key];
-          let value;
-          if (typeof mapFunc === "function") {
-            value = mapFunc(node);
-          } else if (node.hasOwnProperty(key)) {
-            value = node[key];
-          }
-
+          let value = getMachineValue(node, key);
           // Unable to get value for this node. So skip it.
           if (typeof value === "undefined") {
             return false;

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.js
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.js
@@ -1,0 +1,202 @@
+import { Accordion, Button, List, Loader } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React, { useMemo } from "react";
+
+import "./FilterAccordion.scss";
+import {
+  getCurrentFilters,
+  isFilterActive,
+  filtersToString,
+  toggleFilter
+} from "app/machines/search";
+import { getMachineValue } from "app/utils";
+import { machine as machineSelectors } from "app/base/selectors";
+import ContextualMenu from "app/base/components/ContextualMenu";
+
+const filterOrder = [
+  "status",
+  "owner",
+  "pool",
+  "architecture",
+  "release",
+  "tags",
+  "storage_tags",
+  "pod",
+  "subnets",
+  "fabrics",
+  "zone",
+  "numa_nodes_count",
+  "sriov_support",
+  "link_speeds"
+];
+
+const filterNames = new Map([
+  ["architecture", "Architecture"],
+  ["fabric", "Fabric"],
+  ["fabrics", "Fabric"],
+  ["numa_nodes_count", "NUMA nodes"],
+  ["owner", "Owner"],
+  ["pod", "KVM"],
+  ["pool", "Resource pool"],
+  ["rack", "Rack"],
+  ["release", "OS/Release"],
+  ["spaces", "Space"],
+  ["sriov_support", "SR-IOV support"],
+  ["status", "Status"],
+  ["storage_tags", "Storage tags"],
+  ["subnet", "Subnet"],
+  ["subnets", "Subnet"],
+  ["tags", "Tags"],
+  ["vlan", "VLAN"],
+  ["zone", "Zone"],
+  ["link_speeds", "Link speed"]
+]);
+
+const formatSpeedUnits = speedInMbytes => {
+  const megabytesInGigabyte = 1000;
+  const gigabytesInTerabyte = 1000;
+
+  if (
+    speedInMbytes >= megabytesInGigabyte &&
+    speedInMbytes < megabytesInGigabyte * gigabytesInTerabyte
+  ) {
+    return `${Math.round(speedInMbytes / megabytesInGigabyte)} Gbps`;
+  }
+
+  if (speedInMbytes >= megabytesInGigabyte * gigabytesInTerabyte) {
+    return `${Math.round(
+      speedInMbytes / megabytesInGigabyte / gigabytesInTerabyte
+    )} Tbps`;
+  }
+
+  return `${speedInMbytes} Mbps`;
+};
+
+const getFilters = machines => {
+  const filters = new Map();
+  machines.forEach(machine => {
+    filterOrder.forEach(filter => {
+      let value = getMachineValue(machine, filter);
+      // This is not a useful value so skip it.
+      if (!value) {
+        return;
+      }
+      // Turn everything into an array so we can loop over all values.
+      if (!Array.isArray(value)) {
+        value = [value];
+      }
+      let storedFilter = filters.get(filter);
+      if (!storedFilter) {
+        filters.set(filter, new Map());
+        storedFilter = filters.get(filter);
+      }
+      value.forEach(filterValue => {
+        let storedValue = storedFilter.get(filterValue);
+        if (!storedValue) {
+          storedFilter.set(filterValue, 0);
+          storedValue = storedFilter.get(filterValue);
+        }
+        storedFilter.set(filterValue, storedValue + 1);
+      });
+    });
+  });
+  return filters;
+};
+
+const sortByFilterName = (a, b) => {
+  a = a[0];
+  b = b[0];
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+};
+
+const FilterAccordion = ({ searchText, setSearchText }) => {
+  const machines = useSelector(machineSelectors.all);
+  const machinesLoaded = useSelector(machineSelectors.loaded);
+  const filterOptions = useMemo(() => getFilters(machines), [machines]);
+  const currentFilters = getCurrentFilters(searchText);
+  let sections;
+  if (machinesLoaded) {
+    sections = filterOrder.reduce((options, filter) => {
+      const filterValues = filterOptions.get(filter);
+      if (filterValues) {
+        options.push({
+          title: filterNames.get(filter),
+          content: (
+            <List
+              className="u-no-margin--bottom"
+              items={Array.from(filterValues)
+                .sort(sortByFilterName)
+                .map(([filterValue, count]) => (
+                  <Button
+                    appearance="base"
+                    className={classNames(
+                      "u-align-text--left u-no-margin--bottom filter-accordion__item",
+                      {
+                        "is-active": isFilterActive(
+                          currentFilters,
+                          filter,
+                          filterValue,
+                          true
+                        )
+                      }
+                    )}
+                    onClick={() => {
+                      const newFilters = toggleFilter(
+                        currentFilters,
+                        filter,
+                        filterValue,
+                        true
+                      );
+                      setSearchText(filtersToString(newFilters));
+                    }}
+                  >
+                    {filter === "link_speeds"
+                      ? formatSpeedUnits(filterValue)
+                      : filterValue}{" "}
+                    ({count})
+                  </Button>
+                ))}
+            />
+          )
+        });
+      }
+      return options;
+    }, []);
+  }
+
+  return (
+    <ContextualMenu
+      className="filter-accordion"
+      constrainPanelWidth
+      dropdownContent={
+        machinesLoaded ? (
+          <Accordion
+            className="filter-accordion__dropdown"
+            sections={sections}
+          />
+        ) : (
+          <Loader text="Loading..." />
+        )
+      }
+      hasToggleIcon
+      position="left"
+      toggleClassName="filter-accordion__toggle"
+      toggleLabel="Filters"
+    />
+  );
+};
+
+FilterAccordion.propTypes = {
+  searchText: PropTypes.string,
+  setSearchText: PropTypes.func.isRequired
+};
+
+export default FilterAccordion;

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.js
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.js
@@ -11,7 +11,7 @@ import {
   filtersToString,
   toggleFilter
 } from "app/machines/search";
-import { getMachineValue } from "app/utils";
+import { getMachineValue, formatSpeedUnits } from "app/utils";
 import { machine as machineSelectors } from "app/base/selectors";
 import ContextualMenu from "app/base/components/ContextualMenu";
 
@@ -53,26 +53,6 @@ const filterNames = new Map([
   ["zone", "Zone"],
   ["link_speeds", "Link speed"]
 ]);
-
-const formatSpeedUnits = speedInMbytes => {
-  const megabytesInGigabyte = 1000;
-  const gigabytesInTerabyte = 1000;
-
-  if (
-    speedInMbytes >= megabytesInGigabyte &&
-    speedInMbytes < megabytesInGigabyte * gigabytesInTerabyte
-  ) {
-    return `${Math.round(speedInMbytes / megabytesInGigabyte)} Gbps`;
-  }
-
-  if (speedInMbytes >= megabytesInGigabyte * gigabytesInTerabyte) {
-    return `${Math.round(
-      speedInMbytes / megabytesInGigabyte / gigabytesInTerabyte
-    )} Tbps`;
-  }
-
-  return `${speedInMbytes} Mbps`;
-};
 
 const getFilters = machines => {
   const filters = new Map();
@@ -126,7 +106,7 @@ const FilterAccordion = ({ searchText, setSearchText }) => {
   if (machinesLoaded) {
     sections = filterOrder.reduce((options, filter) => {
       const filterValues = filterOptions.get(filter);
-      if (filterValues) {
+      if (filterValues && filterValues.size > 0) {
         options.push({
           title: filterNames.get(filter),
           content: (
@@ -138,7 +118,7 @@ const FilterAccordion = ({ searchText, setSearchText }) => {
                   <Button
                     appearance="base"
                     className={classNames(
-                      "u-align-text--left u-no-margin--bottom filter-accordion__item",
+                      "u-align-text--left u-no-margin--bottom filter-accordion__item is-dense",
                       {
                         "is-active": isFilterActive(
                           currentFilters,

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.scss
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.scss
@@ -43,7 +43,6 @@
 
 .filter-accordion__item {
   padding-left: $sp-unit * 5;
-  // position: relative;
 
   &.is-active {
     background-image: url("data:image/svg+xml,%3Csvg width='22' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h24v24H-1z'/%3E%3Cpath fill='"+vf-url-friendly-color(

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.scss
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.scss
@@ -1,0 +1,58 @@
+@import "~vanilla-framework/scss/global_functions";
+@import "~vanilla-framework/scss/settings_colors";
+@import "~vanilla-framework/scss/settings_spacing";
+
+[class^="p-button"].has-icon.filter-accordion__toggle,
+.filter-accordion__item,
+.filter-accordion {
+  width: 100%;
+}
+
+[class^="p-button"].has-icon.filter-accordion__toggle {
+  padding-left: $spv-inner--small;
+  text-align: left;
+
+  i {
+    position: absolute;
+    right: $spv-inner--large;
+    top: calc(#{$spv-inner--medium} - 1px);
+  }
+}
+
+.filter-accordion .p-accordion__list {
+  margin-bottom: 0;
+}
+
+.filter-accordion__dropdown {
+  max-height: 66vh;
+  overflow-y: auto;
+}
+
+.filter-accordion .p-accordion__panel {
+  padding-left: 0;
+}
+
+.filter-accordion .p-list__item {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.filter-accordion .p-contextual-menu__dropdown {
+  width: calc(100% - 1px);
+}
+
+.filter-accordion__item {
+  padding-left: $sp-unit * 5;
+  // position: relative;
+
+  &.is-active {
+    background-image: url("data:image/svg+xml,%3Csvg width='22' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h24v24H-1z'/%3E%3Cpath fill='"+vf-url-friendly-color(
+        $color-mid-dark
+      )+"' fill-rule='nonzero' d='M2.872 5.933L.6 8.205l7.733 7.734L21.4 2.872 19.128.6 8.333 11.397z'/%3E%3C/g%3E%3C/svg%3E");
+    background-position-x: $sph-inner;
+    background-position-y: center;
+    background-repeat: no-repeat;
+    background-size: map-get($icon-sizes, default);
+    font-weight: 400;
+  }
+}

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.test.js
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.test.js
@@ -1,0 +1,132 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import FilterAccordion from "./FilterAccordion";
+
+const mockStore = configureStore();
+
+describe("FilterAccordion", () => {
+  let state;
+  beforeEach(() => {
+    state = {
+      config: {
+        items: []
+      },
+      machine: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            link_speeds: [100],
+            pool: {
+              id: 1,
+              name: "pool1"
+            },
+            zone: {
+              id: 1,
+              name: "zone1"
+            }
+          }
+        ]
+      }
+    };
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FilterAccordion")).toMatchSnapshot();
+  });
+
+  it("displays a spinner when loading machines", () => {
+    state.machine.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("formats link speeds", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".filter-accordion__item")
+        .findWhere(button => button.text().includes("100 Mbps"))
+        .exists()
+    ).toBe(true);
+  });
+
+  it("can mark an item as active", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion
+            searchText="pool:(=pool1)"
+            setSearchText={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(wrapper.find(".filter-accordion__item.is-active").exists()).toBe(
+      true
+    );
+  });
+
+  it("can set a new filter", () => {
+    const setSearchText = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion setSearchText={setSearchText} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper
+      .find(".filter-accordion__item")
+      .at(0)
+      .simulate("click");
+    expect(setSearchText).toHaveBeenCalledWith("pool:(=pool1)");
+  });
+});

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.test.js
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.test.js
@@ -129,4 +129,48 @@ describe("FilterAccordion", () => {
       .simulate("click");
     expect(setSearchText).toHaveBeenCalledWith("pool:(=pool1)");
   });
+
+  it("hides filters if there are no values", () => {
+    delete state.machine.items[0].link_speeds;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-accordion__tab")
+        .findWhere(button => button.text() === "Link speed")
+        .exists()
+    ).toBe(false);
+  });
+
+  it("hides filters if the value is an empty array", () => {
+    state.machine.items[0].link_speeds = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    expect(
+      wrapper
+        .find(".p-accordion__tab")
+        .findWhere(button => button.text() === "Link speed")
+        .exists()
+    ).toBe(false);
+  });
 });

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FilterAccordion renders 1`] = `
+<FilterAccordion
+  setSearchText={[MockFunction]}
+>
+  <ContextualMenu
+    className="filter-accordion"
+    constrainPanelWidth={true}
+    dropdownContent={
+      <Accordion
+        className="filter-accordion__dropdown"
+        sections={
+          Array [
+            Object {
+              "content": <List
+                className="u-no-margin--bottom"
+                items={
+                  Array [
+                    <Button
+                      appearance="base"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      onClick={[Function]}
+                    >
+                      pool1
+                       
+                      (
+                      1
+                      )
+                    </Button>,
+                  ]
+                }
+              />,
+              "title": "Resource pool",
+            },
+            Object {
+              "content": <List
+                className="u-no-margin--bottom"
+                items={
+                  Array [
+                    <Button
+                      appearance="base"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      onClick={[Function]}
+                    >
+                      zone1
+                       
+                      (
+                      1
+                      )
+                    </Button>,
+                  ]
+                }
+              />,
+              "title": "Zone",
+            },
+            Object {
+              "content": <List
+                className="u-no-margin--bottom"
+                items={
+                  Array [
+                    <Button
+                      appearance="base"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      onClick={[Function]}
+                    >
+                      undefined nodes
+                       
+                      (
+                      1
+                      )
+                    </Button>,
+                  ]
+                }
+              />,
+              "title": "NUMA nodes",
+            },
+            Object {
+              "content": <List
+                className="u-no-margin--bottom"
+                items={
+                  Array [
+                    <Button
+                      appearance="base"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      onClick={[Function]}
+                    >
+                      Not supported
+                       
+                      (
+                      1
+                      )
+                    </Button>,
+                  ]
+                }
+              />,
+              "title": "SR-IOV support",
+            },
+            Object {
+              "content": <List
+                className="u-no-margin--bottom"
+                items={
+                  Array [
+                    <Button
+                      appearance="base"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      onClick={[Function]}
+                    >
+                      100 Mbps
+                       
+                      (
+                      1
+                      )
+                    </Button>,
+                  ]
+                }
+              />,
+              "title": "Link speed",
+            },
+          ]
+        }
+      />
+    }
+    hasToggleIcon={true}
+    position="left"
+    toggleClassName="filter-accordion__toggle"
+    toggleLabel="Filters"
+  >
+    <span
+      className="filter-accordion p-contextual-menu--left"
+    >
+      <Button
+        aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+        aria-expanded="false"
+        aria-haspopup="true"
+        className="p-contextual-menu__toggle filter-accordion__toggle"
+        hasIcon={true}
+        onClick={[Function]}
+      >
+        <button
+          aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
+          aria-expanded="false"
+          aria-haspopup="true"
+          className="p-button--neutral has-icon p-contextual-menu__toggle filter-accordion__toggle"
+          onClick={[Function]}
+        >
+          <span>
+            Filters
+          </span>
+          <i
+            className="p-icon--contextual-menu p-contextual-menu__indicator"
+          />
+        </button>
+      </Button>
+    </span>
+  </ContextualMenu>
+</FilterAccordion>
+`;

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
@@ -19,7 +19,7 @@ exports[`FilterAccordion renders 1`] = `
                   Array [
                     <Button
                       appearance="base"
-                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item is-dense"
                       onClick={[Function]}
                     >
                       pool1
@@ -40,7 +40,7 @@ exports[`FilterAccordion renders 1`] = `
                   Array [
                     <Button
                       appearance="base"
-                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item is-dense"
                       onClick={[Function]}
                     >
                       zone1
@@ -61,7 +61,7 @@ exports[`FilterAccordion renders 1`] = `
                   Array [
                     <Button
                       appearance="base"
-                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item is-dense"
                       onClick={[Function]}
                     >
                       undefined nodes
@@ -82,7 +82,7 @@ exports[`FilterAccordion renders 1`] = `
                   Array [
                     <Button
                       appearance="base"
-                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item is-dense"
                       onClick={[Function]}
                     >
                       Not supported
@@ -103,7 +103,7 @@ exports[`FilterAccordion renders 1`] = `
                   Array [
                     <Button
                       appearance="base"
-                      className="u-align-text--left u-no-margin--bottom filter-accordion__item"
+                      className="u-align-text--left u-no-margin--bottom filter-accordion__item is-dense"
                       onClick={[Function]}
                     >
                       100 Mbps

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/index.js
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/index.js
@@ -1,0 +1,1 @@
+export { default } from "./FilterAccordion";

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -7,7 +7,6 @@ import {
   Notification,
   Row,
   SearchBox,
-  Select,
   Strip
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
@@ -34,6 +33,7 @@ import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
 import DoubleRow from "app/base/components/DoubleRow";
 import FabricColumn from "./FabricColumn";
+import FilterAccordion from "./FilterAccordion";
 import GroupSelect from "./GroupSelect";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
@@ -541,20 +541,17 @@ const MachineList = () => {
     <>
       <Row>
         <Col size={3}>
-          <Select
-            name="machineFilters"
-            defaultValue=""
-            options={[
-              {
-                value: "",
-                disabled: "disabled",
-                label: "Filters"
-              }
-            ]}
+          <FilterAccordion
+            searchText={searchText}
+            setSearchText={setSearchText}
           />
         </Col>
         <Col size={6}>
-          <SearchBox onChange={setSearchText} />
+          <SearchBox
+            externallyControlled
+            onChange={setSearchText}
+            value={searchText}
+          />
         </Col>
         <Col size={3}>
           <GroupSelect

--- a/ui/src/app/utils/formatBytes.js
+++ b/ui/src/app/utils/formatBytes.js
@@ -22,7 +22,7 @@ export const formatBytes = (value, unit, precision = 3) => {
   // Convert to appropriate unit.
   const j = Math.floor(Math.log(valueInBytes) / Math.log(k));
   const valueInUnit = parseFloat(
-    (valueInBytes / Math.pow(k, j)).toPrecision(precision)
+    (valueInBytes / Math.pow(k, j)).toFixed(precision - 1)
   );
 
   return {

--- a/ui/src/app/utils/formatBytes.test.js
+++ b/ui/src/app/utils/formatBytes.test.js
@@ -12,10 +12,17 @@ describe("formatBytes", () => {
   });
 
   it("returns the value to the correct precision", () => {
-    expect(formatBytes(1234, "B", 2)).toStrictEqual({ value: 1.2, unit: "KB" });
+    expect(formatBytes(1234, "B", 2)).toStrictEqual({
+      value: 1.2,
+      unit: "KB"
+    });
     expect(formatBytes(1234, "B", 4)).toStrictEqual({
       value: 1.234,
       unit: "KB"
+    });
+    expect(formatBytes(123, "B", 1)).toStrictEqual({
+      value: 123,
+      unit: "B"
     });
   });
 });

--- a/ui/src/app/utils/formatSpeedUnits.js
+++ b/ui/src/app/utils/formatSpeedUnits.js
@@ -1,0 +1,11 @@
+import { formatBytes } from "./formatBytes";
+
+/**
+ * Format megabytes to an appropriate level of speed.
+ * @param {Number} speedInMbytes The value in the supplied megabyte unit.
+ * @returns {String} Formatted value and unit.
+ */
+export const formatSpeedUnits = speedInMbytes => {
+  const adjusted = formatBytes(speedInMbytes, "MB", 1);
+  return `${adjusted.value} ${adjusted.unit[0]}bps`;
+};

--- a/ui/src/app/utils/formatSpeedUnits.test.js
+++ b/ui/src/app/utils/formatSpeedUnits.test.js
@@ -1,0 +1,15 @@
+import { formatSpeedUnits } from "./formatSpeedUnits";
+
+describe("formatSpeedUnits", () => {
+  it("correctly formats to Mbps", () => {
+    expect(formatSpeedUnits(12)).toStrictEqual("12 Mbps");
+  });
+
+  it("correctly formats to Gbps", () => {
+    expect(formatSpeedUnits(1234)).toStrictEqual("1 Gbps");
+  });
+
+  it("correctly formats to Tbps", () => {
+    expect(formatSpeedUnits(1234567)).toStrictEqual("1 Tbps");
+  });
+});

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -1,5 +1,6 @@
 export { capitaliseFirst } from "./capitaliseFirst";
 export { formatBytes } from "./formatBytes";
+export { getMachineValue } from "./search";
 export { groupAsMap } from "./groupAsMap";
 export { simpleSortByKey } from "./simpleSortByKey";
 export { trimPowerParameters } from "./trimPowerParameters";

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -1,5 +1,6 @@
 export { capitaliseFirst } from "./capitaliseFirst";
 export { formatBytes } from "./formatBytes";
+export { formatSpeedUnits } from "./formatSpeedUnits";
 export { getMachineValue } from "./search";
 export { groupAsMap } from "./groupAsMap";
 export { simpleSortByKey } from "./simpleSortByKey";

--- a/ui/src/app/utils/search.js
+++ b/ui/src/app/utils/search.js
@@ -1,0 +1,41 @@
+// Helpers that convert the pseudo field on node to an actual
+// value from the node.
+const searchMappings = {
+  cpu: node => node.cpu_count,
+  cores: node => node.cpu_count,
+  ram: node => node.memory,
+  mac: node => [node.pxe_mac, ...node.extra_macs],
+  zone: node => node.zone.name,
+  pool: node => node.pool.name,
+  pod: node => node.pod && node.pod.name,
+  "pod-id": node => node.pod && node.pod.id,
+  power: node => node.power_state,
+  release: node =>
+    node.status_code === 6 || node.status_code === 9
+      ? node.osystem + "/" + node.distro_series
+      : "",
+  hostname: node => node.hostname,
+  vlan: node => node.vlan,
+  rack: node => node.observer_hostname,
+  subnet: node => node.subnet_cidr,
+  numa_nodes_count: ({ numa_nodes_count, numa_nodes }) => {
+    const count = numa_nodes_count || (numa_nodes && numa_nodes.length);
+    return `${count} node${count !== 1 ? "s" : ""}`;
+  },
+  sriov_support: ({ sriov_support, interfaces }) =>
+    sriov_support ||
+    (interfaces && interfaces.some(iface => iface.sriov_max_vf >= 1))
+      ? "Supported"
+      : "Not supported"
+};
+
+export const getMachineValue = (machine, filter) => {
+  const mapFunc = searchMappings[filter];
+  let value;
+  if (typeof mapFunc === "function") {
+    value = mapFunc(machine);
+  } else if (machine.hasOwnProperty(filter)) {
+    value = machine[filter];
+  }
+  return value;
+};

--- a/ui/src/app/utils/search.test.js
+++ b/ui/src/app/utils/search.test.js
@@ -1,0 +1,13 @@
+import { getMachineValue } from "./search";
+
+describe("getMachineValue", () => {
+  it("can get an attribute via a mapping function", () => {
+    expect(getMachineValue({ hostname: "machine1" }, "hostname")).toBe(
+      "machine1"
+    );
+  });
+
+  it("can get an attribute directly from the machine", () => {
+    expect(getMachineValue({ id: 808 }, "id")).toBe(808);
+  });
+});


### PR DESCRIPTION
## Done
- Add the filter accordion UI.

## QA
- Visit /r/machines.
- Open the filter accordion and expand different sections, you should see options based on the machines you have.
- Click on some options, your machines should be filtered.

Note: the search box will not be updated with the text until a feature has been added to the react-component lib. This is added in this PR: https://github.com/canonical-web-and-design/react-components/pull/75.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1487.
