### PR TITLE
Fix processing state

### DIFF
--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -66,7 +66,13 @@ export const useFormikErrors = (errors) => {
       !simpleObjectEquality(errors, previousErrors)
     ) {
       Object.keys(errors).forEach((field) => {
-        setFieldError(field, errors[field].join(" "));
+        let errorString;
+        if (Array.isArray(errors[field])) {
+          errorString = errors[field].join(" ");
+        } else {
+          errorString = errors[field];
+        }
+        setFieldError(field, errorString);
         setFieldTouched(field, true, false);
       });
     }

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from "react-redux";
 import pluralize from "pluralize";
-import React, { useState } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
@@ -103,9 +104,13 @@ const useSelectedProcessing = (actionName) => {
   return useSelector(selector);
 };
 
-export const ActionForm = ({ selectedAction, setSelectedAction }) => {
+export const ActionForm = ({
+  processing,
+  setProcessing,
+  selectedAction,
+  setSelectedAction,
+}) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
@@ -155,6 +160,12 @@ export const ActionForm = ({ selectedAction, setSelectedAction }) => {
       saved={saved}
     />
   );
+};
+
+ActionForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default ActionForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
@@ -58,6 +58,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "release" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -80,6 +81,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "release" }}
+            setProcessing={jest.fn()}
             setSelectedAction={setSelectedAction}
           />
         </MemoryRouter>
@@ -103,6 +105,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "delete" }}
+            setProcessing={jest.fn()}
             setSelectedAction={setSelectedAction}
           />
         </MemoryRouter>
