### PR TITLE
Fix AZs heading tooltip.

### DIFF
--- a/legacy/src/app/partials/zones-list.html
+++ b/legacy/src/app/partials/zones-list.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-medium-4 col-8">
             <h1 class="page-header__title">Availability zones</h1>
-            <span class="page-header__status p-tooltip--btm-left">
+            <span class="page-header__status p-tooltip">
                     <i class="p-icon--help">Help:</i>
                     <span class="p-tooltip__message" role="tooltip">A representation of a grouping of nodes, typically by physical location.</span>
             </span>


### PR DESCRIPTION
## Done
- Fixed AZs heading tooltip. I think `.p-tooltip--btm-left` must have been deprecated then removed in a previous version of vanilla.

## QA
- Go to /MAAS/l/zones and check that hovering over the question mark icon shows a tooltip

## Fixes
Fixes #1199 

## Launchpad Issue
[lp#1881262](https://bugs.launchpad.net/maas/+bug/1881262)
