### PR TITLE
Add tooltip for interface DHCP relay info + improve table styling.

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -1519,14 +1519,19 @@ function NodeDetailsController(
     return text;
   };
 
-  // Return the full name for the VLAN.
-  $scope.getFullVLANName = function(vlan_id) {
-    var vlan = VLANsManager.getItemFromList(vlan_id);
-    var fabric = FabricsManager.getItemFromList(vlan.fabric);
-    return FabricsManager.getName(fabric) + "." + VLANsManager.getName(vlan);
+  $scope.isRelayed = (iface) => {
+    const vlan = $scope.vlans.find(vlan => vlan.id === iface.vlan_id);
+    return vlan && vlan.relay_vlan;
   };
 
-  $scope.getDHCPStatus = iface => {
+  // Return the full name for the VLAN.
+  $scope.getFullVLANName = function(vlan_id) {
+    const vlan = VLANsManager.getItemFromList(vlan_id);
+    const fabric = FabricsManager.getItemFromList(vlan.fabric);
+    return `${FabricsManager.getName(fabric)}.${VLANsManager.getName(vlan)}`;
+  };
+
+  $scope.getDHCPStatus = (iface, fullName = false) => {
     const { vlans } = $scope;
     const vlan = vlans.find(vlan => vlan.id === iface.vlan_id);
     if (vlan) {
@@ -1536,8 +1541,14 @@ function NodeDetailsController(
 
       if (vlan.dhcp_on) {
         return "MAAS-provided";
-      } else if (vlan.relay_vlan) {
-        return "Relayed via " + $scope.getFullVLANName(vlan.relay_vlan);
+      }
+
+      if (vlan.relay_vlan) {
+        if (fullName) {
+          return `Relayed via ${$scope.getFullVLANName(vlan.relay_vlan)}`;
+        } else {
+          return "Relayed";
+        }
       }
 
     }

--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -2299,7 +2299,14 @@ export function NodeNetworkingController(
       );
   };
 
-  $scope.getDHCPStatus = vlan => {
+  // Return the full name for the VLAN.
+  $scope.getFullVLANName = (vlanID) => {
+    const vlan = VLANsManager.getItemFromList(vlanID);
+    const fabric = FabricsManager.getItemFromList(vlan.fabric);
+    return `${FabricsManager.getName(fabric)}.${VLANsManager.getName(vlan)}`;
+  };
+
+  $scope.getDHCPStatus = (vlan, fullName) => {
     if (vlan) {
       if (vlan.external_dhcp) {
         return `External (${vlan.external_dhcp})`;
@@ -2307,6 +2314,14 @@ export function NodeNetworkingController(
 
       if (vlan.dhcp_on) {
         return "MAAS-provided";
+      }
+
+      if (vlan.relay_vlan) {
+        if (fullName) {
+          return `Relayed via ${$scope.getFullVLANName(vlan.relay_vlan)}`;
+        } else {
+          return "Relayed";
+        }
       }
     }
 

--- a/legacy/src/app/controllers/tests/test_networks_list.js
+++ b/legacy/src/app/controllers/tests/test_networks_list.js
@@ -473,5 +473,14 @@ describe("NetworksListController", function() {
       const vlan = { external_dhcp: null, dhcp_on: false };
       expect($scope.getDHCPStatus(vlan)).toEqual("No DHCP");
     });
+
+    it("returns correct text if DHCP is relayed", () => {
+      makeController();
+      const fabrics = [{ id: 1, name: "fabric-1" }];
+      const vlans = [{ id: 2, vid: "vlan-1", relay_vlan: 3}, { fabric: 1, id: 3, vid: "vlan-2"}];
+      FabricsManager._items = fabrics;
+      VLANsManager._items = vlans;
+      expect($scope.getDHCPStatus(vlans[0])).toEqual("Relayed via fabric-1.vlan-2");
+    });
   });
 });

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -2863,6 +2863,24 @@ describe("NodeDetailsController", function () {
       $scope.vlans = [];
       expect($scope.getDHCPStatus(iface)).toEqual("No DHCP");
     });
+
+    it("returns correct text if DHCP is relayed", () => {
+      makeController();
+      $scope.vlans = [{ id: 1, relay_vlan: 2 }]
+      const iface = { vlan_id: 1 };
+      expect($scope.getDHCPStatus(iface)).toEqual("Relayed");
+    });
+
+    it("returns correct text if DHCP is relayed and full name required", () => {
+      makeController();
+      const vlans = [{ id: 2, vid: "vlan-1", relay_vlan: 3}, { fabric: 1, id: 3, vid: "vlan-2"}];
+      const fabrics = [{ id: 1, name: "fabric-1" }];
+      const iface = { vlan_id: 2 };
+      $scope.vlans = vlans;
+      FabricsManager._items = fabrics;
+      VLANsManager._items = vlans;
+      expect($scope.getDHCPStatus(iface, true)).toEqual("Relayed via fabric-1.vlan-2");
+    });
   });
 
   describe("getFabricName", () => {

--- a/legacy/src/app/controllers/tests/test_node_details_networking.js
+++ b/legacy/src/app/controllers/tests/test_node_details_networking.js
@@ -4997,6 +4997,21 @@ describe("NodeNetworkingController", function() {
       makeController();
       expect($scope.getDHCPStatus(null)).toEqual("No DHCP");
     });
+
+    it("returns correct text if DHCP is relayed", () => {
+      makeController();
+      const vlan = { fabric: 1, relay_vlan: 5001 };
+      expect($scope.getDHCPStatus(vlan)).toEqual("Relayed");
+    });
+
+    it("returns correct text if DHCP is relayed and full name required", () => {
+      makeController();
+      const fabrics = [{ id: 1, name: "fabric-1" }];
+      const vlans = [{ id: 2, vid: "vlan-1", relay_vlan: 3}, { fabric: 1, id: 3, vid: "vlan-2"}];
+      FabricsManager._items = fabrics;
+      VLANsManager._items = vlans;
+      expect($scope.getDHCPStatus(vlans[0], true)).toEqual("Relayed via fabric-1.vlan-2");
+    });
   });
 
   describe("changeConnectionStatus", () => {

--- a/legacy/src/app/partials/cards/network.html
+++ b/legacy/src/app/partials/cards/network.html
@@ -33,7 +33,7 @@
           <th class="p-table__cell--fabric" role="columnheader" style="overflow: visible;"title="Fabric">
             <span>Fabric</span>
             <span class="p-tooltip--top-right">
-              <i class="p-icon--help" style="height:1rem; width:1rem; position:absolute; left:.25rem; top: -2px;">Help: </i>
+              <i class="p-icon--help" style="height: 1rem; width:.875rem; position:absolute; left:.5rem; top: -2px;">Help: </i>
               <span class="p-tooltip__message" style="text-transform: none; right:-2rem">Untagged traffic only.</span>
             </span>
           </th>
@@ -59,8 +59,12 @@
           <td class="p-table__cell--fabric" title="{$ getFabricName(iface) $}">
             {$ getFabricName(iface) $}
           </td>
-          <td class="p-table__cell--dhcp" title="{$ getDHCPStatus(iface) $}">
+          <td class="p-table__cell--dhcp" style="overflow: visible;" title="{$ getDHCPStatus(iface) $}">
             {$ getDHCPStatus(iface) $}
+            <span class="p-tooltip--btm-right" ng-if="isRelayed(iface)" style="margin-left: .25rem;">
+                <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(iface, true) $}</i>
+                <span class="p-tooltip__message">{$ getDHCPStatus(iface, true) $}</span>
+            </span>
           </td>
           <td class="p-table__cell--sriov" title="{$ !iface.sriov_max_vf ? 'No' : 'Yes' $}">
             {$ !iface.sriov_max_vf ? 'No' : 'Yes' $}

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -970,7 +970,13 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td>{$ getDHCPStatus(interface.vlan) $}</td>
+                                    <td style="overflow: visible;">
+                                        {$ getDHCPStatus(interface.vlan) $}
+                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
+                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
+                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
+                                        </span>
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>
@@ -1309,7 +1315,13 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td ng-if="!isDevice">{$ getDHCPStatus(interface.vlan) $}</td>
+                                    <td style="overflow: visible;">
+                                        {$ getDHCPStatus(interface.vlan) $}
+                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
+                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
+                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
+                                        </span>
+                                    </td>
                                 </tr>
                                 <tr data-ng-repeat="interface in editInterface.members" data-ng-if="isBond(editInterface)">
                                     <td class=" p-double-row" aria-label="Name">
@@ -1446,7 +1458,13 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td>{$ getDHCPStatus(interface.vlan) $}</td>
+                                    <td style="overflow: visible;">
+                                        {$ getDHCPStatus(interface.vlan) $}
+                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
+                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
+                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
+                                        </span>
+                                    </td>
                                 </tr>
                                 <tr class="p-table__row--muted"
                                     data-ng-repeat="interface in interfaces | filterEditInterface:editInterface"
@@ -1545,7 +1563,13 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td aria-label="DHCP">{$ getDHCPStatus(interface.vlan) $}</td>
+                                    <td style="overflow: visible;">
+                                        {$ getDHCPStatus(editInterface.vlan) $}
+                                        <span class="p-tooltip--btm-right" ng-if="editInterface.vlan && editInterface.vlan.relay_vlan" style="margin-left: .25rem;">
+                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(editInterface.vlan, true) $}</i>
+                                            <span class="p-tooltip__message">{$ getDHCPStatus(editInterface.vlan, true) $}</span>
+                                        </span>
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>
@@ -2157,7 +2181,13 @@
                                             </span>
                                         </span>
                                     </td>
-                                    <td>{$ getDHCPStatus(interface.vlan) $}</td>
+                                    <td style="overflow: visible;">
+                                        {$ getDHCPStatus(parent.vlan) $}
+                                        <span class="p-tooltip--btm-right" ng-if="parent.vlan && parent.vlan.relay_vlan" style="margin-left: .25rem;">
+                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(parent.vlan, true) $}</i>
+                                            <span class="p-tooltip__message">{$ getDHCPStatus(parent.vlan, true) $}</span>
+                                        </span>
+                                    </td>
                                 </tr>
                                 <tr class="p-table__row--muted" data-ng-repeat="interface in interfaces | filterSelectedInterfaces:selectedInterfaces:newBondInterface" data-ng-if="isShowingInterfaces">
                                     <td class="p-double-row" aria-label="Name">
