### PR TITLE
Apply style namespacing to the ui views

### DIFF
--- a/legacy/src/app/routes.js
+++ b/legacy/src/app/routes.js
@@ -21,6 +21,9 @@ import zonesListTmpl from "./partials/zones-list.html";
 
 /* @ngInject */
 const configureRoutes = ($stateProvider, $urlRouterProvider) => {
+  // Remove class on the HTML element when initialed to aid styling separation.
+  document.getElementsByTagName('html')[0].classList.remove("ui-view");
+
   $stateProvider
     .state("master", {
       abstract: true,

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -38,6 +38,9 @@ export const store = configureStore({
 sagaMiddleware.run(rootSaga);
 
 const Root = () => {
+  // Apply class on the HTML element when initialed to aid styling separation.
+  document.getElementsByTagName("html")[0].classList.add("ui-view");
+
   console.info(`${appName} ${appVersion} (${process.env.REACT_APP_GIT_SHA}).`);
   return (
     <Provider store={store}>

--- a/ui/src/scss/_patterns_buttons.scss
+++ b/ui/src/scss/_patterns_buttons.scss
@@ -34,9 +34,10 @@
     &.is-inline {
       margin: 0;
     }
+  }
 
-    // Table header sort buttons
-    th & {
+  table {
+    th .p-button--link {
       color: $color-mid-dark;
       font-weight: 400;
 
@@ -45,12 +46,12 @@
         margin-left: $sp-x-small;
       }
     }
-  }
 
-  table .p-button--link {
-    margin-bottom: 0;
-    padding-bottom: 0;
-    padding-top: 0;
+    .p-button--link {
+      margin-bottom: 0;
+      padding-bottom: 0;
+      padding-top: 0;
+    }
   }
 
   .p-button--link:not(:last-of-type):not(:only-of-type) {

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -42,13 +42,19 @@ input[type="checkbox"],
 input[type="radio"] {
   + label {
     margin-bottom: 0.6rem;
+  }
+}
 
-    .p-list__item:not(:first-child) &,
-    .p-form__group:not(:first-child) & {
+.p-list__item,
+.p-form__group {
+  &:not(:first-child) {
+    input[type="checkbox"],
+    input[type="radio"] {
       margin-top: -0.5rem;
     }
   }
 }
+
 .p-form-help-text,
 .p-form-validation__message {
   margin-bottom: 0.8rem;

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -1,98 +1,139 @@
-// Import settings
-@import "./settings";
+// Apply namespacing for the ui views.
+html.ui-view {
+  // Import settings
+  @import "./settings";
 
-// Import and include base Vanilla
-@import "~vanilla-framework/scss/build";
+  // Import and settings
+  @import "~vanilla-framework/scss/settings";
 
-// Import MAAS overrides of Vanilla patterns
-@import "./vanilla-overrides";
-
-// Import and include MAAS global styles
-@import "./patterns_buttons";
-@import "./patterns_double-row";
-@import "./patterns_footer";
-@import "./patterns_forms";
-@import "./patterns_icons";
-@import "./patterns_links";
-@import "./patterns_navigation";
-@import "./patterns_notifications";
-@import "./patterns_table-actions";
-@import "./patterns_tables";
-@import "./patterns_tabs";
-@import "./utilities";
-@include maas-buttons;
-@include maas-double-row;
-@include maas-footer;
-@include maas-forms;
-@include maas-icons;
-@include maas-links;
-@include maas-navigation;
-@include maas-notifications;
-@include maas-table-actions;
-@include maas-tables;
-@include maas-tabs;
-@include maas-utilities;
-
-// Import and include MAAS component styles
-// base
-@import "~app/base/components/ColumnToggle";
-@import "~app/base/components/FormCard";
-@import "~app/base/components/Login";
-@import "~app/base/components/Section";
-@import "~app/base/components/TableMenu";
-@import "~app/base/components/TagSelector";
-@include ColumnToggle;
-@include FormCard;
-@include Login;
-@include Section;
-@include TableMenu;
-@include TagSelector;
-
-// machines
-@import "~app/machines/views/MachineList";
-@import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
-@include MachineList;
-@include FilterAccordion;
-
-// preferences
-@import "~app/preferences/views/APIKeys/APIKeyList";
-@import "~app/preferences/views/SSHKeys/SSHKeyList";
-@import "~app/preferences/views/SSLKeys/AddSSLKey";
-@import "~app/preferences/views/SSLKeys/SSLKeyList";
-@include APIKeyList;
-@include SSHKeyList;
-@include AddSSLKey;
-@include SSLKeyList;
-
-// settings
-@import "~app/settings/components/SettingsTable";
-@import "~app/settings/views/Dhcp/DhcpList";
-@import "~app/settings/views/LicenseKeys/LicenseKeyList";
-@import "~app/settings/views/Repositories/RepositoriesList";
-@import "~app/settings/views/Repositories/RepositoryFormFields";
-@import "~app/settings/views/Scripts/ScriptsList";
-@import "~app/settings/views/Scripts/ScriptsUpload";
-@import "~app/settings/views/Users/UsersList";
-@include SettingsTable;
-@include DhcpList;
-@include LicenseKeyList;
-@include RepositoriesList;
-@include RepositoryFormFields;
-@include ScriptsList;
-@include ScriptsUpload;
-@include UsersList;
-
-html {
+  // the HTML element styling from Vanilla
   height: 100%;
-}
+  box-sizing: border-box;
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  color: $color-dark;
+  font-family: unquote($font-base-family);
+  // These vendor prefixes are unique and cannot be added by autoprefixer
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-weight: 300;
+  // set default line height to match p
+  line-height: map-get($line-heights, default-text);
 
-body {
-  background-color: $color-light;
-  min-height: 100%;
-}
+  @if ($increase-font-size-on-larger-screens) {
+    @media screen and (max-width: $breakpoint-x-large) {
+      font-size: map-get($base-font-sizes, base);
+    }
 
-#root {
-  min-height: 100vh;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
+    @media screen and (min-width: $breakpoint-x-large) {
+      font-size: map-get($base-font-sizes, large);
+      //the rem value is not affected by the change in font-size; it needs to be multiplied by the ratio new font-size/default font-size
+      line-height: map-get($line-heights, default-text) *
+        $font-size-ratio--largescreen;
+    }
+  } @else {
+    font-size: map-get($base-font-sizes, base);
+  }
+
+  // Import and include Vanilla
+  @import "~vanilla-framework/scss/build";
+
+  // Import MAAS overrides of Vanilla patterns
+  @import "./vanilla-overrides";
+
+  // Import and include MAAS global styles
+  @import "./patterns_buttons";
+  @import "./patterns_double-row";
+  @import "./patterns_footer";
+  @import "./patterns_forms";
+  @import "./patterns_icons";
+  @import "./patterns_links";
+  @import "./patterns_navigation";
+  @import "./patterns_notifications";
+  @import "./patterns_table-actions";
+  @import "./patterns_tables";
+  @import "./patterns_tabs";
+  @import "./utilities";
+  @include maas-buttons;
+  @include maas-double-row;
+  @include maas-footer;
+  @include maas-forms;
+  @include maas-icons;
+  @include maas-links;
+  @include maas-navigation;
+  @include maas-notifications;
+  @include maas-table-actions;
+  @include maas-tables;
+  @include maas-tabs;
+  @include maas-utilities;
+
+  // Import and include MAAS component styles
+  // base
+  @import "~app/base/components/ColumnToggle";
+  @import "~app/base/components/FormCard";
+  @import "~app/base/components/Login";
+  @import "~app/base/components/Section";
+  @import "~app/base/components/TableMenu";
+  @import "~app/base/components/TagSelector";
+  @include ColumnToggle;
+  @include FormCard;
+  @include Login;
+  @include Section;
+  @include TableMenu;
+  @include TagSelector;
+
+  // machines
+  @import "~app/machines/views/MachineList";
+  @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
+  @include MachineList;
+  @include FilterAccordion;
+
+  // preferences
+  @import "~app/preferences/views/APIKeys/APIKeyList";
+  @import "~app/preferences/views/SSHKeys/SSHKeyList";
+  @import "~app/preferences/views/SSLKeys/AddSSLKey";
+  @import "~app/preferences/views/SSLKeys/SSLKeyList";
+  @include APIKeyList;
+  @include SSHKeyList;
+  @include AddSSLKey;
+  @include SSLKeyList;
+
+  // settings
+  @import "~app/settings/components/SettingsTable";
+  @import "~app/settings/views/Dhcp/DhcpList";
+  @import "~app/settings/views/LicenseKeys/LicenseKeyList";
+  @import "~app/settings/views/Repositories/RepositoriesList";
+  @import "~app/settings/views/Repositories/RepositoryFormFields";
+  @import "~app/settings/views/Scripts/ScriptsList";
+  @import "~app/settings/views/Scripts/ScriptsUpload";
+  @import "~app/settings/views/Users/UsersList";
+  @include SettingsTable;
+  @include DhcpList;
+  @include LicenseKeyList;
+  @include RepositoriesList;
+  @include RepositoryFormFields;
+  @include ScriptsList;
+  @include ScriptsUpload;
+  @include UsersList;
+
+  // Vanilla uses & & for this pattern and will not work with namespacing but
+  // small enough to move here until we can remove the namespacing
+  .u-fixed-width .u-fixed-width,
+  .row .row {
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  body {
+    background-color: #f7f7f7;
+    min-height: 100%;
+  }
+
+  #root {
+    min-height: 100vh;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+  }
 }


### PR DESCRIPTION
## Done
This seemed the safest way of scoping the styling. If Vanilla is not namespaced we could get strange leakage by applying two versions of Vanilla to the legacy views. If we namepsace Vanilla we lose the HTML or root level styling. But that was the lesser evil in this case.

* Added a class to the HTML element when triggering a ui view
* Apply the `ui-view` style namespacing to the ui views
* Edited some parent-child inheritance in the local patterns
* Ported the HTML element styling from Vanilla directly into the namespace for now

## QA
* Ensure you're on the VPN. 
* Pull down this branch
* Run `yarn clean` 
* Then ` cd proxy`
* Followed by `yarn` then `yarn start`
* When the browser tab loads change the URL to http://0.0.0.0:8400/MAAS/r/machines
* Open the inspector and see there is the `ui-view` class on the `html` element.
* See that the machine list looks as it does [on bolla](http://bolla.internal:5240/MAAS/r/machines)
_If you don't have access to bolla check you are on the VPN. If you are please ask to be added on #maas_
* Click on Subnets to enter a angular view
* In the inspector check the `ui-view` class has been removed
* Check that this view matches the view on bolla
* Refresh the page and see the page looks the same
* Click on Settings to switch to a React view
* In the inspector see that the class has been added again
* Check the view looks the same as bolla
* Click through the pages and menus and check there is nothing out of place 

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-ui/issues/1123

## Launchpad Issue
N/A
