### PR TITLE
Close both websockets when logging out

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -4,7 +4,13 @@ import ReactDOM from "react-dom";
 import { Footer, Header } from "@maas-ui/maas-ui-shared";
 
 /* @ngInject */
-function MasterController($rootScope, $transitions, $window, $http, ErrorService) {
+function MasterController(
+  $rootScope,
+  $transitions,
+  $window,
+  $http,
+  ErrorService
+) {
   const debug = process.env.NODE_ENV === "development";
   const LOGOUT_API = `${process.env.BASENAME}/accounts/logout/`;
   $rootScope.legacyURLBase = `${process.env.BASENAME}${process.env.ANGULAR_BASENAME}`;
@@ -41,7 +47,7 @@ function MasterController($rootScope, $transitions, $window, $http, ErrorService
         logout={() => {
           localStorage.clear();
           $http.post(LOGOUT_API).then(() => {
-            $rootScope.navigateToNew("/");
+            window.location = `${process.env.BASENAME}${process.env.REACT_BASENAME}`;
           });
         }}
         newURLPrefix={process.env.REACT_BASENAME}

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -162,6 +162,9 @@ export const App = () => {
         logout={() => {
           dispatch(statusActions.websocketDisconnect());
           dispatch(statusActions.logout());
+          if (window.legacyWS) {
+            window.legacyWS.close();
+          }
         }}
         showRSD={navigationOptions.rsd}
         urlChange={history.listen}


### PR DESCRIPTION
## Done
- Close both websockets when logging out.

## QA
- Log into the app with the network details open in dev tools.
- Navigate to the ui and legacy apps and you should see two websocket connections.
- Log out from ui and both connections should get closed.
- Log in again and navigate to ui and legacy.
- Log out from legacy.
- You should log out and be redirected to the login screen and there should be no connections in the network tab.