### PR TITLE
Fix the last machine row cutting off the content

### DIFF
--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -13,6 +13,12 @@
     display: none;
   }
 
+  .machine-list__machine:last-child td {
+    // Force the cells in the last row to calculate their height.
+    // See: https://github.com/canonical-web-and-design/maas-ui/issues/935
+    min-height: 1px;
+  }
+
   .machine-list__machine:hover,
   .machine-list__machine--active {
     background-color: $color-x-light;


### PR DESCRIPTION
## Done
- Force the last machine row to calculate its height.

## QA
- First try to replicate this on master (should be broken in Chrome and Firefox):
- - Go to /r/machines.
- - Use the search box to filter the machine.
- - Sometimes the last line will get slightly cut off. Try to replicate this consistently.
- Now checkout my branch and repeat the steps above.
- This time the last row shouldn't get cut off.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/935.