### PR TITLE
Disable/enable Take Action and Add KVM buttons based on machine selection.

### DIFF
--- a/legacy/src/app/directives/call_to_action.js
+++ b/legacy/src/app/directives/call_to_action.js
@@ -14,7 +14,8 @@ export function maasCta() {
     scope: {
       maasCta: "=",
       ngModel: "=",
-      selectedItems: "="
+      selectedItems: "=",
+      disabled: "<"
     },
     template: ctaTmpl,
     link: link,

--- a/legacy/src/app/partials/directives/cta.html
+++ b/legacy/src/app/partials/directives/cta.html
@@ -6,6 +6,7 @@
     aria-haspopup="true"
     data-ng-click="shown=!shown"
     data-ng-class="{'p-button--positive': getTitle() === 'Take action', 'is-selected': shown}"
+    data-ng-disabled="disabled"
   >
     {$ getTitle() $}
   </button>

--- a/legacy/src/app/partials/pods-list.html
+++ b/legacy/src/app/partials/pods-list.html
@@ -6,18 +6,29 @@
         </div>
         <div class="col-small-2 col-medium-2 col-4 u-align--right">
             <div class="page-header__controls">
-                <div data-ng-if="pods.length > 0 && !selectedItems.length && !action.option.isSingle">
-                    <button class="p-button--neutral" data-ng-click="addPod()" data-ng-if="!add.open && canAddPod()">Add {$ getPageHeading() $}</button>
-                </div>
-                <ul class="p-inline-list u-no-margin--top" data-ng-if="showActions() && selectedItems.length">
-                    <li class="p-inline-list__item">{$ selectedItems.length $} Selected</li>
-                    <li class="p-inline-list__item">
-                        <div
-                            data-selected-items="selectedItems.length"
-                            data-ng-click="updateAvailableActions('pods')"
-                            data-maas-cta="action.options"
-                            data-ng-model="action.option">
-                        </div>
+                <ul class="p-inline-list u-no-margin--bottom">
+                    <li class="p-inline-list__item" ng-if="selectedItems.length">{$ selectedItems.length $} selected</li>
+                    <li class="p-inline-list__item" ng-if="canAddPod()">
+                        <button
+                            class="p-button--neutral u-no-margin--bottom"
+                            ng-click="addPod()"
+                            ng-disabled="add.open || selectedItems.length"
+                            ng-if="canAddPod()"
+                        >
+                            Add {$ getPageHeading() $}
+                        </button>
+                    </li>
+                    <li class="p-inline-list__item" ng-if="showActions()">
+                        <span class="p-tooltip--left">
+                            <div
+                                disabled="!selectedItems.length"
+                                maas-cta="action.options"
+                                ng-click="updateAvailableActions('pods')"
+                                ng-model="action.option"
+                                selected-items="selectedItems.length"
+                            ></div>
+                            <span class="p-tooltip__message" ng-if="!selectedItems.length">Select a KVM host to take action</span>
+                        </span>
                     </li>
                 </div>
             </div>
@@ -107,8 +118,8 @@
                         <p maas-obj-hide-saving class="u-no-margin--bottom"><maas-obj-errors></maas-obj-errors></p>
                         <p maas-obj-show-saving class="u-no-margin--bottom"><maas-obj-saving>Trying to connect and discover {$ getPageHeading() $}</maas-obj-saving></p>
                         <div class="page-header__controls u-no-margin--top" maas-obj-hide-saving>
-                            <button class="p-button--base is-inline" type="button" data-ng-click="cancelAddPod()">Cancel</button>
-                            <button class="p-button--positive is-inline u-no-margin--top" maas-obj-save>Save {$ getPageHeading() $}</button>
+                            <button class="p-button--base is-inline u-no-margin--bottom" type="button" data-ng-click="cancelAddPod()">Cancel</button>
+                            <button class="p-button--positive is-inline u-no-margin--bottom" maas-obj-save>Save {$ getPageHeading() $}</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Done
- Disabled/enabled Take Action and Add KVM buttons based on machine selection.

## QA
- When no KVMs are selected, check that Take action is displayed and disabled. Check that a tooltip shows on hover.
- When a KVM is selected, check that the Take action button is enabled and the Add KVM button is disabled.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1870

## Screenshots
### Default
![Screenshot_2020-04-06 KVM bolla MAAS](https://user-images.githubusercontent.com/25733845/78532955-729c6380-782b-11ea-9ef0-4909a3635494.png)


### Tooltip
![Screenshot_2020-04-06 KVM bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/78532962-75975400-782b-11ea-913b-b01d9e6959ec.png)


### KVMs selected
![Screenshot_2020-04-06 KVM bolla MAAS(2)](https://user-images.githubusercontent.com/25733845/78532968-77f9ae00-782b-11ea-9d45-5d2bbfcf6c73.png)

