### PR TITLE
Build KVM table Power and OS cells.

### DIFF
--- a/ui/src/app/base/selectors/pod/pod.js
+++ b/ui/src/app/base/selectors/pod/pod.js
@@ -1,5 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit";
 
+import controller from "../controller";
+import machine from "../machine";
+
 const pod = {};
 
 /**
@@ -51,6 +54,27 @@ pod.errors = (state) => state.pod.errors;
  */
 pod.getById = createSelector([pod.all, (state, id) => id], (pods, id) =>
   pods.find((pod) => pod.id === Number(id))
+);
+
+/**
+ * Returns the pod host, which can be either a machine or controller.
+ * @param {Object} state - The redux state.
+ * @returns {Object} Pod host machine/controller.
+ */
+pod.getHost = createSelector(
+  [machine.all, controller.all, (state, pod) => pod],
+  (machines, controllers, pod) => {
+    if (!(pod && pod.host)) {
+      return;
+    }
+    const hostMachine = machines.find(
+      (machine) => machine.system_id === pod.host
+    );
+    const hostController = controllers.find(
+      (controller) => controller.system_id === pod.host
+    );
+    return hostMachine || hostController;
+  }
 );
 
 export default pod;

--- a/ui/src/app/base/selectors/pod/pod.test.js
+++ b/ui/src/app/base/selectors/pod/pod.test.js
@@ -77,4 +77,46 @@ describe("pod selectors", () => {
       id: 222,
     });
   });
