### PR TITLE
Enable production react profiling.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "start": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts start",
     "serve": "yarn run start",
-    "build": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts build",
+    "build": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-scripts build --profile",
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
     "postbuild": "mkdir -p dist && tar -C build -czvf dist/maas-ui-v$npm_package_version.tar.gz .",
     "test": "react-scripts test",


### PR DESCRIPTION
## Done
* Enable [production react profiling](https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977) temporarily in production. 

I've created a [corresponding issue](https://github.com/canonical-web-and-design/MAAS-squad/issues/1887) for disabling profile before release.
