### PR TITLE
Fix KVM details QA issues.

### DIFF
--- a/legacy/src/app/controllers/tests/test_node_details_storage.js
+++ b/legacy/src/app/controllers/tests/test_node_details_storage.js
@@ -5541,7 +5541,7 @@ describe("NodeStorageController", function() {
       expect($scope.getFormattedTotalDiskSize(disks)).toBe("3 GB");
     });
 
-    it("returns formtted string in TB", function() {
+    it("returns formatted string in TB", function() {
       makeController();
       var disks = [
         {
@@ -5551,7 +5551,7 @@ describe("NodeStorageController", function() {
           size: 2000000000000
         }
       ];
-      expect($scope.getFormattedTotalDiskSize(disks)).toBe("3.00 TB");
+      expect($scope.getFormattedTotalDiskSize(disks)).toBe("3 TB");
     });
   });
 });

--- a/legacy/src/app/directives/maas_obj_form.js
+++ b/legacy/src/app/directives/maas_obj_form.js
@@ -1152,7 +1152,7 @@ export function maasObjErrors($compile) {
     restrict: "E",
     require: ["^^maasObjForm"],
     scope: {},
-    template: '<ul class="p-list u-no-margin--top"></ul>',
+    template: '<ul class="p-list u-no-margin--bottom"></ul>',
     link: function(scope, element, attrs, controllers) {
       // Set on the controller the global error handler.
       controllers[0].errorScope = scope;
@@ -1171,11 +1171,12 @@ export function maasObjErrors($compile) {
             ul.append(
               $compile(
                 '<li class="p-list__item">' +
-                  '<i class="p-icon--error"></i> ' +
-                  '<span ng-bind="errors[' +
-                  i +
-                  ']"></span>' +
-                  "</li>"
+                  '<div class="p-notification--negative">' +
+                    '<p class="p-notification__response">' +
+                      '<span ng-bind="errors[' + i + ']"></span>' +
+                    '</p>' +
+                  '</div>' +
+                '</li>'
               )(scope)
             );
           }

--- a/legacy/src/app/directives/tests/test_maas_obj_form.js
+++ b/legacy/src/app/directives/tests/test_maas_obj_form.js
@@ -1017,7 +1017,7 @@ describe("maasObjForm", function() {
 
       // Error is placed on the input and in the global section.
       expect(getErrorList(field)).toEqual(["Error: " + keyError]);
-      expect(getErrorList(errors)).toEqual([" " + error]);
+      expect(getErrorList(errors)).toEqual([error]);
 
       // Has error returns true.
       expect($scope.obj.$maasForm.hasErrors()).toBe(true);

--- a/legacy/src/app/filters/format_bytes.js
+++ b/legacy/src/app/filters/format_bytes.js
@@ -5,7 +5,7 @@
  */
 
 export function formatBytes() {
-  return function(bytes) {
+  return function (bytes) {
     var bytesInKilobyte = 1000;
     var kilobytesInMegabyte = 1000;
     var megabytesInGigabyte = 1000;
@@ -23,18 +23,25 @@ export function formatBytes() {
     if (bytes >= bytesInTerabyte) {
       return (
         Number(
-          bytes /
+          (
+            bytes /
             bytesInKilobyte /
             kilobytesInMegabyte /
             megabytesInGigabyte /
             gigabytesInTerabyte
-        ).toPrecision(3) + " TB"
+          ).toPrecision(3)
+        ).toString() + " TB"
       );
     } else if (bytes >= bytesInGigabyte) {
       return (
-        Math.round(
-          bytes / bytesInKilobyte / kilobytesInMegabyte / megabytesInGigabyte
-        ) + " GB"
+        Number(
+          (
+            bytes /
+            bytesInKilobyte /
+            kilobytesInMegabyte /
+            megabytesInGigabyte
+          ).toPrecision(3)
+        ).toString() + " GB"
       );
     } else if (bytes >= bytesInMegabyte) {
       return Math.round(bytes / bytesInKilobyte / kilobytesInMegabyte) + " MB";
@@ -49,7 +56,7 @@ export function formatBytes() {
 }
 
 export function convertGigabyteToBytes() {
-  return function(gigabytes) {
+  return function (gigabytes) {
     var bytesInKilobyte = 1000;
     var kilobytesInMegabyte = 1000;
     var megabytesInGigabyte = 1000;

--- a/legacy/src/app/filters/tests/test_format_bytes.js
+++ b/legacy/src/app/filters/tests/test_format_bytes.js
@@ -34,6 +34,6 @@ describe("formatBytes", function() {
 
   it(`returns value in terabytes if greater than
       or equal to 1 terabyte, to 3 significant figures`, function() {
-    expect(formatBytes(2000000000000)).toEqual("2.00 TB");
+    expect(formatBytes(2000000000000)).toEqual("2 TB");
   });
 });

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -28,11 +28,13 @@
             </div>
             <div class="col-medium-2 col-4">
                 <div class="page-header__controls" data-ng-if="canEdit() && !action.option">
-                    <div data-maas-cta="action.options"
-                        data-ng-click="updateAvailableActions('pods')"
-                        data-ng-model="action.option"
-                        data-ng-change="actionOptionChanged()">
-                    </div>
+                    <div
+                        maas-cta="action.options"
+                        ng-change="actionOptionChanged()"
+                        ng-click="updateAvailableActions('pods')"
+                        ng-if="!action.option"
+                        ng-model="action.option"
+                    ></div>
                 </div>
             </div>
         </div>
@@ -42,6 +44,7 @@
                 <div class="row">
                     <div class="col-12">
                         <hr />
+                        <div maas-obj-hide-saving><maas-obj-errors></maas-obj-errors></div>
                         <h3 class="p-heading--four">Compose machine</h3>
                     </div>
                 </div>
@@ -58,15 +61,43 @@
                         <maas-obj-field type="options" key="zone"
                             label="Zone" subtle="false" placeholder="Choose a zone"
                             options="zone.id as zone.name for zone in zones"
-                            label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4" disabled></maas-obj-field>
+                            label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4"></maas-obj-field>
                         <maas-obj-field type="options" key="pool" label="Pool" subtle="false" placeholder="Choose a pool"
                             options="pool.id as pool.name for pool in pools" label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4"></maas-obj-field>
                     </div>
                     <div class="col-6">
                         <maas-obj-field type="options" key="architecture" label="Architecture" subtle="false" placeholder="Any architecture" placeholder-enabled="true"
                             options="arch for arch in pod.architectures" data-ng-if="pod.architectures.length > 1" label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4"></maas-obj-field>
-                        <maas-obj-field type="text" key="cores" label="Cores" subtle="false" placeholder="Number of cores (optional)" subtle-text="{$ availableWithOvercommit(pod.total.cores, pod.used.cores, pod.cpu_over_commit_ratio, 1) $} cores available" label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4"></maas-obj-field>
-                        <maas-obj-field type="text" key="memory" label="RAM (MB)" subtle="false" placeholder="Memory amount (optional)" subtle-text="{$ availableWithOvercommit(pod.total.memory_gb, pod.used.memory_gb, pod.memory_over_commit_ratio, 1) $}GB available" label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4"></maas-obj-field>
+                        <div class="p-form__group row">
+                            <label for="cores" class="p-form__label col-2">Cores</label>
+                            <div class="p-form__control col-4">
+                                <input
+                                    id="cores"
+                                    placeholder="Number of cores (optional)"
+                                    name="cores"
+                                    ng-model="compose.obj.cores"
+                                    type="text"
+                                />
+                                <p class="p-form-help-text">
+                                    {$ availableWithOvercommit(pod.total.cores, pod.used.cores, pod.cpu_over_commit_ratio, 1) $} cores available
+                                </p>
+                            </div>
+                        </div>
+                        <div class="p-form__group row">
+                            <label for="cores" class="p-form__label col-2">RAM (MiB)</label>
+                            <div class="p-form__control col-4">
+                                <input
+                                    id="memory"
+                                    placeholder="Memory amount (optional)"
+                                    name="memory"
+                                    ng-model="compose.obj.memory"
+                                    type="text"
+                                />
+                                <p class="p-form-help-text">
+                                    {$ availableWithOvercommit(pod.total.memory_gb, pod.used.memory_gb, pod.memory_over_commit_ratio, 1) $}GiB available
+                                </p>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="p-strip">
@@ -363,7 +394,6 @@
                 <div class="row">
                     <div class="col-12">
                         <hr>
-                        <div maas-obj-hide-saving><maas-obj-errors></maas-obj-errors></div>
                         <div class="u-align--right" maas-obj-hide-saving>
                             <button class="p-button--base" type="button" data-ng-click="cancelCompose()">Cancel</button>
                             <button class="p-button--positive" maas-obj-save ng-disabled="!validateMachineCompose()" data-ng-click="sendAnalyticsEvent('KVM details', 'Submit form', 'KVM compose')">Compose machine</button>


### PR DESCRIPTION
## Done
- Improved validation of compose machine form
- Improved `maasObjErrors` notification styling
- Hide "Compose" button if compose form is open
- Changed formatBytes for GB to return 3 significant figures with truncated zeroes, i.e. a value of 7620000000 bytes will return "7.62 GB" instead of "8 GB", 7600000000 bytes will return "7.6 GB" instead of "8 GB"

## QA
- Go to a KVM details page and open the compose form
- Check that the Compose button disappears
- Check that the form can be submitted by default (unless there is less than 8GB free on the first storage pool, in which case drop the request lower)
- Check that the form is disabled if you request too many or 0 cores
- Check that the form is disabled if you request too much or 0 RAM
- Check that the form is disabled if you request 0 storage

## Fixes
Fixes #1110 

## Launchpad Issue
Related Launchpad maas issue in the form `lp#number`.

## Screenshots
### Error notification
![2020-05-18_12-35](https://user-images.githubusercontent.com/25733845/82175013-e3986600-9915-11ea-8625-ca6bca0923cd.png)