### PR TITLE
Fix markup in script history expanding cell.

### DIFF
--- a/legacy/src/app/partials/script-results-list.html
+++ b/legacy/src/app/partials/script-results-list.html
@@ -116,7 +116,7 @@
                                     <div class="col-12">
                                         <p class="u-text--loading"><i class="p-icon--spinner u-animation--spin"></i>&nbsp;&nbsp;Loading...</p>
                                     </div>
-                                </div>
+                                </td>
                                 <td class="p-table-expanding__panel col-12" aria-label="history" data-ng-if="result.showing_history">
                                     <div class="row">
                                         <div class="col-12">


### PR DESCRIPTION
## Done
- Fixed incorrect markup in script history expanding cell. I'm fairly certain it's the cause of this bug that only happens in production: https://bugs.launchpad.net/maas/+bug/1877685

## QA
- See that the code is right. Once this is merged and bolla is updated we can check if the bug was actually fixed.

## Launchpad Issue
[lp#1877685](https://bugs.launchpad.net/maas/+bug/1877685)
