### PR TITLE
Set public access in publishConfig.

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@canonical/maas-ui-legacy",
   "version": "0.1.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/canonical-web-and-design/maas-ui.git"
   },
   "bugs": "https://github.com/canonical-web-and-design/maas-ui/issues",
   "license": "AGPL-3.0",
-  "private": false,
   "scripts": {
     "build": "NODE_ENV=production webpack -p --config webpack.prod.js",
     "build-dev": "NODE_ENV=development webpack --config webpack.dev.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "maas-ui-monorepo",
   "version": "1.1.1-monorepo",
+  "private": true,
   "scripts": {
     "build": "yarn build-shared",
     "build-all": "yarn clean-all && yarn build-shared && yarn build-legacy && yarn build-ui && yarn copy-build",
@@ -32,7 +33,6 @@
     "test-shared": "cd shared && yarn run test",
     "test": "yarn build-shared && yarn test-legacy && yarn test-ui && yarn test-shared"
   },
-  "private": true,
   "workspaces": {
     "packages": [
       "legacy",

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,9 @@
   "name": "@canonical/maas-ui",
   "version": "1.1.1",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/canonical-web-and-design/maas-ui.git"


### PR DESCRIPTION
## Done
Set public access in publishConfig. 

Making running:

`yarn publish`

equivalent to 

`yarn publish --access public`
