### PR TITLE
Add hashroute redirect with machine listing fallthrough.

### DIFF
--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -253,7 +253,7 @@ function configureMaas(
   $locationProvider,
   $compileProvider,
   tagsInputConfigProvider,
-  $urlRouterProvider
+  $urlRouterProvider,
 ) {
   // Disable debugInfo unless in a Jest context.
   // Re-enable debugInfo in development by running

--- a/legacy/src/app/routes.js
+++ b/legacy/src/app/routes.js
@@ -148,8 +148,14 @@ const configureRoutes = ($stateProvider, $urlRouterProvider) => {
       template: podDetailsTmpl,
       controller: "PodDetailsController",
     })
-    .state("pods", { url: prefixRoute("/pods"), redirectTo: prefixRoute("/kvm") })
-    .state("podDetails", { url: prefixRoute("/pod/:id"), redirectTo: prefixRoute("/kvm/:id") })
+    .state("pods", {
+      url: prefixRoute("/pods"),
+      redirectTo: prefixRoute("/kvm"),
+    })
+    .state("podDetails", {
+      url: prefixRoute("/pod/:id"),
+      redirectTo: prefixRoute("/kvm/:id"),
+    })
     .state("master.rsd", {
       url: prefixRoute("/rsd"),
       template: podsListTmpl,
@@ -227,6 +233,26 @@ const configureRoutes = ($stateProvider, $urlRouterProvider) => {
       template: dashboardTmpl,
       controller: "DashboardController",
     });
+
+  $urlRouterProvider.otherwise(($injector, $location) => {
+    // Redirect old hash routes to new routes
+    if ($location.hash()) {
+      window.history.pushState(
+        null,
+        null,
+        `${process.env.BASENAME}${
+          process.env.ANGULAR_BASENAME
+        }${$location.hash()}`
+      );
+    } else {
+      // fallthrough redirect machine listing
+      window.history.pushState(
+        null,
+        null,
+        `${process.env.BASENAME}${process.env.REACT_BASENAME}/machines`
+      );
+    }
+  });
 };
 
 export default configureRoutes;

--- a/legacy/src/app/services/tests/test_region.js
+++ b/legacy/src/app/services/tests/test_region.js
@@ -10,7 +10,11 @@ import MockWebSocket from "testing/websocket";
 
 describe("RegionConnection", function() {
   // Load the MAAS module to test.
-  beforeEach(angular.mock.module("MAAS"));
+  beforeEach(
+    angular.mock.module("MAAS", ($urlRouterProvider) =>
+      $urlRouterProvider.deferIntercept()
+    )
+  );
 
   // Grab the needed angular pieces.
   var $timeout, $rootScope, $q, $cookies, $window;

--- a/root/src/root-application.js
+++ b/root/src/root-application.js
@@ -15,7 +15,10 @@ registerApplication({
     showLoading();
     return import("@maas-ui/maas-ui-legacy");
   },
-  activeWhen: `${process.env.BASENAME}${process.env.ANGULAR_BASENAME}`,
+  activeWhen: (location) =>
+    location.pathname.startsWith(
+      `${process.env.BASENAME}${process.env.ANGULAR_BASENAME}`
+    ) || location.hash.startsWith("#"),
 });
 
 registerApplication({


### PR DESCRIPTION
## Done
Add redirect for legacy hash-based routes, with a fall through to the machine listing.

## QA
* Visit a deprecated route such as `/MAAS/#/controllers`, you should be redirected to `/MAAS/l/controllers`. 
* Visit an invalid route such as `/MAAS/l/foo`, you should be redirected to the machine listing.