### PR TITLE
Prevent user from deleting pools that contain machines.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -25,7 +25,7 @@ import {
   user as userActions,
   zone as zoneActions,
 } from "app/base/actions";
-import { groupAsMap, simpleSortByKey } from "app/utils";
+import { formatErrors, groupAsMap, simpleSortByKey } from "app/utils";
 import { machine as machineSelectors } from "app/base/selectors";
 import { nodeStatus } from "app/base/enum";
 import { useLocation, useRouter, useWindowTitle } from "app/base/hooks";
@@ -433,18 +433,7 @@ const MachineList = () => {
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const machinesLoading = useSelector(machineSelectors.loading);
   const errors = useSelector(machineSelectors.errors);
-  let errorMessage;
-  if (errors) {
-    if (Array.isArray(errors)) {
-      errorMessage = errors.join(" ");
-    } else if (typeof errors === "object") {
-      errorMessage = Object.entries(errors)
-        .map(([key, value]) => `${key}: ${value}`)
-        .join(" ");
-    } else {
-      errorMessage = errors;
-    }
-  }
+  const errorMessage = formatErrors(errors);
 
   const [currentSort, setCurrentSort] = useState({
     key: "fqdn",

--- a/ui/src/app/pools/views/Pools.test.js
+++ b/ui/src/app/pools/views/Pools.test.js
@@ -22,6 +22,7 @@ describe("Pools", () => {
         items: [],
       },
       resourcepool: {
+        errors: {},
         loaded: true,
         items: [
           {
@@ -190,6 +191,29 @@ describe("Pools", () => {
     expect(wrapper.find("Button").at(1).props().disabled).toBe(true);
   });
 
+  it("disables the delete button for pools that contain machines", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    state.resourcepool.items = [
+      {
+        id: 0,
+        name: "machines",
+        description: "has machines",
+        is_default: false,
+        permissions: ["edit", "delete"],
+        machine_total_count: 1,
+      },
+    ];
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+          <Pools />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Button").at(1).props().disabled).toBe(true);
+  });
+
   it("does not show a machine link for empty pools", () => {
     const state = { ...initialState };
     state.resourcepool.items[0].machine_total_count = 0;
@@ -226,5 +250,21 @@ describe("Pools", () => {
     expect(link.exists()).toBe(true);
     expect(link.prop("to")).toBe("/machines?pool=default");
     expect(link.text()).toBe("1 of 5 ready");
+  });
+
+  it("displays state errors in a notification", () => {
+    const state = { ...initialState };
+    state.resourcepool.errors = "Pools are not for swimming.";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+          <Pools />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification p").text()).toEqual(
+      "Pools are not for swimming."
+    );
   });
 });

--- a/ui/src/app/utils/formatErrors.js
+++ b/ui/src/app/utils/formatErrors.js
@@ -1,0 +1,24 @@
+/**
+ * Format errors of different types to a single string.
+ *
+ * @param {string|string[]|object} errors - the errors string/array/object
+ * @returns {string} error message
+ */
+
+export const formatErrors = (errors) => {
+  let errorMessage;
+
+  if (errors) {
+    if (Array.isArray(errors)) {
+      errorMessage = errors.join(" ");
+    } else if (typeof errors === "object") {
+      errorMessage = Object.entries(errors)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(" ");
+    } else {
+      errorMessage = errors;
+    }
+  }
+
+  return errorMessage;
+};

--- a/ui/src/app/utils/formatErrors.test.js
+++ b/ui/src/app/utils/formatErrors.test.js
@@ -1,0 +1,21 @@
+import { formatErrors } from "./formatErrors";
+
+describe("formatErrors", () => {
+  it("does not format a single string", () => {
+    const error = "Error message";
+    expect(formatErrors(error)).toEqual("Error message");
+  });
+
+  it("correctly formats an array of error strings", () => {
+    const error = ["Error 1.", "Error 2."];
+    expect(formatErrors(error)).toEqual("Error 1. Error 2.");
+  });
+
+  it("correctly formats an error object", () => {
+    const error = {
+      name: "Too long.",
+      date: "Too late.",
+    };
+    expect(formatErrors(error)).toEqual("name: Too long. date: Too late.");
+  });
+});

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -1,5 +1,6 @@
 export { capitaliseFirst } from "./capitaliseFirst";
 export { formatBytes } from "./formatBytes";
+export { formatErrors } from "./formatErrors";
 export { formatSpeedUnits } from "./formatSpeedUnits";
 export { getMachineValue } from "./search";
 export { generateLegacyURL } from "./generateLegacyURL";


### PR DESCRIPTION
## Done
- Disabled delete button for pools that contain at least one machine.
- Show resourcepool errors in state in a notification on the pool list

## QA
- Go to `/r/pools` and check that resource pools with machines in them have disabled delete buttons that have a tooltip on hover
- Remove the `deleteDisabled` prop from `<TableActions>` in `Pools.js`
- Attempt to delete a pool that you otherwise couldn't and check that a an error notification shows up that you can clear

## Fixes
Fixes #918 
