### PR TITLE
Conditionally require mac address when adding a machine

### DIFF
--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -46,7 +46,10 @@ const generateMachineSchema = (parametersSchema) =>
     power_type: Yup.string().required("Power type required"),
     pxe_mac: Yup.string()
       .matches(/^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$/, "Invalid MAC address")
-      .required("At least one MAC address required"),
+      .when("power_type", {
+        is: (power_type) => power_type !== "ipmi",
+        then: Yup.string().required("At least one MAC address required"),
+      }),
     zone: Yup.string().required("Zone required"),
   });
 

--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
@@ -82,6 +82,9 @@ export const AddMachineFormFields = ({ saved }) => {
     })),
   ];
 
+  const macAddressRequired =
+    values.power_type === "ipmi" ? {} : { required: "required" };
+
   return (
     <Row>
       <Col size="5">
@@ -133,7 +136,7 @@ export const AddMachineFormFields = ({ saved }) => {
             setFieldValue("pxe_mac", formatMacAddress(e.target.value));
           }}
           placeholder="00:00:00:00:00:00"
-          required
+          {...macAddressRequired}
           type="text"
         />
         {extraMACs.map((mac, i) => (

--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
@@ -83,7 +83,7 @@ export const AddMachineFormFields = ({ saved }) => {
   ];
 
   const macAddressRequired =
-    values.power_type === "ipmi" ? {} : { required: "required" };
+    values.power_type === "ipmi" ? {} : { required: true };
 
   return (
     <Row>


### PR DESCRIPTION
## Done

- Conditionally set the required validation on the mac address field
- Conditionally style the field as required

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to http://0.0.0.0:8400/MAAS/r/machines/add
- Focus on the mac address field and blur it while its empty
- You should get validation error that the mac address is required
- Check the power type to IPMI
- See that the required asterisk has been removed and the form submits without a mac address

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1271

## Launchpad issue

lp#1884051
