### PR TITLE
Uniquely identify machine rows

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -127,6 +127,7 @@ const generateRows = ({
     };
 
     return {
+      key: row.system_id,
       className: classNames("machine-list__machine", {
         "machine-list__machine--active": isActive,
       }),


### PR DESCRIPTION
## Done
- Identify each machine table row with the machine id. This allows React to know how to manipulate the DOM nodes. In this case it fixes a Chrome repaint issue when the content changes.

## QA
- First make sure you can reproduce the issue on master.
- Run maas-ui on master, then load /r/machines in Chrome.
- Create two machines. Give one the tags "tagA" and "tag B" and the other machine just "tagA".
On the machine list change to no grouping.
In the search box type "tagB" then delete the "B". You should see a broken border in one of the cells, something like this: https://user-images.githubusercontent.com/18423198/77896527-5a977380-7270-11ea-81a2-fea592626a29.png.
- Now switch to this branch and repeat the search steps: In the search box type "tagB" then delete the "B".
- This time you should not see a broken border.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/925.
