### PR TITLE
Update pod details page to new design.

### DIFF
--- a/legacy/src/app/controllers/pod_details.js
+++ b/legacy/src/app/controllers/pod_details.js
@@ -25,8 +25,7 @@ function PodDetailsController(
   FabricsManager,
   SpacesManager,
   ValidationService,
-  $log,
-  $document
+  $log
 ) {
   // Checks if on RSD page
   $scope.onRSDSection = PodsManager.onRSDSection;
@@ -426,12 +425,12 @@ function PodDetailsController(
   $scope.copyToClipboard = function($event) {
     var clipboardParent = $event.currentTarget.previousSibling;
     var clipboardValue = clipboardParent.previousSibling.value;
-    var el = $document.createElement("textarea");
+    var el = document.createElement("textarea");
     el.value = clipboardValue;
-    $document.body.appendChild(el);
+    document.body.appendChild(el);
     el.select();
-    $document.execCommand("copy");
-    $document.body.removeChild(el);
+    document.execCommand("copy");
+    document.body.removeChild(el);
   };
 
   // Called to cancel composition.

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -65,9 +65,8 @@
                     <div class="col-6">
                         <maas-obj-field type="options" key="architecture" label="Architecture" subtle="false" placeholder="Any architecture" placeholder-enabled="true"
                             options="arch for arch in pod.architectures" data-ng-if="pod.architectures.length > 1" label-width="2" label-width-tablet="2" input-width="3" input-width-tablet="4"></maas-obj-field>
-                        <maas-obj-field type="text" key="cores" label="Minimum Cores" subtle="false" placeholder="Number of cores (optional)" subtle-text="{$ availableWithOvercommit(pod.total.cores, pod.used.cores, pod.cpu_over_commit_ratio, 1) $} cores available" label-width="2" label-width-tablet="2" input-width="3" input-width-tablet="4"></maas-obj-field>
-                        <maas-obj-field type="text" key="cpu_speed" label="Minimum Speed (MHz)" subtle="false" placeholder="CPU speed (optional)" subtle-text="{$ pod.hints.cpu_speed $}MHz maximum" label-width="2" label-width-tablet="2" input-width="3" input-width-tablet="4"></maas-obj-field>
-                        <maas-obj-field type="text" key="memory" label="Minimum RAM (MB)" subtle="false" placeholder="Memory amount (optional)" subtle-text="{$ availableWithOvercommit(pod.total.memory_gb, pod.used.memory_gb, pod.memory_over_commit_ratio, 1) $}GB available" label-width="2" label-width-tablet="2" input-width="3" input-width-tablet="4"></maas-obj-field>
+                        <maas-obj-field type="text" key="cores" label="Cores" subtle="false" placeholder="Number of cores (optional)" subtle-text="{$ availableWithOvercommit(pod.total.cores, pod.used.cores, pod.cpu_over_commit_ratio, 1) $} cores available" label-width="2" label-width-tablet="2" input-width="3" input-width-tablet="4"></maas-obj-field>
+                        <maas-obj-field type="text" key="memory" label="RAM (MB)" subtle="false" placeholder="Memory amount (optional)" subtle-text="{$ availableWithOvercommit(pod.total.memory_gb, pod.used.memory_gb, pod.memory_over_commit_ratio, 1) $}GB available" label-width="2" label-width-tablet="2" input-width="3" input-width-tablet="4"></maas-obj-field>
                     </div>
                 </div>
                 <div class="p-strip">
@@ -434,7 +433,8 @@
         <div class="p-strip is-shallow" ng-if="canEdit()">
             <div class="row">
                 <div class="p-pod-edit">
-                    <label class="p-pod-edit__label" for="virsh">Virsh:</label>
+                    <label class="p-pod-edit__label" ng-if="pod.type === 'lxd'">LXD URL:</label>
+                    <label class="p-pod-edit__label" ng-if="pod.type === 'virsh'">Virsh:</label>
                     <div class="p-code-copyable-wrapper">
                         <div class="p-code-copyable">
                             <input class="p-code-copyable__input" value="{$ pod.power_address $}" readonly="readonly">


### PR DESCRIPTION
## Done
- Changed label for power address if pod is a LXD host (Virsh => LXD URL)
- Fixed copy to clipboard for power address
- Removed speed input from compose form
- Removed "Minimum" from cores and RAM labels in compose form

## QA
- Check that the details page matches the [design](https://app.zeplin.io/project/5e538f1156434564ebb73903/screen/5e8da399f373c323bccb4ede)
- Check that the compose form matches the [design](https://app.zeplin.io/project/5e538f1156434564ebb73903/screen/5e8de1424d7d1d22638dcaa4)
- Check that you can still compose machines

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1877
Fixes #686 