### PR TITLE
Only display spaces on pod details with assigned subnets.

### DIFF
--- a/legacy/src/app/controllers/pod_details.js
+++ b/legacy/src/app/controllers/pod_details.js
@@ -760,7 +760,10 @@ function PodDetailsController(
     FabricsManager,
     SpacesManager
   ]).then(function() {
-    $scope.spaces = SpacesManager.getItems();
+    // Only display spaces with assigned subnets.
+    $scope.spaces = SpacesManager.getItems().filter(
+      (space) => space.subnet_ids.length > 0
+    )
     $scope.subnets = SubnetsManager.getItems();
     $scope.availableSubnets = [];
 


### PR DESCRIPTION
## Done
Filter spaces without subnets on pod details, to prevent empty headings displaying in the subnet dropdown.

## QA
* Compose a machine, add an interface, and click the subnet dropdown - you shouldn't see any space headings without subnets.

## Fixes
Fixes canonical-web-and-design/MAAS-design#917
