### PR TITLE
Fix NUMA card styling errors.

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -7,7 +7,7 @@
 import { HardwareType, NodeTypes } from "../enum";
 
 // Convert MiB to GiB value if over 1024 and round to 4 significant figures.
-const formatNumaMemory = (mib) => {
+export const formatNumaMemory = (mib) => {
   if (mib >= 1024) {
     return `${Number((mib / 1024).toPrecision(4)).toString()} GiB`;
   }
@@ -16,17 +16,18 @@ const formatNumaMemory = (mib) => {
 
 // Convert array of numbers into range strings,
 // e.g [0, 1, 2, 4, 6, 7] => ["0-2", "4", "6-7"]
-const getRanges = (array) => {
+export const getRanges = (array) => {
+  const sortedArray = [...array].sort((a, b) => parseInt(a) - parseInt(b));
   const ranges = [];
   let rangeStart;
   let rangeEnd;
 
-  for (let i = 0; i < array.length; i++) {
-    rangeStart = array[i];
+  for (let i = 0; i < sortedArray.length; i++) {
+    rangeStart = sortedArray[i];
     rangeEnd = rangeStart;
-    // Keep incrementing rangeEnd while its a consecutive number.
-    while (parseInt(array[i + 1]) - parseInt(array[i]) === 1) {
-      rangeEnd = parseInt(array[i + 1]);
+    // Keep incrementing rangeEnd while it's a consecutive number.
+    while (parseInt(sortedArray[i + 1]) - parseInt(sortedArray[i]) === 1) {
+      rangeEnd = parseInt(sortedArray[i + 1]);
       i++;
     }
     ranges.push(
@@ -36,7 +37,6 @@ const getRanges = (array) => {
 
   return ranges;
 };
-
 
 /* @ngInject */
 function NodeDetailsController(

--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -14,6 +14,30 @@ const formatNumaMemory = (mib) => {
   return `${Number(mib.toPrecision(4)).toString()} MiB`;
 };
 
+// Convert array of numbers into range strings,
+// e.g [0, 1, 2, 4, 6, 7] => ["0-2", "4", "6-7"]
+const getRanges = (array) => {
+  const ranges = [];
+  let rangeStart;
+  let rangeEnd;
+
+  for (let i = 0; i < array.length; i++) {
+    rangeStart = array[i];
+    rangeEnd = rangeStart;
+    // Keep incrementing rangeEnd while its a consecutive number.
+    while (parseInt(array[i + 1]) - parseInt(array[i]) === 1) {
+      rangeEnd = parseInt(array[i + 1]);
+      i++;
+    }
+    ranges.push(
+      rangeStart === rangeEnd ? `${rangeStart}` : `${rangeStart}-${rangeEnd}`
+    );
+  }
+
+  return ranges;
+};
+
+
 /* @ngInject */
 function NodeDetailsController(
   $scope,
@@ -453,14 +477,15 @@ function NodeDetailsController(
         const numaInterfaces = node.interfaces
           ? node.interfaces.filter((iface) => iface.numa_node === numa.index)
           : [];
-        const storage = numaDisks.reduce((acc, disk) => acc + disk.size, 0);
         return {
           index: numa.index,
           cores: numa.cores,
-          memory: formatNumaMemory(numa.memory),
-          storage,
-          disks: numaDisks.length,
-          network: numaInterfaces.length,
+          memory: numa.memory,
+          disks: numaDisks,
+          interfaces: numaInterfaces,
+          coresRanges: getRanges(numa.cores).join(", "),
+          formattedMemory: formatNumaMemory(numa.memory),
+          totalStorage: numaDisks.reduce((acc, disk) => acc + disk.size, 0),
         };
       });
     }

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -6,6 +6,7 @@
 
 import { makeInteger, makeName } from "testing/utils";
 import MockWebSocket from "testing/websocket";
+import { formatNumaMemory, getRanges } from "../node_details";
 
 // Make a fake user.
 var userId = 0;
@@ -2961,6 +2962,40 @@ describe("NodeDetailsController", function () {
       makeController();
       const nic = { link_speed: 1000, interface_speed: 1000 };
       expect($scope.linkSpeedValid(nic)).toBe(true);
+    });
+  });
+
+  describe("formatMemory", () => {
+    it("correctly formats memory values less than 1 GiB", () => {
+      expect(formatNumaMemory(0)).toEqual("0 MiB");
+      expect(formatNumaMemory(1.1111111)).toEqual("1.111 MiB");
+      expect(formatNumaMemory(1023)).toEqual("1023 MiB");
+    });
+
+    it("correctly formats memory values above 1 GiB", () => {
+      expect(formatNumaMemory(1024)).toEqual("1 GiB");
+      expect(formatNumaMemory(2048)).toEqual("2 GiB");
+      expect(formatNumaMemory(5555.5555)).toEqual("5.425 GiB");
+    });
+  });
+
+  describe("getRanges", () => {
+    it("correctly groups ranges together", () => {
+      expect(getRanges([0, 1, 2, 3])).toEqual(["0-3"]);
+      expect(getRanges([0, 1, 3, 4])).toEqual(["0-1", "3-4"]);
+      expect(getRanges([0, 2, 3, 4])).toEqual(["0", "2-4"]);
+      expect(getRanges([0, 2, 4, 6])).toEqual(["0", "2", "4", "6"]);
+    });
+
+    it("can handle arrays that are out of order", () => {
+      expect(getRanges([3, 1, 2, 0])).toEqual(["0-3"]);
+      expect(getRanges([4, 0, 1, 3])).toEqual(["0-1", "3-4"]);
+      expect(getRanges([3, 4, 0, 2])).toEqual(["0", "2-4"]);
+      expect(getRanges([6, 4, 2, 0])).toEqual(["0", "2", "4", "6"]);
+    });
+
+    it("can handle different types", () => {
+      expect(getRanges([3, "1", 2, "0"])).toEqual(["0-3"]);
     });
   });
 });

--- a/legacy/src/app/filters/format_bytes.js
+++ b/legacy/src/app/filters/format_bytes.js
@@ -43,7 +43,7 @@ export function formatBytes() {
     } else if (bytes > 0) {
       return bytes + " B";
     } else {
-      return 0;
+      return "0 B";
     }
   };
 }

--- a/legacy/src/app/filters/tests/test_format_bytes.js
+++ b/legacy/src/app/filters/tests/test_format_bytes.js
@@ -14,8 +14,9 @@ describe("formatBytes", function() {
     formatBytes = $filter("formatBytes");
   }));
 
-  it("returns zero if undefined bytes", function() {
-    expect(formatBytes()).toEqual(0);
+  it("returns zero if undefined or zero bytes", function() {
+    expect(formatBytes()).toEqual("0 B");
+    expect(formatBytes(0)).toEqual("0 B");
   });
 
   it("returns value in bytes if less than a kilobyte", function() {

--- a/legacy/src/app/partials/cards/numa.html
+++ b/legacy/src/app/partials/cards/numa.html
@@ -1,6 +1,6 @@
 <div class="p-card">
   <strong class="p-muted-heading u-sv1">
-    {$ numaDetails.length $} NUMA node{$ numaDetails.length > 1 ? "s" : "" $}
+    {$ numaDetails.length $} NUMA node{$ numaDetails.length === 1 ? "" : "s" $}
   </strong>
   <hr />
   <ul ng-if="numaDetails.length" class="p-list u-no-margin--bottom">
@@ -15,10 +15,10 @@
       </button>
       <span ng-if="numaDetails.length <= 2">Node {$ numa.index $}</span>
       <span class="p-numa__collapsed-details" ng-if="!expandedNumas.includes(numa.index)">
-        {$ numa.cores.length $}&nbsp;core{$ numa.cores.length > 1 ? "s" : "" $},
-        {$ numa.memory >= 1024 ? numa.memory / 1024 + " GiB" : numa.memory + " MiB" $},<br>
+        {$ numa.cores.length $}&nbsp;core{$ numa.cores.length === 1 ? "" : "s" $},
+        {$ numa.memory $},<br>
         {$ numa.storage | formatBytes $},
-        {$ numa.network $}&nbsp;interface{$ numa.network > 1 ? "s" : "" $}
+        {$ numa.network $}&nbsp;interface{$ numa.network === 1 ? "" : "s" $}
       </span>
       <ul class="p-list--labelled" ng-if="expandedNumas.includes(numa.index)">
         <li class="p-list__item">
@@ -31,24 +31,24 @@
         <li class="p-list__item">
           <div class="p-list__item-label">Memory</div>
           <div class="p-list__item-value">
-            {$ numa.memory >= 1024 ? numa.memory / 1024 + " GiB" : numa.memory + " MiB" $}
+            {$ numa.memory $}
           </div>
         </li>
         <li class="p-list__item">
           <div class="p-list__item-label">Storage</div>
           <div class="p-list__item-value">
-            {$ numa.storage | formatBytes $} over {$ numa.disks $} disk{$ numa.disks > 1 ? "s" : "" $}
+            {$ numa.storage | formatBytes $} over {$ numa.disks $} disk{$ numa.disks === 1 ? "" : "s" $}
           </div>
         </li>
         <li class="p-list__item">
           <div class="p-list__item-label">Network</div>
           <div class="p-list__item-value">
-            {$ numa.network $} interface{$ numa.network > 1 ? "s" : "" $}
+            {$ numa.network $} interface{$ numa.network === 1 ? "" : "s" $}
           </div>
         </li>
       </ul>
       <hr
-        ng-if="$index !== node.numa_nodes.length - 1"
+        ng-if="$index !== numaDetails.length - 1"
         ng-class="{
           'u-sv1': !expandedNumas.includes(numa.index),
           'u-sv2': expandedNumas.includes(numa.index)

--- a/legacy/src/app/partials/cards/numa.html
+++ b/legacy/src/app/partials/cards/numa.html
@@ -16,34 +16,34 @@
       <span ng-if="numaDetails.length <= 2">Node {$ numa.index $}</span>
       <span class="p-numa__collapsed-details" ng-if="!expandedNumas.includes(numa.index)">
         {$ numa.cores.length $}&nbsp;core{$ numa.cores.length === 1 ? "" : "s" $},
-        {$ numa.memory $},<br>
-        {$ numa.storage | formatBytes $},
-        {$ numa.network $}&nbsp;interface{$ numa.network === 1 ? "" : "s" $}
+        {$ numa.formattedMemory $},<br>
+        {$ numa.totalStorage | formatBytes $},
+        {$ numa.interfaces.length $}&nbsp;interface{$ numa.interfaces.length === 1 ? "" : "s" $}
       </span>
       <ul class="p-list--labelled" ng-if="expandedNumas.includes(numa.index)">
         <li class="p-list__item">
           <div class="p-list__item-label">CPU cores</div>
           <div class="p-list__item-value">
             <span>{$ numa.cores.length $}</span>
-            <span class="p-text--muted">({$ numa.cores.join(", ") $})</span>
+            <span class="p-text--muted" ng-if="numa.cores.length">({$ numa.coresRanges $})</span>
           </div>
         </li>
         <li class="p-list__item">
           <div class="p-list__item-label">Memory</div>
           <div class="p-list__item-value">
-            {$ numa.memory $}
+            {$ numa.formattedMemory $}
           </div>
         </li>
         <li class="p-list__item">
           <div class="p-list__item-label">Storage</div>
           <div class="p-list__item-value">
-            {$ numa.storage | formatBytes $} over {$ numa.disks $} disk{$ numa.disks === 1 ? "" : "s" $}
+            {$ numa.totalStorage | formatBytes $} over {$ numa.disks.length $} disk{$ numa.disks.length === 1 ? "" : "s" $}
           </div>
         </li>
         <li class="p-list__item">
           <div class="p-list__item-label">Network</div>
           <div class="p-list__item-value">
-            {$ numa.network $} interface{$ numa.network === 1 ? "" : "s" $}
+            {$ numa.interfaces.length $} interface{$ numa.interfaces.length === 1 ? "" : "s" $}
           </div>
         </li>
       </ul>

--- a/legacy/src/scss/_patterns_numa.scss
+++ b/legacy/src/scss/_patterns_numa.scss
@@ -24,9 +24,9 @@
     color: $color-mid-dark;
     font-size: 0.75rem;
     font-weight: 400;
-    left: $sp-unit * 13;
+    left: $sp-unit * 11;
     line-height: 1;
-    max-width: $sp-unit * 15;
+    max-width: $sp-unit * 20;
     position: absolute;
     pointer-events: none;
     top: $spv-inner--x-small;


### PR DESCRIPTION
## Done
- Converted NUMA core list into core ranges (e.g. "0, 1, 2, 3, 5, 6, 8" => "0-3, 5-6, 8").
- Rounded NUMA memory values to four significant figures.
- Improved null/zero cases for NUMA values, e.g. "0" => "0 B", "0 disk" => "0 disks".

## QA
- Open `node_details.js` and replace lines 473-479 with [this pastebin](https://pastebin.canonical.com/p/HBSn4GYYbm/).
- Go to the details page of any machine which now has fake data for 4 NUMA nodes.
- Check that the NUMA card matches the [design](https://camo.githubusercontent.com/8d85d6a881645a4fd7cbad80eb42eb16a8f53ee5/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3561663937363732346235383036626332626433303836302f61633134303163382d313464632d343031662d613839332d626634326237306538613361)
- Check that the null cases read better.

## Fixes
Fixes #964 
Fixes #965
Fixes canonical-web-and-design/MAAS-design#895

## Screenshots
### Collapsed
![Screenshot_2020-04-16 alert-roughy maas bolla MAAS](https://user-images.githubusercontent.com/25733845/79430406-3bd50300-800c-11ea-829c-62aa49294819.png)



### Expanded
![Screenshot_2020-04-16 alert-roughy maas bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/79430421-4099b700-800c-11ea-8725-b791a010646e.png)


