### PR TITLE
Don't install the Cypress binary for GitHub actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 jobs:
   build:
     name: Test, build and lint
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn install
+      - run: CYPRESS_INSTALL_BINARY=0 yarn install
       - run: yarn lint
       - run: yarn build-all
       - run: yarn test


### PR DESCRIPTION
## Done
- Don't install the Cypress binary for GitHub actions CI. This should speed up `yarn install` which currently takes about 1m 40s.

## QA
- None, CI should pass.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/894.