### PR TITLE
Disable Add hardware toggle when machines are selected.

### DIFF
--- a/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.js
+++ b/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.js
@@ -3,7 +3,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import { general as generalActions } from "app/base/actions";
-import { general as generalSelectors } from "app/base/selectors";
+import {
+  general as generalSelectors,
+  machine as machineSelectors,
+} from "app/base/selectors";
 import ContextualMenu from "app/base/components/ContextualMenu";
 
 const getAddHardwareLinks = (navigationOptions) => {
@@ -32,6 +35,8 @@ const getAddHardwareLinks = (navigationOptions) => {
 export const AddHardwareMenu = () => {
   const dispatch = useDispatch();
   const navigationOptions = useSelector(generalSelectors.navigationOptions.get);
+  const selectedIds = useSelector(machineSelectors.selectedIDs);
+  const hasSelectedMachines = selectedIds.length > 0;
 
   useEffect(() => {
     dispatch(generalActions.fetchNavigationOptions());
@@ -44,6 +49,7 @@ export const AddHardwareMenu = () => {
       links={getAddHardwareLinks(navigationOptions)}
       position="right"
       toggleAppearance="neutral"
+      toggleDisabled={hasSelectedMachines}
       toggleLabel="Add hardware"
     />
   );

--- a/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.js
+++ b/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.js
@@ -3,10 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import { general as generalActions } from "app/base/actions";
-import {
-  general as generalSelectors,
-  machine as machineSelectors,
-} from "app/base/selectors";
+import { general as generalSelectors } from "app/base/selectors";
 import ContextualMenu from "app/base/components/ContextualMenu";
 
 const getAddHardwareLinks = (navigationOptions) => {
@@ -32,11 +29,9 @@ const getAddHardwareLinks = (navigationOptions) => {
     : links;
 };
 
-export const AddHardwareMenu = () => {
+export const AddHardwareMenu = ({ disabled = false }) => {
   const dispatch = useDispatch();
   const navigationOptions = useSelector(generalSelectors.navigationOptions.get);
-  const selectedIds = useSelector(machineSelectors.selectedIDs);
-  const hasSelectedMachines = selectedIds.length > 0;
 
   useEffect(() => {
     dispatch(generalActions.fetchNavigationOptions());
@@ -49,7 +44,7 @@ export const AddHardwareMenu = () => {
       links={getAddHardwareLinks(navigationOptions)}
       position="right"
       toggleAppearance="neutral"
-      toggleDisabled={hasSelectedMachines}
+      toggleDisabled={disabled}
       toggleLabel="Add hardware"
     />
   );

--- a/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.test.js
@@ -19,9 +19,6 @@ describe("AddHardwareMenu", () => {
           },
         },
       },
-      machine: {
-        selected: [],
-      },
     };
   });
 
@@ -47,13 +44,8 @@ describe("AddHardwareMenu", () => {
     ).toBe("RSD");
   });
 
-  it("disables the Add hardware toggle menu when machines are selected", () => {
-    const state = {
-      ...initialState,
-      machine: {
-        selected: ["foo"],
-      },
-    };
+  it("can be disabled", () => {
+    const state = { ...initialState };
 
     const store = mockStore(state);
     const wrapper = mount(
@@ -61,7 +53,7 @@ describe("AddHardwareMenu", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <AddHardwareMenu />
+          <AddHardwareMenu disabled />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/AddHardwareMenu/AddHardwareMenu.test.js
@@ -19,6 +19,9 @@ describe("AddHardwareMenu", () => {
           },
         },
       },
+      machine: {
+        selected: [],
+      },
     };
   });
 
@@ -42,5 +45,27 @@ describe("AddHardwareMenu", () => {
       wrapper.find('[data-test="add-hardware-dropdown"]').props().links[2]
         .children
     ).toBe("RSD");
+  });
+
+  it("disables the Add hardware toggle menu when machines are selected", () => {
+    const state = {
+      ...initialState,
+      machine: {
+        selected: ["foo"],
+      },
+    };
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddHardwareMenu />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("ContextualMenu").props().toggleDisabled).toBe(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -1,4 +1,5 @@
 import { Button, Col, Loader, Row } from "@canonical/react-components";
+import PropTypes from "prop-types";
 import pluralize from "pluralize";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -91,6 +92,10 @@ export const HeaderStrip = () => {
       <HeaderStripTabs />
     </>
   );
+};
+
+HeaderStrip.propTypes = {
+  disabled: PropTypes.bool,
 };
 
 export default HeaderStrip;

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -16,6 +16,7 @@ export const HeaderStrip = () => {
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const selectedMachines = useSelector(machineSelectors.selected);
+  const hasSelectedMachines = selectedMachines.length > 0;
 
   const [selectedAction, setSelectedAction] = useState();
 
@@ -64,7 +65,7 @@ export const HeaderStrip = () => {
                 {!selectedAction && (
                   <>
                     <li className="p-inline-list__item">
-                      <AddHardwareMenu />
+                      <AddHardwareMenu disabled={hasSelectedMachines} />
                     </li>
                     <li className="p-inline-list__item last-item">
                       <TakeActionMenu setSelectedAction={setSelectedAction} />

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
@@ -159,6 +159,25 @@ describe("HeaderStrip", () => {
     expect(wrapper.find('Button[data-test="add-pool"]').length).toBe(0);
   });
 
+  it("disables the add hardware menu when machines are selected", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["foo"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('ContextualMenu[data-test="add-hardware-dropdown"]').props()
+        .toggleDisabled
+    ).toBe(true);
+  });
+
   it(`displays add pool button and not hardware dropdown when
     at pools route`, () => {
     const state = { ...initialState };


### PR DESCRIPTION
## Done
* Disable Add hardware toggle when machines are selected.

## QA
* Visit `/r/machines` and select a machine, the Add Hardware toggle should be disabled. Unselect all machines and the toggle should be enabled.

## Fixes
Fixes canonical-web-and-design/MAAS-design#883.
