### PR TITLE
Use nanoid from Redux Toolkit

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,6 @@
     "date-fns": "2.11.1",
     "formik": "2.1.4",
     "http-proxy-middleware": "1.0.3",
-    "nanoid": "3.0.2",
     "path-parse": "1.0.6",
     "pluralize": "8.0.0",
     "prop-types": "15.7.2",

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -1,6 +1,6 @@
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
-import { nanoid } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import usePortal from "react-useportal";

--- a/ui/src/app/base/components/FormikField/FormikField.js
+++ b/ui/src/app/base/components/FormikField/FormikField.js
@@ -2,7 +2,7 @@ import { Input } from "@canonical/react-components";
 import { useField } from "formik";
 import PropTypes from "prop-types";
 import React, { useRef } from "react";
-import { nanoid } from "nanoid";
+import { nanoid } from "@reduxjs/toolkit";
 
 const FormikField = ({
   component: Component = Input,

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -3,6 +3,10 @@ import Adapter from "enzyme-adapter-react-16";
 
 Enzyme.configure({ adapter: new Adapter() });
 
-jest.mock("nanoid", () => ({
-  nanoid: jest.fn(() => "Uakgb_J5m9g-0JDMbcJqLJ"),
-}));
+jest.mock("@reduxjs/toolkit", () => {
+  const toolkit = require.requireActual("@reduxjs/toolkit");
+  return {
+    ...toolkit,
+    nanoid: jest.fn(() => "Uakgb_J5m9g-0JDMbcJqLJ"),
+  };
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10551,11 +10551,6 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
-nanoid@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.0.2.tgz#37e91e6f5277ce22335be473e2a5db1bd96dd026"
-  integrity sha512-WOjyy/xu3199NlQiQWlx7VbspSFlGtOxa1bRX9ebmXOnp1fje4bJfjPs1wLQ8jZbJUfD+yceJmw879ZSaVJkdQ==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
## Done
- Replace our nanoid dependency with the import provided by Redux Toolkit.

## QA
- None, CI should pass.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/954.
