### PR TITLE
Add indentation to grouped machine borders.

### DIFF
--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -5,8 +5,23 @@
   $checkbox-offset: 0.1875rem; // Offset checkbox to prevent focus outline truncation
   $grouped-machines-indentation: $box-size + $sph-inner - $checkbox-offset; // Checkbox + label - offset
 
-  .machine-list--grouped .machine-list__machine td:first-child {
-    padding-left: $grouped-machines-indentation;
+  .machine-list--grouped .machine-list__machine {
+    border: 0;
+    position: relative;
+
+    &::after {
+      background-color: $color-mid-light;
+      content: '';
+      height: 1px;
+      left: $grouped-machines-indentation;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    td:first-child {
+      padding-left: $grouped-machines-indentation;
+    }
   }
 
   .machine-list__machine .p-table-menu {


### PR DESCRIPTION
## Done
- Add indentation to machine rows that are in a group.

## QA
- Check the grouped machine borders are indented.

## Fixes
Fixes #1027 

## Screenshot
![Screenshot_2020-04-24 Machines bolla MAAS(2)](https://user-images.githubusercontent.com/25733845/80184580-3439dd80-864e-11ea-848e-6578cda69a71.png)

