### PR TITLE
Add processing labels to machine list action forms.

### DIFF
--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
@@ -8,6 +8,7 @@ import { useRouter } from "app/base/hooks";
 export const FormCardButtons = ({
   bordered = true,
   loading,
+  loadingLabel,
   onCancel,
   secondarySubmit,
   secondarySubmitLabel,
@@ -64,6 +65,14 @@ export const FormCardButtons = ({
           {submitLabel}
         </ActionButton>
       </div>
+      {loading && loadingLabel && (
+        <p
+          className="u-text--light u-align-text--right"
+          data-test="loading-label"
+        >
+          {loadingLabel}
+        </p>
+      )}
     </>
   );
 };
@@ -71,6 +80,7 @@ export const FormCardButtons = ({
 FormCardButtons.propTypes = {
   bordered: PropTypes.bool,
   loading: PropTypes.bool,
+  loadingLabel: PropTypes.string,
   onCancel: PropTypes.func,
   secondarySubmit: PropTypes.func,
   secondarySubmitLabel: PropTypes.string,

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.js
@@ -52,4 +52,19 @@ describe("FormCardButtons ", () => {
     wrapper.find('[data-test="cancel-action"] button').simulate("click");
     expect(onCancel).toHaveBeenCalled();
   });
+
+  it("can display a loading label", () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+        <FormCardButtons
+          loading
+          loadingLabel="Be patient!"
+          submitLabel="Save"
+        />
+      </MemoryRouter>
+    );
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Be patient!"
+    );
+  });
 });

