### PR TITLE
Update state entity on CREATE_<MODEL>_NOTIFY if exists.

### DIFF
--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -150,8 +150,8 @@ const machine = createNextState(
         draft.saving = false;
         break;
       case "CREATE_MACHINE_NOTIFY":
-        // In the event that the server erroneously attempts to create an existing machine
-        // ensure we update instead.
+        // In the event that the server erroneously attempts to create an existing machine,
+        // due to a race condition etc., ensure we update instead of creating duplicates.
         const existingIdx = draft.items.findIndex(
           (draftItem) => draftItem.id === action.payload.id
         );

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -150,8 +150,17 @@ const machine = createNextState(
         draft.saving = false;
         break;
       case "CREATE_MACHINE_NOTIFY":
-        draft.items.push(action.payload);
-        draft.statuses[action.payload.system_id] = DEFAULT_STATUSES;
+        // In the event that the server erroneously attempts to create an existing machine
+        // ensure we update instead.
+        const existingIdx = draft.items.findIndex(
+          (draftItem) => draftItem.id === action.payload.id
+        );
+        if (existingIdx !== -1) {
+          draft.items[existingIdx] = action.payload;
+        } else {
+          draft.items.push(action.payload);
+          draft.statuses[action.payload.system_id] = DEFAULT_STATUSES;
+        }
         break;
       case "DELETE_MACHINE_NOTIFY":
         draft.items = draft.items.filter(

--- a/ui/src/app/base/reducers/machine/machine.test.js
+++ b/ui/src/app/base/reducers/machine/machine.test.js
@@ -205,6 +205,37 @@ describe("machine reducer", () => {
     });
   });
 
+  it("should update if machine exists on CREATE_MACHINE_NOTIFY", () => {
+    expect(
+      machine(
+        {
+          errors: {},
+          items: [{ id: 1, name: "machine1", system_id: "abc" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false,
+          selected: [],
+          statuses: { abc: STATUSES },
+        },
+        {
+          payload: { id: 1, name: "machine1-newname", system_id: "abc" },
+          type: "CREATE_MACHINE_NOTIFY",
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, name: "machine1-newname", system_id: "abc" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+      selected: [],
+      statuses: {
+        abc: STATUSES,
+      },
+    });
+  });
   it("should correctly reduce CREATE_MACHINE_NOTIFY", () => {
     expect(
       machine(

--- a/ui/src/app/utils/redux.js
+++ b/ui/src/app/utils/redux.js
@@ -114,7 +114,16 @@ export const createStandardReducer = (
       state.saving = false;
     },
     [actions.create.notify]: (state, action) => {
-      state.items.push(action.payload);
+      // In the event that the server erroneously attempts to create an existing model,
+      // due to a race condition etc., ensure we update instead of creating duplicates.
+      const existingIdx = state.items.findIndex(
+        (draftItem) => draftItem.id === action.payload.id
+      );
+      if (existingIdx !== -1) {
+        state.items[existingIdx] = action.payload;
+      } else {
+        state.items.push(action.payload);
+      }
     },
     [actions.update.start]: (state) => {
       state.saved = false;

--- a/ui/src/app/utils/redux.test.js
+++ b/ui/src/app/utils/redux.test.js
@@ -320,7 +320,6 @@ describe("createStandardReducer", () => {
         saving: false,
       });
     });
-
   });
 
   describe("update", () => {

--- a/ui/src/app/utils/redux.test.js
+++ b/ui/src/app/utils/redux.test.js
@@ -266,7 +266,7 @@ describe("createStandardReducer", () => {
       });
     });
 
-    it("should correctly reduce CREATE_FOO_NOTIFY", () => {
+    it("should add a new item to state on CREATE_FOO_NOTIFY", () => {
       expect(
         reducer(
           {
@@ -294,6 +294,33 @@ describe("createStandardReducer", () => {
         saving: false,
       });
     });
+
+    it("should update an existing item on CREATE_FOO_NOTIFY", () => {
+      expect(
+        reducer(
+          {
+            errors: {},
+            items: [{ id: 1, name: "foo" }],
+            loaded: false,
+            loading: false,
+            saved: false,
+            saving: false,
+          },
+          {
+            payload: { id: 1, name: "bar" },
+            type: "CREATE_FOO_NOTIFY",
+          }
+        )
+      ).toEqual({
+        errors: {},
+        items: [{ id: 1, name: "bar" }],
+        loaded: false,
+        loading: false,
+        saved: false,
+        saving: false,
+      });
+    });
+
   });
 
   describe("update", () => {


### PR DESCRIPTION
## Done
In the event that the server erroneously attempts to create an entity that already exists in state (e.g. a machine), ensure that the entity is updated in state instead.

## QA
Point maas-ui at a local maas snap. Restart the maas service (`sudo snap restart maas.supervisor`), wait a bit and you should not see duplicate machines in the machine list.

## Fixes
Relevant issue #1211 (will not close until websocket fix has landed).

## Launchpad Issue
[lp#1881275](https://bugs.launchpad.net/maas-ui/+bug/1881275) (note, while this change should effectively fix this bug, the UI still needs to refresh state when the websocket disconnects which will be addressed in a later branch).
