### PR TITLE
Make root app relative.

### DIFF
--- a/root/package.json
+++ b/root/package.json
@@ -4,9 +4,9 @@
   "description": "SingleSPA app which registers maas-ui-legacy and maas-ui apps.",
   "main": "src/root-application.js",
   "scripts": {
-    "start": "webpack-dev-server --host 0.0.0.0 --port 8404",
+    "start": "webpack-dev-server --host 0.0.0.0 --port 8404 --config webpack.dev.js",
     "serve": "yarn start",
-    "build": "webpack --config webpack.config.js -p",
+    "build": "webpack --config webpack.prod.js -p",
     "clean": "rm -rf dist node_modules",
     "lint": "yarn lint-package-json && yarn lint-js",
     "lint-js": "eslint src",
@@ -38,7 +38,8 @@
     "html-webpack-plugin": "4.3.0",
     "npm-package-json-lint": "5.1.0",
     "webpack-cli": "3.3.11",
-    "webpack-dev-server": "3.10.3"
+    "webpack-dev-server": "3.10.3",
+    "webpack-merge": "4.2.2"
   },
   "dependencies": {
     "@maas-ui/maas-ui": "1.1.1",

--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -6,6 +6,6 @@
     <title>MAAS UI</title>
   </head>
   <body>
-    <script src="/root-application.js"></script>
+    <script src="<%= publicPath %>root-application.js"></script>
   </body>
 </html>

--- a/root/webpack.common.js
+++ b/root/webpack.common.js
@@ -1,14 +1,12 @@
 const path = require("path");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const DotenvFlow = require("dotenv-flow-webpack");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
   entry: {
     "root-application": "src/root-application.js",
   },
   output: {
-    publicPath: "/",
     filename: "[name].js",
   },
   module: {
@@ -30,17 +28,6 @@ module.exports = {
       cleanAfterEveryBuildPatterns: ["dist"],
     }),
     new DotenvFlow(),
-    new HtmlWebpackPlugin({
-      template: path.resolve(__dirname, "src", "index.html"),
-      inject: false,
-    }),
   ],
-  devtool: "source-map",
   externals: [],
-  devServer: {
-    disableHostCheck: true,
-    historyApiFallback: true,
-    open: true,
-    public: "0.0.0.0:8400",
-  },
 };

--- a/root/webpack.dev.js
+++ b/root/webpack.dev.js
@@ -1,0 +1,30 @@
+const path = require("path");
+const merge = require("webpack-merge");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+const common = require("./webpack.common.js");
+
+const publicPath = "/";
+
+module.exports = merge(common, {
+  mode: "development",
+  output: {
+    publicPath
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, "src", "index.ejs"),
+      inject: false,
+      templateParameters: {
+        publicPath
+      },
+    }),
+  ],
+  devtool: "inline-source-map",
+  devServer: {
+    disableHostCheck: true,
+    historyApiFallback: true,
+    open: true,
+    public: "0.0.0.0:8400",
+  },
+});

--- a/root/webpack.prod.js
+++ b/root/webpack.prod.js
@@ -1,0 +1,22 @@
+const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const merge = require("webpack-merge");
+
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: "production",
+  output: {
+    publicPath: "",
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, "src", "index.ejs"),
+      inject: false,
+      templateParameters: {
+        publicPath: "",
+      },
+    }),
+  ],
+  devtool: "source-map",
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -16247,7 +16247,7 @@ webpack-manifest-plugin@2.2.0:
     object.entries "^1.1.0"
     tapable "^1.0.0"
 
-webpack-merge@4.2.2:
+webpack-merge@4.2.2, webpack-merge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
   integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==


### PR DESCRIPTION
## Done
* Only set publicPath in dev, and make `root-application.js` relative for production.
* Split root webpack config for dev/prod.

## QA
* Ensure app works in development.