### PR TITLE
Fix tag selector margin.

### DIFF
--- a/ui/src/app/base/components/TagSelector/_index.scss
+++ b/ui/src/app/base/components/TagSelector/_index.scss
@@ -10,7 +10,6 @@
   }
 
   .tag-selector__input {
-    margin-bottom: 0;
     position: relative;
 
     &.tags-selected {
@@ -33,7 +32,7 @@
     overflow: auto;
     position: absolute;
     right: 0;
-    top: 100%;
+    top: calc(100% - #{$input-margin-bottom});
     z-index: 10;
   }
 


### PR DESCRIPTION
## Done
- Added margin back to tag selector input, subtracted it from tag selector dropdown.

## QA
- Select some machines and choose "Tag" from the action dropdown
- Resize screen to small and check there is space between the tag selector and the submit button

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1910
