### PR TITLE
Add application/x-shellscript mimetype to fileupload accept.

### DIFF
--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
@@ -12,7 +12,7 @@ const TableDeleteConfirm = ({
 }) => {
   return (
     <Row>
-      <Col size={sidebar ? "7" : "9"}>
+      <Col size={sidebar ? "6" : "9"}>
         <p className="u-no-margin--bottom u-no-max-width">
           {message ||
             `Are you sure you want to delete ${modelType} "${modelName}"?`}{" "}

--- a/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
+++ b/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TableDeleteConfirm renders 1`] = `
 <Row>
   <Col
-    size="7"
+    size="6"
   >
     <p
       className="u-no-margin--bottom u-no-max-width"

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
@@ -113,11 +113,11 @@ const ScriptsUpload = ({ type }) => {
           {isDragActive ? (
             <p className="u-no-margin--bottom">Drop the file here ...</p>
           ) : (
-            <p className="u-no-margin--bottom">
-              Drag 'n' drop a script here ('.sh' file ext required), or click to
-              select a file
-            </p>
-          )}
+              <p className="u-no-margin--bottom">
+                Drag 'n' drop a script here ('.sh' file ext required), or click to
+                select a file
+              </p>
+            )}
         </div>
       </Row>
       <Row>

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
@@ -78,7 +78,7 @@ const ScriptsUpload = ({ type }) => {
     isDragReject,
   } = useDropzone({
     onDrop,
-    accept: "text/*, application/x-csh, application/x-sh",
+    accept: "text/*, application/x-csh, application/x-sh, application/x-shellscript",
     maxSize: MAX_SIZE_BYTES,
     multiple: false,
   });

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
@@ -78,7 +78,8 @@ const ScriptsUpload = ({ type }) => {
     isDragReject,
   } = useDropzone({
     onDrop,
-    accept: "text/*, application/x-csh, application/x-sh, application/x-shellscript",
+    accept:
+      "text/*, application/x-csh, application/x-sh, application/x-shellscript",
     maxSize: MAX_SIZE_BYTES,
     multiple: false,
   });
@@ -113,11 +114,11 @@ const ScriptsUpload = ({ type }) => {
           {isDragActive ? (
             <p className="u-no-margin--bottom">Drop the file here ...</p>
           ) : (
-              <p className="u-no-margin--bottom">
-                Drag 'n' drop a script here ('.sh' file ext required), or click to
-                select a file
-              </p>
-            )}
+            <p className="u-no-margin--bottom">
+              Drag 'n' drop a script here ('.sh' file ext required), or click to
+              select a file
+            </p>
+          )}
         </div>
       </Row>
       <Row>

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.js
@@ -83,7 +83,7 @@ describe("ScriptsUpload", () => {
     });
 
     expect(store.getActions()[0]["payload"]["message"]).toEqual(
-      "foo.jpg: File type must be text/*, application/x-csh, application/x-sh"
+      "foo.jpg: File type must be text/*, application/x-csh, application/x-sh, application/x-shellscript"
     );
   });
 


### PR DESCRIPTION
## Done
Add application/x-shellscript mimetype to fileupload accept.

To be backported to 2.8 branch.

## QA
Upload a shellscript (from a linux desktop) e.g. MAAS/r/settings/scripts/testing/upload

## Fixes
Fixes #1217 

## Launchpad Issue
[lp#1882313](https://bugs.launchpad.net/maas/+bug/1882313)