### PR TITLE
Add Beta label to LXD option when adding VM host.

### DIFF
--- a/legacy/src/app/controllers/pods_list.js
+++ b/legacy/src/app/controllers/pods_list.js
@@ -269,7 +269,7 @@ function PodsListController(
     if ($scope.onRSDSection()) {
       $scope.add.obj.type = "rsd";
     } else {
-      $scope.add.obj.type = "lxd";
+      $scope.add.obj.type = "virsh";
     }
   };
 

--- a/legacy/src/app/partials/pods-list.html
+++ b/legacy/src/app/partials/pods-list.html
@@ -125,24 +125,20 @@
                 </div>
                 <div class="col-4">
                     <ul class="p-inline-list">
-                        <li class="p-inline-list__item" style="display: inline-block">
-                            <input type="radio" data-ng-model="add.obj.type" id="lxd-pod" value="lxd" />
-                            <label for="lxd-pod">LXD</label>
-                        </li>
-                        <li class="p-inline-list__item" style="display: inline-block">
+                        <li class="p-inline-list__item" style="display: inline-block; margin-right: 1.5rem;">
                             <input type="radio" data-ng-model="add.obj.type" id="virsh-pod" value="virsh" />
                             <label for="virsh-pod">virsh</label>
                         </li>
+                        <li class="p-inline-list__item" style="display: inline-block">
+                            <input type="radio" data-ng-model="add.obj.type" id="lxd-pod" value="lxd" />
+                            <label for="lxd-pod">
+                                LXD
+                                <span class="p-label--new" style="display: inline; margin-left: .5rem;">Beta</span>
+                            </label>
+                        </li>
                     </ul>
-                    <!-- TODO Caleb 28/04/2020 - Replace with real copy when ready -->
-                    <span ng-if="false">
-                        <p ng-if="add.obj.type === 'lxd'">
-                            Why would I like to add a LXD host?<br>
-                            <a class="p-link--external">More about LXD hosts in MAAS...</a>
-                        </p>
-                        <p ng-if="add.obj.type === 'virsh'">
-                            Why would I like to add a virsh host?<br>
-                            <a class="p-link--external">More about virsh hosts in MAAS...</a>
+                        <p>
+                            <a class="p-link--external" href="https://maas.io/docs/intro-to-vm-hosting">More about KVM hosts in MAAS...</a>
                         </p>
                     </span>
                 </div>


### PR DESCRIPTION
## Done
- Added Beta label to LXD option when adding VM host.
- Added a link to VM host docs to "Add KVM" form

## QA
- Go to /MAAS/l/kvm and click "Add KVM"
- Check that "virsh" is selected by default, and next to "LXD" is a Beta label
- Check that the link takes you to the correct docs page about VM hosting

## Fixes
Fixes #1187 

## Screenshot
![0 0 0 0_8400_MAAS_l_kvm (1)](https://user-images.githubusercontent.com/25733845/83475098-f6dc3180-a4d0-11ea-8dfb-410f30b53cdb.png)
