### PR TITLE
Disable thunk middleware

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -20,7 +20,7 @@ const reducer = createRootReducer(history);
 
 const sagaMiddleware = createSagaMiddleware();
 const middleware = [
-  ...getDefaultMiddleware(),
+  ...getDefaultMiddleware({ thunk: false }),
   sagaMiddleware,
   routerMiddleware(history),
 ];


### PR DESCRIPTION
## Done
- Disable the thunk middleware that we don't use.

## QA
- Check that everything works as before.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/939.