### PR TITLE
Add deprecation notices to NotificationList.

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -61,6 +61,12 @@ Object {
       "loaded": false,
       "loading": false,
     },
+    "deprecationNotices": Object {
+      "data": Array [],
+      "errors": Object {},
+      "loaded": false,
+      "loading": false,
+    },
     "hweKernels": Object {
       "data": Array [],
       "errors": Object {},

--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -35,6 +35,11 @@ describe("App", () => {
           loaded: false,
           loading: false,
         },
+        deprecationNotices: {
+          data: [],
+          loaded: true,
+          loading: false,
+        },
         hweKernels: {
           data: [],
           errors: {},

--- a/ui/src/app/base/actions/general/general.js
+++ b/ui/src/app/base/actions/general/general.js
@@ -20,6 +20,7 @@ general.fetchComponentsToDisable = generateGeneralAction(
 general.fetchDefaultMinHweKernel = generateGeneralAction(
   "default_min_hwe_kernel"
 );
+general.fetchDeprecationNotices = generateGeneralAction("deprecation_notices");
 general.fetchHweKernels = generateGeneralAction("hwe_kernels");
 general.fetchKnownArchitectures = generateGeneralAction("known_architectures");
 general.fetchMachineActions = generateGeneralAction("machine_actions");

--- a/ui/src/app/base/actions/general/general.test.js
+++ b/ui/src/app/base/actions/general/general.test.js
@@ -31,6 +31,16 @@ describe("general actions", () => {
     });
   });
 
+  it("should handle fetching deprecationNotices", () => {
+    expect(general.fetchDeprecationNotices()).toEqual({
+      type: "FETCH_GENERAL_DEPRECATION_NOTICES",
+      meta: {
+        model: "general",
+        method: "deprecation_notices",
+      },
+    });
+  });
+
   it("should handle fetching hwe kernels", () => {
     expect(general.fetchHweKernels()).toEqual({
       type: "FETCH_GENERAL_HWE_KERNELS",

--- a/ui/src/app/base/components/DeprecationNotices/DeprecationNotices.js
+++ b/ui/src/app/base/components/DeprecationNotices/DeprecationNotices.js
@@ -1,0 +1,42 @@
+import { Notification } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect } from "react";
+
+import { general as generalActions } from "app/base/actions";
+import { general as generalSelectors } from "app/base/selectors";
+
+const DeprecationList = () => {
+  const dispatch = useDispatch();
+  const deprecationNotices = useSelector(
+    generalSelectors.deprecationNotices.filterByMinorVersion
+  );
+
+  useEffect(() => {
+    dispatch(generalActions.fetchVersion());
+    dispatch(generalActions.fetchDeprecationNotices());
+  }, [dispatch]);
+
+  return (
+    <>
+      {deprecationNotices.map((notice) => (
+        <Notification
+          data-test={`deprecation-${notice.id}`}
+          key={notice.id}
+          type="caution"
+        >
+          {notice.description}
+          <br />
+          {notice.url && (
+            <a className="p-link--external" href={notice.url}>
+              {notice["link-text"]
+                ? `${notice["link-text"]}...`
+                : "Learn more..."}
+            </a>
+          )}
+        </Notification>
+      ))}
+    </>
+  );
+};
+
+export default DeprecationList;

--- a/ui/src/app/base/components/DeprecationNotices/DeprecationNotices.test.js
+++ b/ui/src/app/base/components/DeprecationNotices/DeprecationNotices.test.js
@@ -1,0 +1,116 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import DeprecationNotices from "./DeprecationNotices";
+
+const mockStore = configureStore();
+
+describe("DeprecationNotices", () => {
+  let state;
+
+  beforeEach(() => {
+    state = {
+      general: {
+        deprecationNotices: {
+          data: [],
+          loaded: true,
+          loading: false,
+        },
+        version: {
+          data: "2.8.0",
+          loaded: true,
+          loading: false,
+        },
+      },
+    };
+  });
+
+  it("fetches data for deprecation notices and version", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <DeprecationNotices />
+      </Provider>
+    );
+
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "FETCH_GENERAL_VERSION")
+    ).toBe(true);
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "FETCH_GENERAL_DEPRECATION_NOTICES")
+    ).toBe(true);
+  });
+
+  it("can display deprecation notices with a link", () => {
+    state.general = {
+      deprecationNotices: {
+        data: [
+          {
+            id: 1,
+            description: "Deprecated",
+            "link-text": "Click here to find out why",
+            since: "2.8",
+            url: "www.url.com",
+          },
+        ],
+        loaded: true,
+        loading: false,
+      },
+      version: {
+        data: "2.8.0",
+        loaded: true,
+        loading: false,
+      },
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeprecationNotices />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='deprecation-1']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='deprecation-1'] a").props().href).toBe(
+      "www.url.com"
+    );
+    expect(wrapper.find("[data-test='deprecation-1'] a").text()).toBe(
+      "Click here to find out why..."
+    );
+  });
+
+  it("does not display deprecation notices if version is too old", () => {
+    state.general = {
+      deprecationNotices: {
+        data: [
+          {
+            id: 1,
+            description: "Deprecated",
+            since: "2.9",
+            url: "www.url.com",
+          },
+        ],
+        loaded: true,
+        loading: false,
+      },
+      version: {
+        data: "2.8.0",
+        loaded: true,
+        loading: false,
+      },
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DeprecationNotices />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='deprecation-1']").exists()).toBe(false);
+  });
+});

