### PR TITLE
Fix settings sidebar looking disabled.

### DIFF
--- a/root/src/scss/_settings.scss
+++ b/root/src/scss/_settings.scss
@@ -11,4 +11,12 @@ $breakpoint-x-large: 1300px;
 $breakpoint-navigation-threshold: 870px;
 $increase-font-size-on-larger-screens: false;
 
+// XXX Caleb 02/06/2020 Sidenav looks disabled on #f7f7f7 background.
+// Remove when Vanilla updated >=2.12.1
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3105
+$colors--light-theme--background-highlight: rgba(#111, 0.03);
+$colors--light-theme--border-default: rgba(#111, 0.2);
+$colors--light-theme--border-high-contrast: rgba(#111, 0.56);
+$colors--light-theme--border-low-contrast: rgba(#111, 0.1);
+
 $multi: 1;

--- a/ui/src/app/base/components/Section/Section.js
+++ b/ui/src/app/base/components/Section/Section.js
@@ -22,15 +22,15 @@ const Section = ({ children, headerClassName, sidebar, title }) => {
       <Strip
         element="main"
         includeCol={false}
-        rowClassName="u-flex section__content-wrapper"
+        rowClassName="section__content-wrapper"
         shallow
       >
         {sidebar && (
-          <Col element="aside" size="2" className="section__sidebar">
+          <Col element="aside" size="3" className="section__sidebar">
             {sidebar}
           </Col>
         )}
-        <Col size={sidebar ? 10 : 12} className="section__content">
+        <Col size={sidebar ? 9 : 12} className="section__content">
           <NotificationList />
           {children}
         </Col>

--- a/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
+++ b/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
@@ -18,13 +18,13 @@ exports[`Section renders 1`] = `
   <Strip
     element="main"
     includeCol={false}
-    rowClassName="u-flex section__content-wrapper"
+    rowClassName="section__content-wrapper"
     shallow={true}
   >
     <Col
       className="section__sidebar"
       element="aside"
-      size="2"
+      size="3"
     >
       <div>
         Sidebar
@@ -32,7 +32,7 @@ exports[`Section renders 1`] = `
     </Col>
     <Col
       className="section__content"
-      size={10}
+      size={9}
     >
       <NotificationList />
       content


### PR DESCRIPTION
## Done
- Hardcoded fix from https://github.com/canonical-web-and-design/vanilla-framework/pull/3106 in root css
- Increased Section sidebar width to col-3 and removed flex styling as it was removing gutter widths

## QA
- Go to /MAAS/r/settings and check that you can see the hover/active state on the sidebar nav items.
- Do the same at /MAAS/r/account/prefs

## Fixes
Fixes #1175 

## Screenshot
![0 0 0 0_8400_MAAS_r_settings_configuration_general](https://user-images.githubusercontent.com/25733845/83473923-13c33580-a4ce-11ea-9a17-5bdf33df0a41.png)
