### PR TITLE
Build KVMList action forms.

### DIFF
--- a/ui/src/app/base/actions/pod/pod.test.ts
+++ b/ui/src/app/base/actions/pod/pod.test.ts
@@ -58,6 +58,21 @@ describe("pod actions", () => {
     });
   });
 
+  it("can handle refreshing pods", () => {
+    expect(pod.refresh(1)).toEqual({
+      type: "REFRESH_POD",
+      meta: {
+        model: "pod",
+        method: "refresh",
+      },
+      payload: {
+        params: {
+          id: 1,
+        },
+      },
+    });
+  });
+
   it("can handle selecting pods", () => {
     expect(pod.setSelected([1, 2, 4])).toEqual({
       type: "SET_SELECTED_PODS",

--- a/ui/src/app/base/actions/pod/pod.ts
+++ b/ui/src/app/base/actions/pod/pod.ts
@@ -1,8 +1,22 @@
+import { Pod } from "app/base/types";
 import { createStandardActions } from "app/utils/redux";
 
 const pod = createStandardActions("pod");
 
-pod.setSelected = (podIDs: number[]) => {
+pod.refresh = (podID: Pod["id"]) => {
+  return {
+    type: "REFRESH_POD",
+    meta: {
+      model: "pod",
+      method: "refresh",
+    },
+    payload: {
+      params: { id: podID },
+    },
+  };
+};
+
+pod.setSelected = (podIDs: Pod["id"][]) => {
   return {
     type: "SET_SELECTED_PODS",
     payload: podIDs,

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -14,7 +14,7 @@ type Props = {
   Buttons?: JSX.Element;
   buttonsBordered?: boolean;
   cleanup?: () => void;
-  children: JSX.Element;
+  children?: JSX.Element;
   errors?: TSFixMe;
   initialValues: TSFixMe;
   loading?: boolean;

--- a/ui/src/app/base/reducers/pod/pod.test.ts
+++ b/ui/src/app/base/reducers/pod/pod.test.ts
@@ -177,6 +177,62 @@ describe("pod reducer", () => {
     });
   });
 
+  it("should correctly reduce REFRESH_POD_ERROR", () => {
+    expect(
+      pod(
+        {
+          errors: {},
+          items: [{ id: 1, cpu_speed: 100 }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false,
+          selected: [],
+        },
+        {
+          error: "You dun goofed",
+          type: "REFRESH_POD_ERROR",
+        }
+      )
+    ).toEqual({
+      errors: "You dun goofed",
+      items: [{ id: 1, cpu_speed: 100 }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+      selected: [],
+    });
+  });
+
+  it("should correctly reduce REFRESH_POD_SUCCESS", () => {
+    expect(
+      pod(
+        {
+          errors: {},
+          items: [{ id: 1, cpu_speed: 100 }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false,
+          selected: [],
+        },
+        {
+          payload: { id: 1, cpu_speed: 200 },
+          type: "REFRESH_POD_SUCCESS",
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, cpu_speed: 200 }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+      selected: [],
+    });
+  });
+
   it("should correctly reduce SET_SELECTED_PODS", () => {
     expect(
       pod(

--- a/ui/src/app/base/reducers/pod/pod.ts
+++ b/ui/src/app/base/reducers/pod/pod.ts
@@ -1,7 +1,22 @@
 import { createStandardReducer } from "app/utils/redux";
 
 import { pod as podActions } from "app/base/actions";
-import { PodState, SelectPodAction } from "app/base/types";
+import { Pod, PodState, TSFixMe } from "app/base/types";
+
+type RefreshPodErrorAction = {
+  type: "REFRESH_POD_ERROR";
+  error: TSFixMe;
+};
+
+type RefreshPodSuccessAction = {
+  type: "REFRESH_POD_SUCCESS";
+  payload: Pod;
+};
+
+type SelectPodAction = {
+  type: "SET_SELECTED_PODS";
+  payload: Pod["id"][];
+};
 
 const initialState = {
   errors: {},
@@ -14,6 +29,19 @@ const initialState = {
 };
 
 const pod = createStandardReducer(podActions, initialState, {
+  REFRESH_POD_ERROR: (state: PodState, action: RefreshPodErrorAction) => {
+    state.errors = action.error;
+    state.saving = false;
+    state.saved = false;
+  },
+  REFRESH_POD_SUCCESS: (state: PodState, action: RefreshPodSuccessAction) => {
+    for (const i in state.items) {
+      if (state.items[i].id === action.payload.id) {
+        state.items[i] = action.payload;
+        break;
+      }
+    }
+  },
   SET_SELECTED_PODS: (state: PodState, action: SelectPodAction) => {
     state.selected = action.payload;
   },

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -210,11 +210,6 @@ export type ResourcePoolState = {
   saving: boolean;
 };
 
-export type SelectPodAction = {
-  type: "SET_SELECTED_PODS";
-  payload: number[];
-};
-
 export type TestStatus = {
   status: number;
   pending: number;

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
@@ -22,7 +22,7 @@ import {
   useWindowTitle,
 } from "app/base/hooks";
 import { PowerType, TSFixMe } from "app/base/types";
-import { formatPowerParameters } from "app/utils";
+import { formatErrors, formatPowerParameters } from "app/utils";
 import AddKVMFormFields from "./AddKVMFormFields";
 import FormCard from "app/base/components/FormCard";
 import FormikForm from "app/base/components/FormikForm";
@@ -92,15 +92,7 @@ export const AddKVMForm = (): JSX.Element => {
   );
 
   const allPowerParameters = useAllPowerParameters(powerTypes);
-
-  let errors = "";
-  if (podErrors && typeof podErrors === "string") {
-    errors = podErrors;
-  } else if (podErrors && typeof podErrors === "object") {
-    Object.keys(podErrors).forEach((key) => {
-      errors = errors + `${podErrors[key]} `;
-    });
-  }
+  const errors = formatErrors(podErrors);
 
   return (
     <>

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/DeleteForm.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/DeleteForm.test.js
@@ -1,0 +1,69 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import DeleteForm from "./DeleteForm";
+
+const mockStore = configureStore();
+
+describe("DeleteForm", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      pod: {
+        items: [
+          { id: 1, name: "pod-1", type: "lxd" },
+          { id: 2, name: "pod-2", type: "virsh" },
+        ],
+        selected: [],
+        errors: {},
+      },
+    };
+  });
+
+  it("correctly dispatches actions to delete selected KVMs", () => {
+    const state = { ...initialState };
+    state.pod.selected = [1, 2];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <DeleteForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => wrapper.find("Formik").prop("onSubmit")());
+    expect(
+      store.getActions().filter((action) => action.type === "DELETE_POD")
+    ).toStrictEqual([
+      {
+        type: "DELETE_POD",
+        meta: {
+          model: "pod",
+          method: "delete",
+        },
+        payload: {
+          params: {
+            id: state.pod.items[0].id,
+          },
+        },
+      },
+      {
+        type: "DELETE_POD",
+        meta: {
+          model: "pod",
+          method: "delete",
+        },
+        payload: {
+          params: {
+            id: state.pod.items[1].id,
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { pod as podActions } from "app/base/actions";
+import { pod as podSelectors } from "app/base/selectors";
+import { formatErrors } from "app/utils";
+import FormikForm from "app/base/components/FormikForm";
+import FormCardButtons from "app/base/components/FormCardButtons";
+
+type Props = {
+  setSelectedAction: (action: string) => void;
+};
+
+const DeleteForm = ({ setSelectedAction }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const podErrors = useSelector(podSelectors.errors);
+  const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const selectedCount = `${selectedPodIDs.length} KVM${
+    selectedPodIDs.length === 1 ? "" : "s"
+  }`;
+  const errors = formatErrors(podErrors);
+
+  return (
+    <FormikForm
+      buttons={FormCardButtons}
+      buttonsBordered={false}
+      errors={errors}
+      cleanup={podActions.cleanup}
+      initialValues={{}}
+      onCancel={() => setSelectedAction("")}
+      onSaveAnalytics={{
+        action: "Delete",
+        category: "Take action menu",
+        label: "Delete selected KVMs",
+      }}
+      onSubmit={() => {
+        selectedPodIDs.forEach((podID) => {
+          dispatch(podActions.delete(podID));
+        });
+        setSelectedAction("");
+      }}
+      submitAppearance="negative"
+      submitLabel={`Delete ${selectedCount}`}
+    />
+  );
+};
+
+export default DeleteForm;

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/index.ts
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteForm";

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
@@ -1,0 +1,81 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import KVMActionFormWrapper from "./KVMActionFormWrapper";
+
+const mockStore = configureStore();
+
+describe("KVMActionFormWrapper", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      pod: {
+        items: [
+          { id: 1, name: "pod-1", type: "lxd" },
+          { id: 2, name: "pod-2", type: "virsh" },
+        ],
+        selected: [],
+        errors: {},
+      },
+    };
+  });
+
+  it("does not render if selectedAction is not defined", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMActionFormWrapper
+            selectedAction=""
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='kvm-action-form-wrapper']").exists()).toBe(
+      false
+    );
+  });
+
+  it("renders DeleteForm if delete action selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMActionFormWrapper
+            selectedAction="delete"
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='kvm-action-form-wrapper']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("DeleteForm").exists()).toBe(true);
+  });
+
+  it("renders RefreshForm if refresh action selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMActionFormWrapper
+            selectedAction="refresh"
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='kvm-action-form-wrapper']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("RefreshForm").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.tsx
@@ -1,0 +1,35 @@
+import { Col, Row } from "@canonical/react-components";
+import React from "react";
+
+import DeleteForm from "./DeleteForm";
+import RefreshForm from "./RefreshForm";
+
+type Props = {
+  selectedAction: string;
+  setSelectedAction: (action: string) => void;
+};
+
+const KVMActionFormWrapper = ({
+  selectedAction,
+  setSelectedAction,
+}: Props): JSX.Element => {
+  if (!selectedAction) {
+    return null;
+  }
+
+  return (
+    <Row data-test="kvm-action-form-wrapper">
+      <Col size="12">
+        <hr />
+        {selectedAction === "delete" && (
+          <DeleteForm setSelectedAction={setSelectedAction} />
+        )}
+        {selectedAction === "refresh" && (
+          <RefreshForm setSelectedAction={setSelectedAction} />
+        )}
+      </Col>
+    </Row>
+  );
+};
+
+export default KVMActionFormWrapper;

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/RefreshForm.test.js
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/RefreshForm.test.js
@@ -1,0 +1,69 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import RefreshForm from "./RefreshForm";
+
+const mockStore = configureStore();
+
+describe("RefreshForm", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      pod: {
+        items: [
+          { id: 1, name: "pod-1", type: "lxd" },
+          { id: 2, name: "pod-2", type: "virsh" },
+        ],
+        selected: [],
+        errors: {},
+      },
+    };
+  });
+
+  it("correctly dispatches actions to refresh selected KVMs", () => {
+    const state = { ...initialState };
+    state.pod.selected = [1, 2];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <RefreshForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => wrapper.find("Formik").prop("onSubmit")());
+    expect(
+      store.getActions().filter((action) => action.type === "REFRESH_POD")
+    ).toStrictEqual([
+      {
+        type: "REFRESH_POD",
+        meta: {
+          model: "pod",
+          method: "refresh",
+        },
+        payload: {
+          params: {
+            id: state.pod.items[0].id,
+          },
+        },
+      },
+      {
+        type: "REFRESH_POD",
+        meta: {
+          model: "pod",
+          method: "refresh",
+        },
+        payload: {
+          params: {
+            id: state.pod.items[1].id,
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { pod as podActions } from "app/base/actions";
+import { pod as podSelectors } from "app/base/selectors";
+import { formatErrors } from "app/utils";
+import FormikForm from "app/base/components/FormikForm";
+import FormCardButtons from "app/base/components/FormCardButtons";
+
+type Props = {
+  setSelectedAction: (action: string) => void;
+};
+
+const RefreshForm = ({ setSelectedAction }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const podErrors = useSelector(podSelectors.errors);
+  const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const selectedCount = `${selectedPodIDs.length} KVM${
+    selectedPodIDs.length === 1 ? "" : "s"
+  }`;
+  const errors = formatErrors(podErrors);
+
+  return (
+    <>
+      <p>
+        Refreshing KVMs will cause MAAS to recalculate usage metrics, update
+        information about storage pools, and commission any machines present in
+        the KVMs that are not yet known to MAAS.
+      </p>
+      <FormikForm
+        buttons={FormCardButtons}
+        buttonsBordered={false}
+        errors={errors}
+        cleanup={podActions.cleanup}
+        initialValues={{}}
+        onCancel={() => setSelectedAction("")}
+        onSaveAnalytics={{
+          action: "Refresh",
+          category: "Take action menu",
+          label: "Refresh selected KVMs",
+        }}
+        onSubmit={() => {
+          selectedPodIDs.forEach((podID) => {
+            dispatch(podActions.refresh(podID));
+          });
+          setSelectedAction("");
+        }}
+        submitLabel={`Refresh ${selectedCount}`}
+      />
+    </>
+  );
+};
+
+export default RefreshForm;

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/index.ts
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RefreshForm";

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/index.ts
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMActionFormWrapper";

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
@@ -1,0 +1,65 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import KVMListActionMenu from "./KVMListActionMenu";
+
+const mockStore = configureStore();
+
+describe("KVMListActionMenu", () => {
+  let initialState;
+  beforeEach(() => {
+    initialState = {
+      pod: {
+        items: [],
+        selected: [],
+      },
+    };
+  });
+
+  it("is disabled with tooltip if no KVMs are selected", () => {
+    const state = { ...initialState };
+    state.pod.selected = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <KVMListActionMenu setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="action-dropdown"] button').prop("disabled")
+    ).toBe(true);
+    expect(wrapper.find("Tooltip").prop("message")).toBe(
+      "Select KVMs below to perform an action."
+    );
+  });
+
+  it("is enabled if at least one KVM is selected", () => {
+    const state = { ...initialState };
+    state.pod.items = [
+      { id: 1, name: "pod-1", type: "lxd" },
+      { id: 2, name: "pod-2", type: "virsh" },
+    ];
+    state.pod.selected = [1];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <KVMListActionMenu setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="action-dropdown"] button').props().disabled
+    ).toBe(false);
+    expect(wrapper.find("Tooltip").prop("message")).toBe(undefined);
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.tsx
@@ -1,19 +1,45 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
+import { pod as podSelectors } from "app/base/selectors";
 import ContextualMenu from "app/base/components/ContextualMenu";
+import Tooltip from "app/base/components/Tooltip";
 
-const KVMListActionMenu = (): JSX.Element => {
+type Props = { setSelectedAction: (action: string) => void };
+
+const KVMListActionMenu = ({ setSelectedAction }: Props): JSX.Element => {
+  const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const actionMenuDisabled = selectedPodIDs.length === 0;
+
   return (
-    <ContextualMenu
-      data-test="action-dropdown"
-      hasToggleIcon
-      links={[]}
-      position="right"
-      toggleAppearance="positive"
-      toggleClassName="u-no-margin--bottom"
-      toggleDisabled
-      toggleLabel="Take action"
-    />
+    <Tooltip
+      message={
+        actionMenuDisabled
+          ? "Select KVMs below to perform an action."
+          : undefined
+      }
+      position="left"
+    >
+      <ContextualMenu
+        data-test="action-dropdown"
+        hasToggleIcon
+        links={[
+          {
+            children: "Refresh",
+            onClick: () => setSelectedAction("refresh"),
+          },
+          {
+            children: "Delete",
+            onClick: () => setSelectedAction("delete"),
+          },
+        ]}
+        position="right"
+        toggleAppearance="positive"
+        toggleClassName="u-no-margin--bottom"
+        toggleDisabled={actionMenuDisabled}
+        toggleLabel="Take action"
+      />
+    </Tooltip>
   );
 };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -84,4 +84,20 @@ describe("KVMListHeader", () => {
       "All VM hosts selected"
     );
   });
+
+  it("disables 'Add KVM' button if at least one KVM is selected", () => {
+    const state = { ...initialState };
+    state.pod.selected = [1];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('Button[data-test="add-kvm"]').prop("disabled")).toBe(
+      true
+    );
+  });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -1,12 +1,13 @@
 import { Button, Spinner } from "@canonical/react-components";
 import pluralize from "pluralize";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, Route } from "react-router-dom";
+import { Link, Route, useLocation } from "react-router-dom";
 
 import { pod as podActions } from "app/base/actions";
 import { pod as podSelectors } from "app/base/selectors";
 import { Pod } from "app/base/types";
+import KVMActionFormWrapper from "./KVMActionFormWrapper";
 import KVMListActionMenu from "./KVMListActionMenu";
 
 const getPodCount = (pods: Pod[], selectedPodIDs: number[]) => {
@@ -22,51 +23,67 @@ const getPodCount = (pods: Pod[], selectedPodIDs: number[]) => {
 
 const KVMListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
+  const location = useLocation();
   const pods = useSelector(podSelectors.kvm);
   const podsLoaded = useSelector(podSelectors.loaded);
   const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const [selectedAction, setSelectedAction] = useState("");
 
   useEffect(() => {
     dispatch(podActions.fetch());
   }, [dispatch]);
 
+  useEffect(() => {
+    if (location.pathname !== "/kvm") {
+      setSelectedAction(null);
+    }
+  }, [location.pathname, setSelectedAction]);
+
   return (
-    <div className="u-flex--between u-flex--wrap">
-      <ul className="p-inline-list">
-        <li className="p-inline-list__item p-heading--four">KVM</li>
-        {podsLoaded ? (
-          <li
-            className="p-inline-list__item last-item u-text--light"
-            data-test="pod-count"
-          >
-            {getPodCount(pods, selectedPodIDs)}
-          </li>
-        ) : (
-          <Spinner
-            className="u-no-padding u-no-margin"
-            inline
-            text="Loading..."
-          />
-        )}
-      </ul>
-      <Route exact path="/kvm">
-        <ul className="p-inline-list u-no-margin--bottom">
-          <li className="p-inline-list__item">
-            <Button
-              appearance="neutral"
-              className="u-no-margin--bottom"
-              element={Link}
-              to={"/kvm/add"}
+    <>
+      <div className="u-flex--between u-flex--wrap">
+        <ul className="p-inline-list">
+          <li className="p-inline-list__item p-heading--four">KVM</li>
+          {podsLoaded ? (
+            <li
+              className="p-inline-list__item last-item u-text--light"
+              data-test="pod-count"
             >
-              Add KVM
-            </Button>
-          </li>
-          <li className="p-inline-list__item last-item">
-            <KVMListActionMenu />
-          </li>
+              {getPodCount(pods, selectedPodIDs)}
+            </li>
+          ) : (
+            <Spinner
+              className="u-no-padding u-no-margin"
+              inline
+              text="Loading..."
+            />
+          )}
         </ul>
-      </Route>
-    </div>
+        <Route exact path="/kvm">
+          <ul className="p-inline-list u-no-margin--bottom">
+            <li className="p-inline-list__item">
+              <Button
+                appearance="neutral"
+                className="u-no-margin--bottom"
+                data-test="add-kvm"
+                disabled={selectedPodIDs.length > 0}
+                element={Link}
+                to={"/kvm/add"}
+              >
+                Add KVM
+              </Button>
+            </li>
+            <li className="p-inline-list__item last-item">
+              <KVMListActionMenu setSelectedAction={setSelectedAction} />
+            </li>
+          </ul>
+        </Route>
+      </div>
+      <KVMActionFormWrapper
+        selectedAction={selectedAction}
+        setSelectedAction={setSelectedAction}
+      />
+    </>
   );
 };
 

--- a/ui/src/app/utils/redux.js
+++ b/ui/src/app/utils/redux.js
@@ -161,6 +161,11 @@ export const createStandardReducer = (
     [actions.delete.notify]: (state, action) => {
       const index = state.items.findIndex((item) => item.id === action.payload);
       state.items.splice(index, 1);
+      if ("selected" in state) {
+        state.selected = state.selected.filter(
+          (podId) => podId !== action.payload
+        );
+      }
     },
     [actions.cleanup]: (state) => {
       state.errors = {};

--- a/ui/src/app/utils/redux.test.js
+++ b/ui/src/app/utils/redux.test.js
@@ -475,6 +475,7 @@ describe("createStandardReducer", () => {
             loading: false,
             saved: false,
             saving: false,
+            selected: [1, 2],
           },
           {
             payload: 2,
@@ -488,6 +489,7 @@ describe("createStandardReducer", () => {
         loading: false,
         saved: false,
         saving: false,
+        selected: [1],
       });
     });
   });


### PR DESCRIPTION
## Done

- Added delete and refresh forms to KVM list page.
- Note that for now the forms close immediately after submit. The processing labels (e.g. "1 of 6 KVMs refreshing") and showing the spinner will be handled as a [separate issue](https://github.com/canonical-web-and-design/maas-ui/issues/1300) because it requires a large-ish change to the pod reducer.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/kvm and check that the action menu is disabled with a tooltip.
- Select a KVM and check that the action menu enables
- Open the refresh action form and submit. Check that the websocket request and response is correct.
- Open the delete action form and submit. Check that the websocket request and response is correct, and that the deleted KVM is correctly removed from `state.items` and `state.selected`

## Fixes

Fixes canonical-web-and-design/MAAS-squad#1953