### PR TITLE
Fix edit bond form not saving all values.

### DIFF
--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -154,6 +154,10 @@ export function filterSelectedInterfaces() {
 
       return (
         selectedInterfaces.indexOf(itemKey) === -1 &&
+        item.fabric &&
+        item.vlan &&
+        newBondInterface.fabric &&
+        newBondInterface.vlan &&
         item.fabric.name === newBondInterface.fabric.name &&
         item.vlan.id === newBondInterface.vlan.id
       );

--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -1851,7 +1851,7 @@ export function NodeNetworkingController(
         bond_xmit_hash_policy: "layer2",
         bond_updelay: 0,
         bond_downdelay: 0,
-        bond_miimon: 100
+        bond_miimon: 0,
       };
     }
   };

--- a/legacy/src/app/controllers/tests/test_node_details_networking.js
+++ b/legacy/src/app/controllers/tests/test_node_details_networking.js
@@ -3691,8 +3691,8 @@ describe("NodeNetworkingController", function() {
         fabric: "",
         vlan: {},
         subnet: "",
-        lacpRate: "fast",
-        xmitHashPolicy: "layer2",
+        bond_lacp_rate: "fast",
+        bond_xmit_hash_policy: "layer2",
         bond_updelay: 0,
         bond_downdelay: 0,
         bond_miimon: 100
@@ -3844,14 +3844,14 @@ describe("NodeNetworkingController", function() {
     it("returns true if policy is layer3+4", function() {
       makeController();
       $scope.newBondInterface.bond_mode = "802.3ad";
-      $scope.newBondInterface.xmitHashPolicy = "layer3+4";
+      $scope.newBondInterface.bond_xmit_hash_policy = "layer3+4";
       expect($scope.showLACPRate()).toBe(true);
     });
 
     it("returns true if policy is encap3+4", function() {
       makeController();
       $scope.newBondInterface.bond_mode = "802.3ad";
-      $scope.newBondInterface.xmitHashPolicy = "encap3+4";
+      $scope.newBondInterface.bond_xmit_hash_policy = "encap3+4";
       expect($scope.showLACPRate()).toBe(true);
     });
 
@@ -3862,7 +3862,7 @@ describe("NodeNetworkingController", function() {
         link_id: -1
       };
       $scope.newBondInterface.bond_mode = "802.3ad";
-      $scope.newBondInterface.xmitHashPolicy = "layer2+3";
+      $scope.newBondInterface.bond_xmit_hash_policy = "layer2+3";
       expect($scope.showLACPRate()).toBe(false);
     });
   });
@@ -5194,6 +5194,47 @@ describe("NodeNetworkingController", function() {
       };
       $scope.selectedMode = null;
       expect($scope.canMarkAsConnected(nic)).toBe(true);
+    });
+  });
+
+  describe("handleEditLinkMonitoring", () => {
+    it("clears bond monitoring frequency value if MII not selected", () => {
+      makeController();
+      $scope.editInterface = {
+        bond_miimon: 0,
+        bond_downdelay: 0,
+        bond_updelay: 0,
+      };
+      $scope.handleEditLinkMonitoring("mii");
+      expect($scope.editInterface.bond_miimon).toBe(100);
+      $scope.handleEditLinkMonitoring("");
+      expect($scope.editInterface.bond_miimon).toBe(0);
+    });
+  });
+
+  describe("handleEditBondMode", () => {
+    it("clears LACP rate if bond mode does not support it", () => {
+      makeController();
+      $scope.editInterface = {
+        bond_lacp_rate: "",
+        bond_mode: "balance-rr",
+      };
+      $scope.handleEditBondMode("802.3ad");
+      expect($scope.editInterface.bond_lacp_rate).toBe("fast");
+      $scope.handleEditBondMode("balance-rr");
+      expect($scope.editInterface.bond_lacp_rate).toBe("");
+    });
+
+    it("clears hash policy if bond mode does not support it", () => {
+      makeController();
+      $scope.editInterface = {
+        bond_xmit_hash_policy: "",
+        bond_mode: "balance-rr",
+      };
+      $scope.handleEditBondMode("802.3ad");
+      expect($scope.editInterface.bond_xmit_hash_policy).toBe("layer2");
+      $scope.handleEditBondMode("balance-rr");
+      expect($scope.editInterface.bond_xmit_hash_policy).toBe("");
     });
   });
 

