### PR TITLE
Fix inconsistent header strip sizes in angular pages.

### DIFF
--- a/legacy/src/app/partials/directives/error_overlay.html
+++ b/legacy/src/app/partials/directives/error_overlay.html
@@ -1,11 +1,10 @@
-<header id="error-header" class="page-header" data-ng-show="show()">
+<header id="error-header" class="p-strip--light is-shallow page-header" data-ng-show="show()">
     <div class="row">
-        <h1 class="page-header__title">
-            <span class="p-icon--loading u-animation--spin u-margin--right-small" data-ng-hide="clientError"></span>
-            {$ getTitle() $}
+        <h1 class="page-header__title u-no-margin--bottom">
+            <span data-ng-hide="clientError">{$ getTitle() $}</span>
         </h1>
         <div class="page-header__controls">
-            <button class="button--secondary button--inline" data-ng-click="reload()" data-ng-show="clientError">Reload</button>
+            <button class="p-button--neutral u-no-margin--bottom" data-ng-click="reload()" data-ng-show="clientError">Reload</button>
         </div>
         <div class="page-header__dropdown is-open" data-ng-show="error">
             <div class="page-header__section">

--- a/legacy/src/app/partials/domain-details.html
+++ b/legacy/src/app/partials/domain-details.html
@@ -17,10 +17,10 @@
         </div>
         <div class="col-medium-2 col-4">
             <div class="page-header__controls ng-hide" data-ng-show="isSuperUser() && !loading">
-                <button class="p-button--negative"
+                <button class="p-button--negative u-no-margin--bottom"
                     data-ng-click="deleteButton()"
                     data-ng-hide="actionInProgress || isDefaultDomain()">Delete domain</button>
-                <button class="p-button"
+                <button class="p-button u-no-margin--bottom"
                         data-ng-click="addRecordButton()"
                         data-ng-hide="actionInProgress">Add record</button>
             </div>

--- a/legacy/src/app/partials/domains-list.html
+++ b/legacy/src/app/partials/domains-list.html
@@ -11,12 +11,14 @@
         </div>
         <div class="col-medium-2 col-4">
             <div class="page-header__controls" data-ng-show="isSuperUser()">
-                <button class="p-button--neutral"
+                <button
+                    class="p-button--neutral u-no-margin--bottom"
                     data-ng-click="addDomain()"
-                    data-ng-if="!addDomainScope.viewable">Add domain</button>
-                <button class="p-button--neutral"
-                    data-ng-click="cancelAddDomain()"
-                    data-ng-if="addDomainScope.viewable" disabled>Add domain</button>
+                    data-ng-disabled="addDomainScope.viewable"
+                    data-ng-if="!addDomainScope.viewable"
+                >
+                    Add domain
+                </button>
             </div>
         </div>
     </div>

--- a/legacy/src/app/partials/fabric-details.html
+++ b/legacy/src/app/partials/fabric-details.html
@@ -14,7 +14,7 @@
                     <h1 class="page-header__title">{$ fabric.name $}</h1>
                 </div>
                 <div class="page-header__controls u-no-margin--top ng-hide" data-ng-show="isSuperUser() && !isDefaultFabric() && !loading">
-                    <button class="p-button--negative"
+                    <button class="p-button--negative u-no-margin--bottom"
                         data-ng-click="deleteButton()"
                         data-ng-hide="confirmingDelete">Delete fabric</button>
                 </div>
@@ -22,7 +22,7 @@
                     <section class="u-no-margin--top u-align--right" data-ng-hide="canBeDeleted()">
                         <div class="u-hide--small">
                             <i class="p-icon--error"></i> Fabric cannot be deleted because it is the default fabric.&emsp;
-                            <button class="p-button--base" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
+                            <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
                         </div>
                         <div class="u-hide u-show--small u-align--left">
                             <div class="col-12 u-align--left">
@@ -37,32 +37,32 @@
                     <section class="ng-hide u-no-margin--top u-align--right" data-ng-show="canBeDeleted() && !error">
                         <div class="u-hide--small">
                             <i class="p-icon--warning"></i> Are you sure you want to delete this fabric?&emsp;
