### PR TITLE
Don't persist the selected state in the URL

### DIFF
--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -140,7 +140,9 @@ export const filtersToQueryString = (filters) => {
   let copiedFilters = { ...filters };
   // Remove empty filters.
   Object.keys(copiedFilters).forEach((filter) => {
-    if (copiedFilters[filter].length === 0) {
+    // Remove in:selected in in:!selected from the URL as we don't also persist
+    // the selected states of machines.
+    if (copiedFilters[filter].length === 0 || filter === "in") {
       delete copiedFilters[filter];
     }
   });

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -390,6 +390,15 @@ describe("Search", () => {
       ).toEqual("?q=moon%2Csun&status=new%2Cfailed+comissioning&zone=%21south");
     });
 
+    it("does not include selected filters in query string", () => {
+      expect(
+        filtersToQueryString({
+          q: ["moon", "sun"],
+          in: ["selected"],
+        })
+      ).toEqual("?q=moon%2Csun");
+    });
+
     it("can convert a filter object to a query string and back", () => {
       const queryObject = {
         q: ["moon", "sun"],


### PR DESCRIPTION
## Done
- Don't store the in:selected/!selected state in the URL.

## QA
- Go to the machine list and type in:selected in the search box. It should not be reflected in the URL.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1057.