### PR TITLE
Persist filter menu state

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "clean-ui": "cd ui && yarn run clean",
     "clean-proxy": "cd proxy && yarn run clean",
     "clean-shared": "cd shared && yarn run clean",
+    "link-components": "yarn link \"@canonical/react-components\" && yarn link \"react\" && yarn install",
+    "unlink-components": "yarn unlink react && yarn unlink \"@canonical/react-components\"",
     "lint-legacy": "cd legacy && yarn run lint",
     "lint-ui": "cd ui && yarn run lint",
     "lint-shared": "cd shared && yarn run lint",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@canonical/macaroon-bakery": "0.3.0",
-    "@canonical/react-components": "0.4.0",
+    "@canonical/react-components": "0.6.0",
     "@maas-ui/shared": "0.1.0",
     "@reduxjs/toolkit": "1.3.2",
     "@sentry/browser": "5.15.4",

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.js
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/FilterAccordion.js
@@ -2,7 +2,7 @@ import { Accordion, Button, List, Loader } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 
 import {
   getCurrentFilters,
@@ -101,6 +101,7 @@ const FilterAccordion = ({ searchText, setSearchText }) => {
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const filterOptions = useMemo(() => getFilters(machines), [machines]);
   const currentFilters = getCurrentFilters(searchText);
+  const [expandedSection, setExpandedSection] = useState();
   let sections;
   if (machinesLoaded) {
     sections = filterOrder.reduce((options, filter) => {
@@ -145,6 +146,7 @@ const FilterAccordion = ({ searchText, setSearchText }) => {
                 ))}
             />
           ),
+          key: filter,
         });
       }
       return options;
@@ -159,6 +161,9 @@ const FilterAccordion = ({ searchText, setSearchText }) => {
         machinesLoaded ? (
           <Accordion
             className="filter-accordion__dropdown"
+            expanded={expandedSection}
+            externallyControlled
+            onExpandedChange={setExpandedSection}
             sections={sections}
           />
         ) : (

--- a/ui/src/app/machines/views/MachineList/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
@@ -10,6 +10,8 @@ exports[`FilterAccordion renders 1`] = `
     dropdownContent={
       <Accordion
         className="filter-accordion__dropdown"
+        externallyControlled={true}
+        onExpandedChange={[Function]}
         sections={
           Array [
             Object {
@@ -31,6 +33,7 @@ exports[`FilterAccordion renders 1`] = `
                   ]
                 }
               />,
+              "key": "pool",
               "title": "Resource pool",
             },
             Object {
@@ -52,6 +55,7 @@ exports[`FilterAccordion renders 1`] = `
                   ]
                 }
               />,
+              "key": "zone",
               "title": "Zone",
             },
             Object {
@@ -73,6 +77,7 @@ exports[`FilterAccordion renders 1`] = `
                   ]
                 }
               />,
+              "key": "numa_nodes_count",
               "title": "NUMA nodes",
             },
             Object {
@@ -94,6 +99,7 @@ exports[`FilterAccordion renders 1`] = `
                   ]
                 }
               />,
+              "key": "sriov_support",
               "title": "SR-IOV support",
             },
             Object {
@@ -115,6 +121,7 @@ exports[`FilterAccordion renders 1`] = `
                   ]
                 }
               />,
+              "key": "link_speeds",
               "title": "Link speed",
             },
           ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,14 +1941,14 @@
   dependencies:
     macaroon "^3.0.4"
 
-"@canonical/react-components@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.4.0.tgz#89753941a851438ec60d800435f72bd2c92c2598"
-  integrity sha512-ZE/ndDfITOFkLEmofC0xDVx/g3QokKviLn1L022DGEa4sSxcbf8JLHQrUhIzD7dmRy/dDU1jDjosPx4HM/tqeA==
+"@canonical/react-components@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.6.0.tgz#674efe06c2bbeabd1dd36bbcd5e9769cf49e0782"
+  integrity sha512-38JJIWFs/s91WhQlDes81nVZFheIH0j+O3Uk55OtHLJ14JOcECvFVZPtlttuDJKzyK7488jKeOlj/eI1puYXeQ==
   dependencies:
     classnames "2.2.6"
     prop-types "15.7.2"
-    vanilla-framework "2.8.0"
+    vanilla-framework "2.9.0"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
@@ -15112,11 +15112,6 @@ vanilla-framework@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.0.1.tgz#028e5cc4a156973f21cbd38ab3758c9532f3c36b"
   integrity sha512-vE4e4ck40lrcFmREy06yoXy/dHKF+ewA/lsC6ZeooirXB69/XmZv+jgkCUlftbn6ya+N8F6b9yWGHKfg7AiEkg==
-
-vanilla-framework@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.8.0.tgz#ec20ed3bf4fc2f1ce2d42075edb7a58c26f56982"
-  integrity sha512-fIxO7/BtCmj7aMAFCxxk19fqRB9HVZBv1typ7YL4AEiJhq8Za3qDCLuxjiSP0tFvKzXUtrI7y4KGHYMrFIevKg==
 
 vanilla-framework@2.9.0:
   version "2.9.0"


### PR DESCRIPTION
## Done
- Persist the last opened filter in the machine filter dropdown.

## QA
- Visit /r/machines.
- Open the filters dropdown and expand a filter to see the values.
- Click off the dropdown so it closes.
- Open the dropdown again. The previously opened filter should be open again.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/924.
