### PR TITLE
Add sorting to KVMListTable.

### DIFF
--- a/ui/src/app/base/selectors/pod/pod.test.js
+++ b/ui/src/app/base/selectors/pod/pod.test.js
@@ -115,4 +115,42 @@ describe("pod selectors", () => {
       system_id: "abc123",
     });
   });
+
+  it("can get all pod hosts", () => {
+    const state = {
+      controller: {
+        items: [
+          { name: "playstation-controller", system_id: "aaaaaa" },
+          { name: "xbox-controller", system_id: "bbbbbb" },
+        ],
+      },
+      machine: {
+        items: [
+          { name: "mean-bean-machine", system_id: "cccccc" },
+          { name: "lean-cuisine-machine", system_id: "dddddd" },
+        ],
+      },
+      pod: {
+        items: [
+          { host: "aaaaaa", name: "pod-1" },
+          { host: "bbbbbb", name: "pod-1" },
+          { host: "cccccc", name: "pod-1" },
+        ],
+      },
+    };
+    expect(pod.getAllHosts(state)).toStrictEqual([
+      {
+        name: "playstation-controller",
+        system_id: "aaaaaa",
+      },
+      {
+        name: "xbox-controller",
+        system_id: "bbbbbb",
+      },
+      {
+        name: "mean-bean-machine",
+        system_id: "cccccc",
+      },
+    ]);
+  });
 });

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -1,4 +1,110 @@
-export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+export type Controller = {
+  actions: string[];
+  architecture: string;
+  cpu_count: number;
+  cpu_speed: number;
+  cpu_test_status: TestStatus;
+  description: string;
+  distro_series: string;
+  domain: TSFixMe;
+  fqdn: string;
+  hostname: string;
+  id: number;
+  interface_test_status: TestStatus;
+  last_image_sync: string;
+  link_type: string;
+  locked: boolean;
+  memory_test_status: TestStatus;
+  memory: number;
+  network_test_status: TestStatus;
+  node_type_display: string;
+  node_type: number;
+  osystem: string;
+  other_test_status: TestStatus;
+  permissions: string[];
+  pool: ResourcePool | null;
+  service_ids: number[];
+  status_code: number;
+  status_message: string;
+  status: string;
+  storage_test_status: TestStatus;
+  system_id: string;
+  tags: string[];
+  version_long: string;
+  version_short: string;
+  version: string;
+};
+
+export type ControllerState = {
+  errors: TSFixMe;
+  items: Controller[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};
+
+export type Machine = {
+  actions: string[];
+  architecture: string;
+  commissioning_status: TestStatus;
+  cpu_count: 1;
+  cpu_speed: 0;
+  cpu_test_status: TestStatus;
+  description: string;
+  distro_series: string;
+  domain: TSFixMe;
+  extra_macs: string[];
+  fabrics: string[];
+  fqdn: string;
+  has_logs: boolean;
+  hostname: string;
+  id: number;
+  interface_test_status: TestStatus;
+  ip_addresses: string[];
+  link_speeds: number[];
+  link_type: string;
+  locked: boolean;
+  memory_test_status: TestStatus;
+  memory: 1;
+  network_test_status: TestStatus;
+  node_type_display: string;
+  numa_nodes_count: number;
+  osystem: string;
+  other_test_status: TestStatus;
+  owner: string;
+  permissions: string[];
+  physical_disk_count: number;
+  pod: TSFixMe;
+  pool: TSFixMe;
+  power_state: string;
+  power_type: string;
+  pxe_mac_vendor: string;
+  pxe_mac: string;
+  spaces: string[];
+  sriov_support: boolean;
+  status_code: number;
+  status_message: string;
+  status: string;
+  storage_tags: string[];
+  storage_test_status: TestStatus;
+  storage: number;
+  subnets: string[];
+  system_id: string;
+  tags: string[];
+  testing_status: TestStatus;
+  vlan: TSFixMe;
+  zone: TSFixMe;
+};
+
+export type MachineState = {
+  errors: TSFixMe;
+  items: Machine[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};
 
 export type PodHint = {
   cores: number;
@@ -75,6 +181,16 @@ export type ResourcePoolState = {
   saving: boolean;
 };
 
+export type TestStatus = {
+  status: number;
+  pending: number;
+  running: number;
+  passed: number;
+  failed: number;
+};
+
+export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
 export type Zone = {
   controllers_count: number;
   created: string;
@@ -96,6 +212,8 @@ export type ZoneState = {
 };
 
 export type RootState = {
+  controller: ControllerState;
+  machine: MachineState;
   pod: PodState;
   resourcepool: ResourcePoolState;
   zone: ZoneState;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
@@ -1,7 +1,8 @@
 import { Col, MainTable, Row } from "@canonical/react-components";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { getStatusText } from "app/utils";
 import {
   controller as controllerActions,
   general as generalActions,
@@ -10,8 +11,18 @@ import {
   resourcepool as poolActions,
   zone as zoneActions,
 } from "app/base/actions";
-import { Pod } from "app/base/types";
-import { pod as podSelectors } from "app/base/selectors";
+import {
+  Controller,
+  Machine,
+  Pod,
+  ResourcePool,
+  TSFixMe,
+} from "app/base/types";
+import {
+  general as generalSelectors,
+  pod as podSelectors,
+  resourcepool as poolSelectors,
+} from "app/base/selectors";
 import CPUColumn from "./CPUColumn";
 import NameColumn from "./NameColumn";
 import OSColumn from "./OSColumn";
@@ -19,11 +30,79 @@ import PoolColumn from "./PoolColumn";
 import PowerColumn from "./PowerColumn";
 import RAMColumn from "./RAMColumn";
 import StorageColumn from "./StorageColumn";
+import TableHeader from "app/base/components/TableHeader";
 import TypeColumn from "./TypeColumn";
 import VMsColumn from "./VMsColumn";
 
-const generateRows = (pods: Pod[]) => {
-  return pods.map((pod) => ({
+type Sort = {
+  direction: "ascending" | "descending" | "none";
+  key: string;
+};
+
+const podSort = (
+  currentSort: Sort,
+  podHosts: (Controller | Machine)[],
+  pools: ResourcePool[],
+  osReleases: TSFixMe
+) => {
+  const getSortValue = (pod: Pod, sortKey: Sort["key"]) => {
+    const podHost = podHosts.find((host) => host.system_id === pod.host);
+    const podPool = pools.find((pool) => pod.pool === pool.id);
+
+    switch (sortKey) {
+      case "power":
+        if (podHost && "power_state" in podHost) {
+          return podHost.power_state;
+        }
+        return "unknown";
+      case "os":
+        if (podHost && podHost.osystem in osReleases) {
+          return getStatusText(podHost, osReleases[podHost.osystem]);
+        }
+        return "unknown";
+      case "pool":
+        return podPool?.name || "unknown";
+      case "cpu":
+        return pod.used.cores;
+      case "ram":
+        return pod.used.memory;
+      case "storage":
+        return pod.used.local_storage;
+      default:
+        return pod[sortKey];
+    }
+  };
+
+  const { key, direction } = currentSort;
+
+  return function (podA: Pod, podB: Pod) {
+    const sortA = getSortValue(podA, key);
+    const sortB = getSortValue(podB, key);
+
+    if (direction === "none") {
+      return 0;
+    }
+    if (sortA < sortB) {
+      return direction === "descending" ? -1 : 1;
+    }
+    if (sortA > sortB) {
+      return direction === "descending" ? 1 : -1;
+    }
+    return 0;
+  };
+};
+
+const generateRows = (
+  pods: Pod[],
+  currentSort: Sort,
+  podHosts: (Controller | Machine)[],
+  pools: ResourcePool[],
+  osReleases: TSFixMe
+) => {
+  const sortedPods = [...pods].sort(
+    podSort(currentSort, podHosts, pools, osReleases)
+  );
+  return sortedPods.map((pod) => ({
     key: pod.id,
     columns: [
       { content: <NameColumn id={pod.id} /> },
@@ -42,6 +121,14 @@ const generateRows = (pods: Pod[]) => {
 const KVMListTable = (): JSX.Element => {
   const dispatch = useDispatch();
   const pods = useSelector(podSelectors.all);
+  const podHosts = useSelector(podSelectors.getAllHosts);
+  const pools = useSelector(poolSelectors.all);
+  const osReleases = useSelector(generalSelectors.osInfo.getAllOsReleases);
+
+  const [currentSort, setCurrentSort] = useState<Sort>({
+    key: "name",
+    direction: "descending",
+  });
 
   useEffect(() => {
     dispatch(controllerActions.fetch());
@@ -52,49 +139,147 @@ const KVMListTable = (): JSX.Element => {
     dispatch(zoneActions.fetch());
   }, [dispatch]);
 
+  // Update sort parameters depending on whether the same sort key was clicked.
+  const updateSort = (newSortKey: Sort["key"]) => {
+    const { key, direction } = currentSort;
+
+    if (newSortKey === key) {
+      if (direction === "ascending") {
+        setCurrentSort({ key: "", direction: "none" });
+      } else {
+        setCurrentSort({ key, direction: "ascending" });
+      }
+    } else {
+      setCurrentSort({ key: newSortKey, direction: "descending" });
+    }
+  };
+
   return (
     <Row>
       <Col size={12}>
         <MainTable
           className="kvm-list-table"
           headers={[
-            { content: "FQDN" },
             {
               content: (
-                <span className="p-double-row__header-spacer">Power</span>
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="fqdn-header"
+                  onClick={() => updateSort("name")}
+                  sortKey="name"
+                >
+                  FQDN
+                </TableHeader>
               ),
             },
-            { content: "KVM Host Type" },
+            {
+              content: (
+                <TableHeader
+                  className="p-double-row__header-spacer"
+                  currentSort={currentSort}
+                  data-test="power-header"
+                  onClick={() => updateSort("power")}
+                  sortKey="power"
+                >
+                  Power
+                </TableHeader>
+              ),
+            },
+            {
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="type-header"
+                  onClick={() => updateSort("type")}
+                  sortKey="type"
+                >
+                  KVM host type
+                </TableHeader>
+              ),
+            },
             {
               className: "u-align--right",
               content: (
                 <>
-                  <span>
+                  <TableHeader
+                    currentSort={currentSort}
+                    data-test="vms-header"
+                    onClick={() => updateSort("composed_machines_count")}
+                    sortKey="composed_machines_count"
+                  >
                     VM<span className="u-no-text-transform">s</span>
-                  </span>
-                  <br />
-                  <span>Owners</span>
+                  </TableHeader>
+                  <TableHeader>Owners</TableHeader>
                 </>
               ),
             },
             {
-              content: <span className="p-double-row__header-spacer">OS</span>,
+              content: (
+                <TableHeader
+                  className="p-double-row__header-spacer"
+                  currentSort={currentSort}
+                  data-test="os-header"
+                  onClick={() => updateSort("os")}
+                  sortKey="os"
+                >
+                  OS
+                </TableHeader>
+              ),
             },
             {
               content: (
                 <>
-                  <span>Resource pool</span>
-                  <br />
-                  <span>AZ</span>
+                  <TableHeader
+                    currentSort={currentSort}
+                    data-test="pool-header"
+                    onClick={() => updateSort("pool")}
+                    sortKey="pool"
+                  >
+                    Resource pool
+                  </TableHeader>
+                  <TableHeader>Az</TableHeader>
                 </>
               ),
             },
-            { content: "CPU" },
-            { content: "RAM" },
-            { content: "Storage" },
+            {
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="cpu-header"
+                  onClick={() => updateSort("cpu")}
+                  sortKey="cpu"
+                >
+                  CPU
+                </TableHeader>
+              ),
+            },
+            {
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="ram-header"
+                  onClick={() => updateSort("ram")}
+                  sortKey="ram"
+                >
+                  RAM
+                </TableHeader>
+              ),
+            },
+            {
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="storage-header"
+                  onClick={() => updateSort("storage")}
+                  sortKey="storage"
+                >
+                  Storage
+                </TableHeader>
+              ),
+            },
           ]}
           paginate={50}
-          rows={generateRows(pods)}
+          rows={generateRows(pods, currentSort, podHosts, pools, osReleases)}
         />
       </Col>
     </Row>

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
@@ -26,7 +26,7 @@ const PowerColumn = ({ id }: Props): JSX.Element => {
   const iconClass = getPowerIcon(host, loading);
 
   let powerText = "Unknown";
-  if (host && host.power_state) {
+  if (host && "power_state" in host) {
     powerText = capitaliseFirst(host.power_state);
   } else if (!host && loading) {
     powerText = "";


### PR DESCRIPTION
## Done

- Added sorting to KVMListTable. A bit of extra work was required to be able to sort by things that aren't parameters of the KVMs themselves (power, OS, resource pool).
- Added types for Controller, ControllerState, Machine, MachineState and TestStatus.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/kvm and check that you can sort by every table header.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2024
