### PR TITLE
Move contextual menus when the window is resized

### DIFF
--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -5,63 +5,7 @@ import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 import usePortal from "react-useportal";
 
-const getPositionStyle = (position, wrapper, constrainPanelWidth) => {
-  if (!wrapper || !wrapper.current) {
-    return undefined;
-  }
-  // We want the dimensions of the first child of the contextual menu span, not
-  // the span itself. Guard present just in case a child is not defined.
-  const element = wrapper.current.children.length
-    ? wrapper.current.children[0]
-    : wrapper.current;
-  const { bottom, left, width } = element.getBoundingClientRect();
-  const topPos = bottom + (window.scrollY || 0);
-  let leftPos = left;
-
-  switch (position) {
-    case "left":
-      leftPos = left;
-      break;
-    case "center":
-      leftPos = left + width / 2;
-      break;
-    case "right":
-      leftPos = left + width;
-      break;
-    default:
-      break;
-  }
-
-  let styles = { position: "absolute", left: leftPos, top: topPos };
-
-  if (constrainPanelWidth) {
-    styles.width = width;
-  }
-
-  return styles;
-};
-
-const generateLink = (
-  { children, className, onClick, ...props },
-  key,
-  closePortal
-) => (
-  <Button
-    className={classNames("p-contextual-menu__link", className)}
-    key={key}
-    onClick={
-      onClick
-        ? () => {
-            closePortal();
-            onClick();
-          }
-        : null
-    }
-    {...props}
-  >
-    {children}
-  </Button>
-);
+import ContextualMenuDropdown from "./ContextualMenuDropdown";
 
 const ContextualMenu = ({
   className,
@@ -136,49 +80,19 @@ const ContextualMenu = ({
       )}
       {isOpen && (
         <Portal>
-          <span
-            className={wrapperClass}
-            style={getPositionStyle(
-              position,
-              positionNode || wrapper,
-              constrainPanelWidth
-            )}
-          >
-            <span
-              className={classNames(
-                "p-contextual-menu__dropdown",
-                dropdownClassName
-              )}
-              id={id.current}
-              aria-hidden={isOpen ? "false" : "true"}
-              aria-label="submenu"
-            >
-              {dropdownContent
-                ? dropdownContent
-                : links.map((item, i) => {
-                    if (Array.isArray(item)) {
-                      return (
-                        <span className="p-contextual-menu__group" key={i}>
-                          {item.map((link, j) =>
-                            generateLink(link, j, closePortal)
-                          )}
-                        </span>
-                      );
-                    }
-                    if (typeof item === "string") {
-                      return (
-                        <div
-                          className="p-contextual-menu__non-interactive"
-                          key={i}
-                        >
-                          {item}
-                        </div>
-                      );
-                    }
-                    return generateLink(item, i, closePortal);
-                  })}
-            </span>
-          </span>
+          <ContextualMenuDropdown
+            closePortal={closePortal}
+            constrainPanelWidth={constrainPanelWidth}
+            dropdownClassName={dropdownClassName}
+            dropdownContent={dropdownContent}
+            id={id.current}
+            isOpen={isOpen}
+            links={links}
+            position={position}
+            positionNode={positionNode ? positionNode.current : null}
+            wrapper={wrapper.current}
+            wrapperClass={wrapperClass}
+          />
         </Portal>
       )}
     </span>

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.js
@@ -1,0 +1,161 @@
+import { Button } from "@canonical/react-components";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+
+import { useOnWindowResize } from "app/base/hooks";
+
+const getParent = (wrapper) => {
+  if (!wrapper) {
+    return;
+  }
+  // We want the dimensions of the first child of the contextual menu span, not
+  // the span itself. Guard present just in case a child is not defined.
+  return wrapper.children.length ? wrapper.children[0] : wrapper;
+};
+
+const getParentVisible = (wrapper) => {
+  const element = getParent(wrapper);
+  return !element || element.offsetParent !== null;
+};
+
+const getPositionStyle = (position, wrapper, constrainPanelWidth) => {
+  const element = getParent(wrapper);
+  if (!element) {
+    return;
+  }
+  const { bottom, left, width } = element.getBoundingClientRect();
+  const topPos = bottom + (window.scrollY || 0);
+  let leftPos = left;
+
+  switch (position) {
+    case "left":
+      leftPos = left;
+      break;
+    case "center":
+      leftPos = left + width / 2;
+      break;
+    case "right":
+      leftPos = left + width;
+      break;
+    default:
+      break;
+  }
+
+  let styles = { position: "absolute", left: leftPos, top: topPos };
+
+  if (constrainPanelWidth) {
+    styles.width = width;
+  }
+
+  return styles;
+};
+
+const generateLink = (
+  { children, className, onClick, ...props },
+  key,
+  closePortal
+) => (
+  <Button
+    className={classNames("p-contextual-menu__link", className)}
+    key={key}
+    onClick={
+      onClick
+        ? () => {
+            closePortal();
+            onClick();
+          }
+        : null
+    }
+    {...props}
+  >
+    {children}
+  </Button>
+);
+
+const ContextualMenuDropdown = ({
+  closePortal,
+  constrainPanelWidth,
+  dropdownClassName,
+  dropdownContent,
+  id,
+  isOpen,
+  links,
+  position,
+  positionNode,
+  wrapper,
+  wrapperClass,
+}) => {
+  const [positionStyle, setPositionStyle] = useState(
+    getPositionStyle(position, positionNode || wrapper, constrainPanelWidth)
+  );
+
+  useOnWindowResize(() => {
+    if (!getParentVisible(wrapper)) {
+      // Hide the menu if the item has become hidden.
+      closePortal();
+      return;
+    }
+    const newStyle = getPositionStyle(
+      position,
+      positionNode || wrapper,
+      constrainPanelWidth
+    );
+    if (newStyle !== positionStyle) {
+      setPositionStyle(newStyle);
+    }
+  });
+
+  return (
+    <span className={wrapperClass} style={positionStyle}>
+      <span
+        className={classNames("p-contextual-menu__dropdown", dropdownClassName)}
+        id={id}
+        aria-hidden={isOpen ? "false" : "true"}
+        aria-label="submenu"
+      >
+        {dropdownContent
+          ? dropdownContent
+          : links.map((item, i) => {
+              if (Array.isArray(item)) {
+                return (
+                  <span className="p-contextual-menu__group" key={i}>
+                    {item.map((link, j) => generateLink(link, j, closePortal))}
+                  </span>
+                );
+              }
+              if (typeof item === "string") {
+                return (
+                  <div className="p-contextual-menu__non-interactive" key={i}>
+                    {item}
+                  </div>
+                );
+              }
+              return generateLink(item, i, closePortal);
+            })}
+      </span>
+    </span>
+  );
+};
+
+ContextualMenuDropdown.propTypes = {
+  closePortal: PropTypes.func,
+  constrainPanelWidth: PropTypes.bool,
+  dropdownClassName: PropTypes.string,
+  dropdownContent: PropTypes.node,
+  id: PropTypes.string,
+  isOpen: PropTypes.bool,
+  links: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape(Button.propTypes),
+      PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
+    ])
+  ),
+  position: PropTypes.oneOf(["left", "center", "right"]),
+  positionNode: PropTypes.object,
+  wrapper: PropTypes.object,
+  wrapperClass: PropTypes.string,
+};
+
+export default ContextualMenuDropdown;

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.test.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.test.js
@@ -1,0 +1,46 @@
+import { act } from "react-dom/test-utils";
+import { mount } from "enzyme";
+import React from "react";
+
+import { THROTTLE_DELAY } from "app/base/hooks";
+import ContextualMenuDropdown from "./ContextualMenuDropdown";
+
+jest.useFakeTimers();
+
+describe("ContextualMenuDropdown ", () => {
+  it("renders", () => {
+    const wrapper = mount(
+      <ContextualMenuDropdown links={[{ children: "Link1" }]} />
+    );
+    expect(wrapper.find("ContextualMenuDropdown")).toMatchSnapshot();
+  });
+
+  it("recalculates styles when the window is resized", () => {
+    const wrapper = mount(
+      <ContextualMenuDropdown
+        links={[{ children: "Link1" }]}
+        wrapper={{
+          children: [],
+          getBoundingClientRect: () => ({ bottom: 10, left: 10, width: 10 }),
+        }}
+        wrapperClass="test-node"
+      />
+    );
+    wrapper.setProps({
+      wrapper: {
+        children: [],
+        getBoundingClientRect: () => ({ bottom: 20, left: 20, width: 20 }),
+      },
+    });
+    global.dispatchEvent(new Event("resize"));
+    act(() => {
+      jest.advanceTimersByTime(THROTTLE_DELAY);
+    });
+    wrapper.update();
+    expect(wrapper.find("span.test-node").prop("style")).toStrictEqual({
+      position: "absolute",
+      left: 20,
+      top: 20,
+    });
+  });
+});

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/__snapshots__/ContextualMenuDropdown.test.js.snap
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/__snapshots__/ContextualMenuDropdown.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContextualMenuDropdown  renders 1`] = `
+<ContextualMenuDropdown
+  links={
+    Array [
+      Object {
+        "children": "Link1",
+      },
+    ]
+  }
+>
+  <span>
+    <span
+      aria-hidden="true"
+      aria-label="submenu"
+      className="p-contextual-menu__dropdown"
+    >
+      <Button
+        className="p-contextual-menu__link"
+        key="0"
+        onClick={null}
+      >
+        <button
+          className="p-button--neutral p-contextual-menu__link"
+          onClick={null}
+        >
+          Link1
+        </button>
+      </Button>
+    </span>
+  </span>
+</ContextualMenuDropdown>
+`;

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/index.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ContextualMenuDropdown";

--- a/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
+++ b/ui/src/app/base/components/ContextualMenu/__snapshots__/ContextualMenu.test.js.snap
@@ -24,16 +24,27 @@ exports[`ContextualMenu  renders 1`] = `
           </div>
         }
       >
-        <span
-          className="p-contextual-menu"
+        <ContextualMenuDropdown
+          closePortal={[Function]}
+          id="Uakgb_J5m9g-0JDMbcJqLJ"
+          isOpen={true}
+          links={Array []}
+          position="right"
+          positionNode={null}
+          wrapper={null}
+          wrapperClass="p-contextual-menu"
         >
           <span
-            aria-hidden="false"
-            aria-label="submenu"
-            className="p-contextual-menu__dropdown"
-            id="Uakgb_J5m9g-0JDMbcJqLJ"
-          />
-        </span>
+            className="p-contextual-menu"
+          >
+            <span
+              aria-hidden="false"
+              aria-label="submenu"
+              className="p-contextual-menu__dropdown"
+              id="Uakgb_J5m9g-0JDMbcJqLJ"
+            />
+          </span>
+        </ContextualMenuDropdown>
       </Portal>
     </Component>
   </span>


### PR DESCRIPTION
## Done
- Update the position of contextual menus when the window is resized.

## QA
- View the machine list.
- Click on the take action menu or an in table action menu.
- Resize your window.
- The menu should adjust it's position.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1909.