### PR TITLE
Auto-format MAC address field.

### DIFF
--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
+import { formatMacAddress } from "app/utils";
 import {
   domain as domainSelectors,
   general as generalSelectors,
@@ -23,7 +24,7 @@ export const AddMachineFormFields = ({ saved }) => {
   const [extraMACs, setExtraMACs] = useState([]);
 
   const formikProps = useFormikContext();
-  const { setFieldValue, values } = formikProps;
+  const { errors, setFieldValue, values } = formikProps;
 
   useEffect(() => {
     if (saved) {
@@ -128,6 +129,9 @@ export const AddMachineFormFields = ({ saved }) => {
           label="MAC address"
           maxLength="17"
           name="pxe_mac"
+          onChange={(e) => {
+            setFieldValue("pxe_mac", formatMacAddress(e.target.value));
+          }}
           placeholder="00:00:00:00:00:00"
           required
           type="text"
@@ -139,10 +143,11 @@ export const AddMachineFormFields = ({ saved }) => {
             key={`extra-macs-${i}`}
           >
             <Input
+              error={errors?.extra_macs && errors.extra_macs[i]}
               maxLength="17"
               onChange={(e) => {
                 const newExtraMACs = [...extraMACs];
-                newExtraMACs[i] = e.target.value;
+                newExtraMACs[i] = formatMacAddress(e.target.value);
                 setExtraMACs(newExtraMACs);
                 setFieldValue("extra_macs", newExtraMACs);
               }}

--- a/ui/src/app/utils/formatMacAddress.js
+++ b/ui/src/app/utils/formatMacAddress.js
@@ -1,0 +1,14 @@
+/**
+ * Formats a string into a valid MAC address as its being typed into an input.
+ *
+ * @param {String} value - original MAC address
+ * @returns {String} formatted MAC address
+ */
+
+export const formatMacAddress = (value) => {
+  const hexValues = value.replace(/:/g, "");
+  if (value.length % 3 === 0) {
+    return hexValues.replace(/([0-9A-Za-z]{2})/g, "$1:").substring(0, 17);
+  }
+  return value.substring(0, 17);
+};

--- a/ui/src/app/utils/formatMacAddress.test.js
+++ b/ui/src/app/utils/formatMacAddress.test.js
@@ -1,0 +1,20 @@
+import { formatMacAddress } from "./formatMacAddress";
+
+describe("formatMacAddress", () => {
+  it("returns the value unchanged if MAC address is formatted correctly", () => {
+    expect(formatMacAddress("")).toEqual("");
+    expect(formatMacAddress("12:3")).toEqual("12:3");
+    expect(formatMacAddress("12:34:56:78:9a:bc")).toEqual("12:34:56:78:9a:bc");
+  });
+
+  it("can correctly splice in separators", () => {
+    expect(formatMacAddress("123")).toEqual("12:3");
+    expect(formatMacAddress("123456789abc")).toEqual("12:34:56:78:9a:bc");
+  });
+
+  it("truncates correctly", () => {
+    expect(formatMacAddress("12:34:56:78:9a:bc:de")).toEqual(
+      "12:34:56:78:9a:bc"
+    );
+  });
+});

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -1,6 +1,8 @@
 export { capitaliseFirst } from "./capitaliseFirst";
 export { formatBytes } from "./formatBytes";
 export { formatErrors } from "./formatErrors";
+export { formatMacAddress } from "./formatMacAddress";
+export { formatPowerParameters } from "./formatPowerParameters";
 export { formatSpeedUnits } from "./formatSpeedUnits";
 export { getMachineValue } from "./search";
 export { generateLegacyURL } from "./generateLegacyURL";
@@ -8,4 +10,3 @@ export { groupAsMap } from "./groupAsMap";
 export { isVersionNewer } from "./isVersionNewer";
 export { kebabToCamelCase } from "./kebabToCamelCase";
 export { simpleSortByKey } from "./simpleSortByKey";
-export { formatPowerParameters } from "./formatPowerParameters";


### PR DESCRIPTION
## Done
- Auto-format the MAC address field in the Add machine form.

## QA
- Go to /MAAS/r/machines/add
- Type into the MAC address field and check that separators are spliced in automatically

## Fixes
Fixes #1112 