### PR TITLE
Add URL field to Commissioning form when selecting internet-test scripts.

### DIFF
--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -132,7 +132,8 @@ machine.commission = (
   updateFirmware,
   configureHBA,
   commissioningScripts,
-  testingScripts
+  testingScripts,
+  scriptInputs
 ) => {
   let formattedCommissioningScripts = [];
   if (commissioningScripts && commissioningScripts.length > 0) {
@@ -155,6 +156,7 @@ machine.commission = (
     commissioning_scripts: formattedCommissioningScripts,
     testing_scripts:
       testingScripts && testingScripts.map((script) => script.id),
+    script_input: scriptInputs,
   });
 };
 

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -209,7 +209,8 @@ describe("machine actions", () => {
         [
           { id: 0, name: "testingScript0" },
           { id: 2, name: "testScript2" },
-        ]
+        ],
+        { testingScript0: { url: "www.url.com" } }
       )
     ).toEqual({
       meta: {
@@ -226,6 +227,7 @@ describe("machine actions", () => {
             skip_storage: false,
             commissioning_scripts: [0, 2, "update_firmware", "configure_hba"],
             testing_scripts: [0, 2],
+            script_input: { testingScript0: { url: "www.url.com" } },
           },
           system_id: "abc123",
         },

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -45,6 +45,7 @@ export const CommissionForm = ({ setSelectedAction }) => {
   const saving = useSelector(machineSelectors.saving);
   const errors = useSelector(machineSelectors.errors);
   const commissioningScripts = useSelector(scriptSelectors.commissioning);
+  const urlScripts = useSelector(scriptSelectors.testingWithUrl);
   const testingScripts = useSelector(scriptSelectors.testing);
   const commissioningSelected = useSelector(
     machineSelectors.commissioningSelected
@@ -64,6 +65,16 @@ export const CommissionForm = ({ setSelectedAction }) => {
       (script) => script.name === "smartctl-validate"
     ),
   ].filter(Boolean);
+  const initialScriptInputs = urlScripts.reduce((scriptInputs, script) => {
+    if (
+      !(script.name in scriptInputs) &&
+      script.parameters &&
+      script.parameters.url
+    ) {
+      scriptInputs[script.name] = { url: script.parameters.url.default };
+    }
+    return scriptInputs;
+  }, {});
 
   useEffect(() => {
     dispatch(scriptActions.fetch());
@@ -97,6 +108,7 @@ export const CommissionForm = ({ setSelectedAction }) => {
         commissioningScripts:
           commissioningScripts.length > 0 ? formattedCommissioningScripts : [],
         testingScripts: preselectedTestingScripts,
+        scriptInputs: initialScriptInputs,
       }}
       submitLabel={`Commission ${selectedMachines.length} ${pluralize(
         "machine",
@@ -118,6 +130,7 @@ export const CommissionForm = ({ setSelectedAction }) => {
           configureHBA,
           commissioningScripts,
           testingScripts,
+          scriptInputs,
         } = values;
         selectedMachines.forEach((machine) => {
           dispatch(
@@ -130,7 +143,8 @@ export const CommissionForm = ({ setSelectedAction }) => {
               updateFirmware,
               configureHBA,
               commissioningScripts,
-              testingScripts
+              testingScripts,
+              scriptInputs
             )
           );
         });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
@@ -82,6 +82,7 @@ describe("CommissionForm", () => {
           configureHBA: true,
           testingScripts: [state.scripts.items[0]],
           commissioningScripts: [state.scripts.items[1]],
+          scriptInputs: { testingScript0: { url: "www.url.com" } },
         })
     );
     expect(
@@ -109,6 +110,7 @@ describe("CommissionForm", () => {
                 "configure_hba",
               ],
               testing_scripts: [state.scripts.items[0].id],
+              script_input: { testingScript0: { url: "www.url.com" } },
             },
             system_id: "abc123",
           },
@@ -134,6 +136,7 @@ describe("CommissionForm", () => {
                 "configure_hba",
               ],
               testing_scripts: [state.scripts.items[0].id],
+              script_input: { testingScript0: { url: "www.url.com" } },
             },
             system_id: "def456",
           },

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
@@ -11,7 +11,10 @@ export const CommissionFormFields = ({
   commissioningScripts,
   testingScripts,
 }) => {
-  const { setFieldValue, values } = useFormikContext();
+  const { handleChange, setFieldValue, values } = useFormikContext();
+  const urlScriptsSelected = values.testingScripts.filter((script) =>
+    Object.keys(script.parameters).some((key) => key === "url")
+  );
 
   return (
     <Row>
@@ -33,6 +36,7 @@ export const CommissionFormFields = ({
         />
         <FormikField
           component={TagSelector}
+          data-test="commissioning-scripts-selector"
           disabled={
             values.commissioningScripts.length === commissioningScripts.length
           }
@@ -48,6 +52,7 @@ export const CommissionFormFields = ({
         />
         <FormikField
           component={TagSelector}
+          data-test="testing-scripts-selector"
           disabled={values.testingScripts.length === testingScripts.length}
           initialSelected={preselectedTesting}
           label="Tests"
@@ -59,6 +64,24 @@ export const CommissionFormFields = ({
           required
           tags={testingScripts}
         />
+        {urlScriptsSelected.map((script) => (
+          <FormikField
+            data-test="url-script-input"
+            help={script.parameters.url.description}
+            key={script.name}
+            label={
+              <span>
+                URL(s) to use for <strong>{script.name}</strong> script
+              </span>
+            }
+            name={`scriptInputs[${script.name}].url`}
+            onChange={(e) => {
+              handleChange(e);
+              setFieldValue(`scriptInputs[${script.name}].url`, e.target.value);
+            }}
+            type="text"
+          />
+        ))}
       </Col>
       <Col size="6">
         <FormikField

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.js
@@ -1,0 +1,88 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import CommissionForm from "../CommissionForm";
+
+const mockStore = configureStore();
+
+describe("CommissionForm", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      machine: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [{ system_id: "abc123" }, { system_id: "def456" }],
+        selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
+      },
+      scripts: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            name: "smartctl-validate",
+            tags: ["commissioning", "storage"],
+            parameters: {
+              storage: {
+                argument_format: "{path}",
+                type: "storage",
+              },
+            },
+            type: 2,
+          },
+          {
+            name: "internet-connectivity",
+            tags: ["internet", "network-validation", "network"],
+            parameters: {
+              url: {
+                default: "https://connectivity-check.ubuntu.com",
+                description:
+                  "A comma seperated list of URLs, IPs, or domains to test if the specified interface has access to. Any protocol supported by curl is support. If no protocol or icmp is given the URL will be pinged.",
+                required: true,
+              },
+            },
+            type: 2,
+          },
+        ],
+      },
+    };
+  });
+
+  it("displays a field for URL if a selected script has url parameter", async () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+        >
+          <CommissionForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='url-script-input']").exists()).toBe(false);
+    await act(async () => {
+      wrapper
+        .find(
+          "[data-test='testing-scripts-selector'] Input .tag-selector__input"
+        )
+        .simulate("focus");
+    });
+    wrapper.update();
+    await act(async () => {
+      wrapper.find('[data-test="existing-tag"]').at(0).simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("[data-test='url-script-input']").exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Done
- Added URL field to Commissioning form when selecting internet-test scripts.

## QA
- Select some machines and choose Commission from the action menu
- Choose an internet-connectivity script from Tests
- Check that a URL field for that test shows up below the script selector
- Submit the form and check that the network request includes:
``` json
{ "script_input": { "the-name-of-the-script": { "url" : "the-url-you-used" } } }
```

## Fixes
Fixes #1031 

## Screenshot
![Screenshot_2020-04-29 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/80567166-f23ade00-8a37-11ea-8959-0caf212b8c7a.png)

