### PR TITLE
Rename "Containers" tab in machine details page to "Instances".

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -296,8 +296,8 @@
                     </li>
                     <li class="p-tabs__item" role="presentation">
                         <a role="tab" class="p-tabs__link" data-ng-if="!isController && devices.length"
-                            data-ng-class="{ 'is-active': section.area === 'containers'}"
-                            data-ng-click="openSection('containers')">Containers</a>
+                            data-ng-class="{ 'is-active': section.area === 'instances'}"
+                            data-ng-click="openSection('instances')">Instances</a>
                     </li>
                     <li class="p-tabs__item" role="presentation">
                         <a role="tab" class="p-tabs__link" data-ng-if="isController"
@@ -359,7 +359,7 @@
         <node-details-summary />
     </section>
 
-    <section class="p-strip" data-ng-if="section.area === 'containers'">
+    <section class="p-strip" data-ng-if="section.area === 'instances'">
         <div class="row">
             <table>
                 <thead>


### PR DESCRIPTION
## Done
- Renamed "Containers" tab to "Instances" to generalise the fact that LXD can host both containers and VMs.

## QA
- Go to the machine details page of a machine with devices (there should be at least one in a `make sampledata`'d local MAAS)
- Check that there is a tab that says "Instances" instead of "Containers"

## Fixes
Fixes #1218 

## Launchpad Issue
[lp#1881664](https://bugs.launchpad.net/maas/+bug/1881664)

## Screenshot
![0 0 0 0_8400_MAAS_l_machine_adgsyh_area=instances (1)](https://user-images.githubusercontent.com/25733845/84098027-80e44700-aa49-11ea-9936-d78ffec82f0a.png)

