### PR TITLE
Fix form card column sizes.

### DIFF
--- a/ui/src/app/base/components/FormCard/FormCard.js
+++ b/ui/src/app/base/components/FormCard/FormCard.js
@@ -2,7 +2,10 @@ import { Card, Col, Row } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { COL_SIZES } from "app/base/constants";
+
 export const FormCard = ({ children, sidebar = true, stacked, title }) => {
+  const { CARD_TITLE, SIDEBAR, TOTAL } = COL_SIZES;
   const titleNode = <h4 className="form-card__title">{title}</h4>;
   const content = stacked ? (
     <>
@@ -11,8 +14,10 @@ export const FormCard = ({ children, sidebar = true, stacked, title }) => {
     </>
   ) : (
     <Row>
-      <Col size="2">{titleNode}</Col>
-      <Col size={sidebar ? "8" : "10"}>{children}</Col>
+      <Col size={CARD_TITLE}>{titleNode}</Col>
+      <Col size={sidebar ? TOTAL - SIDEBAR - CARD_TITLE : TOTAL - CARD_TITLE}>
+        {children}
+      </Col>
     </Row>
   );
   return (

--- a/ui/src/app/base/components/FormCard/FormCard.test.js
+++ b/ui/src/app/base/components/FormCard/FormCard.test.js
@@ -19,7 +19,7 @@ describe("FormCard ", () => {
       <FormCard sidebar={false} title="Add user" />
     );
     const withSidebar = shallow(<FormCard sidebar title="Add user" />);
-    expect(withoutSidebar.find("Col").at(1).props().size).toBe("10");
-    expect(withSidebar.find("Col").at(1).props().size).toBe("8");
+    expect(withoutSidebar.find("Col").at(1).props().size).toBe(10);
+    expect(withSidebar.find("Col").at(1).props().size).toBe(7);
   });
 });

--- a/ui/src/app/base/components/FormCard/__snapshots__/FormCard.test.js.snap
+++ b/ui/src/app/base/components/FormCard/__snapshots__/FormCard.test.js.snap
@@ -7,7 +7,7 @@ exports[`FormCard  renders 1`] = `
 >
   <Row>
     <Col
-      size="2"
+      size={2}
     >
       <h4
         className="form-card__title"
@@ -16,7 +16,7 @@ exports[`FormCard  renders 1`] = `
       </h4>
     </Col>
     <Col
-      size="8"
+      size={7}
     />
   </Row>
 </Card>

