### PR TITLE
Add uploading of init-scripts.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -1,4 +1,4 @@
-import { Col, List, Row, Select, Textarea } from "@canonical/react-components";
+import { Col, List, Row, Select } from "@canonical/react-components";
 import React, { useState } from "react";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
@@ -11,6 +11,7 @@ import {
 } from "app/base/selectors";
 import { DeployFormValues } from "../DeployForm";
 import { User } from "app/base/types";
+import UserDataField from "./UserDataField";
 import FormikField from "app/base/components/FormikField";
 
 export const DeployFormFields = (): JSX.Element => {
@@ -113,19 +114,7 @@ export const DeployFormFields = (): JSX.Element => {
             }}
             wrapperClassName={userDataVisible ? "u-sv2" : null}
           />
-          {userDataVisible && (
-            <FormikField
-              autoCapitalize="off"
-              autoComplete="off"
-              autoCorrect="off"
-              className="u-sv2"
-              component={Textarea}
-              name="userData"
-              placeholder="Paste script here"
-              spellCheck="false"
-              style={{ minHeight: "15rem" }}
-            />
-          )}
+          {userDataVisible && <UserDataField />}
         </Col>
       </Row>
       {user.sshkeys_count === 0 && (

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -1,0 +1,208 @@
+import { act } from "react-dom/test-utils";
+import configureStore from "redux-mock-store";
+import { mount, ReactWrapper } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+import React from "react";
+import { Provider } from "react-redux";
+
+import DeployForm from "../../DeployForm";
+import { TSFixMe } from "app/base/types";
+
+const mockStore = configureStore();
+
+const createFile = (
+  name: string,
+  size: number,
+  type: string,
+  contents = ""
+) => {
+  const file = new File([contents], name, { type });
+  Reflect.defineProperty(file, "size", {
+    get() {
+      return size;
+    },
+  });
+  return file;
+};
+
+describe("DeployFormFields", () => {
+  let state: TSFixMe;
+  let wrapper: ReactWrapper;
+
+  beforeEach(async () => {
+    state = {
+      config: {
+        items: [
+          {
+            name: "default_osystem",
+            value: "ubuntu",
+            choices: [
+              ["centos", "CentOS"],
+              ["ubuntu", "Ubuntu"],
+            ],
+          },
+        ],
+        errors: {},
+        loaded: true,
+        loading: false,
+      },
+      general: {
+        defaultMinHweKernel: {
+          data: "",
+          errors: {},
+          loaded: true,
+          loading: false,
+        },
+        osInfo: {
+          data: {
+            osystems: [
+              ["centos", "CentOS"],
+              ["ubuntu", "Ubuntu"],
+            ],
+            releases: [
+              ["centos/centos66", "CentOS 6"],
+              ["centos/centos70", "CentOS 7"],
+              ["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"'],
+              ["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"'],
+            ],
+            kernels: {
+              ubuntu: {
+                bionic: [
+                  ["ga-18.04", "bionic (ga-18.04)"],
+                  ["ga-18.04-lowlatency", "bionic (ga-18.04-lowlatency)"],
+                  ["hwe-18.04", "bionic (hwe-18.04)"],
+                  ["hwe-18.04-edge", "bionic (hwe-18.04-edge)"],
+                  ["hwe-18.04-lowlatency", "bionic (hwe-18.04-lowlatency)"],
+                  [
+                    "hwe-18.04-lowlatency-edge",
+                    "bionic (hwe-18.04-lowlatency-edge)",
+                  ],
+                ],
+                focal: [
+                  ["ga-20.04", "focal (ga-20.04)"],
+                  ["ga-20.04-lowlatency", "focal (ga-20.04-lowlatency)"],
+                ],
+              },
+            },
+            default_osystem: "ubuntu",
+            default_release: "focal",
+          },
+          errors: {},
+          loaded: true,
+          loading: false,
+        },
+      },
+      machine: {
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [
+          {
+            system_id: "abc123",
+          },
+          {
+            system_id: "def456",
+          },
+        ],
+        selected: [],
+        statuses: {
+          abc123: {},
+          def456: {},
+        },
+      },
+      user: {
+        auth: {
+          saved: false,
+          user: {
+            email: "test@example.com",
+            global_permissions: ["machine_create"],
+            id: 1,
+            is_superuser: true,
+            last_name: "",
+            sshkeys_count: 1,
+            username: "admin",
+          },
+        },
+        errors: {},
+        items: [],
+        loaded: true,
+        loading: false,
+        saved: false,
+        saving: false,
+      },
+    };
+    const store = mockStore(state);
+    wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <DeployForm
+            processing={false}
+            setProcessing={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    await act(async () => {
+      wrapper.find("input[name='includeUserData']").simulate("change", {
+        target: { name: "includeUserData", checked: true },
+      });
+    });
+    wrapper.update();
+  });
+
+  it("accepts files of text mimetype", async () => {
+    const files = [createFile("foo.sh", 2000, "text/script")];
+    await act(async () => {
+      wrapper.find("UserDataField input[type='file']").simulate("change", {
+        target: { files },
+      });
+    });
+    wrapper.update();
+    expect(wrapper.find("FormikField[name='userData']").prop("error")).toEqual(
+      null
+    );
+  });
+
+  it("displays an error if a file with a non text mimetype is uploaded", async () => {
+    const files = [createFile("foo.jpg", 200, "image/jpg")];
+    await act(async () => {
+      wrapper.find("UserDataField input[type='file']").simulate("change", {
+        target: { files },
+      });
+    });
+    wrapper.update();
+    expect(wrapper.find("FormikField[name='userData']").prop("error")).toEqual(
+      "File type must be text/*, application/x-csh, application/x-sh, application/x-shellscript, application/json, application/ld+json, application/x-yaml"
+    );
+  });
+
+  it("displays an error if a file larger than 2MB is uploaded", async () => {
+    const files = [createFile("foo.sh", 3000000, "text/script")];
+    await act(async () => {
+      wrapper.find("UserDataField input[type='file']").simulate("change", {
+        target: { files },
+      });
+    });
+    wrapper.update();
+    expect(wrapper.find("FormikField[name='userData']").prop("error")).toEqual(
+      "File is larger than 2000000 bytes"
+    );
+  });
+
+  it("displays a single error if multiple files are uploaded", async () => {
+    const files = [
+      createFile("foo.sh", 1000, "text/script"),
+      createFile("bar.sh", 1000, "text/script"),
+    ];
+    await act(async () => {
+      wrapper.find("UserDataField input[type='file']").simulate("change", {
+        target: { files },
+      });
+    });
+    wrapper.update();
+    expect(wrapper.find("FormikField[name='userData']").prop("error")).toEqual(
+      "Only a single file may be uploaded."
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -5,8 +5,9 @@ import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { Provider } from "react-redux";
 
-import DeployForm from "../../DeployForm";
+import { machine as machineFactory } from "testing/factories";
 import { TSFixMe } from "app/base/types";
+import DeployForm from "../../DeployForm";
 
 const mockStore = configureStore();
 
@@ -15,11 +16,15 @@ class MockFileReader {
   constructor() {
     this.result = "test file content";
   }
-  /* eslint-disable @typescript-eslint/no-empty-function */
-  onabort() {}
-  onerror() {}
-  onload() {}
-  /* eslint-enable @typescript-eslint/no-empty-function */
+  onabort() {
+    // This method can be overridden in this test file as needed.
+  }
+  onerror() {
+    // This method can be overridden in this test file as needed.
+  }
+  onload() {
+    // This method can be overridden in this test file as needed.
+  }
   readAsText() {
     this.onload();
   }
@@ -45,6 +50,7 @@ describe("DeployFormFields", () => {
   let wrapper: ReactWrapper;
 
   beforeEach(async () => {
+    const machines = [machineFactory(), machineFactory()];
     state = {
       config: {
         items: [
@@ -111,19 +117,12 @@ describe("DeployFormFields", () => {
         errors: {},
         loading: false,
         loaded: true,
-        items: [
-          {
-            system_id: "abc123",
-          },
-          {
-            system_id: "def456",
-          },
-        ],
+        items: machines,
         selected: [],
-        statuses: {
-          abc123: {},
-          def456: {},
-        },
+        statuses: machines.reduce((statuses, { system_id }) => {
+          statuses[system_id] = {};
+          return statuses;
+        }, {}),
       },
       user: {
         auth: {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -16,15 +16,9 @@ class MockFileReader {
   constructor() {
     this.result = "test file content";
   }
-  onabort() {
-    // This method can be overridden in this test file as needed.
-  }
-  onerror() {
-    // This method can be overridden in this test file as needed.
-  }
-  onload() {
-    // This method can be overridden in this test file as needed.
-  }
+  onabort = () => undefined;
+  onerror = () => undefined;
+  onload = () => undefined;
   readAsText() {
     this.onload();
   }

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
@@ -1,0 +1,108 @@
+import { Spinner, Textarea } from "@canonical/react-components";
+import { FileRejection, useDropzone } from "react-dropzone";
+import { useFormikContext } from "formik";
+import classNames from "classnames";
+import React, { useState } from "react";
+
+import { DeployFormValues } from "../../DeployForm";
+import FormikField from "app/base/components/FormikField";
+
+const MAX_SIZE_BYTES = 2000000; // 2MB
+
+export const UserDataField = (): JSX.Element => {
+  const [fileErrors, setFileErrors] = useState(null);
+  const [uploadingFile, setUploadingFile] = useState(false);
+
+  const { handleChange, setFieldTouched, setFieldValue } = useFormikContext<
+    DeployFormValues
+  >();
+
+  const onDropAccepted = ([file]) => {
+    setUploadingFile(true);
+    inputRef.current.value = "";
+    const reader = new FileReader();
+
+    reader.onabort = () => {
+      setUploadingFile(false);
+      setFileErrors("Reading file aborted.");
+    };
+    reader.onerror = () => {
+      setUploadingFile(false);
+      setFileErrors("Error reading file.");
+    };
+    reader.onload = () => {
+      setUploadingFile(false);
+      setFieldValue("userData", reader.result as string);
+      setFieldTouched("userData");
+    };
+    reader.readAsText(file);
+  };
+
+  const onDragEnter = () => {
+    // Clear the last file's errors.
+    setFileErrors(null);
+  };
+
+  const onDropRejected = (fileRejections: FileRejection[]) => {
+    let errors: string;
+    if (fileRejections.length > 1) {
+      errors = "Only a single file may be uploaded.";
+    } else {
+      // Convert the errors to a single string.
+      errors = fileRejections[0].errors.map(({ message }) => message).join(" ");
+    }
+    setFileErrors(errors);
+  };
+
+  const {
+    getInputProps,
+    getRootProps,
+    inputRef,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({
+    accept:
+      "text/*, application/x-csh, application/x-sh, application/x-shellscript, application/json, application/ld+json, application/x-yaml",
+    maxSize: MAX_SIZE_BYTES,
+    multiple: false,
+    noClick: true,
+    noKeyboard: true,
+    onDropAccepted,
+    onDragEnter,
+    onDropRejected,
+  });
+
+  return (
+    <div
+      {...getRootProps()}
+      className={classNames({
+        "is-success": isDragAccept,
+        "is-error": isDragReject,
+      })}
+    >
+      <FormikField
+        autoCapitalize="off"
+        autoComplete="off"
+        autoCorrect="off"
+        className="u-sv2"
+        component={Textarea}
+        error={fileErrors}
+        name="userData"
+        onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+          handleChange(evt);
+          if (fileErrors) {
+            // Clear the errors if the text has been changed.
+            setFileErrors(null);
+          }
+        }}
+        placeholder="Paste or drop script here"
+        spellCheck="false"
+        style={{ minHeight: "15rem" }}
+      />
+      {uploadingFile && <Spinner inline text="Uploading file..." />}
+      <input {...getInputProps()} style={null} />
+    </div>
+  );
+};
+
+export default UserDataField;

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/index.ts
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UserDataField";


### PR DESCRIPTION
## Done
- Add support for selecting or dropping a cloud-init script and parsing the script into the textarea.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- Choose a deployable machine in the machine list and open the deploy form.
- Choose the cloud-init option.
- Select or drop different files on the textarea. You should see either the script contents or appropriate errors.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/2034.