@@ -2262,7 +2292,13 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td aria-label="DHCP">{$ getDHCPStatus(interface.vlan) $}</td>
+                                    <td style="overflow: visible;">
+                                        {$ getDHCPStatus(interface.vlan) $}
+                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
+                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
+                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
+                                        </span>
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>
@@ -2725,8 +2761,12 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td>
+                                <td style="overflow: visible;">
                                     {$ getDHCPStatus(interface.vlan) $}
+                                    <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
+                                        <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
+                                        <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
+                                    </span>
                                 </td>
                                 <td class="p-table--action-cell u-vertically-center u-align--right">
                                     <div class="p-contextual-menu" toggle-ctrl data-ng-if="(!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)) && !isEditing(interface) && !(isShowingDeleteConfirm() && isInterfaceSelected(interface))">

--- a/legacy/src/scss/tables/_patterns_table-network-summary.scss
+++ b/legacy/src/scss/tables/_patterns_table-network-summary.scss
@@ -4,7 +4,7 @@
 
     .p-table__cell--name {
       padding-left: 0;
-      width: 20%;
+      width: 18%;
     }
 
     .p-table__cell--mac {
@@ -24,7 +24,7 @@
     }
 
     .p-table__cell--sriov {
-      width: 8%;
+      width: 10%;
     }
 
     @media only screen and (max-width: $breakpoint-small) {

--- a/legacy/src/scss/tables/_patterns_table-subnets.scss
+++ b/legacy/src/scss/tables/_patterns_table-subnets.scss
@@ -1,7 +1,7 @@
 @mixin maas-table-subnets {
     .p-table--subnets {
       .p-table__cell--fabric {
-        width: 14%;
+        width: 13%;
       }
 
       .p-table__cell--space {
@@ -9,19 +9,19 @@
       }
 
       .p-table__cell--vlan {
-        width: 14%;
+        width: 13%;
       }
 
       .p-table__cell--subnet {
-        width: 30%;
+        width: 28%;
       }
 
       .p-table__cell--ips {
-        width: 14%;
+        width: 12%;
       }
 
       .p-table__cell--dhcp {
-        width: 14%;
+        width: 20%;
       }
 
       @media only screen and (max-width: $breakpoint-large) {


### PR DESCRIPTION
## Done
- Building on top of #1195 - only show "Relayed" in machine summary and network tables, alongside a tooltip to show the full info (e.g. "Relayed via fabric-name.vlan-name")
- Add tests for changes to getDHCPStatus.

## QA
- Go to the details page of a machine that has an interface with DHCP relayed via a different vlan (e.g. ace-guinea in bolla: `/MAAS/l/machine/xahhr7`).
- Check that in the Network card under DHCP it says "Relayed" and if you hover over the information icon it shows a tooltip with the fabric/VLAN DHCP is being relayed via.
- Go to the network tab of the same machine and check that the same is shown in the summary there.
- Try editing and adding another interface and check that it still shows up correctly (because of how terrible `node-details.html` is the code for the tooltip is duplicated in about 25 places)

## Launchpad Issue
[lp#1879979](https://bugs.launchpad.net/maas/+bug/1879979)

## Screenshots
![0 0 0 0_8400_MAAS_l_machine_fd7wtc](https://user-images.githubusercontent.com/25733845/83725099-ba513700-a684-11ea-8824-8a067c3457c3.png)
![0 0 0 0_8400_MAAS_l_machine_fd7wtc (1)](https://user-images.githubusercontent.com/25733845/83725106-bcb39100-a684-11ea-9e12-165dc3a43a0d.png)


