### PR TITLE
Autofill VM compose form with defaults + add overcommit sliders for LXD hosts.

### DIFF
--- a/legacy/src/app/controllers/pod_details.js
+++ b/legacy/src/app/controllers/pod_details.js
@@ -74,12 +74,12 @@ function PodDetailsController(
       sentence: "compose"
     },
     obj: {
-      cores: "",
-      memory: "",
+      cores: 0,
+      memory: 0,
       storage: [
         {
           type: "local",
-          size: 8,
+          size: 0,
           tags: [],
           pool: {},
           boot: true
@@ -477,12 +477,12 @@ function PodDetailsController(
   // Called to cancel composition.
   $scope.cancelCompose = function() {
     $scope.compose.obj = {
-      cores: "",
-      memory: "",
+      cores: $scope.getDefaultComposeValue("cores"),
+      memory: $scope.getDefaultComposeValue("memory"),
       storage: [
         {
           type: "local",
-          size: 8,
+          size: $scope.getDefaultComposeValue("storage"),
           tags: [],
           pool: $scope.getDefaultStoragePool(),
           boot: true
@@ -506,7 +506,7 @@ function PodDetailsController(
   $scope.composeAddStorage = function() {
     var storage = {
       type: "local",
-      size: 8,
+      size: $scope.getDefaultComposeValue("storage"),
       tags: [],
       pool: $scope.getDefaultStoragePool(),
       boot: false
@@ -662,6 +662,17 @@ function PodDetailsController(
     }
   };
 
+  $scope.getDefaultComposeValue = (param) => {
+    if ($scope.pod) {
+      const podPowerType = $scope.power_types.find((type) => type.name === $scope.pod.type);
+      if (podPowerType) {
+        const  { defaults } = podPowerType;
+        return defaults[param] || 0;
+      }
+    }
+    return 0;
+  };
+
   // Start watching key fields.
   $scope.startWatching = function() {
     $scope.$watch("subnets", function() {
@@ -746,6 +757,11 @@ function PodDetailsController(
     ) {
       $scope.pod = activePod;
       $scope.compose.obj.storage[0].pool = $scope.getDefaultStoragePool();
+      $scope.compose.obj.storage[0].size = $scope.getDefaultComposeValue(
+        "storage"
+      );
+      $scope.compose.obj.cores = $scope.getDefaultComposeValue("cores");
+      $scope.compose.obj.memory = $scope.getDefaultComposeValue("memory");
       $scope.loaded = true;
       $scope.machinesSearch = "pod-id:=" + $scope.pod.id;
       $scope.startWatching();
@@ -754,6 +770,11 @@ function PodDetailsController(
         function(pod) {
           $scope.pod = pod;
           $scope.compose.obj.storage[0].pool = $scope.getDefaultStoragePool();
+          $scope.compose.obj.storage[0].size = $scope.getDefaultComposeValue(
+            "storage"
+          );
+          $scope.compose.obj.cores = $scope.getDefaultComposeValue("cores");
+          $scope.compose.obj.memory = $scope.getDefaultComposeValue("memory");
           $scope.loaded = true;
           $scope.machinesSearch = "pod-id:=" + $scope.pod.id;
           $scope.startWatching();

--- a/legacy/src/app/controllers/tests/test_pod_details.js
+++ b/legacy/src/app/controllers/tests/test_pod_details.js
@@ -68,11 +68,11 @@ describe("PodDetailsController", function() {
       memory_over_commit_ratio: 1,
       total: {
         cores: 8,
-        memory_gb: 4,
+        memory: 8192,
       },
       used: {
         cores: 0,
-        memory_gb: 0,
+        memory: 0,
       },
     };
     PodsManager._items.push(pod);
@@ -576,6 +576,18 @@ describe("PodDetailsController", function() {
     });
   });
 
+  describe("validateRequest", () => {
+    it("correctly validates requests", () => {
+      makeController();
+      // Request is empty, therefore default is assumed.
+      expect($scope.validateRequest("", 2)).toBe(true);
+      expect($scope.validateRequest(0, 2)).toBe(false);
+      expect($scope.validateRequest(1, 2)).toBe(true);
+      expect($scope.validateRequest(2, 2)).toBe(true);
+      expect($scope.validateRequest(3, 2)).toBe(false);
+    });
+  });
+
   describe("validateMachineCompose", () => {
     it("correctly validates hostname", () => {
       makeController();
@@ -638,7 +650,7 @@ describe("PodDetailsController", function() {
       makeController();
       $scope.pod = makePod();
       $scope.power_types = defaultPowerTypes();
-      $scope.pod.total.memory_gb = 8;
+      $scope.pod.total.memory = 8192;
       $scope.compose.obj.memory = 9000;
       expect($scope.validateMachineCompose()).toBe(false);
       $scope.compose.obj.memory = -1;
@@ -657,7 +669,7 @@ describe("PodDetailsController", function() {
       makeController();
       $scope.pod = makePod();
       $scope.power_types = defaultPowerTypes();
-      $scope.pod.total.memory_gb = 8;
+      $scope.pod.total.memory = 8192;
       $scope.pod.memory_over_commit_ratio = 2.0;
       $scope.compose.obj.memory = 18000;
       expect($scope.validateMachineCompose()).toBe(false);

--- a/legacy/src/app/controllers/tests/test_pod_details.js
+++ b/legacy/src/app/controllers/tests/test_pod_details.js
@@ -1042,4 +1042,17 @@ describe("PodDetailsController", function() {
       expect($scope.onRSDSection()).toBe(false);
     });
   });
+
+  describe("getComposeDefaultValue", () => {
+    it("correctly returns default compose values for pod type", () => {
+      makeControllerResolveSetActiveItem();
+      $scope.pod = { type: "lxd" };
+      $scope.power_types = [
+        { name: "lxd", defaults: { cores: 1, memory: 2048, storage: 8 } },
+      ];
+      expect($scope.getComposeDefaultValue("cores")).toBe(1);
+      expect($scope.getComposeDefaultValue("memory")).toBe(2048);
+      expect($scope.getComposeDefaultValue("storage")).toBe(8);
+    });
+  });
 });

--- a/legacy/src/app/directives/pod_parameters.js
+++ b/legacy/src/app/directives/pod_parameters.js
@@ -61,7 +61,7 @@ export function maasPodParameters(
             }
           });
 
-          if (type.name === "virsh" && attrs.hideSlider !== "true") {
+          if ((type.name === "virsh" || type.name === "lxd") && attrs.hideSlider !== "true") {
             html +=
               '<maas-obj-field type="slider" key="' +
               'cpu_over_commit_ratio" label="CPU overcommit" ' +

--- a/legacy/src/app/directives/tests/test_pod_parameters.js
+++ b/legacy/src/app/directives/tests/test_pod_parameters.js
@@ -95,6 +95,18 @@ describe("maasPodParameters", function() {
           ]
         },
         {
+          name: "lxd",
+          description: "LXD",
+          driver_type: "pod",
+          fields: [
+            {
+              name: "power_address",
+              label: "Power address",
+              scope: "bmc"
+            },
+          ]
+        },
+        {
           name: "ipmi",
           description: "IPMI",
           driver_type: "power",
@@ -108,7 +120,7 @@ describe("maasPodParameters", function() {
     it("sets podTypes", function() {
       var directive = compileDirective("true");
       var scope = directive.isolateScope();
-      podTypes = [powerTypes[0], powerTypes[1]];
+      podTypes = [powerTypes[0], powerTypes[1], powerTypes[2]];
       expect(scope.podTypes).toEqual(podTypes);
     });
 

--- a/legacy/src/app/directives/tests/test_pod_parameters.js
+++ b/legacy/src/app/directives/tests/test_pod_parameters.js
@@ -159,9 +159,20 @@ describe("maasPodParameters", function() {
       expect($scope.obj.$maasForm.fields.rsd_id).toBeUndefined();
     });
 
-    it("creates maas-obj-field with type='slider'", function() {
+    it("creates maas-obj-field with type='slider' and pod type='virsh'", function() {
       var directive = compileDirective("false");
       $scope.obj.$maasForm.updateValue("type", "virsh");
+      $scope.$digest();
+
+      var sliders = angular.element(
+        directive.find('maas-obj-field[type="slider"]')
+      );
+      expect(sliders.length).toBe(2);
+    });
+
+    it("creates maas-obj-field with type='slider' and pod type='lxd'", function() {
+      var directive = compileDirective("false");
+      $scope.obj.$maasForm.updateValue("type", "lxd");
       $scope.$digest();
 
       var sliders = angular.element(

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -94,7 +94,7 @@
                                     type="text"
                                 />
                                 <p class="p-form-help-text">
-                                    {$ availableWithOvercommit(pod.total.memory_gb, pod.used.memory_gb, pod.memory_over_commit_ratio, 1) $}GiB available
+                                    {$ availableWithOvercommit(pod.total.memory, pod.used.memory, pod.memory_over_commit_ratio) $}MiB available
                                 </p>
                             </div>
                         </div>

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -73,7 +73,7 @@
                             <div class="p-form__control col-4">
                                 <input
                                     id="cores"
-                                    placeholder="Number of cores (optional)"
+                                    placeholder="{$ getDefaultComposeValue('cores') $} (default)"
                                     name="cores"
                                     ng-model="compose.obj.cores"
                                     type="text"
@@ -88,7 +88,7 @@
                             <div class="p-form__control col-4">
                                 <input
                                     id="memory"
-                                    placeholder="Memory amount (optional)"
+                                    placeholder="{$ getDefaultComposeValue('memory') $} (default)"
                                     name="memory"
                                     ng-model="compose.obj.memory"
                                     type="text"

--- a/legacy/src/app/partials/pod-details.html
+++ b/legacy/src/app/partials/pod-details.html
@@ -338,15 +338,15 @@
                                     </td>
                                     <td class="p-table--action-cell">
                                         <div class="form__group-input" style="position: relative">
-                                            <input type="number" min="0" class="u-no-margin--bottom" placeholder="Enter capacity" ng-keypress="numberOnly($event)"
+                                            <input type="text" class="u-no-margin--bottom" placeholder="{$ getDefaultComposeValue('storage') $} (default)" ng-eypress="numberOnly($event)"
                                                 data-ng-model="storage.size"
                                                 data-ng-change="updateRequests(storage)"
                                                 data-ng-click="sendAnalyticsEvent('KVM details', 'Change capacity value: ' + storage.size + ' GB', 'KVM compose')"
-                                                ng-class="{'in-warning': !storage.size || storage.size < 8}">
+                                                ng-class="{'in-warning': storage.size !== '' && storage.size < 8}">
                                             <span class="p-tooltip--top-left u-float--right"
                                                 style="position: absolute; top: 8px; right: 8px;"
                                                 aria-describedby="storage-size-warning"
-                                                data-ng-if="(storage.size > 0 && storage.size < 8) || storage.size == 0">
+                                                data-ng-if="storage.size !== '' && storage.size < 8">
                                                 <i class="p-icon--warning">Warning</i>
                                                 <span class="p-tooltip__message" role="tooltip" id="storage-size-warning">Ubuntu typically requires 8GB minimum. Lower allocations may fail.</span>
                                             </span>


### PR DESCRIPTION
## Done
- Backend now provides core, memory and storage defaults for pod types. Now they're being used in the VM compose form - the form is autofilled with defaults, and clearing them displays the default as a placeholder.
- Added overcommit sliders for LXD hosts.
- Tidied up websocket request preprocessor. It was originally sending a bunch of irrelevant garbage - now it's a bit more explicit what's actually being sent.
- Changed memory help text from GiB to MiB - it seemed weird for the form value (and the backend) to be in MiB and to have to calculate from MiB to GiB and back, when we could just use MiB.

## QA
- **Note:** Something has happened with bolla and now I can't seem to compose machines or edit configuration for either the LXD or virsh host - the requests just hang until they time out. This happens even on the production build. I think the best we can do for QA in the meantime is make sure the websocket request is correct.
- Go to a LXD pod details page and check that there are two sliders for CPU and memory overcommit. Submit the form and check that the websocket request includes `cpu_over_commit_ratio` and `memory_over_commit_ratio` and the numbers are correct.
- Open the compose form and check that cores, memory and storage are autofilled.
- Clear the cores, memory and storage fields and check that the placeholder displays the default
- Submit the form and check that the websocket request includes the defaults (even though the fields were empty) and there are only parameters that are allowed by [the api](https://maas.io/docs/api#pod).

## Fixes
Fixes #1144 
Fixes #1145 

## Launchpad Issue
[lp#1879772](https://bugs.launchpad.net/maas/+bug/1879772)
[lp#1879774](https://bugs.launchpad.net/maas/+bug/1879774)