+
+  it("can get a pod's host machine", () => {
+    const state = {
+      controller: {
+        items: [{ name: "fat-controller", system_id: "qwerty" }],
+      },
+      machine: {
+        items: [
+          { name: "mean-bean-machine", system_id: "abc123" },
+          { name: "lean-cuisine-machine", system_id: "def456" },
+        ],
+      },
+      pod: {
+        items: [{ host: "abc123", name: "pod-1" }],
+      },
+    };
+    expect(pod.getHost(state, { host: "abc123" })).toStrictEqual({
+      name: "mean-bean-machine",
+      system_id: "abc123",
+    });
+  });
+
+  it("can get a pod's host controller", () => {
+    const state = {
+      controller: {
+        items: [
+          { name: "playstation-controller", system_id: "abc123" },
+          { name: "xbox-controller", system_id: "def456" },
+        ],
+      },
+      machine: {
+        items: [],
+      },
+      pod: {
+        items: [{ host: "abc123", name: "pod-1" }],
+      },
+    };
+    expect(pod.getHost(state, { host: "abc123" })).toStrictEqual({
+      name: "playstation-controller",
+      system_id: "abc123",
+    });
+  });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.js
@@ -3,6 +3,9 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import {
+  controller as controllerActions,
+  general as generalActions,
+  machine as machineActions,
   pod as podActions,
   resourcepool as poolActions,
   zone as zoneActions,
@@ -40,6 +43,9 @@ const KVMListTable = () => {
   const pods = useSelector(podSelectors.all);
 
   useEffect(() => {
+    dispatch(controllerActions.fetch());
+    dispatch(generalActions.fetchOsInfo());
+    dispatch(machineActions.fetch());
     dispatch(podActions.fetch());
     dispatch(poolActions.fetch());
     dispatch(zoneActions.fetch());
@@ -51,7 +57,11 @@ const KVMListTable = () => {
         <MainTable
           headers={[
             { content: "FQDN" },
-            { content: "Power" },
+            {
+              content: (
+                <span className="p-double-row__header-spacer">Power</span>
+              ),
+            },
             { content: "KVM Host Type" },
             {
               className: "u-align--right",
@@ -65,7 +75,9 @@ const KVMListTable = () => {
                 </>
               ),
             },
-            { content: "OS" },
+            {
+              content: <span className="p-double-row__header-spacer">OS</span>,
+            },
             {
               content: (
                 <>

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.js
@@ -12,6 +12,34 @@ describe("KVMListTable", () => {
   let initialState;
   beforeEach(() => {
     initialState = {
+      controller: {
+        loaded: true,
+        loading: false,
+        items: [],
+      },
+      general: {
+        osInfo: {
+          loaded: true,
+          loading: false,
+          data: {
+            osystems: [
+              ["centos", "CentOS"],
+              ["ubuntu", "Ubuntu"],
+            ],
+            releases: [
+              ["centos/centos66", "CentOS 6"],
+              ["centos/centos70", "CentOS 7"],
+              ["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"'],
+              ["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"'],
+            ],
+          },
+        },
+      },
+      machine: {
+        loaded: true,
+        loading: false,
+        items: [],
+      },
       pod: {
         items: [
           {
@@ -66,7 +94,14 @@ describe("KVMListTable", () => {
         </MemoryRouter>
       </Provider>
     );
-    const expectedActions = ["FETCH_POD", "FETCH_RESOURCEPOOL", "FETCH_ZONE"];
+    const expectedActions = [
+      "FETCH_CONTROLLER",
+      "FETCH_GENERAL_OSINFO",
+      "FETCH_MACHINE",
+      "FETCH_POD",
+      "FETCH_RESOURCEPOOL",
+      "FETCH_ZONE",
+    ];
     const actualActions = store.getActions();
     expect(
       actualActions.every((action) => expectedActions.includes(action.type))

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.js
@@ -3,14 +3,19 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import { pod as podSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 
 const NameColumn = ({ id }) => {
   const pod = useSelector((state) => podSelectors.getById(state, id));
 
   return (
-    <Link to={`/kvm/${pod.id}`}>
-      <strong>{pod.name}</strong>
-    </Link>
+    <DoubleRow
+      primary={
+        <Link to={`/kvm/${pod.id}`}>
+          <strong>{pod.name}</strong>
+        </Link>
+      }
+    />
   );
 };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.js
@@ -1,7 +1,46 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
-const OSColumn = () => {
-  return <>Unknown</>;
+import { getStatusText } from "app/utils";
+import {
+  controller as controllerSelectors,
+  general as generalSelectors,
+  machine as machineSelectors,
+  pod as podSelectors,
+} from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
+
+const OSColumn = ({ id }) => {
+  const pod = useSelector((state) => podSelectors.getById(state, id));
+  const host = useSelector((state) => podSelectors.getHost(state, pod));
+  const osReleases = useSelector((state) =>
+    generalSelectors.osInfo.getOsReleases(state, host && host.osystem)
+  );
+  const machinesLoading = useSelector(machineSelectors.loading);
+  const controllersLoading = useSelector(controllerSelectors.loading);
+  const loading = machinesLoading || controllersLoading;
+
+  let osText = "Unknown";
+  if (host) {
+    osText = getStatusText(host, osReleases);
+  } else if (!host && loading) {
+    osText = "";
+  }
+
+  return (
+    <DoubleRow
+      icon={
+        !host &&
+        loading && <i className="p-icon--spinner u-animation--spin"></i>
+      }
+      iconSpace
+      primary={
+        <span className="u-nudge-right--small" data-test="pod-os">
+          {osText}
+        </span>
+      }
+    />
+  );
 };
 
 export default OSColumn;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.js
@@ -1,0 +1,108 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import { nodeStatus } from "app/base/enum";
+import OSColumn from "./OSColumn";
+
+const mockStore = configureStore();
+
+describe("OSColumn", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      controller: {
+        loaded: true,
+        loading: false,
+        items: [],
+      },
+      general: {
+        osInfo: {
+          loaded: true,
+          loading: false,
+          data: {
+            osystems: [
+              ["centos", "CentOS"],
+              ["ubuntu", "Ubuntu"],
+            ],
+            releases: [
+              ["centos/centos66", "CentOS 6"],
+              ["centos/centos70", "CentOS 7"],
+              ["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"'],
+              ["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"'],
+            ],
+          },
+        },
+      },
+      machine: {
+        loaded: true,
+        loading: false,
+        items: [],
+      },
+      pod: {
+        items: [
+          {
+            id: 1,
+            name: "pod-1",
+          },
+        ],
+      },
+    };
+  });
+
+  it(`shows a spinner if machines/controllers are loading and pod's host has not
+    been found yet`, () => {
+    const state = { ...initialState };
+    state.machine.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <OSColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find(".p-icon--spinner").exists()).toBe(true);
+  });
+
+  it("can display the pod's host OS information", () => {
+    const state = { ...initialState };
+    state.machine.items = [
+      {
+        distro_series: "focal",
+        osystem: "ubuntu",
+        status_code: nodeStatus.DEPLOYED,
+        system_id: "abc123",
+      },
+    ];
+    state.pod.items = [{ host: "abc123", id: 1, name: "pod-1" }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <OSColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='pod-os']").text()).toBe(
+      "Ubuntu 20.04 LTS"
+    );
+  });
+
+  it("displays 'Unknown' if pod's host cannot be found", () => {
+    const state = { ...initialState };
+    state.machine.items = [
+      {
+        distro_series: "focal",
+        osystem: "ubuntu",
+        status_code: nodeStatus.DEPLOYED,
+        system_id: "abc123",
+      },
+    ];
+    state.pod.items = [{ host: "def456", id: 1, name: "pod-1" }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <OSColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='pod-os']").text()).toBe("Unknown");
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.js
@@ -6,6 +6,7 @@ import {
   resourcepool as poolSelectors,
   zone as zoneSelectors,
 } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 
 const PoolColumn = ({ id }) => {
   const pod = useSelector((state) => podSelectors.getById(state, id));
@@ -17,13 +18,10 @@ const PoolColumn = ({ id }) => {
   );
 
   return (
-    <>
-      <span data-test="pod-pool">{pool && pool.name}</span>
-      <br />
-      <small className="u-text--light" data-test="pod-zone">
-        {zone && zone.name}
-      </small>
-    </>
+    <DoubleRow
+      primary={<span data-test="pod-pool">{pool && pool.name}</span>}
+      secondary={<span data-test="pod-zone">{zone && zone.name}</span>}
+    />
   );
 };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.js
@@ -1,7 +1,41 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
-const PowerColumn = () => {
-  return <>Unknown</>;
+import { capitaliseFirst, getPowerIcon } from "app/utils";
+import {
+  controller as controllerSelectors,
+  machine as machineSelectors,
+  pod as podSelectors,
+} from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
+
+const PowerColumn = ({ id }) => {
+  const pod = useSelector((state) => podSelectors.getById(state, id));
+  const host = useSelector((state) => podSelectors.getHost(state, pod));
+  const machinesLoading = useSelector(machineSelectors.loading);
+  const controllersLoading = useSelector(controllerSelectors.loading);
+  const loading = machinesLoading || controllersLoading;
+
+  const iconClass = getPowerIcon(host, loading);
+
+  let powerText = "Unknown";
+  if (host && host.power_state) {
+    powerText = capitaliseFirst(host.power_state);
+  } else if (!host && loading) {
+    powerText = "";
+  }
+
+  return (
+    <DoubleRow
+      icon={<i className={iconClass}></i>}
+      iconSpace
+      primary={
+        <span className="u-nudge-right--small" data-test="pod-power">
+          {powerText}
+        </span>
+      }
+    />
+  );
 };
 
 export default PowerColumn;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.js
@@ -1,0 +1,85 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import PowerColumn from "./PowerColumn";
+
+const mockStore = configureStore();
+
+describe("PowerColumn", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      controller: {
+        loaded: true,
+        loading: false,
+        items: [],
+      },
+      machine: {
+        loaded: true,
+        loading: false,
+        items: [],
+      },
+      pod: {
+        items: [
+          {
+            id: 1,
+            name: "pod-1",
+          },
+        ],
+      },
+    };
+  });
+
+  it(`shows a spinner if machines/controllers are loading and pod's host has not
+    been found yet`, () => {
+    const state = { ...initialState };
+    state.machine.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <PowerColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find(".p-icon--spinner").exists()).toBe(true);
+  });
+
+  it("can display the pod's host power information", () => {
+    const state = { ...initialState };
+    state.machine.items = [
+      {
+        power_state: "on",
+        system_id: "abc123",
+      },
+    ];
+    state.pod.items = [{ host: "abc123", id: 1, name: "pod-1" }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <PowerColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='pod-power']").text()).toBe("On");
+    expect(wrapper.find("i").props().className).toBe("p-icon--power-on");
+  });
+
+  it("displays 'Unknown' if pod's host cannot be found", () => {
+    const state = { ...initialState };
+    state.machine.items = [
+      {
+        power_state: "on",
+        system_id: "abc123",
+      },
+    ];
+    state.pod.items = [{ host: "def456", id: 1, name: "pod-1" }];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <PowerColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='pod-power']").text()).toBe("Unknown");
+    expect(wrapper.find("i").props().className).toBe("p-icon--power-unknown");
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.js
@@ -2,6 +2,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import { pod as podSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 
 const formatHostType = (type) => {
   switch (type) {
@@ -17,7 +18,11 @@ const formatHostType = (type) => {
 const TypeColumn = ({ id }) => {
   const pod = useSelector((state) => podSelectors.getById(state, id));
 
-  return <span data-test="pod-type">{formatHostType(pod.type)}</span>;
+  return (
+    <DoubleRow
+      primary={<span data-test="pod-type">{formatHostType(pod.type)}</span>}
+    />
+  );
 };
 
 export default TypeColumn;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.js
@@ -2,18 +2,22 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import { pod as podSelectors } from "app/base/selectors";
+import DoubleRow from "app/base/components/DoubleRow";
 
 const VMsColumn = ({ id }) => {
   const pod = useSelector((state) => podSelectors.getById(state, id));
 
   return (
-    <>
-      <span data-test="pod-machines-count">{pod.composed_machines_count}</span>
-      <br />
-      <small className="u-text--light" data-test="pod-owners-count">
-        {pod.owners_count}
-      </small>
-    </>
+    <DoubleRow
+      primary={
+        <span data-test="pod-machines-count">
+          {pod.composed_machines_count}
+        </span>
+      }
+      primaryClassName="u-align--right"
+      secondary={<span data-test="pod-owners-count">{pod.owners_count}</span>}
+      secondaryClassName="u-align--right"
+    />
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
@@ -1,9 +1,9 @@
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 
+import { getPowerIcon } from "app/utils";
 import { machine as machineActions } from "app/base/actions";
 import { machine as machineSelectors } from "app/base/selectors";
 import { useToggleMenu } from "app/machines/hooks";
@@ -17,12 +17,7 @@ export const PowerColumn = ({ onToggleMenu, systemId }) => {
   );
   const toggleMenu = useToggleMenu(onToggleMenu, systemId);
 
-  const iconClass = classNames({
-    "p-icon--power-on": machine.power_state === "on",
-    "p-icon--power-off": machine.power_state === "off",
-    "p-icon--power-error": machine.power_state === "error",
-    "p-icon--power-unknown": machine.power_state === "unknown",
-  });
+  const iconClass = getPowerIcon(machine);
 
   const menuLinks = [];
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import React from "react";
 import PropTypes from "prop-types";
 
+import { getStatusText } from "app/utils";
 import {
   general as generalSelectors,
   machine as machineSelectors,
@@ -21,9 +22,6 @@ const hideFailedTestWarningStatuses = [
   nodeStatus.NEW,
   nodeStatus.TESTING,
 ];
-
-// Node statuses for which the OS + release is made human-readable.
-const formattedReleaseStatuses = [nodeStatus.DEPLOYED, nodeStatus.DEPLOYING];
 
 // Node statuses that are temporary.
 const transientStatuses = [
@@ -44,29 +42,6 @@ const failedScriptStatuses = [
   scriptStatus.FAILED_INSTALLING,
   scriptStatus.TIMEDOUT,
 ];
-
-const getStatusText = (machine, osReleases) => {
-  if (formattedReleaseStatuses.includes(machine.status_code)) {
-    const machineRelease = osReleases.find(
-      (release) => release.value === machine.distro_series
-    );
-
-    if (machineRelease) {
-      let releaseTitle;
-      if (machine.osystem === "ubuntu") {
-        releaseTitle = machineRelease.label.split('"')[0].trim();
-      } else {
-        releaseTitle = machineRelease.label;
-      }
-
-      if (machine.status_code === nodeStatus.DEPLOYING) {
-        return `Deploying ${releaseTitle}`;
-      }
-      return releaseTitle;
-    }
-  }
-  return machine.status;
-};
 
 const getProgressText = (machine) => {
   if (transientStatuses.includes(machine.status_code)) {

--- a/ui/src/app/utils/getPowerIcon.js
+++ b/ui/src/app/utils/getPowerIcon.js
@@ -1,0 +1,15 @@
+/**
+ * Returns the correct icon given a machine's power status.
+ * @param {Object} machine - the machine who's power you are checking.
+ * @param {Boolean} loading - whether the data is still loading.
+ * @returns {String} icon class
+ */
+export const getPowerIcon = (machine, loading) => {
+  if (loading && !machine) {
+    return "p-icon--spinner u-animation--spin";
+  }
+  if (machine && machine.power_state) {
+    return `p-icon--power-${machine.power_state}`;
+  }
+  return "p-icon--power-unknown";
+};

--- a/ui/src/app/utils/getPowerIcon.test.js
+++ b/ui/src/app/utils/getPowerIcon.test.js
@@ -1,0 +1,30 @@
+import { getPowerIcon } from "./getPowerIcon";
+
+describe("getPowerIcon", () => {
+  it("correctly returns on icon", () => {
+    expect(getPowerIcon({ power_state: "on" })).toEqual("p-icon--power-on");
+  });
+
+  it("correctly returns off icon", () => {
+    expect(getPowerIcon({ power_state: "off" })).toEqual("p-icon--power-off");
+  });
+
+  it("correctly returns error icon", () => {
+    expect(getPowerIcon({ power_state: "error" })).toEqual(
+      "p-icon--power-error"
+    );
+  });
+
+  it("correctly returns unknown icon", () => {
+    expect(getPowerIcon({ power_state: "unknown" })).toEqual(
+      "p-icon--power-unknown"
+    );
+    expect(getPowerIcon()).toEqual("p-icon--power-unknown");
+  });
+
+  it("correctly returns loading icon", () => {
+    expect(getPowerIcon(undefined, true)).toEqual(
+      "p-icon--spinner u-animation--spin"
+    );
+  });
+});

--- a/ui/src/app/utils/getStatusText.js
+++ b/ui/src/app/utils/getStatusText.js
@@ -1,0 +1,36 @@
+import { nodeStatus } from "app/base/enum";
+
+// Node statuses for which the OS + release is made human-readable.
+const formattedReleaseStatuses = [nodeStatus.DEPLOYED, nodeStatus.DEPLOYING];
+
+/**
+ * Returns formatted status text of a given machine.
+ * @param {Object} machine - the machine who's status you are checking.
+ * @param {Array{}} osReleases - list of OS release options.
+ * @returns {String} formatted status text
+ */
+export const getStatusText = (machine, osReleases) => {
+  if (!machine) {
+    return "Unknown";
+  }
+  if (formattedReleaseStatuses.includes(machine.status_code)) {
+    const machineRelease = osReleases.find(
+      (release) => release.value === machine.distro_series
+    );
+
+    if (machineRelease) {
+      let releaseTitle;
+      if (machine.osystem === "ubuntu") {
+        releaseTitle = machineRelease.label.split('"')[0].trim();
+      } else {
+        releaseTitle = machineRelease.label;
+      }
+
+      if (machine.status_code === nodeStatus.DEPLOYING) {
+        return `Deploying ${releaseTitle}`;
+      }
+      return releaseTitle;
+    }
+  }
+  return machine.status;
+};

--- a/ui/src/app/utils/getStatusText.test.js
+++ b/ui/src/app/utils/getStatusText.test.js
@@ -1,0 +1,52 @@
+import { nodeStatus } from "app/base/enum";
+
+import { getStatusText } from "./getStatusText";
+
+describe("getStatusText", () => {
+  it("displays the machine's status if not deploying or deployed", () => {
+    const machine = { status: "New", status_code: nodeStatus.NEW };
+    expect(getStatusText(machine, [])).toEqual("New");
+  });
+
+  it("displays the short-form of Ubuntu release if deployed", () => {
+    const machine = {
+      distro_series: "bionic",
+      osystem: "ubuntu",
+      status: "Deployed",
+      status_code: nodeStatus.DEPLOYED,
+    };
+    const osReleases = [
+      { label: 'Ubuntu 18.04 LTS "Bionic Beaver"', value: "bionic" },
+    ];
+
+    expect(getStatusText(machine, osReleases)).toEqual("Ubuntu 18.04 LTS");
+  });
+
+  it("displays the full OS and release if non-Ubuntu deployed", () => {
+    const machine = {
+      distro_series: "centos70",
+      osystem: "centos",
+      status: "Deployed",
+      status_code: nodeStatus.DEPLOYED,
+    };
+    const osReleases = [{ label: "CentOS 7", value: "centos70" }];
+
+    expect(getStatusText(machine, osReleases)).toEqual("CentOS 7");
+  });
+
+  it("displays 'Deploying OS release' if machine is deploying", () => {
+    const machine = {
+      distro_series: "bionic",
+      osystem: "ubuntu",
+      status: "Deploying",
+      status_code: nodeStatus.DEPLOYING,
+    };
+    const osReleases = [
+      { label: 'Ubuntu 18.04 LTS "Bionic Beaver"', value: "bionic" },
+    ];
+
+    expect(getStatusText(machine, osReleases)).toEqual(
+      "Deploying Ubuntu 18.04 LTS"
+    );
+  });
+});

--- a/ui/src/app/utils/index.js
+++ b/ui/src/app/utils/index.js
@@ -6,6 +6,8 @@ export { formatPowerParameters } from "./formatPowerParameters";
 export { formatSpeedUnits } from "./formatSpeedUnits";
 export { getMachineValue } from "./search";
 export { generateLegacyURL } from "./generateLegacyURL";
+export { getPowerIcon } from "./getPowerIcon";
+export { getStatusText } from "./getStatusText";
 export { groupAsMap } from "./groupAsMap";
 export { isVersionNewer } from "./isVersionNewer";
 export { kebabToCamelCase } from "./kebabToCamelCase";


### PR DESCRIPTION
## Done
- Built KVM table Power and OS cells.
- Converted the other cells (except for the Meters) to use the DoubleRow component to be consistent with the MachineListTable.
- Note that the secondary row text is slightly misaligned in the DoubleRow component - it should be exactly aligned with the Meter labels. I initially tried to fix it in this PR but it ended up breaking the MachineList rows, so I'll look into it as a follow up.
- Also note that making the table responsive will be handled in canonical-web-and-design/MAAS-squad#2025 so the OS text is likely to get truncated at the moment.

## QA
- Go to /MAAS/r/kvm
- Check that the Power and OS text matches what you see on /MAAS/l/kvm

## Fixes
Fixes canonical-web-and-design/MAAS-squad#2022

## Screenshot
![0 0 0 0_8400_MAAS_r_kvm (4)](https://user-images.githubusercontent.com/25733845/84739112-603e6300-afee-11ea-8395-cdec94f607ef.png)

