### PR TITLE
Fix edit interface form not being able to edit tags/speeds.

### DIFF
--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -1384,11 +1384,11 @@ export function NodeNetworkingController(
     if (nic.tags) {
       params.tags = nic.tags.map(tag => tag.text);
     }
-    if (nic.link_speed && nic.formatted_link_speed) {
-      params.link_speed = nic.formatted_link_speed * 1000;
+    if (parseInt(nic.formatted_link_speed) >= 0) {
+      params.link_speed = parseInt(nic.formatted_link_speed) * 1000;
     }
-    if (nic.interface_speed && nic.formatted_interface_speed) {
-      params.interface_speed = nic.formatted_interface_speed * 1000;
+    if (parseInt(nic.formatted_interface_speed) >= 0) {
+      params.interface_speed = parseInt(nic.formatted_interface_speed) * 1000;
     }
     return params;
   };

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -1686,7 +1686,7 @@
                                                     <div class="p-form__group row" data-ng-if="!isAllNetworkingDisabled(interface)">
                                                         <label class="p-form__label col-2">Tags</label>
                                                         <div class="p-form__control col-4 tags--inline">
-                                                            <tags-input data-ng-model="interface.tags" allow-tags-pattern="[\w-]+"></tags-input>
+                                                            <tags-input data-ng-model="editInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
                                                         </div>
                                                     </div>
                                                     <div class="p-form__group row p-form-validation" data-ng-class="{ 'is-error': !linkSpeedValid(editInterface) }" data-ng-if="editInterface.type === 'physical'">


### PR DESCRIPTION
## Done
- Fixed some incorrect markup that was making the edit form unusable if the machine had a tag.
- Fixed some incorrect logic that prevented link speeds and interface speeds to be updated in the dit interface form.

## QA
- Go to http://bolla.internal:5240/MAAS/#/machine/t4kwcq?area=network and try to edit the first interface. When you submit the form you should get an error about tags.
- Try to edit the link and interface speeds on the second interface. The form should submit but the values should not be updated.
- Pull this branch and attempt to do the same things on the same machine. Also try to add and remove tags. Everything should work.

## Fixes
Fixes #852 

## Launchpad Issue
[#1864241](https://bugs.launchpad.net/maas/+bug/1864241)