-                            <button class="p-button--base" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
-                            <button class="p-button--negative" data-ng-click="deleteConfirmButton()">Delete fabric</button>
+                            <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
+                            <button class="p-button--negative u-no-margin--bottom" data-ng-click="deleteConfirmButton()">Delete fabric</button>
                         </div>
                         <div class="u-hide u-show--small u-align--left">
                             <div class="col-12 u-align--left">
                                 <p><i class="p-icon--warning"></i> Are you sure you want to delete this fabric?</p>
                             </div>
                             <div class="col-12 u-align--right">
-                                <button class="p-button--base" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
-                                <button class="p-button--negative" data-ng-click="deleteConfirmButton()">Delete fabric</button>
+                                <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
+                                <button class="p-button--negative u-no-margin--bottom" data-ng-click="deleteConfirmButton()">Delete fabric</button>
                             </div>
                         </div>
                     </section>
                     <section class="page-header__controls u-no-margin--top u-align--right" data-ng-show="canBeDeleted() && error">
                         <div class="u-hide--small">
                             <i class="p-icon--error"></i> {$ error $}&emsp;
-                            <button class="p-button--base" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
-                            <button class="p-button--neutral" data-ng-click="deleteConfirmButton()">Retry</button>
+                            <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
+                            <button class="p-button--neutral u-no-margin--bottom" data-ng-click="deleteConfirmButton()">Retry</button>
                         </div>
                         <div class="u-hide u-show--small u-align--left">
                             <div class="col-12 u-align--left">
                                 <p><i class="p-icon--error"></i> {$ error $}</p>
                             </div>
                             <div class="col-12 u-align--right">
-                                <button class="p-button--base" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
-                                <button class="p-button--neutral" data-ng-click="deleteConfirmButton()">Retry</button>
+                                <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancelDeleteButton()">Cancel</button>
+                                <button class="p-button--neutral u-no-margin--bottom" data-ng-click="deleteConfirmButton()">Retry</button>
                             </div>
                         </div>
                     </section>

--- a/legacy/src/app/partials/networks-list.html
+++ b/legacy/src/app/partials/networks-list.html
@@ -17,7 +17,8 @@
     </div>
     <div class="page-header__dropdown u-no-margin--top" data-ng-class="{ 'is-open': actionOption.name}">
         <section class="row u-no-margin--bottom ng-hide" data-ng-show="actionOption.name === 'add_fabric'">
-          <div class="p-strip">
+          <hr />
+          <div class="p-strip is-shallow">
             <maas-obj-form obj="newObject" manager="fabricManager" manager-method="createItem"
                 inline="true" save-on-blur="false" after-save="cancelAction">
                 <div class="row">
@@ -30,8 +31,8 @@
                     <div class="col-6">
                         <div class="page-header__controls u-no-margin--top col-4">
                             <div class="u-align--right">
-                                <button class="p-button p-button--inline" data-ng-click="cancelAction()">Cancel</button>
-                                <button class="p-button--positive p-button--inline" maas-obj-save>Add fabric</button>
+                                <button class="p-button u-no-margin--bottom" data-ng-click="cancelAction()">Cancel</button>
+                                <button class="p-button--positive u-no-margin--bottom" maas-obj-save>Add fabric</button>
                             </div>
                         </div>
                     </div>
@@ -42,6 +43,7 @@
         <section class="row u-no-margin--bottom ng-hide" data-ng-show="actionOption.name === 'add_vlan'">
             <maas-obj-form obj="newObject" manager="vlanManager" manager-method="createItem"
                 save-on-blur="false" after-save="cancelAction" class="p-form--stacked">
+                <hr />
                 <div class="p-strip is-shallow">
                     <div class="row">
                         <div class="col-6">
@@ -66,67 +68,76 @@
                 </div>
                 <div class="row u-align--right">
                   <maas-obj-errors></maas-obj-errors>
-                  <div class="page-header__controls">
-                      <button class="p-button p-button--inline" data-ng-click="cancelAction()">Cancel</button>
-                      <button class="p-button--positive p-button--inline" maas-obj-save>Add VLAN</button>
+                  <div class="p-strip is-shallow u-no-padding--top page-header__controls">
+                      <button class="p-button u-no-margin--bottom" data-ng-click="cancelAction()">Cancel</button>
+                      <button class="p-button--positive u-no-margin--bottom" maas-obj-save>Add VLAN</button>
                   </div>
               </div>
             </maas-obj-form>
         </section>
         <section class="row u-no-margin--bottom ng-hide" data-ng-show="actionOption.name === 'add_space'">
