### PR TITLE
Add mixed selection state to machine list checkboxes.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -77,7 +77,11 @@ const getGroupSecondaryString = (machines, selectedMachines) => {
 };
 
 const checkboxChecked = (machines, selectedMachines) =>
-  machines.every((machine) => selectedMachines.includes(machine));
+  machines.some((machine) => selectedMachines.includes(machine));
+
+const checkboxMixed = (machines, selectedMachines) =>
+  selectedMachines.length &&
+  machines.some((machine) => !selectedMachines.includes(machine));
 
 const machineSort = (currentSort) => {
   const { key, direction } = currentSort;
@@ -347,7 +351,12 @@ const generateGroupRows = ({
                 primary={
                   <Input
                     checked={checkboxChecked(machines, selectedMachines)}
-                    className="has-inline-label"
+                    className={classNames("has-inline-label", {
+                      "p-checkbox--mixed": checkboxMixed(
+                        machines,
+                        selectedMachines
+                      ),
+                    })}
                     disabled={false}
                     id={label}
                     label={<strong>{label}</strong>}
@@ -552,7 +561,12 @@ export const MachineListTable = ({
                       checkboxChecked(machines, selectedMachines) &&
                       machines.length !== 0
                     }
-                    className="has-inline-label"
+                    className={classNames("has-inline-label", {
+                      "p-checkbox--mixed": checkboxMixed(
+                        machines,
+                        selectedMachines
+                      ),
+                    })}
                     data-test="all-machines-checkbox"
                     disabled={machines.length === 0}
                     id="all-machines-checkbox"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
@@ -467,6 +467,13 @@ describe("MachineListTable", () => {
       expect(
         wrapper.find("[data-test='group-cell'] input[checked=true]").length
       ).toBe(1);
+      expect(
+        wrapper
+          .find("[data-test='group-cell'] input")
+          .at(0)
+          .props()
+          .className.includes("p-checkbox--mixed")
+      ).toBe(false);
     });
 
     it("shows a checked checkbox in header row if all machines are selected", () => {
@@ -493,6 +500,12 @@ describe("MachineListTable", () => {
         wrapper.find("[data-test='all-machines-checkbox'] input[checked=true]")
           .length
       ).toBe(1);
+      expect(
+        wrapper
+          .find("[data-test='all-machines-checkbox'] input")
+          .props()
+          .className.includes("p-checkbox--mixed")
+      ).toBe(false);
     });
 
     it("correctly dispatches action when unchecked machine checkbox clicked", () => {
@@ -568,7 +581,7 @@ describe("MachineListTable", () => {
 
     it("correctly dispatches action when unchecked group checkbox clicked", () => {
       const state = { ...initialState };
-      state.machine.selected = ["abc123"];
+      state.machine.selected = [];
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
@@ -591,7 +604,7 @@ describe("MachineListTable", () => {
         .simulate("change", {
           target: { name: state.machine.items[0].system_id },
         });
-      // Not all machines in group selected => select machines in group
+      // No machines in group selected => select machines in group
       expect(
         store
           .getActions()
@@ -638,9 +651,37 @@ describe("MachineListTable", () => {
       });
     });
 
-    it("correctly dispatches action when unchecked header checkbox clicked", () => {
+    it("shows group checkbox in mixed selection state if some machines selected", () => {
       const state = { ...initialState };
       state.machine.selected = ["abc123"];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <MachineListTable
+              filter=""
+              grouping="status"
+              hiddenGroups={[]}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+      expect(
+        wrapper
+          .find("[data-test='group-cell'] input")
+          .at(0)
+          .props()
+          .className.includes("p-checkbox--mixed")
+      ).toBe(true);
+    });
+
+    it("correctly dispatches action when unchecked header checkbox clicked", () => {
+      const state = { ...initialState };
+      state.machine.selected = [];
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
@@ -663,7 +704,7 @@ describe("MachineListTable", () => {
         .simulate("change", {
           target: { name: state.machine.items[0].system_id },
         });
-      // Not all machines selected => select all machines
+      // No machines selected => select all machines
       expect(
         store
           .getActions()
@@ -740,6 +781,34 @@ describe("MachineListTable", () => {
           .exists()
       ).toBe(true);
     });
+  });
+
+  it("shows header checkbox in mixed selection state if some machines selected", () => {
+    const state = { ...initialState };
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineListTable
+            filter=""
+            grouping="status"
+            hiddenGroups={[]}
+            setHiddenGroups={jest.fn()}
+            setSearchFilter={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("[data-test='all-machines-checkbox'] input")
+        .at(0)
+        .props()
+        .className.includes("p-checkbox--mixed")
+    ).toBe(true);
   });
 
   it("remove selected filter when unchecking the only checked machine", () => {

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -28,4 +28,12 @@
       }
     }
   }
+
+  .p-checkbox--mixed:checked {
+    + label::after {
+      border-left: 0;
+      top: .3125rem;
+      transform: none;
+    }
+  }
 }


### PR DESCRIPTION
## Done
- Added a new state to machine list checkboxes that indicates whether some (but not all) machines in a group are selected.
- Changed the checkbox functionality so that it actually makes sense with the new state, i.e. if a checkbox is checked (mixed or not) unchecking it will also uncheck all the machines in that group.

## QA
- Select some machines in different groups and check that the checkboxes indicate whether some or all machines in groups are selected.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1907

## Screenshot
![Screenshot_2020-05-04 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/80935592-a78edc80-8e10-11ea-9cc3-5cd30fdcc776.png)

