### PR TITLE
Fix one character search matching

### DIFF
--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -18,7 +18,7 @@ export const getCurrentFilters = search => {
   // Match filters with parens e.g. 'status:(new,deployed)'.
   // Then: match filters without parens e.g. 'status:new,deployed' or 'status'
   const filterMatchingRegex = search.matchAll(
-    /(\b\w+:!*\([^)]+\))|(!*\w+\S+)/g
+    /(\b\w+:!*\([^)]+\))|(!*\w+\S*)/g
   );
   [...filterMatchingRegex].forEach(([group]) => {
     // Get the filter name and values (if supplied).

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -25,6 +25,12 @@ describe("Search", () => {
       }
     },
     {
+      input: "m",
+      filters: {
+        q: ["m"]
+      }
+    },
+    {
       input: "moon !sun",
       filters: {
         q: ["moon", "!sun"]


### PR DESCRIPTION
## Done
- Correctly match against one character searches.

## QA
- Visit /r/machines.
- Using the search box enter a character that doesn't match many machines (e.g. "q").
- Your machines should be filtered.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/868.