--- a/ui/src/app/base/components/FormikForm/FormikForm.js
+++ b/ui/src/app/base/components/FormikForm/FormikForm.js
@@ -23,6 +23,7 @@ const FormikForm = ({
   resetOnSave,
   loading,
   saving,
+  savingLabel,
   saved,
   savedRedirect,
   secondarySubmit,
@@ -70,6 +71,7 @@ const FormikForm = ({
         resetOnSave={resetOnSave}
         loading={loading}
         saving={saving}
+        savingLabel={savingLabel}
         saved={saved}
         secondarySubmit={secondarySubmit}
         secondarySubmitLabel={secondarySubmitLabel}
@@ -102,6 +104,7 @@ FormikForm.propTypes = {
   resetOnSave: PropTypes.bool,
   loading: PropTypes.bool,
   saving: PropTypes.bool,
+  savingLabel: PropTypes.string,
   saved: PropTypes.bool,
   savedRedirect: PropTypes.string,
   secondarySubmit: PropTypes.func,

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
@@ -19,11 +19,11 @@ const FormikFormContent = ({
   resetOnSave,
   loading,
   saving,
+  savingLabel,
   saved,
   secondarySubmit,
   secondarySubmitLabel,
   submitAppearance,
-  submitDisabled,
   submitLabel = "Save",
 }) => {
   const { handleSubmit, resetForm, submitForm, values } = useFormikContext();
@@ -62,6 +62,7 @@ const FormikFormContent = ({
         bordered={buttonsBordered}
         loading={saving}
         onCancel={onCancel}
+        loadingLabel={savingLabel}
         secondarySubmit={
           secondarySubmit
             ? () => {
@@ -82,14 +83,16 @@ const FormikFormContent = ({
 
 FormikFormContent.propTypes = {
   allowAllEmpty: PropTypes.bool,
+  allowUnchanged: PropTypes.bool,
   buttons: PropTypes.func,
   buttonsBordered: PropTypes.bool,
   children: PropTypes.node,
   errors: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  loading: PropTypes.bool,
   onCancel: PropTypes.func,
   onValuesChanged: PropTypes.func,
-  loading: PropTypes.bool,
   saving: PropTypes.bool,
+  savingLabel: PropTypes.string,
   saved: PropTypes.bool,
   secondarySubmit: PropTypes.func,
   secondarySubmitLabel: PropTypes.string,

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.js
@@ -3,6 +3,7 @@ import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { getProcessingLabel } from "../utils";
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import { useMachinesProcessing } from "app/machines/components/HeaderStrip/hooks";
@@ -26,14 +27,8 @@ const getSubmitText = (action, count) => {
       return `Mark ${machineString} broken`;
     case "mark-fixed":
       return `Mark ${machineString} fixed`;
-    case "override-failed-testing":
-      return `Override failed tests for ${machineString}.`;
     case "rescue-mode":
       return `Enter rescue mode for ${machineString}`;
-    case "set-pool":
-      return `Set pool of ${machineString}`;
-    case "set-zone":
-      return `Set zone of ${machineString}`;
     default:
       return `${action.name.charAt(0).toUpperCase()}${action.name.slice(
         1
@@ -117,11 +112,9 @@ export const ActionForm = ({
   const selectedProcessing = useSelectedProcessing(selectedAction.name);
 
   useMachinesProcessing(
-    processing,
     selectedProcessing,
     setProcessing,
     setSelectedAction,
-    selectedAction.name,
     Object.keys(errors).length > 0
   );
 
@@ -154,6 +147,11 @@ export const ActionForm = ({
         setProcessing(true);
       }}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        selectedProcessing.length,
+        selectedMachines.length,
+        selectedAction.name
+      )}
       saved={saved}
     />
   );

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/ActionForm.test.js
@@ -578,6 +578,9 @@ describe("ActionForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Unlocking machine..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/ActionForm/__snapshots__/ActionForm.test.js.snap
@@ -25,6 +25,7 @@ exports[`ActionForm renders 1`] = `
       }
     }
     onSubmit={[Function]}
+    savingLabel="Releasing 0 of 0 machines..."
     submitAppearance="positive"
     submitLabel="Release 0 machines"
   >
@@ -38,6 +39,7 @@ exports[`ActionForm renders 1`] = `
         errors={Object {}}
         initialValues={Object {}}
         onCancel={[Function]}
+        savingLabel="Releasing 0 of 0 machines..."
         submitAppearance="positive"
         submitLabel="Release 0 machines"
       >
@@ -51,6 +53,7 @@ exports[`ActionForm renders 1`] = `
             <div />
             <FormCardButtons
               bordered={false}
+              loadingLabel="Releasing 0 of 0 machines..."
               onCancel={[Function]}
               submitAppearance="positive"
               submitDisabled={false}

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -4,6 +4,7 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import { getProcessingLabel } from "../utils";
 import {
   machine as machineActions,
   scripts as scriptActions,
@@ -84,11 +85,9 @@ export const CommissionForm = ({
   }, [dispatch]);
 
   useMachinesProcessing(
-    processing,
     commissioningSelected,
     setProcessing,
     setSelectedAction,
-    "commission",
     Object.keys(errors).length > 0
   );
 
@@ -152,6 +151,11 @@ export const CommissionForm = ({
         setProcessing(true);
       }}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        commissioningSelected.length,
+        selectedMachines.length,
+        "commission"
+      )}
       saved={saved}
       validationSchema={CommissionFormSchema}
     >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.test.js
@@ -151,6 +151,7 @@ describe("CommissionForm", () => {
   it("can show the status when processing machines", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
+    state.machine.statuses.abc123 = { commissioning: true };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -166,6 +167,9 @@ describe("CommissionForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Starting commissioning for 1 of 2 machines..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.js
@@ -4,6 +4,7 @@ import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
 
+import { getProcessingLabel } from "../utils";
 import {
   general as generalActions,
   machine as machineActions,
@@ -46,11 +47,9 @@ export const DeployForm = ({
   }, [dispatch]);
 
   useMachinesProcessing(
-    processing,
     deployingSelected,
     setProcessing,
     setSelectedAction,
-    "deploy",
     Object.keys(errors).length > 0
   );
 
@@ -90,6 +89,11 @@ export const DeployForm = ({
         setProcessing(true);
       }}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        deployingSelected.length,
+        selectedMachines.length,
+        "deploy"
+      )}
       saved={saved}
       validationSchema={DeploySchema}
     >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/DeployForm/DeployForm.test.js
@@ -188,6 +188,7 @@ describe("DeployForm", () => {
   it("can show the status when processing machines", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
+    state.machine.statuses.abc123 = { deploying: true };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -203,6 +204,9 @@ describe("DeployForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Starting deployment for 1 of 2 machines..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -5,6 +5,7 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import { getProcessingLabel } from "../utils";
 import { generateLegacyURL } from "app/utils";
 import { machine as machineActions } from "app/base/actions";
 import {
@@ -88,11 +89,9 @@ export const OverrideTestForm = ({
   }, [dispatch, selectedMachines]);
 
   useMachinesProcessing(
-    processing,
     overridingFailedTestingSelected,
     setProcessing,
     setSelectedAction,
-    "override-failed-testing",
     Object.keys(errors).length > 0
   );
 
@@ -137,6 +136,11 @@ export const OverrideTestForm = ({
       }}
       loading={!scriptResultsLoaded}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        overridingFailedTestingSelected.length,
+        selectedMachines.length,
+        "override-failed-testing"
+      )}
       saved={saved}
       validationSchema={OverrideTestFormSchema}
     >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -261,6 +261,7 @@ describe("OverrideTestForm", () => {
   it("can render when processing machines", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
+    state.machine.statuses.abc123 = { overridingFailedTesting: true };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -276,6 +277,9 @@ describe("OverrideTestForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Overriding failed tests for 1 of 2 machines..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.js
@@ -4,6 +4,7 @@ import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 
+import { getProcessingLabel } from "../utils";
 import {
   machine as machineActions,
   resourcepool as resourcePoolActions,
@@ -52,11 +53,9 @@ export const SetPoolForm = ({
   );
 
   useMachinesProcessing(
-    processing,
     settingPoolSelected,
     setProcessing,
     setSelectedAction,
-    "set-pool",
     Object.keys(errors).length > 0
   );
 
@@ -94,6 +93,11 @@ export const SetPoolForm = ({
         setProcessing(true);
       }}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        settingPoolSelected.length,
+        selectedMachines.length,
+        "set-pool"
+      )}
       saved={saved}
       validationSchema={SetPoolSchema}
     >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
@@ -108,6 +108,7 @@ describe("SetPoolForm", () => {
   it("can render when processing machines", () => {
     const store = mockStore(state);
     state.machine.selected = ["abc123", "def456"];
+    state.machine.statuses.abc123 = { settingPool: true };
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
@@ -122,6 +123,9 @@ describe("SetPoolForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Setting pool for 1 of 2 machines..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -5,6 +5,7 @@ import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { getProcessingLabel } from "../utils";
 import { machine as machineActions } from "app/base/actions";
 import {
   machine as machineSelectors,
@@ -32,11 +33,9 @@ export const SetZoneForm = ({
   const settingZoneSelected = useSelector(machineSelectors.settingZoneSelected);
 
   useMachinesProcessing(
-    processing,
     settingZoneSelected,
     setProcessing,
     setSelectedAction,
-    "set-zone",
     Object.keys(errors).length > 0
   );
 
@@ -74,6 +73,11 @@ export const SetZoneForm = ({
         setProcessing(true);
       }}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        settingZoneSelected.length,
+        selectedMachines.length,
+        "set-zone"
+      )}
       saved={saved}
       validationSchema={SetZoneSchema}
     >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
@@ -107,6 +107,7 @@ describe("SetZoneForm", () => {
   it("can show the status when processing machines", () => {
     const store = mockStore(state);
     state.machine.selected = ["abc123", "def456"];
+    state.machine.statuses.abc123 = { settingZone: true };
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
@@ -121,6 +122,9 @@ describe("SetZoneForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Setting zone for 1 of 2 machines..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.js
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import { getProcessingLabel } from "../utils";
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import { useMachinesProcessing } from "app/machines/components/HeaderStrip/hooks";
@@ -39,11 +40,9 @@ export const TagForm = ({ processing, setProcessing, setSelectedAction }) => {
   const hasErrors = Object.keys(errors).length > 0;
 
   useMachinesProcessing(
-    processing,
     taggingSelected,
     setProcessing,
     setSelectedAction,
-    "tag",
     hasErrors
   );
 
@@ -74,6 +73,11 @@ export const TagForm = ({ processing, setProcessing, setSelectedAction }) => {
         setProcessing(true);
       }}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        taggingSelected.length,
+        selectedMachines.length,
+        "tag"
+      )}
       saved={saved}
       validationSchema={TagFormSchema}
     >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TagForm/TagForm.test.js
@@ -101,6 +101,7 @@ describe("TagForm", () => {
   it("can show the status when processing machines", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
+    state.machine.statuses.abc123 = { tagging: true };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -116,6 +117,9 @@ describe("TagForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Tagging 1 of 2 machines..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.js
@@ -4,6 +4,7 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import { getProcessingLabel } from "../utils";
 import {
   machine as machineActions,
   scripts as scriptActions,
@@ -63,11 +64,9 @@ export const TestForm = ({ processing, setProcessing, setSelectedAction }) => {
   }, [dispatch]);
 
   useMachinesProcessing(
-    processing,
     testingSelected,
     setProcessing,
     setSelectedAction,
-    "test",
     Object.keys(errors).length > 0
   );
 
@@ -108,6 +107,11 @@ export const TestForm = ({ processing, setProcessing, setSelectedAction }) => {
         setProcessing(true);
       }}
       saving={processing}
+      savingLabel={getProcessingLabel(
+        testingSelected.length,
+        selectedMachines.length,
+        "test"
+      )}
       saved={saved}
       validationSchema={TestFormSchema}
     >

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.test.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/TestForm/TestForm.test.js
@@ -140,6 +140,7 @@ describe("TestForm", () => {
   it("can show the status when processing machines", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
+    state.machine.statuses.abc123 = { testing: true };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -155,6 +156,9 @@ describe("TestForm", () => {
       </Provider>
     );
     expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Starting tests for 1 of 2 machines..."
+    );
   });
 
   it("can set the processing state when successfully submitting", () => {

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/utils/index.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/utils/index.js
@@ -1,0 +1,49 @@
+export const getProcessingLabel = (processingCount, totalCount, action) => {
+  const machineString =
+    totalCount === 1
+      ? "machine"
+      : `${totalCount - processingCount} of ${totalCount} machines`;
+
+  switch (action) {
+    case "abort":
+      return `Aborting actions for ${machineString}...`;
+    case "acquire":
+      return `Acquiring ${machineString}...`;
+    case "commission":
+      return `Starting commissioning for ${machineString}...`;
+    case "delete":
+      return `Deleting ${machineString}...`;
+    case "deploy":
+      return `Starting deployment for ${machineString}...`;
+    case "exit-rescue-mode":
+      return `Exiting rescue mode for ${machineString}...`;
+    case "lock":
+      return `Locking ${machineString}...`;
+    case "on":
+      return `Powering on ${machineString}...`;
+    case "off":
+      return `Powering off ${machineString}...`;
+    case "mark-broken":
+      return `Marking ${machineString} broken...`;
+    case "mark-fixed":
+      return `Marking ${machineString} fixed...`;
+    case "override-failed-testing":
+      return `Overriding failed tests for ${machineString}...`;
+    case "release":
+      return `Releasing ${machineString}...`;
+    case "rescue-mode":
+      return `Entering rescue mode for ${machineString}...`;
+    case "set-pool":
+      return `Setting pool for ${machineString}...`;
+    case "set-zone":
+      return `Setting zone for ${machineString}...`;
+    case "tag":
+      return `Tagging ${machineString}...`;
+    case "test":
+      return `Starting tests for ${machineString}...`;
+    case "unlock":
+      return `Unlocking ${machineString}...`;
+    default:
+      return `Processing ${machineString}...`;
+  }
+};

--- a/ui/src/app/machines/components/HeaderStrip/hooks.js
+++ b/ui/src/app/machines/components/HeaderStrip/hooks.js
@@ -14,11 +14,9 @@ const useCycled = (newState, onCycled) => {
 };
 
 export const useMachinesProcessing = (
-  processing,
   machinesProcessing,
   setProcessing,
   setSelectedAction,
-  action,
   hasErrors = false
 ) => {
   const processingStarted = useRef(false);


### PR DESCRIPTION
## Done
- Added processing labels underneath action forms after the action is submitted. Originally the plan was to build [design #4](https://app.zeplin.io/project/5ec29f2c86bde54724294779/screen/5ec55a4901aaac48362d04a2) but it wasn't clear how to handle errors, so instead we've gone with [design #2](https://app.zeplin.io/project/5ec29f2c86bde54724294779/screen/5ec29f5940b7c5315462141b).

## QA
- Select a bunch of machines and perform an action.
- Check that a processing label shows up underneath the action button, indicating how many machine actions have received an OK from the server.

## Fixes
Fixes #1148 

## Screenshot
![2020-06-08_16-03](https://user-images.githubusercontent.com/25733845/83998435-f09ff680-a9a3-11ea-9062-3f2e57ffc01e.png)

The copy of the processing labels can be found in the JS snippet below. The message is slightly different for 1 vs multiple machines, e.g. "Tagging machine..." vs "Tagging 1 of 4 machines...". Also I've updated the language to imply that if the selected action is a transient process (e.g. commissioning, testing), then it's only starting. Having "Commissioning 1 of 4 machines..." wouldn't be entirely accurate, and if it *were* accurate, it could take a very long time.

``` js
const machineString =
    totalCount === 1
      ? "machine"
      : `${totalCount - processingCount} of ${totalCount} machines`;

  switch (action) {
    case "abort":
      return `Aborting actions for ${machineString}...`;
    case "acquire":
      return `Acquiring ${machineString}...`;
    case "commission":
      return `Starting commissioning for ${machineString}...`;
    case "delete":
      return `Deleting ${machineString}...`;
    case "deploy":
      return `Starting deployment for ${machineString}...`;
    case "exit-rescue-mode":
      return `Exiting rescue mode for ${machineString}...`;
    case "lock":
      return `Locking ${machineString}...`;
    case "on":
      return `Powering on ${machineString}...`;
    case "off":
      return `Powering off ${machineString}...`;
    case "mark-broken":
      return `Marking ${machineString} broken...`;
    case "mark-fixed":
      return `Marking ${machineString} fixed...`;
    case "override-failed-testing":
      return `Overriding failed tests for ${machineString}...`;
    case "release":
      return `Releasing ${machineString}...`;
    case "rescue-mode":
      return `Entering rescue mode for ${machineString}...`;
    case "set-pool":
      return `Setting pool for ${machineString}...`;
    case "set-zone":
      return `Setting zone for ${machineString}...`;
    case "tag":
      return `Tagging ${machineString}...`;
    case "test":
      return `Starting tests for ${machineString}...`;
    case "unlock":
      return `Unlocking ${machineString}...`;
    default:
      return `Processing ${machineString}...`;
```
