### PR TITLE
Add tooltips to truncated content

### DIFF
--- a/ui/src/app/base/components/DoubleRow/DoubleRow.js
+++ b/ui/src/app/base/components/DoubleRow/DoubleRow.js
@@ -17,9 +17,11 @@ const DoubleRow = ({
   primaryAriaLabel,
   primaryClassName,
   primaryTextClassName,
+  primaryTitle,
   secondary,
   secondaryAriaLabel,
   secondaryClassName,
+  secondaryTitle,
 }) => {
   const parent = useRef(null);
   const hasIcon = icon || iconSpace;
@@ -50,6 +52,7 @@ const DoubleRow = ({
               "p-double-row__primary-row-text u-truncate",
               primaryTextClassName
             )}
+            title={primaryTitle}
           >
             {primary}
           </div>
@@ -71,6 +74,7 @@ const DoubleRow = ({
               secondaryClassName
             )}
             aria-label={secondaryAriaLabel}
+            title={secondaryTitle}
           >
             {secondary}
           </div>
@@ -92,9 +96,11 @@ DoubleRow.propTypes = {
   primaryAriaLabel: PropTypes.string,
   primaryClassName: PropTypes.string,
   primaryTextClassName: PropTypes.string,
+  primaryTitle: PropTypes.string,
   secondary: PropTypes.node,
   secondaryAriaLabel: PropTypes.string,
   secondaryClassName: PropTypes.string,
+  secondaryTitle: PropTypes.string,
 };
 
 export default DoubleRow;

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.js
@@ -40,8 +40,10 @@ const FabricColumn = ({ onToggleMenu, systemId }) => {
         </ScriptStatus>
       }
       primaryAriaLabel="Fabric"
+      primaryTitle={fabricName}
       secondary={<span data-test="vlan">{vlan}</span>}
       secondaryAriaLabel="VLAN"
+      secondaryTitle={vlan}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/__snapshots__/FabricColumn.test.js.snap
@@ -26,6 +26,7 @@ exports[`FabricColumn renders 1`] = `
       </ScriptStatus>
     }
     primaryAriaLabel="Fabric"
+    primaryTitle="fabric-0"
     secondary={
       <span
         data-test="vlan"
@@ -34,6 +35,7 @@ exports[`FabricColumn renders 1`] = `
       </span>
     }
     secondaryAriaLabel="VLAN"
+    secondaryTitle="Default VLAN"
   >
     <div
       className="p-double-row"
@@ -47,6 +49,7 @@ exports[`FabricColumn renders 1`] = `
         >
           <div
             className="p-double-row__primary-row-text u-truncate"
+            title="fabric-0"
           >
             <ScriptStatus
               data-test="fabric"
@@ -74,6 +77,7 @@ exports[`FabricColumn renders 1`] = `
         <div
           aria-label="VLAN"
           className="p-double-row__secondary-row u-truncate"
