### PR TITLE
Add warning to login page if no users detected.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,15 @@ jobs:
           command: |
             sudo maas init \
               --maas-url=http://$IP_ADDRESS:5240/MAAS \
-              --admin-username=admin \
-              --admin-password=test \
-              --admin-email=fake@email.com \
               --mode region+rack \
               --database-host=localhost \
               --database-name=$MAAS_DBNAME \
               --database-user=$MAAS_DBUSER \
               --database-pass=$MAAS_DBPASS
+            sudo maas createadmin \
+              --username=admin \
+              --password=test \
+              --email=fake@email.com
             sudo maas config
       - run:
           name: Set proxy url and start cypress tests

--- a/ui/src/app/base/components/Login/Login.js
+++ b/ui/src/app/base/components/Login/Login.js
@@ -1,6 +1,7 @@
 import {
   Button,
   Card,
+  Code,
   Col,
   Notification,
   Row,
@@ -27,6 +28,7 @@ export const Login = () => {
   const authenticating = useSelector(statusSelectors.authenticating);
   const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   const externalLoginURL = useSelector(statusSelectors.externalLoginURL);
+  const noUsers = useSelector(statusSelectors.noUsers);
   const error = useSelector(statusSelectors.authenticationError);
 
   useWindowTitle("Login");
@@ -46,49 +48,65 @@ export const Login = () => {
               {error}
             </Notification>
           )}
-          <Card title="Login">
-            {externalAuthURL ? (
+          {noUsers && !externalAuthURL ? (
+            <Card
+              data-test="no-users-warning"
+              title="No admin user has been created yet"
+            >
+              <p>Use the following command to create one:</p>
+              <Code copyable>sudo maas createadmin</Code>
               <Button
-                appearance="positive"
-                className="login__external"
-                element="a"
-                href={externalLoginURL}
-                rel="noopener noreferrer"
-                target="_blank"
-                title={`Login through ${externalAuthURL}`}
+                className="u-no-margin--bottom"
+                onClick={() => dispatch(statusActions.checkAuthenticated())}
               >
-                Go to login page
+                Retry
               </Button>
-            ) : (
-              <FormikForm
-                errors={error}
-                initialValues={{
-                  password: "",
-                  username: "",
-                }}
-                onSubmit={(values) => {
-                  dispatch(statusActions.login(values));
-                }}
-                saving={authenticating}
-                saved={authenticated}
-                submitLabel="Login"
-                validationSchema={LoginSchema}
-              >
-                <FormikField
-                  name="username"
-                  label="Username"
-                  required={true}
-                  type="text"
-                />
-                <FormikField
-                  name="password"
-                  label="Password"
-                  required={true}
-                  type="password"
-                />
-              </FormikForm>
-            )}
-          </Card>
+            </Card>
+          ) : (
+            <Card title="Login">
+              {externalAuthURL ? (
+                <Button
+                  appearance="positive"
+                  className="login__external"
+                  element="a"
+                  href={externalLoginURL}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  title={`Login through ${externalAuthURL}`}
+                >
+                  Go to login page
+                </Button>
+              ) : (
+                <FormikForm
+                  errors={error}
+                  initialValues={{
+                    password: "",
+                    username: "",
+                  }}
+                  onSubmit={(values) => {
+                    dispatch(statusActions.login(values));
+                  }}
+                  saving={authenticating}
+                  saved={authenticated}
+                  submitLabel="Login"
+                  validationSchema={LoginSchema}
+                >
+                  <FormikField
+                    name="username"
+                    label="Username"
+                    required={true}
+                    type="text"
+                  />
+                  <FormikField
+                    name="password"
+                    label="Password"
+                    required={true}
+                    type="password"
+                  />
+                </FormikForm>
+              )}
+            </Card>
+          )}
         </Col>
       </Row>
     </Strip>

--- a/ui/src/app/base/components/Login/Login.test.js
+++ b/ui/src/app/base/components/Login/Login.test.js
@@ -84,4 +84,17 @@ describe("Login", () => {
       },
     });
   });
+
+  it("shows a warning if no users have been added yet", () => {
+    state.status.noUsers = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <Login />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='no-users-warning']").exists()).toBe(true);
+  });
 });

--- a/ui/src/app/base/reducers/status/status.js
+++ b/ui/src/app/base/reducers/status/status.js
@@ -22,6 +22,7 @@ const initialState = {
   externalAuthURL: null,
   externalLoginURL: null,
   connected: false,
+  noUsers: false,
   error: null,
 };
 
@@ -33,6 +34,7 @@ const status = createReducer(initialState, {
     state.authenticating = false;
     state.authenticated = action.payload.authenticated;
     state.externalAuthURL = action.payload.external_auth_url;
+    state.noUsers = action.payload.no_users;
   },
   [statusActions.login.start]: (state) => {
     state.authenticating = true;

--- a/ui/src/app/base/reducers/status/status.test.js
+++ b/ui/src/app/base/reducers/status/status.test.js
@@ -9,6 +9,7 @@ describe("status", () => {
       error: null,
       externalAuthURL: null,
       externalLoginURL: null,
+      noUsers: false,
     });
   });
 
@@ -102,12 +103,14 @@ describe("status", () => {
         {
           authenticating: true,
           authenticated: false,
+          noUsers: false,
         },
         {
           type: "CHECK_AUTHENTICATED_SUCCESS",
           payload: {
             authenticated: true,
             external_auth_url: "http://login.example.com",
+            no_users: true,
           },
         }
       )
@@ -115,6 +118,7 @@ describe("status", () => {
       authenticating: false,
       authenticated: true,
       externalAuthURL: "http://login.example.com",
+      noUsers: true,
     });
   });
 

--- a/ui/src/app/base/selectors/status/status.js
+++ b/ui/src/app/base/selectors/status/status.js
@@ -56,4 +56,11 @@ status.externalAuthURL = (state) => state.status.externalAuthURL;
  */
 status.externalLoginURL = (state) => state.status.externalLoginURL;
 
+/**
+ * Whether there are currently no MAAS users.
+ * @param {Object} state - The redux state.
+ * @returns {Boolean} No users in MAAS.
+ */
+status.noUsers = (state) => state.status.noUsers;
+
 export default status;

--- a/ui/src/app/base/selectors/status/status.test.js
+++ b/ui/src/app/base/selectors/status/status.test.js
@@ -63,4 +63,13 @@ describe("status", () => {
     };
     expect(status.externalLoginURL(state)).toEqual("http://login.example.com");
   });
+
+  it("can get the noUsers status", () => {
+    const state = {
+      status: {
+        noUsers: true,
+      },
+    };
+    expect(status.noUsers(state)).toEqual(true);
+  });
 });


### PR DESCRIPTION
##  Done
- Added warning to login page if no users detected.

## QA
- Create a MAAS using the latest edge snap but don't create an admin
- Try to log in and check that a message shows up asking you to create an admin
- Click Retry and check that the page is refreshed as normal
- Create an admin using `sudo maas createadmin` and then click the Retry button again
- Check that the Login page shows up

## Fixes
Fixes #969 

## Launchpad fix
https://code.launchpad.net/~ack/maas/+git/maas/+merge/382269

## Screenshot
![Screenshot_2020-04-16 Login MAAS](https://user-images.githubusercontent.com/25733845/79406983-bc2f4000-7fdb-11ea-8604-cbf589d7f7d8.png)
