### PR TITLE
Hoist shared properties to SimpleNode and Node types.

### DIFF
--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -139,17 +139,17 @@ export type Model = {
 /**
  * A named foreign model reference, e.g. machine.domain
  */
-export type ModelRef = {
+export type ModelRef = Model & {
   name: string;
-} & Model;
+};
 
-export type Vlan = {
+export type Vlan = Model & {
   name: string;
   fabric_id: number;
   fabric_name: string;
-} & Model;
+};
 
-export type User = {
+export type User = Model & {
   completed_intro: boolean;
   email: string;
   global_permissions: string[];
@@ -157,9 +157,9 @@ export type User = {
   last_name: string;
   sshkeys_count: number;
   username: string;
-} & Model;
+};
 
-export type Zone = {
+export type Zone = Model & {
   controllers_count: number;
   created: string;
   description: string;
@@ -167,9 +167,9 @@ export type Zone = {
   machines_count: number;
   name: string;
   updated: string;
-} & Model;
+};
 
-export type Pod = {
+export type Pod = Model & {
   architectures: string[];
   available: PodHint;
   capabilities: string[];
@@ -196,7 +196,7 @@ export type Pod = {
   updated: string;
   used: PodHint;
   zone: number;
-} & Model;
+};
 
 export type PodHint = {
   cores: number;
@@ -216,7 +216,7 @@ export type PodHintExtras = {
 /**
  * SimpleNode represents the intersection of Devices, Machines and Controllers
  */
-export type SimpleNode = {
+export type SimpleNode = Model & {
   actions: string[];
   domain: ModelRef;
   hostname: string;
@@ -226,9 +226,9 @@ export type SimpleNode = {
   permissions: string[];
   system_id: string;
   tags: string[];
-} & Model;
+};
 
-export type Device = {
+export type Device = SimpleNode & {
   extra_macs: string[];
   fabrics: string[];
   ip_address?: string;
@@ -240,7 +240,7 @@ export type Device = {
   spaces: string[];
   subnets: string[];
   zone: ModelRef;
-} & SimpleNode;
+};
 
 type NodeStatus =
   | "New"
@@ -270,7 +270,7 @@ type NodeStatus =
 /**
  * Node represents the intersection of Machines and Controllers
  */
-export type Node = {
+export type Node = SimpleNode & {
   architecture: string;
   cpu_count: number;
   cpu_speed: number;
@@ -289,14 +289,14 @@ export type Node = {
   status_message: string;
   status_code: number;
   storage_test_status: TestStatus;
-} & SimpleNode;
+};
 
 type IpAddresses = {
   ip: string;
   is_boot: boolean;
 };
 
-export type Machine = {
+export type Machine = Node & {
   commissioning_status: TestStatus;
   extra_macs: string[];
   fabrics: string[];
@@ -319,16 +319,16 @@ export type Machine = {
   testing_status: TestStatus;
   vlan: Vlan;
   zone: ModelRef;
-} & Node;
+};
 
-export type Controller = {
+export type Controller = Node & {
   last_image_sync: string;
   node_type: number; // TODO: it seems odd that this is only exposed for controller
   service_ids: number[];
   version_long: string;
   version_short: string;
   version: string;
-} & Node;
+};
 
 export type Host = Machine | Controller;
 
@@ -339,7 +339,7 @@ export type Host = Machine | Controller;
 export const isMachine = (host: Host): host is Machine =>
   (host as Machine).link_type === "machine";
 
-export type ResourcePool = {
+export type ResourcePool = Model & {
   created: string;
   description: string;
   is_default: boolean;
@@ -348,4 +348,4 @@ export type ResourcePool = {
   name: string;
   permissions: string[];
   updated: string;
-} & Model;
+};

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -104,14 +104,12 @@ export type ResourcePoolState = {
   saving: boolean;
 };
 
-type TestResult = -1 | 0 | 1;
-
 export type TestStatus = {
-  status: TestResult;
-  pending: TestResult;
-  running: TestResult;
-  passed: TestResult;
-  failed: TestResult;
+  status: number;
+  pending: number;
+  running: number;
+  passed: number;
+  failed: number;
 };
 
 export type UserState = {

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -141,7 +141,6 @@ export type Model = {
 /**
  * A named foreign model reference, e.g. machine.domain
  */
-<<<<<<< HEAD
 export type ModelRef = Model & {
   name: string;
 };
@@ -153,19 +152,6 @@ export type Vlan = Model & {
 };
 
 export type User = Model & {
-=======
-export type ModelRef = {
-  name: string;
-} & Model;
-
-export type Vlan = {
-  name: string;
-  fabric_id: number;
-  fabric_name: string;
-} & Model;
-
-export type User = {
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
   completed_intro: boolean;
   email: string;
   global_permissions: string[];
@@ -232,11 +218,7 @@ export type PodHintExtras = {
 /**
  * SimpleNode represents the intersection of Devices, Machines and Controllers
  */
-<<<<<<< HEAD
 export type SimpleNode = Model & {
-=======
-export type SimpleNode = {
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
   actions: string[];
   domain: ModelRef;
   hostname: string;
@@ -246,15 +228,9 @@ export type SimpleNode = {
   permissions: string[];
   system_id: string;
   tags: string[];
-<<<<<<< HEAD
 };
 
 export type Device = SimpleNode & {
-=======
-} & Model;
-
-export type Device = {
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
   extra_macs: string[];
   fabrics: string[];
   ip_address?: string;
@@ -266,11 +242,7 @@ export type Device = {
   spaces: string[];
   subnets: string[];
   zone: ModelRef;
-<<<<<<< HEAD
 };
-=======
-} & SimpleNode;
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
 
 type NodeStatus =
   | "New"
@@ -300,11 +272,7 @@ type NodeStatus =
 /**
  * Node represents the intersection of Machines and Controllers
  */
-<<<<<<< HEAD
 export type Node = SimpleNode & {
-=======
-export type Node = {
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
   architecture: string;
   cpu_count: number;
   cpu_speed: number;
@@ -323,22 +291,14 @@ export type Node = {
   status_message: string;
   status_code: number;
   storage_test_status: TestStatus;
-<<<<<<< HEAD
 };
-=======
-} & SimpleNode;
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
 
 type IpAddresses = {
   ip: string;
   is_boot: boolean;
 };
 
-<<<<<<< HEAD
 export type Machine = Node & {
-=======
-export type Machine = {
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
   commissioning_status: TestStatus;
   extra_macs: string[];
   fabrics: string[];
@@ -361,7 +321,6 @@ export type Machine = {
   testing_status: TestStatus;
   vlan: Vlan;
   zone: ModelRef;
-<<<<<<< HEAD
 };
 
 export type Controller = Node & {
@@ -383,29 +342,6 @@ export const isMachine = (host: Host): host is Machine =>
   (host as Machine).link_type === "machine";
 
 export type ResourcePool = Model & {
-=======
-} & Node;
-
-export type Controller = {
-  last_image_sync: string;
-  node_type: number; // TODO: it seems odd that this is only exposed for controller
-  service_ids: number[];
-  version_long: string;
-  version_short: string;
-  version: string;
-} & Node;
-
-export type Host = Machine | Controller;
-
-/**
- * Type guard to determine if host is a machine.
- * @param {Host} host - a machine or controller.
- */
-export const isMachine = (host: Host): host is Machine =>
-  (host as Machine).link_type === "machine";
-
-export type ResourcePool = {
->>>>>>> 175e6313439f74ad7714115a2c7199da0724acdf
   created: string;
   description: string;
   is_default: boolean;

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -104,12 +104,14 @@ export type ResourcePoolState = {
   saving: boolean;
 };
 
+type TestResult = -1 | 0 | 1;
+
 export type TestStatus = {
-  status: number;
-  pending: number;
-  running: number;
-  passed: number;
-  failed: number;
+  status: TestResult;
+  pending: TestResult;
+  running: TestResult;
+  passed: TestResult;
+  failed: TestResult;
 };
 
 export type UserState = {
@@ -135,6 +137,19 @@ export type ZoneState = {
 export type Model = {
   id: number;
 };
+
+/**
+ * A named foreign model reference, e.g. machine.domain
+ */
+export type ModelRef = {
+  name: string;
+} & Model;
+
+export type Vlan = {
+  name: string;
+  fabric_id: number;
+  fabric_name: string;
+} & Model;
 
 export type User = {
   completed_intro: boolean;
@@ -200,62 +215,124 @@ export type PodHintExtras = {
   local_disks: number;
 };
 
-// TODO: Machines and Controllers are almost identical save a few properties,
-// the Host type should represent the intersection with Machine and Controller
-// only adding the appropriate specific types e.g. controller.version
-export type Host = Machine | Controller;
-
-export type Machine = {
+/**
+ * SimpleNode represents the intersection of Devices, Machines and Controllers
+ */
+export type SimpleNode = {
   actions: string[];
+  domain: ModelRef;
+  hostname: string;
+  fqdn: string;
+  link_type: string;
+  node_type_display: string;
+  permissions: string[];
+  system_id: string;
+  tags: string[];
+} & Model;
+
+export type Device = {
+  extra_macs: string[];
+  fabrics: string[];
+  ip_address?: string;
+  ip_assignment: "external" | "dynamic" | "static";
+  link_speeds: number[];
+  owner: string;
+  parent?: string;
+  primary_mac: string;
+  spaces: string[];
+  subnets: string[];
+  zone: ModelRef;
+} & SimpleNode;
+
+type NodeStatus =
+  | "New"
+  | "Commissioning"
+  | "Failed commissioning"
+  | "Missing"
+  | "Ready"
+  | "Reserved"
+  | "Allocated"
+  | "Deploying"
+  | "Deployed"
+  | "Retired"
+  | "Broken"
+  | "Failed deployment"
+  | "Releasing"
+  | "Releasing failed"
+  | "Disk erasing"
+  | "Failed disk erasing"
+  | "Rescue mode"
+  | "Entering rescue mode"
+  | "Failed to enter rescue mode"
+  | "Exiting rescue mode"
+  | "Failed to exit rescue mode"
+  | "Testing"
+  | "Failed testing";
+
+/**
+ * Node represents the intersection of Machines and Controllers
+ */
+export type Node = {
   architecture: string;
-  commissioning_status: TestStatus;
-  cpu_count: 1;
-  cpu_speed: 0;
+  cpu_count: number;
+  cpu_speed: number;
   cpu_test_status: TestStatus;
   description: string;
   distro_series: string;
-  domain: TSFixMe;
-  extra_macs: string[];
-  fabrics: string[];
-  fqdn: string;
-  has_logs: boolean;
-  hostname: string;
   interface_test_status: TestStatus;
-  ip_addresses: string[];
-  link_speeds: number[];
-  link_type: string;
   locked: boolean;
+  memory: number;
   memory_test_status: TestStatus;
-  memory: 1;
   network_test_status: TestStatus;
-  node_type_display: string;
-  numa_nodes_count: number;
   osystem: string;
   other_test_status: TestStatus;
+  pool?: ModelRef;
+  status: NodeStatus;
+  status_message: string;
+  status_code: number;
+  storage_test_status: TestStatus;
+} & SimpleNode;
+
+type IpAddresses = {
+  ip: string;
+  is_boot: boolean;
+};
+
+export type Machine = {
+  commissioning_status: TestStatus;
+  extra_macs: string[];
+  fabrics: string[];
+  has_logs: boolean;
+  ip_addresses: IpAddresses[];
+  link_speeds: number[];
+  numa_nodes_count: number;
   owner: string;
-  permissions: string[];
   physical_disk_count: number;
-  pod?: Pod;
-  pool?: ResourcePool;
+  pod?: ModelRef;
   power_state: PowerState;
   power_type: string;
   pxe_mac_vendor: string;
   pxe_mac: string;
   spaces: string[];
   sriov_support: boolean;
-  status_code: number;
-  status_message?: string;
-  status: string;
   storage_tags: string[];
-  storage_test_status: TestStatus;
   storage: number;
   subnets: string[];
-  system_id: string;
-  tags: string[];
   testing_status: TestStatus;
-  vlan: TSFixMe;
-  zone: TSFixMe;
-} & Model;
+  vlan: Vlan;
+  zone: ModelRef;
+} & Node;
+
+export type Controller = {
+  last_image_sync: string;
+  node_type: number; // TODO: it seems odd that this is only exposed for controller
+  service_ids: number[];
+  version_long: string;
+  version_short: string;
+  version: string;
+} & Node;
+
+export type Host = Machine | Controller;
 
 /**
  * Type guard to determine if host is a machine.
@@ -263,42 +340,6 @@ export type Machine = {
  */
 export const isMachine = (host: Host): host is Machine =>
   (host as Machine).link_type === "machine";
-
-export type Controller = {
-  actions: string[];
-  architecture: string;
-  cpu_count: number;
-  cpu_speed: number;
-  cpu_test_status: TestStatus;
-  description: string;
-  distro_series: string;
-  domain: TSFixMe;
-  fqdn: string;
-  hostname: string;
-  interface_test_status: TestStatus;
-  last_image_sync: string;
-  link_type: string;
-  locked: boolean;
-  memory_test_status: TestStatus;
-  memory: number;
-  network_test_status: TestStatus;
-  node_type_display: string;
-  node_type: number;
-  osystem: string;
-  other_test_status: TestStatus;
-  permissions: string[];
-  pool?: ResourcePool;
-  service_ids: number[];
-  status_code: number;
-  status_message: string;
-  status: string;
-  storage_test_status: TestStatus;
-  system_id: string;
-  tags: string[];
-  version_long: string;
-  version_short: string;
-  version: string;
-} & Model;
 
 export type ResourcePool = {
   created: string;

--- a/ui/src/testing/factories.ts
+++ b/ui/src/testing/factories.ts
@@ -1,115 +1,127 @@
 import { define, extend, random, sequence } from "cooky-cutter";
 
-import { Controller, Machine, Model, TestStatus } from "app/base/types";
+import {
+  Controller,
+  Device,
+  Machine,
+  Model,
+  ModelRef,
+  Node,
+  SimpleNode,
+  TestStatus,
+} from "app/base/types";
 
 const model = define<Model>({
   id: sequence,
 });
 
+const modelRef = extend<Model, ModelRef>(model, {
+  name: `modelref-${random}`,
+});
+
 const testStatus = define<TestStatus>({
-  status: 1,
+  status: 0,
   pending: 0,
   running: 0,
-  passed: 1,
+  passed: 0,
   failed: 0,
 });
 
-// TODO: these factory functions should be fleshed out and typed
 const actions = () => [];
 const extra_macs = () => [];
 const fabrics = () => [];
 const ip_addresses = () => [];
 const link_speeds = () => [];
 const permissions = () => [];
-const spaces = () => [];
 const service_ids = () => [];
+const spaces = () => [];
 const storage_tags = () => [];
 const subnets = () => [];
 const tags = () => ["test"];
 
-export const machine = extend<Model, Machine>(model, {
+const simpleNode = extend<Model, SimpleNode>(model, {
   actions,
+  domain: modelRef,
+  hostname: `test-machine-${random}`,
+  fqdn: "test.maas",
+  link_type: "",
+  node_type_display: "",
+  permissions,
+  system_id: random.toString(),
+  tags,
+});
+
+export const device = extend<SimpleNode, Device>(simpleNode, {
+  extra_macs,
+  fabrics,
+  ip_address: "192.168.1.100",
+  ip_assignment: "dynamic",
+  link_speeds,
+  node_type_display: "Device",
+  owner: "admin",
+  parent: null,
+  primary_mac: "de:ad:be:ef:ba:c1",
+  spaces,
+  subnets,
+  zone: null,
+});
+
+const node = extend<SimpleNode, Node>(simpleNode, {
   architecture: "amd64/generic",
-  commissioning_status: testStatus,
+  description: "a test node",
   cpu_count: 1,
   cpu_speed: 0,
   cpu_test_status: testStatus,
-  description: "a test machine",
   distro_series: "",
-  domain: null,
+  interface_test_status: testStatus,
+  locked: false,
+  memory: 1,
+  memory_test_status: testStatus,
+  network_test_status: testStatus,
+  osystem: "ubuntu",
+  other_test_status: testStatus,
+  pool: null,
+  status: "Allocated",
+  status_message: "",
+  status_code: 10,
+  storage_test_status: testStatus,
+});
+
+export const machine = extend<Node, Machine>(node, {
+  commissioning_status: testStatus,
+  description: "a test machine",
   extra_macs,
   fabrics,
-  fqdn: "test.maas",
   has_logs: false,
-  hostname: "test-machine",
-  interface_test_status: testStatus,
   ip_addresses,
   link_speeds,
   link_type: "machine",
-  locked: false,
-  memory_test_status: testStatus,
-  memory: 1,
-  network_test_status: testStatus,
   node_type_display: "Machine",
   numa_nodes_count: 1,
-  osystem: "ubuntu",
-  other_test_status: testStatus,
   owner: "admin",
-  permissions,
   physical_disk_count: 1,
   pod: null,
-  pool: null,
   power_state: "on",
   power_type: "manual",
   pxe_mac_vendor: "Unknown vendor",
   pxe_mac: "de:ad:be:ef:aa:b1",
   spaces,
   sriov_support: false,
-  status_code: 10,
-  status_message: "",
-  status: "Allocated",
   storage_tags,
-  storage_test_status: testStatus,
   storage: 8,
   subnets,
-  system_id: random.toString(),
-  tags,
   testing_status: testStatus,
   vlan: null,
   zone: null,
 });
 
-export const controller = extend<Model, Controller>(model, {
-  actions,
-  architecture: "amd64/generic",
-  cpu_count: 1,
-  cpu_speed: 0,
-  cpu_test_status: testStatus,
-  description: "a test machine",
-  distro_series: "",
-  domain: null,
-  fqdn: "test.maas",
-  hostname: "test-controller",
-  interface_test_status: testStatus,
+export const controller = extend<Node, Controller>(node, {
+  description: "a test controller",
   last_image_sync: "Thu, 02 Jul. 2020 22:55:00",
   link_type: "controller",
-  locked: false,
-  memory_test_status: testStatus,
-  memory: 1,
-  network_test_status: testStatus,
   node_type_display: "Controller",
   node_type: 4,
-  osystem: "ubuntu",
-  other_test_status: testStatus,
-  permissions,
-  pool: null,
   service_ids,
-  status_code: 6,
-  status_message: "",
-  status: "Deployed",
-  storage_test_status: testStatus,
-  system_id: random.toString(),
-  tags,
   version_long: "2.9.0~alpha1 (8668-g.71d5929ae) (snap)",
   version_short: "2.9.0~alpha1",
   version: "2.9.0~alpha1-8668-g.71d5929ae",


### PR DESCRIPTION
## Done

- Add `Node` and `SimpleNode` types to simplify `Device`, `Machine` and `Controller` types.
- Update test factories to reflect changes to types.
- Add a few new types, `ModelRef`, `Vlan`, `Device` and `NodeStatus`.

Note: I wasn't able to find a way to extend a test factory from multiple types, so had to abandon the `DeviceMachineNode` type in favour of some duplication between `Device` and `Machine` types.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- n/a

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
