### PR TITLE
Fix interface constraint construction in VM host compose form.

### DIFF
--- a/legacy/src/app/controllers/tests/test_pod_details.js
+++ b/legacy/src/app/controllers/tests/test_pod_details.js
@@ -758,30 +758,7 @@ describe("PodDetailsController", function() {
       });
     });
 
-    it("sets the interface constraint for subnets", function() {
-      makeControllerResolveSetActiveItem();
-      $scope.compose.obj.interfaces = [
-        {
-          name: "eth0",
-          subnet: { cidr: "172.16.4.0/24" }
-        },
-        {
-          name: "eth1",
-          subnet: { cidr: "192.168.1.0/24" }
-        }
-      ];
-      var expectedInterfaces = [
-        "eth0:subnet_cidr=172.16.4.0/24",
-        "eth1:subnet_cidr=192.168.1.0/24"
-      ].join(";");
-      expect($scope.composePreProcess({})).toEqual({
-        id: $scope.pod.id,
-        storage: "0:8()",
-        interfaces: expectedInterfaces
-      });
-    });
-
-    it("sets the interface constraint favouring ip addresses", function() {
+    it("correctly sets the interface constraints", function() {
       makeControllerResolveSetActiveItem();
       $scope.compose.obj.interfaces = [
         {
@@ -800,8 +777,8 @@ describe("PodDetailsController", function() {
         }
       ];
       var expectedInterfaces = [
-        "eth0:ip=172.16.4.2",
-        "eth1:ip=192.168.1.5",
+        "eth0:ip=172.16.4.2,subnet_cidr=172.16.4.0/24",
+        "eth1:ip=192.168.1.5,subnet_cidr=192.168.1.0/24",
         "eth2:subnet_cidr=192.168.2.0/24"
       ].join(";");
       expect($scope.composePreProcess({})).toEqual({

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -167,16 +167,12 @@
                                                 <div ng-switch-default>
                                                     <div class="form__group-input">
                                                         <input
+                                                            ng-blur="selectSubnetByIP(iface)"
+                                                            ng-keypress="$event.keyCode === 13 && $event.preventDefault()"
+                                                            ng-model="iface.ipaddress"
+                                                            placeholder="Leave empty to auto-assign"
                                                             type="text"
-                                                            data-ng-if="iface.space || iface.subnet && !iface.ipaddress"
-                                                            value="(auto-assigned)" disabled>
-                                                        <input
-                                                            type="text"
-                                                            placeholder="Manual IP Address (optional)"
-                                                            data-ng-if="!iface.space && !iface.subnet || iface.ipaddress"
-                                                            data-ng-model="iface.ipaddress"
-                                                            data-ng-blur="selectSubnetByIP(iface)"
-                                                            data-ng-keypress="$event.keyCode === 13 && $event.preventDefault()">
+                                                        >
                                                     </div>
                                                 </div>
                                             </div>
@@ -190,9 +186,10 @@
                                                     data-ng-model="iface.selectedSpace"
                                                     data-ng-change="resetSubnetList(iface)"
                                                     data-ng-if="spaces.length > 0"
-                                                    data-ng-disabled="iface.ipaddress.length > 0"
-                                                    data-ng-keypress="$event.keyCode === 13 && $event.preventDefault()">
-                                                    <option value="">Select a space (optional)</option>
+                                                    data-ng-keypress="$event.keyCode === 13 && $event.preventDefault()"
+                                                >
+                                                    <option disabled>Select a space</option>
+                                                    <option value="">None</option>
                                                     <option data-ng-repeat="space in spaces">{$ space.name $}</option>
                                                 </select>
                                             </div>
@@ -208,12 +205,11 @@
                                                             placeholder="Select a subnet"
                                                             data-ng-model="iface.subnet.displayName"
                                                             data-ng-focus="openSubnetOptions(iface)"
-                                                            data-ng-disabled="iface.ipaddress.length > 0"
                                                             data-ng-keypress="$event.keyCode === 13 && $event.preventDefault()">
                                                         <div
                                                             class="p-option-selector__options--subnets"
                                                             ng-if="iface.showOptions">
-                                                            <button class="p-button--close" ng-click="closeOptions(iface)">
+                                                            <button class="p-button--close p-button--base" ng-click="closeOptions(iface)">
                                                                 <i class="p-icon--close">Close</i>
                                                             </button>
                                                             <div>

--- a/legacy/src/scss/_patterns_option-selector.scss
+++ b/legacy/src/scss/_patterns_option-selector.scss
@@ -174,7 +174,7 @@
     .p-option-selector__options--subnets {
       @extend %p-card--highlighted;
       left: -45vw;
-      padding-bottom: 0;
+      padding-bottom: $spv-inner--scaleable;
       position: absolute;
       width: 90vw;
       z-index: 10;
@@ -195,6 +195,7 @@
       @extend %muted-heading;
       border-bottom: 1px solid $color-mid-light;
       margin-bottom: 0;
+      margin-top: $spv-inner--x-small--scaleable;
       padding-bottom: $spv-inner--x-small--scaleable;
     }
 
@@ -202,10 +203,6 @@
       @include vf-focus;
       cursor: pointer;
       display: flex;
-
-      &:last-of-type {
-        margin-bottom: $spv-outer--small-scaleable;
-      }
 
       &:not(:last-of-type) {
         position: relative;


### PR DESCRIPTION
## Done
- Fixed interface constraint logic in VM host compose form.
- Slightly updated subnet list styling to be less space-y.

## QA
- Go to the KVM details page of a KVM that has attached VLANs (e.g. bolla LXD) and open the machine compose dropdown.
- Confirm that you can still compose a machine with default interface constraints. Check the websocket request has `params.interfaces : ""`.
- Open the compose dropdown again and add a couple of custom interface constraints. Check that the first available subnet is already selected by default, and the IP address field has a placeholder saying "Leave empty to auto-assign"
- For the first interface just select a subnet, and for the second select a subnet and enter an IP address.
- Submit the form and check that the websocket request correctly adheres to [the api](https://maas.io/docs/api#pod). You might get some cryptic errors if you input an IP address that is not part of the selected subnet.

## Fixes
Fixes #1107 

## Launchpad Issue
[lp#1876180](https://bugs.launchpad.net/maas/+bug/1876180)

## Screenshot
![Screenshot_2020-05-19 MAAS UI](https://user-images.githubusercontent.com/25733845/82289983-3a22a480-99e9-11ea-87d1-e8f44e1af57a.png)

