### PR TITLE
Change LXD KVM password input to type="password".

### DIFF
--- a/legacy/src/app/directives/pod_parameters.js
+++ b/legacy/src/app/directives/pod_parameters.js
@@ -44,7 +44,7 @@ export function maasPodParameters(
           var html = "";
           angular.forEach(type.fields, function(field) {
             if (field.scope === "bmc") {
-              if (field.name === "power_pass") {
+              if (field.name === "power_pass" || field.name === "password") {
                 html += '<maas-obj-field type="password" key="';
               } else {
                 html += '<maas-obj-field type="text" key="';


### PR DESCRIPTION
## Done
- Changed LXD KVM password input to type="password".

## QA
- Go to /kvm and open the Add KVM form
- Select LXD type and check that the password input has `type="password"`

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1920

## Launchpad Issue
[lp#1876921](https://bugs.launchpad.net/maas/+bug/1876921)
