### PR TITLE
Upgrade Vanilla to 2.10.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,7 +41,7 @@
     "redux": "4.0.5",
     "redux-devtools-extension": "2.13.8",
     "redux-saga": "1.1.3",
-    "vanilla-framework": "2.10.0",
+    "vanilla-framework": "2.10.1",
     "yup": "0.28.5"
   },
   "scripts": {

--- a/ui/src/app/base/components/Section/_index.scss
+++ b/ui/src/app/base/components/Section/_index.scss
@@ -14,4 +14,9 @@
     height: $spv-inner--large;
     width: $spv-inner--large;
   }
+
+  .section__content {
+    // Raise the content above the sidebar so that the card shadows are on top.
+    z-index: 1;
+  }
 }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -54,9 +54,3 @@ input[type="radio"] {
   margin-bottom: 0.8rem;
   margin-top: -0.5rem;
 }
-
-// 30-04-2020 Caleb: z-index of mobile tabs chevron is too high
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/3027
-.p-tabs::before {
-  z-index: 1;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15669,6 +15669,11 @@ vanilla-framework@2.10.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.10.0.tgz#74c0cba977ce058552aa4443cccaa6bbf9308e9e"
   integrity sha512-otQLBXzRBLyiN8RFtHP0E19Iy2p3Frbm7E4TIU7Q7LN+ScmfmgAc7InqbYXvTL9oIATTs0sBD7T/2Fzezgmalg==
 
+vanilla-framework@2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.10.1.tgz#66d06ca99bfe92deba742bf67fe55c7d321479f3"
+  integrity sha512-ojwn6XbyJB2VlelFbcB9grYShT49smbjPHP2O+zYsIbPIswX4ATt7MeNLLuHkOrK1lkreIB583vN1Y5D9lwi0Q==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
## Done
- Upgrade to Vanilla 2.10.1.
- Fixed sidebar overlapping issue.
- Removed Vanilla override for https://github.com/canonical-web-and-design/vanilla-framework/issues/3027.

## QA
- Have a poke around and make sure everything looks OK.
- Visit /MAAS/r/settings/users/add
- Check that the selected sidebar item doesn't overlap the card shadow.