### PR TITLE
Exclude jquery from renovate grouping.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
         "*"
       ],
       "excludePackagePatterns": [
+        "jquery",
         "vanilla-framework"
       ],
       "extends": ["schedule:weekly"],


### PR DESCRIPTION
## Done
Exclude jquery from renovate grouping.

## QA
n/a

## Fixes
Fixes #989
