### PR TITLE
Combine available and selected machine strings.

### DIFF
--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -18,6 +18,27 @@ import AddHardwareMenu from "./AddHardwareMenu";
 import HeaderStripTabs from "./HeaderStripTabs";
 import TakeActionMenu from "./TakeActionMenu";
 
+const getMachineCount = (machines, selectedMachines, setSearchFilter) => {
+  const machineCountString = `${machines.length} ${pluralize(
+    "machine",
+    machines.length
+  )}`;
+  if (selectedMachines.length) {
+    if (machines.length === selectedMachines.length) {
+      return "All machines selected";
+    }
+    return (
+      <Button
+        className="p-button--link"
+        onClick={() => setSearchFilter("in:(Selected)")}
+      >
+        {`${selectedMachines.length} of ${machineCountString} selected`}
+      </Button>
+    );
+  }
+  return `${machineCountString} available`;
+};
+
 export const HeaderStrip = ({ searchFilter, setSearchFilter }) => {
   const dispatch = useDispatch();
   const { location } = useLocation();
@@ -63,10 +84,7 @@ export const HeaderStrip = ({ searchFilter, setSearchFilter }) => {
               className="p-inline-list__item last-item u-text--light"
               data-test="machine-count"
             >
-              {`${machines.length} ${pluralize(
-                "machine",
-                machines.length
-              )} available`}
+              {getMachineCount(machines, selectedMachines, setSearchFilter)}
             </li>
           ) : (
             <Spinner
@@ -79,15 +97,6 @@ export const HeaderStrip = ({ searchFilter, setSearchFilter }) => {
         <Switch>
           <Route exact path="/machines">
             <ul className="p-inline-list u-no-margin--bottom">
-              {selectedMachines.length > 0 && (
-                <li
-                  className="p-inline-list__item u-text--light"
-                  data-test="selected-count"
-                >
-                  <span>{`${selectedMachines.length} selected`}</span>
-                  <span className="p-heading--four" />
-                </li>
-              )}
               {!selectedAction && (
                 <>
                   <li className="p-inline-list__item">

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
@@ -5,7 +5,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import { nodeStatus, scriptStatus } from "app/base/enum";
 import HeaderStrip from "./HeaderStrip";
 
 const mockStore = configureStore();
@@ -45,51 +44,11 @@ describe("HeaderStrip", () => {
       machine: {
         errors: {},
         loaded: true,
-        items: [
-          {
-            actions: [],
-            architecture: "amd64/generic",
-            cpu_count: 4,
-            cpu_test_status: {
-              status: scriptStatus.RUNNING,
-            },
-            distro_series: "bionic",
-            domain: {
-              name: "example",
-            },
-            extra_macs: [],
-            hostname: "koala",
-            ip_addresses: [],
-            memory: 8,
-            memory_test_status: {
-              status: scriptStatus.PASSED,
-            },
-            network_test_status: {
-              status: scriptStatus.PASSED,
-            },
-            osystem: "ubuntu",
-            permissions: ["edit", "delete"],
-            physical_disk_count: 1,
-            pool: {},
-            pxe_mac: "00:11:22:33:44:55",
-            spaces: [],
-            status: "Releasing",
-            status_code: nodeStatus.RELEASING,
-            status_message: "",
-            storage: 8,
-            storage_test_status: {
-              status: scriptStatus.PASSED,
-            },
-            testing_status: {
-              status: scriptStatus.PASSED,
-            },
-            system_id: "abc123",
-            zone: {},
-          },
-        ],
+        items: [{ system_id: "abc123" }, { system_id: "def456" }],
         selected: [],
         statuses: {
           abc123: {},
+          def456: {},
         },
       },
       resourcepool: {
@@ -145,7 +104,48 @@ describe("HeaderStrip", () => {
       </Provider>
     );
     expect(wrapper.find('[data-test="machine-count"]').text()).toBe(
-      "1 machine available"
+      "2 machines available"
+    );
+  });
+
+  it("displays a selected machine filter button if some machines have been selected", () => {
+    const state = { ...initialState };
+    state.machine.loaded = true;
+    state.machine.selected = ["abc123"];
+    const setSearchFilter = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip setSearchFilter={setSearchFilter} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="machine-count"]').text()).toBe(
+      "1 of 2 machines selected"
+    );
+    wrapper.find('[data-test="machine-count"] Button').simulate("click");
+    expect(setSearchFilter).toHaveBeenCalledWith("in:(Selected)");
+  });
+
+  it("displays a message when all machines have been selected", () => {
+    const state = { ...initialState };
+    state.machine.loaded = true;
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip setSearchFilter={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="machine-count"]').text()).toBe(
+      "All machines selected"
     );
   });
 


### PR DESCRIPTION
## Done
- Exploration related to https://github.com/canonical-web-and-design/MAAS-squad/issues/1891 and https://github.com/canonical-web-and-design/MAAS-squad/issues/1894
- Changed machines count to read:
  - None selected: "Y machines available"
  - Some selected: "X of Y machines selected" - this is a link that filters to selected when clicked
  - All selected: "All machines selected"

## QA
- See that the text next to machines reads "Y machines available"
- Select some machines and check that the text is now a "button" link that reads "X of Y machines selected"
- Click the button and check the machine list is filtered to selected machines
- Remove filter, select all machines and check that the text reads "All machines selected"

Fixes canonical-web-and-design/MAAS-squad#1891
Fixes canonical-web-and-design/MAAS-squad#1894

## Screenshots
### None
![Screenshot_2020-04-29 Machines bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/80570292-df2b0c80-8a3d-11ea-8d98-f652ac304b81.png)

### Some
![Screenshot_2020-04-29 Machines bolla MAAS(2)](https://user-images.githubusercontent.com/25733845/80570327-e94d0b00-8a3d-11ea-9bad-034adac1d7a0.png)

### Filtered
![Screenshot_2020-04-29 Machines bolla MAAS(3)](https://user-images.githubusercontent.com/25733845/80570340-ed792880-8a3d-11ea-9cf6-28e59c94979b.png)

### All
![Screenshot_2020-04-29 Machines bolla MAAS(4)](https://user-images.githubusercontent.com/25733845/80570352-f10caf80-8a3d-11ea-9796-2935c4f74c0a.png)
