### PR TITLE
Remove redundant loader on machine listing.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -2,7 +2,6 @@ import {
   Button,
   Col,
   Input,
-  Loader,
   MainTable,
   Notification,
   Row,

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -579,13 +579,6 @@ const MachineList = () => {
           />
         </Col>
       </Row>
-      {machinesLoading && (
-        <Row>
-          <Col className="u-align--center" size={12}>
-            <Loader text="Loading..." />
-          </Col>
-        </Row>
-      )}
       {errorMessage ? (
         <Notification type="negative">{errorMessage}</Notification>
       ) : null}


### PR DESCRIPTION
## Done
Remove redundant loader on machine listing, as we already have a loading component in the header.

## QA
* View the machine listing, there should only be one "loading..." spinner.

## Fixes
Fixes #974
