### PR TITLE
Close action form when navigating away from /machines.

### DIFF
--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, Route, Switch } from "react-router-dom";
 
+import { useLocation } from "app/base/hooks";
 import {
   filtersToString,
   getCurrentFilters,
@@ -19,6 +20,7 @@ import TakeActionMenu from "./TakeActionMenu";
 
 export const HeaderStrip = ({ searchFilter, setSearchFilter }) => {
   const dispatch = useDispatch();
+  const { location } = useLocation();
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const selectedMachines = useSelector(machineSelectors.selected);
@@ -29,6 +31,12 @@ export const HeaderStrip = ({ searchFilter, setSearchFilter }) => {
   useEffect(() => {
     dispatch(machineActions.fetch());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (location.pathname !== "/machines") {
+      setSelectedAction(null);
+    }
+  }, [location.pathname]);
 
   const setAction = (action, deselect) => {
     if (action || deselect) {

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -312,4 +312,37 @@ describe("Machines", () => {
     });
     expect(location.search).toBe("?status=new");
   });
+
+  it("closes the take action form when route changes from /machines", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123"];
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open action form
+    act(() =>
+      wrapper
+        .find("TakeActionMenu")
+        .props()
+        .setSelectedAction({ name: "set-pool" })
+    );
+    wrapper.update();
+    expect(wrapper.find("ActionFormWrapper").exists()).toBe(true);
+
+    // Click pools tab, action form should close
+    act(() => {
+      wrapper
+        .find("HeaderStrip Link[to='/pools']")
+        .simulate("click", { button: 0 });
+    });
+    wrapper.update();
+    expect(wrapper.find("ActionFormWrapper").exists()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Done
- Close action form when navigating away from /machines

## QA
- Select some machines and choose an action
- Click to somewhere else that still shows the machine header (e.g. pools, add machine)
- Check that the action form closes

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1906
