### PR TITLE
Reconnect to an existing websocket in the legacy app

### DIFF
--- a/legacy/src/app/bootstrap.js
+++ b/legacy/src/app/bootstrap.js
@@ -33,7 +33,7 @@ const buildUrl = () => {
 const setupWebsocket = () => {
   return new Promise((resolve, reject) => {
     let config = {};
-    const webSocket = new WebSocket(buildUrl());
+    window.legacyWS = new WebSocket(buildUrl());
 
     const sendMsg = (id, method) => {
       var msg = {
@@ -42,11 +42,11 @@ const setupWebsocket = () => {
         method,
       };
 
-      webSocket.send(JSON.stringify(msg));
+      window.legacyWS.send(JSON.stringify(msg));
     };
 
     const messagesReceived = [];
-    webSocket.onmessage = (event) => {
+    window.legacyWS.onmessage = (event) => {
       const msg = JSON.parse(event.data);
 
       switch (msg.request_id) {
@@ -93,19 +93,18 @@ const setupWebsocket = () => {
       }
       if (messagesReceived.length === 4) {
         window.CONFIG = config;
-        webSocket.close();
         resolve(config);
       }
     };
 
-    webSocket.onopen = () => {
+    window.legacyWS.onopen = () => {
       sendMsg(1, "user.auth_user");
       sendMsg(2, "config.list");
       sendMsg(3, "general.version");
       sendMsg(4, "general.navigation_options");
     };
 
-    webSocket.onerror = (err) => reject(err);
+    window.legacyWS.onerror = (err) => reject(err);
   });
 };
 

--- a/legacy/src/app/controllers/tests/test_add_device.js
+++ b/legacy/src/app/controllers/tests/test_add_device.js
@@ -35,7 +35,7 @@ describe("AddDeviceController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create the parent scope and the scope for the controller.

--- a/legacy/src/app/controllers/tests/test_add_domain.js
+++ b/legacy/src/app/controllers/tests/test_add_domain.js
@@ -32,7 +32,7 @@ describe("AddDomainController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create the parent scope and the scope for the controller.

--- a/legacy/src/app/controllers/tests/test_add_hardware.js
+++ b/legacy/src/app/controllers/tests/test_add_hardware.js
@@ -41,7 +41,7 @@ describe("AddHardwareController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create the parent scope and the scope for the controller.

--- a/legacy/src/app/controllers/tests/test_dashboard.js
+++ b/legacy/src/app/controllers/tests/test_dashboard.js
@@ -43,7 +43,7 @@ describe("DashboardController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_domain_details.js
+++ b/legacy/src/app/controllers/tests/test_domain_details.js
@@ -47,7 +47,7 @@ describe("DomainDetailsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_domains_list.js
+++ b/legacy/src/app/controllers/tests/test_domains_list.js
@@ -33,7 +33,7 @@ describe("DomainsListController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_fabric_details.js
+++ b/legacy/src/app/controllers/tests/test_fabric_details.js
@@ -51,7 +51,7 @@ describe("FabricDetailsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_images.js
+++ b/legacy/src/app/controllers/tests/test_images.js
@@ -32,7 +32,7 @@ describe("ImagesController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_networks_list.js
+++ b/legacy/src/app/controllers/tests/test_networks_list.js
@@ -37,7 +37,7 @@ describe("NetworksListController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -75,7 +75,7 @@ describe("NodeDetailsController", function () {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_node_details_networking.js
+++ b/legacy/src/app/controllers/tests/test_node_details_networking.js
@@ -524,7 +524,7 @@ describe("NodeNetworkingController", function() {
     RegionConnection = $injector.get("RegionConnection");
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_node_details_storage.js
+++ b/legacy/src/app/controllers/tests/test_node_details_storage.js
@@ -5037,7 +5037,7 @@ describe("NodeStorageController", function() {
 
       // Mock buildSocket so an actual connection is not made.
       webSocket = new MockWebSocket();
-      spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+      spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     }));
 
     it("false when status is Ready", function() {

--- a/legacy/src/app/controllers/tests/test_node_events.js
+++ b/legacy/src/app/controllers/tests/test_node_events.js
@@ -36,7 +36,7 @@ describe("NodeEventsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_node_result.js
+++ b/legacy/src/app/controllers/tests/test_node_result.js
@@ -37,7 +37,7 @@ describe("NodeResultController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_node_results.js
+++ b/legacy/src/app/controllers/tests/test_node_results.js
@@ -59,7 +59,7 @@ describe("NodeResultsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Make a fake node.

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -74,7 +74,7 @@ describe("NodesListController", function() {
     RegionConnection = $injector.get("RegionConnection");
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_pod_details.js
+++ b/legacy/src/app/controllers/tests/test_pod_details.js
@@ -50,7 +50,7 @@ describe("PodDetailsController", function() {
     RegionConnection = $injector.get("RegionConnection");
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_pods_list.js
+++ b/legacy/src/app/controllers/tests/test_pods_list.js
@@ -49,7 +49,7 @@ describe("PodsListController", function () {
     RegionConnection = $injector.get("RegionConnection");
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_settings.js
+++ b/legacy/src/app/controllers/tests/test_settings.js
@@ -39,7 +39,7 @@ describe("SettingsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_subnet_details.js
+++ b/legacy/src/app/controllers/tests/test_subnet_details.js
@@ -84,7 +84,7 @@ describe("SubnetDetailsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_vlan_details.js
+++ b/legacy/src/app/controllers/tests/test_vlan_details.js
@@ -125,7 +125,7 @@ describe("VLANDetailsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_zone_details.js
+++ b/legacy/src/app/controllers/tests/test_zone_details.js
@@ -45,7 +45,7 @@ describe("ZoneDetailsController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/controllers/tests/test_zones_list.js
+++ b/legacy/src/app/controllers/tests/test_zones_list.js
@@ -32,7 +32,7 @@ describe("ZonesListController", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
     spyOn(RegionConnection, "callMethod").and.returnValue($q.defer().promise);
   }));
 

--- a/legacy/src/app/directives/tests/test_boot_images.js
+++ b/legacy/src/app/directives/tests/test_boot_images.js
@@ -30,7 +30,7 @@ describe("maasBootImages", function() {
     // Mock buildSocket so an actual connection is not made.
     let RegionConnection = $injector.get("RegionConnection");
     let webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create a new scope before each test.

--- a/legacy/src/app/directives/tests/test_ipranges.js
+++ b/legacy/src/app/directives/tests/test_ipranges.js
@@ -29,7 +29,7 @@ describe("maasIPRanges", function() {
     // Mock buildSocket so an actual connection is not made.
     let RegionConnection = $injector.get("RegionConnection");
     let webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create a new scope before each test.

--- a/legacy/src/app/directives/tests/test_notifications.js
+++ b/legacy/src/app/directives/tests/test_notifications.js
@@ -74,7 +74,7 @@ describe("maasNotifications", function() {
     // Mock buildSocket so an actual connection is not made.
     let RegionConnection = $injector.get("RegionConnection");
     let webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   describe("maas-notifications", function() {

--- a/legacy/src/app/directives/tests/test_pod_parameters.js
+++ b/legacy/src/app/directives/tests/test_pod_parameters.js
@@ -18,7 +18,7 @@ describe("maasPodParameters", function() {
     // Mock buildSocket so an actual connection is not made.
     let RegionConnection = $injector.get("RegionConnection");
     let webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create a new scope before each test.

--- a/legacy/src/app/directives/tests/test_release_options.js
+++ b/legacy/src/app/directives/tests/test_release_options.js
@@ -24,7 +24,7 @@ describe("maasReleaseOptions", function() {
     // Mock buildSocket so an actual connection is not made.
     let RegionConnection = $injector.get("RegionConnection");
     let webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create a new scope before each test.

--- a/legacy/src/app/directives/tests/test_script_select.js
+++ b/legacy/src/app/directives/tests/test_script_select.js
@@ -36,7 +36,7 @@ describe("maasScriptSelect", function() {
     RegionConnection = $injector.get("RegionConnection");
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   function makeScript(script_type, tags, for_hardware) {

--- a/legacy/src/app/directives/tests/test_ssh_keys.js
+++ b/legacy/src/app/directives/tests/test_ssh_keys.js
@@ -30,7 +30,7 @@ describe("maasSshKeys", function() {
     // Mock buildSocket so an actual connection is not made.
     let RegionConnection = $injector.get("RegionConnection");
     let webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create a new scope before each test.

--- a/legacy/src/app/directives/tests/test_version_reloader.js
+++ b/legacy/src/app/directives/tests/test_version_reloader.js
@@ -28,7 +28,7 @@ describe("maasVersionReloader", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Create a new scope before each test.

--- a/legacy/src/app/factories/tests/test_bootresources.js
+++ b/legacy/src/app/factories/tests/test_bootresources.js
@@ -28,7 +28,7 @@ describe("BootResourcesManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   it("sets initial values", function() {

--- a/legacy/src/app/factories/tests/test_controllers.js
+++ b/legacy/src/app/factories/tests/test_controllers.js
@@ -20,15 +20,12 @@ describe("ControllersManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a random controller.

--- a/legacy/src/app/factories/tests/test_devices.js
+++ b/legacy/src/app/factories/tests/test_devices.js
@@ -20,15 +20,12 @@ describe("DevicesManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a random device.

--- a/legacy/src/app/factories/tests/test_dhcpsnippets.js
+++ b/legacy/src/app/factories/tests/test_dhcpsnippets.js
@@ -20,15 +20,12 @@ describe("DHCPSnippetsManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a random snippet.

--- a/legacy/src/app/factories/tests/test_general.js
+++ b/legacy/src/app/factories/tests/test_general.js
@@ -27,17 +27,14 @@ describe("GeneralManager", function() {
     RegionConnection = $injector.get("RegionConnection");
     ErrorService = $injector.get("ErrorService");
 
-    // Mock buildSocket so an actual connection is not made.
+    // Mock getWebSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   it("sets timeout values", function() {

--- a/legacy/src/app/factories/tests/test_machines.js
+++ b/legacy/src/app/factories/tests/test_machines.js
@@ -20,15 +20,12 @@ describe("MachinesManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   it("sanity check", function() {

--- a/legacy/src/app/factories/tests/test_node_results.js
+++ b/legacy/src/app/factories/tests/test_node_results.js
@@ -26,15 +26,12 @@ describe("NodeResultsManagerFactory", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a random node.

--- a/legacy/src/app/factories/tests/test_nodes.js
+++ b/legacy/src/app/factories/tests/test_nodes.js
@@ -20,17 +20,14 @@ describe("NodesManager", function() {
     RegionConnection = $injector.get("RegionConnection");
     $log = $injector.get("$log");
 
-    // Mock buildSocket so an actual connection is not made.
+    // Mock getWebSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a random machine.

--- a/legacy/src/app/factories/tests/test_packagerepositories.js
+++ b/legacy/src/app/factories/tests/test_packagerepositories.js
@@ -20,15 +20,12 @@ describe("PackageRepositoriesManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a random repo.

--- a/legacy/src/app/factories/tests/test_pods.js
+++ b/legacy/src/app/factories/tests/test_pods.js
@@ -18,17 +18,14 @@ describe("PodsManager", function() {
     PodsManager = $injector.get("PodsManager");
     RegionConnection = $injector.get("RegionConnection");
 
-    // Mock buildSocket so an actual connection is not made.
+    // Mock getWebSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a fake pod.

--- a/legacy/src/app/factories/tests/test_switches.js
+++ b/legacy/src/app/factories/tests/test_switches.js
@@ -20,15 +20,12 @@ describe("SwitchesManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Make a random device.

--- a/legacy/src/app/services/tests/test_manager.js
+++ b/legacy/src/app/services/tests/test_manager.js
@@ -49,17 +49,14 @@ describe("Manager", function() {
     FakeNodesManager.prototype = new Manager();
     NodesManager = new FakeNodesManager();
 
-    // Mock buildSocket so an actual connection is not made.
+    // Mock getWebSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   // Copy node and remove $selected field.
@@ -753,7 +750,7 @@ describe("Manager", function() {
         expect(NodesManager._activeItem).toBeNull();
         done();
       });
-      $timeout.flush();
+      $timeout.flush(1000);
     });
 
     it("sets _activeItem to item", function(done) {

--- a/legacy/src/app/services/tests/test_pollingmanager.js
+++ b/legacy/src/app/services/tests/test_pollingmanager.js
@@ -43,15 +43,12 @@ describe("PollingManager", function() {
 
     // Mock buildSocket so an actual connection is not made.
     webSocket = new MockWebSocket();
-    spyOn(RegionConnection, "buildSocket").and.returnValue(webSocket);
+    spyOn(RegionConnection, "getWebSocket").and.returnValue(webSocket);
   }));
 
   // Open the connection to the region before each test.
   beforeEach(function(done) {
-    RegionConnection.registerHandler("open", function() {
-      done();
-    });
-    RegionConnection.connect("");
+    RegionConnection.connect(() => done());
   });
 
   afterAll(() => {

--- a/ui/src/websocket-client.js
+++ b/ui/src/websocket-client.js
@@ -21,7 +21,7 @@ class WebSocketClient {
     }
     const { hostname, port } = window.location;
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    return `${protocol}//${hostname}:${port}/MAAS/ws?csrftoken=${csrftoken}`;
+    return `${protocol}//${hostname}:${port}${process.env.REACT_APP_BASENAME}/ws?csrftoken=${csrftoken}`;
   }
 
   /**


### PR DESCRIPTION
## Done
- Reconnect to an existing websocket in the legacy app.
- Share the websocket between the bootstrap and region modules.

## QA
- Load a legacy page with the network details open in the dev tools.
- Switch between the react and angular clients a few times.
- The app should not reopen a websocket for the legacy client and you should only end up with two websocket connections.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1203.
See: https://github.com/canonical-web-and-design/maas-ui/issues/1211
