### PR TITLE
Apply some padding the to storage view

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -3386,7 +3386,7 @@
     </section>
 
     <section data-ng-if="section.area === 'storage'" data-ng-controller="NodeStorageController">
-        <form>
+        <form class="p-strip">
             <div data-ng-if="canEdit() && (node.status_code === 4 || node.status_code === 10)">
                 <div class="u-fixed-width" data-ng-if="!confirmStorageLayout">
                     <div class="p-form__group u-align--right">


### PR DESCRIPTION
## Done
Add `p-strip` to the container of the storage content

## QA
* Go to a machine
* Click storage
* See there is a little more space top and bottom of the storage tables


| Before  | After |
| ------------- | ------------- |
| ![Screenshot_2020-06-02 MAAS UI](https://user-images.githubusercontent.com/1413534/83514562-c645c900-a4cb-11ea-823c-94137c39db47.png)  | ![Screenshot_2020-06-02 Machines bolla MAAS](https://user-images.githubusercontent.com/1413534/83514572-cd6cd700-a4cb-11ea-8b87-d5bf1e29919d.png)  |

