### PR TITLE
Take action statuses

### DIFF
--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -1,7 +1,112 @@
 import { createNextState } from "@reduxjs/toolkit";
 
+export const ACTIONS = [
+  {
+    status: "aborting",
+    type: "ABORT_MACHINE",
+  },
+  {
+    status: "acquiring",
+    type: "ACQUIRE_MACHINE",
+  },
+  {
+    status: "checkingPower",
+    type: "CHECK_MACHINE_POWER",
+  },
+  {
+    status: "commissioning",
+    type: "COMMISSION_MACHINE",
+  },
+  {
+    status: "deleting",
+    type: "DELETE_MACHINE",
+  },
+  {
+    status: "deploying",
+    type: "DEPLOY_MACHINE",
+  },
+  {
+    status: "enteringRescueMode",
+    type: "MACHINE_RESCUE_MODE",
+  },
+  {
+    status: "exitingRescueMode",
+    type: "MACHINE_EXIT_RESCUE_MODE",
+  },
+  {
+    status: "locking",
+    type: "LOCK_MACHINE",
+  },
+  {
+    status: "markingBroken",
+    type: "MARK_MACHINE_BROKEN",
+  },
+  {
+    status: "markingFixed",
+    type: "MARK_MACHINE_FIXED",
+  },
+  {
+    status: "overridingFailedTesting",
+    type: "MACHINE_OVERRIDE_FAILED_TESTING",
+  },
+  {
+    status: "releasing",
+    type: "RELEASE_MACHINE",
+  },
+  {
+    status: "settingPool",
+    type: "SET_MACHINE_POOL",
+  },
+  {
+    status: "settingZone",
+    type: "SET_MACHINE_ZONE",
+  },
+  {
+    status: "tagging",
+    type: "TAG_MACHINE",
+  },
+  {
+    status: "testing",
+    type: "TEST_MACHINE",
+  },
+  {
+    status: "turningOff",
+    type: "TURN_MACHINE_OFF",
+  },
+  {
+    status: "turningOn",
+    type: "TURN_MACHINE_ON_ERROR",
+  },
+  {
+    status: "unlocking",
+    type: "UNLOCK_MACHINE",
+  },
+];
+
+let DEFAULT_STATUSES = {};
+ACTIONS.forEach(({ status }) => {
+  DEFAULT_STATUSES[status] = false;
+});
+
 const machine = createNextState(
   (draft, action) => {
+    // Handle actions that have the same shape.
+    ACTIONS.forEach(({ status, type }) => {
+      switch (action.type) {
+        case `${type}_START`:
+          draft.statuses[action.meta.item.system_id][status] = true;
+          break;
+        case `${type}_SUCCESS`:
+          draft.statuses[action.meta.item.system_id][status] = false;
+          break;
+        case `${type}_ERROR`:
+          draft.statuses[action.meta.item.system_id][status] = false;
+          draft.errors = action.error;
+          break;
+        default:
+          break;
+      }
+    });
     switch (action.type) {
       case "FETCH_MACHINE_START":
         draft.loading = true;
@@ -22,9 +127,7 @@ const machine = createNextState(
           } else {
             draft.items.push(newItem);
             // Set up the statuses for this machine.
-            draft.statuses[newItem.system_id] = {
-              savingPool: false,
-            };
+            draft.statuses[newItem.system_id] = DEFAULT_STATUSES;
           }
         });
         break;
@@ -65,36 +168,6 @@ const machine = createNextState(
             break;
           }
         }
-        break;
-      case "SET_MACHINE_POOL_START":
-        draft.statuses[action.meta.item.system_id].savingPool = true;
-        break;
-      case "SET_MACHINE_POOL_SUCCESS":
-        draft.statuses[action.meta.item.system_id].savingPool = false;
-        break;
-      case "SET_MACHINE_POOL_ERROR":
-        draft.statuses[action.meta.item.system_id].savingPool = false;
-        draft.errors = action.error;
-        break;
-      case "ACQUIRE_MACHINE_ERROR":
-      case "RELEASE_MACHINE_ERROR":
-      case "COMMISSION_MACHINE_ERROR":
-      case "DEPLOY_MACHINE_ERROR":
-      case "ABORT_MACHINE_ERROR":
-      case "TEST_MACHINE_ERROR":
-      case "MACHINE_RESCUE_MODE_ERROR":
-      case "MACHINE_EXIT_RESCUE_MODE_ERROR":
-      case "MARK_MACHINE_BROKEN_ERROR":
-      case "MARK_MACHINE_FIXED_ERROR":
-      case "MACHINE_OVERRIDE_FAILED_TESTING_ERROR":
-      case "LOCK_MACHINE_ERROR":
-      case "UNLOCK_MACHINE_ERROR":
-      case "TAG_MACHINE_ERROR":
-      case "SET_MACHINE_ZONE_ERROR":
-      case "TURN_MACHINE_OFF_ERROR":
-      case "TURN_MACHINE_ON_ERROR":
-      case "CHECK_MACHINE_POWER_ERROR":
-        draft.errors = action.error;
         break;
       case "SET_SELECTED_MACHINES":
         draft.selected = action.payload;

