### PR TITLE
Build hashes

### DIFF
--- a/legacy/src/app/partials/layout.html
+++ b/legacy/src/app/partials/layout.html
@@ -1,4 +1,3 @@
-<link href="/MAAS/assets/css/maas.css" rel="stylesheet" />
 <div id="maas-legacy">
   <div id="header">
     <header class="p-navigation is-dark">
@@ -33,7 +32,7 @@
       </div>
     </header>
   </div>
-  
+
   <main class="u-no-margin--top" id="main-content" data-maas-error-overlay>
     <div class="wrapper--inner">
       <header

--- a/legacy/webpack.common.js
+++ b/legacy/webpack.common.js
@@ -67,10 +67,6 @@ module.exports = {
     new CopyWebpackPlugin([
       { from: path.resolve(__dirname, "./src/assets"), to: "assets" },
     ]),
-    new MiniCssExtractPlugin({
-      // This file is relative to output.path above.
-      filename: "assets/css/[name].[contenthash].css",
-    }),
     new webpack.ProvidePlugin({
       "window.jQuery": "jquery",
     }),

--- a/legacy/webpack.common.js
+++ b/legacy/webpack.common.js
@@ -69,7 +69,7 @@ module.exports = {
     ]),
     new MiniCssExtractPlugin({
       // This file is relative to output.path above.
-      filename: "assets/css/[name].css",
+      filename: "assets/css/[name].[contenthash].css",
     }),
     new webpack.ProvidePlugin({
       "window.jQuery": "jquery",

--- a/legacy/webpack.dev.js
+++ b/legacy/webpack.dev.js
@@ -1,4 +1,5 @@
 const merge = require("webpack-merge");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require("path");
 
 const common = require("./webpack.common.js");
@@ -14,4 +15,9 @@ module.exports = merge(common, {
     writeToDisk: true,
   },
   devtool: "eval-source-map",
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "assets/css/[name].css",
+    }),
+  ],
 });

--- a/legacy/webpack.prod.js
+++ b/legacy/webpack.prod.js
@@ -1,5 +1,6 @@
 const merge = require("webpack-merge");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 
 const common = require("./webpack.common.js");