@@ -123,6 +126,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "abort" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -162,6 +166,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "acquire" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -201,6 +206,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "delete" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -242,6 +248,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "exit-rescue-mode" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -283,6 +290,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "lock" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -322,6 +330,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "mark-broken" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -361,6 +370,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "mark-fixed" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -400,6 +410,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "off" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -439,6 +450,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "on" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -478,6 +490,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "release" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -517,6 +530,7 @@ describe("ActionForm", () => {
         >
           <ActionForm
             selectedAction={{ name: "unlock" }}
+            setProcessing={jest.fn()}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -555,14 +569,37 @@ describe("ActionForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <ActionForm
+            processing={true}
             selectedAction={{ name: "unlock" }}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const state = { ...initialState };
+    state.machine.items = [{ system_id: "abc123", actions: ["unlock"] }];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ActionForm
+            selectedAction={{ name: "unlock" }}
+            setProcessing={setProcessing}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
       </Provider>
     );
     act(() => wrapper.find("Formik").props().onSubmit());
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
@@ -7,6 +7,7 @@ exports[`ActionForm renders 1`] = `
       "name": "release",
     }
   }
+  setProcessing={[MockFunction]}
   setSelectedAction={[MockFunction]}
 >
   <FormikForm

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.js
@@ -1,7 +1,7 @@
 import { Button, Col, Row } from "@canonical/react-components";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
-import React, { useLayoutEffect, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { machine as machineActions } from "app/base/actions";
@@ -38,25 +38,30 @@ const getErrorSentence = (action, count) => {
   }
 };
 
-export const ActionFormWrapper = ({ selectedAction, setSelectedAction }) => {
+export const ActionFormWrapper = ({
+  selectedAction,
+  setSelectedAction,
+  _processing = false,
+}) => {
   const dispatch = useDispatch();
-
+  // Initialise the processing state from a prop to allow testing the state change.
+  const [processing, setProcessing] = useState(_processing);
   const selectedMachines = useSelector(machineSelectors.selected);
-
-  const [actionableMachines, setActionableMachines] = useState([]);
-  const actionDisabled = actionableMachines.length !== selectedMachines.length;
-
-  useLayoutEffect(() => {
-    if (selectedAction) {
-      const actionable = selectedMachines.filter((machine) =>
-        machine.actions.includes(selectedAction.name)
-      );
-      setActionableMachines(actionable);
-    }
-  }, [selectedAction, selectedMachines]);
+  let actionableMachines = [];
+  if (selectedAction) {
+    actionableMachines = selectedMachines.filter((machine) =>
+      machine.actions.includes(selectedAction.name)
+    );
+  }
+  // The action should be disabled if not all the selected machines can perform
+  // The selected action. When machines are processing the available actions
+  // can change, so the action should not be disabled while processing.
+  const actionDisabled =
+    !processing && actionableMachines.length !== selectedMachines.length;
 
   useEffect(() => {
     if (selectedMachines.length === 0) {
+      // All the machines were deselected so close the form.
       setSelectedAction(null);
     }
   }, [selectedMachines, setSelectedAction]);
@@ -65,22 +70,66 @@ export const ActionFormWrapper = ({ selectedAction, setSelectedAction }) => {
     if (selectedAction && selectedAction.name) {
       switch (selectedAction.name) {
         case "commission":
-          return <CommissionForm setSelectedAction={setSelectedAction} />;
+          return (
+            <CommissionForm
+              processing={processing}
+              setProcessing={setProcessing}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         case "deploy":
-          return <DeployForm setSelectedAction={setSelectedAction} />;
+          return (
+            <DeployForm
+              processing={processing}
+              setProcessing={setProcessing}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         case "override-failed-testing":
-          return <OverrideTestForm setSelectedAction={setSelectedAction} />;
+          return (
+            <OverrideTestForm
+              processing={processing}
+              setProcessing={setProcessing}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         case "set-pool":
-          return <SetPoolForm setSelectedAction={setSelectedAction} />;
+          return (
+            <SetPoolForm
+              processing={processing}
+              setProcessing={setProcessing}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         case "set-zone":
-          return <SetZoneForm setSelectedAction={setSelectedAction} />;
+          return (
+            <SetZoneForm
+              processing={processing}
+              setProcessing={setProcessing}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         case "tag":
-          return <TagForm setSelectedAction={setSelectedAction} />;
+          return (
+            <TagForm
+              processing={processing}
+              setProcessing={setProcessing}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         case "test":
-          return <TestForm setSelectedAction={setSelectedAction} />;
+          return (
+            <TestForm
+              processing={processing}
+              setProcessing={setProcessing}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         default:
           return (
             <ActionForm
+              processing={processing}
+              setProcessing={setProcessing}
               selectedAction={selectedAction}
               setSelectedAction={setSelectedAction}
             />

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionFormWrapper.test.js
@@ -1,4 +1,3 @@
-import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
@@ -106,7 +105,6 @@ describe("ActionFormWrapper", () => {
       </Provider>,
       { context: store }
     );
-    // act(() => wrapper.find("CommissionForm").props().setProcessing(true));
     expect(wrapper.find("[data-test='machine-action-warning']").exists()).toBe(
       false
     );

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -1,5 +1,6 @@
 import pluralize from "pluralize";
-import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -37,9 +38,12 @@ const CommissionFormSchema = Yup.object().shape({
     .required(),
 });
 
-export const CommissionForm = ({ setSelectedAction }) => {
+export const CommissionForm = ({
+  processing,
+  setProcessing,
+  setSelectedAction,
+}) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
@@ -162,6 +166,12 @@ export const CommissionForm = ({ setSelectedAction }) => {
       />
     </FormikForm>
   );
+};
+
+CommissionForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default CommissionForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
@@ -64,7 +64,10 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CommissionForm setSelectedAction={jest.fn()} />
+          <CommissionForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -154,7 +157,31 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <CommissionForm setSelectedAction={jest.fn()} />
+          <CommissionForm
+            processing={true}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CommissionForm
+            setProcessing={setProcessing}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -173,7 +200,6 @@ describe("CommissionForm", () => {
           commissioningScripts: [state.scripts.items[1]],
         })
     );
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.js
@@ -66,7 +66,10 @@ describe("CommissionForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <CommissionForm setSelectedAction={jest.fn()} />
+          <CommissionForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
@@ -1,7 +1,8 @@
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import pluralize from "pluralize";
-import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import React, { useEffect } from "react";
 
 import {
   general as generalActions,
@@ -23,9 +24,12 @@ const DeploySchema = Yup.object().shape({
   installKVM: Yup.boolean(),
 });
 
-export const DeployForm = ({ setSelectedAction }) => {
+export const DeployForm = ({
+  processing,
+  setProcessing,
+  setSelectedAction,
+}) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
@@ -95,6 +99,12 @@ export const DeployForm = ({ setSelectedAction }) => {
       <DeployFormFields />
     </FormikForm>
   );
+};
+
+DeployForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default DeployForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.test.js
@@ -128,7 +128,7 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm setSelectedAction={jest.fn()} />
+          <DeployForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -194,7 +194,31 @@ describe("DeployForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DeployForm setSelectedAction={jest.fn()} />
+          <DeployForm
+            processing={true}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm
+            setProcessing={setProcessing}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -206,7 +230,6 @@ describe("DeployForm", () => {
         installKVM: false,
       })
     );
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.js
@@ -124,7 +124,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm />
+          <DeployForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -140,7 +140,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm />
+          <DeployForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -156,7 +156,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm />
+          <DeployForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -173,7 +173,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm />
+          <DeployForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -202,7 +202,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm />
+          <DeployForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -240,7 +240,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm />
+          <DeployForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -1,6 +1,7 @@
 import { Col, Row, Spinner } from "@canonical/react-components";
 import pluralize from "pluralize";
-import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -60,9 +61,12 @@ const OverrideTestFormSchema = Yup.object().shape({
   suppressResults: Yup.boolean(),
 });
 
-export const OverrideTestForm = ({ setSelectedAction }) => {
+export const OverrideTestForm = ({
+  processing,
+  setProcessing,
+  setSelectedAction,
+}) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
@@ -183,6 +187,12 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
       </Row>
     </FormikForm>
   );
+};
+
+OverrideTestForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default OverrideTestForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -65,7 +65,10 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
+          <OverrideTestForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -89,7 +92,10 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
+          <OverrideTestForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -111,7 +117,10 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
+          <OverrideTestForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -133,7 +142,10 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
+          <OverrideTestForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -152,7 +164,10 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
+          <OverrideTestForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -207,7 +222,10 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
+          <OverrideTestForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -247,7 +265,31 @@ describe("OverrideTestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OverrideTestForm setSelectedAction={jest.fn()} />
+          <OverrideTestForm
+            processing={true}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OverrideTestForm
+            setProcessing={setProcessing}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -256,7 +298,6 @@ describe("OverrideTestForm", () => {
         suppressResults: true,
       })
     );
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import pluralize from "pluralize";
+import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 
 import {
@@ -22,9 +23,12 @@ const SetPoolSchema = Yup.object().shape({
   poolSelection: Yup.string().oneOf(["create", "select"]).required(),
 });
 
-export const SetPoolForm = ({ setSelectedAction }) => {
+export const SetPoolForm = ({
+  processing,
+  setProcessing,
+  setSelectedAction,
+}) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const [initialValues, setInitialValues] = useState({
     poolSelection: "select",
     description: "",
@@ -100,6 +104,12 @@ export const SetPoolForm = ({ setSelectedAction }) => {
       <SetPoolFormFields />
     </FormikForm>
   );
+};
+
+SetPoolForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default SetPoolForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
@@ -54,7 +54,10 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm setSelectedAction={jest.fn()} />
+          <SetPoolForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -110,7 +113,30 @@ describe("SetPoolForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm setSelectedAction={jest.fn()} />
+          <SetPoolForm
+            processing={true}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const store = mockStore(state);
+    state.machine.selected = ["abc123", "def456"];
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SetPoolForm
+            setProcessing={setProcessing}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -121,7 +147,6 @@ describe("SetPoolForm", () => {
         description: "",
       })
     );
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.js
@@ -47,7 +47,10 @@ describe("SetPoolFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm setSelectedAction={jest.fn()} />
+          <SetPoolForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -67,7 +70,10 @@ describe("SetPoolFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetPoolForm setSelectedAction={jest.fn()} />
+          <SetPoolForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -2,7 +2,8 @@ import { Col, Row, Select } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import pluralize from "pluralize";
-import React, { useState } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import { machine as machineActions } from "app/base/actions";
 import {
@@ -18,9 +19,12 @@ const SetZoneSchema = Yup.object().shape({
   zone: Yup.string().required("Zone is required"),
 });
 
-export const SetZoneForm = ({ setSelectedAction }) => {
+export const SetZoneForm = ({
+  processing,
+  setProcessing,
+  setSelectedAction,
+}) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
@@ -89,6 +93,12 @@ export const SetZoneForm = ({ setSelectedAction }) => {
       </Row>
     </FormikForm>
   );
+};
+
+SetZoneForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default SetZoneForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
@@ -53,7 +53,10 @@ describe("SetZoneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetZoneForm setSelectedAction={jest.fn()} />
+          <SetZoneForm
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -109,7 +112,30 @@ describe("SetZoneForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <SetZoneForm setSelectedAction={jest.fn()} />
+          <SetZoneForm
+            processing={true}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const store = mockStore(state);
+    state.machine.selected = ["abc123", "def456"];
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <SetZoneForm
+            setProcessing={setProcessing}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -118,7 +144,6 @@ describe("SetZoneForm", () => {
         zone: "zone-1",
       })
     );
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
@@ -1,4 +1,5 @@
 import pluralize from "pluralize";
+import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
@@ -22,9 +23,8 @@ const TagFormSchema = Yup.object().shape({
     .required("You must select at least one tag."),
 });
 
-export const TagForm = ({ setSelectedAction }) => {
+export const TagForm = ({ processing, setProcessing, setSelectedAction }) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const [initialValues, setInitialValues] = useState({ tags: [] });
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
@@ -83,6 +83,12 @@ export const TagForm = ({ setSelectedAction }) => {
       <TagFormFields />
     </FormikForm>
   );
+};
+
+TagForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default TagForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.test.js
@@ -47,7 +47,7 @@ describe("TagForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TagForm setSelectedAction={jest.fn()} />
+          <TagForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -107,7 +107,31 @@ describe("TagForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TagForm setSelectedAction={jest.fn()} />
+          <TagForm
+            processing={true}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TagForm
+            setProcessing={setProcessing}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -119,7 +143,6 @@ describe("TagForm", () => {
           tags: [{ name: "tag1" }, { name: "tag2" }],
         })
     );
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.js
@@ -40,7 +40,7 @@ describe("TagFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TagForm setSelectedAction={jest.fn()} />
+          <TagForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
@@ -1,5 +1,6 @@
 import pluralize from "pluralize";
-import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -31,9 +32,8 @@ const TestFormSchema = Yup.object().shape({
   urls: Yup.object(),
 });
 
-export const TestForm = ({ setSelectedAction }) => {
+export const TestForm = ({ processing, setProcessing, setSelectedAction }) => {
   const dispatch = useDispatch();
-  const [processing, setProcessing] = useState(false);
   const selectedMachines = useSelector(machineSelectors.selected);
   const saved = useSelector(machineSelectors.saved);
   const saving = useSelector(machineSelectors.saving);
@@ -118,6 +118,12 @@ export const TestForm = ({ setSelectedAction }) => {
       <TestFormFields preselected={preselected} scripts={formattedScripts} />
     </FormikForm>
   );
+};
+
+TestForm.propTypes = {
+  processing: PropTypes.bool,
+  setProcessing: PropTypes.func.isRequired,
+  setSelectedAction: PropTypes.func.isRequired,
 };
 
 export default TestForm;

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.test.js
@@ -72,7 +72,7 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TestForm setSelectedAction={jest.fn()} />
+          <TestForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -146,7 +146,31 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <TestForm setSelectedAction={jest.fn()} />
+          <TestForm
+            processing={true}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+  });
+
+  it("can set the processing state when successfully submitting", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const setProcessing = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TestForm
+            setProcessing={setProcessing}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -162,7 +186,6 @@ describe("TestForm", () => {
           },
         })
     );
-    wrapper.update();
-    expect(wrapper.find("MachinesProcessing").exists()).toBe(true);
+    expect(setProcessing).toHaveBeenCalledWith(true);
   });
 });

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.js
@@ -66,7 +66,7 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <TestForm setSelectedAction={jest.fn()} />
+          <TestForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );


### PR DESCRIPTION
## Done
- Prevent the "update your selection" notice from appearing once machines have begun to be processed. This was causing a bug as when the machines begin to be changed they can change the allowable actions from that machine, resulting in that machine being shown.

## QA
- Selecting a number of new machines (at least 5).
- Using the take action menu select "Commission" and submit the form.
- The machines should transition to commissioning and the "update your selection" warning should not appear.
- You might have to do this a few times (you can abort once they transition to commissioning) to be satisfied this is fixed.

## Fixes
Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/1897.