### PR TITLE
Search filter URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn-error.log*
 
 # local configuratinon
 .env.*.local
+.env.local
 
 # junk
 *.DS_Store

--- a/ui/src/app/machines/filter-nodes.js
+++ b/ui/src/app/machines/filter-nodes.js
@@ -41,8 +41,8 @@ const filterByTerms = (filteredNodes, attr, terms, selectedIDs) =>
     let matched = false;
     let exclude = false;
     // Loop through the attributes to check. If this is for the
-    // generic "_" filter then check against all node attributes.
-    (attr === "_" ? Object.keys(node) : [attr]).some(filterAttribute => {
+    // generic "q" filter then check against all node attributes.
+    (attr === "q" ? Object.keys(node) : [attr]).some(filterAttribute => {
       if (filterAttribute === "in") {
         // "in:" is used to filter the nodes by those that are
         // currently selected.
@@ -114,7 +114,7 @@ const filterNodes = (nodes, search, selectedIDs) => {
       // If this attribute has no associated terms then skip it.
       return;
     }
-    if (attr === "_") {
+    if (attr === "q") {
       // When filtering free search we need all terms to match so subsequent
       // terms will reduce the list to those that match all.
       terms.forEach(term => {

--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -2,7 +2,12 @@
 const storedFilters = {};
 
 // Return a new empty filter;
-export const getEmptyFilter = () => ({ _: [] });
+export const getEmptyFilter = () => ({
+  // "q" is for free search, i.e. not a specific machine attribute. "q" has
+  // been chosen because it shouldn't conflict with any machine attributes and
+  // also is the key name in the search URL query params.
+  q: []
+});
 
 // Return all of the currently active filters for the given search.
 export const getCurrentFilters = search => {
@@ -45,7 +50,7 @@ export const getCurrentFilters = search => {
       filters[groupName] = valueList;
     } else if (!group.includes(":")) {
       // This is a free search value.
-      filters._.push(groupName);
+      filters.q.push(groupName);
     }
   });
   return filters;
@@ -53,11 +58,11 @@ export const getCurrentFilters = search => {
 
 // Convert "filters" into a search string.
 export const filtersToString = filters => {
-  let search = filters._.length > 0 ? `${filters._.join(" ")}` : "";
+  let search = filters.q.length > 0 ? `${filters.q.join(" ")}` : "";
   Object.entries(filters).forEach(([type, terms]) => {
-    // Skip empty and skip "_" as it gets appended at the
+    // Skip empty and skip "q" as it gets appended at the
     // beginning of the search.
-    if (terms.length === 0 || type === "_") {
+    if (terms.length === 0 || type === "q") {
       return;
     }
     search += ` ${type}:(${terms.join(",")})`;
@@ -123,11 +128,7 @@ export const queryStringToFilters = queryString => {
       // There are no values for this filter so ignore it.
       return;
     }
-    if (name === "q") {
-      filters._ = values.split(" ");
-    } else {
-      filters[name] = values.split(",");
-    }
+    filters[name] = values.split(",");
   });
   return filters;
 };
@@ -143,10 +144,5 @@ export const filtersToQueryString = filters => {
       delete copiedFilters[filter];
     }
   });
-  // Replace _ with q.
-  if (copiedFilters._) {
-    copiedFilters.q = copiedFilters._.join(" ");
-    delete copiedFilters._;
-  }
   return `?${new URLSearchParams(copiedFilters).toString()}`;
 };

--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -114,3 +114,39 @@ export const storeFilters = (name, filters) => {
 
 // Retrieve a stored filter.
 export const retrieveFilters = name => storedFilters[name];
+
+// Convert a URL query string into a filter object.
+export const queryStringToFilters = queryString => {
+  let filters = getEmptyFilter();
+  [...new URLSearchParams(queryString)].forEach(([name, values]) => {
+    if (!values.length) {
+      // There are no values for this filter so ignore it.
+      return;
+    }
+    if (name === "q") {
+      filters._ = values.split(" ");
+    } else {
+      filters[name] = values.split(",");
+    }
+  });
+  return filters;
+};
+
+// Convert a filter object into a URL query string.
+export const filtersToQueryString = filters => {
+  // Shallow copy the object, this should be good enough for the manipulation
+  // we do below.
+  let copiedFilters = { ...filters };
+  // Remove empty filters.
+  Object.keys(copiedFilters).forEach(filter => {
+    if (copiedFilters[filter].length === 0) {
+      delete copiedFilters[filter];
+    }
+  });
+  // Replace _ with q.
+  if (copiedFilters._) {
+    copiedFilters.q = copiedFilters._.join(" ");
+    delete copiedFilters._;
+  }
+  return `?${new URLSearchParams(copiedFilters).toString()}`;
+};

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -1,8 +1,10 @@
 import {
+  filtersToQueryString,
   filtersToString,
   getCurrentFilters,
   getEmptyFilter,
   isFilterActive,
+  queryStringToFilters,
   retrieveFilters,
   storeFilters,
   toggleFilter
@@ -346,6 +348,50 @@ describe("Search", () => {
       names.forEach((name, idx) => {
         expect(retrieveFilters(name)).toBe(objects[idx]);
       });
+    });
+  });
+
+  describe("queryStringToFilters", () => {
+    it("can convert a query string to a filter object", () => {
+      expect(
+        queryStringToFilters(
+          "?q=moon+sun&status=new,failed+comissioning&zone=!south&hostname="
+        )
+      ).toEqual({
+        _: ["moon", "sun"],
+        status: ["new", "failed comissioning"],
+        zone: ["!south"]
+      });
+    });
+
+    it("can convert a query string to a filter object and back", () => {
+      const queryString =
+        "?status=new%2Cfailed+comissioning&zone=%21south&q=moon+sun";
+      const queryObject = queryStringToFilters(queryString);
+      expect(filtersToQueryString(queryObject)).toEqual(queryString);
+    });
+  });
+
+  describe("filtersToQueryString", () => {
+    it("can convert a filter object to a query string", () => {
+      expect(
+        filtersToQueryString({
+          _: ["moon", "sun"],
+          hostname: [],
+          status: ["new", "failed comissioning"],
+          zone: ["!south"]
+        })
+      ).toEqual("?status=new%2Cfailed+comissioning&zone=%21south&q=moon+sun");
+    });
+
+    it("can convert a filter object to a query string and back", () => {
+      const queryObject = {
+        _: ["moon", "sun"],
+        status: ["new", "failed comissioning"],
+        zone: ["!south"]
+      };
+      const queryString = filtersToQueryString(queryObject);
+      expect(queryStringToFilters(queryString)).toEqual(queryObject);
     });
   });
 });

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -15,31 +15,31 @@ describe("Search", () => {
     {
       input: "",
       filters: {
-        _: []
+        q: []
       }
     },
     {
       input: "moon",
       filters: {
-        _: ["moon"]
+        q: ["moon"]
       }
     },
     {
       input: "moon !sun",
       filters: {
-        _: ["moon", "!sun"]
+        q: ["moon", "!sun"]
       }
     },
     {
       input: "moon !!sun",
       filters: {
-        _: ["moon", "!!sun"]
+        q: ["moon", "!!sun"]
       }
     },
     {
       input: "moon status:(new)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["new"]
       }
     },
@@ -47,21 +47,21 @@ describe("Search", () => {
       input: "moon status:(new) star",
       output: "moon star status:(new)",
       filters: {
-        _: ["moon", "star"],
+        q: ["moon", "star"],
         status: ["new"]
       }
     },
     {
       input: "moon status:(new,deployed)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["new", "deployed"]
       }
     },
     {
       input: "moon status:(new,failed disk erasing)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["new", "failed disk erasing"]
       }
     },
@@ -69,7 +69,7 @@ describe("Search", () => {
       input: "moon status:!(!new,failed disk erasing)",
       output: "moon status:(!!new,!failed disk erasing)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["!!new", "!failed disk erasing"]
       }
     },
@@ -77,7 +77,7 @@ describe("Search", () => {
       input: "moon status:!!(new,failed commissioning)",
       output: "moon status:(new,failed commissioning)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["new", "failed commissioning"]
       }
     },
@@ -85,7 +85,7 @@ describe("Search", () => {
       input: "moon status:!!(!new)",
       output: "moon status:(!new)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["!new"]
       }
     },
@@ -93,14 +93,14 @@ describe("Search", () => {
       input: "moon status:!!(!!new)",
       output: "moon status:(!!new)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["!!new"]
       }
     },
     {
       input: "moon status:(new,failed disk erasing,pending)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["new", "failed disk erasing", "pending"]
       }
     },
@@ -108,7 +108,7 @@ describe("Search", () => {
       input: "moon status:new,deployed",
       output: "moon status:(new,deployed)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["new", "deployed"]
       }
     },
@@ -116,7 +116,7 @@ describe("Search", () => {
       input: "moon status:new,failed disk erasing",
       output: "moon disk erasing status:(new,failed)",
       filters: {
-        _: ["moon", "disk", "erasing"],
+        q: ["moon", "disk", "erasing"],
         status: ["new", "failed"]
       }
     },
@@ -124,28 +124,28 @@ describe("Search", () => {
       input: "moon status:(new,failed disk erasing",
       output: "moon disk erasing",
       filters: {
-        _: ["moon", "disk", "erasing"]
+        q: ["moon", "disk", "erasing"]
       }
     },
     {
       input: "moon status:(",
       output: "moon",
       filters: {
-        _: ["moon"]
+        q: ["moon"]
       }
     },
     {
       input: "moon status:",
       output: "moon",
       filters: {
-        _: ["moon"]
+        q: ["moon"]
       }
     },
     {
       input: "moon mac:28:76:03:77:5a:b5 status:new",
       output: "moon mac:(28:76:03:77:5a:b5) status:(new)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         mac: ["28:76:03:77:5a:b5"],
         status: ["new"]
       }
@@ -154,7 +154,7 @@ describe("Search", () => {
       input: "moon mac:(28:76:03:77:5a:b5) status:new",
       output: "moon mac:(28:76:03:77:5a:b5) status:(new)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         mac: ["28:76:03:77:5a:b5"],
         status: ["new"]
       }
@@ -163,14 +163,14 @@ describe("Search", () => {
       input: "moon mac:(28:76:03:77:5a:b5,d6:4d:bc:0e:26:bc)",
       output: "moon mac:(28:76:03:77:5a:b5,d6:4d:bc:0e:26:bc)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         mac: ["28:76:03:77:5a:b5", "d6:4d:bc:0e:26:bc"]
       }
     },
     {
       input: "moon status:(=new,!failed disk erasing,=!pending,!=deploying)",
       filters: {
-        _: ["moon"],
+        q: ["moon"],
         status: ["=new", "!failed disk erasing", "=!pending", "!=deploying"]
       }
     }
@@ -322,8 +322,8 @@ describe("Search", () => {
   });
 
   describe("getEmptyFilter", () => {
-    it("includes _ empty list", () => {
-      expect(getEmptyFilter()).toEqual({ _: [] });
+    it("includes q empty list", () => {
+      expect(getEmptyFilter()).toEqual({ q: [] });
     });
 
     it("returns different object on each call", () => {
@@ -355,10 +355,10 @@ describe("Search", () => {
     it("can convert a query string to a filter object", () => {
       expect(
         queryStringToFilters(
-          "?q=moon+sun&status=new,failed+comissioning&zone=!south&hostname="
+          "?q=moon%2Csun&status=new,failed+comissioning&zone=!south&hostname="
         )
       ).toEqual({
-        _: ["moon", "sun"],
+        q: ["moon", "sun"],
         status: ["new", "failed comissioning"],
         zone: ["!south"]
       });
@@ -366,7 +366,7 @@ describe("Search", () => {
 
     it("can convert a query string to a filter object and back", () => {
       const queryString =
-        "?status=new%2Cfailed+comissioning&zone=%21south&q=moon+sun";
+        "?q=moon%2Csun&status=new%2Cfailed+comissioning&zone=%21south";
       const queryObject = queryStringToFilters(queryString);
       expect(filtersToQueryString(queryObject)).toEqual(queryString);
     });
@@ -376,17 +376,17 @@ describe("Search", () => {
     it("can convert a filter object to a query string", () => {
       expect(
         filtersToQueryString({
-          _: ["moon", "sun"],
+          q: ["moon", "sun"],
           hostname: [],
           status: ["new", "failed comissioning"],
           zone: ["!south"]
         })
-      ).toEqual("?status=new%2Cfailed+comissioning&zone=%21south&q=moon+sun");
+      ).toEqual("?q=moon%2Csun&status=new%2Cfailed+comissioning&zone=%21south");
     });
 
     it("can convert a filter object to a query string and back", () => {
       const queryObject = {
-        _: ["moon", "sun"],
+        q: ["moon", "sun"],
         status: ["new", "failed comissioning"],
         zone: ["!south"]
       };

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -27,7 +27,13 @@ import {
 import { groupAsMap, simpleSortByKey } from "app/utils";
 import { machine as machineSelectors } from "app/base/selectors";
 import { nodeStatus } from "app/base/enum";
-import { useWindowTitle } from "app/base/hooks";
+import { useLocation, useRouter, useWindowTitle } from "app/base/hooks";
+import {
+  filtersToString,
+  filtersToQueryString,
+  getCurrentFilters,
+  queryStringToFilters
+} from "app/machines/search";
 import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
 import DoubleRow from "app/base/components/DoubleRow";
@@ -412,7 +418,11 @@ const generateGroupRows = ({
 
 const MachineList = () => {
   const dispatch = useDispatch();
-  const [searchText, setSearchText] = useState("");
+  const { history } = useRouter();
+  const { location } = useLocation();
+  const currentFilters = queryStringToFilters(location.search);
+  // The search text state is initialised from the URL.
+  const [searchText, setSearchText] = useState(filtersToString(currentFilters));
   const selectedMachines = useSelector(machineSelectors.selected);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
   const machines = useSelector(state =>
@@ -537,19 +547,28 @@ const MachineList = () => {
     showMAC
   };
 
+  // Handle updating the search text state and URL.
+  const changeFilters = searchText => {
+    // Update the search text state.
+    setSearchText(searchText);
+    // Convert the search string into a query string and update the URL.
+    const filters = getCurrentFilters(searchText);
+    history.push({ search: filtersToQueryString(filters) });
+  };
+
   return (
     <>
       <Row>
         <Col size={3}>
           <FilterAccordion
             searchText={searchText}
-            setSearchText={setSearchText}
+            setSearchText={changeFilters}
           />
         </Col>
         <Col size={6}>
           <SearchBox
             externallyControlled
-            onChange={setSearchText}
+            onChange={changeFilters}
             value={searchText}
           />
         </Col>

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -1,4 +1,5 @@
-import { MemoryRouter } from "react-router-dom";
+import { act } from "react-dom/test-utils";
+import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -209,6 +210,52 @@ describe("MachineList", () => {
       </Provider>
     );
     expect(wrapper.find("Loader").exists()).toBe(true);
+  });
+
+  it("can set the search from the URL", () => {
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machines", search: "?q=test+search", key: "testKey" }
+          ]}
+        >
+          <MachineList selectedMachines={[]} setSelectedMachines={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("SearchBox").prop("value")).toBe("test search");
+  });
+
+  it("change the URL when the search text changes", () => {
+    let location;
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machines", search: "?q=test+search", key: "testKey" }
+          ]}
+        >
+          <MachineList selectedMachines={[]} setSelectedMachines={jest.fn()} />
+          <Route
+            path="*"
+            render={props => {
+              location = props.location;
+              return null;
+            }}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => {
+      wrapper
+        .find("SearchBox")
+        .props()
+        .onChange("status:new");
+    });
+    expect(location.search).toBe("?status=new");
   });
 
   it("includes groups", () => {


### PR DESCRIPTION
## Done
- Added utils to converting to and from URL query strings and filters.
- Initialise the search filters from the URL and update the URL when the filters change.

## QA
- Load /r/machines.
- Type a search into the search box, the URL should change.
- Select some filters in the filter dropdown, the URL should change.
- Refresh the page, your filters should be restored.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1798.

## Launchpad Issue
Related Launchpad maas issue in the form `lp#number`.
