### PR TITLE
Add commissioning form.

### DIFF
--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -96,8 +96,24 @@ machine.acquire = (systemId) =>
 machine.release = (systemId) =>
   generateMachineAction("RELEASE_MACHINE", "release", systemId);
 
-machine.commission = (systemId) =>
-  generateMachineAction("COMMISSION_MACHINE", "commission", systemId);
+machine.commission = (
+  systemId,
+  enableSSH,
+  skipBMCConfig,
+  skipNetworking,
+  skipStorage,
+  commissioningScripts,
+  testingScripts
+) =>
+  generateMachineAction("COMMISSION_MACHINE", "commission", systemId, {
+    enable_ssh: enableSSH,
+    skip_bmc_config: skipBMCConfig,
+    skip_networking: skipNetworking,
+    skip_storage: skipStorage,
+    commissioning_scripts:
+      commissioningScripts && commissioningScripts.map((script) => script.id),
+    testingScripts: testingScripts && testingScripts.map((script) => script.id),
+  });
 
 machine.deploy = (systemId, extra = {}) =>
   generateMachineAction("DEPLOY_MACHINE", "deploy", systemId, extra);

--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -102,18 +102,34 @@ machine.commission = (
   skipBMCConfig,
   skipNetworking,
   skipStorage,
+  updateFirmware,
+  configureHBA,
   commissioningScripts,
   testingScripts
-) =>
-  generateMachineAction("COMMISSION_MACHINE", "commission", systemId, {
+) => {
+  let formattedCommissioningScripts = [];
+  if (commissioningScripts && commissioningScripts.length > 0) {
+    formattedCommissioningScripts = commissioningScripts.map(
+      (script) => script.id
+    );
+    if (updateFirmware) {
+      formattedCommissioningScripts.push("update_firmware");
+    }
+    if (configureHBA) {
+      formattedCommissioningScripts.push("configure_hba");
+    }
+  }
+
+  return generateMachineAction("COMMISSION_MACHINE", "commission", systemId, {
     enable_ssh: enableSSH,
     skip_bmc_config: skipBMCConfig,
     skip_networking: skipNetworking,
     skip_storage: skipStorage,
-    commissioning_scripts:
-      commissioningScripts && commissioningScripts.map((script) => script.id),
-    testingScripts: testingScripts && testingScripts.map((script) => script.id),
+    commissioning_scripts: formattedCommissioningScripts,
+    testing_scripts:
+      testingScripts && testingScripts.map((script) => script.id),
   });
+};
 
 machine.deploy = (systemId, extra = {}) =>
   generateMachineAction("DEPLOY_MACHINE", "deploy", systemId, extra);

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -209,6 +209,46 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle commissioning a machine", () => {
+    expect(
+      machine.commission(
+        "abc123",
+        true,
+        false,
+        false,
+        false,
+        [
+          { id: 0, name: "commissioningScript0" },
+          { id: 2, name: "commissioningScript2" },
+        ],
+        [
+          { id: 0, name: "testingScript0" },
+          { id: 2, name: "testScript2" },
+        ]
+      )
+    ).toEqual({
+      meta: {
+        method: "action",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          action: "commission",
+          extra: {
+            commissioning_scripts: [0, 2],
+            enable_ssh: true,
+            skip_bmc_config: false,
+            skip_networking: false,
+            skip_storage: false,
+            testingScripts: [0, 2],
+          },
+          system_id: "abc123",
+        },
+      },
+      type: "COMMISSION_MACHINE",
+    });
+  });
+
   it("can handle testing a machine", () => {
     expect(
       machine.test(

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -153,23 +153,6 @@ describe("machine actions", () => {
     });
   });
 
-  it("can handle commissioning a machine", () => {
-    expect(machine.commission("abc123")).toEqual({
-      type: "COMMISSION_MACHINE",
-      meta: {
-        model: "machine",
-        method: "action",
-      },
-      payload: {
-        params: {
-          action: "commission",
-          extra: {},
-          system_id: "abc123",
-        },
-      },
-    });
-  });
-
   it("can handle deploying a machine", () => {
     const extra = {
       osystem: "ubuntu",
@@ -217,6 +200,8 @@ describe("machine actions", () => {
         false,
         false,
         false,
+        true,
+        true,
         [
           { id: 0, name: "commissioningScript0" },
           { id: 2, name: "commissioningScript2" },
@@ -235,12 +220,12 @@ describe("machine actions", () => {
         params: {
           action: "commission",
           extra: {
-            commissioning_scripts: [0, 2],
             enable_ssh: true,
             skip_bmc_config: false,
             skip_networking: false,
             skip_storage: false,
-            testingScripts: [0, 2],
+            commissioning_scripts: [0, 2, "update_firmware", "configure_hba"],
+            testing_scripts: [0, 2],
           },
           system_id: "abc123",
         },

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import ActionForm from "./ActionForm";
+import CommissionForm from "./CommissionForm";
 import DeployForm from "./DeployForm";
 import SetPoolForm from "./SetPoolForm";
 import SetZoneForm from "./SetZoneForm";
@@ -62,6 +63,8 @@ export const ActionFormWrapper = ({ selectedAction, setSelectedAction }) => {
   const getFormComponent = () => {
     if (selectedAction && selectedAction.name) {
       switch (selectedAction.name) {
+        case "commission":
+          return <CommissionForm setSelectedAction={setSelectedAction} />;
         case "deploy":
           return <DeployForm setSelectedAction={setSelectedAction} />;
         case "set-pool":

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
@@ -1,0 +1,135 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import CommissionForm from "./CommissionForm";
+
+const mockStore = configureStore();
+
+describe("CommissionForm", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      machine: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [{ system_id: "abc123" }, { system_id: "def456" }],
+        selected: [],
+      },
+      scripts: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "smartctl-validate",
+            tags: ["commissioning", "storage"],
+            parameters: {
+              storage: {
+                argument_format: "{path}",
+                type: "storage",
+              },
+            },
+            type: 2,
+          },
+          {
+            name: "custom-commissioning-script",
+            tags: ["node"],
+            type: 0,
+          },
+        ],
+      },
+    };
+  });
+
+  it("correctly dispatches actions to commission selected machines", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CommissionForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          enableSSH: true,
+          skipBMCConfig: true,
+          skipNetworking: true,
+          skipStorage: true,
+          updateFirmware: true,
+          configureHBA: true,
+          testingScripts: [state.scripts.items[0]],
+          commissioningScripts: [state.scripts.items[1]],
+        })
+    );
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "COMMISSION_MACHINE")
+    ).toStrictEqual([
+      {
+        type: "COMMISSION_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action",
+        },
+        payload: {
+          params: {
+            action: "commission",
+            extra: {
+              enable_ssh: true,
+              skip_bmc_config: true,
+              skip_networking: true,
+              skip_storage: true,
+              commissioning_scripts: [
+                state.scripts.items[1].id,
+                "update_firmware",
+                "configure_hba",
+              ],
+              testing_scripts: [state.scripts.items[0].id],
+            },
+            system_id: "abc123",
+          },
+        },
+      },
+      {
+        type: "COMMISSION_MACHINE",
+        meta: {
+          model: "machine",
+          method: "action",
+        },
+        payload: {
+          params: {
+            action: "commission",
+            extra: {
+              enable_ssh: true,
+              skip_bmc_config: true,
+              skip_networking: true,
+              skip_storage: true,
+              commissioning_scripts: [
+                state.scripts.items[1].id,
+                "update_firmware",
+                "configure_hba",
+              ],
+              testing_scripts: [state.scripts.items[0].id],
+            },
+            system_id: "def456",
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
@@ -1,0 +1,84 @@
+import { Col, Row } from "@canonical/react-components";
+import React from "react";
+import { useFormikContext } from "formik";
+
+import FormikField from "app/base/components/FormikField";
+import TagSelector from "app/base/components/TagSelector";
+
+export const CommissionFormFields = ({
+  preselectedTesting,
+  preselectedCommissioning,
+  commissioningScripts,
+  testingScripts,
+}) => {
+  const { handleChange, setFieldValue, values } = useFormikContext();
+
+  return (
+    <Row>
+      <Col size="6">
+        <FormikField
+          label="Allow SSH access and prevent machine powering off"
+          name="enableSSH"
+          type="checkbox"
+        />
+        <FormikField
+          label="Skip configuring supported BMC controllers with a MAAS generated username and password"
+          name="skipBMCConfig"
+          type="checkbox"
+        />
+        <FormikField
+          label="Retain network configuration"
+          name="skipNetworking"
+          type="checkbox"
+        />
+        <FormikField
+          component={TagSelector}
+          disabled={
+            values.commissioningScripts.length === commissioningScripts.length
+          }
+          initialSelected={preselectedCommissioning}
+          label="Additional commissioning scripts"
+          name="commissioningScripts"
+          onTagsUpdate={(selectedScripts) =>
+            setFieldValue("commissioningScripts", selectedScripts)
+          }
+          placeholder="Select commissioning scripts"
+          required
+          tags={commissioningScripts}
+        />
+        <FormikField
+          component={TagSelector}
+          disabled={values.testingScripts.length === testingScripts.length}
+          initialSelected={preselectedTesting}
+          label="Tests"
+          name="tests"
+          onTagsUpdate={(selectedScripts) =>
+            setFieldValue("testingScripts", selectedScripts)
+          }
+          placeholder="Select testing scripts"
+          required
+          tags={testingScripts}
+        />
+      </Col>
+      <Col size="6">
+        <FormikField
+          label="Retain storage configuration"
+          name="skipStorage"
+          type="checkbox"
+        />
+        <FormikField
+          label="Update firmware"
+          name="updateFirmware"
+          type="checkbox"
+        />
+        <FormikField
+          label="Configure HBA"
+          name="configureHBA"
+          type="checkbox"
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default CommissionFormFields;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
@@ -11,7 +11,7 @@ export const CommissionFormFields = ({
   commissioningScripts,
   testingScripts,
 }) => {
-  const { handleChange, setFieldValue, values } = useFormikContext();
+  const { setFieldValue, values } = useFormikContext();
 
   return (
     <Row>

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CommissionFormFields";

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/index.js
@@ -1,0 +1,1 @@
+export { default } from "./CommissionForm";


### PR DESCRIPTION
## Done
Add commissioning global take action form.

## QA
* Select 1 or more commissionable machines (e.g. "new"), and select commission from the global take action menu.
* Select some options from the form.
* Ensure the redux action and websocket request matches the options you've provided.
* Ensure your machine(s) are moved to the "commissioning" state.

## Screenshot
![image](https://user-images.githubusercontent.com/130286/79299983-876aac80-7f39-11ea-8d41-8d7c5e9cb529.png)

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1779.