### PR TITLE
Add root error boundary.

### DIFF
--- a/ui/src/single-spa-entry.js
+++ b/ui/src/single-spa-entry.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import singleSpaReact from "single-spa-react";
 
+import { bugs } from "../package.json";
 import rootComponent from "./index";
 
 const reactLifecycles = singleSpaReact({
@@ -14,11 +15,7 @@ const reactLifecycles = singleSpaReact({
         <p>Unable to load MAAS.</p>
         <p>
           Please refresh your browser, and if the issue persists submit an issue
-          at:{" "}
-          <span>
-            https://github.com/canonical-web-and-design/maas-ui/issues
-          </span>{" "}
-          with the following details:
+          at: <span>{bugs}</span> with the following details:
         </p>
         <p>{err}</p>
         <p>{info}</p>

--- a/ui/src/single-spa-entry.js
+++ b/ui/src/single-spa-entry.js
@@ -8,7 +8,25 @@ const reactLifecycles = singleSpaReact({
   React,
   ReactDOM,
   rootComponent,
+  errorBoundary(err, info, props) {
+    return (
+      <div>
+        <p>Unable to load MAAS.</p>
+        <p>
+          Please refresh your browser, and if the issue persists submit an issue
+          at:{" "}
+          <span>
+            https://github.com/canonical-web-and-design/maas-ui/issues
+          </span>{" "}
+          with the following details:
+        </p>
+        <p>{err}</p>
+        <p>{info}</p>
+      </div>
+    );
+  },
 });
+
 export const { bootstrap } = reactLifecycles;
 export const { mount } = reactLifecycles;
 export const { unmount } = reactLifecycles;


### PR DESCRIPTION
## Done
* Add root `ErrorBoundary`. In actual practice, the user is very unlikely to see this as we _already_ implement ErrorBoundaries further up the component hierarchy, which are more likely to catch first, but this does suppress the annoying warning from singleSpaReact.

## QA
* Load the app, the error boundary warnings should no longer appear.

## Fixes
Fixes canonical-web-and-design/MAAS-squad#2002