@@ -10,5 +11,10 @@ module.exports = merge(common, {
   optimization: {
     minimizer: [new OptimizeCSSAssetsPlugin({})],
   },
-  plugins: [new CleanWebpackPlugin()],
+  plugins: [
+    new CleanWebpackPlugin(),
+    new MiniCssExtractPlugin({
+      filename: "assets/css/[name].[contenthash].css",
+    }),
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "copy-build": "mkdir -p build && yarn copy-root && yarn copy-legacy-assets && yarn copy-ui-css",
     "copy-legacy-assets": "cp -Ru legacy/dist/assets build/",
     "copy-root": "cp -R root/dist/* build/",
-    "copy-ui-css": "cp ui/dist/static/css/main.*.css.map build/assets/css/ui.css.map && cp ui/dist/static/css/main.*.css build/assets/css/ui.css",
+    "copy-ui-css": "cp ui/dist/static/css/* build/assets/css/",
     "release": "cd ui && yarn run release",
     "serve": "cd proxy && yarn start",
     "start": "yarn serve",

--- a/root/.eslintrc
+++ b/root/.eslintrc
@@ -5,7 +5,8 @@
   },
   "extends": ["eslint:recommended"],
   "globals": {
-    "document": false
+    "document": false,
+    "window": false
   },
   "rules": {},
   "parser": "babel-eslint",

--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -4,7 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="shortcut icon" href="<%= publicPath %>maas-favicon-32px.png" />
-    <link rel="stylesheet" href="<%= publicPath %>assets/css/root-application.css" />
+    <% htmlWebpackPlugin.files.css.forEach(function(file){ %>
+      <link rel="stylesheet" href="<%= file %>" />
+    <% }); %>
     <title>MAAS UI</title>
   </head>
   <body>
@@ -51,6 +53,8 @@
         </div>
       </header>
     </div>
-    <script src="<%= publicPath %>root-application.js"></script>
+    <% htmlWebpackPlugin.files.js.forEach(function(file){ %>
+      <script src="<%= file %>"></script>
+    <% }); %>
   </body>
 </html>

--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -7,6 +7,12 @@
     <% htmlWebpackPlugin.files.css.forEach(function(file){ %>
       <link rel="stylesheet" href="<%= file %>" />
     <% }); %>
+    <% if (uiStylesheet) { %>
+      <link rel="stylesheet" href="<%= uiStylesheet %>" class="ui-stylesheet" />
+    <% } %>
+    <% if (legacyStylesheet) { %>
+      <link rel="stylesheet" href="<%= legacyStylesheet %>" class="legacy-stylesheet" />
+    <% } %>
     <title>MAAS UI</title>
   </head>
   <body>

--- a/root/src/root-application.js
+++ b/root/src/root-application.js
@@ -9,6 +9,25 @@ const showLoading = () => {
   }
 };
 
+window.addEventListener("single-spa:before-app-change", (evt) => {
+  const {
+    legacy = "NOT_MOUNTED",
+    ui = "NOT_MOUNTED",
+  } = evt.detail.newAppStatuses;
+  const uiStylesheet = document.querySelector(".ui-stylesheet");
+  const legacyStylesheet = document.querySelector(".legacy-stylesheet");
+  if (ui === "MOUNTED") {
+    uiStylesheet.disabled = false;
+  } else {
+    uiStylesheet.disabled = true;
+  }
+  if (legacy === "MOUNTED") {
+    legacyStylesheet.disabled = false;
+  } else {
+    legacyStylesheet.disabled = true;
+  }
+});
+
 registerApplication({
   name: "legacy",
   app: () => {

--- a/root/src/root-application.js
+++ b/root/src/root-application.js
@@ -16,15 +16,19 @@ window.addEventListener("single-spa:before-app-change", (evt) => {
   } = evt.detail.newAppStatuses;
   const uiStylesheet = document.querySelector(".ui-stylesheet");
   const legacyStylesheet = document.querySelector(".legacy-stylesheet");
-  if (ui === "MOUNTED") {
-    uiStylesheet.disabled = false;
-  } else {
-    uiStylesheet.disabled = true;
+  if (uiStylesheet) {
+    if (ui === "MOUNTED") {
+      uiStylesheet.disabled = false;
+    } else {
+      uiStylesheet.disabled = true;
+    }
   }
-  if (legacy === "MOUNTED") {
-    legacyStylesheet.disabled = false;
-  } else {
-    legacyStylesheet.disabled = true;
+  if (legacyStylesheet) {
+    if (legacy === "MOUNTED") {
+      legacyStylesheet.disabled = false;
+    } else {
+      legacyStylesheet.disabled = true;
+    }
   }
 });
 

--- a/root/webpack.common.js
+++ b/root/webpack.common.js
@@ -9,7 +9,7 @@ module.exports = {
     "root-application": "src/root-application.js",
   },
   output: {
-    filename: "[name].js",
+    filename: "[name].[contenthash].js",
   },
   module: {
     rules: [
@@ -54,7 +54,7 @@ module.exports = {
     ]),
     new DotenvFlow(),
     new MiniCssExtractPlugin({
-      filename: "assets/css/[name].css",
+      filename: "assets/css/[name].[contenthash].css",
     }),
   ],
   externals: [],

--- a/root/webpack.dev.js
+++ b/root/webpack.dev.js
@@ -16,7 +16,9 @@ module.exports = merge(common, {
       template: path.resolve(__dirname, "src", "index.ejs"),
       inject: false,
       templateParameters: {
+        legacyStylesheet: `/MAAS/assets/css/maas.css`,
         publicPath,
+        uiStylesheet: null,
       },
     }),
   ],

--- a/root/webpack.prod.js
+++ b/root/webpack.prod.js
@@ -10,7 +10,10 @@ const publicPath = "/MAAS/r/";
 
 const getStylesheet = (dir) => {
   const outputPath = path.resolve(process.cwd(), dir);
-  return fs.readdirSync(outputPath).find((file) => file.endsWith(".css"));
+  const stylesheet = fs
+    .readdirSync(outputPath)
+    .find((file) => file.endsWith(".css"));
+  return `${publicPath}assets/css/${stylesheet}`;
 };
 
 module.exports = merge(common, {

--- a/root/webpack.prod.js
+++ b/root/webpack.prod.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
@@ -6,6 +7,11 @@ const merge = require("webpack-merge");
 const common = require("./webpack.common.js");
 
 const publicPath = "/MAAS/r/";
+
+const getStylesheet = (dir) => {
+  const outputPath = path.resolve(process.cwd(), dir);
+  return fs.readdirSync(outputPath).find((file) => file.endsWith(".css"));
+};
 
 module.exports = merge(common, {
   mode: "production",
@@ -17,7 +23,9 @@ module.exports = merge(common, {
       template: path.resolve(__dirname, "src", "index.ejs"),
       inject: false,
       templateParameters: {
+        legacyStylesheet: getStylesheet("../legacy/dist/assets/css"),
         publicPath,
+        uiStylesheet: getStylesheet("../ui/dist/static/css"),
       },
     }),
   ],

--- a/ui/package.json
+++ b/ui/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "standalone": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` REACT_APP_STANDALONE=true react-scripts start",
-    "start": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` react-app-rewired start",
+    "start": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` REACT_APP_STANDALONE=false react-app-rewired start",
     "serve": "yarn run start",
     "build": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` REACT_APP_STANDALONE=false react-app-rewired build --profile && rm -rf dist && mv build dist",
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -49,23 +49,11 @@ const Root = () => {
   }, []);
 
   console.info(`${appName} ${appVersion} (${process.env.REACT_APP_GIT_SHA}).`);
-  let styles;
-  if (process.env.NODE_ENV === "production") {
-    styles = (
-      <link
-        href={`${process.env.REACT_APP_BASENAME}/assets/css/ui.css`}
-        rel="stylesheet"
-      />
-    );
-  }
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>
         <React.StrictMode>
-          <>
-            {styles}
-            <App />
-          </>
+          <App />
         </React.StrictMode>
       </ConnectedRouter>
     </Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11274,7 +11274,7 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-sass-tilde-importer@^1.0.2:
+node-sass-tilde-importer@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
   integrity sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==


### PR DESCRIPTION
## Done
- Add hashes to the built file names to help with updating caches.
- Load css files in the single-spa template to improve app loading.

## QA
- Run `dotrun`, the app should load normally for the react/angular apps.
- In a local MAAS run the following:
```shell
git config --file=.gitmodules submodule.src/maasui/src.url https://github.com/huwshimi/maas-ui.git
git config --file=.gitmodules submodule.src/maasui/src.branch build-hashes
git submodule sync
git submodule update --init --recursive --remote
make clean-ui
make ui
```
You may have to use `SKIP_PREFLIGHT_CHECK=true make ui` like I did.
- The app should load normally for the react/angular apps.
- There should also be a small improvement to the content flash when switching between apps.
