### PR TITLE
Fix wording on node events "full history" view.

### DIFF
--- a/legacy/src/app/partials/node-events.html
+++ b/legacy/src/app/partials/node-events.html
@@ -15,7 +15,7 @@
                     </li>
                     <li class="p-inline-list__item">
                         <p class="page-header__status">
-                            {$ node.events.length $} {$ type_name $} events in the past {$ days $} days
+                            {$ node.events.length $} total {$ type_name $} events. Showing events from past {$ days $} days.
                         </p>
                     </li>
                     <li class="p-inline-list__item">


### PR DESCRIPTION
## Done
The node events full history view has misleading text, suggesting that all events are within the last 1 day by default. Instead it should display an event total, and make it clear that the page is showing events for the last n days.

## QA
n/a, but if it helps understand the problem to see it in context, have a look at a machine's "full history" page e.g. MAAS/l/machine/machine-id/events

## Fixes
Fixes canonical-web-and-design/MAAS-design#911
