### PR TITLE
Improve machine list page styling on smaller screens.

### DIFF
--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
@@ -28,7 +28,7 @@ export const FormCardButtons = ({
       >
         <Button
           appearance="base"
-          className="u-no-margin--bottom"
+          className={classNames({ "u-no-margin--bottom": bordered })}
           data-test="cancel-action"
           onClick={() => {
             if (onCancel) {
@@ -44,7 +44,7 @@ export const FormCardButtons = ({
         {secondarySubmit && secondarySubmitLabel && (
           <Button
             appearance="neutral"
-            className="u-no-margin--bottom"
+            className={classNames({ "u-no-margin--bottom": bordered })}
             data-test="secondary-submit"
             disabled={submitDisabled}
             onClick={secondarySubmit}
@@ -55,7 +55,7 @@ export const FormCardButtons = ({
         )}
         <ActionButton
           appearance={submitAppearance}
-          className="u-no-margin--bottom"
+          className={classNames({ "u-no-margin--bottom": bordered })}
           disabled={submitDisabled}
           loading={loading}
           success={success}

--- a/ui/src/app/base/components/Section/Section.js
+++ b/ui/src/app/base/components/Section/Section.js
@@ -29,7 +29,7 @@ const Section = ({
       <Strip
         element="main"
         includeCol={false}
-        rowClassName="u-equal-height section__content-wrapper"
+        rowClassName="u-flex section__content-wrapper"
         shallow
       >
         {sidebar && (

--- a/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
+++ b/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
@@ -18,7 +18,7 @@ exports[`Section renders 1`] = `
   <Strip
     element="main"
     includeCol={false}
-    rowClassName="u-equal-height section__content-wrapper"
+    rowClassName="u-flex section__content-wrapper"
     shallow={true}
   >
     <Col

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
@@ -60,13 +60,13 @@ exports[`ActionForm renders 1`] = `
               >
                 <Button
                   appearance="base"
-                  className="u-no-margin--bottom"
+                  className=""
                   data-test="cancel-action"
                   onClick={[Function]}
                   type="button"
                 >
                   <button
-                    className="p-button--base u-no-margin--bottom"
+                    className="p-button--base"
                     data-test="cancel-action"
                     onClick={[Function]}
                     type="button"
@@ -76,12 +76,12 @@ exports[`ActionForm renders 1`] = `
                 </Button>
                 <ActionButton
                   appearance="positive"
-                  className="u-no-margin--bottom"
+                  className=""
                   disabled={false}
                   type="submit"
                 >
                   <button
-                    className="u-no-margin--bottom p-action-button p-button--positive"
+                    className="p-action-button p-button--positive"
                     disabled={false}
                     type="submit"
                   >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.js
@@ -66,27 +66,34 @@ export const DeployFormFields = () => {
           />
         )}
         <p>Additional installs</p>
-        <FormikField
-          disabled={!canBeKVMHost}
-          label="Register as MAAS KVM host"
-          name="installKVM"
-          type="checkbox"
-          wrapperClassName="u-sv-1"
-        />
+        <ul className="p-inline-list">
+          <li
+            className="p-inline-list__item"
+            style={{ display: "inline-block" }}
+          >
+            <FormikField
+              disabled={!canBeKVMHost}
+              label="Register as MAAS KVM host"
+              name="installKVM"
+              type="checkbox"
+              wrapperClassName="u-sv-1"
+            />
+          </li>
+          <li className="p-inline-list__item">
+            <a
+              className="p-link--external"
+              href="https://maas.io/docs/kvm-introduction"
+            >
+              About MAAS KVM hosts
+            </a>
+          </li>
+        </ul>
         {!canBeKVMHost && (
           <p data-test="kvm-warning">
             <i className="p-icon--warning is-inline"></i>
             Ubuntu 18.04 is required to create a KVM host.
           </p>
         )}
-        <p>
-          <a
-            className="p-link--external"
-            href="https://maas.io/docs/kvm-introduction"
-          >
-            About MAAS KVM hosts
-          </a>
-        </p>
         {user.sshkeys_count === 0 && (
           <p data-test="sshkeys-warning">
             <i className="p-icon--warning is-inline"></i>

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -1,4 +1,4 @@
-import { Button, Col, Spinner, Row } from "@canonical/react-components";
+import { Button, Spinner } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import pluralize from "pluralize";
 import React, { useEffect, useState } from "react";
@@ -47,62 +47,58 @@ export const HeaderStrip = ({ searchFilter, setSearchFilter }) => {
 
   return (
     <>
-      <Row>
-        <Col size="6">
-          <ul className="p-inline-list">
-            <li className="p-inline-list__item p-heading--four">Machines</li>
-            {machinesLoaded ? (
-              <li
-                className="p-inline-list__item last-item u-text--light"
-                data-test="machine-count"
-              >
-                {`${machines.length} ${pluralize(
-                  "machine",
-                  machines.length
-                )} available`}
-              </li>
-            ) : (
-              <Spinner
-                className="u-no-padding u-no-margin"
-                inline
-                text="Loading..."
-              />
-            )}
-          </ul>
-        </Col>
-        <Col size="6" className="u-align--right">
-          <Switch>
-            <Route exact path="/machines">
-              <ul className="p-inline-list u-no-margin--bottom">
-                {selectedMachines.length > 0 && (
-                  <li
-                    className="p-inline-list__item u-text--light"
-                    data-test="selected-count"
-                  >
-                    <span>{`${selectedMachines.length} selected`}</span>
-                    <span className="p-heading--four" />
+      <div className="u-flex--between u-flex--wrap">
+        <ul className="p-inline-list">
+          <li className="p-inline-list__item p-heading--four">Machines</li>
+          {machinesLoaded ? (
+            <li
+              className="p-inline-list__item last-item u-text--light"
+              data-test="machine-count"
+            >
+              {`${machines.length} ${pluralize(
+                "machine",
+                machines.length
+              )} available`}
+            </li>
+          ) : (
+            <Spinner
+              className="u-no-padding u-no-margin"
+              inline
+              text="Loading..."
+            />
+          )}
+        </ul>
+        <Switch>
+          <Route exact path="/machines">
+            <ul className="p-inline-list u-no-margin--bottom">
+              {selectedMachines.length > 0 && (
+                <li
+                  className="p-inline-list__item u-text--light"
+                  data-test="selected-count"
+                >
+                  <span>{`${selectedMachines.length} selected`}</span>
+                  <span className="p-heading--four" />
+                </li>
+              )}
+              {!selectedAction && (
+                <>
+                  <li className="p-inline-list__item">
+                    <AddHardwareMenu disabled={hasSelectedMachines} />
                   </li>
-                )}
-                {!selectedAction && (
-                  <>
-                    <li className="p-inline-list__item">
-                      <AddHardwareMenu disabled={hasSelectedMachines} />
-                    </li>
-                    <li className="p-inline-list__item last-item">
-                      <TakeActionMenu setSelectedAction={setAction} />
-                    </li>
-                  </>
-                )}
-              </ul>
-            </Route>
-            <Route exact path="/pools">
-              <Button data-test="add-pool" element={Link} to="/pools/add">
-                Add pool
-              </Button>
-            </Route>
-          </Switch>
-        </Col>
-      </Row>
+                  <li className="p-inline-list__item last-item">
+                    <TakeActionMenu setSelectedAction={setAction} />
+                  </li>
+                </>
+              )}
+            </ul>
+          </Route>
+          <Route exact path="/pools">
+            <Button data-test="add-pool" element={Link} to="/pools/add">
+              Add pool
+            </Button>
+          </Route>
+        </Switch>
+      </div>
       {selectedAction && (
         <ActionFormWrapper
           selectedAction={selectedAction}

--- a/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/TakeActionMenu.js
+++ b/ui/src/app/machines/components/HeaderStrip/TakeActionMenu/TakeActionMenu.js
@@ -31,7 +31,7 @@ const getTakeActionLinks = (actionOptions, machines, setSelectedAction) => {
       const group = groups.find((group) => group.type === option.type);
       group.items.push({
         children: (
-          <div className="u-flex-between">
+          <div className="u-flex--between">
             <span data-test={`action-title-${option.name}`}>
               {option.title}
             </span>

--- a/ui/src/app/machines/views/MachineList/MachineListControls/FilterAccordion/_index.scss
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/FilterAccordion/_index.scss
@@ -35,6 +35,7 @@
   }
 
   .filter-accordion .p-contextual-menu__dropdown {
+    max-width: none;
     width: calc(100% - 1px);
   }
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -546,7 +546,7 @@ export const MachineListTable = ({
           headers={[
             {
               content: (
-                <div className="u-equal-height u-nudge--checkbox">
+                <div className="u-flex u-nudge--checkbox">
                   <Input
                     checked={
                       checkboxChecked(machines, selectedMachines) &&

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -1,7 +1,16 @@
 @mixin maas-utilities {
-  .u-flex-between {
+  .u-flex {
+    display: flex;
+  }
+
+  .u-flex--between {
     display: flex;
     justify-content: space-between;
+  }
+
+  .u-flex--wrap {
+    display: flex;
+    flex-wrap: wrap;
   }
 
   .u-mirror--y {

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -54,3 +54,9 @@ input[type="radio"] {
   margin-bottom: 0.8rem;
   margin-top: -0.5rem;
 }
+
+// 30-04-2020 Caleb: z-index of mobile tabs chevron is too high
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3027
+.p-tabs::before {
+  z-index: 1;
+}


### PR DESCRIPTION
## Done
- Fixed various styling errors on small screens
- Moved deploy KVM link inline with checkbox
- Increased margins underneath action form buttons

## QA
- Open deploy form and check that there is more space underneath the submit button
- Check that the KVM link is inline with the checkbox
- Resize to small screen and check that:
  - the machine list header checkbox isn't wrapped
  - the filter accordion is full width
  - when you open the take action menu the tab chevron doesn't show up on top


## Fixes
Fixes canonical-web-and-design/MAAS-squad#1888
Fixes canonical-web-and-design/MAAS-squad#1889
Fixes canonical-web-and-design/MAAS-squad#1893
Fixes canonical-web-and-design/MAAS-squad#1895
Fixes canonical-web-and-design/MAAS-squad#1896

## Screenshots
![screenshot](https://user-images.githubusercontent.com/25733845/80675136-16112900-8af7-11ea-843e-9dc4ff80f00c.png)
![screenshot2](https://user-images.githubusercontent.com/25733845/80675143-18738300-8af7-11ea-8b37-77a4c900741c.png)
![screenshot3](https://user-images.githubusercontent.com/25733845/80675144-1a3d4680-8af7-11ea-974c-73248a64f426.png)
![screenshot4](https://user-images.githubusercontent.com/25733845/80675149-1c9fa080-8af7-11ea-90c0-0f1053e9f563.png)