--- a/legacy/src/app/controllers/tests/test_node_details_networking.js
+++ b/legacy/src/app/controllers/tests/test_node_details_networking.js
@@ -3695,7 +3695,7 @@ describe("NodeNetworkingController", function() {
         bond_xmit_hash_policy: "layer2",
         bond_updelay: 0,
         bond_downdelay: 0,
-        bond_miimon: 100
+        bond_miimon: 0
       });
     });
   });
@@ -4008,7 +4008,7 @@ describe("NodeNetworkingController", function() {
         subnet: subnet.id,
         mode: "static",
         ip_address: "192.168.1.100",
-        bond_miimon: 100,
+        bond_miimon: 0,
         bond_updelay: 0,
         bond_downdelay: 0
       });
@@ -4061,7 +4061,7 @@ describe("NodeNetworkingController", function() {
         subnet: null,
         mode: undefined,
         ip_address: undefined,
-        bond_miimon: 100,
+        bond_miimon: 0,
         bond_updelay: 0,
         bond_downdelay: 0
       });

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -1855,9 +1855,12 @@
                                                     <div class="p-form__group row">
                                                         <label for="bond-mode" class="p-form__label col-2">Bond mode</label>
                                                         <div class="p-form__control col-4">
-                                                            <select name="bond-mode"
-                                                                data-ng-model="editInterface.bond_mode"
-                                                                data-ng-options="mode[0] as mode[1] for mode in bondOptions.modes">
+                                                            <select
+                                                                name="bond-mode"
+                                                                ng-change="handleEditBondMode(editInterface.bond_mode)"
+                                                                ng-model="editInterface.bond_mode"
+                                                                ng-options="mode[0] as mode[1] for mode in bondOptions.modes"
+                                                            >
                                                             </select>
                                                         </div>
                                                     </div>
@@ -1867,7 +1870,7 @@
                                                         <div class="p-form__control col-4">
                                                             <select name="xmit-hash-policy"
                                                                 class="p-form-validation__input"
-                                                                data-ng-model="editInterface.xmitHashPolicy"
+                                                                data-ng-model="editInterface.bond_xmit_hash_policy"
                                                                 data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies">
                                                             </select>
                                                             <p class="p-form-validation__message" data-ng-if="showLACPRate() && modeAndPolicyCompliant()">
@@ -1879,7 +1882,7 @@
                                                         <label for="lacp-rate" class="p-form__label col-2">LACP rate</label>
                                                         <div class="p-form__control col-4">
                                                             <select name="lacp-rate"
-                                                                data-ng-model="editInterface.lacpRate"
+                                                                data-ng-model="editInterface.bond_lacp_rate"
                                                                 data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates">
                                                             </select>
                                                         </div>
@@ -1981,7 +1984,12 @@
                                                     <div class="p-form__group row">
                                                         <label for="link-monitoring" class="p-form__label col-2">Link monitoring</label>
                                                         <div class="p-form__control col-4">
-                                                            <select name="link-monitoring" id="link-monitoring" data-ng-model="editInterfaceLinkMonitoring">
+                                                            <select
+                                                                id="link-monitoring"
+                                                                name="link-monitoring"
+                                                                ng-change="handleEditLinkMonitoring(editInterfaceLinkMonitoring)"
+                                                                ng-model="editInterfaceLinkMonitoring"
+                                                            >
                                                                 <option value="">No link monitoring</option>
                                                                 <option value="mii">MII link monitoring</option>
                                                             </select>