+            <hr />
             <maas-obj-form obj="newObject" manager="spaceManager" manager-method="createItem" inline="true" save-on-blur="false" after-save="cancelAction">
-                <div class="row">
-                    <div class="col-6">
-                        <maas-obj-field
-                            type="text" key="name" label="Add space" subtle="false"
-                            placeholder="Name (optional)"></maas-obj-field>
-                        <maas-obj-errors></maas-obj-errors>
-                    </div>
-                    <div class="col-6">
-                        <div class="page-header__controls u-no-margin--top u-align--right col-4">
-                            <button class="p-button p-button--inline" data-ng-click="cancelAction()">Cancel</button>
-                            <button class="p-button--positive p-button--inline" maas-obj-save>Add space</button>
+                <div class="p-strip is-shallow">
+                    <div class="row">
+                        <div class="col-6">
+                            <maas-obj-field
+                                type="text" key="name" label="Add space" subtle="false"
+                                placeholder="Name (optional)"></maas-obj-field>
+                            <maas-obj-errors></maas-obj-errors>
+                        </div>
+                        <div class="col-6">
+                            <div class="page-header__controls u-no-margin--top u-align--right col-4">
+                                <button class="p-button u-no-margin--bottom" data-ng-click="cancelAction()">Cancel</button>
+                                <button class="p-button--positive u-no-margin--bottom" maas-obj-save>Add space</button>
+                            </div>
                         </div>
                     </div>
                 </div>
             </maas-obj-form>
         </section>
         <section class="row ng-hide" data-ng-show="actionOption.name == 'add_subnet'">
-        <maas-obj-form obj="newObject" manager="subnetManager" manager-method="createItem" class="p-form--stacked"
-            table-form="true" save-on-blur="false" pre-process="actionSubnetPreSave" after-save="cancelAction">
-            <section class="row">
-              <div class="col-6">
-                <maas-obj-field
-                    subtle="false" type="text" key="name" label="Name" placeholder="Name (optional)"
-                    label-width="2" input-width="4"></maas-obj-field>
-                <maas-obj-field
-                    subtle="false" type="text" key="cidr" label="CIDR"
-                    placeholder="Use IPv4 or IPv6 format"
-                    label-width="2" input-width="4"></maas-obj-field>
-                <maas-obj-field
-                    subtle="false" type="text" key="gateway_ip" label="Gateway IP"
-                    placeholder="Use IPv4 or IPv6 format (optional)"
-                    label-width="2" input-width="4"></maas-obj-field>
-              </div>
-              <div class="col-6">
-                <maas-obj-field
-                    subtle="false" type="text" key="dns_servers" label="DNS servers"
-                    placeholder="Use IPv4 or IPv6 format (optional)"
-                    label-width="2" input-width="4"></maas-obj-field>
-                <maas-obj-field
-                    subtle="false" type="options" key="vlan" label="Fabric &amp; VLAN" placeholder="Choose Fabric &amp; VLAN"
-                    options="v.id as getVLANName(v) group by getFabricNameById(v.fabric) for v in vlans"
-                    label-width="2" input-width="4"></maas-obj-field>
-              </div>
-            </section>
-            <section class="u-no-margin--top">
-                <maas-obj-errors class="page-header__message page-header__message--error"></maas-obj-errors>
-                <div class="page-header__controls u-no-margin--top">
-                    <button class="p-button p-button--inline" data-ng-click="cancelAction()">Cancel</button>
-                    <button class="p-button--positive p-button--inline" maas-obj-save>Add subnet</button>
+            <hr />
+            <maas-obj-form obj="newObject" manager="subnetManager" manager-method="createItem" class="p-form--stacked"
+                table-form="true" save-on-blur="false" pre-process="actionSubnetPreSave" after-save="cancelAction">
+                <div class="p-strip is-shallow">
+                    <section class="row">
+                        <div class="col-6">
+                            <maas-obj-field
+                                subtle="false" type="text" key="name" label="Name" placeholder="Name (optional)"
+                                label-width="2" input-width="4"></maas-obj-field>
+                            <maas-obj-field
+                                subtle="false" type="text" key="cidr" label="CIDR"
+                                placeholder="Use IPv4 or IPv6 format"
+                                label-width="2" input-width="4"></maas-obj-field>
+                            <maas-obj-field
+                                subtle="false" type="text" key="gateway_ip" label="Gateway IP"
+                                placeholder="Use IPv4 or IPv6 format (optional)"
+                                label-width="2" input-width="4"></maas-obj-field>
+                        </div>
+                        <div class="col-6">
+                            <maas-obj-field
+                                subtle="false" type="text" key="dns_servers" label="DNS servers"
+                                placeholder="Use IPv4 or IPv6 format (optional)"
+                                label-width="2" input-width="4"></maas-obj-field>
+                            <maas-obj-field
+                                subtle="false" type="options" key="vlan" label="Fabric &amp; VLAN" placeholder="Choose Fabric &amp; VLAN"
+                                options="v.id as getVLANName(v) group by getFabricNameById(v.fabric) for v in vlans"
+                                label-width="2" input-width="4"></maas-obj-field>
+                        </div>
+                    </section>
                 </div>
