### PR TITLE
scripts history order is descending now.

### DIFF
--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.js
@@ -27,7 +27,7 @@ const generateRows = (
     const expanded = expandedId === script.id;
     const showDelete = expandedType === "delete";
 
-    const [lastHistory] = script.history.slice(0);
+    const lastHistory = script.history[0];
 
     let scriptSrc;
     if (lastHistory.data) {

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.js
@@ -27,7 +27,7 @@ const generateRows = (
     const expanded = expandedId === script.id;
     const showDelete = expandedType === "delete";
 
-    const [lastHistory] = script.history.slice(-1);
+    const [lastHistory] = script.history.slice(0);
 
     let scriptSrc;
     if (lastHistory.data) {


### PR DESCRIPTION
scripts history order is descending now.
so slice(0) access latest one

now, it shows always the oldest one after script created. even if script is updated with cli

## Done
* Itemised list of what was changed by this PR.

## QA
* Steps for QA.

## Fixes
Fixes # .

## Launchpad Issue
Related Launchpad maas issue in the form `lp#1879986`.