+          title="Default VLAN"
         >
           <span
             data-test="vlan"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -40,7 +40,10 @@ const generateIPAddresses = (machine) => {
 
   if (ipAddresses.length) {
     let ipAddressesLine = (
-      <span data-test="ip-addresses" title={ipAddresses[0]}>
+      <span
+        data-test="ip-addresses"
+        title={ipAddresses.length === 1 ? ipAddresses[0] : null}
+      >
         {bootIP || ipAddresses[0]}
         {ipAddresses.length > 1 ? ` (+${ipAddresses.length - 1})` : null}
       </span>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -40,7 +40,7 @@ const generateIPAddresses = (machine) => {
 
   if (ipAddresses.length) {
     let ipAddressesLine = (
-      <span data-test="ip-addresses">
+      <span data-test="ip-addresses" title={ipAddresses[0]}>
         {bootIP || ipAddresses[0]}
         {ipAddresses.length > 1 ? ` (+${ipAddresses.length - 1})` : null}
       </span>
@@ -111,7 +111,7 @@ const NameColumn = ({
           label={primaryRow}
           onChange={() => handleCheckbox(machine)}
           type="checkbox"
-          wrapperClassName="u-no-margin--bottom"
+          wrapperClassName="u-no-margin--bottom machine-list--inline-input"
         />
       }
       primaryTextClassName="u-nudge--checkbox"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -25,7 +25,7 @@ exports[`NameColumn renders 1`] = `
         }
         onChange={[Function]}
         type="checkbox"
-        wrapperClassName="u-no-margin--bottom"
+        wrapperClassName="u-no-margin--bottom machine-list--inline-input"
       />
     }
     primaryTextClassName="u-nudge--checkbox"
@@ -62,10 +62,10 @@ exports[`NameColumn renders 1`] = `
               }
               onChange={[Function]}
               type="checkbox"
-              wrapperClassName="u-no-margin--bottom"
+              wrapperClassName="u-no-margin--bottom machine-list--inline-input"
             >
               <Field
-                className="u-no-margin--bottom"
+                className="u-no-margin--bottom machine-list--inline-input"
                 forId="abc123"
                 label={
                   <a
@@ -83,7 +83,7 @@ exports[`NameColumn renders 1`] = `
                 labelFirst={false}
               >
                 <div
-                  className="p-form__group p-form-validation u-no-margin--bottom"
+                  className="p-form__group p-form-validation u-no-margin--bottom machine-list--inline-input"
                 >
                   <div
                     className="p-form__control u-clearfix"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
@@ -44,11 +44,13 @@ const OwnerColumn = ({ onToggleMenu, systemId }) => {
           <span data-test="owner">{owner}</span>
         </>
       }
+      primaryTitle={owner}
       secondary={
         <span title={tags} data-test="tags">
           {tags}
         </span>
       }
+      secondaryTitle={tags}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -23,6 +23,7 @@ exports[`OwnerColumn renders 1`] = `
         </span>
       </React.Fragment>
     }
+    primaryTitle="admin"
     secondary={
       <span
         data-test="tags"
@@ -31,6 +32,7 @@ exports[`OwnerColumn renders 1`] = `
         
       </span>
     }
+    secondaryTitle=""
   >
     <div
       className="p-double-row"
@@ -43,6 +45,7 @@ exports[`OwnerColumn renders 1`] = `
         >
           <div
             className="p-double-row__primary-row-text u-truncate"
+            title="admin"
           >
             <span
               data-test="owner"
@@ -66,6 +69,7 @@ exports[`OwnerColumn renders 1`] = `
                 >
                   <div
                     class="p-double-row__primary-row-text u-truncate"
+                    title="admin"
                   >
                     <span
                       data-test="owner"
@@ -112,6 +116,7 @@ exports[`OwnerColumn renders 1`] = `
                   >
                     <div
                       class="p-double-row__primary-row-text u-truncate"
+                      title="admin"
                     >
                       <span
                         data-test="owner"
@@ -169,6 +174,7 @@ exports[`OwnerColumn renders 1`] = `
         </div>
         <div
           className="p-double-row__secondary-row u-truncate"
+          title=""
         >
           <span
             data-test="tags"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
@@ -60,12 +60,14 @@ const PoolColumn = ({ onToggleMenu, systemId }) => {
         </span>
       }
       primaryAriaLabel="Pool"
+      primaryTitle={machine.pool.name}
       secondary={
         <span title={machine.description} data-test="note">
           {machine.description}
         </span>
       }
       secondaryAriaLabel="Note"
+      secondaryTitle={machine.description}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -27,6 +27,7 @@ exports[`PoolColumn renders 1`] = `
       </span>
     }
     primaryAriaLabel="Pool"
+    primaryTitle="default"
     secondary={
       <span
         data-test="note"
@@ -36,6 +37,7 @@ exports[`PoolColumn renders 1`] = `
       </span>
     }
     secondaryAriaLabel="Note"
+    secondaryTitle="Firmware old"
   >
     <div
       className="p-double-row"
@@ -49,6 +51,7 @@ exports[`PoolColumn renders 1`] = `
         >
           <div
             className="p-double-row__primary-row-text u-truncate"
+            title="default"
           >
             <span
               data-test="pool"
@@ -90,6 +93,7 @@ exports[`PoolColumn renders 1`] = `
                 >
                   <div
                     class="p-double-row__primary-row-text u-truncate"
+                    title="default"
                   >
                     <span
                       data-test="pool"
@@ -142,6 +146,7 @@ exports[`PoolColumn renders 1`] = `
                   >
                     <div
                       class="p-double-row__primary-row-text u-truncate"
+                      title="default"
                     >
                       <span
                         data-test="pool"
@@ -205,6 +210,7 @@ exports[`PoolColumn renders 1`] = `
         <div
           aria-label="Note"
           className="p-double-row__secondary-row u-truncate"
+          title="Firmware old"
         >
           <span
             data-test="note"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
@@ -106,6 +106,7 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
           {powerState}
         </div>
       }
+      primaryTitle={powerState}
       secondary={
         <div
           className="u-upper-case--first"
@@ -115,6 +116,7 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
           {machine.power_type}
         </div>
       }
+      secondaryTitle={machine.power_type}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -35,6 +35,7 @@ exports[`PowerColumn renders 1`] = `
         on
       </div>
     }
+    primaryTitle="on"
     secondary={
       <div
         className="u-upper-case--first"
@@ -44,6 +45,7 @@ exports[`PowerColumn renders 1`] = `
         virsh
       </div>
     }
+    secondaryTitle="virsh"
   >
     <div
       className="p-double-row--with-icon"
@@ -64,6 +66,7 @@ exports[`PowerColumn renders 1`] = `
         >
           <div
             className="p-double-row__primary-row-text u-truncate"
+            title="on"
           >
             <div
               className="u-upper-case--first u-truncate"
@@ -94,6 +97,7 @@ exports[`PowerColumn renders 1`] = `
                 >
                   <div
                     class="p-double-row__primary-row-text u-truncate"
+                    title="on"
                   >
                     <div
                       class="u-upper-case--first u-truncate"
@@ -146,6 +150,7 @@ exports[`PowerColumn renders 1`] = `
                   >
                     <div
                       class="p-double-row__primary-row-text u-truncate"
+                      title="on"
                     >
                       <div
                         class="u-upper-case--first u-truncate"
@@ -204,6 +209,7 @@ exports[`PowerColumn renders 1`] = `
         </div>
         <div
           className="p-double-row__secondary-row u-truncate"
+          title="virsh"
         >
           <div
             className="u-upper-case--first"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
@@ -21,7 +21,11 @@ const getSpaces = (machine) => {
       </Tooltip>
     );
   }
-  return <span data-test="spaces">{machine.spaces[0]}</span>;
+  return (
+    <span data-test="spaces" title={machine.spaces[0]}>
+      {machine.spaces[0]}
+    </span>
+  );
 };
 
 const ZoneColumn = ({ onToggleMenu, systemId }) => {
@@ -75,6 +79,7 @@ const ZoneColumn = ({ onToggleMenu, systemId }) => {
           </a>
         </span>
       }
+      primaryTitle={machine.zone.name}
       secondary={getSpaces(machine)}
     />
   );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -26,9 +26,11 @@ exports[`ZoneColumn renders 1`] = `
         </a>
       </span>
     }
+    primaryTitle="zone-north"
     secondary={
       <span
         data-test="spaces"
+        title="management"
       >
         management
       </span>
@@ -45,6 +47,7 @@ exports[`ZoneColumn renders 1`] = `
         >
           <div
             className="p-double-row__primary-row-text u-truncate"
+            title="zone-north"
           >
             <span
               data-test="zone"
@@ -73,6 +76,7 @@ exports[`ZoneColumn renders 1`] = `
                 >
                   <div
                     class="p-double-row__primary-row-text u-truncate"
+                    title="zone-north"
                   >
                     <span
                       data-test="zone"
@@ -124,6 +128,7 @@ exports[`ZoneColumn renders 1`] = `
                   >
                     <div
                       class="p-double-row__primary-row-text u-truncate"
+                      title="zone-north"
                     >
                       <span
                         data-test="zone"
@@ -189,6 +194,7 @@ exports[`ZoneColumn renders 1`] = `
         >
           <span
             data-test="spaces"
+            title="management"
           >
             management
           </span>

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -116,4 +116,9 @@
   .u-nudge--secondary-row {
     padding-left: $box-size + $sph-inner + $checkbox-offset;
   }
+
+  .machine-list--inline-input .p-form__control,
+  .machine-list--inline-input {
+    display: inline;
+  }
 }


### PR DESCRIPTION
## Done
- Add tooltips to the cell content in the machine list.

## QA
- View the machine list.
- Resize the window to different sizes and look for content that gets truncated.
- Check that the top and bottom rows of the cell content have tooltips .

## Fixes
Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/1913.