-            </section>
-        </maas-obj-form>
+                <div class="p-strip is-shallow u-no-padding--top">
+                    <maas-obj-errors class="page-header__message page-header__message--error"></maas-obj-errors>
+                    <div class="row u-align--right">
+                        <div class="page-header__controls u-no-margin--top">
+                            <button class="p-button u-no-margin--bottom" data-ng-click="cancelAction()">Cancel</button>
+                            <button class="p-button--positive u-no-margin--bottom" maas-obj-save>Add subnet</button>
+                        </div>
+                    </div>
+                </div>
+            </maas-obj-form>
+        </section>
     </div>
 </header>
 

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -44,7 +44,7 @@
                     </li>
                     <li class="p-inline-list__item u-no-wrap">
                         <i class="p-icon--power-{$ getPowerStateClass() $}"></i> {$ getPowerStateText() $}
-                        <button class="p-button--base" data-ng-show="canCheckPowerState()"
+                        <button class="p-button--base u-no-margin--bottom" data-ng-show="canCheckPowerState()"
                             data-ng-click="checkPowerState(); sendAnalyticsEvent('Machine details', 'Check power state', 'Machine summary tab')">check
                             now</button>
                     </li>

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -43,7 +43,7 @@
         <div data-ng-show="currentpage === 'pools'">
             <div class="page-header__controls"
                  data-ng-show="canCreateResourcePool()">
-              <button class="p-button--neutral"
+              <button class="p-button--neutral u-no-margin--bottom"
                       data-ng-click="tabs.pools.addPool()"
                       data-ng-if="!tabs.pools.actionOption">Add pool</button>
               <button class="p-button--neutral ng-hide"
@@ -80,12 +80,9 @@
 
             <div class="page-header__controls page-header__controls--controllers u-no-margin--top" data-ng-show="currentpage === 'controllers'">
                 <div data-ng-if="!tabs.controllers.selectedItems.length">
-                    <button class="p-button--neutral"
+                    <button class="p-button--neutral u-no-margin--bottom"
                         data-ng-click="tabs.controllers.addController = true"
                         data-ng-if="!tabs.controllers.addController">Add rack controller</button>
-                    <button class="p-button--neutral"
-                        data-ng-click="tabs.controllers.addController = false"
-                        data-ng-if="tabs.controllers.addController">Close add rack controller</button>
                 </div>
                 <ul class="p-inline-list u-no-margin--top u-no-margin--bottom" data-ng-show="tabs.controllers.selectedItems.length">
                     <li class="p-inline-list__item">

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -366,12 +366,12 @@
                         <hr>
                         <div maas-obj-hide-saving><maas-obj-errors></maas-obj-errors></div>
                         <div class="u-align--right" maas-obj-hide-saving>
-                            <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancelCompose()">Cancel</button>
-                            <button class="p-button--positive u-no-margin--bottom" maas-obj-save ng-disabled="!validateMachineCompose()" data-ng-click="sendAnalyticsEvent('KVM details', 'Submit form', 'KVM compose')">Compose machine</button>
+                            <button class="p-button--base" type="button" data-ng-click="cancelCompose()">Cancel</button>
+                            <button class="p-button--positive" maas-obj-save ng-disabled="!validateMachineCompose()" data-ng-click="sendAnalyticsEvent('KVM details', 'Submit form', 'KVM compose')">Compose machine</button>
                         </div>
                         <div class="u-align--right" maas-obj-show-saving>
