### PR TITLE
Use style-loader in production build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-ui": "cd ui && yarn install && yarn build",
     "cypress-open": "cd proxy && yarn cypress-open",
     "cypress-run": "cd proxy && yarn cypress-run",
-    "copy-build": "mkdir -p build && cp -R root/dist/* build/ && cp -R legacy/dist/assets build/ && cp -R ui/dist/static build/",
+    "copy-build": "mkdir -p build && cp -R root/dist/* build/ && cp -R legacy/dist/assets build/",
     "release": "cd ui && yarn run release",
     "serve": "cd proxy && yarn start",
     "start": "yarn serve",

--- a/ui/config-overrides.js
+++ b/ui/config-overrides.js
@@ -16,7 +16,6 @@ const addLoaders = (loaderOptions = {}) => (config) => {
   const getStyleLoader = () => [
     {
       loader: "style-loader",
-      options: { injectType: "lazyStyleTag" },
     },
     {
       loader: require.resolve("css-loader"),

--- a/ui/config-overrides.js
+++ b/ui/config-overrides.js
@@ -1,4 +1,62 @@
 const webpack = require("webpack");
+const path = require("path");
+const { edit, remove, getPaths } = require("@rescripts/utilities");
+
+const addLoaders = (loaderOptions = {}) => (config) => {
+  const sassRegex = /\.(sass|scss)$/;
+
+  //Matchers to find the array of rules and sass-file loader
+  const loadersMatcher = (inQuestion) =>
+    inQuestion.rules &&
+    inQuestion.rules.find((rule) => Array.isArray(rule.oneOf));
+  const sassMatcher = (inQuestion) =>
+    inQuestion.test && inQuestion.test.toString() === sassRegex.toString();
+
+  //Return set of loaders needed to process sass files
+  const getStyleLoader = () => [
+    {
+      loader: "style-loader",
+      options: { injectType: "lazyStyleTag" },
+    },
+    {
+      loader: require.resolve("css-loader"),
+      options: { importLoaders: 2 },
+    },
+    {
+      loader: "sass-loader",
+      options: {
+        sourceMap: process.env.NODE_ENV !== "production",
+      },
+    },
+  ];
+
+  //Transformer function
+  const transform = (match) => ({
+    ...match,
+    rules: [
+      ...match.rules.filter((rule) => !Array.isArray(rule.oneOf)),
+      {
+        oneOf: [
+          {
+            test: sassRegex,
+            exclude: [path.resolve(__dirname, "node_modules")],
+            use: getStyleLoader(),
+            sideEffects: true,
+          },
+          ...match.rules.find((rule) => Array.isArray(rule.oneOf)).oneOf,
+        ],
+      },
+    ],
+  });
+
+  //Remove the set of already configured loaders to process sass files
+  config = remove(getPaths(sassMatcher, config), config);
+
+  //Add our set of newly configured loaders
+  config = edit(transform, getPaths(loadersMatcher, config), config);
+
+  return config;
+};
 
 module.exports = {
   webpack: function (config, env) {
@@ -17,6 +75,7 @@ module.exports = {
         maxChunks: 1,
       })
     );
+    config = addLoaders()(config);
     return config;
   },
   devServer: function (configFunction) {

--- a/ui/package.json
+++ b/ui/package.json
@@ -71,6 +71,8 @@
     ]
   },
   "devDependencies": {
+    "@rescripts/utilities": "^0.0.7",
+    "css-loader": "^3.5.3",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.4.4",
@@ -82,7 +84,9 @@
     "prettier": "2.0.5",
     "react-app-rewired": "2.1.6",
     "redux-mock-store": "1.5.4",
-    "redux-saga-test-plan": "4.0.0-rc.3"
+    "redux-saga-test-plan": "4.0.0-rc.3",
+    "sass-loader": "^8.0.2",
+    "style-loader": "^1.2.1"
   },
   "jest": {
     "snapshotSerializers": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -71,8 +71,8 @@
     ]
   },
   "devDependencies": {
-    "@rescripts/utilities": "^0.0.7",
-    "css-loader": "^3.5.3",
+    "@rescripts/utilities": "0.0.7",
+    "css-loader": "3.5.3",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.4.4",
@@ -85,8 +85,8 @@
     "react-app-rewired": "2.1.6",
     "redux-mock-store": "1.5.4",
     "redux-saga-test-plan": "4.0.0-rc.3",
-    "sass-loader": "^8.0.2",
-    "style-loader": "^1.2.1"
+    "sass-loader": "8.0.2",
+    "style-loader": "1.2.1"
   },
   "jest": {
     "snapshotSerializers": [

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -4,6 +4,8 @@ import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect } from "react";
 import * as Sentry from "@sentry/browser";
 
+import styles from "../scss/index.scss";
+
 import {
   auth as authActions,
   general as generalActions,
@@ -40,6 +42,11 @@ export const App = () => {
   const dispatch = useDispatch();
   const basename = process.env.REACT_APP_BASENAME;
   const debug = process.env.NODE_ENV === "development";
+
+  useEffect(() => {
+    //load styles once application is mounted
+    styles.use();
+  }, []);
 
   useEffect(() => {
     // window.history.pushState events from *outside* of react

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect } from "react";
 import * as Sentry from "@sentry/browser";
 
-import styles from "../scss/index.scss";
+import "../scss/index.scss";
 
 import {
   auth as authActions,
@@ -42,11 +42,6 @@ export const App = () => {
   const dispatch = useDispatch();
   const basename = process.env.REACT_APP_BASENAME;
   const debug = process.env.NODE_ENV === "development";
-
-  useEffect(() => {
-    //load styles once application is mounted
-    styles.use();
-  }, []);
 
   useEffect(() => {
     // window.history.pushState events from *outside* of react

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -7,7 +7,6 @@ import createSagaMiddleware from "redux-saga";
 
 import { name as appName, version as appVersion } from "../package.json";
 import rootSaga from "./root-saga";
-import "./scss/index.scss";
 import * as serviceWorker from "./serviceWorker";
 import App from "./app/App";
 import createRootReducer from "./root-reducer";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,6 +2499,13 @@
     redux-thunk "^2.3.0"
     reselect "^4.0.0"
 
+"@rescripts/utilities@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@rescripts/utilities/-/utilities-0.0.7.tgz#fac07a981fcc9674c9b55cedb9da67f03dadda52"
+  integrity sha512-kdk4qvNYXOH7mVJCP/URokp5J+1HCR+tT1Zgtp8X9hLywn6WoKlU/tQ2ECB/NPOHrZjp/DGXWeQBAchLXV8q2w==
+  dependencies:
+    ramda "^0.26.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -5534,7 +5541,7 @@ css-loader@3.4.2:
     postcss-value-parser "^4.0.2"
     schema-utils "^2.6.0"
 
-css-loader@3.5.3:
+css-loader@3.5.3, css-loader@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.5.3.tgz#95ac16468e1adcd95c844729e0bb167639eb0bcf"
   integrity sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==
@@ -13156,7 +13163,7 @@ railroad-diagrams@^1.0.0:
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
   integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
 
-ramda@0.26.1:
+ramda@0.26.1, ramda@^0.26.0:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
@@ -14255,7 +14262,7 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-sass-loader@8.0.2:
+sass-loader@8.0.2, sass-loader@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
   integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
@@ -15180,6 +15187,14 @@ style-loader@0.23.1:
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
+
+style-loader@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.2.1.tgz#c5cbbfbf1170d076cfdd86e0109c5bba114baa1a"
+  integrity sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^2.6.6"
 
 stylehacks@^4.0.0:
   version "4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,7 +2499,7 @@
     redux-thunk "^2.3.0"
     reselect "^4.0.0"
 
-"@rescripts/utilities@^0.0.7":
+"@rescripts/utilities@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@rescripts/utilities/-/utilities-0.0.7.tgz#fac07a981fcc9674c9b55cedb9da67f03dadda52"
   integrity sha512-kdk4qvNYXOH7mVJCP/URokp5J+1HCR+tT1Zgtp8X9hLywn6WoKlU/tQ2ECB/NPOHrZjp/DGXWeQBAchLXV8q2w==
@@ -5541,7 +5541,7 @@ css-loader@3.4.2:
     postcss-value-parser "^4.0.2"
     schema-utils "^2.6.0"
 
-css-loader@3.5.3, css-loader@^3.5.3:
+css-loader@3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.5.3.tgz#95ac16468e1adcd95c844729e0bb167639eb0bcf"
   integrity sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==
@@ -14262,7 +14262,7 @@ sass-graph@2.2.5:
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
 
-sass-loader@8.0.2, sass-loader@^8.0.2:
+sass-loader@8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
   integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
@@ -15188,7 +15188,7 @@ style-loader@0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-style-loader@^1.2.1:
+style-loader@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.2.1.tgz#c5cbbfbf1170d076cfdd86e0109c5bba114baa1a"
   integrity sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==
@@ -16262,7 +16262,7 @@ webpack-manifest-plugin@2.2.0:
     object.entries "^1.1.0"
     tapable "^1.0.0"
 
-webpack-merge@4.2.2, webpack-merge@^4.2.2:
+webpack-merge@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
   integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==


### PR DESCRIPTION
## Done
* Use `style-loader` rather than `mini-css-extract-plugin` (the CRA default) in production. This is required as we no longer have a static file to serve the extracted css build from with singlespa.

## QA
Sorry, not that easy. In a MAAS VM/Container from your `maas` root directory...

```
git config --file=.gitmodules submodule.src/maasui/src.url https://github.com/squidsoup/maas-ui.git
git config --file=.gitmodules submodule.src/maasui/src.branch fix-prod-css-react
git submodule sync
git submodule update --init --recursive --remote
cd src/maasui/
make
```
(from root), run MAAS. You should see the react app with css rendering correctly.