### PR TITLE
Clear the redux store when disconnected

### DIFF
--- a/ui/src/app/base/reducers/user/user.js
+++ b/ui/src/app/base/reducers/user/user.js
@@ -2,7 +2,7 @@ import { createStandardReducer } from "app/utils/redux";
 
 import { user as userActions } from "app/base/actions";
 
-const initialState = {
+export const initialState = {
   auth: {},
   errors: {},
   items: [],

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -230,6 +230,7 @@ export function* handleMessage(socketChannel, socketClient) {
       yield put({ type: "WEBSOCKET_DISCONNECTED" });
     } else if (response.type === "open") {
       yield put({ type: "WEBSOCKET_CONNECTED" });
+      resetLoaded();
     } else {
       // This is a response message, fetch the corresponding action for the
       // message that was sent.

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -26,6 +26,7 @@ import {
   zone,
 } from "./app/base/reducers";
 import { config } from "./app/settings/reducers";
+import { initialState as userInitialState } from "./app/base/reducers/user/user";
 import { token, sshkey, sslkey } from "./app/preferences/reducers";
 
 const createAppReducer = (history) =>
@@ -63,6 +64,23 @@ const createRootReducer = (history) => (state, action) => {
       // Status reducer defaults to authenticating = true to stop login screen
       // flashing. It's overwritten here otherwise app is stuck loading.
       { status: { authenticating: false } },
+      action
+    );
+  } else if (
+    [
+      "WEBSOCKET_ERROR",
+      "WEBSOCKET_DISCONNECTED",
+      "CHECK_AUTHENTICATED_ERROR",
+    ].includes(action.type)
+  ) {
+    return createAppReducer(history)(
+      {
+        status: state.status,
+        user: {
+          ...userInitialState,
+          auth: state.user.auth,
+        },
+      },
       action
     );
   }

--- a/ui/src/root-reducer.test.js
+++ b/ui/src/root-reducer.test.js
@@ -13,4 +13,27 @@ describe("rootReducer", () => {
     expect(newState.status.authenticating).toBe(false);
     expect(newState).toMatchSnapshot();
   });
+
+  it("it should clear the state when disconnected from the websocket", () => {
+    const initialState = {
+      machine: {
+        items: [1, 2, 3],
+      },
+      status: { authenticating: true },
+      user: {
+        items: [1, 2, 3],
+        auth: {
+          user: { id: 1 },
+        },
+      },
+    };
+    const newState = createRootReducer({})(initialState, {
+      type: "WEBSOCKET_DISCONNECTED",
+    });
+
+    expect(newState.machine.items.length).toBe(0);
+    expect(newState.status.authenticating).toBe(true);
+    expect(newState.user.items.length).toBe(0);
+    expect(newState.user.auth.user).toStrictEqual({ id: 1 });
+  });
 });


### PR DESCRIPTION
## Done
- Clear the redux store when the websocket gets disconnected.

## QA
- Load the react ui.
- Restart your maas server.
- the ui should reconnect and the data in the redux store should be reset (except for auth and status).

## Fixes
See: https://github.com/canonical-web-and-design/maas-ui/issues/1222.
See: https://github.com/canonical-web-and-design/maas-ui/issues/1211.