### PR TITLE
Filter out duplicate alias members from interface list.

### DIFF
--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -2409,6 +2409,13 @@ export function NodeNetworkingController(
     );
   };
 
+  $scope.isInterfaceConnected = (nic) => {
+    if (nic.type === 'alias' && nic.members.length) {
+      return nic.members.some((member) => member.link_connected);
+    }
+    return nic.link_connected;
+  };
+
   $scope.formatSpeedUnits = speedInMbytes => {
     const megabytesInGigabyte = 1000;
     const gigabytesInTerabyte = 1000;

--- a/legacy/src/app/controllers/tests/test_node_details_networking.js
+++ b/legacy/src/app/controllers/tests/test_node_details_networking.js
@@ -5289,4 +5289,30 @@ describe("NodeNetworkingController", function() {
       expect($scope.getInterfaceNumaNodes(iface)).toEqual([0, 1, 2]);
     });
   });
+
+  describe("isInterfaceConnected", () => {
+    it("returns true if the interface itself is connected", () => {
+      makeController();
+      const connected = {
+        link_connected: true
+      };
+      const notConnected = { link_connected: false };
+      expect($scope.isInterfaceConnected(connected)).toEqual(true);
+      expect($scope.isInterfaceConnected(notConnected)).toEqual(false);
+    });
+
+    it("returns true if the interface that is being aliased is connected", () => {
+      makeController();
+      const connected = {
+        type: 'alias',
+        members: [{ link_connected: true }],
+      };
+      const notConnected = {
+        type: 'alias',
+        members: [{ link_connected: false }],
+      };
+      expect($scope.isInterfaceConnected(connected)).toEqual(true);
+      expect($scope.isInterfaceConnected(notConnected)).toEqual(false);
+    });
+  });
 });

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -888,19 +888,26 @@
                                     <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
                                         <div class="p-double-row__icon-container">
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                                <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
-                                                    aria-describedby="not-connected-tooltip">
+                                                <span
+                                                    aria-describedby="not-connected-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="!isInterfaceConnected(interface)"
+                                                >
                                                     <i class="p-icon--disconnected"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
-                                                <span class="p-tooltip--top-left"
-                                                    data-ng-if="interface.link_connected && interface.link_speed < interface.interface_speed"
-                                                    aria-describedby="link-speed-tooltip">
+                                                <span
+                                                    aria-describedby="link-speed-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                                >
                                                     <i class="p-icon--warning"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                                 </span>
-                                                <i data-ng-if="interface.link_connected && interface.link_speed === interface.interface_speed"
-                                                    class="p-icon--placeholder"></i>
+                                                <i
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed"
+                                                    class="p-icon--placeholder">
+                                                </i>
                                             </span>
                                         </div>
                                         <div class="p-double-row__rows-container--icon">
@@ -1207,19 +1214,26 @@
                                     <td class="p-table__col--status p-double-row" aria-label="Link and interface speed" ng-if="!isDevice">
                                         <div class="p-double-row__icon-container">
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                                <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
-                                                    aria-describedby="not-connected-tooltip">
+                                                <span
+                                                    aria-describedby="not-connected-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="!isInterfaceConnected(interface)"
+                                                >
                                                     <i class="p-icon--disconnected"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
-                                                <span class="p-tooltip--top-left"
-                                                    data-ng-if="interface.link_connected && interface.link_speed < interface.interface_speed"
-                                                    aria-describedby="link-speed-tooltip">
+                                                <span
+                                                    aria-describedby="link-speed-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                                >
                                                     <i class="p-icon--warning"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                                 </span>
-                                                <i data-ng-if="interface.link_connected && interface.link_speed === interface.interface_speed"
-                                                    class="p-icon--placeholder"></i>
+                                                <i
+                                                    class="p-icon--placeholder"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
+                                                </i>
                                             </span>
                                         </div>
                                         <div class="p-double-row__rows-container--icon">
@@ -1339,19 +1353,26 @@
                                     <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
                                         <div class="p-double-row__icon-container">
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                                <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
-                                                    aria-describedby="not-connected-tooltip">
+                                                <span
+                                                    aria-describedby="not-connected-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="!isInterfaceConnected(interface)"
+                                                >
                                                     <i class="p-icon--disconnected"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
