### PR TITLE
Update OverrideFailedTestForm formatting and warning text.

### DIFF
--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -54,7 +54,8 @@ describe("OverrideTestForm", () => {
     };
   });
 
-  it("displays message for a single machine with no failed tests", () => {
+  it(`displays failed tests warning without suppress tests checkbox for a single
+    machine with no failed tests`, () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123"];
     state.scriptresults.items = {};
@@ -69,31 +70,16 @@ describe("OverrideTestForm", () => {
       </Provider>
     );
 
-    expect(wrapper.find('[data-test-id="failed-results-message"]').html()).toBe(
-      '<span data-test-id="failed-results-message">Machine <strong>host1</strong> has<a href="/MAAS/#/machine/abc123"> failed 0 tests.</a></span>'
+    expect(wrapper.find('[data-test-id="failed-results-message"]').text()).toBe(
+      "Machine host1 has not failed any tests. This can occur if the test suite failed to start."
+    );
+    expect(wrapper.find('FormikField[name="suppressTests"]').exists()).toBe(
+      false
     );
   });
 
-  it("displays message for a single machine with failed tests", () => {
-    const state = { ...initialState };
-    state.machine.selected = ["abc123"];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find('[data-test-id="failed-results-message"]').html()).toBe(
-      '<span data-test-id="failed-results-message">Machine <strong>host1</strong> has<a href="/MAAS/#/machine/abc123"> failed 2 tests.</a></span>'
-    );
-  });
-
-  it("displays message for multiple machines with no failed tests", () => {
+  it(`displays failed tests warning without suppress tests checkbox for multiple
+    machines with no failed tests`, () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
     state.scriptresults.items = {};
@@ -109,8 +95,33 @@ describe("OverrideTestForm", () => {
     );
 
     expect(wrapper.find('[data-test-id="failed-results-message"]').text()).toBe(
-      "2 machines have failed 0 tests."
+      "2 machines have not failed any tests. This can occur if the test suite failed to start."
     );
+    expect(wrapper.find('FormikField[name="suppressTests"]').exists()).toBe(
+      false
+    );
+  });
+
+  it("displays message with link for a single machine with failed tests", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OverrideTestForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find('[data-test-id="failed-results-message"]').text()).toBe(
+      "Machine host1 has failed 2 tests."
+    );
+    expect(
+      wrapper.find('[data-test-id="failed-results-message"] a').props().href
+    ).toBe(`${process.env.REACT_APP_BASENAME}/#/machine/abc123`);
   });
 
   it("displays message for multiple machines with failed tests", () => {


### PR DESCRIPTION
## Done
- Updated warning text to describe why machines could be in Failed testing with 0 failed tests.
- Updated form spacing.

## QA
- Choose some failed testing machines that have 0 failed tests.
- Check that the message displayed is different and the suppress tests checkbox does not show.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1902

## Screenshots
### Multiple non-failed
![Screenshot_2020-05-01 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/80777012-2f71ae00-8ba7-11ea-9e7c-111fc4466645.png)

### Single non-failed
![Screenshot_2020-05-01 Machines bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/80777019-33053500-8ba7-11ea-87cb-54c7304dc8b3.png)

### Multiple failed
![Screenshot_2020-05-01 Machines bolla MAAS(2)](https://user-images.githubusercontent.com/25733845/80777022-3698bc00-8ba7-11ea-9cef-3ae6f51e3a68.png)

### Single failed
![Screenshot_2020-05-01 Machines bolla MAAS(3)](https://user-images.githubusercontent.com/25733845/80777030-38fb1600-8ba7-11ea-9b19-a20d6deb8caf.png)
