### PR TITLE
Update the filters when clicking on a pool link

### DIFF
--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Route, Switch } from "react-router-dom";
 
-import { useLocation, useRouter } from "app/base/hooks";
+import { useLocation, usePrevious, useRouter } from "app/base/hooks";
 import {
   filtersToQueryString,
   filtersToString,
@@ -32,6 +32,15 @@ const Machines = () => {
     const filters = getCurrentFilters(searchText);
     history.push({ search: filtersToQueryString(filters) });
   };
+
+  const previousPath = usePrevious(location.pathname);
+
+  useEffect(() => {
+    // When the page changes (e.g. /pools -> /machines) then update the filters.
+    if (location.pathname !== previousPath) {
+      setFilter(filtersToString(currentFilters));
+    }
+  }, [location.pathname, currentFilters, previousPath]);
 
   return (
     <Section

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -165,7 +165,24 @@ describe("Machines", () => {
         items: [],
       },
       resourcepool: {
-        items: [],
+        errors: {},
+        loaded: true,
+        items: [
+          {
+            id: 0,
+            name: "default",
+            description: "default",
+            is_default: true,
+            permissions: [],
+          },
+          {
+            id: 1,
+            name: "Backup",
+            description: "A backup pool",
+            is_default: false,
+            permissions: [],
+          },
+        ],
       },
       zone: {
         items: [],
@@ -278,6 +295,32 @@ describe("Machines", () => {
     );
     expect(wrapper.find("MachineList").prop("searchFilter")).toBe(
       "test search"
+    );
+  });
+
+  it("updates the filter when the page changes", () => {
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machines", search: "?q=test+search", key: "testKey" },
+          ]}
+        >
+          <Machines />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("HeaderStrip Link[to='/pools']")
+      .simulate("click", { button: 0 });
+    wrapper.update();
+    wrapper
+      .find("Link[to='/machines?pool=%3Ddefault']")
+      .simulate("click", { button: 0 });
+    wrapper.update();
+    expect(wrapper.find("MachineList").prop("searchFilter")).toBe(
+      "pool:(=default)"
     );
   });
 

--- a/ui/src/app/pools/views/Pools.js
+++ b/ui/src/app/pools/views/Pools.js
@@ -24,8 +24,9 @@ const getMachinesLabel = (row) => {
   if (row.machine_total_count === 0) {
     return "Empty pool";
   }
+  const filters = filtersToQueryString({ pool: `=${row.name}` });
   return (
-    <Link to={`/machines${filtersToQueryString({ pool: row.name })}`}>
+    <Link to={`/machines${filters}`}>
       {`${row.machine_ready_count} of ${row.machine_total_count} ready`}
     </Link>
   );

--- a/ui/src/app/pools/views/Pools.test.js
+++ b/ui/src/app/pools/views/Pools.test.js
@@ -248,7 +248,7 @@ describe("Pools", () => {
       .at(1)
       .find("Link");
     expect(link.exists()).toBe(true);
-    expect(link.prop("to")).toBe("/machines?pool=default");
+    expect(link.prop("to")).toBe("/machines?pool=%3Ddefault");
     expect(link.text()).toBe("1 of 5 ready");
   });
 


### PR DESCRIPTION
## Done
- When clicking on the link to the machines in a pool the filters were not being updated.

## QA
- Visit the pool page.
- Click the link to view the machines in the pool.
- The machine list should appear with only the machines in the pool (and the filter should be in the search box).

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1181.

## Launchpad Issue
https://bugs.launchpad.net/maas-ui/+bug/1881247