-                            <button class="p-button--base u-no-margin--bottom" type="button" data-ng-disabled="true">Cancel</button>
-                            <button class="p-button--positive p-action-button is-indeterminate u-no-margin--bottom" ng-disabled="true">Composing machine...</button>
+                            <button class="p-button--base" type="button" data-ng-disabled="true">Cancel</button>
+                            <button class="p-button--positive p-action-button is-indeterminate" ng-disabled="true">Composing machine...</button>
                         </div>
                     </div>
                 </div>
@@ -379,6 +379,7 @@
         </div>
 
         <div class="page-header__dropdown u-hide" data-ng-class="{ 'u-show': action.option && action.option.name !== 'compose' }">
+            <hr />
             <div class="row" data-ng-if="action.inProgress">
                 <div class="col-12">
                     <p>
@@ -387,48 +388,46 @@
                     </p>
                 </div>
             </div>
-            <div class="row u-equal-height" data-ng-if="action.option && !action.inProgress">
-                <form class="p-form p-form--inline u-align--right">
-                    <div class="col-8 u-vertically-center">
+            <form class="p-form">
+                <div class="row" data-ng-if="action.option && !action.inProgress">
+                    <div class="col-8">
                         <div data-ng-if="action.error">
-                            <p class="u-remove-max-width">
+                            <p class="u-no-max-width">
                                 <i class="p-icon--error">Error:</i> Performing {$ action.option.sentence $} failed: {$ action.error $}
                             </p>
                         </div>
                         <div data-ng-if="action.option.name === 'refresh'">
-                            <p class="u-remove-max-width u-align--left">
+                            <p class="u-no-max-width">
                                 Refreshing this {$ pageType $} will cause MAAS to recalculate usage metrics, update information about storage pools,
                                 and commission any machines present in the {$ pageType $} that are not yet known to MAAS.
                             </p>
                         </div>
                     </div>
-                    <div class="col-4">
-                        <div class="u-align--right">
-                            <button class="p-button--base" type="button" data-ng-click="actionCancel()">Cancel</button>
-                            <button class="u-no-margin--top u-no-margin--top" data-ng-class="action.option.name === 'delete' ? 'p-button--negative' : 'p-button--positive'" data-ng-click="actionGo()" data-ng-if="!action.error">
-                                <span data-ng-if="action.option.name === 'refresh'">Refresh {$ pageType $}</span>
-                                <span data-ng-if="action.option.name === 'delete'">Delete {$ pageType $}</span>
-                            </button>
-                            <button class="p-button--neutral u-no-margin--top" data-ng-click="actionGo()" data-ng-if="action.error">Retry</button>
-                        </div>
-                    </div>
-                </form>
-            </div>
-        </div>
-        <div class="p-strip is-shallow u-no-padding--bottom" media-query="min-width: 769px" offset="89">
-            <nav class="p-tabs u-hr--fixed-width">
-                <div class="row">
-                    <ul class="p-tabs__list" role="tablist" data-ng-class="{ 'u-hide': action.option }">
-                        <li class="p-tabs__item" role="presentation">
-                            <a href="" role="tab" class="p-tabs__link" data-ng-class="{ 'is-active': section.area === 'summary'}" data-ng-click="section.area = 'summary'">{$ pod.composed_machines_count $} composed machines</a>
-                        </li>
-                        <li class="p-tabs__item" role="presentation">
-                            <a href="" role="tab" class="p-tabs__link" data-ng-if="canEdit()" data-ng-class="{ 'is-active': section.area === 'configuration'}" data-ng-click="section.area= 'configuration'">Configuration</a>
-                        </li>
-                    </ul>
                 </div>
-            </nav>
+                <div class="row">
+                    <div class="col-12 u-align--right">
+                        <button class="p-button--base" type="button" data-ng-click="actionCancel()">Cancel</button>
+                        <button class="u-no-margin--top u-no-margin--top" data-ng-class="action.option.name === 'delete' ? 'p-button--negative' : 'p-button--positive'" data-ng-click="actionGo()" data-ng-if="!action.error">
+                            <span data-ng-if="action.option.name === 'refresh'">Refresh {$ pageType $}</span>
+                            <span data-ng-if="action.option.name === 'delete'">Delete {$ pageType $}</span>
+                        </button>
+                        <button class="p-button--neutral u-no-margin--top" data-ng-click="actionGo()" data-ng-if="action.error">Retry</button>
+                    </div>
+                </div>
+            </form>
         </div>
