### PR TITLE
Fix subnets hightlight

### DIFF
--- a/shared/src/components/Header/Header.js
+++ b/shared/src/components/Header/Header.js
@@ -65,7 +65,7 @@ export const Header = ({
       window.ga("set", "dimension2", uuid);
 
       const sendPageview = () => {
-        const path = window.location.pathname + window.location.hash;
+        const path = window.location.pathname + window.location.search;
         window.ga("send", "pageview", path);
       };
       if (rootScope) {
@@ -179,7 +179,7 @@ export const Header = ({
 
   const generateNavItems = (links) => {
     const hardwareLinks = links.filter((link) => link.inHardwareMenu);
-    const path = location.pathname + location.hash;
+    const path = location.pathname + location.search;
 
     const linkItems = links.map((link) => (
       <li
@@ -333,7 +333,7 @@ Header.propTypes = {
   enableAnalytics: PropTypes.bool,
   generateLocalLink: PropTypes.func,
   location: PropTypes.shape({
-    hash: PropTypes.string,
+    search: PropTypes.string,
     pathname: PropTypes.string.isRequired,
   }).isRequired,
   logout: PropTypes.func.isRequired,

--- a/shared/src/components/Header/Header.test.js
+++ b/shared/src/components/Header/Header.test.js
@@ -115,8 +115,7 @@ describe("Header", () => {
         basename="/MAAS"
         completedIntro={true}
         location={{
-          hash: "l/devices",
-          pathname: "/MAAS/",
+          pathname: "/MAAS/l/devices",
         }}
         logout={jest.fn()}
       />
@@ -124,5 +123,26 @@ describe("Header", () => {
     const selected = wrapper.find(".p-navigation__link.is-selected");
     expect(selected.exists()).toBe(true);
     expect(selected.text()).toEqual("Devices");
+  });
+
+  it("can highlight a url with a query param", () => {
+    const wrapper = shallow(
+      <Header
+        authUser={{
+          is_superuser: true,
+          username: "koala",
+        }}
+        basename="/MAAS"
+        completedIntro={true}
+        location={{
+          search: "?by=fabric",
+          pathname: "/MAAS/l/networks",
+        }}
+        logout={jest.fn()}
+      />
+    );
+    const selected = wrapper.find(".p-navigation__link.is-selected");
+    expect(selected.exists()).toBe(true);
+    expect(selected.text()).toEqual("Subnets");
   });
 });


### PR DESCRIPTION
## Done
- Highlight the subnets nav item.

## QA
- Click on the subnets item in the main nav, it should stay highlighted.
- Click on other items, they should still highlight.