### PR TITLE
Enable legacy machine listing route

### DIFF
--- a/legacy/src/app/directives/machines_table.js
+++ b/legacy/src/app/directives/machines_table.js
@@ -91,7 +91,7 @@ function maasMachinesTable(
       machineActions: GeneralManager.getData("machine_actions")
     };
 
-    $scope.DISPLAY_LIMIT = $scope.displayLimit || 5;
+    $scope.DISPLAY_LIMIT = $scope.displayLimit || 50;
     $scope.displayLimits = {};
     const groupLabels = [
       "Failed",

--- a/legacy/src/app/directives/machines_table.js
+++ b/legacy/src/app/directives/machines_table.js
@@ -91,7 +91,7 @@ function maasMachinesTable(
       machineActions: GeneralManager.getData("machine_actions")
     };
 
-    $scope.DISPLAY_LIMIT = $scope.displayLimit || 50;
+    $scope.DISPLAY_LIMIT = $scope.displayLimit || 1000;
     $scope.displayLimits = {};
     const groupLabels = [
       "Failed",

--- a/legacy/src/app/routes.js
+++ b/legacy/src/app/routes.js
@@ -26,6 +26,10 @@ const configureRoutes = ($routeProvider) => {
       template: introTmpl,
       controller: "IntroController",
     })
+    .when("/machines-legacy", {
+      template: nodesListTmpl,
+      controller: "NodesListController"
+    })
     .when("/intro/user", {
       template: introUserTmpl,
       controller: "IntroUserController",

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -711,7 +711,7 @@ const MachineListTable = ({
               className: "u-align--right",
             },
           ]}
-          paginate={50}
+          paginate={200}
           rows={
             grouping === "none"
               ? generateRows({ machines, selectedMachines, ...rowProps })


### PR DESCRIPTION
## Done
This will be reverted, but I'd like to have parity on the machine listing for production performance profiling on bolla.