### PR TITLE
Link from pools to machines

### DIFF
--- a/ui/src/app/pools/views/Pools.js
+++ b/ui/src/app/pools/views/Pools.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Col, Loader, MainTable, Row } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 
 import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
@@ -10,12 +11,17 @@ import {
 } from "app/base/actions";
 import { useAddMessage, useWindowTitle } from "app/base/hooks";
 import { resourcepool as resourcePoolSelectors } from "app/base/selectors";
+import { filtersToQueryString } from "app/machines/search";
 
 const getMachinesLabel = row => {
   if (row.machine_total_count === 0) {
     return "Empty pool";
   }
-  return `${row.machine_ready_count} of ${row.machine_total_count} ready`;
+  return (
+    <Link to={`/machines${filtersToQueryString({ pool: row.name })}`}>
+      {`${row.machine_ready_count} of ${row.machine_total_count} ready`}
+    </Link>
+  );
 };
 
 const generateRows = (rows, expandedId, setExpandedId, dispatch, setDeleting) =>

--- a/ui/src/app/pools/views/Pools.test.js
+++ b/ui/src/app/pools/views/Pools.test.js
@@ -219,4 +219,46 @@ describe("Pools", () => {
         .props().disabled
     ).toBe(true);
   });
+
+  it("does not show a machine link for empty pools", () => {
+    const state = { ...initialState };
+    state.resourcepool.items[0].machine_total_count = 0;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+          <Pools />
+        </MemoryRouter>
+      </Provider>
+    );
+    const name = wrapper
+      .find("TableRow")
+      .at(1)
+      .find("TableCell")
+      .at(1);
+    expect(name.text()).toBe("Empty pool");
+  });
+
+  it("can show a machine link for non-empty pools", () => {
+    const state = { ...initialState };
+    state.resourcepool.items[0].machine_total_count = 5;
+    state.resourcepool.items[0].machine_ready_count = 1;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+          <Pools />
+        </MemoryRouter>
+      </Provider>
+    );
+    const link = wrapper
+      .find("TableRow")
+      .at(1)
+      .find("TableCell")
+      .at(1)
+      .find("Link");
+    expect(link.exists()).toBe(true);
+    expect(link.prop("to")).toBe("/machines?pool=default");
+    expect(link.text()).toBe("1 of 5 ready");
+  });
 });


### PR DESCRIPTION
## Done
- Link from pools to the machine list.

## QA
- Visit /r/pools.
- Add a pool (using the Add pool button in the top right) and add 1 or more machines to that pool (click on a machine from the machine list and then click on Configuration and change 'Resource pool').
- Add another pool and leave it empty.
- Go back to the pool list and the pool with no machines should have "Empty pool" in the machines column.
- For a pool with machines you should see something like "0 of 1 ready". Click on that link. You should be take to the machine list with only the machines in that pool visible.


## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1807.