### PR TITLE
Fix duplicate tag manager scripts

### DIFF
--- a/shared/src/components/Header/Header.js
+++ b/shared/src/components/Header/Header.js
@@ -45,8 +45,11 @@ export const Header = ({
           j = d.createElement(s),
           dl = l !== "dataLayer" ? "&l=" + l : "";
         j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
+        const src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        j.src = src;
+        if (document.querySelectorAll(`script[src="${src}"]`).length === 0) {
+          f.parentNode.insertBefore(j, f);
+        }
       })(window, document, "script", "dataLayer", "GTM-P4TGJR9");
 
       window.ga =


### PR DESCRIPTION
## Done
- Don't append the tag manager script if it already exists

## QA
- Run the app in dev or production.
- If in dev you'll need to remove `!debug` from this line: https://github.com/canonical-web-and-design/maas-ui/blob/master/shared/src/components/Header/Header.js#L40.
- Switch between the react and angular apps a few times.
- Inspect the header.
- You should only see one script tag for google tag manager.

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-ui/issues/1163.