### PR TITLE
Persist grouping

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "react-router-hash-link": "1.2.2",
     "react-router-prop-types": "1.0.4",
     "react-scripts": "3.4.1",
+    "react-storage-hooks": "4.0.0",
     "react-useportal": "1.0.13",
     "reconnecting-websocket": "4.4.0",
     "reduce-reducers": "1.0.4",

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -10,6 +10,7 @@ import {
   Strip
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { useStorageState } from "react-storage-hooks";
 import classNames from "classnames";
 import React, { useEffect, useMemo, useState } from "react";
 import pluralize from "pluralize";
@@ -448,8 +449,16 @@ const MachineList = () => {
     key: "fqdn",
     direction: "descending"
   });
-  const [grouping, setGrouping] = useState("status");
-  const [hiddenGroups, setHiddenGroups] = useState([]);
+  const [grouping, setGrouping] = useStorageState(
+    localStorage,
+    "grouping",
+    "status"
+  );
+  const [hiddenGroups, setHiddenGroups] = useStorageState(
+    localStorage,
+    "hiddenGroups",
+    []
+  );
   const [activeRow, setActiveRow] = useState(null);
   const [showMAC, setShowMAC] = useState(false);
   const groups = useMemo(() => generateGroups(grouping, machines), [

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -196,6 +196,10 @@ describe("MachineList", () => {
     };
   });
 
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it("displays a loading component if machines are loading", () => {
     const state = { ...initialState };
     state.machine.loading = true;
@@ -341,6 +345,77 @@ describe("MachineList", () => {
         .find("strong")
         .text()
     ).toBe("admin");
+  });
+
+  it("can store the group in local storage", () => {
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList selectedMachines={[]} setSelectedMachines={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find('Select[name="machine-groupings"]')
+        .find("select")
+        .prop("defaultValue")
+    ).toBe("status");
+    wrapper
+      .find('Select[name="machine-groupings"] select')
+      .simulate("change", { target: { value: "owner" } });
+    // Render another machine list, this time it should restore the value
+    // set by the select.
+    const store2 = mockStore(initialState);
+    const wrapper2 = mount(
+      <Provider store={store2}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList selectedMachines={[]} setSelectedMachines={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper2
+        .find('Select[name="machine-groupings"] select')
+        .prop("defaultValue")
+    ).toBe("owner");
+  });
+
+  it("can store hidden groups in local storage", () => {
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList selectedMachines={[]} setSelectedMachines={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("tr.machine-list__machine").length).toBe(3);
+    // Click the button to toggle the group.
+    wrapper
+      .find(".machine-list__group button")
+      .at(0)
+      .simulate("click");
+    // Render another machine list, this time it should restore the
+    // hidden group state.
+    const store2 = mockStore(initialState);
+    const wrapper2 = mount(
+      <Provider store={store2}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineList selectedMachines={[]} setSelectedMachines={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper2.find("tr.machine-list__machine").length).toBe(1);
   });
 
   it("can change machines to display PXE MAC instead of FQDN", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5184,7 +5184,7 @@ cypress@4.2.0:
     ospath "1.2.2"
     pretty-bytes "5.3.0"
     ramda "0.26.1"
-    request "github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16"
+    request cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16
     request-progress "3.0.0"
     supports-color "7.1.0"
     tmp "0.1.0"
@@ -12460,6 +12460,11 @@ react-scripts@3.4.1:
   optionalDependencies:
     fsevents "2.1.2"
 
+react-storage-hooks@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-storage-hooks/-/react-storage-hooks-4.0.0.tgz#1ebe40367cbe7699bf7d7cd0e24041b9717c0048"
+  integrity sha512-b0iTTosRF7EbQMwi17kjIOkD+3po/AxEueObKm3fQoQXERWaMVYIt+iGN0Lhbwm5YkyJMb+hzEyK+IM8kYwT6w==
+
 react-test-renderer@^16.0.0-0:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.10.2.tgz#4d8492f8678c9b43b721a7d79ed0840fdae7c518"
@@ -12973,7 +12978,6 @@ request@^2.87.0, request@^2.88.0:
 
 "request@github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16":
   version "2.88.1"
-  uid b5af0d1fa47eec97ba980cde90a13e69a2afcd16
   resolved "https://codeload.github.com/cypress-io/request/tar.gz/b5af0d1fa47eec97ba980cde90a13e69a2afcd16"
   dependencies:
     aws-sign2 "~0.7.0"


### PR DESCRIPTION
## Done
- Persist the grouping type and collapsed groups using local storage.

## QA
- Visit /r/machines.
- Change the grouping (using the Group by... select box).
- Collapse some groups (the "-" minus icon to the right of the group names in the table).
- Refresh the page. The grouping type and collapsed groups should be the same.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1852.
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1851.