### PR TITLE
Create a pool and attach machines to it

### DIFF
--- a/ui/src/app/base/actions/resourcepool/resourcepool.js
+++ b/ui/src/app/base/actions/resourcepool/resourcepool.js
@@ -2,4 +2,19 @@ import { createStandardActions } from "app/utils/redux";
 
 const resourcepool = createStandardActions("resourcepool");
 
+/**
+ * Create a pool and attach machines to it.
+ * @param {Object} pool - The pool details.
+ * @param {Array} machines - A list of machine ids.
+ */
+resourcepool.createWithMachines = (pool, machines) => ({
+  type: "CREATE_RESOURCEPOOL_WITH_MACHINES",
+  payload: {
+    params: {
+      pool,
+      machines,
+    },
+  },
+});
+
 export default resourcepool;

--- a/ui/src/app/base/actions/resourcepool/resourcepool.test.js
+++ b/ui/src/app/base/actions/resourcepool/resourcepool.test.js
@@ -67,4 +67,23 @@ describe("resourcepool actions", () => {
       type: "CLEANUP_RESOURCEPOOL",
     });
   });
+
+  it("can handle creating resource pools with machines", () => {
+    expect(
+      resourcepool.createWithMachines({ name: "pool1" }, [
+        "machine1",
+        "machine2",
+      ])
+    ).toEqual({
+      type: "CREATE_RESOURCEPOOL_WITH_MACHINES",
+      payload: {
+        params: {
+          pool: {
+            name: "pool1",
+          },
+          machines: ["machine1", "machine2"],
+        },
+      },
+    });
+  });
 });

