### PR TITLE
Set up routes and wrapper components for KVM react rebuild.

### DIFF
--- a/ui/src/app/Routes.js
+++ b/ui/src/app/Routes.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Route, Switch } from "react-router-dom";
 
 import ErrorBoundary from "app/base/components/ErrorBoundary";
+import KVM from "app/kvm/views/KVM";
 import Machines from "app/machines/views/Machines";
 import NotFound from "app/base/views/NotFound";
 import Preferences from "app/preferences/views/Preferences";
@@ -18,10 +19,18 @@ const Routes = () => (
       }}
     />
     <Route
-      path="/settings"
+      path="/account/prefs"
       render={() => (
         <ErrorBoundary>
-          <Settings />
+          <Preferences />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path="/kvm"
+      render={() => (
+        <ErrorBoundary>
+          <KVM />
         </ErrorBoundary>
       )}
     />
@@ -42,10 +51,10 @@ const Routes = () => (
       )}
     />
     <Route
-      path="/account/prefs"
+      path="/settings"
       render={() => (
         <ErrorBoundary>
-          <Preferences />
+          <Settings />
         </ErrorBoundary>
       )}
     />

--- a/ui/src/app/base/selectors/pod/pod.js
+++ b/ui/src/app/base/selectors/pod/pod.js
@@ -1,3 +1,5 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 const pod = {};
 
 /**
@@ -41,5 +43,14 @@ pod.saved = (state) => state.pod.saved;
  * @returns {Object} Machine errors state.
  */
 pod.errors = (state) => state.pod.errors;
+
+/**
+ * Returns a pod for the given id.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A machine.
+ */
+pod.getById = createSelector([pod.all, (state, id) => id], (pods, id) =>
+  pods.find((pod) => pod.id === Number(id))
+);
 
 export default pod;

--- a/ui/src/app/base/selectors/pod/pod.test.js
+++ b/ui/src/app/base/selectors/pod/pod.test.js
@@ -58,4 +58,23 @@ describe("pod selectors", () => {
     };
     expect(pod.errors(state)).toStrictEqual("Data is incorrect");
   });
+
+  it("can get a pod by id", () => {
+    const state = {
+      pod: {
+        items: [
+          { name: "pod-1", id: 111 },
+          { name: "podrick", id: 222 },
+        ],
+      },
+    };
+    expect(pod.getById(state, 222)).toStrictEqual({
+      name: "podrick",
+      id: 222,
+    });
+    expect(pod.getById(state, "222")).toStrictEqual({
+      name: "podrick",
+      id: 222,
+    });
+  });
 });