--- a/ui/src/app/base/components/DeprecationNotices/index.js
+++ b/ui/src/app/base/components/DeprecationNotices/index.js
@@ -1,0 +1,1 @@
+export { default } from "./DeprecationNotices";

--- a/ui/src/app/base/components/NotificationList/NotificationList.js
+++ b/ui/src/app/base/components/NotificationList/NotificationList.js
@@ -25,7 +25,7 @@ const generateMessages = (messages, dispatch) =>
     </Notification>
   ));
 
-const NotificationList = ({ children, sidebar, title }) => {
+const NotificationList = () => {
   const messages = useSelector(messageSelectors.all);
 
   const notifications = {
@@ -68,7 +68,6 @@ const NotificationList = ({ children, sidebar, title }) => {
         }
         return null;
       })}
-
       {generateMessages(messages, dispatch)}
     </>
   );

--- a/ui/src/app/base/components/NotificationList/NotificationList.test.js
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.js
@@ -44,7 +44,9 @@ describe("NotificationList", () => {
     );
     wrapper.find("Notification").props().close();
 
-    expect(store.getActions()[1]).toEqual({
+    expect(
+      store.getActions().find((action) => action.type === "REMOVE_MESSAGE")
+    ).toEqual({
       type: "REMOVE_MESSAGE",
       payload: 1,
     });

--- a/ui/src/app/base/components/Section/Section.js
+++ b/ui/src/app/base/components/Section/Section.js
@@ -3,9 +3,16 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
+import DeprecationNotices from "app/base/components/DeprecationNotices";
 import NotificationList from "app/base/components/NotificationList";
 
-const Section = ({ children, headerClassName, sidebar, title }) => {
+const Section = ({
+  children,
+  headerClassName,
+  showDeprecations = false,
+  sidebar,
+  title,
+}) => {
   return (
     <div className="section">
       <Strip
@@ -31,6 +38,7 @@ const Section = ({ children, headerClassName, sidebar, title }) => {
           </Col>
         )}
         <Col size={sidebar ? 10 : 12} className="section__content">
+          {showDeprecations && <DeprecationNotices />}
           <NotificationList />
           {children}
         </Col>
@@ -42,6 +50,7 @@ const Section = ({ children, headerClassName, sidebar, title }) => {
 Section.propTypes = {
   children: PropTypes.node,
   headerClassName: PropTypes.string,
+  showDeprecations: PropTypes.bool,
   sidebar: PropTypes.node,
   title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
 };

--- a/ui/src/app/base/reducers/general/general.js
+++ b/ui/src/app/base/reducers/general/general.js
@@ -35,6 +35,7 @@ const defaultMinHweKernel = generateGeneralReducer(
   "DEFAULT_MIN_HWE_KERNEL",
   ""
 );
+const deprecationNotices = generateGeneralReducer("DEPRECATION_NOTICES", []);
 const hweKernels = generateGeneralReducer("HWE_KERNELS", []);
 const knownArchitectures = generateGeneralReducer("KNOWN_ARCHITECTURES", []);
 const machineActions = generateGeneralReducer("MACHINE_ACTIONS", []);
@@ -48,6 +49,7 @@ export const general = combineReducers({
   architectures,
   componentsToDisable,
   defaultMinHweKernel,
+  deprecationNotices,
   hweKernels,
   knownArchitectures,
   machineActions,

--- a/ui/src/app/base/reducers/general/general.test.js
+++ b/ui/src/app/base/reducers/general/general.test.js
@@ -21,6 +21,12 @@ describe("general reducer", () => {
         loaded: false,
         loading: false,
       },
+      deprecationNotices: {
+        data: [],
+        errors: {},
+        loaded: false,
+        loading: false,
+      },
       hweKernels: {
         data: [],
         errors: {},

--- a/ui/src/app/base/selectors/general/deprecationNotices.js
+++ b/ui/src/app/base/selectors/general/deprecationNotices.js
@@ -1,0 +1,19 @@
+/**
+ * Selector for the default minimum hwe kernel.
+ */
+
+import { createSelector } from "@reduxjs/toolkit";
+
+import { isVersionNewer } from "app/utils";
+import { generateGeneralSelector } from "./utils";
+import version from "./version";
+
+const deprecationNotices = generateGeneralSelector("deprecationNotices");
+
+deprecationNotices.filterByMinorVersion = createSelector(
+  [deprecationNotices.get, version.minor],
+  (notices, minorVersion) =>
+    notices.filter((notice) => !isVersionNewer(notice.since, minorVersion))
+);
+
+export default deprecationNotices;

--- a/ui/src/app/base/selectors/general/deprecationNotices.test.js
+++ b/ui/src/app/base/selectors/general/deprecationNotices.test.js
@@ -1,0 +1,98 @@
+import deprecationNotices from "./deprecationNotices";
+
+describe("deprecationNotices selectors", () => {
+  describe("get", () => {
+    it("returns deprecation notices", () => {
+      const data = [{ id: "MD1", description: "Everything is deprecated" }];
+      const state = {
+        general: {
+          deprecationNotices: {
+            data,
+            errors: {},
+            loaded: true,
+            loading: false,
+          },
+        },
+      };
+      expect(deprecationNotices.get(state)).toStrictEqual(data);
+    });
+  });
+
+  describe("loading", () => {
+    it("returns deprecation notices loading state", () => {
+      const loading = true;
+      const state = {
+        general: {
+          deprecationNotices: {
+            data: [],
+            errors: {},
+            loaded: false,
+            loading,
+          },
+        },
+      };
+      expect(deprecationNotices.loading(state)).toStrictEqual(loading);
+    });
+  });
+
+  describe("loaded", () => {
+    it("returns deprecation notices loaded state", () => {
+      const loaded = true;
+      const state = {
+        general: {
+          deprecationNotices: {
+            data: [],
+            errors: {},
+            loaded,
+            loading: false,
+          },
+        },
+      };
+      expect(deprecationNotices.loaded(state)).toStrictEqual(loaded);
+    });
+  });
+
+  describe("errors", () => {
+    it("returns deprecation notices errors state", () => {
+      const errors = "Cannot fetch deprecation notices.";
+      const state = {
+        general: {
+          deprecationNotices: {
+            data: [],
+            errors,
+            loaded: true,
+            loading: false,
+          },
+        },
+      };
+      expect(deprecationNotices.errors(state)).toStrictEqual(errors);
+    });
+  });
+
+  describe("filterByMinorVersion", () => {
+    it("filters deprecation notices that are newer than version", () => {
+      const state = {
+        general: {
+          deprecationNotices: {
+            data: [
+              { id: 1, since: "2.8" },
+              { id: 2, since: "2.9" },
+            ],
+            errors: {},
+            loaded: true,
+            loading: false,
+          },
+          version: {
+            data: "2.8.0~beta-1",
+            errors: {},
+            loaded: true,
+            loading: false,
+          },
+        },
+      };
+      expect(deprecationNotices.filterByMinorVersion(state)).toStrictEqual([
+        { id: 1, since: "2.8" },
+      ]);
+    });
+  });
+});

--- a/ui/src/app/base/selectors/general/index.js
+++ b/ui/src/app/base/selectors/general/index.js
@@ -1,6 +1,7 @@
 import architectures from "./architectures";
 import componentsToDisable from "./componentsToDisable";
 import defaultMinHweKernel from "./defaultMinHweKernel";
+import deprecationNotices from "./deprecationNotices";
 import hweKernels from "./hweKernels";
 import knownArchitectures from "./knownArchitectures";
 import machineActions from "./machineActions";
@@ -14,6 +15,7 @@ export const general = {
   architectures,
   componentsToDisable,
   defaultMinHweKernel,
+  deprecationNotices,
   hweKernels,
   knownArchitectures,
   machineActions,

--- a/ui/src/app/base/selectors/general/version.js
+++ b/ui/src/app/base/selectors/general/version.js
@@ -6,4 +6,13 @@ import { generateGeneralSelector } from "./utils";
 
 const version = generateGeneralSelector("version");
 
+version.minor = (state) => {
+  const { data } = state.general.version;
+  const splitVersion = data.split(".");
+  if (splitVersion[0] && splitVersion[1]) {
+    return `${splitVersion[0]}.${splitVersion[1]}`;
+  }
+  return "";
+};
+
 export default version;

--- a/ui/src/app/base/selectors/general/version.test.js
+++ b/ui/src/app/base/selectors/general/version.test.js
@@ -69,4 +69,20 @@ describe("version selectors", () => {
       expect(version.errors(state)).toStrictEqual(errors);
     });
   });
+
+  describe("minor", () => {
+    it("returns the minor version", () => {
+      const state = {
+        general: {
+          version: {
+            data: "2.8.0~alpha1",
+            errors: {},
+            loaded: true,
+            loading: false,
+          },
+        },
+      };
+      expect(version.minor(state)).toStrictEqual("2.8");
+    });
+  });
 });

--- a/ui/src/app/base/views/NotFound/NotFound.test.js
+++ b/ui/src/app/base/views/NotFound/NotFound.test.js
@@ -16,6 +16,18 @@ describe("NotFound ", () => {
       config: {
         items: [],
       },
+      general: {
+        deprecationNotices: {
+          data: [],
+          loaded: true,
+          loading: false,
+        },
+        version: {
+          data: "2.8.0",
+          loaded: true,
+          loading: false,
+        },
+      },
       messages: {
         items: [],
       },

--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -12,7 +12,11 @@ import HeaderStrip from "app/machines/components/HeaderStrip";
 import Section from "app/base/components/Section";
 
 const Machines = () => (
-  <Section headerClassName="u-no-padding--bottom" title={<HeaderStrip />}>
+  <Section
+    headerClassName="u-no-padding--bottom"
+    showDeprecations
+    title={<HeaderStrip />}
+  >
     <Switch>
       <Route exact path="/machines">
         <MachineList />

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -30,6 +30,11 @@ describe("Machines", () => {
           loaded: false,
           loading: false,
         },
+        deprecationNotices: {
+          data: [],
+          loaded: true,
+          loading: false,
+        },
         hweKernels: {
           data: [],
           loaded: false,
@@ -57,6 +62,11 @@ describe("Machines", () => {
         powerTypes: {
           data: [],
           loaded: false,
+          loading: false,
+        },
+        version: {
+          data: "2.8.0",
+          loaded: true,
           loading: false,
         },
       },

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -5,6 +5,7 @@ export { formatSpeedUnits } from "./formatSpeedUnits";
 export { getMachineValue } from "./search";
 export { generateLegacyURL } from "./generateLegacyURL";
 export { groupAsMap } from "./groupAsMap";
+export { isVersionNewer } from "./isVersionNewer";
 export { kebabToCamelCase } from "./kebabToCamelCase";
 export { simpleSortByKey } from "./simpleSortByKey";
 export { trimPowerParameters } from "./trimPowerParameters";

--- a/ui/src/app/utils/isVersionNewer.js
+++ b/ui/src/app/utils/isVersionNewer.js
@@ -1,0 +1,19 @@
+/**
+ * Returns whether a version string is newer than another version string.
+ * @param {String} versionA - a dot separated version string, e.g. "2.8.0"
+ * @param {String} versionB - the version string to compare against
+ * @returns {Boolean} versionA is newer than versionB
+ */
+export const isVersionNewer = (versionA, versionB) => {
+  const partsA = versionA.split(".");
+  const partsB = versionB.split(".");
+  const numParts =
+    partsA.length > partsB.length ? partsA.length : partsB.length;
+
+  for (let i = 0; i < numParts; i++) {
+    if ((parseInt(partsA[i]) || 0) !== (parseInt(partsB[i]) || 0)) {
+      return (parseInt(partsA[i]) || 0) > (parseInt(partsB[i]) || 0);
+    }
+  }
+  return false;
+};

--- a/ui/src/app/utils/isVersionNewer.test.js
+++ b/ui/src/app/utils/isVersionNewer.test.js
@@ -1,0 +1,26 @@
+import { isVersionNewer } from "./isVersionNewer";
+
+describe("isVersionNewer", () => {
+  it("returns true if the version is newer than the one being compared to", () => {
+    expect(isVersionNewer("2.0.0", "1.0.0")).toEqual(true);
+    expect(isVersionNewer("2.0", "1.0")).toEqual(true);
+    expect(isVersionNewer("2", "1")).toEqual(true);
+  });
+
+  it("returns true if the version has a higher minor version number", () => {
+    expect(isVersionNewer("1.2.0", "1.1.0")).toEqual(true);
+    expect(isVersionNewer("1.2", "1.1")).toEqual(true);
+    expect(isVersionNewer("1.10", "1.9")).toEqual(true);
+  });
+
+  it("returns true if the version has a higher patch version number", () => {
+    expect(isVersionNewer("1.2.3", "1.2.0")).toEqual(true);
+    expect(isVersionNewer("1.2.10", "1.2.9")).toEqual(true);
+  });
+
+  it("returns false if the versions are equal", () => {
+    expect(isVersionNewer("1.2.3", "1.2.3")).toEqual(false);
+    expect(isVersionNewer("1.2.0", "1.2")).toEqual(false);
+    expect(isVersionNewer("1.0.0", "1")).toEqual(false);
+  });
+});


### PR DESCRIPTION
## Done
- Added actions, reducers and selectors for fetching deprecation notices.
- Display deprecation notices in state at the top of NotificationList.

## QA
- Run this branch on bolla and check that a deprecation notice shows up at the top of the section.

## Fixes
Fixes #1008 

## Screenshot
![Screenshot_2020-04-21 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/79828190-8e833600-83e3-11ea-8513-ed70ff8f9b5d.png)
