### PR TITLE
Revert jquery to 3.4.1

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -64,7 +64,7 @@
     "angular-vs-repeat": "1.1.11",
     "babel-polyfill": "6.26.0",
     "cross-env": "7.0.2",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "js-cookie": "2.2.1",
     "macaroon-bakery": "0.2.1",
     "ng-tags-input": "3.2.0",

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -204,7 +204,7 @@
             <div class="row ng-hide" data-ng-show="action.showing_confirmation">
                 <div class="col-12">
                     <p>
-                        <i class="p-icon--warning" /><b>Confirm:</b> {$ action.confirmation_message $}
+                        <i class="p-icon--warning"></i><b>Confirm:</b> {$ action.confirmation_message $}
                     </p>
                     <div data-ng-repeat="confirmation_detail in action.confirmation_details">
                         <span>{$ confirmation_detail $}</span>

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -423,7 +423,7 @@
             <section class="page-header__section row u-no-margin--top ng-hide" data-ng-show="tabs[tab].actionProgress.showing_confirmation">
                 <div class="col-12">
                     <p>
-                        <i class="p-icon--warning" /><b>Confirm:</b> {$ tabs[tab].actionProgress.confirmation_message $}
+                        <i class="p-icon--warning"></i><b>Confirm:</b> {$ tabs[tab].actionProgress.confirmation_message $}
                     </p>
                     <div data-ng-repeat="confirmation_detail in tabs[tab].actionProgress.confirmation_details">
                         <span>{$ confirmation_detail $}</span>
@@ -698,7 +698,7 @@
             <div class="row">
                 <div class="col-12">
                     <p>
-                        <i class="p-icon--warning" /><b>Confirm:</b> {$ tabs.controllers.actionProgress.confirmation_message $}
+                        <i class="p-icon--warning"></i><b>Confirm:</b> {$ tabs.controllers.actionProgress.confirmation_message $}
                     </p>
                     <div data-ng-repeat="confirmation_detail in tabs.controllers.actionProgress.confirmation_details">
                         <span>{$ confirmation_detail $}</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9599,10 +9599,10 @@ jest@25.3.0:
     import-local "^3.0.2"
     jest-cli "^25.3.0"
 
-jquery@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
## Done
- Reverted jquery from 3.5.0 to 3.4.1. The issue could have been [this breaking change](https://github.com/jquery/jquery/issues/4665).

## QA
- Checkout master, clean your node_modules (`yarn clean-all` or `dotrun clean`) and run
- Confirm that node details, devices list, and controllers list are all broken with warning icons.
- Checkout this branch and clean your node_modules and run again
- Confirm that the node details, devices list and controllers list look normal

## Fixes
Fixes #977

