### PR TITLE
Handle styling to legacy redirects

### DIFF
--- a/root/src/root-application.js
+++ b/root/src/root-application.js
@@ -13,6 +13,7 @@ const showLoading = () => {
 console.info(`${appName} ${appVersion} (${process.env.GIT_SHA}).`);
 
 window.addEventListener("single-spa:before-app-change", (evt) => {
+
   const {
     legacy = "NOT_MOUNTED",
     ui = "NOT_MOUNTED",
@@ -31,6 +32,11 @@ window.addEventListener("single-spa:before-app-change", (evt) => {
       legacyStylesheet.disabled = false;
     } else {
       legacyStylesheet.disabled = true;
+    }
+
+    // If both apps are not mounted, likely a result of a redirect to legacy.
+    if (legacy !== "MOUNTED" && ui !== "MOUNTED") {
+      legacyStylesheet.disabled = false;
     }
   }
 });


### PR DESCRIPTION
## Done
* If both apps do not load then it is likely a legacy redirect to a legacy view, therefore, load the legacy styles as a fallback. 

## QA
* I couldn't replicate from the UI alone so Adam is QA'ing

## Fixes
Fixes https://github.com/canonical-web-and-design/maas-ui/issues/1240

## Launchpad Issue
[lp1883132](https://bugs.launchpad.net/maas/+bug/1883132)
