### PR TITLE
Update machine details page with VM/KVM data.

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -29,6 +29,7 @@ function NodeDetailsController(
   ResourcePoolsManager,
   VLANsManager,
   FabricsManager,
+  PodsManager,
   $log,
   $window
 ) {
@@ -43,6 +44,8 @@ function NodeDetailsController(
   $rootScope.title = "Loading...";
 
   // Initial values.
+  $scope.legacyUrlBase =
+    `${process.env.BASENAME}${process.env.ANGULAR_BASENAME}`;
   $scope.loaded = false;
   $scope.node = null;
   $scope.action = {
@@ -91,6 +94,7 @@ function NodeDetailsController(
   $scope.numaDetails = [];
   $scope.expandedNumas = [];
   $scope.groupedInterfaces = [];
+  $scope.isVM = false;
 
   // Node header section.
   $scope.header = {
@@ -575,7 +579,15 @@ function NodeDetailsController(
   // Called when the node has been loaded.
   function nodeLoaded(node) {
     $scope.node = node;
-    $scope.loaded = true;
+    if (node.pod) {
+      PodsManager.getItem(node.pod.id).then((pod) => {
+        $scope.isVM = MachinesManager.isVM(node, pod);
+        $scope.loaded = true;
+      });
+    } else {
+      $scope.isVM = MachinesManager.isVM(node);
+      $scope.loaded = true;
+    }
 
     updateTitle();
     updateSummary();
@@ -1581,7 +1593,7 @@ function NodeDetailsController(
     $rootScope.page = "devices";
   } else {
     $scope.nodesManager = MachinesManager;
-    page_managers = [MachinesManager, ScriptsManager];
+    page_managers = [MachinesManager, PodsManager, ScriptsManager];
     $scope.isController = false;
     $scope.isDevice = false;
     $scope.type_name = "machine";

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -50,7 +50,7 @@ describe("NodeDetailsController", function () {
   var DevicesManager, GeneralManager, UsersManager, DomainsManager;
   var TagsManager, RegionConnection, ManagerHelperService, ErrorService;
   var ScriptsManager, ResourcePoolsManager, VLANsManager, ZonesManager;
-  var webSocket;
+  var PodsManager, webSocket;
   beforeEach(inject(function ($injector) {
     MachinesManager = $injector.get("MachinesManager");
     DevicesManager = $injector.get("DevicesManager");
@@ -68,6 +68,7 @@ describe("NodeDetailsController", function () {
     ScriptsManager = $injector.get("ScriptsManager");
     VLANsManager = $injector.get("VLANsManager");
     FabricsManager = $injector.get("FabricsManager");
+    PodsManager = $injector.get("PodsManager");
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
@@ -201,6 +202,7 @@ describe("NodeDetailsController", function () {
       ErrorService: ErrorService,
       ScriptsManager: ScriptsManager,
       ResourcePoolsManager: ResourcePoolsManager,
+      PodsManager: PodsManager,
     });
 
     // Since the osSelection directive is not used in this test the
@@ -262,6 +264,7 @@ describe("NodeDetailsController", function () {
     expect($scope.services).toEqual({});
     expect($scope.numaDetails).toEqual([]);
     expect($scope.expandedNumas).toEqual([]);
+    expect($scope.isVM).toEqual(false);
   });
 
   it("sets initial values for summary section", function () {
@@ -334,6 +337,7 @@ describe("NodeDetailsController", function () {
       FabricsManager,
       VLANsManager,
       MachinesManager,
+      PodsManager,
       ScriptsManager,
     ]);
   });
@@ -419,7 +423,19 @@ describe("NodeDetailsController", function () {
     expect($scope.type_name_title).toBe("Machine");
   });
 
-  it("sets controller values on load", function () {
+  it("fetches pod details if node has a pod", function() {
+    node.pod = { id: 1 };
+    MachinesManager._activeItem = node;
+    spyOn(PodsManager, "getItem").and.returnValue($q.defer().promise);
+    var defer = $q.defer();
+    makeController(defer);
+
+    defer.resolve();
+    $rootScope.$digest();
+    expect(PodsManager.getItem).toHaveBeenCalledWith(node.pod.id);
+  });
+
+  it("sets controller values on load", function() {
     $location.path("/controller");
     spyOn(MachinesManager, "setActiveItem").and.returnValue($q.defer().promise);
     spyOn(ControllersManager, "setActiveItem").and.returnValue(

--- a/legacy/src/app/factories/nodes.js
+++ b/legacy/src/app/factories/nodes.js
@@ -410,6 +410,21 @@ function NodesManager(RegionConnection, Manager, KVMDeployOSBlacklist, $log) {
     return validUrls.length === values.length;
   };
 
+  NodesManager.prototype.isVM = (node, pod) => {
+    // 08-04-2020 Caleb - Nodes are automatically tagged "virtual" in the
+    // commissioning process by using the 00-maas-02-virtuality script. Since
+    // tags can be removed, we also have a fallback to check that the node has
+    // a pod, or that the node's power_type is in a list of known VM types.
+    if (node.tags && node.tags.includes("virtual")) {
+      return true;
+    }
+
+    const vmPowerTypes = ["lxd", "virsh", "vmware"];
+    return pod
+      ? vmPowerTypes.includes(pod.type)
+      : vmPowerTypes.includes(node.power_type);
+  };
+
   return NodesManager;
 }
 

--- a/legacy/src/app/factories/tests/test_nodes.js
+++ b/legacy/src/app/factories/tests/test_nodes.js
@@ -889,4 +889,39 @@ describe("NodesManager", function() {
       expect(MachinesManager.urlValuesValid(values)).toBe(false);
     });
   });
+
+  describe("isVM", () => {
+    it("returns true for machines with the 'virtual' tag", () => {
+      const virtualMachine = makemachine();
+      const nonVirtualMachine = makemachine();
+      virtualMachine.tags = ["virtual"];
+
+      expect(MachinesManager.isVM(virtualMachine)).toBe(true);
+      expect(MachinesManager.isVM(nonVirtualMachine)).toBe(false);
+    });
+
+    it("returns true for machines with lxd, virsh or vmware power type", () => {
+      const virtualMachine1 = makemachine();
+      const virtualMachine2 = makemachine();
+      const virtualMachine3 = makemachine();
+      const nonVirtualMachine = makemachine();
+      virtualMachine1.power_type = "lxd";
+      virtualMachine2.power_type = "virsh";
+      virtualMachine3.power_type = "vmware";
+
+      expect(MachinesManager.isVM(virtualMachine1)).toBe(true);
+      expect(MachinesManager.isVM(virtualMachine2)).toBe(true);
+      expect(MachinesManager.isVM(virtualMachine3)).toBe(true);
+      expect(MachinesManager.isVM(nonVirtualMachine)).toBe(false);
+    });
+
+    it("returns true for machines that have a pod", () => {
+      const virtualMachine = makemachine();
+      const nonVirtualMachine = makemachine();
+      const pod = { type: "virsh" };
+
+      expect(MachinesManager.isVM(virtualMachine, pod)).toBe(true);
+      expect(MachinesManager.isVM(nonVirtualMachine)).toBe(false);
+    });
+  });
 });

--- a/legacy/src/app/partials/cards/machine-overview.html
+++ b/legacy/src/app/partials/cards/machine-overview.html
@@ -1,7 +1,7 @@
 <span class="l-grid__machine-overview p-card u-no-padding">
 
   <div class="overview">
-    <strong class="p-muted-heading u-sv1">Overview</strong>
+    <strong class="p-muted-heading u-sv1">{$ isVM ? "Virtual Machine Status" : "Machine Status" $}</strong>
     <h4 class="u-no-margin--bottom">
       <i class="p-icon--locked" ng-if="node.locked">Locked: </i>
       {$ node.status $}
@@ -171,6 +171,10 @@
     <div>
       <div class="p-text--muted">Domain</div>
       <span title="{$ header.domain.selected.name $}">{$ header.domain.selected.name $}</span>
+    </div>
+    <div ng-if="node.pod">
+      <div class="p-text--muted">Host</div>
+      <a href="{$ legacyUrlBase $}/kvm/{$ node.pod.id $}">{$ node.pod.name $}&nbsp;&rsaquo;</a>
     </div>
     <div>
       <div>

--- a/legacy/src/scss/grids/_patterns_machine-overview.scss
+++ b/legacy/src/scss/grids/_patterns_machine-overview.scss
@@ -100,11 +100,18 @@
 
     .details {
       @include pseudo-border(top);
-      display: grid;
+      display: flex;
       grid-area: details;
-      grid-column-gap: map-get($grid-gutter-widths, large);
-      grid-template-columns: repeat(6, 1fr);
       padding: $spv-inner--large $sph-inner;
+
+      > * {
+        flex: 1 auto;
+        padding-right: $sph-inner;
+
+        &:last-child {
+          padding-right: 0;
+        }
+      }
     }
 
     @media only screen and (max-width: $breakpoint-x-large) {
@@ -122,13 +129,6 @@
       .cpu-tests {
         &::after {
           content: none;
-        }
-      }
-
-      .details {
-        padding: $spv-inner--large 0;
-        > *:last-child {
-          padding-right: $sph-inner;
         }
       }
 
@@ -199,13 +199,6 @@
       .storage {
         @include pseudo-border(top);
       }
-
-      .details {
-        padding: $spv-inner--large $sph-inner;
-        > *:last-child {
-          padding-right: 0;
-        }
-      }
     }
 
     @media only screen and (max-width: $breakpoint-medium) {
@@ -245,15 +238,17 @@
       }
 
       .details {
-        grid-column-gap: map-get($grid-gutter-widths, medium);
-        grid-row-gap: $spv-inner--large;
-        grid-template-columns: repeat(3, 1fr);
-      }
-    }
+        flex-wrap: wrap;
 
-    @media only screen and (max-width: $breakpoint-small) {
-      .details {
-        grid-column-gap: map-get($grid-gutter-widths, small);
+        > * {
+          flex: 1 50%;
+          padding-bottom: $spv-inner--small;
+
+          &:last-child,
+          &:nth-last-child(2) {
+            padding-bottom: 0;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Waiting on backend engineers for info on:
- [x] Proper method to determine that a machine is a VM.
- [x] ~~NUMA details of KVM host~~ **Not this cycle**.

## Done
- Machine title changed from "Overview" to "Machine Status", unless the machine is a VM then it becomes "Virtual Machine Status".
- If the machine has a pod host a "Host" section is added to the summary card with a link to it.

## QA
- Check that the page matches the [design](https://app.zeplin.io/project/5e538f1156434564ebb73903/screen/5e8da39ae67405b8ca0ee3a3)
- Check that the machine details title is "Virtual Machine Status" for VMs, and "Machine Status" for normal machines
- Check that machines with a pod have a link to it.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1867
Fixes canonical-web-and-design/MAAS-squad#1868
Fixes canonical-web-and-design/MAAS-squad#1869

## Screenshot
![Screenshot_2020-04-09 usertestingisfunny maas bolla MAAS](https://user-images.githubusercontent.com/25733845/78847604-a3121680-7a52-11ea-9175-fc84059fd252.png)

