### PR TITLE
Replace custom useHistory and useLocation implementation

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 import { Spinner, Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect } from "react";
@@ -18,15 +18,14 @@ import { config as configSelectors } from "app/settings/selectors";
 import { Footer, Header } from "@maas-ui/maas-ui-shared";
 import { status } from "app/base/selectors";
 import { status as statusActions } from "app/base/actions";
-import { useLocation, useRouter } from "app/base/hooks";
 import { websocket } from "./base/actions";
 import Login from "app/base/components/Login";
 import Routes from "app/Routes";
 import Section from "app/base/components/Section";
 
 export const App = () => {
-  const { history } = useRouter();
-  const { location } = useLocation();
+  const history = useHistory();
+  const location = useLocation();
   const authUser = useSelector(authSelectors.get);
   const authenticated = useSelector(status.authenticated);
   const authenticating = useSelector(status.authenticating);

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
@@ -2,8 +2,7 @@ import { ActionButton, Button } from "@canonical/react-components";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
-
-import { useRouter } from "app/base/hooks";
+import { useHistory } from "react-router-dom";
 
 export const FormCardButtons = ({
   bordered = true,
@@ -17,7 +16,7 @@ export const FormCardButtons = ({
   submitLabel,
   success,
 }) => {
-  const { history } = useRouter();
+  const history = useHistory();
 
   return (
     <>

--- a/ui/src/app/base/components/SideNav/SideNav.js
+++ b/ui/src/app/base/components/SideNav/SideNav.js
@@ -1,9 +1,7 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
-import { Link, useRouteMatch } from "react-router-dom";
-
-import { useLocation } from "app/base/hooks";
+import { Link, useRouteMatch, useLocation } from "react-router-dom";
 
 const _generateSection = (section, location, match) => {
   let subNav = null;
@@ -63,7 +61,7 @@ const _generateSection = (section, location, match) => {
 
 export const SideNav = ({ items }) => {
   const match = useRouteMatch();
-  const { location } = useLocation();
+  const location = useLocation();
   const sections = items.map((item) => _generateSection(item, location, match));
   return (
     <nav className="p-side-navigation">

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -1,6 +1,4 @@
-import { __RouterContext as RouterContext } from "react-router";
 import { notificationTypes } from "@canonical/react-components";
-import { useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFormikContext } from "formik";
@@ -14,26 +12,6 @@ import { machine as machineSelectors } from "app/base/selectors";
 import { messages } from "app/base/actions";
 import { kebabToCamelCase } from "app/utils";
 import { simpleObjectEquality } from "app/settings/utils";
-
-// Router hooks inspired by: https://github.com/ReactTraining/react-router/issues/6430#issuecomment-510266079
-// These should be replaced with official hooks if/when they become available.
-
-export const useRouter = () => useContext(RouterContext);
-
-export const useLocation = () => {
-  const { location, history } = useRouter();
-  function navigate(to, { replace = false } = {}) {
-    if (replace) {
-      history.replace(to);
-    } else {
-      history.push(to);
-    }
-  }
-  return {
-    location,
-    navigate,
-  };
-};
 
 /**
  * Returns previous value of a variable.

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -3,10 +3,11 @@ import pluralize from "pluralize";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
+import { useLocation } from "react-router-dom";
 
 import { pod as podActions } from "app/base/actions";
 import { pod as podSelectors } from "app/base/selectors";
-import { useRouter, useWindowTitle } from "app/base/hooks";
+import { useWindowTitle } from "app/base/hooks";
 
 import { RootState } from "app/base/types";
 import Section from "app/base/components/Section";
@@ -15,7 +16,7 @@ import Tabs from "app/base/components/Tabs";
 const KVMDetails = (): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams();
-  const { location } = useRouter();
+  const location = useLocation();
 
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStrip.js
@@ -3,9 +3,8 @@ import PropTypes from "prop-types";
 import pluralize from "pluralize";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, Route, Switch } from "react-router-dom";
+import { Link, Route, Switch, useLocation } from "react-router-dom";
 
-import { useLocation } from "app/base/hooks";
 import {
   filtersToString,
   getCurrentFilters,
@@ -46,7 +45,7 @@ export const HeaderStrip = ({
   setSelectedAction,
 }) => {
   const dispatch = useDispatch();
-  const { location } = useLocation();
+  const location = useLocation();
   const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const selectedMachines = useSelector(machineSelectors.selected);

--- a/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/HeaderStripTabs.js
+++ b/ui/src/app/machines/components/HeaderStrip/HeaderStripTabs/HeaderStripTabs.js
@@ -2,6 +2,7 @@ import { Col, Row } from "@canonical/react-components";
 import pluralize from "pluralize";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 
 import {
   machine as machineActions,
@@ -11,7 +12,6 @@ import {
   machine as machineSelectors,
   resourcepool as resourcePoolSelectors,
 } from "app/base/selectors";
-import { useRouter } from "app/base/hooks";
 import Tabs from "app/base/components/Tabs";
 
 export const HeaderStripTabs = () => {
@@ -21,7 +21,7 @@ export const HeaderStripTabs = () => {
   const machinesLoading = useSelector(machineSelectors.loading);
   const resourcePools = useSelector(resourcePoolSelectors.all);
   const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
-  const { location } = useRouter();
+  const location = useLocation();
 
   useEffect(() => {
     dispatch(machineActions.fetch());

--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Route, Switch } from "react-router-dom";
+import { Route, Switch, useHistory, useLocation } from "react-router-dom";
 
-import { useLocation, usePrevious, useRouter } from "app/base/hooks";
+import { usePrevious } from "app/base/hooks";
 import {
   filtersToQueryString,
   filtersToString,
@@ -20,8 +20,8 @@ import HeaderStrip from "app/machines/components/HeaderStrip";
 import Section from "app/base/components/Section";
 
 const Machines = () => {
-  const { history } = useRouter();
-  const { location } = useLocation();
+  const history = useHistory();
+  const location = useLocation();
   const currentFilters = queryStringToFilters(location.search);
   // The filter state is initialised from the URL.
   const [searchFilter, setFilter] = useState(filtersToString(currentFilters));


### PR DESCRIPTION

## Done
- Replace custom instances of `useHistory` and `useLocation` with hooks provided by `react-router-dom`.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- App should still work, check machine listing, settings etc.
