### PR TITLE
Improve search DSL and add selected filtering

### DIFF
--- a/ui/src/app/base/selectors/machine/machine.js
+++ b/ui/src/app/base/selectors/machine/machine.js
@@ -69,12 +69,16 @@ machine.getBySystemId = (state, id) =>
 machine.errors = state => state.machine.errors;
 
 /**
- * Gets the search terms.
+ * Gets the search terms and selected machines.
  * @param {Object} state - The redux state.
- * @param {Array} terms - The search terms.
- * @returns {Array} The search terms.
+ * @param {String} terms - The search string.
+ * @param {Array} selectedIDs - The selected machine ids.
+ * @returns {Array} The search terms and selected machines.
  */
-machine._getTerms = (state, terms) => terms;
+machine._getSearchParams = (state, terms, selectedIDs) => ({
+  terms,
+  selectedIDs
+});
 
 /**
  * Get machines that match terms.
@@ -83,12 +87,12 @@ machine._getTerms = (state, terms) => terms;
  * @returns {Array} A filtered list of machines.
  */
 machine.search = createSelector(
-  [machine.all, machine._getTerms],
-  (items, terms) => {
+  [machine.all, machine._getSearchParams],
+  (items, { terms, selectedIDs }) => {
     if (!terms) {
       return items;
     }
-    return filterNodes(items, terms);
+    return filterNodes(items, terms, selectedIDs);
   }
 );
 

--- a/ui/src/app/machines/filter-nodes.js
+++ b/ui/src/app/machines/filter-nodes.js
@@ -36,7 +36,7 @@ const matches = (value, lowerTerm, exact, negate) => {
   return negate ? !match : match;
 };
 
-const filterNodes = (nodes, search) => {
+const filterNodes = (nodes, search, selectedIDs) => {
   if (
     typeof nodes === "undefined" ||
     typeof search === "undefined" ||
@@ -45,6 +45,10 @@ const filterNodes = (nodes, search) => {
     return nodes;
   }
   const filters = getCurrentFilters(search);
+  if (!filters) {
+    // No matching filters were found.
+    return [];
+  }
   Object.entries(filters).forEach(([attr, terms]) => {
     if (terms.length === 0) {
       // If this attribute has no associated terms then skip it.
@@ -54,15 +58,15 @@ const filterNodes = (nodes, search) => {
       // "in:" is used to filter the nodes by those that are
       // currently selected.
       terms.forEach(term => {
-        const matched = [];
-        nodes.forEach(node => {
-          if (node.$selected && term.toLowerCase() === "selected") {
-            matched.push(node);
-          } else if (!node.$selected && term.toLowerCase() === "!selected") {
-            matched.push(node);
-          }
-        });
-        nodes = matched;
+        if (term.toLowerCase() === "selected") {
+          nodes = nodes.filter(({ system_id }) =>
+            selectedIDs.includes(system_id)
+          );
+        } else if (term.toLowerCase() === "!selected") {
+          nodes = nodes.filter(
+            ({ system_id }) => !selectedIDs.includes(system_id)
+          );
+        }
       });
     } else {
       // Loop through each item and only select the matching.

--- a/ui/src/app/machines/filter-nodes.js
+++ b/ui/src/app/machines/filter-nodes.js
@@ -36,7 +36,66 @@ const matches = (value, lowerTerm, exact, negate) => {
   return negate ? !match : match;
 };
 
+const filterByTerms = (filteredNodes, attr, terms, selectedIDs) =>
+  filteredNodes.filter(node => {
+    let matched = false;
+    let exclude = false;
+    // Loop through the attributes to check. If this is for the
+    // generic "_" filter then check against all node attributes.
+    (attr === "_" ? Object.keys(node) : [attr]).some(filterAttribute => {
+      if (filterAttribute === "in") {
+        // "in:" is used to filter the nodes by those that are
+        // currently selected.
+        const selected = selectedIDs.includes(node.system_id);
+        // The terms will be an array, but it is invalid to have more than
+        // one of 'selected' or '!selected'.
+        const term = terms[0].toLowerCase();
+        const onlySelected = term === "selected";
+        const onlyNotSelected = term === "!selected";
+        if ((selected && onlySelected) || (!selected && onlyNotSelected)) {
+          matched = true;
+        } else {
+          exclude = true;
+        }
+        return false;
+      }
+      let machineAttribute = getMachineValue(node, filterAttribute);
+      if (typeof machineAttribute === "undefined") {
+        // Unable to get value for this node. So skip it.
+        return false;
+      }
+      return terms.some(term => {
+        let cleanTerm = term.toLowerCase();
+        // Get the first two characters, to check for ! or =.
+        const special = cleanTerm.substring(0, 2);
+        const exact = special.includes("=");
+        const negate = special.includes("!") && special !== "!!";
+        // Remove the special characters to get the term.
+        cleanTerm = cleanTerm.replace(/^[!|=]+/, "");
+        return (Array.isArray(machineAttribute)
+          ? machineAttribute
+          : [machineAttribute]
+        ).some(attribute => {
+          const match = matches(attribute, cleanTerm, exact, false);
+          if (match) {
+            if (negate) {
+              exclude = true;
+            } else {
+              matched = true;
+            }
+          } else if (negate) {
+            matched = true;
+          }
+          // If an exclude was found then exit the loop.
+          return exclude;
+        });
+      });
+    });
+    return matched && !exclude;
+  });
+
 const filterNodes = (nodes, search, selectedIDs) => {
+  let filteredNodes = nodes;
   if (
     typeof nodes === "undefined" ||
     typeof search === "undefined" ||
@@ -49,97 +108,23 @@ const filterNodes = (nodes, search, selectedIDs) => {
     // No matching filters were found.
     return [];
   }
+  // Progressively filter the list of machines for each search term.
   Object.entries(filters).forEach(([attr, terms]) => {
     if (terms.length === 0) {
       // If this attribute has no associated terms then skip it.
       return;
     }
-    if (attr === "in") {
-      // "in:" is used to filter the nodes by those that are
-      // currently selected.
+    if (attr === "_") {
+      // When filtering free search we need all terms to match so subsequent
+      // terms will reduce the list to those that match all.
       terms.forEach(term => {
-        if (term.toLowerCase() === "selected") {
-          nodes = nodes.filter(({ system_id }) =>
-            selectedIDs.includes(system_id)
-          );
-        } else if (term.toLowerCase() === "!selected") {
-          nodes = nodes.filter(
-            ({ system_id }) => !selectedIDs.includes(system_id)
-          );
-        }
+        filteredNodes = filterByTerms(filteredNodes, attr, [term], selectedIDs);
       });
     } else {
-      // Loop through each item and only select the matching.
-      const matched = [];
-      nodes.forEach(node => {
-        // Loop through the attributes to check. If this is for the
-        // generic "_" filter then check against all node attributes.
-        (attr === "_" ? Object.keys(node) : [attr]).some(key => {
-          let value = getMachineValue(node, key);
-          // Unable to get value for this node. So skip it.
-          if (typeof value === "undefined") {
-            return false;
-          }
-
-          return terms.some(term => {
-            term = term.toLowerCase();
-            let exact = false;
-            let negate = false;
-
-            // '!' at the beginning means the term is negated.
-            while (term.indexOf("!") === 0) {
-              negate = !negate;
-              term = term.substring(1);
-            }
-
-            // '=' at the beginning means to match exactly.
-            if (term.indexOf("=") === 0) {
-              exact = true;
-              term = term.substring(1);
-            }
-
-            // Allow '!' after the '=' as well.
-            while (term.indexOf("!") === 0) {
-              negate = !negate;
-              term = term.substring(1);
-            }
-
-            if (Array.isArray(value)) {
-              // If value is an array check if the
-              // term matches any value in the
-              // array. If negated, check whether no
-              // value in the array matches.
-              const match = value.some(v => {
-                if (matches(v, term, exact, false)) {
-                  return true;
-                }
-                return false;
-              });
-              if (negate) {
-                // Push to matched only if no value in the array matches term.
-                if (!match) {
-                  matched.push(node);
-                  return true;
-                }
-              } else if (match) {
-                matched.push(node);
-                return true;
-              }
-            } else {
-              // Standard value check that it matches the term.
-              if (matches(value, term, exact, negate)) {
-                matched.push(node);
-                return true;
-              }
-            }
-            return false;
-          });
-        });
-      });
-      nodes = matched;
+      filteredNodes = filterByTerms(filteredNodes, attr, terms, selectedIDs);
     }
   });
-  return nodes;
+  return filteredNodes;
 };
 
 export default filterNodes;

--- a/ui/src/app/machines/filter-nodes.test.js
+++ b/ui/src/app/machines/filter-nodes.test.js
@@ -1,473 +1,275 @@
 import filterNodes from "./filter-nodes";
 
 describe("filterNodes", () => {
-  it("handles no filters", () => {
-    const matchingNode = {
-      hostname: "name"
-    };
-    const otherNode = {
-      hostname: "other"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "status:(=")).toEqual(nodes);
-  });
+  // If a scenario is not provided `result`, `nodes` or `selected` then the
+  // following defaults are used.
+  const DEFAULT_RESULT = [0];
+  const DEFAULT_NODES = [{ hostname: "name" }, { hostname: "other" }];
+  const DEFAULT_SELECTED = null;
+  // These are common nodes to prevent duplication:
+  const tagNodes = [
+    { tags: ["first", "second"] },
+    { tags: ["second", "third"] }
+  ];
 
-  it("matches using standard filter", () => {
-    const matchingNode = {
-      hostname: "name"
-    };
-    const otherNode = {
-      hostname: "other"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "nam")).toEqual([matchingNode]);
-  });
+  const scenarios = [
+    {
+      description: "handles no filters",
+      filter: "hostname:(=",
+      result: [0, 1]
+    },
+    {
+      description: "matches using standard filter",
+      filter: "nam"
+    },
+    {
+      description: "doesn't return duplicates using standard filter",
+      filter: "nam am",
+      nodes: [
+        { hostname: "name", pod: { name: "name" } },
+        { hostname: "other" }
+      ]
+    },
+    {
+      description: "matches selected uppercase",
+      filter: "in:Selected",
+      nodes: [{ system_id: "1" }, { system_id: "2" }],
+      selected: ["1"]
+    },
+    {
+      description: "matches selected uppercase",
+      filter: "in:(Selected)",
+      nodes: [{ system_id: "1" }, { system_id: "2" }],
+      selected: ["1"]
+    },
+    {
+      description: "matches non-selected",
+      filter: "in:!selected",
+      nodes: [{ system_id: "1" }, { system_id: "2" }],
+      selected: ["2"]
+    },
+    {
+      description: "matches non-selected uppercase",
+      filter: "in:!Selected",
+      nodes: [{ system_id: "1" }, { system_id: "2" }],
+      selected: ["2"]
+    },
+    {
+      description: "matches non-selected uppercase in brackets",
+      filter: "in:(!Selected)",
+      nodes: [{ system_id: "1" }, { system_id: "2" }],
+      selected: ["2"]
+    },
+    {
+      description: "matches on attribute",
+      filter: "hostname:name"
+    },
+    {
+      description: "matches with contains on attribute",
+      filter: "hostname:na"
+    },
+    {
+      description: "matches on negating attribute",
+      filter: "hostname:!other"
+    },
+    {
+      description: "matches on exact attribute",
+      filter: "hostname:=other",
+      nodes: [{ hostname: "other" }, { hostname: "other2" }]
+    },
+    {
+      description: "matches on array",
+      filter: "hostnames:first",
+      nodes: [
+        { hostnames: ["name", "first"] },
+        { hostnames: ["other", "second"] }
+      ]
+    },
+    {
+      description: "matches integer values",
+      filter: "count:3",
+      nodes: [{ count: 4 }, { count: 2 }]
+    },
+    {
+      description: "matches float values",
+      filter: "count:1.5",
+      nodes: [{ count: 2.2 }, { count: 1.1 }]
+    },
+    {
+      description: "matches using cpu mapping function",
+      filter: "cpu:3",
+      nodes: [{ cpu_count: 4 }, { cpu_count: 2 }]
+    },
+    {
+      description: "matches using cores mapping function",
+      filter: "cores:3",
+      nodes: [{ cpu_count: 4 }, { cpu_count: 2 }]
+    },
+    {
+      description: "matches using ram mapping function",
+      filter: "ram:2000",
+      nodes: [{ memory: 2048 }, { memory: 1024 }]
+    },
+    {
+      description: "matches using mac mapping function",
+      filter: "mac:aa:bb:cc:dd:ee:ff",
+      nodes: [
+        { pxe_mac: "00:11:22:33:44:55", extra_macs: ["aa:bb:cc:dd:ee:ff"] },
+        { pxe_mac: "66:11:22:33:44:55", extra_macs: ["00:bb:cc:dd:ee:ff"] }
+      ]
+    },
+    {
+      description: "matches using mac mapping function",
+      filter: "zone:first",
+      nodes: [{ zone: { name: "first" } }, { zone: { name: "second" } }]
+    },
+    {
+      description: "matches using pool mapping function",
+      filter: "pool:pool1",
+      nodes: [{ pool: { name: "pool1" } }, { pool: { name: "pool2" } }]
+    },
+    {
+      description: "matches using pod mapping function",
+      filter: "pod:pod1",
+      nodes: [{ pod: { name: "pod1" } }, { pod: { name: "pod2" } }]
+    },
+    {
+      description: "matches using pod-id mapping function",
+      filter: "pod-id:=1",
+      nodes: [
+        { pod: { name: "pod1", id: 1 } },
+        { pod: { name: "pod2", id: 2 } }
+      ]
+    },
+    {
+      description: "matches using power mapping function",
+      filter: "power:on",
+      nodes: [{ power_state: "on" }, { power_state: "off" }]
+    },
+    {
+      description: "matches accumulate",
+      filter: "power:on zone:first",
+      nodes: [
+        {
+          power_state: "on",
+          zone: {
+            name: "first"
+          }
+        },
+        {
+          power_state: "on",
+          zone: {
+            name: "second"
+          }
+        }
+      ]
+    },
+    {
+      description: "matches a tag",
+      filter: "tags:first",
+      nodes: tagNodes
+    },
+    {
+      description: "matches a negated tag",
+      filter: "tags:!third",
+      nodes: tagNodes
+    },
+    {
+      description: "matches a negated tag with parens",
+      filter: "tags:(!third)",
+      nodes: tagNodes
+    },
+    {
+      description: "matches a negated tag with the parens negated",
+      filter: "tags:!(third)",
+      nodes: tagNodes
+    },
+    {
+      description: "matches a double negated tag",
+      filter: "tags:!!first",
+      nodes: tagNodes
+    },
+    {
+      description: "matches a double negated tag with parens",
+      filter: "tags:(!!first)",
+      nodes: tagNodes
+    },
+    {
+      description: "matches a double negated tag with in and outside negated",
+      filter: "tags:!(!first)",
+      nodes: tagNodes
+    },
+    {
+      description: "matches a direct and a negated tag",
+      filter: "tags:(first,!third)",
+      nodes: tagNodes
+    },
+    {
+      description: "matches an exact direct and a negated tag",
+      filter: "tags:(=first,!third)",
+      nodes: tagNodes
+    },
+    {
+      description: "matches two negated tags",
+      filter: "tags:(!second,!third)",
+      nodes: tagNodes
+    },
+    {
+      description: "matches any values",
+      filter: "status:Ne,Dep",
+      nodes: [
+        { status: "New" },
+        { status: "Failed commissioning" },
+        { status: "Deploying" }
+      ],
+      result: [0, 2]
+    },
+    {
+      description: "matches any exact values",
+      filter: "status:(=Ne,=Failed commissioning,=Deploying)",
+      nodes: [
+        { status: "New" },
+        { status: "Failed commissioning" },
+        { status: "Deploying" }
+      ],
+      result: [1, 2]
+    },
+    {
+      description: "matches any values but only those that match other filters",
+      filter: "status:New,Deploying owner:admin",
+      nodes: [
+        { owner: "user", status: "New" },
+        { owner: "admin", status: "Failed commissioning" },
+        { owner: "admin", status: "Deploying" }
+      ],
+      result: [2]
+    },
+    {
+      description: "matches using release mapping function",
+      filter: "release:ubuntu/xenial",
+      nodes: [
+        { status_code: 9, osystem: "ubuntu", distro_series: "xenial" },
+        { status_code: 6, osystem: "ubuntu", distro_series: "xenial" },
+        { status_code: 5, osystem: "ubuntu", distro_series: "xenial" },
+        { status_code: 6, osystem: "ubuntu", distro_series: "trusty" }
+      ],
+      result: [0, 1]
+    }
+  ];
 
-  it("doesn't return duplicates using standard filter", () => {
-    const matchingNode = {
-      hostname: "name",
-      pod: {
-        name: "name"
-      }
-    };
-    const otherNode = {
-      hostname: "other"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "nam am")).toEqual([matchingNode]);
-  });
-
-  it("matches selected", () => {
-    const matchingNode = {
-      system_id: "1"
-    };
-    const otherNode = {
-      system_id: "2"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:selected", ["1"])).toEqual([matchingNode]);
-  });
-
-  it("matches selected uppercase", () => {
-    const matchingNode = {
-      system_id: "1"
-    };
-    const otherNode = {
-      system_id: "2"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:Selected", ["1"])).toEqual([matchingNode]);
-  });
-
-  it("matches selected uppercase in brackets", () => {
-    const matchingNode = {
-      system_id: "1"
-    };
-    const otherNode = {
-      system_id: "2"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:(Selected)", ["1"])).toEqual([matchingNode]);
-  });
-
-  it("matches non-selected", () => {
-    const matchingNode = {
-      system_id: "1"
-    };
-    const otherNode = {
-      system_id: "2"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:!selected", ["2"])).toEqual([matchingNode]);
-  });
-
-  it("matches non-selected uppercase", () => {
-    const matchingNode = {
-      system_id: "1"
-    };
-    const otherNode = {
-      system_id: "2"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:!Selected", ["2"])).toEqual([matchingNode]);
-  });
-
-  it("matches non-selected uppercase in brackets", () => {
-    const matchingNode = {
-      system_id: "1"
-    };
-    const otherNode = {
-      system_id: "2"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:(!Selected)", ["2"])).toEqual([matchingNode]);
-  });
-
-  it("matches on attribute", () => {
-    const matchingNode = {
-      hostname: "name"
-    };
-    const otherNode = {
-      hostname: "other"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "hostname:name")).toEqual([matchingNode]);
-  });
-
-  it("matches with contains on attribute", () => {
-    const matchingNode = {
-      hostname: "name"
-    };
-    const otherNode = {
-      hostname: "other"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "hostname:na")).toEqual([matchingNode]);
-  });
-
-  it("matches on negating attribute", () => {
-    const matchingNode = {
-      hostname: "name"
-    };
-    const otherNode = {
-      hostname: "other"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "hostname:!other")).toEqual([matchingNode]);
-  });
-
-  it("matches on exact attribute", () => {
-    const matchingNode = {
-      hostname: "other"
-    };
-    const otherNode = {
-      hostname: "other2"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "hostname:=other")).toEqual([matchingNode]);
-  });
-
-  it("matches on array", () => {
-    const matchingNode = {
-      hostnames: ["name", "first"]
-    };
-    const otherNode = {
-      hostnames: ["other", "second"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "hostnames:first")).toEqual([matchingNode]);
-  });
-
-  it("matches integer values", () => {
-    const matchingNode = {
-      count: 4
-    };
-    const otherNode = {
-      count: 2
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "count:3")).toEqual([matchingNode]);
-  });
-
-  it("matches float values", () => {
-    const matchingNode = {
-      count: 2.2
-    };
-    const otherNode = {
-      count: 1.1
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "count:1.5")).toEqual([matchingNode]);
-  });
-
-  it("matches using cpu mapping function", () => {
-    const matchingNode = {
-      cpu_count: 4
-    };
-    const otherNode = {
-      cpu_count: 2
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "cpu:3")).toEqual([matchingNode]);
-  });
-
-  it("matches using cores mapping function", () => {
-    const matchingNode = {
-      cpu_count: 4
-    };
-    const otherNode = {
-      cpu_count: 2
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "cores:3")).toEqual([matchingNode]);
-  });
-
-  it("matches using ram mapping function", () => {
-    const matchingNode = {
-      memory: 2048
-    };
-    const otherNode = {
-      memory: 1024
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "ram:2000")).toEqual([matchingNode]);
-  });
-
-  it("matches using mac mapping function", () => {
-    const matchingNode = {
-      pxe_mac: "00:11:22:33:44:55",
-      extra_macs: ["aa:bb:cc:dd:ee:ff"]
-    };
-    const otherNode = {
-      pxe_mac: "66:11:22:33:44:55",
-      extra_macs: ["00:bb:cc:dd:ee:ff"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "mac:aa:bb:cc:dd:ee:ff")).toEqual([matchingNode]);
-  });
-
-  it("matches using zone mapping function", () => {
-    const matchingNode = {
-      zone: {
-        name: "first"
-      }
-    };
-    const otherNode = {
-      zone: {
-        name: "second"
-      }
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "zone:first")).toEqual([matchingNode]);
-  });
-
-  it("matches using pool mapping function", () => {
-    const matchingNode = {
-      pool: {
-        name: "pool1"
-      }
-    };
-    const otherNode = {
-      pool: {
-        name: "pool2"
-      }
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "pool:pool1")).toEqual([matchingNode]);
-  });
-
-  it("matches using pod mapping function", () => {
-    const matchingNode = {
-      pod: {
-        name: "pod1"
-      }
-    };
-    const otherNode = {
-      pod: {
-        name: "pod2"
-      }
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "pod:pod1")).toEqual([matchingNode]);
-  });
-
-  it("matches using pod-id mapping function", () => {
-    const matchingNode = {
-      pod: {
-        name: "pod1",
-        id: 1
-      }
-    };
-    const otherNode = {
-      pod: {
-        name: "pod2",
-        id: 2
-      }
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "pod-id:=1")).toEqual([matchingNode]);
-  });
-
-  it("matches using power mapping function", () => {
-    const matchingNode = {
-      power_state: "on"
-    };
-    const otherNode = {
-      power_state: "off"
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "power:on")).toEqual([matchingNode]);
-  });
-
-  it("matches accumulate", () => {
-    const matchingNode = {
-      power_state: "on",
-      zone: {
-        name: "first"
-      }
-    };
-    const otherNode = {
-      power_state: "on",
-      zone: {
-        name: "second"
-      }
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "power:on zone:first")).toEqual([matchingNode]);
-  });
-
-  it("matches a tag", () => {
-    const matchingNode = {
-      tags: ["first", "second"]
-    };
-    const otherNode = {
-      tags: ["second", "third"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "tags:first")).toEqual([matchingNode]);
-  });
-
-  it("matches a negated tag", () => {
-    const matchingNode = {
-      tags: ["first", "second"]
-    };
-    const otherNode = {
-      tags: ["second", "third"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "tags:!third")).toEqual([matchingNode]);
-    expect(filterNodes(nodes, "tags:!(third)")).toEqual([matchingNode]);
-    expect(filterNodes(nodes, "tags:(!third)")).toEqual([matchingNode]);
-  });
-
-  it("matches a double negated tag", () => {
-    const matchingNode = {
-      tags: ["first", "second"]
-    };
-    const otherNode = {
-      tags: ["second", "third"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "tags:!!first")).toEqual([matchingNode]);
-    expect(filterNodes(nodes, "tags:!(!first)")).toEqual([matchingNode]);
-    expect(filterNodes(nodes, "tags:(!!first)")).toEqual([matchingNode]);
-  });
-
-  it("matches a direct and a negated tag", () => {
-    const matchingNode = {
-      tags: ["first", "second"]
-    };
-    const otherNode = {
-      tags: ["second", "third"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "tags:(first,!third)")).toEqual([matchingNode]);
-  });
-
-  it("matches an exact direct and a negated tag", () => {
-    const matchingNode = {
-      tags: ["first", "second"]
-    };
-    const otherNode = {
-      tags: ["first1", "third"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "tags:(=first,!third)")).toEqual([matchingNode]);
-  });
-
-  it("matches two negated tags", () => {
-    const matchingNode = {
-      tags: ["first", "second"]
-    };
-    const otherNode = {
-      tags: ["second", "third"]
-    };
-    const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "tags:(!second,!third)")).toEqual([matchingNode]);
-  });
-
-  it("matches any values", () => {
-    const nodes = [
-      {
-        status: "New"
-      },
-      {
-        status: "Failed commissioning"
-      },
-      {
-        status: "Deploying"
-      }
-    ];
-    expect(filterNodes(nodes, "status:Ne,Dep")).toEqual([nodes[0], nodes[2]]);
-  });
-
-  it("matches any exact values", () => {
-    const nodes = [
-      {
-        status: "New"
-      },
-      {
-        status: "Failed commissioning"
-      },
-      {
-        status: "Deploying"
-      }
-    ];
-    expect(
-      filterNodes(nodes, "status:(=Ne,=Failed commissioning,=Deploying)")
-    ).toEqual([nodes[1], nodes[2]]);
-  });
-
-  it("matches any values but only those that match other filters", () => {
-    const nodes = [
-      {
-        owner: "user",
-        status: "New"
-      },
-      {
-        owner: "admin",
-        status: "Failed commissioning"
-      },
-      {
-        owner: "admin",
-        status: "Deploying"
-      }
-    ];
-    expect(filterNodes(nodes, "status:New,Deploying owner:admin")).toEqual([
-      nodes[2]
-    ]);
-  });
-
-  it("matches using release mapping function", () => {
-    const deployingNode = {
-      status_code: 9,
-      osystem: "ubuntu",
-      distro_series: "xenial"
-    };
-    const deployedNode = {
-      status_code: 6,
-      osystem: "ubuntu",
-      distro_series: "xenial"
-    };
-    const allocatedNode = {
-      status_code: 5,
-      osystem: "ubuntu",
-      distro_series: "xenial"
-    };
-    const deployedOtherNode = {
-      status_code: 6,
-      osystem: "ubuntu",
-      distro_series: "trusty"
-    };
-    const nodes = [
-      deployingNode,
-      deployedNode,
-      allocatedNode,
-      deployedOtherNode
-    ];
-    expect(filterNodes(nodes, "release:ubuntu/xenial")).toEqual([
-      deployingNode,
-      deployedNode
-    ]);
-  });
+  scenarios.forEach(
+    ({
+      result = DEFAULT_RESULT,
+      filter,
+      description,
+      nodes = DEFAULT_NODES,
+      selected = DEFAULT_SELECTED
+    }) => {
+      it(`${description}: ${filter}`, () => {
+        expect(filterNodes(nodes, filter, selected)).toEqual(
+          result.map(index => nodes[index])
+        );
+      });
+    }
+  );
 });

