### PR TITLE
Fix invalid interpolated version string for usabilla.

### DIFF
--- a/shared/src/components/Footer/Footer.js
+++ b/shared/src/components/Footer/Footer.js
@@ -9,7 +9,7 @@ export const Footer = ({ maasName, version }) => {
     window.usabilla_live("hide");
     // Add MAAS version to the custom data
     window.usabilla_live("data", {"custom":
-        {"MAAS version": "${version}" }
+        {"MAAS version": version}
     });
   }, [])
 


### PR DESCRIPTION
I noticed today that Usabilla thinks MAAS 2.8 is 2.7 today on bolla, which made me think we weren't using the version string supplied by the app @lilyvidenova. Turns out the version string we supply was broken anyway (we would have been sending you the literal string `"${version}"`)! I suspect there might be something to tweak in the message template on Usabilla once this lands @lilyvidenova?

Also possible that you may need us to supply a "friendly" version string (just major and minor numbers, e.g. "2.8"). If so, please create an issue for it @lilyvidenova and we can try to fix that for the release.

## Done
Fix invalid interpolated version string for usabilla.