+        <nav class="p-tabs u-hr--fixed-width">
+            <div class="row">
+                <ul class="p-tabs__list" role="tablist" data-ng-class="{ 'u-hide': action.option }">
+                    <li class="p-tabs__item" role="presentation">
+                        <a href="" role="tab" class="p-tabs__link" data-ng-class="{ 'is-active': section.area === 'summary'}" data-ng-click="section.area = 'summary'">{$ pod.composed_machines_count $} composed machines</a>
+                    </li>
+                    <li class="p-tabs__item" role="presentation">
+                        <a href="" role="tab" class="p-tabs__link" data-ng-if="canEdit()" data-ng-class="{ 'is-active': section.area === 'configuration'}" data-ng-click="section.area= 'configuration'">Configuration</a>
+                    </li>
+                </ul>
+            </div>
+        </nav>
     </header>
 
     <section data-ng-if="section.area === 'summary'">

--- a/legacy/src/app/partials/space-details.html
+++ b/legacy/src/app/partials/space-details.html
@@ -6,7 +6,7 @@
             </div>
             <div class="col-small-2 col-medium-2 col-4">
                 <div class="page-header__controls ng-hide" data-ng-show="isSuperUser() && !isDefaultSpace() && !loading">
-                    <button class="p-button--neutral"
+                    <button class="p-button--neutral u-no-margin--bottom"
                         data-ng-click="deleteButton()"
                         data-ng-hide="confirmingDelete">Delete space</button>
                 </div>

--- a/legacy/src/app/partials/zones-list.html
+++ b/legacy/src/app/partials/zones-list.html
@@ -14,28 +14,41 @@
         </div>
         <div class="col-medium-2 col-4">
             <div class="page-header__controls" data-ng-show="isSuperUser()">
-                <button class="button--secondary button--inline"
+                <button
+                    class="p-button--neutral u-no-margin--bottom"
                     data-ng-click="addZone()"
-                    data-ng-hide="action.open">Add AZ</button>
-                <button class="button--secondary button--inline"
-                    data-ng-click="closeZone()"
-                    data-ng-show="action.open">Cancel add AZ</button>
+                    data-ng-hide="action.open"
+                >
+                    Add AZ
+                </button>
             </div>
         </div>
     </div>
     <div class="row u-no-margin--top" data-ng-if="action.open">
         <hr />
-        <maas-obj-form obj="action.obj" manager="zoneManager" manager-method="createItem"
-            inline="true" save-on-blur="false" after-save="closeZone">
-            <div class="col-6">
-                <maas-obj-field
-                    type="text" key="name" label="Name (required)" subtle="false"
-                    placeholder="Name (required)" label-width="2" input-width="3" ></maas-obj-field>
-            </div>
-            <div class="col-6">
-                <div class="u-align--right">
-                    <button class="p-button--base" type="button"data-ng-click="closeZone()">Cancel</button>
-                    <button class="p-button--positive u-no-margin--top" maas-obj-save>Add AZ</button>
+        <maas-obj-form
+            after-save="closeZone"
+            inline="true"
+            manager="zoneManager"
+            manager-method="createItem"
+            obj="action.obj"
+            save-on-blur="false"
+        >
+            <div class="row">
+                <div class="col-6">
+                    <maas-obj-field
+                        input-width="3"
+                        key="name"
+                        label="Name (required)"
+                        label-width="2"
+                        placeholder="Name (required)"
+                        subtle="false"
+                        type="text"
+                    ></maas-obj-field>
+                </div>
+                <div class="col-6 u-align--right">
+                    <button class="p-button--base" type="button" data-ng-click="closeZone()">Cancel</button>
+                    <button class="p-button--positive" maas-obj-save>Add AZ</button>
                 </div>
             </div>
         </maas-obj-form>


### PR DESCRIPTION
## Done
- Fixed inconsistent header strip sizes in angular pages.

## QA
- Navigate between angular pages (and react pages if you want) and check that the header strip does not change height, with the exception of pages with tab strips (e.g. machine list, node details).
- Reload the page and check that the transition from Loading... > Connecting... > Page title does not change the header height.

## Fixes
Fixes #961