--- a/ui/src/app/base/sagas/actions.js
+++ b/ui/src/app/base/sagas/actions.js
@@ -11,7 +11,7 @@ import {
  * @param {Array} machines - A list of machine ids.
  * @returns {Array} The list of action creator functions.
  */
-export const generateActionCreators = (machines) =>
+export const generateMachinePoolActionCreators = (machines) =>
   machines.map((machineID) => (result) =>
     machineActions.setPool(machineID, result.id)
   );
@@ -28,7 +28,10 @@ export function* createPoolWithMachines(
   { payload }
 ) {
   const { machines, pool } = payload.params;
-  const actionCreators = yield call(generateActionCreators, machines);
+  const actionCreators = yield call(
+    generateMachinePoolActionCreators,
+    machines
+  );
   // Send the initial action via the websocket.
   yield call(
     sendMessage,

--- a/ui/src/app/base/sagas/actions.js
+++ b/ui/src/app/base/sagas/actions.js
@@ -1,0 +1,47 @@
+import { call } from "redux-saga/effects";
+
+import {
+  machine as machineActions,
+  resourcepool as resourcePoolActions,
+} from "app/base/actions";
+
+/**
+ * Generate functions that will use the response to create the dispatchable
+ * action to set the pool for each machine.
+ * @param {Array} machines - A list of machine ids.
+ * @returns {Array} The list of action creator functions.
+ */
+export const generateActionCreators = (machines) =>
+  machines.map((machineID) => (result) =>
+    machineActions.setPool(machineID, result.id)
+  );
+
+/**
+ * Handle creating a pool and then attaching machines to that pool.
+ * @param {Object} socketClient - The websocket client instance.
+ * @param {Function} sendMessage - The saga that handles sending websocket messages.
+ * @param {Object} action - The redux action with pool and machine data.
+ */
+export function* createPoolWithMachines(
+  socketClient,
+  sendMessage,
+  { payload }
+) {
+  const { machines, pool } = payload.params;
+  const actionCreators = yield call(generateActionCreators, machines);
+  // Send the initial action via the websocket.
+  yield call(
+    sendMessage,
+    socketClient,
+    resourcePoolActions.create(pool),
+    actionCreators
+  );
+}
+
+// Sagas to be handled by the websocket channel.
+export default [
+  {
+    action: "CREATE_RESOURCEPOOL_WITH_MACHINES",
+    method: createPoolWithMachines,
+  },
+];

--- a/ui/src/app/base/sagas/actions.test.js
+++ b/ui/src/app/base/sagas/actions.test.js
@@ -1,0 +1,34 @@
+import { expectSaga } from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+
+import { createPoolWithMachines, generateActionCreators } from "./actions";
+
+jest.mock("../../../websocket-client");
+
+describe("websocket sagas", () => {
+  it("can send a message to create a pool then attach machines", () => {
+    const socketClient = jest.fn();
+    const sendMessage = jest.fn();
+    const actionCreators = [jest.fn()];
+    const pool = { name: "pool1", description: "a pool" };
+    const action = { payload: { params: { machines: ["machine1"], pool } } };
+    return expectSaga(createPoolWithMachines, socketClient, sendMessage, action)
+      .provide([[matchers.call.fn(generateActionCreators), actionCreators]])
+      .call(
+        sendMessage,
+        socketClient,
+        {
+          type: "CREATE_RESOURCEPOOL",
+          payload: {
+            params: pool,
+          },
+          meta: {
+            model: "resourcepool",
+            method: "create",
+          },
+        },
+        actionCreators
+      )
+      .run();
+  });
+});

--- a/ui/src/app/base/sagas/actions.test.js
+++ b/ui/src/app/base/sagas/actions.test.js
@@ -1,7 +1,10 @@
 import { expectSaga } from "redux-saga-test-plan";
 import * as matchers from "redux-saga-test-plan/matchers";
 
-import { createPoolWithMachines, generateActionCreators } from "./actions";
+import {
+  createPoolWithMachines,
+  generateMachinePoolActionCreators,
+} from "./actions";
 
 jest.mock("../../../websocket-client");
 
@@ -13,7 +16,9 @@ describe("websocket sagas", () => {
     const pool = { name: "pool1", description: "a pool" };
     const action = { payload: { params: { machines: ["machine1"], pool } } };
     return expectSaga(createPoolWithMachines, socketClient, sendMessage, action)
-      .provide([[matchers.call.fn(generateActionCreators), actionCreators]])
+      .provide([
+        [matchers.call.fn(generateMachinePoolActionCreators), actionCreators],
+      ])
       .call(
         sendMessage,
         socketClient,

--- a/ui/src/app/base/sagas/index.js
+++ b/ui/src/app/base/sagas/index.js
@@ -1,3 +1,4 @@
+import actionHandlers from "./actions";
 import { watchWebSockets } from "./websockets";
 import {
   watchCheckAuthenticated,
@@ -15,6 +16,7 @@ import {
 } from "./http";
 
 export {
+  actionHandlers,
   watchCheckAuthenticated,
   watchLogin,
   watchLogout,

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -199,7 +199,8 @@ function* storeNextActions(nextActionCreators, requestIDs) {
  *
  * @param {Object} response - A websocket response.
  */
-export function* handleNextActions({ request_id, result }) {
+export function* handleNextActions(response) {
+  const { request_id, result } = response;
   const actionCreators = yield call(getNextActions, request_id);
   if (actionCreators && actionCreators.length) {
     for (let actionCreator of actionCreators) {
@@ -339,6 +340,8 @@ export function* sendMessage(socketClient, action, nextActionCreators) {
 
 /**
  * Connect to the WebSocket and watch for message.
+ * @param {Array} messageHandlers - Sagas that should handle specific messages
+ * via the websocket channel.
  */
 export function* setupWebSocket(messageHandlers = []) {
   try {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
@@ -49,15 +49,15 @@ export const SetPoolForm = ({ setSelectedAction }) => {
       }}
       onSubmit={(values) => {
         if (values.poolSelection === "create") {
-          // TODO: Add method for creating a pool then setting selected machines to it
-          // https://github.com/canonical-web-and-design/maas-ui/issues/928
-          dispatch(resourcePoolActions.create(values));
-        }
-        const pool = resourcePools.find((pool) => pool.name === values.name);
-        if (pool) {
-          selectedMachines.forEach((machine) => {
-            dispatch(machineActions.setPool(machine.system_id, pool.id));
-          });
+          const machineIDs = selectedMachines.map(({ system_id }) => system_id);
+          dispatch(resourcePoolActions.createWithMachines(values, machineIDs));
+        } else {
+          const pool = resourcePools.find((pool) => pool.name === values.name);
+          if (pool) {
+            selectedMachines.forEach((machine) => {
+              dispatch(machineActions.setPool(machine.system_id, pool.id));
+            });
+          }
         }
         setSelectedAction(null);
       }}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.js
@@ -34,11 +34,8 @@ export const SetPoolFormFields = () => {
             />
           </li>
           <li className="p-inline-list__item">
-            {/* Disabled until we have a method for handling sequenced websocket requests.
-                https://github.com/canonical-web-and-design/maas-ui/issues/928 */}
             <FormikField
               data-test="create-pool"
-              disabled
               label="Create pool"
               name="poolSelection"
               type="radio"

--- a/ui/src/root-saga.js
+++ b/ui/src/root-saga.js
@@ -1,6 +1,7 @@
 import { all } from "redux-saga/effects";
 
 import {
+  actionHandlers,
   watchCheckAuthenticated,
   watchLogin,
   watchLogout,
@@ -22,7 +23,7 @@ export default function* rootSaga() {
     watchLogin(),
     watchLogout(),
     watchExternalLogin(),
-    watchWebSockets(),
+    watchWebSockets(actionHandlers),
     watchCreateLicenseKey(),
     watchUpdateLicenseKey(),
     watchDeleteLicenseKey(),


### PR DESCRIPTION
## Done
- Set up the websocket channel to receive additional messages.
- Handle creating a pool and attaching machines to it.

Note: Errors and saving state will be handled by https://github.com/canonical-web-and-design/maas-ui/issues/984 and https://github.com/canonical-web-and-design/maas-ui/issues/881.

## QA
- Visit the machine list. Select machines and choose "Set resource pool..." from the take action menu.
- Change the radiobutton to "Create pool".
- Enter a new pool name and submit the form.
- Your selected machines should be attached to the new pool.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/928.