### PR TITLE
Add guards to node details networking functions.

### DIFF
--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -342,9 +342,9 @@ export function NodeNetworkingController(
     }
   ];
 
-  $scope.isBond = item => item.type === "bond";
-  $scope.isBridge = item => item.type === "bridge";
-  $scope.isInterface = item => item.type === "physical";
+  $scope.isBond = item => item && item.type === "bond";
+  $scope.isBridge = item => item && item.type === "bridge";
+  $scope.isInterface = item => item && item.type === "physical";
 
   // Sets loaded to true if both the node has been loaded at the
   // other required managers for this scope have been loaded.
@@ -2029,18 +2029,16 @@ export function NodeNetworkingController(
   // Return true when a bridge can be created based on the current
   // selection. Only can be done if no aliases are selected and only
   // one interface is selected.
-  $scope.canCreateBridge = function() {
-    if ($scope.selectedMode !== SELECTION_MODE.SINGLE) {
+  $scope.canCreateBridge = () => {
+    const selectedInterfaces = getSelectedInterfaces();
+    const nic = selectedInterfaces.length && selectedInterfaces[0];
+
+    if ($scope.selectedMode !== SELECTION_MODE.SINGLE || !nic) {
       return false;
     }
-    var nic = getSelectedInterfaces()[0];
-    if (
-      nic.type === INTERFACE_TYPE.ALIAS ||
-      nic.type === INTERFACE_TYPE.BRIDGE
-    ) {
-      return false;
-    }
-    return true;
+    return !(
+      nic.type === INTERFACE_TYPE.ALIAS || nic.type === INTERFACE_TYPE.BRIDGE
+    );
   };
 
   // Return true when the create bridge view is being shown.

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -926,9 +926,9 @@
                                     <td class="p-double-row" aria-label="Fabric">
                                         <div class="p-double-row__rows-container">
                                             <div class="p-double-row__main-row">
-                                                <div title="{$ interface.fabric.name || 'Disconnected' $}">
-                                                    {$ interface.fabric.name $}
-                                                    <span data-ng-if="!interface.fabric.name">Disconnected</span>
+                                                <div title="{$ interface.fabric && interface.fabric.name || 'Disconnected' $}">
+                                                    {$ interface.fabric && interface.fabric.name $}
+                                                    <span data-ng-if="!(interface.fabric && interface.fabric.name)">Disconnected</span>
                                                 </div>
                                             </div>
                                             <div class="p-double-row__muted-row">
@@ -2277,7 +2277,7 @@
 
                         <button class="p-button--neutral" data-ng-click="toggleInterfaces()" data-ng-if="showCreateEditButton()">
                             <span data-ng-if="isShowingInterfaces">Hide interfaces</span>
-                            <span data-ng-if="!isShowingInterfaces" data-ng-click="Network table', Edit bond')">Edit bond members</span>
+                            <span data-ng-if="!isShowingInterfaces" data-ng-click="sendAnalyticsEvent('Machine details', 'Edit bond', 'Network tab')">Edit bond members</span>
                         </button>
 
                         <div class="p-strip is-shallow">


### PR DESCRIPTION
## Done
- Added guards to a few node details networking functions.
- Removed a bit of broken markup (which actually might have been the cause of all the errors - angular templating tracebacks have never been very helpful)

## QA
- This one is hard to QA because I couldn't reliably reproduce the errors. I did get the `type is not defined` one a couple of times, each after marking an interface as connected or disconnected. So I'm not sure... click around on all the different buttons, add/delete interfaces, bridges, bonds... and check that you don't get any errors in the console?

## Fixes
Fixes #892 
Fixes #893 