### PR TITLE
Use createSelector for all selectors that can use it

### DIFF
--- a/ui/src/app/base/selectors/controller/controller.js
+++ b/ui/src/app/base/selectors/controller/controller.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const controller = {};
 
 /**
@@ -26,7 +28,9 @@ controller.loaded = (state) => state.controller.loaded;
  * @param {Object} state - The redux state.
  * @returns {Array} A controller.
  */
-controller.getBySystemId = (state, id) =>
-  state.controller.items.find((controller) => controller.system_id === id);
+controller.getBySystemId = createSelector(
+  [controller.all, (state, id) => id],
+  (controllers, id) => controllers.find(({ system_id }) => system_id === id)
+);
 
 export default controller;

--- a/ui/src/app/base/selectors/device/device.js
+++ b/ui/src/app/base/selectors/device/device.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const device = {};
 
 /**
@@ -26,7 +28,9 @@ device.loaded = (state) => state.device.loaded;
  * @param {Object} state - The redux state.
  * @returns {Array} A device.
  */
-device.getBySystemId = (state, id) =>
-  state.device.items.find((device) => device.system_id === id);
+device.getBySystemId = createSelector(
+  [device.all, (state, id) => id],
+  (devices, id) => devices.find(({ system_id }) => system_id === id)
+);
 
 export default device;

--- a/ui/src/app/base/selectors/dhcpsnippet/dhcpsnippet.js
+++ b/ui/src/app/base/selectors/dhcpsnippet/dhcpsnippet.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const dhcpsnippet = {};
 
 /**
@@ -13,19 +15,24 @@ dhcpsnippet.all = (state) => state.dhcpsnippet.items;
  * @param {String} term - The term to match against.
  * @returns {Array} A filtered list of dhcp snippets.
  */
-dhcpsnippet.search = (state, term) => {
-  return state.dhcpsnippet.items.filter(
-    (dhcpsnippet) =>
-      dhcpsnippet.name.includes(term) || dhcpsnippet.description.includes(term)
-  );
-};
+dhcpsnippet.search = createSelector(
+  [dhcpsnippet.all, (state, term) => term],
+  (dhcpsnippets, term) =>
+    dhcpsnippets.filter(
+      (snippet) =>
+        snippet.name.includes(term) || snippet.description.includes(term)
+    )
+);
 
 /**
  * Returns number of dhcp snippets
  * @param {Object} state - The redux state.
  * @returns {Array} A list of all dhcp snippets.
  */
-dhcpsnippet.count = (state) => state.dhcpsnippet.items.length;
+dhcpsnippet.count = createSelector(
+  [dhcpsnippet.all],
+  (dhcpsnippets) => dhcpsnippets.length
+);
 
 /**
  * Whether dhcp snippets are loading.
@@ -67,7 +74,9 @@ dhcpsnippet.saved = (state) => state.dhcpsnippet.saved;
  * @param {Object} state - The redux state.
  * @returns {Array} A dhcp snippet.
  */
-dhcpsnippet.getById = (state, id) =>
-  state.dhcpsnippet.items.find((dhcpsnippet) => dhcpsnippet.id === id);
+dhcpsnippet.getById = createSelector(
+  [dhcpsnippet.all, (state, id) => id],
+  (dhcpsnippets, id) => dhcpsnippets.find((snippet) => snippet.id === id)
+);
 
 export default dhcpsnippet;

--- a/ui/src/app/base/selectors/general/osInfo.js
+++ b/ui/src/app/base/selectors/general/osInfo.js
@@ -8,13 +8,12 @@ import { generateGeneralSelector } from "./utils";
 const osInfo = generateGeneralSelector("osInfo");
 
 /**
- * Returns kernels data
- * @param {Object} state - the redux state
- * @param {String} release - the release to get kernel options for
- * @returns {Array} - the available kernel options
+ * Returns kernels data.
+ * @param {Object} data - The osinfo data.
+ * @param {String} release - The release to get kernel options for.
+ * @returns {Array} - The available kernel options.
  */
