### PR TITLE
Fix the table row borders in Chrome

### DIFF
--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -8,10 +8,11 @@
   .machine-list--grouped .machine-list__machine {
     border: 0;
     position: relative;
+    transform: scale(1);
 
     &::after {
       background-color: $color-mid-light;
-      content: '';
+      content: "";
       height: 1px;
       left: $grouped-machines-indentation;
       position: absolute;


### PR DESCRIPTION
## Done
Setting an element with display table properties to `position: relative;` in Chrome is invalid. But, works in FF. 

## QA
* Run the UI in Chrome
* See that the borders render in the correct place
* Check it in FF and other browsers
* See that they continue to work

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-ui/issues/1034
