### PR TITLE
Log maas-ui version to console when app starts.

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -6,6 +6,7 @@ import { ConnectedRouter, routerMiddleware } from "connected-react-router";
 import { createBrowserHistory } from "history";
 import createSagaMiddleware from "redux-saga";
 
+import { name as appName, version as appVersion } from "../package.json";
 import rootSaga from "./root-saga";
 import "./scss/index.scss";
 import * as serviceWorker from "./serviceWorker";
@@ -44,3 +45,5 @@ ReactDOM.render(
 );
 
 serviceWorker.unregister();
+
+console.info(`${appName} ${appVersion}.`);


### PR DESCRIPTION
## Done
Log the maas-ui version to console when the app starts.

We don't want to expose the maas-ui version to users in the app (they should be reporting just the MAAS version), but it's helpful for debugging production builds.

## QA
* Start the app, and open the console. You should see `@maas-ui/ui 1.1.0`.