### PR TITLE
Speed up checkbox checking

### DIFF
--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -29,6 +29,7 @@ const ContextualMenu = ({
   const { openPortal, closePortal, isOpen, Portal } = usePortal({
     isOpen: !hasToggle,
   });
+  const previousIsOpen = useRef(isOpen);
   const labelNode = toggleLabel ? <span>{toggleLabel}</span> : null;
   const wrapperClass = classNames(
     className,
@@ -38,7 +39,13 @@ const ContextualMenu = ({
   );
 
   useEffect(() => {
-    onToggleMenu && onToggleMenu(isOpen);
+    // The isOpen state is compared to the previous state so that we can
+    // initialise the previous state in a way that means that this effect does
+    // not call onToggleMenu on first render.
+    if (isOpen !== previousIsOpen.current) {
+      onToggleMenu && onToggleMenu(isOpen);
+      previousIsOpen.current = isOpen;
+    }
     // onToggleMenu is excluded from the useEffect deps as onToggleMenu gets
     // redefined on a state update which causes an infinite loop here.
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -6,6 +6,7 @@ import React, { useEffect, useRef } from "react";
 import usePortal from "react-useportal";
 
 import ContextualMenuDropdown from "./ContextualMenuDropdown";
+import { usePrevious } from "app/base/hooks";
 
 const ContextualMenu = ({
   className,
@@ -29,7 +30,7 @@ const ContextualMenu = ({
   const { openPortal, closePortal, isOpen, Portal } = usePortal({
     isOpen: !hasToggle,
   });
-  const previousIsOpen = useRef(isOpen);
+  const previousIsOpen = usePrevious(isOpen);
   const labelNode = toggleLabel ? <span>{toggleLabel}</span> : null;
   const wrapperClass = classNames(
     className,
@@ -42,9 +43,8 @@ const ContextualMenu = ({
     // The isOpen state is compared to the previous state so that we can
     // initialise the previous state in a way that means that this effect does
     // not call onToggleMenu on first render.
-    if (isOpen !== previousIsOpen.current) {
+    if (isOpen !== previousIsOpen) {
       onToggleMenu && onToggleMenu(isOpen);
-      previousIsOpen.current = isOpen;
     }
     // onToggleMenu is excluded from the useEffect deps as onToggleMenu gets
     // redefined on a state update which causes an infinite loop here.

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -43,10 +43,10 @@ export const useLocation = () => {
  * @returns {*} Previous value.
  */
 export const usePrevious = (value) => {
-  const ref = useRef();
+  const ref = useRef(value);
   useEffect(() => {
     ref.current = value;
-  });
+  }, [value]);
   return ref.current;
 };
 

--- a/ui/src/app/machines/hooks.js
+++ b/ui/src/app/machines/hooks.js
@@ -1,0 +1,14 @@
+import { useCallback } from "react";
+
+/**
+ * Create a callback for toggling the menu
+ * @param {Function} onToggleMenu - The function to toggle the menu.
+ * @param {String} systemId - The machine id.
+ * @returns {Function} The toggle callback.
+ */
+export const useToggleMenu = (onToggleMenu, systemId) => {
+  return useCallback((open) => onToggleMenu(systemId, open), [
+    onToggleMenu,
+    systemId,
+  ]);
+};

--- a/ui/src/app/machines/views/MachineList/MachineListTable/CoresColumn/CoresColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/CoresColumn/CoresColumn.js
@@ -7,7 +7,7 @@ import ScriptStatus from "app/base/components/ScriptStatus";
 import Tooltip from "app/base/components/Tooltip";
 import { machine as machineSelectors } from "app/base/selectors";
 
-const CoresColumn = ({ onToggleMenu, systemId }) => {
+export const CoresColumn = ({ systemId }) => {
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -18,7 +18,6 @@ const CoresColumn = ({ onToggleMenu, systemId }) => {
   return (
     <DoubleRow
       className="u-align--right"
-      onToggleMenu={onToggleMenu}
       primary={
         <ScriptStatus
           data-test="cores"
@@ -42,8 +41,7 @@ const CoresColumn = ({ onToggleMenu, systemId }) => {
 };
 
 CoresColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 
-export default CoresColumn;
+export default React.memo(CoresColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/CoresColumn/CoresColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/CoresColumn/CoresColumn.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import CoresColumn from "./CoresColumn";
+import { CoresColumn } from "./CoresColumn";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/DisksColumn/DisksColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/DisksColumn/DisksColumn.js
@@ -6,14 +6,13 @@ import { machine as machineSelectors } from "app/base/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
 import ScriptStatus from "app/base/components/ScriptStatus";
 
-const DisksColumn = ({ onToggleMenu, systemId }) => {
+export const DisksColumn = ({ systemId }) => {
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
 
   return (
     <DoubleRow
-      onToggleMenu={onToggleMenu}
       primary={
         <ScriptStatus
           data-test="disks"
@@ -30,8 +29,7 @@ const DisksColumn = ({ onToggleMenu, systemId }) => {
 };
 
 DisksColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 
-export default DisksColumn;
+export default React.memo(DisksColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/DisksColumn/DisksColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/DisksColumn/DisksColumn.test.js
@@ -5,7 +5,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import { scriptStatus } from "app/base/enum";
-import DisksColumn from "./DisksColumn";
+import { DisksColumn } from "./DisksColumn";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.js
@@ -7,7 +7,7 @@ import { generateLegacyURL } from "app/utils";
 import DoubleRow from "app/base/components/DoubleRow";
 import ScriptStatus from "app/base/components/ScriptStatus";
 
-const FabricColumn = ({ onToggleMenu, systemId }) => {
+export const FabricColumn = ({ systemId }) => {
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -18,7 +18,6 @@ const FabricColumn = ({ onToggleMenu, systemId }) => {
 
   return (
     <DoubleRow
-      onToggleMenu={onToggleMenu}
       primary={
         <ScriptStatus
           data-test="fabric"
@@ -49,8 +48,7 @@ const FabricColumn = ({ onToggleMenu, systemId }) => {
 };
 
 FabricColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 
-export default FabricColumn;
+export default React.memo(FabricColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import FabricColumn from "./FabricColumn";
+import { FabricColumn } from "./FabricColumn";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -9,7 +9,7 @@ import {
 import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import classNames from "classnames";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import pluralize from "pluralize";
 
 import {
@@ -109,19 +109,12 @@ const generateRows = ({
   handleMachineCheckbox,
   machines,
   selectedMachines,
-  setActiveRow,
+  onToggleMenu,
   showMAC,
 }) => {
   const sortedMachines = [...machines].sort(machineSort(currentSort));
   return sortedMachines.map((row) => {
     const isActive = activeRow === row.system_id;
-    const onToggleMenu = (open) => {
-      if (open && !activeRow) {
-        setActiveRow(row.system_id);
-      } else if (!open || (open && activeRow)) {
-        setActiveRow(null);
-      }
-    };
 
     return {
       key: row.system_id,
@@ -133,7 +126,6 @@ const generateRows = ({
           content: (
             <NameColumn
               handleCheckbox={handleMachineCheckbox}
-              onToggleMenu={onToggleMenu}
               selected={selectedMachines.includes(row)}
               showMAC={showMAC}
               systemId={row.system_id}
@@ -169,35 +161,19 @@ const generateRows = ({
           ),
         },
         {
-          content: (
-            <FabricColumn
-              onToggleMenu={onToggleMenu}
-              systemId={row.system_id}
-            />
-          ),
+          content: <FabricColumn systemId={row.system_id} />,
         },
         {
-          content: (
-            <CoresColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
-          ),
+          content: <CoresColumn systemId={row.system_id} />,
         },
         {
-          content: (
-            <RamColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
-          ),
+          content: <RamColumn systemId={row.system_id} />,
         },
         {
-          content: (
-            <DisksColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
-          ),
+          content: <DisksColumn systemId={row.system_id} />,
         },
         {
-          content: (
-            <StorageColumn
-              onToggleMenu={onToggleMenu}
-              systemId={row.system_id}
-            />
-          ),
+          content: <StorageColumn systemId={row.system_id} />,
         },
       ],
     };
@@ -537,11 +513,22 @@ export const MachineListTable = ({
     dispatch(machineActions.setSelected(newSelectedMachines));
   };
 
+  const onToggleMenu = useCallback(
+    (systemId, open) => {
+      if (open && !activeRow) {
+        setActiveRow(systemId);
+      } else if (!open || (open && activeRow)) {
+        setActiveRow(null);
+      }
+    },
+    [activeRow]
+  );
+
   const rowProps = {
     activeRow,
     currentSort,
     handleMachineCheckbox,
-    setActiveRow,
+    onToggleMenu,
     showMAC,
   };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -86,13 +86,7 @@ const generateMAC = (machine, machineURL) => {
   );
 };
 
-const NameColumn = ({
-  handleCheckbox,
-  onToggleMenu,
-  selected,
-  showMAC,
-  systemId,
-}) => {
+export const NameColumn = ({ handleCheckbox, selected, showMAC, systemId }) => {
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -105,7 +99,6 @@ const NameColumn = ({
   return (
     <DoubleRow
       data-test="name-column"
-      onToggleMenu={onToggleMenu}
       primary={
         <Input
           checked={selected}
@@ -127,9 +120,8 @@ const NameColumn = ({
 NameColumn.propTypes = {
   handleCheckbox: PropTypes.func,
   selected: PropTypes.bool,
-  onToggleMenu: PropTypes.func,
   showMAC: PropTypes.bool,
   systemId: PropTypes.string.isRequired,
 };
 
-export default NameColumn;
+export default React.memo(NameColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import NameColumn from "./NameColumn";
+import { NameColumn } from "./NameColumn";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
@@ -5,13 +5,15 @@ import PropTypes from "prop-types";
 
 import { machine as machineSelectors } from "app/base/selectors";
 import { useMachineActions } from "app/base/hooks";
+import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 
-const OwnerColumn = ({ onToggleMenu, systemId }) => {
+export const OwnerColumn = ({ onToggleMenu, systemId }) => {
   const [updating, setUpdating] = useState(null);
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
+  const toggleMenu = useToggleMenu(onToggleMenu, systemId);
 
   const owner = machine.owner ? machine.owner : "-";
   const tags = machine.tags ? machine.tags.join(", ") : "";
@@ -35,7 +37,7 @@ const OwnerColumn = ({ onToggleMenu, systemId }) => {
     <DoubleRow
       menuLinks={menuLinks}
       menuTitle="Take action:"
-      onToggleMenu={onToggleMenu}
+      onToggleMenu={toggleMenu}
       primary={
         <>
           {updating === null ? null : (
@@ -56,8 +58,8 @@ const OwnerColumn = ({ onToggleMenu, systemId }) => {
 };
 
 OwnerColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
+  onToggleMenu: PropTypes.func.isRequired,
   systemId: PropTypes.string.isRequired,
 };
 
-export default OwnerColumn;
+export default React.memo(OwnerColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import OwnerColumn from "./OwnerColumn";
+import { OwnerColumn } from "./OwnerColumn";
 
 const mockStore = configureStore();
 
@@ -46,7 +46,7 @@ describe("OwnerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OwnerColumn systemId="abc123" />
+          <OwnerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -62,7 +62,7 @@ describe("OwnerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OwnerColumn systemId="abc123" />
+          <OwnerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -78,7 +78,7 @@ describe("OwnerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OwnerColumn systemId="abc123" />
+          <OwnerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -94,7 +94,7 @@ describe("OwnerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OwnerColumn systemId="abc123" />
+          <OwnerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -113,7 +113,7 @@ describe("OwnerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OwnerColumn systemId="abc123" />
+          <OwnerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -131,7 +131,7 @@ describe("OwnerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <OwnerColumn systemId="abc123" />
+          <OwnerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`OwnerColumn renders 1`] = `
 <OwnerColumn
+  onToggleMenu={[MockFunction]}
   systemId="abc123"
 >
   <DoubleRow
@@ -14,6 +15,7 @@ exports[`OwnerColumn renders 1`] = `
       ]
     }
     menuTitle="Take action:"
+    onToggleMenu={[Function]}
     primary={
       <React.Fragment>
         <span
@@ -62,6 +64,7 @@ exports[`OwnerColumn renders 1`] = `
                 },
               ]
             }
+            onToggleMenu={[Function]}
             positionNode={
               Object {
                 "current": <div
@@ -108,6 +111,7 @@ exports[`OwnerColumn renders 1`] = `
                   },
                 ]
               }
+              onToggleMenu={[Function]}
               position="left"
               positionNode={
                 Object {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
@@ -9,15 +9,17 @@ import {
   machine as machineSelectors,
   resourcepool as resourcePoolSelectors,
 } from "app/base/selectors";
+import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 
-const PoolColumn = ({ onToggleMenu, systemId }) => {
+export const PoolColumn = ({ onToggleMenu, systemId }) => {
   const dispatch = useDispatch();
   const [updating, setUpdating] = useState(null);
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
   const resourcePools = useSelector(resourcePoolSelectors.all);
+  const toggleMenu = useToggleMenu(onToggleMenu, systemId);
 
   let poolLinks = resourcePools.filter((pool) => pool.id !== machine.pool.id);
   if (machine.actions.includes("set-pool")) {
@@ -48,7 +50,7 @@ const PoolColumn = ({ onToggleMenu, systemId }) => {
     <DoubleRow
       menuLinks={poolLinks}
       menuTitle="Change pool:"
-      onToggleMenu={onToggleMenu}
+      onToggleMenu={toggleMenu}
       primary={
         <span data-test="pool">
           {updating !== null ? (
@@ -73,8 +75,8 @@ const PoolColumn = ({ onToggleMenu, systemId }) => {
 };
 
 PoolColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
+  onToggleMenu: PropTypes.func.isRequired,
   systemId: PropTypes.string.isRequired,
 };
 
-export default PoolColumn;
+export default React.memo(PoolColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
@@ -5,7 +5,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import PoolColumn from "./PoolColumn";
+import { PoolColumn } from "./PoolColumn";
 
 const mockStore = configureStore();
 
@@ -52,7 +52,7 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -68,7 +68,7 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -84,7 +84,7 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -105,7 +105,7 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -125,7 +125,7 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -144,7 +144,7 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -178,7 +178,7 @@ describe("PoolColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PoolColumn systemId="abc123" />
+          <PoolColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`PoolColumn renders 1`] = `
 <PoolColumn
+  onToggleMenu={[MockFunction]}
   systemId="abc123"
 >
   <DoubleRow
@@ -14,6 +15,7 @@ exports[`PoolColumn renders 1`] = `
       ]
     }
     menuTitle="Change pool:"
+    onToggleMenu={[Function]}
     primary={
       <span
         data-test="pool"
@@ -85,6 +87,7 @@ exports[`PoolColumn renders 1`] = `
                 },
               ]
             }
+            onToggleMenu={[Function]}
             positionNode={
               Object {
                 "current": <div
@@ -137,6 +140,7 @@ exports[`PoolColumn renders 1`] = `
                   },
                 ]
               }
+              onToggleMenu={[Function]}
               position="left"
               positionNode={
                 Object {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
@@ -6,14 +6,16 @@ import React, { useEffect, useState } from "react";
 
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
+import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 
-const PowerColumn = ({ onToggleMenu, systemId }) => {
+export const PowerColumn = ({ onToggleMenu, systemId }) => {
   const dispatch = useDispatch();
   const [updating, setUpdating] = useState(null);
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
+  const toggleMenu = useToggleMenu(onToggleMenu, systemId);
 
   const iconClass = classNames({
     "p-icon--power-on": machine.power_state === "on",
@@ -100,7 +102,7 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
       menuClassName="p-table-menu--hasIcon"
       menuLinks={menuLinks}
       menuTitle="Take action:"
-      onToggleMenu={onToggleMenu}
+      onToggleMenu={toggleMenu}
       primary={
         <div className="u-upper-case--first u-truncate" data-test="power_state">
           {powerState}
@@ -122,8 +124,8 @@ const PowerColumn = ({ onToggleMenu, systemId }) => {
 };
 
 PowerColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
+  onToggleMenu: PropTypes.func.isRequired,
   systemId: PropTypes.string.isRequired,
 };
 
-export default PowerColumn;
+export default React.memo(PowerColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import PowerColumn from "./PowerColumn";
+import { PowerColumn } from "./PowerColumn";
 
 const mockStore = configureStore();
 
@@ -38,7 +38,7 @@ describe("PowerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PowerColumn systemId="abc123" />
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -54,7 +54,7 @@ describe("PowerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PowerColumn systemId="abc123" />
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -70,7 +70,7 @@ describe("PowerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PowerColumn systemId="abc123" />
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -87,7 +87,7 @@ describe("PowerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PowerColumn systemId="abc123" />
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -106,7 +106,7 @@ describe("PowerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PowerColumn systemId="abc123" />
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -124,7 +124,7 @@ describe("PowerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PowerColumn systemId="abc123" />
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -143,7 +143,7 @@ describe("PowerColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <PowerColumn systemId="abc123" />
+          <PowerColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`PowerColumn renders 1`] = `
 <PowerColumn
+  onToggleMenu={[MockFunction]}
   systemId="abc123"
 >
   <DoubleRow
@@ -27,6 +28,7 @@ exports[`PowerColumn renders 1`] = `
       ]
     }
     menuTitle="Take action:"
+    onToggleMenu={[Function]}
     primary={
       <div
         className="u-upper-case--first u-truncate"
@@ -90,6 +92,7 @@ exports[`PowerColumn renders 1`] = `
                 },
               ]
             }
+            onToggleMenu={[Function]}
             positionNode={
               Object {
                 "current": <div
@@ -142,6 +145,7 @@ exports[`PowerColumn renders 1`] = `
                   },
                 ]
               }
+              onToggleMenu={[Function]}
               position="left"
               positionNode={
                 Object {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/RamColumn/RamColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/RamColumn/RamColumn.js
@@ -6,14 +6,13 @@ import { machine as machineSelectors } from "app/base/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
 import ScriptStatus from "app/base/components/ScriptStatus";
 
-const RamColumn = ({ onToggleMenu, systemId }) => {
+export const RamColumn = ({ systemId }) => {
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
 
   return (
     <DoubleRow
-      onToggleMenu={onToggleMenu}
       primary={
         <ScriptStatus
           hidePassedIcon
@@ -30,8 +29,7 @@ const RamColumn = ({ onToggleMenu, systemId }) => {
 };
 
 RamColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 
-export default RamColumn;
+export default React.memo(RamColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/RamColumn/RamColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/RamColumn/RamColumn.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import RamColumn from "../RamColumn";
+import { RamColumn } from "./RamColumn";
 import { scriptStatus } from "app/base/enum";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
@@ -9,6 +9,7 @@ import {
 } from "app/base/selectors";
 import { nodeStatus, scriptStatus } from "app/base/enum";
 import { useMachineActions } from "app/base/hooks";
+import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 import Tooltip from "app/base/components/Tooltip";
 
@@ -99,13 +100,14 @@ const getStatusIcon = (machine) => {
   return "";
 };
 
-const StatusColumn = ({ onToggleMenu, systemId }) => {
+export const StatusColumn = ({ onToggleMenu, systemId }) => {
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
   const osReleases = useSelector((state) =>
     generalSelectors.osInfo.getOsReleases(state, machine.osystem)
   );
+  const toggleMenu = useToggleMenu(onToggleMenu, systemId);
 
   const actionLinks = useMachineActions(systemId, [
     "abort",
@@ -145,7 +147,7 @@ const StatusColumn = ({ onToggleMenu, systemId }) => {
       iconSpace={true}
       menuLinks={menuLinks}
       menuTitle="Take action:"
-      onToggleMenu={onToggleMenu}
+      onToggleMenu={toggleMenu}
       primary={
         <span
           data-test="status-text"
@@ -164,8 +166,8 @@ const StatusColumn = ({ onToggleMenu, systemId }) => {
 };
 
 StatusColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
+  onToggleMenu: PropTypes.func.isRequired,
   systemId: PropTypes.string.isRequired,
 };
 
-export default StatusColumn;
+export default React.memo(StatusColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.js
@@ -5,7 +5,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import { nodeStatus, scriptStatus } from "app/base/enum";
-import StatusColumn from "./StatusColumn";
+import { StatusColumn } from "./StatusColumn";
 
 const mockStore = configureStore();
 
@@ -63,7 +63,7 @@ describe("StatusColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <StatusColumn systemId="abc123" />
+          <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -80,7 +80,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -99,7 +99,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -120,7 +120,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -139,7 +139,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -161,7 +161,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -182,7 +182,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -201,7 +201,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -220,7 +220,7 @@ describe("StatusColumn", () => {
           <MemoryRouter
             initialEntries={[{ pathname: "/machines", key: "testKey" }]}
           >
-            <StatusColumn systemId="abc123" />
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
           </MemoryRouter>
         </Provider>
       );
@@ -252,7 +252,7 @@ describe("StatusColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <StatusColumn systemId="abc123" />
+          <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -214,6 +214,7 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
 
 exports[`StatusColumn renders 1`] = `
 <StatusColumn
+  onToggleMenu={[MockFunction]}
   systemId="abc123"
 >
   <DoubleRow
@@ -237,6 +238,7 @@ exports[`StatusColumn renders 1`] = `
       ]
     }
     menuTitle="Take action:"
+    onToggleMenu={[Function]}
     primary={
       <span
         data-test="status-text"
@@ -298,6 +300,7 @@ exports[`StatusColumn renders 1`] = `
                 ],
               ]
             }
+            onToggleMenu={[Function]}
             positionNode={
               Object {
                 "current": <div
@@ -353,6 +356,7 @@ exports[`StatusColumn renders 1`] = `
                   ],
                 ]
               }
+              onToggleMenu={[Function]}
               position="left"
               positionNode={
                 Object {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StorageColumn/StorageColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StorageColumn/StorageColumn.js
@@ -6,7 +6,7 @@ import { machine as machineSelectors } from "app/base/selectors";
 import { formatBytes } from "app/utils";
 import DoubleRow from "app/base/components/DoubleRow";
 
-const StorageColumn = ({ onToggleMenu, systemId }) => {
+export const StorageColumn = ({ systemId }) => {
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
@@ -14,7 +14,6 @@ const StorageColumn = ({ onToggleMenu, systemId }) => {
 
   return (
     <DoubleRow
-      onToggleMenu={onToggleMenu}
       primary={
         <>
           <span data-test="storage-value">{formattedStorage.value}</span>&nbsp;
@@ -29,8 +28,7 @@ const StorageColumn = ({ onToggleMenu, systemId }) => {
 };
 
 StorageColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 
-export default StorageColumn;
+export default React.memo(StorageColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StorageColumn/StorageColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StorageColumn/StorageColumn.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import StorageColumn from "./StorageColumn";
+import { StorageColumn } from "./StorageColumn";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
@@ -10,6 +10,7 @@ import {
   zone as zoneSelectors,
 } from "app/base/selectors";
 import { generateLegacyURL } from "app/utils";
+import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 
 const getSpaces = (machine) => {
@@ -28,14 +29,14 @@ const getSpaces = (machine) => {
   );
 };
 
-const ZoneColumn = ({ onToggleMenu, systemId }) => {
+export const ZoneColumn = ({ onToggleMenu, systemId }) => {
   const dispatch = useDispatch();
   const [updating, setUpdating] = useState(null);
   const machine = useSelector((state) =>
     machineSelectors.getBySystemId(state, systemId)
   );
   const zones = useSelector(zoneSelectors.all);
-
+  const toggleMenu = useToggleMenu(onToggleMenu, systemId);
   let zoneLinks = zones.filter((zone) => zone.id !== machine.zone.id);
   if (machine.actions.includes("set-zone")) {
     if (zoneLinks.length !== 0) {
@@ -65,7 +66,7 @@ const ZoneColumn = ({ onToggleMenu, systemId }) => {
     <DoubleRow
       menuLinks={zoneLinks}
       menuTitle="Change AZ:"
-      onToggleMenu={onToggleMenu}
+      onToggleMenu={toggleMenu}
       primary={
         <span data-test="zone">
           {updating !== null ? (
@@ -86,8 +87,8 @@ const ZoneColumn = ({ onToggleMenu, systemId }) => {
 };
 
 ZoneColumn.propTypes = {
-  onToggleMenu: PropTypes.func,
+  onToggleMenu: PropTypes.func.isRequired,
   systemId: PropTypes.string.isRequired,
 };
 
-export default ZoneColumn;
+export default React.memo(ZoneColumn);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
@@ -5,7 +5,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import ZoneColumn from "./ZoneColumn";
+import { ZoneColumn } from "./ZoneColumn";
 
 const mockStore = configureStore();
 
@@ -52,7 +52,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -68,7 +68,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -84,7 +84,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -100,7 +100,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -116,7 +116,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -134,7 +134,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -153,7 +153,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -187,7 +187,7 @@ describe("ZoneColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <ZoneColumn systemId="abc123" />
+          <ZoneColumn onToggleMenu={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`ZoneColumn renders 1`] = `
 <ZoneColumn
+  onToggleMenu={[MockFunction]}
   systemId="abc123"
 >
   <DoubleRow
@@ -14,6 +15,7 @@ exports[`ZoneColumn renders 1`] = `
       ]
     }
     menuTitle="Change AZ:"
+    onToggleMenu={[Function]}
     primary={
       <span
         data-test="zone"
@@ -69,6 +71,7 @@ exports[`ZoneColumn renders 1`] = `
                 },
               ]
             }
+            onToggleMenu={[Function]}
             positionNode={
               Object {
                 "current": <div
@@ -120,6 +123,7 @@ exports[`ZoneColumn renders 1`] = `
                   },
                 ]
               }
+              onToggleMenu={[Function]}
               position="left"
               positionNode={
                 Object {


### PR DESCRIPTION
## Done
- Wrap machine table columns in React.memo so they don't rerender if the props don't change.
- Wrap the menu change function in useCallback so it doesn't update and force the columns to rerender.
- Remove the menu change function from columns that don't use it.

These changes made the speed of checking all the checkboxes go from ~270ms to ~40ms.

### Before

<img width="409" alt="before checkbox optimise" src="https://user-images.githubusercontent.com/361637/81253802-c9849b00-906c-11ea-803e-542faa68d481.png">

### After

<img width="409" alt="after checkbox optimise" src="https://user-images.githubusercontent.com/361637/81253810-d1dcd600-906c-11ea-89bc-0106088a6300.png">


## QA
- View the machine list.
- Click on a machine, group or all checkbox. The checkbox(es) should get checked quickly.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1044.