--- a/ui/src/app/kvm/views/KVM.js
+++ b/ui/src/app/kvm/views/KVM.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+
+import KVMDetails from "./KVMDetails";
+import KVMList from "./KVMList";
+import NotFound from "app/base/views/NotFound";
+
+const KVM = () => {
+  return (
+    <Switch>
+      <Route exact path="/kvm">
+        <KVMList />
+      </Route>
+      <Route path="/kvm/:id">
+        <KVMDetails />
+      </Route>
+      <Route path="*">
+        <NotFound />
+      </Route>
+    </Switch>
+  );
+};
+
+export default KVM;

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.js
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.js
@@ -1,0 +1,73 @@
+import { Spinner } from "@canonical/react-components";
+import pluralize from "pluralize";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { pod as podActions } from "app/base/actions";
+import { pod as podSelectors } from "app/base/selectors";
+import { useParams, useRouter, useWindowTitle } from "app/base/hooks";
+import Section from "app/base/components/Section";
+import Tabs from "app/base/components/Tabs";
+
+const KVMDetails = () => {
+  const dispatch = useDispatch();
+  const { id } = useParams();
+  const { location } = useRouter();
+
+  const pod = useSelector((state) => podSelectors.getById(state, id));
+
+  useWindowTitle(`KVM ${pod?.name || "details"}`);
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Section
+      headerClassName={pod && "u-no-padding--bottom"}
+      title={
+        pod ? (
+          <>
+            <div>
+              <h4 className="u-sv1" data-test="pod-name">
+                {pod.name}
+              </h4>
+            </div>
+            <hr className="u-no-margin--bottom" />
+            <Tabs
+              data-test="kvm-details-tabs"
+              links={[
+                {
+                  active: location.pathname.endsWith(`/kvm/${pod.id}`),
+                  label: `${pod.composed_machines_count} ${pluralize(
+                    "composed machine",
+                    pod.composed_machines_count
+                  )}`,
+                  path: `/kvm/${pod.id}`,
+                },
+                {
+                  active: location.pathname.endsWith(`/kvm/${pod.id}/edit`),
+                  label: "Configuration",
+                  path: `/kvm/${pod.id}/edit`,
+                },
+              ]}
+              listClassName="u-no-margin--bottom"
+              noBorder
+            />
+          </>
+        ) : (
+          <>
+            <span className="p-heading--four"></span>
+            <Spinner
+              className="u-no-padding u-no-margin"
+              inline
+              text="Loading..."
+            />
+          </>
+        )
+      }
+    />
+  );
+};
+
+export default KVMDetails;

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.js
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.js
@@ -1,0 +1,89 @@
+import React from "react";
+import configureStore from "redux-mock-store";
+import { mount } from "enzyme";
+import { MemoryRouter, Route } from "react-router-dom";
+import { Provider } from "react-redux";
+
+import KVMDetails from "./KVMDetails";
+
+const mockStore = configureStore();
+
+describe("KVMDetails", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      config: {
+        items: [],
+      },
+      messages: {
+        items: [],
+      },
+      notification: {
+        items: [],
+      },
+      pod: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [],
+      },
+    };
+  });
+
+  it("displays a spinner if pods are loading", () => {
+    const state = { ...initialState };
+    state.pod.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <KVMDetails />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays pod name in header strip when loaded", () => {
+    const state = { ...initialState };
+    state.pod.items = [{ id: 1, name: "pod-name" }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <Route
+            exact
+            path="/kvm/:id"
+            component={(props) => <KVMDetails {...props} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="pod-name"]').text()).toBe("pod-name");
+  });
+
+  it("can display composed machines count", () => {
+    const state = { ...initialState };
+    state.pod.items = [{ id: 1, composed_machines_count: 5 }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <Route
+            exact
+            path="/kvm/:id"
+            component={(props) => <KVMDetails {...props} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='kvm-details-tabs'] Link").at(0).text()
+    ).toBe("5 composed machines");
+    expect(
+      wrapper.find("[data-test='kvm-details-tabs'] Link").at(0).props()[
+        "aria-selected"
+      ]
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/index.js
+++ b/ui/src/app/kvm/views/KVMDetails/index.js
@@ -1,0 +1,1 @@
+export { default } from "./KVMDetails";

--- a/ui/src/app/kvm/views/KVMList/KVMList.js
+++ b/ui/src/app/kvm/views/KVMList/KVMList.js
@@ -1,0 +1,71 @@
+import { Col, Row, Spinner } from "@canonical/react-components";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import { pod as podActions } from "app/base/actions";
+import { pod as podSelectors } from "app/base/selectors";
+import { useWindowTitle } from "app/base/hooks";
+import Section from "app/base/components/Section";
+
+const KVMList = () => {
+  useWindowTitle("KVM");
+  const dispatch = useDispatch();
+
+  const pods = useSelector(podSelectors.all);
+  const podsLoading = useSelector(podSelectors.loading);
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Section title="KVM">
+      <Row>
+        <Col size={12}>
+          <div>
+            {podsLoading && (
+              <div className="u-align--center">
+                <Spinner text="Loading..." />
+              </div>
+            )}
+            <table>
+              <thead>
+                <tr>
+                  <th>FQDN</th>
+                  <th>Power</th>
+                  <th>VM Host Type</th>
+                  <th>VMs</th>
+                  <th>OS</th>
+                  <th>Resource Pool</th>
+                  <th>CPU</th>
+                  <th>RAM</th>
+                  <th>Storage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pods.map((pod) => (
+                  <tr key={pod.id}>
+                    <td>
+                      <Link to={`/kvm/${pod.id}`}>{pod.name}</Link>
+                    </td>
+                    <td>Unknown</td>
+                    <td>Unknown</td>
+                    <td>Unknown</td>
+                    <td>Unknown</td>
+                    <td>Unknown</td>
+                    <td>Unknown</td>
+                    <td>Unknown</td>
+                    <td>Unknown</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Col>
+      </Row>
+    </Section>
+  );
+};
+
+export default KVMList;

--- a/ui/src/app/kvm/views/KVMList/KVMList.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMList.test.js
@@ -1,0 +1,63 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import KVMList from "./KVMList";
+
+const mockStore = configureStore();
+
+describe("KVMList", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      config: {
+        items: [],
+      },
+      messages: {
+        items: [],
+      },
+      notification: {
+        items: [],
+      },
+      pod: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [],
+      },
+    };
+  });
+
+  it("displays a spinner if pods are loading", () => {
+    const state = { ...initialState };
+    state.pod.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays links to details pages", () => {
+    const state = { ...initialState };
+    state.pod.items = [{ id: 1 }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("table tbody tr").at(0).find("td:first-child Link").props()
+        .to
+    ).toBe("/kvm/1");
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/index.js
+++ b/ui/src/app/kvm/views/KVMList/index.js
@@ -1,0 +1,1 @@
+export { default } from "./KVMList";

--- a/ui/src/scss/_patterns_tabs.scss
+++ b/ui/src/scss/_patterns_tabs.scss
@@ -1,5 +1,8 @@
 @mixin maas-tabs {
-  .p-tabs__list.no-border::after {
-    content: none;
+  .p-tabs__list.no-border {
+    &::after,
+    .p-tabs__item::after {
+      content: none;
+    }
   }
 }


### PR DESCRIPTION
## Done
- Added wrapper components:
  - KVM, which at the moment just handles routing between list and details
  - KVMList, a basic Vanilla table with links to details
  - KVMDetails, a headerstrip with tabs between composed machines and configuration 
- Added routes KVM react pages

## QA
- Go to /MAAS/r/kvm and check that the list of pod names is correct
- Click on the links and check that they take you to the pod details pages
- Check you can go between composed machines count and configuration tabs
- Navigate directly to /MAAS/r/kvm, /MAAS/r/kvm/<pod.id> and /MAAS/r/kvm/<pod.id>/edit and check that the pages load properly

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1946

## Screenshots
![0 0 0 0_8400_MAAS_r_kvm](https://user-images.githubusercontent.com/25733845/82981920-687b3200-a030-11ea-859e-840f9066e34f.png)
![0 0 0 0_8400_MAAS_r_kvm (1)](https://user-images.githubusercontent.com/25733845/82981925-6c0eb900-a030-11ea-8c94-a2dd0761eb5b.png)