-                                                <span class="p-tooltip--top-left"
-                                                    data-ng-if="interface.link_connected && interface.link_speed < interface.interface_speed"
-                                                    aria-describedby="link-speed-tooltip">
+                                                <span
+                                                    aria-describedby="link-speed-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                                >
                                                     <i class="p-icon--warning"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                                 </span>
-                                                <i data-ng-if="interface.link_connected && interface.link_speed === interface.interface_speed"
-                                                    class="p-icon--placeholder"></i>
+                                                <i
+                                                    class="p-icon--placeholder"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
+                                                </i>
                                             </span>
                                         </div>
                                         <div class="p-double-row__rows-container--icon">
@@ -1474,19 +1495,26 @@
                                     <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
                                         <div class="p-double-row__icon-container">
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                                <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
-                                                    aria-describedby="not-connected-tooltip">
+                                                <span
+                                                    aria-describedby="not-connected-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="!isInterfaceConnected(interface)"
+                                                >
                                                     <i class="p-icon--error"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
-                                                <span class="p-tooltip--top-left"
-                                                    data-ng-if="interface.link_connected && interface.link_speed < interface.interface_speed"
-                                                    aria-describedby="link-speed-tooltip">
+                                                <span
+                                                    aria-describedby="link-speed-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                                >
                                                     <i class="p-icon--warning"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                                 </span>
-                                                <i data-ng-if="interface.link_connected && interface.link_speed === interface.interface_speed"
-                                                    class="p-icon--placeholder"></i>
+                                                <i
+                                                    class="p-icon--placeholder"
+                                                    ng-if="isInterfaceConnected(interface)d && interface.link_speed === interface.interface_speed">
+                                                </i>
                                                 </span>
                                         </div>
                                         <div class="p-double-row__rows-container--icon">
@@ -2086,19 +2114,26 @@
                                     <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
                                         <div class="p-double-row__icon-container">
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                                <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
-                                                    aria-describedby="not-connected-tooltip">
+                                                <span
+                                                    aria-describedby="not-connected-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="!isInterfaceConnected(interface)"
+                                                >
                                                     <i class="p-icon--error"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
-                                                <span class="p-tooltip--top-left"
-                                                    data-ng-if="interface.link_connected && interface.link_speed < interface.interface_speed"
-                                                    aria-describedby="link-speed-tooltip">
+                                                <span
+                                                    aria-describedby="link-speed-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                                >
                                                     <i class="p-icon--warning"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                                 </span>
-                                                <i data-ng-if="interface.link_connected && interface.link_speed === interface.interface_speed"
-                                                    class="p-icon--placeholder"></i>
+                                                <i
+                                                    class="p-icon--placeholder"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
+                                                </i>
                                             </span>
                                         </div>
                                         <div class="p-double-row__rows-container--icon">
@@ -2181,19 +2216,26 @@
                                     <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
                                         <div class="p-double-row__icon-container">
                                             <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                                <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
-                                                    aria-describedby="not-connected-tooltip">
+                                                <span
+                                                    aria-describedby="not-connected-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="!isInterfaceConnected(interface)"
+                                                >
                                                     <i class="p-icon--error"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                                 </span>
-                                                <span class="p-tooltip--top-left"
-                                                    data-ng-if="interface.link_connected && interface.link_speed < interface.interface_speed"
-                                                    aria-describedby="link-speed-tooltip">
+                                                <span
+                                                    aria-describedby="link-speed-tooltip"
+                                                    class="p-tooltip--top-left"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                                >
                                                     <i class="p-icon--warning"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                                 </span>
-                                                <i data-ng-if="interface.link_connected && interface.link_speed === interface.interface_speed"
-                                                    class="p-icon--placeholder"></i>
+                                                <i
+                                                    class="p-icon--placeholder"
+                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
+                                                </i>
                                             </span>
                                         </div>
                                         <div class="p-double-row__rows-container--icon">
@@ -2620,19 +2662,26 @@
                                 <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
                                     <div class="p-double-row__icon-container">
                                         <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                            <span class="p-tooltip--top-left" data-ng-if="!interface.link_connected"
-                                                aria-describedby="not-connected-tooltip">
+                                            <span
+                                                aria-describedby="not-connected-tooltip"
+                                                class="p-tooltip--top-left"
+                                                ng-if="!isInterfaceConnected(interface)"
+                                            >
                                                 <i class="p-icon--disconnected"></i>
                                                 <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
                                             </span>
