### PR TITLE
Filter select when taking action

### DIFF
--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
@@ -134,7 +134,7 @@ export const ActionForm = ({ selectedAction, setSelectedAction }) => {
         selectedAction.name === "delete" ? "negative" : "positive"
       }
       submitLabel={getSubmitText(selectedAction, selectedMachines.length)}
-      onCancel={() => setSelectedAction(null)}
+      onCancel={() => setSelectedAction(null, true)}
       onSaveAnalytics={{
         action: selectedAction.name,
         category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
@@ -87,7 +87,7 @@ describe("ActionForm", () => {
     );
     wrapper.find('[data-test="cancel-action"] button').simulate("click");
 
-    expect(setSelectedAction).toHaveBeenCalledWith(null);
+    expect(setSelectedAction).toHaveBeenCalledWith(null, true);
   });
 
   it("displays a negative submit button if selected action is delete", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -114,7 +114,7 @@ export const CommissionForm = ({ setSelectedAction }) => {
         "machine",
         selectedMachines.length
       )}`}
-      onCancel={() => setSelectedAction(null)}
+      onCancel={() => setSelectedAction(null, true)}
       onSaveAnalytics={{
         action: "Commission",
         category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
@@ -70,7 +70,7 @@ export const DeployForm = ({ setSelectedAction }) => {
         "machine",
         selectedMachines.length
       )}`}
