### PR TITLE
Fix machine details links and routing.

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -70,7 +70,7 @@
     "@maas-ui/maas-ui-shared": "0.1.1",
     "@sentry/browser": "5.15.5",
     "@sentry/integrations": "5.15.5",
-    "@uirouter/angularjs": "^1.0.26",
+    "@uirouter/angularjs": "1.0.26",
     "angular": "1.7.9",
     "angular-cookies": "1.7.9",
     "angular-route": "1.7.9",

--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom";
 import { Footer, Header } from "@maas-ui/maas-ui-shared";
 
 /* @ngInject */
-function MasterController($rootScope, $window, $http) {
+function MasterController($rootScope, $transitions, $window, $http) {
   const debug = process.env.NODE_ENV === "development";
   const LOGOUT_API = `${process.env.BASENAME}/accounts/logout/`;
 
@@ -69,12 +69,12 @@ function MasterController($rootScope, $window, $http) {
     $rootScope.site = window.CONFIG.maas_name;
     renderHeader();
     renderFooter();
-
-    $rootScope.$on("$routeChangeSuccess", function (event, next, current) {
-      // Update the header when the route changes.
-      renderHeader();
-    });
   };
+
+  $transitions.onSuccess({}, () => {
+    // Update the header when the route changes.
+    renderHeader();
+  });
 
   displayTemplate();
 }

--- a/legacy/src/app/controllers/pods_list.js
+++ b/legacy/src/app/controllers/pods_list.js
@@ -6,7 +6,7 @@
 import angular from "angular";
 
 const getOSShortName = (node, osInfo) => {
-  if (node) {
+  if (node && osInfo.releases) {
     const baseString = `${node.osystem}/${node.distro_series}`;
     const releaseArr = osInfo.releases.find(
       (release) => release[0] === baseString

--- a/root/package.json
+++ b/root/package.json
@@ -30,6 +30,6 @@
   "dependencies": {
     "@maas-ui/maas-ui": "1.1.1",
     "@maas-ui/maas-ui-legacy": "0.1.0",
-    "single-spa": "5.4.0"
+    "single-spa": "5.5.0"
   }
 }

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -41,6 +41,29 @@ export const App = () => {
   const basename = process.env.REACT_APP_BASENAME;
   const debug = process.env.NODE_ENV === "development";
 
+
+  useEffect(() => {
+    window.addEventListener("popstate", (evt) => {
+      if (evt.singleSpa) {
+        const reactRoute =
+          window.location.pathname.split("/")[2] ===
+          process.env.REACT_APP_REACT_BASENAME.substr(1);
+        if (reactRoute) {
+          // get subPath e.g. 'settings' in '/MAAS/r/settings/configuration'
+          const newSubpath = window.location.pathname.split("/").slice(3)[0];
+          const lastSubpath = history.location.pathname.split("/")[1];
+          console.log("new path", newSubpath);
+          console.log("last path", lastSubpath);
+          if (newSubpath !== lastSubpath) {
+            console.log("updating history to", `/${newSubpath}`);
+            history.push(`/${newSubpath}`);
+          }
+        }
+      }
+    });
+  }, []);
+
+
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
   }, [dispatch]);

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -41,28 +41,30 @@ export const App = () => {
   const basename = process.env.REACT_APP_BASENAME;
   const debug = process.env.NODE_ENV === "development";
 
-
   useEffect(() => {
-    window.addEventListener("popstate", (evt) => {
-      if (evt.singleSpa) {
-        const reactRoute =
-          window.location.pathname.split("/")[2] ===
-          process.env.REACT_APP_REACT_BASENAME.substr(1);
-        if (reactRoute) {
-          // get subPath e.g. 'settings' in '/MAAS/r/settings/configuration'
-          const newSubpath = window.location.pathname.split("/").slice(3)[0];
-          const lastSubpath = history.location.pathname.split("/")[1];
-          console.log("new path", newSubpath);
-          console.log("last path", lastSubpath);
-          if (newSubpath !== lastSubpath) {
-            console.log("updating history to", `/${newSubpath}`);
-            history.push(`/${newSubpath}`);
+    // window.history.pushState events from *outside* of react
+    // are not observeable by react-router, which watches the history
+    // object for changes. To compensate for this, we manually push a route
+    // to history when SingleSPA mounts the react app, otherwise react just
+    // renders the last view when the app was unmounted.
+    if (history) {
+      window.addEventListener("popstate", (evt) => {
+        if (evt.singleSpa) {
+          const reactRoute =
+            window.location.pathname.split("/")[2] ===
+            process.env.REACT_APP_REACT_BASENAME.substr(1);
+          if (reactRoute) {
+            // get subPath e.g. 'settings' in '/MAAS/r/settings/configuration'
+            const newSubpath = window.location.pathname.split("/").slice(3)[0];
+            const lastSubpath = history.location.pathname.split("/")[1];
+            if (newSubpath !== lastSubpath) {
+              history.replace(`/${newSubpath}`);
+            }
           }
         }
-      }
-    });
-  }, []);
-
+      });
+    }
+  }, [history]);
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -9,7 +9,18 @@ import Tooltip from "app/base/components/Tooltip";
 
 const generateFQDN = (machine, machineURL) => {
   return (
-    <a href={machineURL} title={machine.fqdn}>
+    <a
+      href={machineURL}
+      onClick={(evt) => {
+        evt.preventDefault();
+        window.history.pushState(
+          null,
+          null,
+          `${process.env.REACT_APP_BASENAME}${machineURL}`
+        );
+      }}
+      title={machine.fqdn}
+    >
       <strong>
         {machine.locked ? (
           <span title="This machine is locked. You have to unlock it to perform any actions.">

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -13,6 +13,7 @@ exports[`NameColumn renders 1`] = `
         label={
           <a
             href="/#/undefined/abc123"
+            onClick={[Function]}
           >
             <strong>
               koala
@@ -50,6 +51,7 @@ exports[`NameColumn renders 1`] = `
               label={
                 <a
                   href="/#/undefined/abc123"
+                  onClick={[Function]}
                 >
                   <strong>
                     koala
@@ -70,6 +72,7 @@ exports[`NameColumn renders 1`] = `
                 label={
                   <a
                     href="/#/undefined/abc123"
+                    onClick={[Function]}
                   >
                     <strong>
                       koala
@@ -103,6 +106,7 @@ exports[`NameColumn renders 1`] = `
                       >
                         <a
                           href="/#/undefined/abc123"
+                          onClick={[Function]}
                         >
                           <strong>
                             koala

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -53,3 +53,26 @@ const Root = () => {
 export default Root;
 
 serviceWorker.unregister();
+
+window.addEventListener("popstate", (evt) => {
+  if (evt.singleSpa) {
+    // not a maas-ui-legacy route
+    console.log(window.location.pathname.split("/"));
+    const reactRoute =
+      window.location.pathname.split("/")[2] ===
+      process.env.REACT_APP_REACT_BASENAME.substr(1);
+    console.log("reactROute", reactRoute);
+    if (reactRoute) {
+      console.log(window.location.pathname);
+      console.log(history.location.pathname);
+      const newPath = window.location.pathname.split("/").slice(3)[0];
+      const lastPath = history.location.pathname.split("/")[1];
+      console.log("new path", newPath);
+      console.log("last path", lastPath);
+      if (newPath !== lastPath) {
+        console.log("updating history to", `/${newPath}`);
+        history.push(`/${newPath}`);
+      }
+    }
+  }
+});

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -53,26 +53,3 @@ const Root = () => {
 export default Root;
 
 serviceWorker.unregister();
-
-window.addEventListener("popstate", (evt) => {
-  if (evt.singleSpa) {
-    // not a maas-ui-legacy route
-    console.log(window.location.pathname.split("/"));
-    const reactRoute =
-      window.location.pathname.split("/")[2] ===
-      process.env.REACT_APP_REACT_BASENAME.substr(1);
-    console.log("reactROute", reactRoute);
-    if (reactRoute) {
-      console.log(window.location.pathname);
-      console.log(history.location.pathname);
-      const newPath = window.location.pathname.split("/").slice(3)[0];
-      const lastPath = history.location.pathname.split("/")[1];
-      console.log("new path", newPath);
-      console.log("last path", lastPath);
-      if (newPath !== lastPath) {
-        console.log("updating history to", `/${newPath}`);
-        history.push(`/${newPath}`);
-      }
-    }
-  }
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3041,7 +3041,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@uirouter/angularjs@^1.0.26":
+"@uirouter/angularjs@1.0.26":
   version "1.0.26"
   resolved "https://registry.yarnpkg.com/@uirouter/angularjs/-/angularjs-1.0.26.tgz#680ba48ac2c5608a6621c09fadb88a80ceb2e0cc"
   integrity sha512-90kS4j0cBk1rpipE/CFC+/cNpc32WHI5536oHsJzAOIDY1NoSmb5TMOISrJslg7sBGF56NEtGoRVf42gaACrfA==
@@ -14395,10 +14395,10 @@ single-spa-react@2.14.0:
   resolved "https://registry.yarnpkg.com/single-spa-react/-/single-spa-react-2.14.0.tgz#4a55ea74a57db06adb41f0de3419a0c378745e1b"
   integrity sha512-KQ2/y7/JBIquK0WUiwb1/Y7f4qTZITNotw+JwNPesj0WKeCi91u0LOZe2ps56QMJbyB4UrA5IzMBwbYWDr1pIw==
 
-single-spa@5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/single-spa/-/single-spa-5.4.0.tgz#da3c5cf60f79e02c2ed7bebd86299d4f37fec569"
-  integrity sha512-VxD4kh7sCOuMUqYbFjtBz2eHDySTOQnmwuFmDJvhQwDXUz9mOX7Ps9xSnqGXEZDXOf/YEAE1mRfmX1cwVSjkag==
+single-spa@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/single-spa/-/single-spa-5.5.0.tgz#3546ba3f07a82bef9311abb6da748cec8b75dfbf"
+  integrity sha512-ZmHmBz5mSB8RYPIApBMzFoP7a35DWg6wo5E5LQVLYw87Rk5s2JPQH3BHU7cu+Ndls5GEWcMq6ryrwstZQGhyag==
 
 sisteransi@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Done
* Ensure Machine Listing -> Machine Details links do not trigger a full page refresh.
* Fix issue where react router is unable to observe changes to `window.history.pushState` by listening for singleSPA popstate events, and manually calling `history.replace`. The way this manifest previously, navigating from an angularjs route to a react route would always load the last react route in memory before the app was unmounted, regardless of the actual route.
* Driveby fix for intermittent crash on pods list.
* Upgrade to singlespa 5.5.0.

## QA
* Bootstrap both maas-ui-legacy and maas-ui (e.g. navigate to /MAAS/#/devices and /MAAS/r/machines).
* Ensure navigating away from machine listing and back again does not refetch machines (state is preserved).
* Click a node from the machine listing and ensure the page does not refresh. Return to the machine list via the navbar and state should be preserved.
* Click around on the navbar and ensure links are hilighted.
* Ensure navigating from legacy view -> react view always renders the correct view.

## Fixes
Fixes #canonical-web-and-design/MAAS-squad#1996, fixes #canonical-web-and-design/MAAS-squad#1997


## Launchpad Issue
Related Launchpad maas issue in the form `lp#number`.
