### PR TITLE
Fix DHCP status for DHCP relay (#1173)

### DIFF
--- a/legacy/src/app/controllers/networks_list.js
+++ b/legacy/src/app/controllers/networks_list.js
@@ -286,9 +286,16 @@ function NetworksListController(
     $scope.newObject = null;
   };
 
-  // Return the name name for the VLAN.
+  // Return the short name for the VLAN.
   $scope.getVLANName = function(vlan) {
     return VLANsManager.getName(vlan);
+  };
+
+  // Return the full name for the VLAN.
+  $scope.getFullVLANName = function(vlan_id) {
+    var vlan = VLANsManager.getItemFromList(vlan_id);
+    var fabric = FabricsManager.getItemFromList(vlan.fabric);
+    return FabricsManager.getName(fabric) + "." + VLANsManager.getName(vlan);
   };
 
   // Return the name of the fabric from its given ID.
@@ -310,6 +317,8 @@ function NetworksListController(
 
     if (vlan.dhcp_on) {
       return "MAAS-provided";
+    } else if (vlan.relay_vlan) {
+      return "Relayed via " + $scope.getFullVLANName(vlan.relay_vlan);
     }
 
     return "No DHCP";

--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -1519,6 +1519,13 @@ function NodeDetailsController(
     return text;
   };
 
+  // Return the full name for the VLAN.
+  $scope.getFullVLANName = function(vlan_id) {
+    var vlan = VLANsManager.getItemFromList(vlan_id);
+    var fabric = FabricsManager.getItemFromList(vlan.fabric);
+    return FabricsManager.getName(fabric) + "." + VLANsManager.getName(vlan);
+  };
+
   $scope.getDHCPStatus = iface => {
     const { vlans } = $scope;
     const vlan = vlans.find(vlan => vlan.id === iface.vlan_id);
@@ -1529,7 +1536,10 @@ function NodeDetailsController(
 
       if (vlan.dhcp_on) {
         return "MAAS-provided";
+      } else if (vlan.relay_vlan) {
+        return "Relayed via " + $scope.getFullVLANName(vlan.relay_vlan);
       }
+
     }
     return "No DHCP";
   };


### PR DESCRIPTION
## Done
* Set DHCP status to "Relayed via ##" instead of "No DHCP" when DHCP is relayed, both in the node and the network pages

## QA
In a machine with two fabrics (e.g. fabric-0 and fabric-1) with a different subnet each:
* Enable DHCP in fabric-0's vlan page
* Enable DHCP relay in fabric-1's vlan page
* /MAAS/#/networks?by=fabric should show "Relayed via fabric-0.untagged" for fabric-1 instead of "No DHCP"
* After deploying a machine with an interface on fabric-1, the machine should show "Relayed via fabric-0.untagged" instead of "No DHCP" in /MAAS/#/machine/$id

## Fixes
Fixes #1173 .

## Launchpad Issue
lp#1879979