--- a/ui/src/app/base/reducers/machine/machine.test.js
+++ b/ui/src/app/base/reducers/machine/machine.test.js
@@ -32,6 +32,28 @@ describe("machine reducer", () => {
   });
 
   it("should correctly reduce FETCH_MACHINE_SUCCESS", () => {
+    const statuses = {
+      aborting: false,
+      acquiring: false,
+      checkingPower: false,
+      commissioning: false,
+      deleting: false,
+      deploying: false,
+      enteringRescueMode: false,
+      exitingRescueMode: false,
+      locking: false,
+      markingBroken: false,
+      markingFixed: false,
+      overridingFailedTesting: false,
+      releasing: false,
+      settingPool: false,
+      settingZone: false,
+      tagging: false,
+      testing: false,
+      turningOff: false,
+      turningOn: false,
+      unlocking: false,
+    };
     expect(
       machine(
         {
@@ -43,9 +65,7 @@ describe("machine reducer", () => {
           saving: false,
           selected: [],
           statuses: {
-            abc: {
-              savingPool: false,
-            },
+            abc: statuses,
           },
         },
         {
@@ -68,12 +88,8 @@ describe("machine reducer", () => {
       saving: false,
       selected: [],
       statuses: {
-        abc: {
-          savingPool: false,
-        },
-        def: {
-          savingPool: false,
-        },
+        abc: statuses,
+        def: statuses,
       },
     });
   });
@@ -298,8 +314,14 @@ describe("machine reducer", () => {
           loaded: false,
           loading: true,
           selected: [],
+          statuses: { abc: { checkingPower: true } },
         },
         {
+          meta: {
+            item: {
+              system_id: "abc",
+            },
+          },
           type: "CHECK_MACHINE_POWER_ERROR",
           error: "Uh oh!",
         }
@@ -310,6 +332,7 @@ describe("machine reducer", () => {
       loaded: false,
       items: [],
       selected: [],
+      statuses: { abc: { checkingPower: false } },
     });
   });
 
@@ -354,7 +377,7 @@ describe("machine reducer", () => {
           {
             statuses: {
               abc: {
-                savingPool: false,
+                settingPool: false,
               },
             },
           },
@@ -370,7 +393,7 @@ describe("machine reducer", () => {
       ).toEqual({
         statuses: {
           abc: {
-            savingPool: true,
+            settingPool: true,
           },
         },
       });
@@ -382,7 +405,7 @@ describe("machine reducer", () => {
           {
             statuses: {
               abc: {
-                savingPool: true,
+                settingPool: true,
               },
             },
           },
@@ -398,7 +421,7 @@ describe("machine reducer", () => {
       ).toEqual({
         statuses: {
           abc: {
-            savingPool: false,
+            settingPool: false,
           },
         },
       });
@@ -411,7 +434,7 @@ describe("machine reducer", () => {
             errors: null,
             statuses: {
               abc: {
-                savingPool: false,
+                settingPool: false,
               },
             },
           },
@@ -429,7 +452,7 @@ describe("machine reducer", () => {
         errors: "Uh oh",
         statuses: {
           abc: {
-            savingPool: false,
+            settingPool: false,
           },
         },
       });

--- a/ui/src/app/base/selectors/general/machineActions.js
+++ b/ui/src/app/base/selectors/general/machineActions.js
@@ -9,21 +9,14 @@ import { generateGeneralSelector } from "./utils";
 const machineActions = generateGeneralSelector("machineActions");
 
 /**
- * An intermediary selector to get and pass params to the selector.
- * @param {Object} state - The redux state.
- * @returns {Array} The provided params.
- */
-const getParams = (state, ...params) => [...params];
-
-/**
  * Get a machine action by name.
  * @param {Object} state - The redux state.
  * @param {String} name - The name of a machine action.
  * @returns {Object} A machine action.
  */
 machineActions.getByName = createSelector(
-  [machineActions.get, getParams],
-  (items, [name]) => items.find((item) => item.name === name)
+  [machineActions.get, (state, name) => name],
+  (actions, name) => actions.find((action) => action.name === name)
 );
 
 export default machineActions;

--- a/ui/src/app/base/selectors/machine/machine.js
+++ b/ui/src/app/base/selectors/machine/machine.js
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import filterNodes from "app/machines/filter-nodes";
+import { ACTIONS } from "app/base/reducers/machine/machine";
 
 const machine = {};
 
@@ -60,16 +61,23 @@ machine.selectedIDs = (state) => state.machine.selected;
  */
 machine.statuses = (state) => state.machine.statuses;
 
-/**
- * Get machines that are saving pools.
- * @param {Object} state - The redux state.
- * @returns {Array} The machines that are saving pools.
- */
-machine.savingPools = createSelector(
-  [machine.all, machine.statuses],
-  (machines, statuses) =>
-    machines.filter(({ system_id }) => statuses[system_id].savingPool)
-);
+// Create a selector for each machine status.
+ACTIONS.forEach(({ status }) => {
+  machine[status] = createSelector(
+    [machine.all, machine.statuses],
+    (machines, statuses) =>
+      machines.filter(({ system_id }) => statuses[system_id][status])
+  );
+});
+
+// Create a selector for selected machines in each machine status.
+ACTIONS.forEach(({ status }) => {
+  machine[`${status}Selected`] = createSelector(
+    [machine[status], machine.selectedIDs],
+    (machines, selectedIDs) =>
+      machines.filter(({ system_id }) => selectedIDs.includes(system_id))
+  );
+});
 
 /**
  * Returns a machine for the given id.
@@ -125,17 +133,6 @@ machine.selected = createSelector(
     selectedIDs.map((id) =>
       machines.find((machine) => id === machine.system_id)
     )
-);
-
-/**
- * Returns selected machines that are saving pools.
- * @param {Object} state - The redux state.
- * @returns {Array} Machines that are selected and saving pools.
- */
-machine.selectedSavingPools = createSelector(
-  [machine.savingPools, machine.selectedIDs],
-  (savingPools, selectedIDs) =>
-    savingPools.filter(({ system_id }) => selectedIDs.includes(system_id))
 );
 
 export default machine;

--- a/ui/src/app/base/selectors/machine/machine.test.js
+++ b/ui/src/app/base/selectors/machine/machine.test.js
@@ -105,12 +105,12 @@ describe("machine selectors", () => {
       machine: {
         items: [{ system_id: 808 }, { system_id: 909 }],
         statuses: {
-          808: { savingPool: false },
-          909: { savingPool: true },
+          808: { settingPool: false },
+          909: { settingPool: true },
         },
       },
     };
-    expect(machine.savingPools(state)).toStrictEqual([{ system_id: 909 }]);
+    expect(machine.settingPool(state)).toStrictEqual([{ system_id: 909 }]);
   });
 
   it("can get machines that are both selected and saving pools", () => {
@@ -119,13 +119,13 @@ describe("machine selectors", () => {
         items: [{ system_id: 808 }, { system_id: 808 }, { system_id: 909 }],
         selected: [909],
         statuses: {
-          707: { savingPool: true },
-          808: { savingPool: false },
-          909: { savingPool: true },
+          707: { settingPool: true },
+          808: { settingPool: false },
+          909: { settingPool: true },
         },
       },
     };
-    expect(machine.selectedSavingPools(state)).toStrictEqual([
+    expect(machine.settingPoolSelected(state)).toStrictEqual([
       { system_id: 909 },
     ]);
   });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
@@ -1,11 +1,12 @@
 import { useDispatch, useSelector } from "react-redux";
 import pluralize from "pluralize";
-import React from "react";
+import React, { useState } from "react";
 
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import FormikForm from "app/base/components/FormikForm";
 import FormCardButtons from "app/base/components/FormCardButtons";
+import MachinesProcessing from "../MachinesProcessing";
 import { kebabToCamelCase } from "app/utils";
 
 const getSubmitText = (action, count) => {
@@ -57,13 +58,70 @@ const fieldlessActions = [
   "unlock",
 ];
 
+const useSelectedProcessing = (actionName) => {
+  let selector;
+  switch (actionName) {
+    case "abort":
+      selector = machineSelectors.abortingSelected;
+      break;
+    case "acquire":
+      selector = machineSelectors.acquiringSelected;
+      break;
+    case "delete":
+      selector = machineSelectors.deletingSelected;
+      break;
+    case "exit-rescue-mode":
+      selector = machineSelectors.exitingRescueModeSelected;
+      break;
+    case "lock":
+      selector = machineSelectors.lockingSelected;
+      break;
+    case "mark-broken":
+      selector = machineSelectors.markingBrokenSelected;
+      break;
+    case "mark-fixed":
+      selector = machineSelectors.markingFixedSelected;
+      break;
+    case "off":
+      selector = machineSelectors.turningOffSelected;
+      break;
+    case "on":
+      selector = machineSelectors.turningOnSelected;
+      break;
+    case "release":
+      selector = machineSelectors.releasingSelected;
+      break;
+    case "rescue-mode":
+      selector = machineSelectors.enteringRescueModeSelected;
+      break;
+    case "unlock":
+      selector = machineSelectors.unlockingSelected;
+      break;
+    default:
+      break;
+  }
+  return useSelector(selector);
+};
+
 export const ActionForm = ({ selectedAction, setSelectedAction }) => {
   const dispatch = useDispatch();
-
+  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
+  const selectedProcessing = useSelectedProcessing(selectedAction.name);
+
+  if (processing) {
+    return (
+      <MachinesProcessing
+        action={selectedAction.name}
+        machinesProcessing={selectedProcessing}
+        setProcessing={setProcessing}
+        setSelectedAction={setSelectedAction}
+      />
+    );
+  }
 
   return (
     <FormikForm
@@ -91,7 +149,7 @@ export const ActionForm = ({ selectedAction, setSelectedAction }) => {
             }
           });
         }
-        setSelectedAction(null);
+        setProcessing(true);
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
@@ -23,6 +23,27 @@ describe("ActionForm", () => {
           },
         ],
         selected: [],
+        statuses: {
+          abc123: {},
+        },
+      },
+      general: {
+        machineActions: {
+          data: [
+            { name: "abort", sentence: "abort" },
+            { name: "acquire", sentence: "acquire" },
+            { name: "delete", sentence: "delete" },
+            { name: "exit-rescue-mode", sentence: "exit-rescue-mode" },
+            { name: "lock", sentence: "lock" },
+            { name: "mark-broken", sentence: "mark-broken" },
+            { name: "mark-fixed", sentence: "mark-fixed" },
+            { name: "off", sentence: "off" },
+            { name: "on", sentence: "on" },
+            { name: "release", sentence: "release" },
+            { name: "rescue-mode", sentence: "rescue-mode" },
+            { name: "unlock", sentence: "unlock" },
+          ],
+        },
       },
     };
   });
@@ -36,7 +57,7 @@ describe("ActionForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <ActionForm
-            selectedAction={{ name: "commission" }}
+            selectedAction={{ name: "release" }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -47,8 +68,9 @@ describe("ActionForm", () => {
 
   it("can unset the selected action", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "a", actions: ["commission"] }];
+    state.machine.items = [{ system_id: "a", actions: ["release"] }];
     state.machine.selected = ["a"];
+    state.machine.statuses = { a: {} };
     const store = mockStore(state);
     const setSelectedAction = jest.fn();
     const wrapper = mount(
@@ -57,7 +79,7 @@ describe("ActionForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <ActionForm
-            selectedAction={{ name: "commission" }}
+            selectedAction={{ name: "release" }}
             setSelectedAction={setSelectedAction}
           />
         </MemoryRouter>
@@ -108,7 +130,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "ABORT_MACHINE")
+    ).toStrictEqual([
       {
         type: "ABORT_MACHINE",
         meta: {
@@ -145,7 +169,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "ACQUIRE_MACHINE")
+    ).toStrictEqual([
       {
         type: "ACQUIRE_MACHINE",
         meta: {
@@ -182,7 +208,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "DELETE_MACHINE")
+    ).toStrictEqual([
       {
         type: "DELETE_MACHINE",
         meta: {
@@ -221,7 +249,11 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store
+        .getActions()
+        .filter(({ type }) => type === "MACHINE_EXIT_RESCUE_MODE")
+    ).toStrictEqual([
       {
         type: "MACHINE_EXIT_RESCUE_MODE",
         meta: {
@@ -258,7 +290,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "LOCK_MACHINE")
+    ).toStrictEqual([
       {
         type: "LOCK_MACHINE",
         meta: {
@@ -295,7 +329,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "MARK_MACHINE_BROKEN")
+    ).toStrictEqual([
       {
         type: "MARK_MACHINE_BROKEN",
         meta: {
@@ -332,7 +368,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "MARK_MACHINE_FIXED")
+    ).toStrictEqual([
       {
         type: "MARK_MACHINE_FIXED",
         meta: {
@@ -369,7 +407,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "TURN_MACHINE_OFF")
+    ).toStrictEqual([
       {
         type: "TURN_MACHINE_OFF",
         meta: {
@@ -406,7 +446,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "TURN_MACHINE_ON")
+    ).toStrictEqual([
       {
         type: "TURN_MACHINE_ON",
         meta: {
@@ -443,7 +485,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "RELEASE_MACHINE")
+    ).toStrictEqual([
       {
         type: "RELEASE_MACHINE",
         meta: {
@@ -480,7 +524,9 @@ describe("ActionForm", () => {
     );
 
     act(() => wrapper.find("Formik").props().onSubmit());
-    expect(store.getActions()).toStrictEqual([
+    expect(
+      store.getActions().filter(({ type }) => type === "UNLOCK_MACHINE")
+    ).toStrictEqual([
       {
         type: "UNLOCK_MACHINE",
         meta: {
@@ -496,5 +542,27 @@ describe("ActionForm", () => {
         },
       },
     ]);
+  });
+
+  it("can show the status when processing machines", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["unlock"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "unlock" }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => wrapper.find("Formik").props().onSubmit());
+    wrapper.update();
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
@@ -4,7 +4,7 @@ exports[`ActionForm renders 1`] = `
 <ActionForm
   selectedAction={
     Object {
-      "name": "commission",
+      "name": "release",
     }
   }
   setSelectedAction={[MockFunction]}
@@ -18,14 +18,14 @@ exports[`ActionForm renders 1`] = `
     onCancel={[Function]}
     onSaveAnalytics={
       Object {
-        "action": "commission",
+        "action": "release",
         "category": "Take action menu",
         "label": undefined,
       }
     }
     onSubmit={[Function]}
     submitAppearance="positive"
-    submitLabel="Commission 0 machines"
+    submitLabel="Release 0 machines"
   >
     <Formik
       initialValues={Object {}}
@@ -38,7 +38,7 @@ exports[`ActionForm renders 1`] = `
         initialValues={Object {}}
         onCancel={[Function]}
         submitAppearance="positive"
-        submitLabel="Commission 0 machines"
+        submitLabel="Release 0 machines"
       >
         <Form
           onSubmit={[Function]}
@@ -53,7 +53,7 @@ exports[`ActionForm renders 1`] = `
               onCancel={[Function]}
               submitAppearance="positive"
               submitDisabled={false}
-              submitLabel="Commission 0 machines"
+              submitLabel="Release 0 machines"
             >
               <div
                 className="form-card__buttons"
@@ -85,7 +85,7 @@ exports[`ActionForm renders 1`] = `
                     disabled={false}
                     type="submit"
                   >
-                    Commission 0 machines
+                    Release 0 machines
                   </button>
                 </ActionButton>
               </div>

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -1,5 +1,5 @@
 import pluralize from "pluralize";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -13,6 +13,7 @@ import {
 } from "app/base/selectors";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
+import MachinesProcessing from "../MachinesProcessing";
 import CommissionFormFields from "./CommissionFormFields";
 
 const CommissionFormSchema = Yup.object().shape({
@@ -38,14 +39,16 @@ const CommissionFormSchema = Yup.object().shape({
 
 export const CommissionForm = ({ setSelectedAction }) => {
   const dispatch = useDispatch();
-
+  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
-
   const commissioningScripts = useSelector(scriptSelectors.commissioning);
   const testingScripts = useSelector(scriptSelectors.testing);
+  const commissioningSelected = useSelector(
+    machineSelectors.commissioningSelected
+  );
 
   const formatScripts = (scripts) =>
     scripts.map((script) => ({
@@ -65,6 +68,17 @@ export const CommissionForm = ({ setSelectedAction }) => {
   useEffect(() => {
     dispatch(scriptActions.fetch());
   }, [dispatch]);
+
+  if (processing) {
+    return (
+      <MachinesProcessing
+        machinesProcessing={commissioningSelected}
+        setProcessing={setProcessing}
+        setSelectedAction={setSelectedAction}
+        action="commission"
+      />
+    );
+  }
 
   return (
     <FormikForm
@@ -120,7 +134,7 @@ export const CommissionForm = ({ setSelectedAction }) => {
             )
           );
         });
-        setSelectedAction(null);
+        setProcessing(true);
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
@@ -13,12 +13,21 @@ describe("CommissionForm", () => {
   let initialState;
   beforeEach(() => {
     initialState = {
+      general: {
+        machineActions: {
+          data: [{ name: "commission", sentence: "commission" }],
+        },
+      },
       machine: {
         errors: {},
         loading: false,
         loaded: true,
         items: [{ system_id: "abc123" }, { system_id: "def456" }],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       scripts: {
         errors: {},
@@ -131,5 +140,37 @@ describe("CommissionForm", () => {
         },
       },
     ]);
+  });
+
+  it("can show the status when processing machines", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CommissionForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          enableSSH: true,
+          skipBMCConfig: true,
+          skipNetworking: true,
+          skipStorage: true,
+          updateFirmware: true,
+          configureHBA: true,
+          testingScripts: [state.scripts.items[0]],
+          commissioningScripts: [state.scripts.items[1]],
+        })
+    );
+    wrapper.update();
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import pluralize from "pluralize";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 import {
   general as generalActions,
@@ -13,6 +13,7 @@ import {
 } from "app/base/selectors";
 import FormikForm from "app/base/components/FormikForm";
 import FormCardButtons from "app/base/components/FormCardButtons";
+import MachinesProcessing from "../MachinesProcessing";
 import DeployFormFields from "./DeployFormFields";
 
 const DeploySchema = Yup.object().shape({
@@ -24,22 +25,33 @@ const DeploySchema = Yup.object().shape({
 
 export const DeployForm = ({ setSelectedAction }) => {
   const dispatch = useDispatch();
-
+  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
-
   const defaultMinHweKernel = useSelector(
     generalSelectors.defaultMinHweKernel.get
   );
   const osInfo = useSelector(generalSelectors.osInfo.get);
+  const deployingSelected = useSelector(machineSelectors.deployingSelected);
 
   useEffect(() => {
     dispatch(generalActions.fetchDefaultMinHweKernel());
     dispatch(generalActions.fetchOsInfo());
     dispatch(machineActions.fetch());
   }, [dispatch]);
+
+  if (processing) {
+    return (
+      <MachinesProcessing
+        machinesProcessing={deployingSelected}
+        setProcessing={setProcessing}
+        setSelectedAction={setSelectedAction}
+        action="deploy"
+      />
+    );
+  }
 
   return (
     <FormikForm
@@ -74,7 +86,7 @@ export const DeployForm = ({ setSelectedAction }) => {
         selectedMachines.forEach((machine) => {
           dispatch(machineActions.deploy(machine.system_id, extra));
         });
-        setSelectedAction(null);
+        setProcessing(true);
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.test.js
@@ -35,6 +35,10 @@ describe("DeployForm", () => {
           loaded: true,
           loading: false,
         },
+
+        machineActions: {
+          data: [{ name: "deploy", sentence: "deploy" }],
+        },
         osInfo: {
           data: {
             osystems: [
@@ -87,6 +91,10 @@ describe("DeployForm", () => {
           },
         ],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       user: {
         auth: {
@@ -175,5 +183,30 @@ describe("DeployForm", () => {
         },
       },
     ]);
+  });
+
+  it("can show the status when processing machines", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper.find("Formik").props().onSubmit({
+        oSystem: "ubuntu",
+        release: "bionic",
+        kernel: "",
+        installKVM: false,
+      })
+    );
+    wrapper.update();
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.js
@@ -87,6 +87,10 @@ describe("DeployFormFields", () => {
           },
         ],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       user: {
         auth: {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
@@ -30,12 +30,12 @@ export const SetPoolForm = ({ setSelectedAction }) => {
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
   const resourcePools = useSelector(resourcePoolSelectors.all);
-  const selectedSavingPools = useSelector(machineSelectors.selectedSavingPools);
+  const settingPoolSelected = useSelector(machineSelectors.settingPoolSelected);
 
   if (processing) {
     return (
       <MachinesProcessing
-        machinesProcessing={selectedSavingPools}
+        machinesProcessing={settingPoolSelected}
         setProcessing={setProcessing}
         setSelectedAction={setSelectedAction}
         action="set-pool"

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
@@ -32,8 +32,8 @@ describe("SetPoolForm", () => {
         ],
         selected: [],
         statuses: {
-          abc123: { savingPool: false },
-          def456: { savingPool: false },
+          abc123: { settingPool: false },
+          def456: { settingPool: false },
         },
       },
       resourcepool: {
@@ -114,7 +114,6 @@ describe("SetPoolForm", () => {
         </MemoryRouter>
       </Provider>
     );
-
     act(() =>
       wrapper.find("Formik").props().onSubmit({
         poolSelection: "select",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.js
@@ -27,8 +27,8 @@ describe("SetPoolFormFields", () => {
         ],
         selected: ["abc123", "def456"],
         statuses: {
-          abc123: { savingPool: false },
-          def456: { savingPool: false },
+          abc123: { settingPool: false },
+          def456: { settingPool: false },
         },
       },
       resourcepool: {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -2,7 +2,7 @@ import { Col, Row, Select } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import pluralize from "pluralize";
-import React from "react";
+import React, { useState } from "react";
 
 import { machine as machineActions } from "app/base/actions";
 import {
@@ -12,6 +12,7 @@ import {
 import FormikForm from "app/base/components/FormikForm";
 import FormikField from "app/base/components/FormikField";
 import FormCardButtons from "app/base/components/FormCardButtons";
+import MachinesProcessing from "../MachinesProcessing";
 
 const SetZoneSchema = Yup.object().shape({
   zone: Yup.string().required("Zone is required"),
@@ -19,12 +20,24 @@ const SetZoneSchema = Yup.object().shape({
 
 export const SetZoneForm = ({ setSelectedAction }) => {
   const dispatch = useDispatch();
-
+  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
   const zones = useSelector(zoneSelectors.all);
+  const settingZoneSelected = useSelector(machineSelectors.settingZoneSelected);
+
+  if (processing) {
+    return (
+      <MachinesProcessing
+        machinesProcessing={settingZoneSelected}
+        setProcessing={setProcessing}
+        setSelectedAction={setSelectedAction}
+        action="set-zone"
+      />
+    );
+  }
 
   const zoneOptions = [
     { label: "Select your zone", value: "", disabled: true },
@@ -57,7 +70,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
         selectedMachines.forEach((machine) => {
           dispatch(machineActions.setZone(machine.system_id, zone.id));
         });
-        setSelectedAction(null);
+        setProcessing(true);
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
@@ -13,6 +13,11 @@ describe("SetZoneForm", () => {
   let state;
   beforeEach(() => {
     state = {
+      general: {
+        machineActions: {
+          data: [{ name: "set-zone", sentence: "set-zone" }],
+        },
+      },
       machine: {
         errors: {},
         loading: false,
@@ -26,6 +31,10 @@ describe("SetZoneForm", () => {
           },
         ],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       zone: {
         items: [
@@ -90,5 +99,26 @@ describe("SetZoneForm", () => {
         },
       },
     ]);
+  });
+
+  it("can show the status when processing machines", () => {
+    const store = mockStore(state);
+    state.machine.selected = ["abc123", "def456"];
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SetZoneForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper.find("Formik").props().onSubmit({
+        zone: "zone-1",
+      })
+    );
+    wrapper.update();
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
@@ -1,5 +1,5 @@
 import pluralize from "pluralize";
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -7,6 +7,7 @@ import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
+import MachinesProcessing from "../MachinesProcessing";
 import TagFormFields from "./TagFormFields";
 
 const TagFormSchema = Yup.object().shape({
@@ -23,10 +24,23 @@ const TagFormSchema = Yup.object().shape({
 
 export const TagForm = ({ setSelectedAction }) => {
   const dispatch = useDispatch();
+  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
+  const taggingSelected = useSelector(machineSelectors.taggingSelected);
+
+  if (processing) {
+    return (
+      <MachinesProcessing
+        machinesProcessing={taggingSelected}
+        setProcessing={setProcessing}
+        setSelectedAction={setSelectedAction}
+        action="tag"
+      />
+    );
+  }
 
   return (
     <FormikForm
@@ -51,7 +65,7 @@ export const TagForm = ({ setSelectedAction }) => {
             dispatch(machineActions.tag(machine.system_id, values.tags));
           });
         }
-        setSelectedAction(null);
+        setProcessing(true);
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.test.js
@@ -13,12 +13,21 @@ describe("TagForm", () => {
   let initialState;
   beforeEach(() => {
     initialState = {
+      general: {
+        machineActions: {
+          data: [{ name: "tag", sentence: "tag" }],
+        },
+      },
       machine: {
         errors: {},
         loading: false,
         loaded: true,
         items: [{ system_id: "abc123" }, { system_id: "def456" }],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       tag: {
         errors: {},
@@ -87,5 +96,30 @@ describe("TagForm", () => {
         },
       },
     ]);
+  });
+
+  it("can show the status when processing machines", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TagForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          tags: [{ name: "tag1" }, { name: "tag2" }],
+        })
+    );
+    wrapper.update();
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.js
@@ -18,6 +18,10 @@ describe("TagFormFields", () => {
         loaded: true,
         items: [{ system_id: "abc123" }, { system_id: "def456" }],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       tag: {
         errors: {},

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
@@ -1,5 +1,5 @@
 import pluralize from "pluralize";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -13,6 +13,7 @@ import {
 } from "app/base/selectors";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
+import MachinesProcessing from "../MachinesProcessing";
 import TestFormFields from "./TestFormFields";
 
 const TestFormSchema = Yup.object().shape({
@@ -32,12 +33,12 @@ const TestFormSchema = Yup.object().shape({
 
 export const TestForm = ({ setSelectedAction }) => {
   const dispatch = useDispatch();
-
+  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
-
+  const testingSelected = useSelector(machineSelectors.testingSelected);
   const scripts = useSelector(scriptSelectors.testing);
   const urlScripts = useSelector(scriptSelectors.testingWithUrl);
   const formattedScripts = scripts.map((script) => ({
@@ -61,6 +62,17 @@ export const TestForm = ({ setSelectedAction }) => {
   useEffect(() => {
     dispatch(scriptActions.fetch());
   }, [dispatch]);
+
+  if (processing) {
+    return (
+      <MachinesProcessing
+        machinesProcessing={testingSelected}
+        setProcessing={setProcessing}
+        setSelectedAction={setSelectedAction}
+        action="test"
+      />
+    );
+  }
 
   return (
     <FormikForm
@@ -96,7 +108,7 @@ export const TestForm = ({ setSelectedAction }) => {
             )
           );
         });
-        setSelectedAction(null);
+        setProcessing(true);
       }}
       saving={saving}
       saved={saved}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.test.js
@@ -13,12 +13,21 @@ describe("TestForm", () => {
   let initialState;
   beforeEach(() => {
     initialState = {
+      general: {
+        machineActions: {
+          data: [{ name: "test", sentence: "test" }],
+        },
+      },
       machine: {
         errors: {},
         loading: false,
         loaded: true,
         items: [{ system_id: "abc123" }, { system_id: "def456" }],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       scripts: {
         errors: {},
@@ -126,5 +135,34 @@ describe("TestForm", () => {
         },
       },
     ]);
+  });
+
+  it("can show the status when processing machines", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TestForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          enableSSH: true,
+          scripts: state.scripts.items,
+          scriptInputs: {
+            "internet-connectivity": "https://connectivity-check.ubuntu.com",
+          },
+        })
+    );
+    wrapper.update();
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.js
@@ -19,6 +19,10 @@ describe("TestForm", () => {
         loaded: true,
         items: [{ system_id: "abc123" }, { system_id: "def456" }],
         selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
       },
       scripts: {
         errors: {},


### PR DESCRIPTION
## Done
- Display processing state for remaining actions in the take action menu.

## QA
- Open the machine list.
- Select some machines and use the take action menu to do different actions.
- Each action should show the processing status of the machines.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1010.