### PR TITLE
Allow root prod build to configure PUBLIC_PATH from env.

### DIFF
--- a/root/webpack.prod.js
+++ b/root/webpack.prod.js
@@ -4,7 +4,7 @@ const merge = require("webpack-merge");
 
 const common = require('./webpack.common.js');
 
-const publicPath = '/MAAS/r/';
+const publicPath = process.env.PUBLIC_PATH || '/MAAS/r/';
 
 module.exports = merge(common, {
   mode: "production",


### PR DESCRIPTION
## Done
Allow root prod build to configure PUBLIC_PATH from env. This is required as maas-ui is served in two different contexts in MAAS (twisted/django, and from nginx in the snap).

## QA
Run `PUBLIC_PATH='/WHATEVS/' yarn build-all`. Ensure root builds with the specified public path (checking root/dist/index.html is easiest).