### PR TITLE
Change radio button to icon for pxe boot interface column

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -1208,9 +1208,7 @@
                                     </td>
                                     <td aria-label="Boot interface" ng-if="!isDevice">
                                         <span class="u-align--center u-hide u-show--large">
-                                            <input type="radio" name="bootInterface" id="{$ interface.name $}" checked
-                                                data-ng-if="!isController && isBootInterface(interface)" class="u-no-margin">
-                                            <label class="is-inline-label" for="{$ interface.name $}"></label>
+                                            <i class="p-icon--success" id="{$ interface.name $}" name="bootInterface" data-ng-if="!isController && isBootInterface(interface)"></i>
                                         </span>
                                         <span class="u-hide--large"
                                             data-ng-if="!isController && isBootInterface(interface) && !isEditing(interface)">Yes</span>
@@ -2697,10 +2695,7 @@
                                 </td>
                                 <td aria-label="Boot interface">
                                     <span class="u-align--center">
-                                        <input type="radio" name="bootInterface" id="{$ interface.name $}" checked
-                                            data-ng-if="!isController && isBootInterface(interface) && !isEditing(interface)"
-                                            class="u-no-margin">
-                                        <label class="is-inline-label" for="{$ interface.name $}"></label>
+                                        <i class="p-icon--success" id="{$ interface.name $}" name="bootInterface" data-ng-if="!isController && isBootInterface(interface)"></i>
                                     </span>
                                 </td>
                                 <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">


### PR DESCRIPTION
Note: this was proposed against 2.7 and has been reviewed.

https://github.com/canonical-web-and-design/maas-ui/pull/1322

## Done

- removed checkbox in pxe details table and converted to icon 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run MAAS v2.7.1 with Maas UI 2.7
- Create local VM
- Attach virsh VM to MAAS instance
- Navigate to Machines tab 
- Click the VM machine you have added above
- Click Network tab
- PXE column now shows an icon with a check mark no clickable checkboxes or hidden checkboxes exist 
- Also, You can click Edit Physical in the drop down menu under Actions-> Edit Physical to the right 
- It shows the same table with the icon and no more clickable checkboxes

## Fixes

Fixes: #1164 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#1880765`.

Attached zip file for videos of before & after. Created with SimpleScreenRecorder and viewed with VLC
[maas-ui-pxe.zip](https://github.com/canonical-web-and-design/maas-ui/files/4860016/maas-ui-pxe.zip)


![Screenshot from 2020-06-26 14-55-23](https://user-images.githubusercontent.com/62671519/86282809-29934b80-bb9d-11ea-87e7-6ef2725ae4e6.png)

![Screenshot from 2020-07-01 09-34-08](https://user-images.githubusercontent.com/62671519/86282815-2c8e3c00-bb9d-11ea-8140-215c4fd0c768.png)




