### PR TITLE
Fix legacy deploy form styling.

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -44,6 +44,8 @@ function NodesListController(
   $rootScope.page = "machines";
 
   // Set initial values.
+  $scope.BASENAME = process.env.BASENAME;
+  $scope.REACT_BASENAME = process.env.REACT_BASENAME;
   $scope.machines = MachinesManager.getItems();
   $scope.zones = ZonesManager.getItems();
   $scope.pools = ResourcePoolsManager.getItems();

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -201,7 +201,7 @@
                                     </div>
                                 </div>
                                 <div class="row" ng-if="isSuperUser()">
-                                    <div class="u-sv1">
+                                    <div>
                                         <p class="u-no-margin--bottom">
                                             Additional installs
                                         </p>
@@ -212,18 +212,20 @@
                                             type="checkbox"
                                         >
                                         <label class="u-no-margin--bottom" for="installKVM">Register as MAAS KVM host</label>
-                                        <p class="u-sv-1 u-no-max-width" ng-if="!nodesManager.canBeKvmHost(tabs[tab].osSelection)">
+                                        <p class="u-sv-1" ng-if="!nodesManager.canBeKvmHost(tabs[tab].osSelection)">
                                             <i class="p-icon--warning"></i>&nbsp;Ubuntu 18.04 is required to create a KVM host.
                                         </p>
-                                        <p class="u-no-max-width u-no-margin--bottom">
+                                        <p class="u-sv-1">
                                             <a class="p-link--external" href="https://maas.io/docs/kvm-introduction" target="_blank">
                                                 About MAAS KVM hosts
                                             </a>
                                         </p>
+                                        <p ng-if="isSSHKeyWarning(tab)">
+                                            <i class="p-icon--warning">Warning:</i>
+                                            <span>Login will not be possible because no SSH keys have been added to your account.</span><br />
+                                            <span>To add an SSH key, visit <a href="{$ BASENAME $}{$ REACT_BASENAME $}/account/prefs/ssh-keys">your account page</a>.</span>
+                                        </p>
                                     </div>
-                                </div>
-                                <div class="row" ng-if="isSSHKeyWarning(tab)">
-                                    <i class="p-icon--warning">Warning:</i> Login will not be possible because no SSH keys have been added to your account. To add an SSH key, visit <a href="account/prefs/">your account page</a>.
                                 </div>
                             </div>
                             <div ng-if="tabs[tab].actionOption.name === 'release'">

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.js
@@ -86,7 +86,9 @@ export const DeployFormFields = () => {
           <p data-test="sshkeys-warning">
             <i className="p-icon--warning is-inline"></i>
             Login will not be possible because no SSH keys have been added to
-            your account. To add an SSH key, visit your{" "}
+            your account.
+            <br />
+            To add an SSH key, visit your{" "}
             <Link to="/account/prefs/ssh-keys">account page</Link>.
           </p>
         )}


### PR DESCRIPTION
## Done
- Fixed styling regression of SSH key warning in deploy form.
- Fixed link to account prefs ssh keys page

## QA
- Log in as a user without ssh keys (or remove them from your user)
- Go to legacy machine list, and try to deploy a machine from the action dropdown
- Check that a warning shows up about SSH keys, and is styled correctly
- Check that the link takes you to the React SSH keys page

## Fixes
Fixes #926 

## Screenshot
![Screenshot_2020-04-01 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/78110051-b82ceb00-743d-11ea-8825-8a4265602aa9.png)
