### PR TITLE
Fix nic.members not existing for non-aggregate interfaces. (#1248)

### DIFF
--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -2463,7 +2463,7 @@ export function NodeNetworkingController(
       return;
     }
 
-    if (nic.type === 'alias' && nic.members.length) {
+    if (nic.type === 'alias' && nic.members && nic.members.length) {
       return nic.members.some((member) => member.link_connected);
     }
     return nic.link_connected;


### PR DESCRIPTION
## Done
* Add guard for `nic.members` before checking for `nic.members.length`

## QA
* Add alias to a single NIC
* Add alias to a bond
* Add alias to a bridge

## Fixes
Fixes #1248  .

## Launchpad Issue
Related Launchpad maas issue in the form `lp#number`.