@@ -2137,11 +2145,11 @@
                                     </td>
                                     <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
                                         <div class="p-double-row__icon-container">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface)">
+                                            <span ng-if="!isBond(parent) && !isBridge(parent)">
                                                 <span
                                                     aria-describedby="not-connected-tooltip"
                                                     class="p-tooltip--top-left"
-                                                    ng-if="!isInterfaceConnected(interface)"
+                                                    ng-if="!isInterfaceConnected(parent)"
                                                 >
                                                     <i class="p-icon--error"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
@@ -2149,20 +2157,20 @@
                                                 <span
                                                     aria-describedby="link-speed-tooltip"
                                                     class="p-tooltip--top-left"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                                                    ng-if="isInterfaceConnected(parent) && parent.link_speed < parent.interface_speed"
                                                 >
                                                     <i class="p-icon--warning"></i>
                                                     <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
                                                 </span>
                                                 <i
                                                     class="p-icon--placeholder"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
+                                                    ng-if="isInterfaceConnected(parent) && parent.link_speed === parent.interface_speed">
                                                 </i>
                                             </span>
                                         </div>
                                         <div class="p-double-row__rows-container--icon">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface)">
-                                                {$ formatSpeedUnits(interface.link_speed) $}/{$ formatSpeedUnits(interface.interface_speed) $}
+                                            <span ng-if="!isBond(parent) && !isBridge(parent)">
+                                                {$ formatSpeedUnits(parent.link_speed) $}/{$ formatSpeedUnits(parent.interface_speed) $}
                                             </span>
                                         </div>
                                     </td>
@@ -2370,7 +2378,7 @@
                                         <div class="p-form__control col-4">
                                             <select name="xmit-hash-policy"
                                                 class="p-form-validation__input"
-                                                data-ng-model="newBondInterface.xmitHashPolicy"
+                                                data-ng-model="newBondInterface.bond_xmit_hash_policy"
                                                 data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies">
                                             </select>
                                             <p class="p-form-validation__message" data-ng-if="showLACPRate() && modeAndPolicyCompliant()">
@@ -2382,7 +2390,7 @@
                                         <label for="lacp-rate" class="p-form__label col-2">LACP rate</label>
                                         <div class="p-form__control col-4">
                                             <select name="lacp-rate"
-                                                data-ng-model="newBondInterface.lacpRate"
+                                                data-ng-model="newBondInterface.bond_lacp_rate"
                                                 data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates">
                                             </select>
                                         </div>
@@ -3228,7 +3236,7 @@
                                                     <label for="lacp-rate" class="p-form__label">LACP rate</label>
                                                     <div class="p-form__control">
                                                         <select name="lacp-rate"
-                                                            data-ng-model="newBondInterface.lacpRate"
+                                                            data-ng-model="newBondInterface.bond_lacp_rate"
                                                             data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates">
                                                         </select>
                                                     </div>
@@ -3237,7 +3245,7 @@
                                                     <label for="xmit-hash-policy" class="p-form__label">XMIT hash policy</label>
                                                     <div class="p-form__control">
                                                         <select name="xmit-hash-policy"
-                                                            data-ng-model="newBondInterface.xmitHashPolicy"
+                                                            data-ng-model="newBondInterface.bond_xmit_hash_policy"
                                                             data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies">
                                                         </select>
                                                     </div>


### PR DESCRIPTION
## Done
- Fixed edit bond form not saving some values correctly.
- Driveby fix for disconnected icon on "Create bond" form

## QA
- Go to the network details of a New machine and create a bond by combining two interfaces on the same VLAN. Make sure to change the bond mode, hash policy, LACP rate and link monitoring.
- Check that the bond is created successfully, then open the edit bond form.
- Change the values for bond mode, hash policy, LACP rate and link monitoring and save
- Reopen the edit bond form and check that the values were saved correctly.

## Fixes
Fixes #1193 
