### PR TITLE
Use database-uri flag with maas init for cypress setup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,7 @@ jobs:
           command: |
             sudo maas init region+rack \
               --maas-url=http://$IP_ADDRESS:5240/MAAS \
-              --database-host=localhost \
-              --database-name=$MAAS_DBNAME \
-              --database-user=$MAAS_DBUSER \
-              --database-pass=$MAAS_DBPASS
+              --database-uri=postgres://$MAAS_DBUSER:$MAAS_DBPASS@localhost/$MAAS_DBNAME
             sudo maas createadmin \
               --username=admin \
               --password=test \


### PR DESCRIPTION
Cypress tests in CI are currently broken due to the deprecation of a number of flags for database initialisation with `maas init` in 2.8.

## Done

- Replace deprecated db init flags with `--database-uri` when setting up MAAS for cypress.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- none, cypress should pass.

