### PR TITLE
Manage the list of loaded models in the saga module

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -123,6 +123,7 @@ export const App = () => {
         )}
         location={location}
         logout={() => {
+          dispatch(statusActions.websocketDisconnect());
           dispatch(statusActions.logout());
         }}
         showRSD={navigationOptions.rsd}

--- a/ui/src/app/base/actions/status/status.js
+++ b/ui/src/app/base/actions/status/status.js
@@ -8,6 +8,7 @@ const status = {
   checkAuthenticated: createAction("CHECK_AUTHENTICATED"),
   websocketConnect: createAction("WEBSOCKET_CONNECT"),
   websocketConnected: createAction("WEBSOCKET_CONNECTED"),
+  websocketDisconnect: createAction("WEBSOCKET_DISCONNECT"),
   websocketDisconnected: createAction("WEBSOCKET_DISCONNECTED"),
   websocketError: createAction("WEBSOCKET_ERROR"),
 };

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -116,25 +116,11 @@ describe("websocket sagas", () => {
         type: MESSAGE_TYPES.REQUEST,
       },
     };
+    const previous = sendMessage(socketClient, action);
+    previous.next();
     const saga = sendMessage(socketClient, action);
-    saga.next();
     // The saga should have finished.
-    expect(saga.next({ test: { loaded: true } }).done).toBe(true);
-  });
-
-  it("continues if data has is being fetched for list methods", () => {
-    const action = {
-      type: "FETCH_TEST",
-      meta: {
-        model: "test",
-        method: "test.list",
-        type: MESSAGE_TYPES.REQUEST,
-      },
-    };
-    const saga = sendMessage(socketClient, action);
-    saga.next();
-    // The saga should have finished.
-    expect(saga.next({ test: { loading: true } }).done).toBe(true);
+    expect(saga.next().done).toBe(true);
   });
 
   it("can handle params as an array", () => {

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -484,7 +484,7 @@ const MachineList = () => {
     dispatch(tagActions.fetch());
     dispatch(userActions.fetch());
     dispatch(zoneActions.fetch());
-  }, [dispatch, machinesLoaded]);
+  }, [dispatch]);
 
   // Update sort parameters depending on whether the same sort key was clicked.
   const updateSort = (newSortKey) => {


### PR DESCRIPTION
## Done
- To deal with multiple components requesting the same data at once the loaded models are stored in the saga module.
- Drive-by to disconnect from the websocket when logging out.

## QA
- View /r/machines.
- In your network tab check the websocket for machine.list. You should only see one.
- Log out and back in, your models should load again.