### PR TITLE
Build form components for actions that do not require fields.

### DIFF
--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -56,10 +56,10 @@ machine.setZone = (systemId, zoneId) =>
     zone_id: zoneId
   });
 
-machine.turnOff = systemId =>
+machine.off = systemId =>
   generateMachineAction("TURN_MACHINE_OFF", "off", systemId);
 
-machine.turnOn = systemId =>
+machine.on = systemId =>
   generateMachineAction("TURN_MACHINE_ON", "on", systemId);
 
 machine.checkPower = systemId => {
@@ -123,6 +123,9 @@ machine.lock = systemId =>
 
 machine.unlock = systemId =>
   generateMachineAction("UNLOCK_MACHINE", "unlock", systemId);
+
+machine.delete = systemId =>
+  generateMachineAction("DELETE_MACHINE", "delete", systemId);
 
 machine.cleanup = () => {
   return {

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -68,7 +68,7 @@ describe("machine actions", () => {
   });
 
   it("can handle turning on the machine", () => {
-    expect(machine.turnOn("abc123")).toEqual({
+    expect(machine.on("abc123")).toEqual({
       type: "TURN_MACHINE_ON",
       meta: {
         model: "machine",
@@ -85,7 +85,7 @@ describe("machine actions", () => {
   });
 
   it("can handle turning off the machine", () => {
-    expect(machine.turnOff("abc123")).toEqual({
+    expect(machine.off("abc123")).toEqual({
       type: "TURN_MACHINE_OFF",
       meta: {
         model: "machine",
@@ -330,6 +330,23 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "unlock",
+          extra: {},
+          system_id: "abc123"
+        }
+      }
+    });
+  });
+
+  it("can handle deleting a machine", () => {
+    expect(machine.delete("abc123")).toEqual({
+      type: "DELETE_MACHINE",
+      meta: {
+        model: "machine",
+        method: "action"
+      },
+      payload: {
+        params: {
+          action: "delete",
           extra: {},
           system_id: "abc123"
         }

--- a/ui/src/app/base/components/FormCard/_index.scss
+++ b/ui/src/app/base/components/FormCard/_index.scss
@@ -1,9 +1,7 @@
 @mixin FormCard {
   .form-card__buttons {
-    border-top: $border;
     display: flex;
     justify-content: flex-end;
-    padding-top: $spv-inner--large;
 
     &:not(.is-bordered) {
       margin-bottom: calc(#{$spv-inner--x-small--scaleable} - 2px);

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
@@ -11,6 +11,7 @@ export const FormCardButtons = ({
   onCancel,
   secondarySubmit,
   secondarySubmitLabel,
+  submitAppearance = "positive",
   submitDisabled,
   submitLabel,
   success
@@ -53,7 +54,7 @@ export const FormCardButtons = ({
           </Button>
         )}
         <ActionButton
-          appearance="positive"
+          appearance={submitAppearance}
           className="u-no-margin--bottom"
           disabled={submitDisabled}
           loading={loading}
@@ -73,6 +74,7 @@ FormCardButtons.propTypes = {
   onCancel: PropTypes.func,
   secondarySubmit: PropTypes.func,
   secondarySubmitLabel: PropTypes.string,
+  submitAppearance: PropTypes.string,
   submitDisabled: PropTypes.bool,
   submitLabel: PropTypes.string.isRequired,
   success: PropTypes.bool

--- a/ui/src/app/base/components/FormikForm/FormikForm.js
+++ b/ui/src/app/base/components/FormikForm/FormikForm.js
@@ -25,6 +25,7 @@ const FormikForm = ({
   savedRedirect,
   secondarySubmit,
   secondarySubmitLabel,
+  submitAppearance,
   submitLabel,
   validationSchema,
   ...props
@@ -68,6 +69,7 @@ const FormikForm = ({
         saved={saved}
         secondarySubmit={secondarySubmit}
         secondarySubmitLabel={secondarySubmitLabel}
+        submitAppearance={submitAppearance}
         submitLabel={submitLabel}
       >
         {children}
@@ -81,7 +83,7 @@ FormikForm.propTypes = {
   buttons: PropTypes.func,
   buttonsBordered: PropTypes.bool,
   cleanup: PropTypes.func,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   errors: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   initialValues: PropTypes.object.isRequired,
   onCancel: PropTypes.func,
@@ -98,8 +100,9 @@ FormikForm.propTypes = {
   savedRedirect: PropTypes.string,
   secondarySubmit: PropTypes.func,
   secondarySubmitLabel: PropTypes.string,
+  submitAppearance: PropTypes.string,
   submitLabel: PropTypes.string,
-  validationSchema: PropTypes.object.isRequired
+  validationSchema: PropTypes.object
 };
 
 export default FormikForm;

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
@@ -20,6 +20,7 @@ const FormikFormContent = ({
   saved,
   secondarySubmit,
   secondarySubmitLabel,
+  submitAppearance,
   submitLabel = "Save"
 }) => {
   const { handleSubmit, resetForm, submitForm, values } = useFormikContext();
@@ -67,6 +68,7 @@ const FormikFormContent = ({
             : undefined
         }
         secondarySubmitLabel={secondarySubmitLabel}
+        submitAppearance={submitAppearance}
         submitDisabled={saving || formDisabled}
         submitLabel={submitLabel}
         success={saved}
@@ -79,7 +81,7 @@ FormikFormContent.propTypes = {
   allowAllEmpty: PropTypes.bool,
   buttons: PropTypes.func,
   buttonsBordered: PropTypes.bool,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   errors: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   onCancel: PropTypes.func,
   onValuesChanged: PropTypes.func,
@@ -87,6 +89,7 @@ FormikFormContent.propTypes = {
   saved: PropTypes.bool,
   secondarySubmit: PropTypes.func,
   secondarySubmitLabel: PropTypes.string,
+  submitAppearance: PropTypes.string,
   submitLabel: PropTypes.string
 };
 

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -12,6 +12,7 @@ import { general as generalSelectors } from "app/base/selectors";
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import { messages } from "app/base/actions";
+import { kebabToCamelCase } from "app/utils";
 import { simpleObjectEquality } from "app/settings/utils";
 
 // Router hooks inspired by: https://github.com/ReactTraining/react-router/issues/6430#issuecomment-510266079
@@ -161,14 +162,6 @@ export const useSendAnalytics = (
   }, [sendCondition, eventCategory, eventAction, eventLabel]);
 };
 
-const actionMethodOverrides = new Map([
-  ["exit-rescue-mode", "exitRescueMode"],
-  ["mark-broken", "markBroken"],
-  ["mark-fixed", "markFixed"],
-  ["override-failed-testing", "overrideFailedTesting"],
-  ["rescue-mode", "rescueMode"]
-]);
-
 /**
  * Generate menu items for the available actins on a machine.
  * @param {String} systemId - The system id for a machine.
@@ -197,7 +190,7 @@ export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
       actionLinks.push({
         children: actionLabel,
         onClick: () => {
-          const actionMethod = actionMethodOverrides.get(action) || action;
+          const actionMethod = kebabToCamelCase(action);
           dispatch(machineActions[actionMethod](systemId));
           onClick && onClick();
         }

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -31,6 +31,14 @@ const machine = produce(
       case "CREATE_MACHINE_NOTIFY":
         draft.items.push(action.payload);
         break;
+      case "DELETE_MACHINE_NOTIFY":
+        draft.items = draft.items.filter(
+          machine => machine.system_id !== action.payload
+        );
+        draft.selected = draft.selected.filter(
+          machineId => machineId !== action.payload
+        );
+        break;
       case "UPDATE_MACHINE_NOTIFY":
         for (let i in draft.items) {
           if (draft.items[i].id === action.payload.id) {

--- a/ui/src/app/base/reducers/machine/machine.test.js
+++ b/ui/src/app/base/reducers/machine/machine.test.js
@@ -177,6 +177,37 @@ describe("machine reducer", () => {
     });
   });
 
+  it("should correctly reduce DELETE_MACHINE_NOTIFY", () => {
+    expect(
+      machine(
+        {
+          errors: {},
+          items: [
+            { id: 1, system_id: "abc" },
+            { id: 2, system_id: "def" }
+          ],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false,
+          selected: ["abc"]
+        },
+        {
+          payload: "abc",
+          type: "DELETE_MACHINE_NOTIFY"
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 2, system_id: "def" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+      selected: []
+    });
+  });
+
   it("should correctly reduce UPDATE_MACHINE_NOTIFY", () => {
     expect(
       machine(

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
@@ -1,3 +1,4 @@
+import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
@@ -65,5 +66,490 @@ describe("ActionForm", () => {
     wrapper.find('[data-test="cancel-action"] button').simulate("click");
 
     expect(setSelectedAction).toHaveBeenCalledWith(null);
+  });
+
+  it("displays a negative submit button if selected action is delete", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["delete"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const setSelectedAction = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "delete" }}
+            setSelectedAction={setSelectedAction}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("ActionButton").props().appearance).toBe("negative");
+  });
+
+  it("can dispatch abort action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["abort"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "abort" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "ABORT_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "abort",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch acquire action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["acquire"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "acquire" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "ACQUIRE_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "acquire",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch delete action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["delete"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "delete" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "DELETE_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "delete",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch exit rescue mode action", () => {
+    const state = { ...initialState };
+    state.machine.items = [
+      { system_id: "abc123", actions: ["exit-rescue-mode"] }
+    ];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "exit-rescue-mode" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "MACHINE_EXIT_RESCUE_MODE",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "exit-rescue-mode",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch lock action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["lock"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "lock" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "LOCK_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "lock",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch mark broken action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["mark-broken"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "mark-broken" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "MARK_MACHINE_BROKEN",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "mark-broken",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch mark fixed action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["mark-fixed"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "mark-fixed" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "MARK_MACHINE_FIXED",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "mark-fixed",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch power off action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["off"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "off" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "TURN_MACHINE_OFF",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "off",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch power on action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["on"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "on" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "TURN_MACHINE_ON",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "on",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch release action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["release"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "release" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "RELEASE_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "release",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
+  });
+
+  it("can dispatch unlock action", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["unlock"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "unlock" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit()
+    );
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "UNLOCK_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action"
+        },
+        payload: {
+          params: {
+            action: "unlock",
+            extra: {},
+            system_id: "abc123"
+          }
+        }
+      }
+    ]);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
@@ -9,43 +9,91 @@ exports[`ActionForm renders 1`] = `
   }
   setSelectedAction={[MockFunction]}
 >
-  <FormCardButtons
-    bordered={false}
+  <FormikForm
+    buttons={[Function]}
+    buttonsBordered={false}
+    cleanup={[Function]}
+    errors={Object {}}
+    initialValues={Object {}}
     onCancel={[Function]}
+    onSaveAnalytics={
+      Object {
+        "action": "commission",
+        "category": "Take action menu",
+        "label": undefined,
+      }
+    }
+    onSubmit={[Function]}
+    submitAppearance="positive"
     submitLabel="Commission 0 machines"
   >
-    <div
-      className="form-card__buttons"
+    <Formik
+      initialValues={Object {}}
+      onSubmit={[Function]}
     >
-      <Button
-        appearance="base"
-        className="u-no-margin--bottom"
-        data-test="cancel-action"
-        onClick={[Function]}
-        type="button"
+      <FormikFormContent
+        buttons={[Function]}
+        buttonsBordered={false}
+        errors={Object {}}
+        initialValues={Object {}}
+        onCancel={[Function]}
+        submitAppearance="positive"
+        submitLabel="Commission 0 machines"
       >
-        <button
-          className="p-button--base u-no-margin--bottom"
-          data-test="cancel-action"
-          onClick={[Function]}
-          type="button"
+        <Form
+          onSubmit={[Function]}
         >
-          Cancel
-        </button>
-      </Button>
-      <ActionButton
-        appearance="positive"
-        className="u-no-margin--bottom"
-        type="submit"
-      >
-        <button
-          className="u-no-margin--bottom p-action-button p-button--positive"
-          type="submit"
-        >
-          Commission 0 machines
-        </button>
-      </ActionButton>
-    </div>
-  </FormCardButtons>
+          <form
+            className=""
+            onSubmit={[Function]}
+          >
+            <div />
+            <FormCardButtons
+              bordered={false}
+              onCancel={[Function]}
+              submitAppearance="positive"
+              submitDisabled={false}
+              submitLabel="Commission 0 machines"
+            >
+              <div
+                className="form-card__buttons"
+              >
+                <Button
+                  appearance="base"
+                  className="u-no-margin--bottom"
+                  data-test="cancel-action"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <button
+                    className="p-button--base u-no-margin--bottom"
+                    data-test="cancel-action"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </Button>
+                <ActionButton
+                  appearance="positive"
+                  className="u-no-margin--bottom"
+                  disabled={false}
+                  type="submit"
+                >
+                  <button
+                    className="u-no-margin--bottom p-action-button p-button--positive"
+                    disabled={false}
+                    type="submit"
+                  >
+                    Commission 0 machines
+                  </button>
+                </ActionButton>
+              </div>
+            </FormCardButtons>
+          </form>
+        </Form>
+      </FormikFormContent>
+    </Formik>
+  </FormikForm>
 </ActionForm>
 `;

--- a/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/PowerColumn/PowerColumn.js
@@ -35,7 +35,7 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
         </>
       ),
       onClick: () => {
-        dispatch(machineActions.turnOn(systemId));
+        dispatch(machineActions.on(systemId));
         setUpdating(machine.power_state);
       }
     });
@@ -48,7 +48,7 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
         </>
       ),
       onClick: () => {
-        dispatch(machineActions.turnOff(systemId));
+        dispatch(machineActions.off(systemId));
         setUpdating(machine.power_state);
       }
     });

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -3,5 +3,6 @@ export { formatBytes } from "./formatBytes";
 export { formatSpeedUnits } from "./formatSpeedUnits";
 export { getMachineValue } from "./search";
 export { groupAsMap } from "./groupAsMap";
+export { kebabToCamelCase } from "./kebabToCamelCase";
 export { simpleSortByKey } from "./simpleSortByKey";
 export { trimPowerParameters } from "./trimPowerParameters";

--- a/ui/src/app/utils/kebabToCamelCase.js
+++ b/ui/src/app/utils/kebabToCamelCase.js
@@ -1,0 +1,9 @@
+/**
+ * Convert a kebab case string into a camel case string,
+ * e.g. my-string => myString
+ *
+ * @param {string} string - the kebab case string to convert
+ * @returns {string} camel case string
+ */
+export const kebabToCamelCase = str =>
+  str.replace(/-([a-z])/g, g => g[1].toUpperCase());

--- a/ui/src/app/utils/kebabToCamelCase.test.js
+++ b/ui/src/app/utils/kebabToCamelCase.test.js
@@ -1,0 +1,9 @@
+import { kebabToCamelCase } from "./kebabToCamelCase";
+
+describe("kebabToCamelCase", () => {
+  it("correctly converts kebab case strings to camel case strings", () => {
+    expect(kebabToCamelCase("string")).toEqual("string");
+    expect(kebabToCamelCase("my-string")).toEqual("myString");
+    expect(kebabToCamelCase("my-long-string")).toEqual("myLongString");
+  });
+});


### PR DESCRIPTION
## #882 should be merged first - this PR builds on top of it

## Done
- Updated `ActionForm` to dispatch actions for forms that don't have fields, which are the following:
  - Acquire
  - Release
  - Abort
  - Power on
  - Power off
  - Lock
  - Unlock
  - Rescue mode
  - Exit rescue mode
  - Mark broken
  - Mark fixed
  - Delete (red button)
- Added a string util function `kebabToCamelCase` for converting the websocket method names into our redux action names.

## QA
- Select some machines and check that you can successfully perform the above actions, taking note that the delete action should remove the machine from `items` state and `selected` state.
- Check that the delete button is red instead of green.
- Note that errors and progress will be tackled in #881 - this PR merely makes it possible to perform these actions in batch. 

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1783