--- a/ui/src/app/base/components/Section/Section.js
+++ b/ui/src/app/base/components/Section/Section.js
@@ -3,9 +3,11 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { COL_SIZES } from "app/base/constants";
 import NotificationList from "app/base/components/NotificationList";
 
 const Section = ({ children, headerClassName, sidebar, title }) => {
+  const { SIDEBAR, TOTAL } = COL_SIZES;
   return (
     <div className="section">
       <Strip
@@ -26,11 +28,14 @@ const Section = ({ children, headerClassName, sidebar, title }) => {
         shallow
       >
         {sidebar && (
-          <Col element="aside" size="3" className="section__sidebar">
+          <Col element="aside" size={SIDEBAR} className="section__sidebar">
             {sidebar}
           </Col>
         )}
-        <Col size={sidebar ? 9 : 12} className="section__content">
+        <Col
+          size={sidebar ? TOTAL - SIDEBAR : TOTAL}
+          className="section__content"
+        >
           <NotificationList />
           {children}
         </Col>

--- a/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
+++ b/ui/src/app/base/components/Section/__snapshots__/Section.test.js.snap
@@ -24,7 +24,7 @@ exports[`Section renders 1`] = `
     <Col
       className="section__sidebar"
       element="aside"
-      size="3"
+      size={3}
     >
       <div>
         Sidebar

--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.js
@@ -2,6 +2,8 @@ import { Button, Col, Row } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { COL_SIZES } from "app/base/constants";
+
 const TableDeleteConfirm = ({
   sidebar = true,
   message,
@@ -10,9 +12,16 @@ const TableDeleteConfirm = ({
   onCancel,
   onConfirm,
 }) => {
+  const { DELETE_ROW_BUTTONS, SIDEBAR, TOTAL } = COL_SIZES;
   return (
     <Row>
-      <Col size={sidebar ? "6" : "9"}>
+      <Col
+        size={
+          sidebar
+            ? TOTAL - SIDEBAR - DELETE_ROW_BUTTONS
+            : TOTAL - DELETE_ROW_BUTTONS
+        }
+      >
         <p className="u-no-margin--bottom u-no-max-width">
           {message ||
             `Are you sure you want to delete ${modelType} "${modelName}"?`}{" "}
@@ -21,7 +30,7 @@ const TableDeleteConfirm = ({
           </span>
         </p>
       </Col>
-      <Col size="3" className="u-align--right">
+      <Col size={DELETE_ROW_BUTTONS} className="u-align--right">
         <Button className="u-no-margin--bottom" onClick={onCancel}>
           Cancel
         </Button>

--- a/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
+++ b/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TableDeleteConfirm renders 1`] = `
 <Row>
   <Col
-    size="6"
+    size={5}
   >
     <p
       className="u-no-margin--bottom u-no-max-width"
@@ -19,7 +19,7 @@ exports[`TableDeleteConfirm renders 1`] = `
   </Col>
   <Col
     className="u-align--right"
-    size="3"
+    size={4}
   >
     <Button
       className="u-no-margin--bottom"

--- a/ui/src/app/base/constants.js
+++ b/ui/src/app/base/constants.js
@@ -1,10 +1,20 @@
 /**
  * Message types defined by MAAS websocket API
  */
-const MESSAGE_TYPES = {
+export const MESSAGE_TYPES = {
   REQUEST: 0,
   RESPONSE: 1,
   NOTIFY: 2,
+};
+
+/**
+ * Common column sizes used in <Col> components
+ */
+export const COL_SIZES = {
+  CARD_TITLE: 2,
+  DELETE_ROW_BUTTONS: 4,
+  SIDEBAR: 3,
+  TOTAL: 12,
 };
 
 export default MESSAGE_TYPES;

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -9,7 +9,7 @@ import {
   race,
 } from "redux-saga/effects";
 
-import MESSAGE_TYPES from "app/base/constants";
+import { MESSAGE_TYPES } from "app/base/constants";
 
 let loadedModels = [];
 

--- a/ui/src/app/settings/views/Dhcp/DhcpFormFields/DhcpFormFields.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpFormFields/DhcpFormFields.js
@@ -1,8 +1,6 @@
 import {
-  Col,
   Spinner,
   Notification,
-  Row,
   Select,
   Textarea,
 } from "@canonical/react-components";
@@ -76,52 +74,46 @@ export const DhcpFormFields = ({ editing }) => {
           This snippet is disabled and will not be used by MAAS.
         </Notification>
       )}
-      <Row>
-        <Col size="4">
-          <FormikField
-            name="name"
-            label="Snippet name"
-            required={true}
-            type="text"
-          />
-          <FormikField name="enabled" label="Enabled" type="checkbox" />
-          <FormikField
-            component={Textarea}
-            name="description"
-            label="Description"
-          />
-        </Col>
-        <Col size="4">
+      <FormikField
+        name="name"
+        label="Snippet name"
+        required={true}
+        type="text"
+      />
+      <FormikField name="enabled" label="Enabled" type="checkbox" />
+      <FormikField
+        component={Textarea}
+        name="description"
+        label="Description"
+      />
+      <FormikField
+        component={Select}
+        name="type"
+        label="Type"
+        onChange={(e) => {
+          formikProps.handleChange(e);
+          formikProps.setFieldValue("entity", "");
+          formikProps.setFieldTouched("entity", false, false);
+        }}
+        options={[
+          { value: "", label: "Global" },
+          { value: "subnet", label: "Subnet" },
+          { value: "controller", label: "Controller" },
+          { value: "machine", label: "Machine" },
+          { value: "device", label: "Device" },
+        ]}
+      />
+      {type &&
+        (isLoading || !hasLoaded ? (
+          <Spinner text="loading..." />
+        ) : (
           <FormikField
             component={Select}
-            name="type"
-            label="Type"
-            onChange={(e) => {
-              formikProps.handleChange(e);
-              formikProps.setFieldValue("entity", "");
-              formikProps.setFieldTouched("entity", false, false);
-            }}
-            options={[
-              { value: "", label: "Global" },
-              { value: "subnet", label: "Subnet" },
-              { value: "controller", label: "Controller" },
-              { value: "machine", label: "Machine" },
-              { value: "device", label: "Device" },
-            ]}
+            name="entity"
+            label="Applies to"
+            options={generateOptions(type, models)}
           />
-          {type &&
-            (isLoading || !hasLoaded ? (
-              <Spinner text="loading..." />
-            ) : (
-              <FormikField
-                component={Select}
-                name="entity"
-                label="Applies to"
-                options={generateOptions(type, models)}
-              />
-            ))}
-        </Col>
-      </Row>
+        ))}
       <FormikField
         component={Textarea}
         name="value"


### PR DESCRIPTION
## Done
- Fixed col sizes in form cards.
- Put col sizes into a constants file so we hopefully don't get regressions like this again. Ideally we should be using these constants wherever we have a Col component but for now I've just used them wherever a sidebar might be present.

## QA
- Go to settings, see that the add user form card and delete user expanded rows look good.

## Fixes
Fixes canonical-web-and-design/maas-design#907

## Screenshot
![0 0 0 0_8400_MAAS_r_settings_users](https://user-images.githubusercontent.com/25733845/84240383-48279900-ab41-11ea-83cd-67d9994eb32e.png)

Also updated DHCP snippets form:
![2020-06-10_18-59](https://user-images.githubusercontent.com/25733845/84248256-88404900-ab4c-11ea-9365-d2981e51e330.png)