-      onCancel={() => setSelectedAction(null)}
+      onCancel={() => setSelectedAction(null, true)}
       onSaveAnalytics={{
         action: "Deploy",
         category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -107,7 +107,7 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
         submitLabel={`Override failed tests for ${
           selectedMachines.length
         } ${pluralize("machine", selectedMachines.length)}`}
-        onCancel={() => setSelectedAction(null)}
+        onCancel={() => setSelectedAction(null, true)}
         onSaveAnalytics={{
           action: "Override",
           category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
@@ -70,7 +70,7 @@ export const SetPoolForm = ({ setSelectedAction }) => {
         "machine",
         selectedMachines.length
       )}`}
-      onCancel={() => setSelectedAction(null)}
+      onCancel={() => setSelectedAction(null, true)}
       onSaveAnalytics={{
         action: "Set resource pool",
         category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -59,7 +59,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
         "machine",
         selectedMachines.length
       )}`}
-      onCancel={() => setSelectedAction(null)}
+      onCancel={() => setSelectedAction(null, true)}
       onSaveAnalytics={{
         action: "Set zone",
         category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
@@ -61,7 +61,7 @@ export const TagForm = ({ setSelectedAction }) => {
         "machine",
         selectedMachines.length
       )}`}
-      onCancel={() => setSelectedAction(null)}
+      onCancel={() => setSelectedAction(null, true)}
       onSaveAnalytics={{
         action: "Tag",
         category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
@@ -91,7 +91,7 @@ export const TestForm = ({ setSelectedAction }) => {
         "machine",
         selectedMachines.length
       )}`}
-      onCancel={() => setSelectedAction(null)}
+      onCancel={() => setSelectedAction(null, true)}
       onSaveAnalytics={{
         action: "Test",
         category: "Take action menu",

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -5,6 +5,11 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, Route, Switch } from "react-router-dom";
 
+import {
+  filtersToString,
+  getCurrentFilters,
+  toggleFilter,
+} from "app/machines/search";
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import ActionFormWrapper from "./ActionFormWrapper";
@@ -12,7 +17,7 @@ import AddHardwareMenu from "./AddHardwareMenu";
 import HeaderStripTabs from "./HeaderStripTabs";
 import TakeActionMenu from "./TakeActionMenu";
 
-export const HeaderStrip = () => {
+export const HeaderStrip = ({ searchFilter, setSearchFilter }) => {
   const dispatch = useDispatch();
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
@@ -24,6 +29,21 @@ export const HeaderStrip = () => {
   useEffect(() => {
     dispatch(machineActions.fetch());
   }, [dispatch]);
+
+  const setAction = (action, deselect) => {
+    if (action || deselect) {
+      const filters = getCurrentFilters(searchFilter);
+      const newFilters = toggleFilter(
+        filters,
+        "in",
+        "selected",
+        false,
+        !deselect
+      );
+      setSearchFilter(filtersToString(newFilters));
+    }
+    setSelectedAction(action);
+  };
 
   return (
     <>
@@ -69,7 +89,7 @@ export const HeaderStrip = () => {
                       <AddHardwareMenu disabled={hasSelectedMachines} />
                     </li>
                     <li className="p-inline-list__item last-item">
-                      <TakeActionMenu setSelectedAction={setSelectedAction} />
+                      <TakeActionMenu setSelectedAction={setAction} />
                     </li>
                   </>
                 )}
@@ -86,7 +106,7 @@ export const HeaderStrip = () => {
       {selectedAction && (
         <ActionFormWrapper
           selectedAction={selectedAction}
-          setSelectedAction={setSelectedAction}
+          setSelectedAction={setAction}
         />
       )}
       <HeaderStripTabs />
@@ -95,7 +115,8 @@ export const HeaderStrip = () => {
 };
 
 HeaderStrip.propTypes = {
-  disabled: PropTypes.bool,
+  searchFilter: PropTypes.string,
+  setSearchFilter: PropTypes.func.isRequired,
 };
 
 export default HeaderStrip;

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.test.js
@@ -1,3 +1,4 @@
+import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
@@ -42,6 +43,7 @@ describe("HeaderStrip", () => {
         items: [],
       },
       machine: {
+        errors: {},
         loaded: true,
         items: [
           {
@@ -86,10 +88,16 @@ describe("HeaderStrip", () => {
           },
         ],
         selected: [],
+        statuses: {
+          abc123: {},
+        },
       },
       resourcepool: {
         loaded: false,
-        items: [1, 2],
+        items: [
+          { id: 0, name: "default" },
+          { id: 1, name: "other" },
+        ],
       },
       zone: {
         loaded: true,
@@ -116,7 +124,7 @@ describe("HeaderStrip", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
+          <HeaderStrip setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -132,7 +140,7 @@ describe("HeaderStrip", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
+          <HeaderStrip setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -149,7 +157,7 @@ describe("HeaderStrip", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
+          <HeaderStrip setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -168,7 +176,7 @@ describe("HeaderStrip", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
+          <HeaderStrip setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -185,7 +193,7 @@ describe("HeaderStrip", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <HeaderStrip selectedMachines={[]} setSelectedMachines={jest.fn()} />
+          <HeaderStrip setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -193,5 +201,47 @@ describe("HeaderStrip", () => {
     expect(
       wrapper.find('Button[data-test="add-hardware-dropdown"]').length
     ).toBe(0);
+  });
+
+  it("can add the selected filter when displaying a form", () => {
+    const store = mockStore(initialState);
+    const setSearchFilter = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip setSearchFilter={setSearchFilter} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper
+        .find("TakeActionMenu")
+        .props()
+        .setSelectedAction({ name: "set-pool" })
+    );
+    expect(setSearchFilter).toHaveBeenCalledWith("in:(selected)");
+  });
+
+  it("can remove the selected filter when cancelling a form", () => {
+    const store = mockStore(initialState);
+    const setSearchFilter = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <HeaderStrip
+            searchFilter="in:selected"
+            setSearchFilter={setSearchFilter}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper.find("TakeActionMenu").props().setSelectedAction(null, true)
+    );
+    expect(setSearchFilter).toHaveBeenCalledWith("");
   });
 });

--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -95,19 +95,38 @@ export const isFilterActive = (filters, type, value, exact = false) => {
   return _getFilterValueIndex(filters, type, value) !== -1;
 };
 
-// Toggles a filter on or off based on type and value.
-export const toggleFilter = (filters, type, value, exact) => {
-  if (typeof filters[type] === "undefined") {
-    filters[type] = [];
-  }
+/**
+ * Toggles a filter on or off based on type and value.
+ * @param {Object} filters - The initial filters.
+ * @param {String} type - The filter key.
+ * @param {Any} value - The filter value to toggle.
+ * @param {Boolean} exact - Optional value for whether the value should
+ * exactly match.
+ * @param {Boolean} shouldExist - An optional value for whether the value should
+ * exist or not i.e. if true and the value exists there will be no change and
+ * vice versa.
+ * @returns {Boolean} Tag loading state.
+ */
+export const toggleFilter = (filters, type, value, exact, shouldExist) => {
   if (exact) {
     value = "=" + value;
   }
   const idx = _getFilterValueIndex(filters, type, value);
-  if (idx === -1) {
-    filters[type].push(value);
-  } else {
-    filters[type].splice(idx, 1);
+  const exists = idx !== -1;
+  if (!exists) {
+    if (shouldExist === undefined ? true : shouldExist) {
+      if (typeof filters[type] === "undefined") {
+        filters[type] = [];
+      }
+      filters[type].push(value);
+    }
+  } else if (exists) {
+    if (shouldExist === undefined ? true : !shouldExist) {
+      filters[type].splice(idx, 1);
+      if (filters[type].length === 0) {
+        delete filters[type];
+      }
+    }
   }
   return filters;
 };

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -325,6 +325,32 @@ describe("Search", () => {
         type: ["exists"],
       });
     });
+
+    it("can handle an expected value when it already exists", () => {
+      const filters = {
+        type: ["value"],
+      };
+      expect(toggleFilter(filters, "type", "value", false, true)).toEqual({
+        type: ["value"],
+      });
+    });
+
+    it("can toggle an expected value", () => {
+      const filters = {
+        type: ["value"],
+      };
+      expect(toggleFilter(filters, "type", "value", false, false)).toEqual({});
+    });
+
+    it("can handle an expected false value when it already does not exist", () => {
+      expect(toggleFilter({}, "type", "value", false, false)).toEqual({});
+    });
+
+    it("can toggle an expected false value", () => {
+      expect(toggleFilter({}, "type", "value", false, true)).toEqual({
+        type: ["value"],
+      });
+    });
   });
 
   describe("getEmptyFilter", () => {

--- a/ui/src/app/machines/views/MachineList/MachineList.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.js
@@ -1,26 +1,21 @@
 import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
-import React, { useState } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import { formatErrors } from "app/utils";
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
-import { useLocation, useWindowTitle } from "app/base/hooks";
-import { filtersToString, queryStringToFilters } from "app/machines/search";
+import { useWindowTitle } from "app/base/hooks";
 import MachineListControls from "./MachineListControls";
 import MachineListTable from "./MachineListTable";
 
-const MachineList = () => {
+const MachineList = ({ searchFilter, setSearchFilter }) => {
   useWindowTitle("Machines");
   const dispatch = useDispatch();
-  const { location } = useLocation();
-  const currentFilters = queryStringToFilters(location.search);
   const errors = useSelector(machineSelectors.errors);
   const errorMessage = formatErrors(errors);
-
-  // The filter state is initialised from the URL.
-  const [filter, setFilter] = useState(filtersToString(currentFilters));
   const [grouping, setGrouping] = useStorageState(
     localStorage,
     "grouping",
@@ -43,20 +38,26 @@ const MachineList = () => {
         </Notification>
       ) : null}
       <MachineListControls
-        filter={filter}
+        filter={searchFilter}
         grouping={grouping}
-        setFilter={setFilter}
+        setFilter={setSearchFilter}
         setGrouping={setGrouping}
         setHiddenGroups={setHiddenGroups}
       />
       <MachineListTable
-        filter={filter}
+        filter={searchFilter}
         grouping={grouping}
         hiddenGroups={hiddenGroups}
+        setSearchFilter={setSearchFilter}
         setHiddenGroups={setHiddenGroups}
       />
     </>
   );
+};
+
+MachineList.propTypes = {
+  searchFilter: PropTypes.string,
+  setSearchFilter: PropTypes.func.isRequired,
 };
 
 export default MachineList;

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -1,4 +1,3 @@
-import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
@@ -6,7 +5,6 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import MachineList from "./MachineList";
-import { DEBOUNCE_INTERVAL } from "./MachineListControls";
 import { nodeStatus, scriptStatus } from "app/base/enum";
 
 const mockStore = configureStore();
@@ -212,7 +210,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -220,22 +218,6 @@ describe("MachineList", () => {
     // The machine list should also be visible as the machines are
     // loaded in batches.
     expect(wrapper.find("Memo(MachineListTable)").exists()).toBe(true);
-  });
-
-  it("can set the search from the URL", () => {
-    const store = mockStore(initialState);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machines", search: "?q=test+search", key: "testKey" },
-          ]}
-        >
-          <MachineList />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("SearchBox").prop("value")).toBe("test search");
   });
 
   it("can filter groups", () => {
@@ -246,7 +228,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -265,7 +247,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -290,7 +272,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -311,7 +293,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -329,7 +311,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -344,7 +326,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -360,7 +342,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -377,7 +359,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -396,7 +378,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -415,7 +397,7 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList setSearchFilter={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -433,15 +415,13 @@ describe("MachineList", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <MachineList />
+          <MachineList
+            searchFilter="this does not match anything"
+            setSearchFilter={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
-    act(() => {
-      wrapper.find("SearchBox").props().onChange("no-machines");
-      jest.advanceTimersByTime(DEBOUNCE_INTERVAL);
-    });
-    wrapper.update();
     expect(wrapper.find("Strip span").text()).toBe(
       "No machines match the search criteria."
     );

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.js
@@ -1,5 +1,5 @@
 import { act } from "react-dom/test-utils";
-import { MemoryRouter, Route } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -29,9 +29,9 @@ describe("MachineListControls", () => {
     localStorage.clear();
   });
 
-  it("changes the URL when the search text changes, after the debounce interval", () => {
-    let location;
+  it("changes the filter when the search text changes, after the debounce interval", () => {
     const store = mockStore(initialState);
+    const setFilter = jest.fn();
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
@@ -42,16 +42,9 @@ describe("MachineListControls", () => {
           <MachineListControls
             filter=""
             grouping="none"
-            setFilter={jest.fn()}
+            setFilter={setFilter}
             setGrouping={jest.fn()}
             setHiddenGroups={jest.fn()}
-          />
-          <Route
-            path="*"
-            render={(props) => {
-              location = props.location;
-              return null;
-            }}
           />
         </MemoryRouter>
       </Provider>
@@ -59,16 +52,16 @@ describe("MachineListControls", () => {
     act(() => {
       wrapper.find("SearchBox").props().onChange("status:new");
     });
+    expect(setFilter).not.toHaveBeenCalled();
     act(() => {
       jest.advanceTimersByTime(DEBOUNCE_INTERVAL);
     });
-    wrapper.update();
-    expect(location.search).toBe("?status=new");
+    expect(setFilter).toHaveBeenCalledWith("status:new");
   });
 
-  it("changes the URL when the filter accordion changes", () => {
-    let location;
+  it("changes the filter when the filter accordion changes", () => {
     const store = mockStore(initialState);
+    const setFilter = jest.fn();
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
@@ -79,16 +72,9 @@ describe("MachineListControls", () => {
           <MachineListControls
             filter=""
             grouping="none"
-            setFilter={jest.fn()}
+            setFilter={setFilter}
             setGrouping={jest.fn()}
             setHiddenGroups={jest.fn()}
-          />
-          <Route
-            path="*"
-            render={(props) => {
-              location = props.location;
-              return null;
-            }}
           />
         </MemoryRouter>
       </Provider>
@@ -96,8 +82,7 @@ describe("MachineListControls", () => {
     act(() => {
       wrapper.find("FilterAccordion").props().setSearchText("status:new");
     });
-    wrapper.update();
-    expect(location.search).toBe("?status=new");
+    expect(setFilter).toHaveBeenCalledWith("status:new");
   });
 
   it("displays a spinner while debouncing search box input", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -13,6 +13,11 @@ import React, { useEffect, useMemo, useState } from "react";
 import pluralize from "pluralize";
 
 import {
+  filtersToString,
+  getCurrentFilters,
+  toggleFilter,
+} from "app/machines/search";
+import {
   general as generalActions,
   machine as machineActions,
   resourcepool as resourcePoolActions,
@@ -411,6 +416,7 @@ export const MachineListTable = ({
   grouping,
   hiddenGroups,
   setHiddenGroups,
+  setSearchFilter,
 }) => {
   const dispatch = useDispatch();
   const selectedMachines = useSelector(machineSelectors.selected);
@@ -429,6 +435,11 @@ export const MachineListTable = ({
     grouping,
     machines,
   ]);
+  const removeSelectedFilter = () => {
+    const filters = getCurrentFilters(filter);
+    const newFilters = toggleFilter(filters, "in", "selected", false, false);
+    setSearchFilter(filtersToString(newFilters));
+  };
 
   useEffect(() => {
     dispatch(generalActions.fetchArchitectures());
@@ -469,6 +480,9 @@ export const MachineListTable = ({
     } else {
       newSelectedMachines = [...selectedMachines, machine];
     }
+    if (newSelectedMachines.length === 0) {
+      removeSelectedFilter();
+    }
     dispatch(machineActions.setSelected(newSelectedMachines));
   };
 
@@ -497,6 +511,9 @@ export const MachineListTable = ({
         [...selectedMachines]
       );
     }
+    if (newSelectedMachines.length === 0) {
+      removeSelectedFilter();
+    }
     dispatch(machineActions.setSelected(newSelectedMachines));
   };
 
@@ -504,6 +521,7 @@ export const MachineListTable = ({
     let newSelectedMachines;
     if (checkboxChecked(machines, selectedMachines)) {
       newSelectedMachines = [];
+      removeSelectedFilter();
     } else {
       newSelectedMachines = machines;
     }
@@ -743,6 +761,7 @@ MachineListTable.propTypes = {
   hiddenGroups: PropTypes.arrayOf(PropTypes.string),
   filter: PropTypes.string,
   setHiddenGroups: PropTypes.func,
+  setSearchFilter: PropTypes.func.isRequired,
 };
 
 export default React.memo(MachineListTable);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
@@ -209,6 +209,7 @@ describe("MachineListTable", () => {
             grouping="status"
             hiddenGroups={[]}
             setHiddenGroups={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -235,6 +236,7 @@ describe("MachineListTable", () => {
             grouping="status"
             hiddenGroups={[]}
             setHiddenGroups={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -274,6 +276,7 @@ describe("MachineListTable", () => {
             grouping="none"
             hiddenGroups={[]}
             setHiddenGroups={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -323,6 +326,7 @@ describe("MachineListTable", () => {
             grouping="none"
             hiddenGroups={[]}
             setHiddenGroups={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -402,6 +406,7 @@ describe("MachineListTable", () => {
             grouping="status"
             hiddenGroups={[]}
             setHiddenGroups={jest.fn()}
+            setSearchFilter={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
@@ -429,6 +434,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -453,6 +459,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -477,6 +484,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -500,6 +508,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -535,6 +544,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -570,6 +580,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -605,6 +616,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -640,6 +652,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -675,6 +688,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -710,6 +724,7 @@ describe("MachineListTable", () => {
               grouping="status"
               hiddenGroups={[]}
               setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
             />
           </MemoryRouter>
         </Provider>
@@ -725,5 +740,92 @@ describe("MachineListTable", () => {
           .exists()
       ).toBe(true);
     });
+  });
+
+  it("remove selected filter when unchecking the only checked machine", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const setSearchFilter = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineListTable
+            filter="in:selected"
+            grouping="status"
+            hiddenGroups={[]}
+            setHiddenGroups={jest.fn()}
+            setSearchFilter={setSearchFilter}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("[data-test='name-column'] input")
+      .at(0)
+      .simulate("change", {
+        target: { name: state.machine.items[0].system_id },
+      });
+    expect(setSearchFilter).toHaveBeenCalledWith("");
+  });
+
+  it("remove selected filter when unchecking the only checked group", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const setSearchFilter = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineListTable
+            filter="in:selected"
+            grouping="status"
+            hiddenGroups={[]}
+            setHiddenGroups={jest.fn()}
+            setSearchFilter={setSearchFilter}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("[data-test='group-cell'] input")
+      .at(0)
+      .simulate("change", {
+        target: { name: state.machine.items[0].system_id },
+      });
+    expect(setSearchFilter).toHaveBeenCalledWith("");
+  });
+
+  it("remove selected filter when unchecking the all machines checkbox", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456", "ghi789"];
+    const store = mockStore(state);
+    const setSearchFilter = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineListTable
+            filter="in:selected"
+            grouping="status"
+            hiddenGroups={[]}
+            setHiddenGroups={jest.fn()}
+            setSearchFilter={setSearchFilter}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("[data-test='all-machines-checkbox'] input")
+      .at(0)
+      .simulate("change", {
+        target: { name: state.machine.items[0].system_id },
+      });
+    expect(setSearchFilter).toHaveBeenCalledWith("");
   });
 });

--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -1,6 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import { Route, Switch } from "react-router-dom";
 
+import { useLocation, useRouter } from "app/base/hooks";
+import {
+  filtersToQueryString,
+  filtersToString,
+  getCurrentFilters,
+  queryStringToFilters,
+} from "app/machines/search";
 import AddChassisForm from "app/machines/views/AddChassis/AddChassisForm";
 import AddMachineForm from "app/machines/views/AddMachine/AddMachineForm";
 import AddRSDForm from "app/machines/views/AddRSD/AddRSDForm";
@@ -12,39 +19,61 @@ import Pools from "app/pools/views/Pools";
 import HeaderStrip from "app/machines/components/HeaderStrip";
 import Section from "app/base/components/Section";
 
-const Machines = () => (
-  <Section
-    headerClassName="u-no-padding--bottom"
-    showDeprecations
-    title={<HeaderStrip />}
-  >
-    <Switch>
-      <Route exact path="/machines">
-        <MachineList />
-      </Route>
-      <Route exact path="/machines/add">
-        <AddMachineForm />
-      </Route>
-      <Route exact path="/machines/chassis/add">
-        <AddChassisForm />
-      </Route>
-      <Route exact path="/machines/rsd/add">
-        <AddRSDForm />
-      </Route>
-      <Route exact path="/pools">
-        <Pools />
-      </Route>
-      <Route exact path="/pools/add">
-        <PoolAdd />
-      </Route>
-      <Route exact path="/pools/:id/edit">
-        <PoolEdit />
-      </Route>
-      <Route path="*">
-        <NotFound />
-      </Route>
-    </Switch>
-  </Section>
-);
+const Machines = () => {
+  const { history } = useRouter();
+  const { location } = useLocation();
+  const currentFilters = queryStringToFilters(location.search);
+  // The filter state is initialised from the URL.
+  const [searchFilter, setFilter] = useState(filtersToString(currentFilters));
+
+  const setSearchFilter = (searchText) => {
+    setFilter(searchText);
+    const filters = getCurrentFilters(searchText);
+    history.push({ search: filtersToQueryString(filters) });
+  };
+
+  return (
+    <Section
+      headerClassName="u-no-padding--bottom"
+      showDeprecations
+      title={
+        <HeaderStrip
+          searchFilter={searchFilter}
+          setSearchFilter={setSearchFilter}
+        />
+      }
+    >
+      <Switch>
+        <Route exact path="/machines">
+          <MachineList
+            searchFilter={searchFilter}
+            setSearchFilter={setSearchFilter}
+          />
+        </Route>
+        <Route exact path="/machines/add">
+          <AddMachineForm />
+        </Route>
+        <Route exact path="/machines/chassis/add">
+          <AddChassisForm />
+        </Route>
+        <Route exact path="/machines/rsd/add">
+          <AddRSDForm />
+        </Route>
+        <Route exact path="/pools">
+          <Pools />
+        </Route>
+        <Route exact path="/pools/add">
+          <PoolAdd />
+        </Route>
+        <Route exact path="/pools/:id/edit">
+          <PoolEdit />
+        </Route>
+        <Route path="*">
+          <NotFound />
+        </Route>
+      </Switch>
+    </Section>
+  );
+};
 
 export default Machines;

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -1,4 +1,5 @@
-import { MemoryRouter } from "react-router-dom";
+import { act } from "react-dom/test-utils";
+import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -265,5 +266,50 @@ describe("Machines", () => {
       </Provider>
     );
     expect(wrapper.find("NotFound").length).toBe(1);
+  });
+
+  it("can set the search from the URL", () => {
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machines", search: "?q=test+search", key: "testKey" },
+          ]}
+        >
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachineList").prop("searchFilter")).toBe(
+      "test search"
+    );
+  });
+
+  it("changes the URL when the search text changes", () => {
+    let location;
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machines", search: "?q=test+search", key: "testKey" },
+          ]}
+        >
+          <Machines />
+          <Route
+            path="*"
+            render={(props) => {
+              location = props.location;
+              return null;
+            }}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => {
+      wrapper.find("MachineList").props().setSearchFilter("status:new");
+    });
+    expect(location.search).toBe("?status=new");
   });
 });


### PR DESCRIPTION
## Done
- Filter selected machines when opening a take action form.

## QA
- Select a machine that can be commissioned.
- Using the take action menu open the form.
- The machine list should now be filtered by in:selected.
- Submit the form.
- The machine should transition to commissioning but the update-your-selection warning should not appear (like https://user-images.githubusercontent.com/17980375/80403010-c0e6d480-88b6-11ea-813b-8917aa9eb479.png).
- Click the machine, group or all machines checkbox, the machine list should no longer be filtered

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1042.
Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/1897.