-                                            <span class="p-tooltip--top-left"
-                                                data-ng-if="interface.link_connected && interface.link_speed < interface.interface_speed"
-                                                aria-describedby="link-speed-tooltip">
+                                            <span
+                                                aria-describedby="link-speed-tooltip"
+                                                class="p-tooltip--top-left"
+                                                ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                            >
                                                 <i class="p-icon--warning"></i>
                                                 <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                             </span>
-                                            <i data-ng-if="interface.link_connected && interface.link_speed === interface.interface_speed"
-                                                class="p-icon--placeholder"></i>
+                                            <i
+                                                class="p-icon--placeholder"
+                                                ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
+                                            </i>
                                         </span>
                                     </div>
                                     <div class="p-double-row__rows-container--icon">
@@ -2789,19 +2838,19 @@
                                         <div class="row" data-ng-if="isChangingConnectionStatus">
                                             <div class="p-warning-message">
                                                 <i class="p-icon--warning p-warning-message__icon"></i>
-                                                <div data-ng-if="interface.link_connected">
+                                                <div data-ng-if="isInterfaceConnected(interface)">
                                                     This interface was detected as <strong>connected</strong>. Are you sure you want to mark it as disconnected?
                                                     <br>
                                                     When the interface is disconnected, it cannot be configured.
                                                 </div>
-                                                <div data-ng-if="!interface.link_connected">
+                                                <div data-ng-if="!isInterfaceConnected(interface)">
                                                     This interface was detected as <strong>disconnected</strong>. Are you sure you want to mark it as connected?
                                                 </div>
                                             </div>
                                             <div class="u-align--right">
                                                 <button class="p-button--base" data-ng-click="cancel()">Cancel</button>
-                                                <button class="u-no-margin--top" data-ng-click="saveConnectionStatus(interface)" data-ng-class="{'p-button--positive': !interface.link_connected, 'p-button--negative': interface.link_connected}">
-                                                    Mark as <span data-ng-if="interface.link_connected">disconnected</span><span data-ng-if="!interface.link_connected">connected</span>
+                                                <button class="u-no-margin--top" data-ng-click="saveConnectionStatus(interface)" data-ng-class="{'p-button--positive': !isInterfaceConnected(interface), 'p-button--negative': isInterfaceConnected(interface)}">
+                                                    Mark as <span data-ng-if="isInterfaceConnected(interface)">disconnected</span><span data-ng-if="!isInterfaceConnected(interface)">connected</span>
                                                 </button>
                                             </div>
                                         </div>
@@ -2980,7 +3029,7 @@
 
                             <tr
                                 class="p-table--is-not-device indented-border"
-                                ng-if="interface.members && interface.members.length > 0"
+                                ng-if="interface.members && interface.members.length > 0 && interface.type !== 'alias'"
                                 ng-repeat="member in interface.members"
                             >
                                 <td class="p-double-row" aria-label="Name">
@@ -3009,7 +3058,7 @@
                                             <span
                                                 aria-describedby="not-connected-tooltip"
                                                 class="p-tooltip--top-left"
-                                                ng-if="!member.link_connected"
+                                                ng-if="!isInterfaceConnected(member)"
                                             >
                                                 <i class="p-icon--disconnected"></i>
                                                 <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
@@ -3017,13 +3066,13 @@
                                             <span
                                                 aria-describedby="link-speed-tooltip"
                                                 class="p-tooltip--top-left"
-                                                ng-if="member.link_connected && member.link_speed < member.interface_speed"
+                                                ng-if="isInterfaceConnected(member) && member.link_speed < member.interface_speed"
                                             >
                                                 <i class="p-icon--warning"></i>
                                                 <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                             </span>
                                             <i
-                                                ng-if="member.link_connected && member.link_speed === member.interface_speed"
+                                                ng-if="isInterfaceConnected(member) && member.link_speed === member.interface_speed"
                                                 class="p-icon--placeholder"
                                             ></i>
                                         </span>


### PR DESCRIPTION
## Done
- Filter out duplicate alias members from interface list.

## QA
- Go to the networking page of a New, Allocated or Ready machine.
- Add a physical interface.
- Create a bridge from that interface.
- Add an alias of the bridge.
- Check that the physical interface only shows up once in the list, and that the alias does not show

## Fixes
Fixes #1219 

## Launchpad Issue
[lp#1881804](https://bugs.launchpad.net/maas/+bug/1881804)
