### PR TITLE
Accept script uploads with mimetype application/x-shellscript.

### DIFF
--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.js
@@ -82,7 +82,7 @@ const ScriptsUpload = ({ type }) => {
     isDragReject
   } = useDropzone({
     onDrop,
-    accept: "text/*, application/x-csh, application/x-sh",
+    accept: "text/*, application/x-csh, application/x-sh, application/x-shellscript",
     maxSize: MAX_SIZE_BYTES,
     multiple: false
   });

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.js
@@ -82,7 +82,8 @@ const ScriptsUpload = ({ type }) => {
     isDragReject
   } = useDropzone({
     onDrop,
-    accept: "text/*, application/x-csh, application/x-sh, application/x-shellscript",
+    accept:
+      "text/*, application/x-csh, application/x-sh, application/x-shellscript",
     maxSize: MAX_SIZE_BYTES,
     multiple: false
   });

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
@@ -17,7 +17,7 @@ const createFile = (name, size, type, contents = "") => {
   Reflect.defineProperty(file, "size", {
     get() {
       return size;
-    },
+    }
   });
   return file;
 };
@@ -27,14 +27,14 @@ describe("ScriptsUpload", () => {
   beforeEach(() => {
     initialState = {
       config: {
-        items: [],
+        items: []
       },
       scripts: {
         loading: false,
         loaded: true,
         errors: {},
-        items: [],
-      },
+        items: []
+      }
     };
   });
 
@@ -55,7 +55,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {},
+        persist: () => {}
       });
     });
 
@@ -79,7 +79,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {},
+        persist: () => {}
       });
     });
 
@@ -102,7 +102,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {},
+        persist: () => {}
       });
     });
 
@@ -127,7 +127,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {},
+        persist: () => {}
       });
     });
 
@@ -140,7 +140,7 @@ describe("ScriptsUpload", () => {
     const store = mockStore(initialState);
     const files = [
       createFile("foo.sh", 1000, "text/script"),
-      createFile("bar.sh", 1000, "text/script"),
+      createFile("bar.sh", 1000, "text/script")
     ];
 
     const wrapper = mount(
@@ -155,7 +155,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {},
+        persist: () => {}
       });
     });
 
@@ -171,7 +171,7 @@ describe("ScriptsUpload", () => {
       callback({
         name: "foo",
         script: contents,
-        hasMetadata: true,
+        hasMetadata: true
       });
     });
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
@@ -188,7 +188,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {},
+        persist: () => {}
       });
     });
 
@@ -200,8 +200,8 @@ describe("ScriptsUpload", () => {
       { type: "CLEANUP_SCRIPTS" },
       {
         payload: { contents, type: "testing" },
-        type: "UPLOAD_SCRIPT",
-      },
+        type: "UPLOAD_SCRIPT"
+      }
     ]);
   });
 
@@ -212,7 +212,7 @@ describe("ScriptsUpload", () => {
       callback({
         name: "foo",
         script: contents,
-        hasMetadata: false,
+        hasMetadata: false
       });
     });
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
@@ -229,7 +229,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {},
+        persist: () => {}
       });
     });
 
@@ -241,8 +241,8 @@ describe("ScriptsUpload", () => {
       { type: "CLEANUP_SCRIPTS" },
       {
         payload: { contents, type: "testing", name: "foo" },
-        type: "UPLOAD_SCRIPT",
-      },
+        type: "UPLOAD_SCRIPT"
+      }
     ]);
   });
 });

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
@@ -38,7 +38,7 @@ describe("ScriptsUpload", () => {
     };
   });
 
-  it("accepts files of text and application mimetype", async () => {
+  it("accepts files of text mimetype", async () => {
     const store = mockStore(initialState);
 
     const files = [createFile("foo.sh", 2000, "text/script")];

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
@@ -17,7 +17,7 @@ const createFile = (name, size, type, contents = "") => {
   Reflect.defineProperty(file, "size", {
     get() {
       return size;
-    }
+    },
   });
   return file;
 };
@@ -27,18 +27,18 @@ describe("ScriptsUpload", () => {
   beforeEach(() => {
     initialState = {
       config: {
-        items: []
+        items: [],
       },
       scripts: {
         loading: false,
         loaded: true,
         errors: {},
-        items: []
-      }
+        items: [],
+      },
     };
   });
 
-  it("accepts files of text mimetype", async () => {
+  it("accepts files of text and application mimetype", async () => {
     const store = mockStore(initialState);
 
     const files = [createFile("foo.sh", 2000, "text/script")];
@@ -55,7 +55,31 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
+      });
+    });
+
+    expect(wrapper.text()).toContain("foo.sh (2000 bytes) ready for upload");
+  });
+
+  it("accepts files of application mimetype", async () => {
+    const store = mockStore(initialState);
+
+    const files = [createFile("foo.sh", 2000, "application/x-shellscript")];
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <ScriptsUpload type="testing" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await act(async () => {
+      wrapper.find("input").simulate("change", {
+        target: { files },
+        preventDefault: () => {},
+        persist: () => {},
       });
     });
 
@@ -78,7 +102,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -103,7 +127,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -116,7 +140,7 @@ describe("ScriptsUpload", () => {
     const store = mockStore(initialState);
     const files = [
       createFile("foo.sh", 1000, "text/script"),
-      createFile("bar.sh", 1000, "text/script")
+      createFile("bar.sh", 1000, "text/script"),
     ];
 
     const wrapper = mount(
@@ -131,7 +155,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -147,7 +171,7 @@ describe("ScriptsUpload", () => {
       callback({
         name: "foo",
         script: contents,
-        hasMetadata: true
+        hasMetadata: true,
       });
     });
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
@@ -164,7 +188,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -176,8 +200,8 @@ describe("ScriptsUpload", () => {
       { type: "CLEANUP_SCRIPTS" },
       {
         payload: { contents, type: "testing" },
-        type: "UPLOAD_SCRIPT"
-      }
+        type: "UPLOAD_SCRIPT",
+      },
     ]);
   });
 
@@ -188,7 +212,7 @@ describe("ScriptsUpload", () => {
       callback({
         name: "foo",
         script: contents,
-        hasMetadata: false
+        hasMetadata: false,
       });
     });
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
@@ -205,7 +229,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -217,8 +241,8 @@ describe("ScriptsUpload", () => {
       { type: "CLEANUP_SCRIPTS" },
       {
         payload: { contents, type: "testing", name: "foo" },
-        type: "UPLOAD_SCRIPT"
-      }
+        type: "UPLOAD_SCRIPT",
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Done
* Accept script uploads with mimetype application/x-shellscript. (This is a backport of https://github.com/canonical-web-and-design/maas-ui/pull/1223)

## QA
Upload a shellscript (from a linux desktop) e.g. MAAS/r/settings/scripts/testing/upload

## Fixes
Fixes #1217

## Launchpad Issue
lp#1882313