--- a/ui/src/app/machines/filter-nodes.test.js
+++ b/ui/src/app/machines/filter-nodes.test.js
@@ -1,6 +1,17 @@
 import filterNodes from "./filter-nodes";
 
 describe("filterNodes", () => {
+  it("handles no filters", () => {
+    const matchingNode = {
+      hostname: "name"
+    };
+    const otherNode = {
+      hostname: "other"
+    };
+    const nodes = [matchingNode, otherNode];
+    expect(filterNodes(nodes, "status:(=")).toEqual(nodes);
+  });
+
   it("matches using standard filter", () => {
     const matchingNode = {
       hostname: "name"
@@ -28,68 +39,68 @@ describe("filterNodes", () => {
 
   it("matches selected", () => {
     const matchingNode = {
-      $selected: true
+      system_id: "1"
     };
     const otherNode = {
-      $selected: false
+      system_id: "2"
     };
     const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:selected")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "in:selected", ["1"])).toEqual([matchingNode]);
   });
 
   it("matches selected uppercase", () => {
     const matchingNode = {
-      $selected: true
+      system_id: "1"
     };
     const otherNode = {
-      $selected: false
+      system_id: "2"
     };
     const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:Selected")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "in:Selected", ["1"])).toEqual([matchingNode]);
   });
 
   it("matches selected uppercase in brackets", () => {
     const matchingNode = {
-      $selected: true
+      system_id: "1"
     };
     const otherNode = {
-      $selected: false
+      system_id: "2"
     };
     const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:(Selected)")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "in:(Selected)", ["1"])).toEqual([matchingNode]);
   });
 
   it("matches non-selected", () => {
     const matchingNode = {
-      $selected: false
+      system_id: "1"
     };
     const otherNode = {
-      $selected: true
+      system_id: "2"
     };
     const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:!selected")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "in:!selected", ["2"])).toEqual([matchingNode]);
   });
 
   it("matches non-selected uppercase", () => {
     const matchingNode = {
-      $selected: false
+      system_id: "1"
     };
     const otherNode = {
-      $selected: true
+      system_id: "2"
     };
     const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:!Selected")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "in:!Selected", ["2"])).toEqual([matchingNode]);
   });
 
   it("matches non-selected uppercase in brackets", () => {
     const matchingNode = {
-      $selected: false
+      system_id: "1"
     };
     const otherNode = {
-      $selected: true
+      system_id: "2"
     };
     const nodes = [matchingNode, otherNode];
-    expect(filterNodes(nodes, "in:(!Selected)")).toEqual([matchingNode]);
+    expect(filterNodes(nodes, "in:(!Selected)", ["2"])).toEqual([matchingNode]);
   });
 
   it("matches on attribute", () => {
@@ -373,6 +384,58 @@ describe("filterNodes", () => {
     };
     const nodes = [matchingNode, otherNode];
     expect(filterNodes(nodes, "tags:(!second,!third)")).toEqual([matchingNode]);
+  });
+
+  it("matches any values", () => {
+    const nodes = [
+      {
+        status: "New"
+      },
+      {
+        status: "Failed commissioning"
+      },
+      {
+        status: "Deploying"
+      }
+    ];
+    expect(filterNodes(nodes, "status:Ne,Dep")).toEqual([nodes[0], nodes[2]]);
+  });
+
+  it("matches any exact values", () => {
+    const nodes = [
+      {
+        status: "New"
+      },
+      {
+        status: "Failed commissioning"
+      },
+      {
+        status: "Deploying"
+      }
+    ];
+    expect(
+      filterNodes(nodes, "status:(=Ne,=Failed commissioning,=Deploying)")
+    ).toEqual([nodes[1], nodes[2]]);
+  });
+
+  it("matches any values but only those that match other filters", () => {
+    const nodes = [
+      {
+        owner: "user",
+        status: "New"
+      },
+      {
+        owner: "admin",
+        status: "Failed commissioning"
+      },
+      {
+        owner: "admin",
+        status: "Deploying"
+      }
+    ];
+    expect(filterNodes(nodes, "status:New,Deploying owner:admin")).toEqual([
+      nodes[2]
+    ]);
   });
 
   it("matches using release mapping function", () => {

--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -12,8 +12,10 @@ export const getCurrentFilters = search => {
   }
   // Match filters with parens e.g. 'status:(new,deployed)'.
   // Then: match filters without parens e.g. 'status:new,deployed' or 'status'
-  const filterMatchingRegex = search.matchAll(/(\b\w+:!?\([^)]+\))|(\w+\S+)/g);
-  Array.from(filterMatchingRegex).forEach(([group]) => {
+  const filterMatchingRegex = search.matchAll(
+    /(\b\w+:!*\([^)]+\))|(!*\w+\S+)/g
+  );
+  [...filterMatchingRegex].forEach(([group]) => {
     // Get the filter name and values (if supplied).
     let [groupName, groupValues] = group.split(/:(.+)/);
     if (groupValues) {
@@ -21,6 +23,9 @@ export const getCurrentFilters = search => {
       if (allNegated) {
         // Remove the "!"
         groupValues = groupValues.substr(1);
+      } else if (groupValues.startsWith("!!(")) {
+        // Remove the "!!"
+        groupValues = groupValues.substr(2);
       }
       if (groupValues.startsWith("(") !== groupValues.endsWith(")")) {
         // The filter must contain opening and closing parens or neither.

--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -10,55 +10,39 @@ export const getCurrentFilters = search => {
   if (!search) {
     return filters;
   }
-  const terms = search.split(" ");
-  let processingFilter;
-  terms.forEach(term => {
-    if (processingFilter) {
-      const filter = filters[processingFilter];
-      // A previous term had a space in it. This may contain multiple comma
-      // separated terms, the first of which will be part of the last term to
-      // be added to the filter.
-      term.split(",").forEach((termItem, i) => {
-        termItem = termItem.replace(")", "");
-        if (i === 0) {
-          // If this is the first term it is part of the last term to be added.
-          filter[filter.length - 1] += ` ${termItem}`;
-        } else {
-          // This is a new term.
-          filter.push(termItem);
-        }
-      });
-      // If the term contains the ending ')' then it's the last in the group.
-      if (term.includes(")")) {
-        processingFilter = null;
+  // Match filters with parens e.g. 'status:(new,deployed)'.
+  // Then: match filters without parens e.g. 'status:new,deployed' or 'status'
+  const filterMatchingRegex = search.matchAll(/(\b\w+:!?\([^)]+\))|(\w+\S+)/g);
+  Array.from(filterMatchingRegex).forEach(([group]) => {
+    // Get the filter name and values (if supplied).
+    let [groupName, groupValues] = group.split(/:(.+)/);
+    if (groupValues) {
+      const allNegated = groupValues.startsWith("!(");
+      if (allNegated) {
+        // Remove the "!"
+        groupValues = groupValues.substr(1);
       }
-    } else if (term.includes(":")) {
-      // This is a filter for a specific property.
-      let [filter, values: ""] = term.split(":");
-      // Remove the starting '(' and ending ')'.
-      values = values.replace("(", "").replace(")", "");
-      if (!values) {
-        // This filter has no values so skip it.
+      if (groupValues.startsWith("(") !== groupValues.endsWith(")")) {
+        // The filter must contain opening and closing parens or neither.
         return;
       }
-      // Add the values to the filter.
-      filters[filter] = values.split(",");
-      if (term.includes("(") && !term.includes(")")) {
-        // Contains a starting '(' but not an ending ')' so the next term in the
-        // array is part of the current filter.
-        processingFilter = filter;
+      // Remove the surrounding parens.
+      const cleanValues = groupValues.match(/[^(|^)]+/g);
+      if (!cleanValues) {
+        // There are no values inside the parens;
+        return;
       }
-    } else {
-      // Term is not part of a previous '(..)' span so add it to the generic
-      // filters.
-      filters._.push(term);
+      // Split the comma separated values and add the filter.
+      let valueList = cleanValues[0].split(",");
+      if (allNegated) {
+        valueList = valueList.map(value => `!${value}`);
+      }
+      filters[groupName] = valueList;
+    } else if (!group.includes(":")) {
+      // This is a free search value.
+      filters._.push(groupName);
     }
   });
-  // If the filter has finished looping over the terms without
-  // closing the current filter then it is malformed.
-  if (processingFilter) {
-    return null;
-  }
   return filters;
 };
 
@@ -88,6 +72,9 @@ const _getFilterValueIndex = (filters, type, value) => {
 
 // Whether the type and value are in the filters.
 export const isFilterActive = (filters, type, value, exact = false) => {
+  if (!filters) {
+    return false;
+  }
   const values = filters[type];
   if (!values) {
     return false;

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -30,6 +30,14 @@ describe("SearchService", () => {
       }
     },
     {
+      input: "moon status:(new) star",
+      output: "moon star status:(new)",
+      filters: {
+        _: ["moon", "star"],
+        status: ["new"]
+      }
+    },
+    {
       input: "moon status:(new,deployed)",
       filters: {
         _: ["moon"],
@@ -41,6 +49,14 @@ describe("SearchService", () => {
       filters: {
         _: ["moon"],
         status: ["new", "failed disk erasing"]
+      }
+    },
+    {
+      input: "moon status:!(!new,failed disk erasing)",
+      output: "moon status:(!!new,!failed disk erasing)",
+      filters: {
+        _: ["moon"],
+        status: ["!!new", "!failed disk erasing"]
       }
     },
     {
@@ -68,7 +84,10 @@ describe("SearchService", () => {
     },
     {
       input: "moon status:(new,failed disk erasing",
-      filters: null
+      output: "moon disk erasing",
+      filters: {
+        _: ["moon", "disk", "erasing"]
+      }
     },
     {
       input: "moon status:(",
@@ -82,6 +101,39 @@ describe("SearchService", () => {
       output: "moon",
       filters: {
         _: ["moon"]
+      }
+    },
+    {
+      input: "moon mac:28:76:03:77:5a:b5 status:new",
+      output: "moon mac:(28:76:03:77:5a:b5) status:(new)",
+      filters: {
+        _: ["moon"],
+        mac: ["28:76:03:77:5a:b5"],
+        status: ["new"]
+      }
+    },
+    {
+      input: "moon mac:(28:76:03:77:5a:b5) status:new",
+      output: "moon mac:(28:76:03:77:5a:b5) status:(new)",
+      filters: {
+        _: ["moon"],
+        mac: ["28:76:03:77:5a:b5"],
+        status: ["new"]
+      }
+    },
+    {
+      input: "moon mac:(28:76:03:77:5a:b5,d6:4d:bc:0e:26:bc)",
+      output: "moon mac:(28:76:03:77:5a:b5,d6:4d:bc:0e:26:bc)",
+      filters: {
+        _: ["moon"],
+        mac: ["28:76:03:77:5a:b5", "d6:4d:bc:0e:26:bc"]
+      }
+    },
+    {
+      input: "moon status:(=new,!failed disk erasing,=!pending,!=deploying)",
+      filters: {
+        _: ["moon"],
+        status: ["=new", "!failed disk erasing", "=!pending", "!=deploying"]
       }
     }
   ];
@@ -108,6 +160,10 @@ describe("SearchService", () => {
   describe("isFilterActive", () => {
     it("returns false if type not in filter", () => {
       expect(isFilterActive({}, "type", "invalid")).toBe(false);
+    });
+
+    it("returns false if there are no filters", () => {
+      expect(isFilterActive(null, "type", "invalid")).toBe(false);
     });
 
     it("returns false if value not in type", () => {

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -8,7 +8,7 @@ import {
   toggleFilter
 } from "./search";
 
-describe("SearchService", () => {
+describe("Search", () => {
   const scenarios = [
     {
       input: "",
@@ -20,6 +20,18 @@ describe("SearchService", () => {
       input: "moon",
       filters: {
         _: ["moon"]
+      }
+    },
+    {
+      input: "moon !sun",
+      filters: {
+        _: ["moon", "!sun"]
+      }
+    },
+    {
+      input: "moon !!sun",
+      filters: {
+        _: ["moon", "!!sun"]
       }
     },
     {
@@ -57,6 +69,30 @@ describe("SearchService", () => {
       filters: {
         _: ["moon"],
         status: ["!!new", "!failed disk erasing"]
+      }
+    },
+    {
+      input: "moon status:!!(new,failed commissioning)",
+      output: "moon status:(new,failed commissioning)",
+      filters: {
+        _: ["moon"],
+        status: ["new", "failed commissioning"]
+      }
+    },
+    {
+      input: "moon status:!!(!new)",
+      output: "moon status:(!new)",
+      filters: {
+        _: ["moon"],
+        status: ["!new"]
+      }
+    },
+    {
+      input: "moon status:!!(!!new)",
+      output: "moon status:(!!new)",
+      filters: {
+        _: ["moon"],
+        status: ["!!new"]
       }
     },
     {

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -413,12 +413,13 @@ const generateGroupRows = ({
 const MachineList = () => {
   const dispatch = useDispatch();
   const [searchText, setSearchText] = useState("");
+  const selectedMachines = useSelector(machineSelectors.selected);
+  const selectedIDs = useSelector(machineSelectors.selectedIDs);
   const machines = useSelector(state =>
-    machineSelectors.search(state, searchText)
+    machineSelectors.search(state, searchText, selectedIDs)
   );
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const machinesLoading = useSelector(machineSelectors.loading);
-  const selectedMachines = useSelector(machineSelectors.selected);
   const errors = useSelector(machineSelectors.errors);
   let errorMessage;
   if (errors) {

--- a/ui/src/app/utils/search.js
+++ b/ui/src/app/utils/search.js
@@ -15,6 +15,7 @@ const searchMappings = {
       ? node.osystem + "/" + node.distro_series
       : "",
   hostname: node => node.hostname,
+  ip_addresses: node => node.ip_addresses.map(({ ip }) => ip),
   vlan: node => node.vlan,
   rack: node => node.observer_hostname,
   subnet: node => node.subnet_cidr,


### PR DESCRIPTION
## Done
- Clean up DSL destructuring.
- Implement selected filtering.
- Fix DSL bugs.

## QA
- Visit /r/machines.
- Select some machines.
- In the search box search for `in:selected`, you should only see your selected machines.
- In the search box search for `in:!selected`, you should not see your selected machines.
- Check that you can search in other ways according to: https://maas.io/docs/interactive-search

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1799.