### PR TITLE
Update images page to allow selecting architectures on a per-release basis.

### DIFF
--- a/legacy/src/app/enum.js
+++ b/legacy/src/app/enum.js
@@ -47,7 +47,7 @@ export const NodeStatus = {
   // Running tests on Node
   TESTING: 21,
   // Testing has failed
-  FAILED_TESTING: 22
+  FAILED_TESTING: 22,
 };
 
 export const ScriptStatus = {
@@ -62,11 +62,11 @@ export const ScriptStatus = {
   FAILED_INSTALLING: 8,
   SKIPPED: 9,
   APPLYING_NETCONF: 10,
-  FAILED_APPLYING_NETCONF: 11
+  FAILED_APPLYING_NETCONF: 11,
 };
 
 export const NodeTypes = {
-  REGION_CONTROLLER: 3
+  REGION_CONTROLLER: 3,
 };
 
 export const HardwareType = {
@@ -74,5 +74,11 @@ export const HardwareType = {
   CPU: 1,
   MEMORY: 2,
   STORAGE: 3,
-  NETWORK: 4
+  NETWORK: 4,
+};
+
+export const BootResourceType = {
+  DOWNLOADED: 0,
+  GENERATED: 1,
+  UPLOADED: 2,
 };

--- a/legacy/src/app/partials/boot-images.html
+++ b/legacy/src/app/partials/boot-images.html
@@ -1,48 +1,59 @@
-<form class="form">
-    <div data-ng-if="!loading" data-ng-class="{'p-strip is-bordered': design === 'page', 'p-card--highlighted col-12': design === 'card'}">
+
+<div data-ng-if="!loading" data-ng-class="{ 'p-card--highlighted col-12': design === 'card' }">
+    <!-- Heading -->
+    <div class="p-strip is-shallow">
         <div class="row">
             <div class="col-12">
-                <h2 class="p-heading--four"><span data-ng-if="design === 'card'"><i class="{$ getTitleIcon() $}"></i>&nbsp;</span>Ubuntu</h2>
+                <h4><span data-ng-if="design === 'card'"><i class="{$ getTitleIcon() $}"></i>&nbsp;</span>Ubuntu</h4>
                 <hr />
                 <p data-ng-if="isSuperUser() && !source.tooMany">
-                    Select images and architecture to be imported and kept in sync daily. Images will be available for deploying to machines managed by MAAS.
+                    Select images to be imported and kept in sync daily. Images will be available for deploying to machines managed by MAAS.
                 </p>
             </div>
         </div>
-        <div class="row" data-ng-if="isSuperUser() && !source.tooMany">
-            <h3 class="p-heading--four">Choose source</h3>
-        </div>
-        <div class="row" data-ng-if="isSuperUser() && !source.tooMany">
-            <div class="col-2">
-                <input type="radio" data-ng-model="source.source_type" id="source_maas" value="maas.io" data-ng-change="sourceChanged()" data-ng-disabled="saving">
-                <label for="source_maas">maas.io</label>
+    </div>
+
+    <!-- Source selection -->
+    <div class="p-strip is-shallow u-no-padding--top" data-ng-if="isSuperUser() && !source.tooMany">
+        <div class="row">
+            <div class="col-12">
+                <h3 class="p-heading--four">Choose source</h3>
+                <ul class="p-inline-list">
+                    <li class="p-inline-list__item">
+                        <input type="radio" data-ng-model="source.source_type" id="source_maas" value="maas.io" data-ng-change="sourceChanged()" data-ng-disabled="saving">
+                        <label class="is-inline-label" for="source_maas">maas.io</label>
+                    </li>
+                    <li class="p-inline-list__item">
+                        <input type="radio" data-ng-model="source.source_type" id="source_custom" value="custom" data-ng-change="sourceChanged()" data-ng-disabled="saving">
+                        <label class="is-inline-label" for="source_custom">Custom</label>
+                    </li>
+                </ul>
             </div>
-            <div class="col-2">
-                <input type="radio" data-ng-model="source.source_type" id="source_custom" value="custom" data-ng-change="sourceChanged()" data-ng-disabled="saving">
-                <label for="source_custom">Custom</label>
-            </div>
         </div>
-        <div class="row" data-ng-if="isSuperUser() && !source.tooMany && showMirrorPath()">
+    </div>
+
+    <!-- Mirror URL -->
+    <div class="p-strip is-shallow u-no-padding--top" data-ng-if="isSuperUser() && !source.tooMany && showMirrorPath()">
+        <div class="row" >
             <div class="col-8">
-                <h3 class="p-heading--five">Mirror URL</h3>
+                <h3 class="p-heading--four">Mirror URL</h3>
                 <p>Add the URL you want to use to select your images from.</p>
             </div>
         </div>
-        <div class="row" data-ng-if="isSuperUser() && !source.tooMany && showMirrorPath()">
+        <div class="row">
             <div class="col-8">
                 <div class="row">
                     <div class="col-5 p-form-validation u-no-margin--top" data-ng-class="{ 'is-error': !source.connecting && source.errorMessage }">
                         <input class="p-form-validation__input" type="text" name="mirrorUrl" placeholder="e.g. http:// or https://" data-ng-model="source.url" data-ng-change="sourceChanged()">
                         <div class="p-form-validation__message" data-ng-if="!source.connecting && source.errorMessage">
-                              <p>
-                                  <span class="p-notification__status">Error:</span>{$ source.errorMessage $}
-                                  <a class="p-notification__action" data-ng-if="source.source_type === 'maas.io'" data-ng-click="connect()">Retry</a>
-                              </p>
+                            <p>
+                                <span class="p-notification__status">Error:</span>{$ source.errorMessage $}
+                                <a class="p-notification__action" data-ng-if="source.source_type === 'maas.io'" data-ng-click="connect()">Retry</a>
+                            </p>
                         </div>
                     </div>
                     <div class="col-3">
                         <button class="p-button--neutral" aria-label="Toggle advanced URL controls" data-ng-click="toggleAdvancedOptions()">
-
                             <span data-ng-if="!isShowingAdvancedOptions()">
                                 Show advanced options <i class="p-icon--plus p-icon--inline-right"></i>
                             </span>
@@ -75,42 +86,81 @@
                 <button class="p-button--positive" data-ng-if="showConnectButton()" data-ng-disabled="isConnectButtonDisabled()" data-ng-click="connect()">Connect</button>
             </div>
         </div>
-        <div class="row" data-ng-if="showConnectBlock()">
+    </div>
+
+    <!-- Connecting block -->
+    <div class="p-strip is-shallow u-no-padding--top" data-ng-if="showConnectBlock()">
+        <div class="row">
             <div class="col-8">
                 <p data-ng-if="source.connecting">
                     <i class="p-icon--spinner u-animation--spin"></i> Connecting
                 </p>
             </div>
         </div>
+    </div>
 
-        <div class="row p-divider" data-ng-if="isSuperUser() && !source.tooMany && showSelections()">
+    <!-- Ubuntu release / architecture selection -->
+    <div class="p-strip is-shallow u-no-padding--top" data-ng-if="isSuperUser() && !source.tooMany && showSelections()">
+        <div class="row p-divider">
             <div class="col-6 p-divider__block">
-                <h3 class="p-heading--four">Images</h3>
+                <h3 class="p-heading--four">Releases</h3>
                 <div class="row">
-                    <ul class="col-3 p-list">
-                        <li  class="p-list__item" data-ng-repeat="release in getUbuntuLTSReleases() | orderBy:'-title'">
-                            <input type="checkbox" id="{$ release.name $}" data-ng-checked="isSelected('releases', release)" data-ng-click="toggleSelection('releases', release)" data-ng-disabled="saving">
+                    <div class="col-3">
+                        <div ng-repeat="release in getUbuntuLTSReleases() | orderBy: '-title'">
+                            <input
+                                id="{$ release.name $}"
+                                name="selected-release"
+                                ng-disabled="saving"
+                                ng-model="$parent.selectedUbuntuRelease"
+                                type="radio"
+                                value="{$ release.name $}"
+                            >
                             <label for="{$ release.name $}">{$ release.title $}</label>
-                        </li>
-                    </ul>
-                    <ul class="col-3 p-list">
-                        <li class="p-list__item" data-ng-repeat="release in getUbuntuNonLTSReleases() | orderBy:'-title'">
-                            <input type="checkbox" id="{$ release.name $}" data-ng-checked="isSelected('releases', release)" data-ng-click="toggleSelection('releases', release)" data-ng-disabled="saving">
+                        </div>
+                    </div>
+                    <div class="col-3">
+                        <div ng-repeat="release in getUbuntuNonLTSReleases() | orderBy: '-title'">
+                            <input
+                                id="{$ release.name $}"
+                                name="selected-release"
+                                ng-disabled="saving"
+                                ng-model="$parent.selectedUbuntuRelease"
+                                type="radio"
+                                value="{$ release.name $}"
+                            >
                             <label for="{$ release.name $}">{$ release.title $}</label>
-                        </li>
-                    </ul>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="col-6 p-divider__block">
                 <h3 class="p-heading--four">Architectures</h3>
-                <ul class="p-list is-split">
-                    <li class="p-list__item" data-ng-repeat="arch in getArchitectures() | orderBy:'title'">
-                        <input type="checkbox" id="{$ arch.name $}" data-ng-checked="isSelected('arches', arch)" data-ng-click="toggleSelection('arches', arch)" data-ng-disabled="saving">
+                <div ng-repeat="arch in getArchitectures() | orderBy:'title'">
+                    <span class="p-tooltip--top-left">
+                        <input
+                            id="{$ arch.name $}"
+                            ng-checked="isOSSelected(selectedUbuntuRelease, arch.name)"
+                            ng-click="toggleSelectedOS(selectedUbuntuRelease, arch.name)"
+                            ng-disabled="saving || !selectedUbuntuRelease || unsupportedArch(selectedUbuntuRelease, arch.name)"
+                            type="checkbox"
+                        >
                         <label for="{$ arch.name $}">{$ arch.title $}</label>
-                    </li>
-                </ul>
+                        <span
+                            class="p-tooltip__message"
+                            ng-if="selectedUbuntuRelease && unsupportedArch(selectedUbuntuRelease, arch.name)"
+                        >This release/architecture combination is unsupported.</span>
+                        <span
+                            class="p-tooltip__message"
+                            ng-if="!selectedUbuntuRelease"
+                        >Please select a release first.</span>
+                    </span>
+                </div>
             </div>
         </div>
+    </div>
+
+    <!-- Ubuntu images table -->
+    <div class="p-strip is-shallow">
         <div class="row">
             <table class="p-table-expanding p-table--images" data-ng-if="showImagesTable()">
                 <thead>
@@ -185,205 +235,237 @@
             </div>
         </div>
     </div>
-</form>
 
-<div data-ng-if="ubuntu_core.images.length" data-ng-class="{'p-strip': design === 'page'}">
-    <div class="row">
-        <div class="col-8">
-            <h2 class="p-heading--four">Ubuntu Core</h2>
-            <div data-ng-if="isSuperUser() && !source.tooMany">
-                <span data-ng-repeat="image in ubuntu_core.images | orderBy:['-title']">
-                    <input type="checkbox" id="{$ image.name $}" data-ng-checked="image.checked" data-ng-click="toggleUbuntuCoreSelection(image)" data-ng-disabled="saving">
-                    <label for="{$ image.name $}">{$ image.title $}</label>
-                </span>
+    <!-- Ubuntu core images -->
+    <div data-ng-if="ubuntu_core.images.length">
+        <!-- Ubuntu core image selection -->
+        <div class="p-strip is-shallow u-no-padding--top">
+            <div class="row">
+                <div class="col-8">
+                    <h2 class="p-heading--four">Ubuntu Core</h2>
+                    <div data-ng-if="isSuperUser() && !source.tooMany">
+                        <span data-ng-repeat="image in ubuntu_core.images | orderBy:['-title']">
+                            <input type="checkbox" id="{$ image.name $}" data-ng-checked="image.checked" data-ng-click="toggleUbuntuCoreSelection(image)" data-ng-disabled="saving">
+                            <label for="{$ image.name $}">{$ image.title $}</label>
+                        </span>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <table class="p-table-expanding p-table--images">
-                <thead>
-                    <tr class="p-table__row">
-                        <th class="p-table__cell">Name</th>
-                        <th class="p-table__cell">Architecture</th>
-                        <th class="p-table__cell">Size</th>
-                        <th class="p-table__cell">Status</th>
-                        <th class="p-table__cell">&nbsp;</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr data-ng-if="!ubuntuCoreImages.length">
-                        <td colspan="4" class="table-cell--100">No images have been selected for syncing.</td>
-                    </tr>
-                    <tr class="p-table__row" data-ng-repeat="image in ubuntuCoreImages | orderBy:['-title', 'arch']">
-                        <td class="p-table__cell" aria-label="Name"><i class="{$ image.icon $}"></i>{$ image.title $}</td>
-                        <td class="p-table__cell" aria-label="Architecture">{$ image.arch $}</td>
-                        <td class="p-table__cell" aria-label="Size">{$ image.size $}</td>
-                        <td class="p-table__cell" aria-label="Status">{$ image.status $}</td>
-                        <td class="p-table__cell">&nbsp;</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-    <div class="row" data-ng-if="!source.tooMany">
-        <div class="col-12">
-            <div class="u-align--right">
-                <maas-action-button
-                    class="p-button--positive"
-                    indeterminate-state="saving"
-                    done-state="saved"
-                    data-ng-if="isSuperUser()"
-                    data-ng-disabled="!canSaveSelection()"
-                    data-ng-click="saveUbuntuCoreSelection()">
-                    {$ getSaveSelectionText() $}
-                </maas-action-button>
-            </div>
-        </div>
-    </div>
-</div>
 
-<div data-ng-if="design === 'page' && other.images.length && !source.isNew" data-ng-class="{'p-strip': design === 'page'}">
-    <div class="p-strip">
-        <div class="row">
-            <h2 class="p-heading--four">Other Images</h2>
-            <div data-ng-if="isSuperUser() && !source.tooMany">
-                <div class="col-3" data-ng-repeat="image in other.images | orderBy:['-title']">
-                    <input type="checkbox" id="{$ image.name $}" data-ng-checked="image.checked" data-ng-click="toggleOtherSelection(image)" data-ng-disabled="saving">
-                    <label for="{$ image.name $}" class="u-no-margin--bottom">{$ image.title $}</label>
+        <!-- Ubuntu core images table -->
+        <div class="p-strip is-shallow">
+            <div class="row">
+                <div class="col-12">
+                    <table class="p-table-expanding p-table--images">
+                        <thead>
+                            <tr class="p-table__row">
+                                <th class="p-table__cell">Name</th>
+                                <th class="p-table__cell">Architecture</th>
+                                <th class="p-table__cell">Size</th>
+                                <th class="p-table__cell">Status</th>
+                                <th class="p-table__cell">&nbsp;</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr data-ng-if="!ubuntuCoreImages.length">
+                                <td colspan="4" class="table-cell--100">No images have been selected for syncing.</td>
+                            </tr>
+                            <tr class="p-table__row" data-ng-repeat="image in ubuntuCoreImages | orderBy:['-title', 'arch']">
+                                <td class="p-table__cell" aria-label="Name"><i class="{$ image.icon $}"></i>{$ image.title $}</td>
+                                <td class="p-table__cell" aria-label="Architecture">{$ image.arch $}</td>
+                                <td class="p-table__cell" aria-label="Size">{$ image.size $}</td>
+                                <td class="p-table__cell" aria-label="Status">{$ image.status $}</td>
+                                <td class="p-table__cell">&nbsp;</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="row" data-ng-if="!source.tooMany">
+                <div class="col-12">
+                    <div class="u-align--right">
+                        <maas-action-button
+                            class="p-button--positive"
+                            indeterminate-state="saving"
+                            done-state="saved"
+                            data-ng-if="isSuperUser()"
+                            data-ng-disabled="!canSaveSelection()"
+                            data-ng-click="saveUbuntuCoreSelection()">
+                            {$ getSaveSelectionText() $}
+                        </maas-action-button>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-    <div class="row">
-        <div class="col-12">
-            <table class="p-table-expanding p-table--images">
-                <thead>
-                    <tr class="p-table__row">
-                        <th class="p-table__cell">Release</th>
-                        <th class="p-table__cell">Architecture</th>
-                        <th class="p-table__cell">Size</th>
-                        <th class="p-table__cell">Status</th>
-                        <th class="p-table__cell">&nbsp;</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr data-ng-if="!otherImages.length">
-                        <td colspan="4" class="col-12">
-                            No images have been selected for syncing.
-                        </td>
-                    </tr>
-                    <tr class="p-table__row" data-ng-repeat="image in otherImages | orderBy:['-title', 'arch']">
-                        <td aria-label="Release" class="p-table__cell">
-                            <i class="{$ image.icon $}"></i>
-                            {$ image.title $}
-                        </td>
-                        <td aria-label="Architecture" class="p-table__cell">{$ image.arch $}</td>
-                        <td aria-label="Size" class="p-table__cell">{$ image.size $}</td>
-                        <td aria-label="Status" class="p-table__cell">{$ image.status $}</td>
-                        <td class="p-table__cell">&nbsp;</td>
-                    </tr>
-                </tbody>
-            </table>
+
+    <!-- Other images -->
+    <div data-ng-if="design === 'page' && other.images.length && !source.isNew">
+        <!-- Other images selection -->
+        <div class="p-strip is-shallow u-no-padding--top">
+            <div class="row">
+                <div class="col-12">
+                    <hr />
+                    <h2 class="p-heading--four">Other Images</h2>
+                    <div data-ng-if="isSuperUser() && !source.tooMany">
+                        <div class="col-3" data-ng-repeat="image in other.images | orderBy:['-title']">
+                            <input type="checkbox" id="{$ image.name $}" data-ng-checked="image.checked" data-ng-click="toggleOtherSelection(image)" data-ng-disabled="saving">
+                            <label for="{$ image.name $}" class="u-no-margin--bottom">{$ image.title $}</label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Other images table -->
+        <div class="p-strip is-shallow">
+            <div class="row">
+                <div class="col-12">
+                    <table class="p-table-expanding p-table--images">
+                        <thead>
+                            <tr class="p-table__row">
+                                <th class="p-table__cell">Release</th>
+                                <th class="p-table__cell">Architecture</th>
+                                <th class="p-table__cell">Size</th>
+                                <th class="p-table__cell">Status</th>
+                                <th class="p-table__cell">&nbsp;</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr data-ng-if="!otherImages.length">
+                                <td colspan="4" class="col-12">
+                                    No images have been selected for syncing.
+                                </td>
+                            </tr>
+                            <tr class="p-table__row" data-ng-repeat="image in otherImages | orderBy:['-title', 'arch']">
+                                <td aria-label="Release" class="p-table__cell">
+                                    <i class="{$ image.icon $}"></i>
+                                    {$ image.title $}
+                                </td>
+                                <td aria-label="Architecture" class="p-table__cell">{$ image.arch $}</td>
+                                <td aria-label="Size" class="p-table__cell">{$ image.size $}</td>
+                                <td aria-label="Status" class="p-table__cell">{$ image.status $}</td>
+                                <td class="p-table__cell">&nbsp;</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="row" data-ng-if="!source.tooMany">
+                <div class="col-12">
+                    <div class="u-align--right">
+                        <maas-action-button
+                            class="p-button--positive"
+                            indeterminate-state="saving"
+                            done-state="saved"
+                            data-ng-if="isSuperUser()"
+                            data-ng-disabled="saving"
+                            data-ng-click="saveOtherSelection()">
+                            {$ getSaveSelectionText() $}
+                        </maas-action-button>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
-    <div class="row" data-ng-if="!source.tooMany">
-        <div class="col-12">
-            <div class="u-align--right">
-                <maas-action-button
-                    class="p-button--positive"
-                    indeterminate-state="saving"
-                    done-state="saved"
-                    data-ng-if="isSuperUser()"
-                    data-ng-disabled="saving"
-                    data-ng-click="saveOtherSelection()">
-                    {$ getSaveSelectionText() $}
-                </maas-action-button>
+
+    <!-- Generated images -->
+    <div ng-if="design === 'page' && generatedImages.length">
+        <!-- Generated images table -->
+        <div class="p-strip is-shallow">
+            <div class="row">
+                <div class="wrapper--inner">
+                    <h2 class="p-heading--four">Generated Images</h2>
+                    <table class="p-table-expanding p-table--images">
+                        <thead>
+                            <tr class="p-table__row">
+                                <th class="p-table__cell">Release</th>
+                                <th class="p-table__cell">Architecture</th>
+                                <th class="p-table__cell">Size</th>
+                                <th class="p-table__cell">Status</th>
+                                <th class="p-table__cell u-align--right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr data-ng-if="!generatedImages.length">
+                                <td colspan="6">
+                                    No images have been uploaded.
+                                </td>
+                            </tr>
+                            <tr class="p-table__row" data-ng-repeat="image in generatedImages | orderBy:['-title', 'arch']" data-ng-class="{ 'is-active': isShowingDeleteConfirm(image)}">
+                                <td aria-label="Release" class="p-table__cell">
+                                    <i class="{$ image.icon $}"></i>
+                                    {$ image.title $}
+                                </td>
+                                <td aria-label="Architecture" class="p-table__cell">{$ image.arch $}</td>
+                                <td aria-label="Size" class="p-table__cell">{$ image.size $}</td>
+                                <td aria-label="Status" class="p-table__cell">{$ image.status $}</td>
+                                <td class="p-table__cell u-align--right">
+                                    <button class="p-button--negative" aria-label="Remove" data-ng-if="isSuperUser()" data-ng-click="quickRemove(image)">Remove image</button>
+                                </td>
+                                <td class="p-table-expanding__panel col-12" data-ng-if="isShowingDeleteConfirm(image)">
+                                    <h2 data-ng-click="cancelRemove()" class="u-float--left p-heading--four">Remove image</h2>
+                                    <p><i class="p-icon--warning">Warning: </i> Are you sure you want to remove this image?</p>
+                                    <div class="u-float--right">
+                                        <a class="p-button--neutral is-inline" type="button" data-ng-click="cancelRemove()">Cancel</a>
+                                        <button class="p-button--negative" data-ng-click="confirmRemove(image)">Remove</button>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Custom images -->
+    <div data-ng-if="design === 'page' && customImages.length">
+        <!-- Custom images table -->
+        <div class="p-strip is-shallow">
+            <div class="row">
+                <div class="col-12">
+                    <h2 class="p-heading--four">Custom Images</h2>
+                    <table class="p-table-expanding p-table--images">
+                        <thead>
+                            <tr class="p-table__row">
+                                <th class="p-table__cell">Release</th>
+                                <th class="p-table__cell">Architecture</th>
+                                <th class="p-table__cell">Size</th>
+                                <th class="p-table__cell">Status</th>
+                                <th class="p-table__cell">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr data-ng-if="!customImages.length">
+                                <td colspan="6">
+                                    No images have been uploaded.
+                                </td>
+                            </tr>
+                            <tr class="p-table__row" data-ng-repeat="image in customImages | orderBy:['-title', 'arch']" data-ng-class="{ 'is-active': isShowingDeleteConfirm(image)}">
+                                <td aria-label="Release" class="p-table__cell">
+                                    <i class="{$ image.icon $}"></i>
+                                    {$ image.title $}
+                                </td>
+                                <td aria-label="Architecture" class="p-table__cell">{$ image.arch $}</td>
+                                <td aria-label="Size" class="p-table__cell">{$ image.size $}</td>
+                                <td aria-label="Status" class="p-table__cell">{$ image.status $}</td>
+                                <td class="p-table__cell u-align--right">
+                                    <a aria-label="Remove" data-ng-if="isSuperUser()" data-ng-click="toggleMenu(); quickRemove(image)">Remove image</a>
+                                </td>
+                                <td class="p-table-expanding__panel col-12" data-ng-if="isShowingDeleteConfirm(image)">
+                                    <h2 class="p-heading--four" data-ng-click="cancelRemove()">Remove image</h2>
+                                    <p><i class="p-icon--warning">Warning: </i> Are you sure you want to remove this image?</p>
+                                    <button class="p-button--neutral is-inline" type="button" data-ng-click="cancelRemove()">Cancel</button>
+                                    <button class="p-button--negative is-inline" data-ng-click="confirmRemove(image)">Remove</button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>
 </div>
-<div class="row" data-ng-if="design === 'page' && generatedImages.length">
-    <div class="wrapper--inner">
-        <h2 class="p-heading--four">Generated Images</h2>
-        <table class="p-table-expanding p-table--images">
-            <thead>
-                <tr class="p-table__row">
-                    <th class="p-table__cell">Release</th>
-                    <th class="p-table__cell">Architecture</th>
-                    <th class="p-table__cell">Size</th>
-                    <th class="p-table__cell">Status</th>
-                    <th class="p-table__cell u-align--right">Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr data-ng-if="!generatedImages.length">
-                    <td colspan="6">
-                        No images have been uploaded.
-                    </td>
-                </tr>
-                <tr class="p-table__row" data-ng-repeat="image in generatedImages | orderBy:['-title', 'arch']" data-ng-class="{ 'is-active': isShowingDeleteConfirm(image)}">
-                    <td aria-label="Release" class="p-table__cell">
-                        <i class="{$ image.icon $}"></i>
-                        {$ image.title $}
-                    </td>
-                    <td aria-label="Architecture" class="p-table__cell">{$ image.arch $}</td>
-                    <td aria-label="Size" class="p-table__cell">{$ image.size $}</td>
-                    <td aria-label="Status" class="p-table__cell">{$ image.status $}</td>
-                    <td class="p-table__cell u-align--right">
-                        <button class="p-button--negative" aria-label="Remove" data-ng-if="isSuperUser()" data-ng-click="quickRemove(image)">Remove image</button>
-                    </td>
-                    <td class="p-table-expanding__panel col-12" data-ng-if="isShowingDeleteConfirm(image)">
-                        <h2 data-ng-click="cancelRemove()" class="u-float--left p-heading--four">Remove image</h2>
-                        <p><i class="p-icon--warning">Warning: </i> Are you sure you want to remove this image?</p>
-                        <div class="u-float--right">
-                            <a class="p-button--neutral is-inline" type="button" data-ng-click="cancelRemove()">Cancel</a>
-                            <button class="p-button--negative" data-ng-click="confirmRemove(image)">Remove</button>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
-<div data-ng-if="design === 'page' && customImages.length" data-ng-class="{'p-strip': design === 'page'}">
-    <div class="row">
-        <h2 class="p-heading--four">Custom Images</h2>
-        <table class="p-table-expanding p-table--images">
-            <thead>
-                <tr class="p-table__row">
-                    <th class="p-table__cell">Release</th>
-                    <th class="p-table__cell">Architecture</th>
-                    <th class="p-table__cell">Size</th>
-                    <th class="p-table__cell">Status</th>
-                    <th class="p-table__cell">Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr data-ng-if="!customImages.length">
-                    <td colspan="6">
-                        No images have been uploaded.
-                    </td>
-                </tr>
-                <tr class="p-table__row" data-ng-repeat="image in customImages | orderBy:['-title', 'arch']" data-ng-class="{ 'is-active': isShowingDeleteConfirm(image)}">
-                    <td aria-label="Release" class="p-table__cell">
-                        <i class="{$ image.icon $}"></i>
-                        {$ image.title $}
-                    </td>
-                    <td aria-label="Architecture" class="p-table__cell">{$ image.arch $}</td>
-                    <td aria-label="Size" class="p-table__cell">{$ image.size $}</td>
-                    <td aria-label="Status" class="p-table__cell">{$ image.status $}</td>
-                    <td class="p-table__cell u-align--right">
-                        <a aria-label="Remove" data-ng-if="isSuperUser()" data-ng-click="toggleMenu(); quickRemove(image)">Remove image</a>
-                    </td>
-                    <td class="p-table-expanding__panel col-12" data-ng-if="isShowingDeleteConfirm(image)">
-                        <h2 class="p-heading--four" data-ng-click="cancelRemove()">Remove image</h2>
-                        <p><i class="p-icon--warning">Warning: </i> Are you sure you want to remove this image?</p>
-                        <button class="p-button--neutral is-inline" type="button" data-ng-click="cancelRemove()">Cancel</button>
-                        <button class="p-button--negative is-inline" data-ng-click="confirmRemove(image)">Remove</button>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-</div>
+

--- a/legacy/src/app/partials/intro-user.html
+++ b/legacy/src/app/partials/intro-user.html
@@ -2,10 +2,10 @@
     <div class="row">
         <div class="p-card--highlighted">
             <div class="p-card__content u-no-margin--top">
-                <h2 class="p-card__title p-heading--four">
+                <h4 class="p-card__title">
                     <i data-ng-class="{'p-icon--success': canContinue(), 'p-icon--success-muted': !canContinue()}"></i>
                     SSH keys for {$ user.username $}
-                </h2>
+                </h4>
                 <hr />
                 <p>Add multiple keys from Launchpad and Github or enter them manually.</p>
                 <h3 class="p-heading--four">Keys</h3>

--- a/legacy/src/app/partials/intro.html
+++ b/legacy/src/app/partials/intro.html
@@ -2,10 +2,10 @@
     <div class="row">
         <div class="col-12">
             <div class="p-card--highlighted">
-                <h2 class="p-card__title p-heading--four">
+                <h4 class="p-card__title">
                     <i data-ng-class="{ 'p-icon--success': !welcomeInError(), 'p-icon--error': welcomeInError() }"></i>
                     Welcome to MAAS
-                </h2>
+                </h4>
                 <hr />
                 <div class="p-card__content">
                     <maas-obj-form obj="maasName" manager="configManager" class="p-form p-form--stacked">
@@ -18,9 +18,9 @@
     <div class="row">
         <div class="col-12">
             <div class="p-card--highlighted">
-                <h2 class="p-card__title p-heading--four">
+                <h4 class="p-card__title">
                     <i data-ng-class="{ 'p-icon--success': !networkInError(), 'p-icon--error': networkInError() }"></i>&nbsp;Connectivity
-                </h2>
+                </h4>
                 <hr />
                 <ul class="p-card__content p-list">
                     <li>


### PR DESCRIPTION
##  Done
- Updated images page to allow selecting architectures on a per-release basis. Originally, selecting releases and architectures would download every possible combination.
- Disable release/arch combinations that are unsupported.
- Rearranged markup in boot_images.html to make a bit more sense.

## QA
- Run a local MAAS using [this branch](https://code.launchpad.net/~ltrager/maas/+git/maas/+merge/385331), which updates the websocket handler to allow for per-release selections.
- Go to /MAAS/l/images and check that you can select architectures per release, and the table below displays the summary correctly.
- Check that 20.04/i386 is disabled with a tooltip.
- Click "Save selection" and check that the downloads start correctly.
- Check that once the downloads are complete you can also remove them correctly.

## Fixes
Fixes #1159
Fixes canonical-web-and-design/maas-design#910

## Launchpad Issue
[lp#1877585](https://bugs.launchpad.net/maas/+bug/1877585)

## Screenshot
![0 0 0 0_8400_MAAS_l_intro_user](https://user-images.githubusercontent.com/25733845/84233733-3ee4ff00-ab36-11ea-86a9-09f9c9876cd1.png)

