### PR TITLE
Add selectors for KVM/RSD pods. 

### DIFF
--- a/legacy/src/app/controllers/pods_list.js
+++ b/legacy/src/app/controllers/pods_list.js
@@ -39,6 +39,8 @@ function PodsListController(
   // Set initial values.
   $scope.podManager = PodsManager;
   $scope.pods = PodsManager.getItems();
+  $scope.kvms = [];
+  $scope.rsds = [];
   $scope.loading = true;
 
   if ($scope.onRSDSection()) {
@@ -531,6 +533,8 @@ function PodsListController(
       $scope.addPod();
     }
 
+    $scope.kvms = $scope.pods.filter((pod) => pod.type !== "rsd");
+    $scope.rsds = $scope.pods.filter((pod) => pod.type === "rsd");
     $scope.loadDetails();
 
     $scope.loading = false;

--- a/legacy/src/app/partials/pods-list.html
+++ b/legacy/src/app/partials/pods-list.html
@@ -14,13 +14,24 @@
                     </li>
                     <li class="p-inline-list__item p-text--muted" ng-if="!loading && page !== 'rsd'">
                         <span ng-if="!selectedItems.length">
-                            {$ pods.length $} <ng-pluralize count="pods.length" when="{'one': 'VM host available', 'other': 'VM hosts available'}"></ng-pluralize>
+                            {$ kvms.length $} <ng-pluralize count="kvms.length" when="{'one': 'VM host available', 'other': 'VM hosts available'}"></ng-pluralize>
                         </span>
-                        <span ng-if="selectedItems.length && selectedItems.length !== pods.length">
-                            {$ selectedItems.length $} of {$ pods.length $} <ng-pluralize count="pods.length" when="{'one': 'VM host selected', 'other': 'VM hosts selected'}"></ng-pluralize>
+                        <span ng-if="selectedItems.length && selectedItems.length !== kvms.length">
+                            {$ selectedItems.length $} of {$ kvms.length $} <ng-pluralize count="kvms.length" when="{'one': 'VM host selected', 'other': 'VM hosts selected'}"></ng-pluralize>
                         </span>
-                        <span ng-if="selectedItems.length && selectedItems.length === pods.length">
-                            {$ pods.length $} <ng-pluralize count="pods.length" when="{'one': 'VM host selected', 'other': 'VM hosts selected'}"></ng-pluralize>
+                        <span ng-if="selectedItems.length && selectedItems.length === kvms.length">
+                            {$ kvms.length $} <ng-pluralize count="kvms.length" when="{'one': 'VM host selected', 'other': 'VM hosts selected'}"></ng-pluralize>
+                        </span>
+                    </li>
+                    <li class="p-inline-list__item p-text--muted" ng-if="!loading && page === 'rsd'">
+                        <span ng-if="!selectedItems.length">
+                            {$ rsds.length $} <ng-pluralize count="rsds.length" when="{'one': 'RSD available', 'other': 'RSDs available'}"></ng-pluralize>
+                        </span>
+                        <span ng-if="selectedItems.length && selectedItems.length !== rsds.length">
+                            {$ selectedItems.length $} of {$ rsds.length $} <ng-pluralize count="rsds.length" when="{'one': 'RSD selected', 'other': 'RSDs selected'}"></ng-pluralize>
+                        </span>
+                        <span ng-if="selectedItems.length && selectedItems.length === rsds.length">
+                            {$ rsds.length $} <ng-pluralize count="rsds.length" when="{'one': 'RSD selected', 'other': 'RSDs selected'}"></ng-pluralize>
                         </span>
                     </li>
                 </ul>

--- a/ui/src/app/base/selectors/pod/pod.test.js
+++ b/ui/src/app/base/selectors/pod/pod.test.js
@@ -10,6 +10,40 @@ describe("pod selectors", () => {
     expect(pod.all(state)).toEqual([{ name: "pod1" }]);
   });
 
+  it("can get all KVMs", () => {
+    const state = {
+      pod: {
+        items: [
+          { name: "kvm1", type: "virsh" },
+          { name: "kvm2", type: "lxd" },
+          { name: "rsd1", type: "rsd" },
+          { name: "rsd2", type: "rsd" },
+        ],
+      },
+    };
+    expect(pod.kvm(state)).toStrictEqual([
+      { name: "kvm1", type: "virsh" },
+      { name: "kvm2", type: "lxd" },
+    ]);
+  });
+
+  it("can get all RSDs", () => {
+    const state = {
+      pod: {
+        items: [
+          { name: "kvm1", type: "virsh" },
+          { name: "kvm2", type: "lxd" },
+          { name: "rsd1", type: "rsd" },
+          { name: "rsd2", type: "rsd" },
+        ],
+      },
+    };
+    expect(pod.rsd(state)).toStrictEqual([
+      { name: "rsd1", type: "rsd" },
+      { name: "rsd2", type: "rsd" },
+    ]);
+  });
+
   it("can get the loading state", () => {
     const state = {
       pod: {

--- a/ui/src/app/base/selectors/pod/pod.ts
+++ b/ui/src/app/base/selectors/pod/pod.ts
@@ -12,6 +12,22 @@ import machine from "../machine";
 const all = (state: RootState): Pod[] => state.pod.items;
 
 /**
+ * Returns all KVMs.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all KVMs.
+ */
+const kvm = (state: RootState): Pod[] =>
+  state.pod.items.filter((pod) => pod.type !== "rsd");
+
+/**
+ * Returns all RSDs.
+ * @param {Object} state - The redux state.
+ * @returns {Array} A list of all RSDs.
+ */
+const rsd = (state: RootState): Pod[] =>
+  state.pod.items.filter((pod) => pod.type === "rsd");
+
+/**
  * Whether pods are loading.
  * @param {Object} state - The redux state.
  * @returns {Boolean} Machines loading state.
@@ -128,8 +144,10 @@ const pod = {
   getAllHosts,
   getById,
   getHost,
+  kvm,
   loaded,
   loading,
+  rsd,
   saving,
   saved,
   selected,

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -22,7 +22,7 @@ const getPodCount = (pods: Pod[], selectedPodIDs: number[]) => {
 
 const KVMListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
-  const pods = useSelector(podSelectors.all);
+  const pods = useSelector(podSelectors.kvm);
   const podsLoaded = useSelector(podSelectors.loaded);
   const selectedPodIDs = useSelector(podSelectors.selectedIDs);
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
@@ -131,7 +131,7 @@ const generateRows = (
 const KVMListTable = (): JSX.Element => {
   const dispatch = useDispatch();
   const osReleases = useSelector(generalSelectors.osInfo.getAllOsReleases);
-  const pods = useSelector(podSelectors.all);
+  const pods = useSelector(podSelectors.kvm);
   const podHosts = useSelector(podSelectors.getAllHosts);
   const pools = useSelector(poolSelectors.all);
   const selectedPodIDs = useSelector(podSelectors.selectedIDs);


### PR DESCRIPTION
## Done

- Added `pod.kvm` and `pod.rsd` selectors.
- Fixed available/selected counts in legacy KVM/RSD pages.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run a MAAS that has some KVMs and RSDs. By default, a `make sampledata`'d MAAS should have 3 of each.
- Go to /MAAS/r/kvm and check that the count next to the KVM title is correct (e.g. "1 of 3 VM hosts selected").
- Check the counts at /MAAS/l/kvm and /MAAS/l/rsd.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2030
