### PR TITLE
Fix machine list checkbox behaviour.

### DIFF
--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
@@ -24,7 +24,7 @@ const getErrorSentence = (action, count) => {
     case "lock":
       return `${machineString} cannot be locked`;
     case "override-failed-testing":
-      return `Cannot override failed tests on ${machineString}.`;
+      return `Cannot override failed tests on ${machineString}`;
     case "rescue-mode":
       return `${machineString} cannot be put in rescue mode`;
     case "set-pool":

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.js
@@ -25,7 +25,7 @@ const FabricColumn = ({ onToggleMenu, systemId }) => {
           hidePassedIcon
           hideNotRunIcon
           scriptType={machine.network_test_status}
-          tooltipPosition="top-right"
+          tooltipPosition="top-left"
         >
           {fabricName ? (
             <a

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.js.snap
@@ -15,7 +15,7 @@ exports[`FabricColumn renders 1`] = `
             "status": 1,
           }
         }
-        tooltipPosition="top-right"
+        tooltipPosition="top-left"
       >
         <a
           className="p-link--soft"
@@ -57,7 +57,7 @@ exports[`FabricColumn renders 1`] = `
                   "status": 1,
                 }
               }
-              tooltipPosition="top-right"
+              tooltipPosition="top-left"
             >
               <i
                 className="p-icon--running is-inline"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -530,10 +530,13 @@ const MachineListTable = ({
               content: (
                 <div className="u-equal-height u-nudge--checkbox">
                   <Input
-                    checked={checkboxChecked(machines, selectedMachines)}
+                    checked={
+                      checkboxChecked(machines, selectedMachines) &&
+                      machines.length !== 0
+                    }
                     className="has-inline-label"
                     data-test="all-machines-checkbox"
-                    disabled={false}
+                    disabled={machines.length === 0}
                     id="all-machines-checkbox"
                     label={" "}
                     onChange={() => handleAllCheckbox()}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
@@ -695,5 +695,35 @@ describe("MachineListTable", () => {
         payload: [],
       });
     });
+
+    it("disables checkbox in header row if there are no machines", () => {
+      const state = { ...initialState };
+      state.machine.items = [];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <MachineListTable
+              filter=""
+              grouping="status"
+              hiddenGroups={[]}
+              setHiddenGroups={jest.fn()}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+      expect(
+        wrapper
+          .find("[data-test='all-machines-checkbox'] input[checked=true]")
+          .exists()
+      ).toBe(false);
+      expect(
+        wrapper
+          .find("[data-test='all-machines-checkbox'] input[disabled]")
+          .exists()
+      ).toBe(true);
+    });
   });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -98,35 +98,21 @@ const NameColumn = ({
     ? generateMAC(machine, machineURL)
     : generateFQDN(machine, machineURL);
   const secondaryRow = !showMAC && generateIPAddresses(machine);
-  const canEdit = machine.permissions.includes("edit");
-  const checkbox = (
-    <Input
-      checked={selected}
-      className="has-inline-label keep-label-opacity"
-      disabled={!canEdit}
-      id={systemId}
-      label={primaryRow}
-      onChange={() => handleCheckbox(machine)}
-      type="checkbox"
-      wrapperClassName="u-no-margin--bottom"
-    />
-  );
 
   return (
     <DoubleRow
       data-test="name-column"
       onToggleMenu={onToggleMenu}
       primary={
-        canEdit ? (
-          checkbox
-        ) : (
-          <Tooltip
-            message="You do not have permission to edit this machine."
-            position="top-left"
-          >
-            {checkbox}
-          </Tooltip>
-        )
+        <Input
+          checked={selected}
+          className="has-inline-label keep-label-opacity"
+          id={systemId}
+          label={primaryRow}
+          onChange={() => handleCheckbox(machine)}
+          type="checkbox"
+          wrapperClassName="u-no-margin--bottom"
+        />
       }
       primaryTextClassName="u-nudge--checkbox"
       secondary={secondaryRow}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
@@ -250,33 +250,4 @@ describe("NameColumn", () => {
     );
     expect(wrapper.find("Input").props().checked).toBe(true);
   });
-
-  it(`disables checkbox and shows tooltip if machine does not
-    have edit permission`, () => {
-    state.machine.items[0] = {
-      domain: {
-        name: "example",
-      },
-      hostname: "koala",
-      permissions: [],
-      system_id: "abc123",
-    };
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <NameColumn
-            handleCheckbox={jest.fn()}
-            selected
-            showMAC={true}
-            systemId="abc123"
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Input").props().disabled).toBe(true);
-    expect(wrapper.find("Tooltip").exists()).toBe(true);
-  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -9,7 +9,6 @@ exports[`NameColumn renders 1`] = `
     primary={
       <Input
         className="has-inline-label keep-label-opacity"
-        disabled={false}
         id="abc123"
         label={
           <a
@@ -47,7 +46,6 @@ exports[`NameColumn renders 1`] = `
           >
             <Input
               className="has-inline-label keep-label-opacity"
-              disabled={false}
               id="abc123"
               label={
                 <a
@@ -92,7 +90,6 @@ exports[`NameColumn renders 1`] = `
                   >
                     <input
                       className="p-form-validation__input has-inline-label keep-label-opacity"
-                      disabled={false}
                       id="abc123"
                       onChange={[Function]}
                       type="checkbox"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
@@ -18,17 +18,24 @@ const PoolColumn = ({ onToggleMenu, systemId }) => {
     machineSelectors.getBySystemId(state, systemId)
   );
   const resourcePools = useSelector(resourcePoolSelectors.all);
-  let pools = resourcePools
-    .filter((pool) => pool.id !== machine.pool.id)
-    .map((pool) => ({
-      children: pool.name,
-      onClick: () => {
-        dispatch(machineActions.setPool(systemId, pool.id));
-        setUpdating(pool.id);
-      },
-    }));
-  if (pools.length === 0) {
-    pools = [{ children: "No other pools available", disabled: true }];
+
+  let poolLinks = resourcePools.filter((pool) => pool.id !== machine.pool.id);
+  if (machine.actions.includes("set-pool")) {
+    if (poolLinks.length !== 0) {
+      poolLinks = poolLinks.map((pool) => ({
+        children: pool.name,
+        onClick: () => {
+          dispatch(machineActions.setPool(systemId, pool.id));
+          setUpdating(pool.id);
+        },
+      }));
+    } else {
+      poolLinks = [{ children: "No other pools available", disabled: true }];
+    }
+  } else {
+    poolLinks = [
+      { children: "Cannot change pool of this machine", disabled: true },
+    ];
   }
 
   useEffect(() => {
@@ -39,7 +46,7 @@ const PoolColumn = ({ onToggleMenu, systemId }) => {
 
   return (
     <DoubleRow
-      menuLinks={pools}
+      menuLinks={poolLinks}
       menuTitle="Change pool:"
       onToggleMenu={onToggleMenu}
       primary={

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
@@ -25,6 +25,7 @@ describe("PoolColumn", () => {
             system_id: "abc123",
             pool: { id: 0, name: "default" },
             description: "Firmware old",
+            actions: ["set-pool"],
           },
         ],
       },
@@ -112,6 +113,26 @@ describe("PoolColumn", () => {
     expect(items.length).toBe(1);
     expect(items[0]).toStrictEqual({
       children: "No other pools available",
+      disabled: true,
+    });
+  });
+
+  it("displays a message if the machine cannot have its pool changed", () => {
+    state.machine.items[0].actions = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PoolColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    const items = wrapper.find("DoubleRow").prop("menuLinks");
+    expect(items.length).toBe(1);
+    expect(items[0]).toStrictEqual({
+      children: "Cannot change pool of this machine",
       disabled: true,
     });
   });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
@@ -31,17 +31,24 @@ const ZoneColumn = ({ onToggleMenu, systemId }) => {
     machineSelectors.getBySystemId(state, systemId)
   );
   const zones = useSelector(zoneSelectors.all);
-  let zoneLinks = zones
-    .filter((zone) => zone.id !== machine.zone.id)
-    .map((zone) => ({
-      children: zone.name,
-      onClick: () => {
-        dispatch(machineActions.setZone(systemId, zone.id));
-        setUpdating(zone.id);
-      },
-    }));
-  if (zoneLinks.length === 0) {
-    zoneLinks = [{ children: "No other zones available", disabled: true }];
+
+  let zoneLinks = zones.filter((zone) => zone.id !== machine.zone.id);
+  if (machine.actions.includes("set-zone")) {
+    if (zoneLinks.length !== 0) {
+      zoneLinks = zoneLinks.map((zone) => ({
+        children: zone.name,
+        onClick: () => {
+          dispatch(machineActions.setZone(systemId, zone.id));
+          setUpdating(zone.id);
+        },
+      }));
+    } else {
+      zoneLinks = [{ children: "No other zones available", disabled: true }];
+    }
+  } else {
+    zoneLinks = [
+      { children: "Cannot change zone of this machine", disabled: true },
+    ];
   }
 
   useEffect(() => {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
@@ -25,6 +25,7 @@ describe("ZoneColumn", () => {
             system_id: "abc123",
             zone: { name: "zone-north", id: 0 },
             spaces: ["management"],
+            actions: ["set-zone"],
           },
         ],
       },
@@ -123,6 +124,26 @@ describe("ZoneColumn", () => {
     expect(wrapper.find("Tooltip").prop("message")).toEqual(
       "space1\nspace2\nspace3"
     );
+  });
+
+  it("displays a message if the machine cannot have its zone changed", () => {
+    state.machine.items[0].actions = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ZoneColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    const items = wrapper.find("DoubleRow").prop("menuLinks");
+    expect(items.length).toBe(1);
+    expect(items[0]).toStrictEqual({
+      children: "Cannot change zone of this machine",
+      disabled: true,
+    });
   });
 
   it("can change zones", () => {

--- a/ui/src/scss/_patterns_buttons.scss
+++ b/ui/src/scss/_patterns_buttons.scss
@@ -31,6 +31,10 @@
       text-decoration: underline;
     }
 
+    &.is-inline {
+      margin: 0;
+    }
+
     // Table header sort buttons
     th & {
       color: $color-mid-dark;


### PR DESCRIPTION
## Done
- Disabled all machine checkbox if there are not machines in the list.
- Removed all instances of machine list checkboxes being disabled.
- Filter out zone and pool in-table actions if they can't be performed on the machine.
- Removed `p-button--link is-inline` margin so the "Update your selection" text doesn't look weird.
- Removed extra "." in override failed test message.
- Fixed wonky fabric test failed tooltip.

## QA
- Lock a machine
- Check that the in-table action for pool and zone have a message saying you can't change them
- Check that you can still select the machine and unlock it from the in-table action and global action menu.
- Select a bunch of machines that aren't all "Failed testing" and choose "Override failed testing" from the global take action menu.
- Check that the "Update your selection" text looks good.
- Filter all machines and check that the all checkbox is unchecked and disabled.

## Fixes
Fixes #972 
Fixes #1006 
Fixes #1014
Fixes #1024  