### PR TITLE
2.7: Fix cores chart when over 32 cores.

### DIFF
--- a/legacy/src/scss/_patterns_cores-chart.scss
+++ b/legacy/src/scss/_patterns_cores-chart.scss
@@ -122,7 +122,7 @@ $bar-height: 11px;
     @extend %chart-bar;
     min-width: 100%;
     width: 100%;
-    background-image: url(../assets/images/kvm-graph-tex-filler-light.svg);
+    background-image: url(../images/kvm-graph-tex-filler-light.svg);
     background-position: top left;
   }
 
@@ -131,7 +131,7 @@ $bar-height: 11px;
     position: absolute;
     top: 0;
     left: 0;
-    background-image: url(../assets/images/kvm-graph-tex-filler.svg);
+    background-image: url(../images/kvm-graph-tex-filler.svg);
     background-position: center left;
   }
 


### PR DESCRIPTION
## Done
- Fixed cores chart when number of cores is above 32 and background changes to little dots. Now the dots file is found at the right place.

## QA
- Go to /MAAS/#/kvm and check the cores chart works when a KVM has more than 32 cores (bolla-kvm has 8 cores with 10x overcommit = 80 cores) 

Fixes #1202

## Launchpad Issue
[lp#1881892](https://bugs.launchpad.net/maas/+bug/1881892)

## Screenshots
Before:
![2020-06-04_10-54](https://user-images.githubusercontent.com/25733845/83703088-da1b3780-a651-11ea-8dc5-827cd8cb0b0c.png)


After:
![2020-06-04_10-53](https://user-images.githubusercontent.com/25733845/83703091-de475500-a651-11ea-83db-bc2e4bff7b08.png)

