### PR TITLE
Hide the error overlay when navigating away

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom";
 import { Footer, Header } from "@maas-ui/maas-ui-shared";
 
 /* @ngInject */
-function MasterController($rootScope, $transitions, $window, $http) {
+function MasterController($rootScope, $transitions, $window, $http, ErrorService) {
   const debug = process.env.NODE_ENV === "development";
   const LOGOUT_API = `${process.env.BASENAME}/accounts/logout/`;
   $rootScope.legacyURLBase = `${process.env.BASENAME}${process.env.ANGULAR_BASENAME}`;
@@ -82,6 +82,11 @@ function MasterController($rootScope, $transitions, $window, $http) {
     renderHeader();
     renderFooter();
   };
+
+  $transitions.onStart({}, () => {
+    // Clear the error overlay if it exists.
+    ErrorService.clearError();
+  });
 
   $transitions.onSuccess({}, () => {
     // Update the header when the route changes.

--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -1691,7 +1691,7 @@ function NodeDetailsController(
       );
       activeNode = $scope.nodesManager.getActiveItem();
     }
-    if ($scope.isDevice) {
+    if ($scope.isDevice && activeNode) {
       $scope.ip_assignment = activeNode.ip_assignment;
     }
   });

--- a/legacy/src/app/directives/error_overlay.js
+++ b/legacy/src/app/directives/error_overlay.js
@@ -114,6 +114,8 @@ export function maasErrorOverlay(
         if (angular.isString(error)) {
           scope.clientError = true;
           scope.error = ErrorService._error;
+        } else {
+          scope.clientError = false;
         }
       };
 

--- a/legacy/src/app/services/error.js
+++ b/legacy/src/app/services/error.js
@@ -17,6 +17,11 @@ function ErrorService() {
       this._error = error;
     }
   };
+
+  // Clear the current error.
+  this.clearError = function() {
+    this._error = null;
+  };
 }
 
 export default ErrorService;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11274,7 +11274,7 @@ node-releases@^1.1.53:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
 
-node-sass-tilde-importer@^1.0.2:
+node-sass-tilde-importer@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
   integrity sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==


### PR DESCRIPTION
## Done
- Hide the error overlay when navigating away.

## QA
- Visit an entity url that doesn't exist, e.g. /MAAS/l/device/bob.
- You should see an error screen.
- In the header click on another angular route.
- The error screen should close and you should see the page you clicked on.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1185.

## Launchpad Issue
https://bugs.launchpad.net/maas/+bug/1881555
