### PR TITLE
Fix legacy window titles.

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -93,6 +93,13 @@ function MasterController($rootScope, $transitions, $window, $http, ErrorService
     renderHeader();
   });
 
+  $rootScope.$watch("title", () => {
+    const maasName = window.CONFIG.maas_name;
+    const maasNamePart = maasName ? `${maasName} ` : "";
+    const titlePart = $rootScope.title ? `${$rootScope.title} | ` : "";
+    $window.document.title = `${titlePart}${maasNamePart}MAAS`;
+  });
+
   displayTemplate();
 }
 

--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -13,7 +13,7 @@
     <% if (legacyStylesheet) { %>
       <link rel="stylesheet" href="<%= legacyStylesheet %>" class="legacy-stylesheet" />
     <% } %>
-    <title>MAAS UI</title>
+    <title>MAAS</title>
   </head>
   <body>
     <div class="root-loading">


### PR DESCRIPTION
## Done
- Fixed legacy window titles.
- Renamed root title from "MAAS UI" to "MAAS". I don't think we use "MAAS UI" anywhere else so may as well keep it consistent.

## QA
- Navigate around the legacy angular pages and check that the window title updates correctly.

## Fixes
Fixes #1204 
