### PR TITLE
Fix # redirects

### DIFF
--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -8,10 +8,10 @@
       <link rel="stylesheet" href="<%= file %>" />
     <% }); %>
     <% if (uiStylesheet) { %>
-      <link rel="stylesheet" href="<%= uiStylesheet %>" class="ui-stylesheet" />
+      <link rel="stylesheet" href="<%= uiStylesheet %>" class="ui-stylesheet" disabled="" />
     <% } %>
     <% if (legacyStylesheet) { %>
-      <link rel="stylesheet" href="<%= legacyStylesheet %>" class="legacy-stylesheet" />
+      <link rel="stylesheet" href="<%= legacyStylesheet %>" class="legacy-stylesheet" disabled="" />
     <% } %>
     <title>MAAS</title>
   </head>

--- a/root/src/root-application.js
+++ b/root/src/root-application.js
@@ -13,23 +13,20 @@ const showLoading = () => {
 console.info(`${appName} ${appVersion} (${process.env.GIT_SHA}).`);
 
 window.addEventListener("single-spa:before-app-change", (evt) => {
-  const {
-    legacy = "NOT_MOUNTED",
-    ui = "NOT_MOUNTED",
-  } = evt.detail.newAppStatuses;
+  const { legacy, ui } = evt.detail.newAppStatuses;
   const uiStylesheet = document.querySelector(".ui-stylesheet");
   const legacyStylesheet = document.querySelector(".legacy-stylesheet");
   if (uiStylesheet) {
     if (ui === "MOUNTED") {
       uiStylesheet.disabled = false;
-    } else {
+    } else if (ui === "NOT_MOUNTED") {
       uiStylesheet.disabled = true;
     }
   }
   if (legacyStylesheet) {
     if (legacy === "MOUNTED") {
       legacyStylesheet.disabled = false;
-    } else {
+    } else if (legacy === "NOT_MOUNTED") {
       legacyStylesheet.disabled = true;
     }
   }
@@ -53,7 +50,10 @@ registerApplication({
     showLoading();
     return import("@maas-ui/maas-ui");
   },
-  activeWhen: `${process.env.BASENAME}${process.env.REACT_BASENAME}`,
+  activeWhen: (location) =>
+    location.pathname.startsWith(
+      `${process.env.BASENAME}${process.env.REACT_BASENAME}`
+    ) && !location.hash.startsWith("#"),
 });
 
 start();


### PR DESCRIPTION
## Done
- Fix redirects that land at old legacy # urls

## QA
- Run `dotrun`, the app should load normally for the react/angular apps.
- In a local MAAS run the following:
```shell
git config --file=.gitmodules submodule.src/maasui/src.url https://github.com/huwshimi/maas-ui.git
git config --file=.gitmodules submodule.src/maasui/src.branch fix-hash-redirects
git submodule sync
git submodule update --init --recursive --remote
make clean-ui
make ui
```
You may have to use `SKIP_PREFLIGHT_CHECK=true make ui` like I did.
- Visit <url of your maas >/MAAS/#/kvm a few times **using Firefox**. You should get redirected to /l/kvm.

## Fixes
Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1240.

## Launchpad Issue
https://bugs.launchpad.net/maas/+bug/1883132
