### PR TITLE
Build Meter component and use in KVM list table.

### DIFF
--- a/ui/src/app/base/components/Meter/Meter.js
+++ b/ui/src/app/base/components/Meter/Meter.js
@@ -1,0 +1,100 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+const DEFAULT_COLORS = ["#007AA6", "#0E8420", "#C7162B", "#F99B11"];
+
+const colorValidator = (props, propName, componentName) => {
+  if (props[propName] && !/^#(?:[0-9a-fA-F]{3}){1,2}$/.test(props[propName])) {
+    return new Error(
+      `Invalid prop ${propName} supplied to ${componentName}. Must be a valid color code.`
+    );
+  }
+};
+
+const Meter = ({
+  className,
+  data,
+  emptyColor = "#D3E4ED",
+  labelsClassName,
+  max,
+  overColor = "#F99B11",
+  small = false,
+}) => {
+  const hasLabels = data.some((datum) => datum.label);
+  const valueSum = data.reduce((sum, datum) => sum + datum.value, 0);
+  const maximum = max || valueSum;
+  const widths = data.map((datum) => (datum.value / maximum) * 100);
+
+  return (
+    <div
+      className={classNames(small ? "p-meter--small" : "p-meter", className)}
+    >
+      <div className="p-meter__bar" style={{ backgroundColor: emptyColor }}>
+        {valueSum > maximum ? (
+          <div
+            className="p-meter__filled"
+            style={{
+              backgroundColor: overColor,
+              width: "100%",
+            }}
+          ></div>
+        ) : (
+          data.map((datum, i) => (
+            <div
+              className="p-meter__filled"
+              key={`${datum.key}-bar`}
+              style={{
+                backgroundColor:
+                  datum.color || DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+                borderRight: `1px solid ${emptyColor}`,
+                left: `${widths.reduce(
+                  (leftPos, width, j) => (i > j ? leftPos + width : leftPos),
+                  0
+                )}%`,
+                width: `${widths[i]}%`,
+              }}
+            ></div>
+          ))
+        )}
+      </div>
+      {hasLabels && (
+        <div className={classNames("p-meter__labels", labelsClassName)}>
+          {data.map((datum) => {
+            if (!datum.label) {
+              return null;
+            }
+            return (
+              <div key={`${datum.key}-label`}>
+                {small ? (
+                  <small className="u-text--light">{datum.label}</small>
+                ) : (
+                  datum.label
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+Meter.propTypes = {
+  className: PropTypes.string,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      color: colorValidator,
+      key: PropTypes.string.isRequired,
+      label: PropTypes.node,
+      value: PropTypes.number,
+    })
+  ).isRequired,
+  emptyColor: colorValidator,
+  labelsClassName: PropTypes.string,
+  max: PropTypes.number,
+  overColor: colorValidator,
+  small: PropTypes.bool,
+};
+
+export default Meter;

--- a/ui/src/app/base/components/Meter/Meter.test.js
+++ b/ui/src/app/base/components/Meter/Meter.test.js
@@ -1,0 +1,127 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Meter from "./Meter";
+
+describe("Meter", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <Meter
+        data={[
+          { key: "datum-1", label: "One", value: 1 },
+          { key: "datum-2", label: "Two", value: 3 },
+        ]}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can be made small", () => {
+    const wrapper = shallow(<Meter data={[]} small />);
+    expect(wrapper.find("div").at(0).props().className).toBe("p-meter--small");
+  });
+
+  it("can be given labels", () => {
+    const wrapper = shallow(
+      <Meter
+        data={[
+          { key: "datum-1", label: "One", value: 1 },
+          { key: "datum-2", label: "Two", value: 3 },
+        ]}
+      />
+    );
+    expect(wrapper.find(".p-meter__labels div").at(0).text()).toBe("One");
+    expect(wrapper.find(".p-meter__labels div").at(1).text()).toBe("Two");
+  });
+
+  it("can be given a custom empty colour", () => {
+    const wrapper = shallow(<Meter data={[]} emptyColor="#ABC" />);
+    expect(wrapper.find(".p-meter__bar").props().style.backgroundColor).toBe(
+      "#ABC"
+    );
+  });
+
+  it("can be given custom bar colours", () => {
+    const wrapper = shallow(
+      <Meter
+        data={[
+          { color: "#AAA", key: "aaa", value: 1 },
+          { color: "#BBB", key: "bbb", value: 2 },
+          { color: "#CCC", key: "ccc", value: 3 },
+        ]}
+      />
+    );
+    expect(
+      wrapper.find(".p-meter__filled").at(0).props().style.backgroundColor
+    ).toBe("#AAA");
+    expect(
+      wrapper.find(".p-meter__filled").at(1).props().style.backgroundColor
+    ).toBe("#BBB");
+    expect(
+      wrapper.find(".p-meter__filled").at(2).props().style.backgroundColor
+    ).toBe("#CCC");
+  });
+
+  it("changes colour if values exceed given maximum value", () => {
+    const wrapper = shallow(
+      <Meter
+        data={[{ color: "#ABC", key: "key", value: 100 }]}
+        max={10}
+        overColor="#DEF"
+      />
+    );
+    expect(wrapper.find(".p-meter__filled").props().style.backgroundColor).toBe(
+      "#DEF"
+    );
+  });
+
+  it("correctly calculates datum widths", () => {
+    const wrapper = shallow(
+      <Meter
+        data={[
+          { key: "ten", value: 10 }, // 10/100 = 10%
+          { key: "twenty", value: 20 }, // 20/100 = 20%
+          { key: "thirty", value: 30 }, // 30/100 = 30%
+          { key: "forty", value: 40 }, // 40/100 = 40%
+        ]}
+      />
+    );
+    expect(wrapper.find(".p-meter__filled").at(0).props().style.width).toBe(
+      "10%"
+    );
+    expect(wrapper.find(".p-meter__filled").at(1).props().style.width).toBe(
+      "20%"
+    );
+    expect(wrapper.find(".p-meter__filled").at(2).props().style.width).toBe(
+      "30%"
+    );
+    expect(wrapper.find(".p-meter__filled").at(3).props().style.width).toBe(
+      "40%"
+    );
+  });
+
+  it("correctly calculates datum positions", () => {
+    const wrapper = shallow(
+      <Meter
+        data={[
+          { key: "ten", value: 10 }, // 1st = 0%
+          { key: "twenty", value: 20 }, // 2nd = 1st width = 10%
+          { key: "thirty", value: 30 }, // 3rd = 1st + 2nd width = 30%
+          { key: "forty", value: 40 }, // 4th = 1st + 2nd + 3rd width = 60%
+        ]}
+      />
+    );
+    expect(wrapper.find(".p-meter__filled").at(0).props().style.left).toBe(
+      "0%"
+    );
+    expect(wrapper.find(".p-meter__filled").at(1).props().style.left).toBe(
+      "10%"
+    );
+    expect(wrapper.find(".p-meter__filled").at(2).props().style.left).toBe(
+      "30%"
+    );
+    expect(wrapper.find(".p-meter__filled").at(3).props().style.left).toBe(
+      "60%"
+    );
+  });
+});

--- a/ui/src/app/base/components/Meter/__snapshots__/Meter.test.js.snap
+++ b/ui/src/app/base/components/Meter/__snapshots__/Meter.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Meter renders 1`] = `
+<div
+  className="p-meter"
+>
+  <div
+    className="p-meter__bar"
+    style={
+      Object {
+        "backgroundColor": "#D3E4ED",
+      }
+    }
+  >
+    <div
+      className="p-meter__filled"
+      key="datum-1-bar"
+      style={
+        Object {
+          "backgroundColor": "#007AA6",
+          "borderRight": "1px solid #D3E4ED",
+          "left": "0%",
+          "width": "25%",
+        }
+      }
+    />
+    <div
+      className="p-meter__filled"
+      key="datum-2-bar"
+      style={
+        Object {
+          "backgroundColor": "#0E8420",
+          "borderRight": "1px solid #D3E4ED",
+          "left": "25%",
+          "width": "75%",
+        }
+      }
+    />
+  </div>
+  <div
+    className="p-meter__labels"
+  >
+    <div
+      key="datum-1-label"
+    >
+      One
+    </div>
+    <div
+      key="datum-2-label"
+    >
+      Two
+    </div>
+  </div>
+</div>
+`;

--- a/ui/src/app/base/components/Meter/_index.scss
+++ b/ui/src/app/base/components/Meter/_index.scss
@@ -1,0 +1,45 @@
+@mixin Meter {
+  $meter-height: $sp-unit * 2;
+  $meter-height--small: $sp-unit * 1.5;
+
+  .p-meter {
+    margin-bottom: $sp-unit * 1.5;
+    padding-top: $spv-inner--x-small;
+  }
+
+  .p-meter__bar {
+    border-radius: $meter-height;
+    height: $meter-height;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .p-meter__labels {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: -#{$sp-unit * .25};
+    padding-top: $sp-unit * 1.25;
+  }
+
+  .p-meter__filled {
+    height: 100%;
+    position: absolute;
+    width: 0%;
+  }
+
+  .p-meter--small {
+    margin-bottom: $sp-unit * 1.75;;
+    padding-top: $sp-unit * .75;
+
+    .p-meter__bar {
+      border-radius: $meter-height--small;
+      height: $meter-height--small;
+      margin-bottom: $sp-unit * .75;
+    }
+
+    .p-meter__labels {
+      margin-bottom: 0;
+      padding-top: $sp-unit * .25;
+    }
+  }
+}

--- a/ui/src/app/base/components/Meter/index.js
+++ b/ui/src/app/base/components/Meter/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Meter";

--- a/ui/src/app/kvm/views/KVMList/KVMList.js
+++ b/ui/src/app/kvm/views/KVMList/KVMList.js
@@ -47,19 +47,10 @@ const KVMList = () => {
               </thead>
               <tbody>
                 {pods.map((pod) => {
-                  const freeCores =
-                    pod.total.cores * pod.cpu_over_commit_ratio -
-                    pod.used.cores;
-                  const freeMemory = formatBytes(
-                    pod.total.memory * pod.memory_over_commit_ratio -
-                      pod.used.memory,
-                    "MiB",
-                    { binary: true }
-                  );
-                  const freeStorage = formatBytes(
-                    pod.total.local_storage - pod.used.local_storage,
-                    "B"
-                  );
+                  const usedMemory = formatBytes(pod.used.memory, "MiB", {
+                    binary: true,
+                  });
+                  const usedStorage = formatBytes(pod.used.local_storage, "B");
                   return (
                     <tr key={pod.id}>
                       <td>
@@ -76,7 +67,7 @@ const KVMList = () => {
                           data={[
                             {
                               key: `${pod.name}-cpu-meter`,
-                              label: `${freeCores} cores free`,
+                              label: `${pod.total.cores}`,
                               value: pod.used.cores,
                             },
                           ]}
@@ -91,7 +82,7 @@ const KVMList = () => {
                           data={[
                             {
                               key: `${pod.name}-memory-meter`,
-                              label: `${freeMemory.value} ${freeMemory.unit} free`,
+                              label: `${usedMemory.value} ${usedMemory.unit}`,
                               value: pod.used.memory,
                             },
                           ]}
@@ -106,7 +97,7 @@ const KVMList = () => {
                           data={[
                             {
                               key: `${pod.name}-storage-meter`,
-                              label: `${freeStorage.value} ${freeStorage.unit} free`,
+                              label: `${usedStorage.value} ${usedStorage.unit}`,
                               value: pod.used.local_storage,
                             },
                           ]}

--- a/ui/src/app/kvm/views/KVMList/KVMList.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMList.test.js
@@ -25,7 +25,24 @@ describe("KVMList", () => {
         errors: {},
         loading: false,
         loaded: true,
-        items: [],
+        items: [
+          {
+            cpu_over_commit_ratio: 1,
+            id: 1,
+            memory_over_commit_ratio: 1,
+            name: "pod-1",
+            total: {
+              memory: 8192,
+              cores: 8,
+              local_storage: 1000000000000,
+            },
+            used: {
+              memory: 2048,
+              cores: 4,
+              local_storage: 100000000000,
+            },
+          },
+        ],
       },
     };
   });
@@ -46,7 +63,6 @@ describe("KVMList", () => {
 
   it("displays links to details pages", () => {
     const state = { ...initialState };
-    state.pod.items = [{ id: 1 }];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -59,5 +75,50 @@ describe("KVMList", () => {
       wrapper.find("table tbody tr").at(0).find("td:first-child Link").props()
         .to
     ).toBe("/kvm/1");
+  });
+
+  it("displays available cores", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Meter").at(0).find(".p-meter__labels").text()).toBe(
+      "4 cores free"
+    );
+  });
+
+  it("displays available memory", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Meter").at(1).find(".p-meter__labels").text()).toBe(
+      "6 GiB free"
+    );
+  });
+
+  it("displays available storage", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Meter").at(2).find(".p-meter__labels").text()).toBe(
+      "900 GB free"
+    );
   });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMList.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMList.test.js
@@ -77,7 +77,7 @@ describe("KVMList", () => {
     ).toBe("/kvm/1");
   });
 
-  it("displays available cores", () => {
+  it("displays total cores", () => {
     const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
@@ -88,11 +88,11 @@ describe("KVMList", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").at(0).find(".p-meter__labels").text()).toBe(
-      "4 cores free"
+      "8"
     );
   });
 
-  it("displays available memory", () => {
+  it("displays used memory", () => {
     const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
@@ -103,11 +103,11 @@ describe("KVMList", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").at(1).find(".p-meter__labels").text()).toBe(
-      "6 GiB free"
+      "2 GiB"
     );
   });
 
-  it("displays available storage", () => {
+  it("displays used storage", () => {
     const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
@@ -118,7 +118,7 @@ describe("KVMList", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").at(2).find(".p-meter__labels").text()).toBe(
-      "900 GB free"
+      "100 GB"
     );
   });
 });

--- a/ui/src/app/utils/formatBytes.js
+++ b/ui/src/app/utils/formatBytes.js
@@ -14,7 +14,8 @@ export const formatBytes = (
   unit,
   { binary = false, precision = 2 } = {}
 ) => {
-  const parsedValue = parseFloat(value);
+  const negative = value < 0;
+  const parsedValue = parseFloat(Math.abs(value));
   if (parsedValue === 0) {
     return { value: 0, unit: "B" };
   }
@@ -34,7 +35,7 @@ export const formatBytes = (
   );
 
   return {
-    value: valueInUnit,
+    value: negative ? -valueInUnit : valueInUnit,
     unit: sizes[j],
   };
 };

--- a/ui/src/app/utils/formatBytes.js
+++ b/ui/src/app/utils/formatBytes.js
@@ -3,17 +3,25 @@
  *
  * @param {number} value - the value in the supplied byte unit
  * @param {string} unit - the byte unit, e.g. "KB", "TB"
- * @param {number} precision - significant figures of returned value
+ * @param {object} config - config object
+ * @param {boolean} config.binary - whether formatting should be done in base 10 or 2
+ * @param {number} config.precision - significant figures of returned value
  * @returns {object} formatted value and unit object
  */
 
-export const formatBytes = (value, unit, precision = 3) => {
+export const formatBytes = (
+  value,
+  unit,
+  { binary = false, precision = 2 } = {}
+) => {
   const parsedValue = parseFloat(value);
   if (parsedValue === 0) {
     return { value: 0, unit: "B" };
   }
-  const k = 1000;
-  const sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const k = binary ? 1024 : 1000;
+  const sizes = binary
+    ? ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+    : ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
   // Convert to bytes.
   const i = sizes.findIndex((size) => size === unit) || 0;

--- a/ui/src/app/utils/formatBytes.test.js
+++ b/ui/src/app/utils/formatBytes.test.js
@@ -40,4 +40,23 @@ describe("formatBytes", () => {
       unit: "GiB",
     });
   });
+
+  it("can handle negative numbers", () => {
+    expect(formatBytes(-1, "B")).toStrictEqual({
+      value: -1,
+      unit: "B",
+    });
+    expect(formatBytes(-2000, "MB")).toStrictEqual({
+      value: -2,
+      unit: "GB",
+    });
+    expect(formatBytes(-1234, "GB", { precision: 4 })).toStrictEqual({
+      value: -1.234,
+      unit: "TB",
+    });
+    expect(formatBytes(-1024, "MiB", { binary: true })).toStrictEqual({
+      value: -1,
+      unit: "GiB",
+    });
+  });
 });

--- a/ui/src/app/utils/formatBytes.test.js
+++ b/ui/src/app/utils/formatBytes.test.js
@@ -12,17 +12,32 @@ describe("formatBytes", () => {
   });
 
   it("returns the value to the correct precision", () => {
-    expect(formatBytes(1234, "B", 2)).toStrictEqual({
+    expect(formatBytes(1234, "B", { precision: 2 })).toStrictEqual({
       value: 1.2,
       unit: "KB",
     });
-    expect(formatBytes(1234, "B", 4)).toStrictEqual({
+    expect(formatBytes(1234, "B", { precision: 4 })).toStrictEqual({
       value: 1.234,
       unit: "KB",
     });
-    expect(formatBytes(123, "B", 1)).toStrictEqual({
+    expect(formatBytes(123, "B", { precision: 1 })).toStrictEqual({
       value: 123,
       unit: "B",
+    });
+  });
+
+  it("can handle binary units", () => {
+    expect(formatBytes(0, "B", { binary: true })).toStrictEqual({
+      value: 0,
+      unit: "B",
+    });
+    expect(formatBytes(1023, "MiB", { binary: true })).toStrictEqual({
+      value: 1023,
+      unit: "MiB",
+    });
+    expect(formatBytes(1024, "MiB", { binary: true })).toStrictEqual({
+      value: 1,
+      unit: "GiB",
     });
   });
 });

--- a/ui/src/app/utils/formatSpeedUnits.js
+++ b/ui/src/app/utils/formatSpeedUnits.js
@@ -6,6 +6,6 @@ import { formatBytes } from "./formatBytes";
  * @returns {String} Formatted value and unit.
  */
 export const formatSpeedUnits = (speedInMbytes) => {
-  const adjusted = formatBytes(speedInMbytes, "MB", 1);
+  const adjusted = formatBytes(speedInMbytes, "MB", { precision: 1 });
   return `${adjusted.value} ${adjusted.unit[0]}bps`;
 };

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -47,12 +47,14 @@
 @import "~app/base/components/ColumnToggle";
 @import "~app/base/components/FormCard";
 @import "~app/base/components/Login";
+@import "~app/base/components/Meter";
 @import "~app/base/components/Section";
 @import "~app/base/components/TableMenu";
 @import "~app/base/components/TagSelector";
 @include ColumnToggle;
 @include FormCard;
 @include Login;
+@include Meter;
 @include Section;
 @include TableMenu;
 @include TagSelector;


### PR DESCRIPTION
## Done
- Built Meter component and used it in the KVM list table. In the near future we'll do the same thing we did with the machine list and use MainTable with individual cell components. For now I'm just using a basic implementation to show how the meter looks.
- Updated `formatBytes` util to be able to handle binary units (e.g. "MiB", "GiB" etc).

## QA
- Go to /MAAS/r/kvm and check that the table shows simple meter components with the used v free cpu/memory/storage.
- Add this Row below the KVMList Row in KVMList.js to see some different ways you can use the component:
``` js
<Row>
  <Col size="6">
    <h4>Default</h4>
    <Meter data={[{ key: "default", value: 1 }]} max={3} />
    <h4>Over</h4>
    <Meter data={[{ key: "default-over", value: 3 }]} max={1} />
    <h4>Labels</h4>
    <Meter
      data={[
        { key: "default-label-1", label: "Used", value: 1 },
        { key: "default-label-2", label: "Free" },
      ]}
      max={3}
    />
    <h4>Multi</h4>
    <Meter
      data={[
        { key: "default-multi-1", label: "10 GB", value: 10 },
        { key: "default-multi-2", label: "2 GB", value: 2 },
        { key: "default-multi-3", label: "3 GB", value: 3 },
        { key: "default-multi-4", label: "5 GB" },
      ]}
      max={20}
    />
  </Col>
  <Col size="6">
    <h4>Small</h4>
    <Meter data={[{ key: "small", value: 1 }]} max={3} small />
    <h4>Small over</h4>
    <Meter data={[{ key: "small-over", value: 3 }]} max={1} small />
    <h4>Small labels</h4>
    <Meter
      data={[
        { key: "small-label-1", label: "Used", value: 1 },
        { key: "small-label-2", label: "Free" },
      ]}
      max={3}
      small
    />
    <h4>Small multi</h4>
    <Meter
      data={[
        { key: "small-multi-1", label: "10 GB", value: 10 },
        { key: "small-multi-2", label: "2 GB", value: 2 },
        { key: "small-multi-3", label: "3 GB", value: 3 },
        { key: "small-multi-4", label: "5 GB" },
      ]}
      max={20}
      small
    />
  </Col>
</Row>
```
- Check that the api makes sense and is flexible enough to build [these different meter types](https://github.com/canonical-web-and-design/maas-squad/issues/1947).

## Fixes
Fixes canonical-web-and-design/MAAS-squad#1947

## Screenshot
![0 0 0 0_8400_MAAS_r_kvm (3)](https://user-images.githubusercontent.com/25733845/83381948-52e97c00-a425-11ea-9443-1bf9ae1ccc4f.png)


