### PR TITLE
Fix lock icon background-image to be a padlock.

### DIFF
--- a/ui/src/scss/_patterns_icons.scss
+++ b/ui/src/scss/_patterns_icons.scss
@@ -22,6 +22,10 @@
     )+"'%3E%3C/path%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }
 
+@mixin maas-icon-lock($color) {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='12'%3E%3Cpath d='M6 0C3.793 0 2 1.793 2 4v3H0v9h12V7h-2V4c0-2.207-1.793-4-4-4zm0 1c1.67 0 3 1.33 3 3v3H3V4c0-1.67 1.33-3 3-3zm1 8.5V14H5v-4l2-.5z' fill='"+ vf-url-friendly-color($color) + "' fill-rule='evenodd'/%3E%3C/svg%3E");
+}
+
 @mixin maas-icons {
   .p-icon--edit {
     @extend %icon;
@@ -30,7 +34,7 @@
 
   .p-icon--locked {
     @extend %icon;
-    @include maas-icon-power($color-mid-dark);
+    @include maas-icon-lock($color-mid-dark);
   }
 
   .p-icon--pending {


### PR DESCRIPTION
## Done
- Fixed bug where lock icon was a grey power icon instead of a padlock.
- Ran padlock svg through svgo and converted to background-image css that doesn't rely on the ubuntu asset server

## QA
- Lock a machine and check that a padlock icon shows up next to it

## Fixes
Fixes #996

![Screenshot_2020-04-17 Machines bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/79539964-af3d4a00-80ca-11ea-93fe-616e661e939b.png)