-osInfo.getUbuntuKernelOptions = (state, release) => {
-  const { data } = state.general.osInfo;
+const _getUbuntuKernelOptions = (data, release) => {
   let kernelOptions = [];
 
   if (data.kernels && data.kernels.ubuntu && data.kernels.ubuntu[release]) {
@@ -30,35 +29,44 @@ osInfo.getUbuntuKernelOptions = (state, release) => {
 };
 
 /**
+ * Returns kernels data.
+ * @param {Object} state -The redux state.
+ * @param {String} release - The release to get kernel options for.
+ * @returns {Array} - The available kernel options.
+ */
+osInfo.getUbuntuKernelOptions = createSelector(
+  [osInfo.get, (state, release) => release],
+  (allOsInfo, release) => _getUbuntuKernelOptions(allOsInfo, release)
+);
+
+/**
  * Returns all ubuntu kernel options
  * @param {Object} state - the redux state
  * @returns {Object} - all ubuntu kernel options
  */
-osInfo.getAllUbuntuKernelOptions = (state) => {
-  const { data } = state.general.osInfo;
+osInfo.getAllUbuntuKernelOptions = createSelector([osInfo.get], (allOsInfo) => {
   let allUbuntuKernelOptions = {};
 
-  if (data.kernels && data.kernels.ubuntu) {
-    Object.keys(data.kernels.ubuntu).forEach((key) => {
-      allUbuntuKernelOptions[key] = osInfo.getUbuntuKernelOptions(state, key);
+  if (allOsInfo.kernels && allOsInfo.kernels.ubuntu) {
+    Object.keys(allOsInfo.kernels.ubuntu).forEach((key) => {
+      allUbuntuKernelOptions[key] = _getUbuntuKernelOptions(allOsInfo, key);
     });
   }
 
   return allUbuntuKernelOptions;
-};
+});
 
 /**
  * Returns OS releases
- * @param {Object} state - the redux state
+ * @param {Object} data - The osinfo data.
  * @param {String} os - the OS to get releases of
  * @returns {Array} - the available OS releases
  */
-osInfo.getOsReleases = (state, os) => {
-  const { data } = state.general.osInfo;
+const _getOsReleases = (allOsInfo, os) => {
   let osReleases = [];
 
-  if (data.releases) {
-    osReleases = data.releases
+  if (allOsInfo.releases) {
+    osReleases = allOsInfo.releases
       .filter((release) => release[0].includes(os))
       .map((release) => ({
         value: release[0].split("/")[1],
@@ -70,23 +78,33 @@ osInfo.getOsReleases = (state, os) => {
 };
 
 /**
+ * Returns OS releases
+ * @param {Object} state - the redux state
+ * @param {String} os - the OS to get releases of
+ * @returns {Array} - the available OS releases
+ */
+osInfo.getOsReleases = createSelector(
+  [osInfo.get, (state, os) => os],
+  (allOsInfo, os) => _getOsReleases(allOsInfo, os)
+);
+
+/**
  * Returns an object with all OS releases
  * @param {Object} state - the redux state
  * @returns {Object} - all OS releases
  */
-osInfo.getAllOsReleases = (state) => {
-  const { data } = state.general.osInfo;
+osInfo.getAllOsReleases = createSelector([osInfo.get], (allOsInfo) => {
   const allOsReleases = {};
 
-  if (data.osystems && data.releases) {
-    data.osystems.forEach((osystem) => {
+  if (allOsInfo.osystems && allOsInfo.releases) {
+    allOsInfo.osystems.forEach((osystem) => {
       const os = osystem[0];
-      allOsReleases[os] = osInfo.getOsReleases(state, os);
+      allOsReleases[os] = _getOsReleases(allOsInfo, os);
     });
   }
 
   return allOsReleases;
-};
+});
 
 /**
  * Returns an object with all OS releases

--- a/ui/src/app/base/selectors/general/version.js
+++ b/ui/src/app/base/selectors/general/version.js
@@ -2,17 +2,18 @@
  * Selector for the MAAS version.
  */
 
+import { createSelector } from "@reduxjs/toolkit";
+
 import { generateGeneralSelector } from "./utils";
 
 const version = generateGeneralSelector("version");
 
-version.minor = (state) => {
-  const { data } = state.general.version;
+version.minor = createSelector([version.get], (data) => {
   const splitVersion = data.split(".");
   if (splitVersion[0] && splitVersion[1]) {
     return `${splitVersion[0]}.${splitVersion[1]}`;
   }
   return "";
-};
+});
 
 export default version;

--- a/ui/src/app/base/selectors/licensekeys/licensekeys.js
+++ b/ui/src/app/base/selectors/licensekeys/licensekeys.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const licensekeys = {};
 
 /**
@@ -30,14 +32,6 @@ licensekeys.loaded = (state) => state.licensekeys.loaded;
 licensekeys.saved = (state) => state.licensekeys.saved;
 
 /**
- * Returns true if license keys have errors
- * @param {Object} state - Redux state
- * @returns {Boolean} License keys have errors
- */
-licensekeys.hasErrors = (state) =>
-  Object.entries(state.licensekeys.errors).length > 0;
-
-/**
  * Returns license keys errors.
  * @param {Object} state - The redux state.
  * @returns {Array} Errors for license keys.
@@ -45,15 +39,28 @@ licensekeys.hasErrors = (state) =>
 licensekeys.errors = (state) => state.licensekeys.errors;
 
 /**
+ * Returns true if license keys have errors
+ * @param {Object} state - Redux state
+ * @returns {Boolean} License keys have errors
+ */
+licensekeys.hasErrors = createSelector(
+  [licensekeys.errors],
+  (errors) => Object.entries(errors).length > 0
+);
+
+/**
  * Get license keys that match a term.
  * @param {Object} state - The redux state.
  * @param {String} term - The term to match against.
  * @returns {Array} A filtered list of license keys.
  */
-licensekeys.search = (state, term) =>
-  state.licensekeys.items.filter(
-    (item) => item.osystem.includes(term) || item.distro_series.includes(term)
-  );
+licensekeys.search = createSelector(
+  [licensekeys.all, (state, term) => term],
+  (licencekeyItems, term) =>
+    licencekeyItems.filter(
+      (item) => item.osystem.includes(term) || item.distro_series.includes(term)
+    )
+);
 
 /**
  * Get license keys for a given osystem and distro_series.
@@ -66,6 +73,17 @@ licensekeys.getByOsystemAndDistroSeries = (state, osystem, distro_series) =>
   state.licensekeys.items.filter(
     (item) => item.osystem === osystem && item.distro_series === distro_series
   )[0];
+
+licensekeys.getByOsystemAndDistroSeries = createSelector(
+  [
+    licensekeys.all,
+    (state, osystem, distro_series) => ({ osystem, distro_series }),
+  ],
+  (licencekeyItems, { osystem, distro_series }) =>
+    licencekeyItems.filter(
+      (item) => item.osystem === osystem && item.distro_series === distro_series
+    )[0]
+);
 
 /**
  * Get the saving state.

--- a/ui/src/app/base/selectors/machine/machine.js
+++ b/ui/src/app/base/selectors/machine/machine.js
@@ -86,8 +86,10 @@ ACTIONS.forEach(({ status }) => {
  * @param {Object} state - The redux state.
  * @returns {Array} A machine.
  */
-machine.getBySystemId = (state, id) =>
-  state.machine.items.find((machine) => machine.system_id === id);
+machine.getBySystemId = createSelector(
+  [machine.all, (state, id) => id],
+  (machines, id) => machines.find(({ system_id }) => system_id === id)
+);
 
 /**
  * Returns machine errors.
@@ -97,25 +99,19 @@ machine.getBySystemId = (state, id) =>
 machine.errors = (state) => state.machine.errors;
 
 /**
- * Gets the search terms and selected machines.
- * @param {Object} state - The redux state.
- * @param {String} terms - The search string.
- * @param {Array} selectedIDs - The selected machine ids.
- * @returns {Array} The search terms and selected machines.
- */
-machine._getSearchParams = (state, terms, selectedIDs) => ({
-  terms,
-  selectedIDs,
-});
-
-/**
  * Get machines that match terms.
  * @param {Object} state - The redux state.
  * @param {String} terms - The terms to match against.
  * @returns {Array} A filtered list of machines.
  */
 machine.search = createSelector(
-  [machine.all, machine._getSearchParams],
+  [
+    machine.all,
+    (state, terms, selectedIDs) => ({
+      terms,
+      selectedIDs,
+    }),
+  ],
   (items, { terms, selectedIDs }) => {
     if (!terms) {
       return items;

--- a/ui/src/app/base/selectors/notification/notification.js
+++ b/ui/src/app/base/selectors/notification/notification.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const notification = {};
 
 /**
@@ -26,47 +28,46 @@ notification.loaded = (state) => state.notification.loaded;
  * @param {Object} state - The redux state.
  * @returns {Array} A notification.
  */
-notification.getById = (state, id) =>
-  state.notification.items.find((notification) => notification.id === id);
+notification.getById = createSelector(
+  [notification.all, (state, id) => id],
+  (notifications, id) =>
+    notifications.find((notification) => notification.id === id)
+);
 
 /**
  * Returns notifications of type 'warning'
  * @param {Object} state - The redux state.
  * @returns {Array} A notification.
  */
-notification.warnings = (state) =>
-  state.notification.items.filter(
-    (notification) => notification.category === "warning"
-  );
+notification.warnings = createSelector([notification.all], (notifications) =>
+  notifications.filter((notification) => notification.category === "warning")
+);
 
 /**
  * Returns notifications of type 'error'
  * @param {Object} state - The redux state.
  * @returns {Array} A notification.
  */
-notification.errors = (state) =>
-  state.notification.items.filter(
-    (notification) => notification.category === "error"
-  );
+notification.errors = createSelector([notification.all], (notifications) =>
+  notifications.filter((notification) => notification.category === "error")
+);
 
 /**
  * Returns notifications of type 'success'
  * @param {Object} state - The redux state.
  * @returns {Array} A notification.
  */
-notification.success = (state) =>
-  state.notification.items.filter(
-    (notification) => notification.category === "success"
-  );
+notification.success = createSelector([notification.all], (notifications) =>
+  notifications.filter((notification) => notification.category === "success")
+);
 
 /**
  * Returns notifications of type 'info'
  * @param {Object} state - The redux state.
  * @returns {Array} A notification.
  */
-notification.info = (state) =>
-  state.notification.items.filter(
-    (notification) => notification.category === "info"
-  );
+notification.info = createSelector([notification.all], (notifications) =>
+  notifications.filter((notification) => notification.category === "info")
+);
 
 export default notification;

--- a/ui/src/app/base/selectors/packagerepository/packagerepository.js
+++ b/ui/src/app/base/selectors/packagerepository/packagerepository.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const packagerepository = {};
 
 /**
@@ -12,7 +14,10 @@ packagerepository.all = (state) => state.packagerepository.items;
  * @param {Object} state - The redux state.
  * @returns {Number} Count of all repositories.
  */
-packagerepository.count = (state) => state.packagerepository.items.length;
+packagerepository.count = createSelector(
+  [packagerepository.all],
+  (repositories) => repositories.length
+);
 
 /**
  * Returns true if repositories are loading.
@@ -55,11 +60,13 @@ packagerepository.errors = (state) => state.packagerepository.errors;
  * @param {String} term - The term to match against.
  * @returns {Array} A filtered list of repositories.
  */
-packagerepository.search = (state, term) => {
-  return state.packagerepository.items.filter(
-    (repo) => repo.name.includes(term) || repo.url.includes(term)
-  );
-};
+packagerepository.search = createSelector(
+  [packagerepository.all, (state, term) => term],
+  (repositories, term) =>
+    repositories.filter(
+      (repo) => repo.name.includes(term) || repo.url.includes(term)
+    )
+);
 
 /**
  * Returns repository that matches given id
@@ -67,7 +74,9 @@ packagerepository.search = (state, term) => {
  * @param {Number} id - id of repository to return.
  * @returns {Object} Repository that matches id.
  */
-packagerepository.getById = (state, id) =>
-  state.packagerepository.items.find((repo) => repo.id === id);
+packagerepository.getById = createSelector(
+  [packagerepository.all, (state, id) => id],
+  (repositories, id) => repositories.find((repo) => repo.id === id)
+);
 
 export default packagerepository;

--- a/ui/src/app/base/selectors/resourcepool/resourcepool.js
+++ b/ui/src/app/base/selectors/resourcepool/resourcepool.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const resourcepool = {};
 
 /**
@@ -48,7 +50,9 @@ resourcepool.saved = (state) => state.resourcepool.saved;
  * @param {Number} id - id of resource pool to return.
  * @returns {Object} Resource pool that matches id.
  */
-resourcepool.getById = (state, id) =>
-  state.resourcepool.items.find((pool) => pool.id === id);
+resourcepool.getById = createSelector(
+  [resourcepool.all, (state, id) => id],
+  (pools, id) => pools.find((pool) => pool.id === id)
+);
 
 export default resourcepool;

--- a/ui/src/app/base/selectors/scriptresults/scriptresults.js
+++ b/ui/src/app/base/selectors/scriptresults/scriptresults.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const scriptresults = {};
 
 /**
@@ -30,18 +32,20 @@ scriptresults.loaded = (state) => state.scriptresults.loaded;
 scriptresults.saved = (state) => state.scriptresults.saved;
 
 /**
- * Returns true if script results have errors
- * @param {Object} state - Redux state
- * @returns {Boolean} Script results have errors
- */
-scriptresults.hasErrors = (state) =>
-  Object.entries(state.scriptresults.errors).length > 0;
-
-/**
  * Returns script result errors.
  * @param {Object} state - The redux state.
  * @returns {Array} Errors for a script result.
  */
 scriptresults.errors = (state) => state.scripts.errors;
+
+/**
+ * Returns true if script results have errors
+ * @param {Object} state - Redux state
+ * @returns {Boolean} Script results have errors
+ */
+scriptresults.hasErrors = createSelector(
+  [scriptresults.errors],
+  (errors) => Object.entries(errors).length > 0
+);
 
 export default scriptresults;

--- a/ui/src/app/base/selectors/scripts/scripts.js
+++ b/ui/src/app/base/selectors/scripts/scripts.js
@@ -27,8 +27,10 @@ scripts.loading = (state) => state.scripts.loading;
  * @param {Object} state - Redux state
  * @returns {Number} Number of scripts
  */
-
-scripts.count = (state) => state.scripts.items.length;
+scripts.count = createSelector(
+  [scripts.all],
+  (scriptItems) => scriptItems.length
+);
 
 /**
  * Returns true if scripts have loaded
@@ -45,13 +47,6 @@ scripts.loaded = (state) => state.scripts.loaded;
 scripts.saved = (state) => state.scripts.saved;
 
 /**
- * Returns true if scripts have errors
- * @param {Object} state - Redux state
- * @returns {Boolean} Scripts have errors
- */
-scripts.hasErrors = (state) => Object.entries(state.scripts.errors).length > 0;
-
-/**
  * Returns script errors.
  * @param {Object} state - The redux state.
  * @returns {Array} Errors for a script.
@@ -59,22 +54,32 @@ scripts.hasErrors = (state) => Object.entries(state.scripts.errors).length > 0;
 scripts.errors = (state) => state.scripts.errors;
 
 /**
+ * Returns true if scripts have errors
+ * @param {Object} state - Redux state
+ * @returns {Boolean} Scripts have errors
+ */
+scripts.hasErrors = createSelector(
+  [scripts.errors],
+  (errors) => Object.entries(errors).length > 0
+);
+
+/**
  * Returns all commissioning scripts
  * @param {Object} state - Redux state
  * @returns {Array} Commissioning scripts
  */
-scripts.commissioning = (state) =>
-  state.scripts.items.filter(
-    (item) => item.type === SCRIPT_TYPES.COMMISSIONING
-  );
+scripts.commissioning = createSelector([scripts.all], (scriptItems) =>
+  scriptItems.filter((item) => item.type === SCRIPT_TYPES.COMMISSIONING)
+);
 
 /**
  * Returns all testing scripts
  * @param {Object} state - Redux state
  * @returns {Array} Testing scripts
  */
-scripts.testing = (state) =>
-  state.scripts.items.filter((item) => item.type === SCRIPT_TYPES.TESTING);
+scripts.testing = createSelector([scripts.all], (scriptItems) =>
+  scriptItems.filter((item) => item.type === SCRIPT_TYPES.TESTING)
+);
 
 /**
  * Returns testing scripts that contain a URL parameter
@@ -94,16 +99,19 @@ scripts.testingWithUrl = createSelector([scripts.testing], (testScripts) =>
  * @param {String} type - The type of script.
  * @returns {Array} A filtered list of scripts.
  */
-scripts.search = (state, term, type) => {
-  const scripts = state.scripts.items.filter(
-    (item) => item.type === SCRIPT_TYPES[type.toUpperCase()]
-  );
-  if (term) {
-    return scripts.filter(
-      (item) => item.name.includes(term) || item.description.includes(term)
+scripts.search = createSelector(
+  [scripts.all, (state, term, type) => ({ term, type })],
+  (scriptItems, { term, type }) => {
+    const scripts = scriptItems.filter(
+      (item) => item.type === SCRIPT_TYPES[type.toUpperCase()]
     );
+    if (term) {
+      return scripts.filter(
+        (item) => item.name.includes(term) || item.description.includes(term)
+      );
+    }
+    return scripts;
   }
-  return scripts;
-};
+);
 
 export default scripts;

--- a/ui/src/app/base/selectors/subnet/subnet.js
+++ b/ui/src/app/base/selectors/subnet/subnet.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const subnet = {};
 
 /**
@@ -26,7 +28,9 @@ subnet.loaded = (state) => state.subnet.loaded;
  * @param {Object} state - The redux state.
  * @returns {Array} A subnet.
  */
-subnet.getById = (state, id) =>
-  state.subnet.items.find((subnet) => subnet.id === id);
+subnet.getById = createSelector(
+  [subnet.all, (state, id) => id],
+  (subnets, id) => subnets.find((subnet) => subnet.id === id)
+);
 
 export default subnet;

--- a/ui/src/app/base/selectors/user/user.js
+++ b/ui/src/app/base/selectors/user/user.js
@@ -1,17 +1,13 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const user = {};
 
 /**
  * Returns all users
  * @param {Object} state - The redux state.
- * @param {Number} batch - Number of users to return.
  * @returns {Array} A list of all users.
  */
-user.get = (state, batch) => {
-  if (batch) {
-    return state.user.items.slice(0, batch);
-  }
-  return state.user.items;
-};
+user.get = (state) => state.user.items;
 
 /**
  * Get users that match a term.
@@ -19,14 +15,14 @@ user.get = (state, batch) => {
  * @param {String} term - The term to match against.
  * @returns {Array} A filtered list of users.
  */
-user.search = (state, term) => {
-  return state.user.items.filter(
+user.search = createSelector([user.get, (state, term) => term], (users, term) =>
+  users.filter(
     (user) =>
       user.username.includes(term) ||
       user.email.includes(term) ||
       user.last_name.includes(term)
-  );
-};
+  )
+);
 
 /**
  * Returns true if users are loading.
@@ -47,7 +43,7 @@ user.loaded = (state) => state.user.loaded;
  * @param {Object} state - The redux state.
  * @returns {Array} A list of all users.
  */
-user.count = (state) => state.user.items.length;
+user.count = createSelector([user.get], (users) => users.length);
 
 /**
  * Returns users errors.
@@ -75,6 +71,8 @@ user.saved = (state) => state.user.saved;
  * @param {Object} state - The redux state.
  * @returns {Array} A user.
  */
-user.getById = (state, id) => state.user.items.find((user) => user.id === id);
+user.getById = createSelector([user.get, (state, id) => id], (users, id) =>
+  users.find((user) => user.id === id)
+);
 
 export default user;

--- a/ui/src/app/preferences/selectors/token/token.js
+++ b/ui/src/app/preferences/selectors/token/token.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const token = {};
 
 /**
@@ -48,7 +50,9 @@ token.saved = (state) => state.token.saved;
  * @param {String} id - A token id.
  * @returns {Array} An authorisation token.
  */
-token.getById = (state, id) =>
-  state.token.items.find((token) => token.id === id);
+
+token.getById = createSelector([token.all, (state, id) => id], (tokens, id) =>
+  tokens.find((token) => token.id === id)
+);
 
 export default token;


### PR DESCRIPTION
## Done
- Update all selectors that are fetching and manipulating state to use `createSelector`.
- This resulted in an up to about 50ms improvement on the first render of the machine list and went from 11 rerenders to 4.

### Before:
<img width="457" alt="Screen Shot 2020-05-05 at 10 10 41 am" src="https://user-images.githubusercontent.com/361637/81025326-b382a900-8eb9-11ea-9aaf-886e8dac284c.png">

### After:
<img width="459" alt="Screen Shot 2020-05-05 at 10 12 20 am" src="https://user-images.githubusercontent.com/361637/81025340-baa9b700-8eb9-11ea-8da1-a81d991531ca.png">

## QA
- These should all be internal changes to the selectors so the tests should pass, but you could poke around the machine list/prefs/settings to make sure everything works.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/1872.
