### PR TITLE
Add husky and pre-push betterer hook.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: CYPRESS_INSTALL_BINARY=0 yarn install
       - run: yarn betterer > results.txt
-        continue-on-error: true
         env:
           CI: true
       - name: Upload betterer results

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "husky": {
     "hooks": {
-      "post-commit": "yarn run betterer"
+      "pre-push": "yarn run betterer"
     }
   },
   "workspaces": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
     "test": "yarn build-shared && yarn test-legacy && yarn test-ui && yarn test-shared",
     "ui": "cd proxy && yarn start-ui"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn run betterer"
+    }
+  },
   "workspaces": {
     "packages": [
       "legacy",
@@ -57,5 +62,8 @@
       "**/jest",
       "**/webpack**"
     ]
+  },
+  "devDependencies": {
+    "husky": "4.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run betterer"
+      "post-commit": "yarn run betterer"
     }
   },
   "workspaces": {

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,47 +1,103 @@
-// BETTERER RESULTS V1.
+// BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
-  timestamp: 1592774737565,
   value: `{
-    "src/app/base/reducers/pod/pod.test.ts:1930988215": [
-      [144, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
-      [144, 27, 4, "Type \'string\' is not assignable to type \'never\'.", "2087876002"]
+    "src/app/base/actions/pod/pod.test.ts:2464677720": [
+      [61, 15, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"],
+      [76, 15, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
     ],
-    "src/app/base/selectors/pod/pod.ts:361290740": [
-      [66, 23, 17, "No overload matches this call.\\n  Overload 1 of 3, \'(callbackfn: (previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod, initialValue: Pod): Pod\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod\'.\\n      Types of parameters \'hosts\' and \'previousValue\' are incompatible.\\n        Type \'Pod\' is missing the following properties from type \'never[]\': length, pop, push, concat, and 28 more.\\n  Overload 2 of 3, \'(callbackfn: (previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[], initialValue: never[]): never[]\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[]\'.\\n      Type \'Controller[] | Machine[]\' is not assignable to type \'never[]\'.\\n        Type \'Controller[]\' is not assignable to type \'never[]\'.\\n          Type \'Controller\' is not assignable to type \'never\'.", "4184440056"]
+    "src/app/base/actions/pod/pod.ts:4076093096": [
+      [5, 4, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"],
+      [18, 4, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
     ],
-    "src/app/kvm/views/KVM.tsx:2802410770": [
-      [1, 30, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"]
+    "src/app/base/components/FormikField/FormikField.tsx:2739954440": [
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:1684615486": [
-      [1, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
-      [2, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [3, 36, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
+    "src/app/base/components/FormikForm/FormikForm.tsx:495053752": [
+      [70, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
+    ],
+    "src/app/base/components/SectionHeader/SectionHeader.tsx:3404939375": [
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [60, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
+    ],
+    "src/app/base/reducers/pod/pod.test.ts:1336984638": [
+      [163, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [163, 27, 4, "Type \'string\' is not assignable to type \'never\'.", "2087876002"],
+      [196, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [230, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [264, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [299, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [299, 31, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [334, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [368, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [368, 27, 9, "Type \'number\' is not assignable to type \'never\'.", "56784379"],
+      [403, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [403, 27, 9, "Type \'number\' is not assignable to type \'never\'.", "56784379"]
+    ],
+    "src/app/base/reducers/pod/pod.ts:3820624972": [
+      [27, 2, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2764002661"]
+    ],
+    "src/app/base/selectors/pod/pod.ts:2742582221": [
+      [112, 23, 17, "No overload matches this call.\\n  Overload 1 of 3, \'(callbackfn: (previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod, initialValue: Pod): Pod\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod\'.\\n      Types of parameters \'hosts\' and \'previousValue\' are incompatible.\\n        Type \'Pod\' is missing the following properties from type \'never[]\': length, pop, push, concat, and 28 more.\\n  Overload 2 of 3, \'(callbackfn: (previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[], initialValue: never[]): never[]\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[]\'.\\n      Type \'Controller[] | Machine[]\' is not assignable to type \'never[]\'.\\n        Type \'Controller[]\' is not assignable to type \'never[]\'.\\n          Type \'Controller\' is not assignable to type \'never\'.", "4184440056"]
+    ],
+    "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:2847492569": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [33, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [47, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [56, 24, 5, "Parameter \'props\' implicitly has an \'any\' type.", "187023499"],
-      [65, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [74, 24, 5, "Parameter \'props\' implicitly has an \'any\' type.", "187023499"]
+      [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [76, 24, 5, "Parameter \'props\' implicitly has an \'any\' type.", "187023499"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMDetails.tsx:3694518590": [
-      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [1, 22, 11, "Could not find a declaration file for module \'pluralize\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/pluralize/pluralize.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/pluralize\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'pluralize\';\`", "1850933701"],
-      [4, 26, 14, "Could not find a declaration file for module \'react-router\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router\';\`", "1913807490"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx:2826559237": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 29, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [3, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [23, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [37, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:3132221287": [
+    "src/app/kvm/views/KVMDetails/KVMDetails.tsx:864158551": [
       [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:43178706": [
+      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [3, 21, 5, "Could not find a declaration file for module \'yup\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+    ],
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:475451368": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [129, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx:4073178480": [
+      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx:247885016": [
+      [29, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx:88432150": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [36, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [54, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.tsx:284015728": [
+      [15, 4, 12, "Type \'null\' is not assignable to type \'Element\'.", "3224621615"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx:754837317": [
+      [29, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
+      [56, 32, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx:2184902936": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [22, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx:2739913947": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [28, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [42, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [58, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [75, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [92, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [108, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:1826050549": [
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [39, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<string>\'.", "2087897566"],
+      [45, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
+      [65, 6, 11, "Type \'\\"\\" | Element\' is not assignable to type \'Element | undefined\'.\\n  Type \'\\"\\"\' is not assignable to type \'Element | undefined\'.", "3453098368"]
+    ],
     "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx:2065549093": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [44, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
@@ -53,52 +109,48 @@ exports[`stricter compilation`] = {
       [25, 11, 3, "Object is possibly \'undefined\'.", "193426238"],
       [25, 29, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:1754334357": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 29, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [3, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:2374633436": [
       [12, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [110, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [129, 27, 6, "Parameter \'action\' implicitly has an \'any\' type.", "1314712411"],
-      [134, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [153, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [205, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [252, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [303, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+      [111, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [135, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [146, 6, 88, "Object is possibly \'undefined\'.", "465871270"],
+      [154, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [206, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [253, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [304, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [349, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [363, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
+      [371, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [385, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
+      [393, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [418, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:2888575480": [
-      [0, 36, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [71, 15, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'Pod\'.\\n  No index signature with a parameter of type \'string\' was found on type \'Pod\'.", "2363910037"],
-      [125, 57, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
-      [281, 48, 8, "Argument of type \'Pod\' is not assignable to parameter of type \'(Controller | Machine)[]\'.\\n  Type \'Pod\' is missing the following properties from type \'(Controller | Machine)[]\': length, pop, push, concat, and 28 more.", "612212173"]
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:3546046688": [
+      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [70, 13, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'Pod\'.\\n  No index signature with a parameter of type \'string\' was found on type \'Pod\'.", "2363910037"],
+      [104, 57, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
+      [119, 24, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx:1102421723": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 29, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [3, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
+    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx:2529226174": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [26, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+      [27, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [41, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx:2333705587": [
-      [2, 21, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [18, 26, 3, "Object is possibly \'undefined\'.", "193426238"],
-      [19, 19, 3, "Object is possibly \'undefined\'.", "193426238"]
+    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx:3029140426": [
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [30, 23, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx:2642544460": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [55, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [89, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:189060714": [
-      [20, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.", "193426238"],
+    "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:3625001769": [
+      [20, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "193426238"],
       [23, 28, 13, "Property \'getOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "1772678613"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx:2138170176": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
@@ -106,21 +158,17 @@ exports[`stricter compilation`] = {
       [18, 33, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2973346775"],
       [21, 33, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2973147829"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx:3552592969": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
-      [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [36, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [48, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx:2627892494": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [39, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [52, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:1354181980": [
-      [19, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.", "193426238"],
-      [25, 33, 4, "Argument of type \'Controller | Machine | null | undefined\' is not assignable to parameter of type \'Object\'.\\n  Type \'undefined\' is not assignable to type \'Object\'.", "2087793957"]
+    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:2517204159": [
+      [19, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "193426238"],
+      [25, 33, 4, "Argument of type \'Controller | Machine | null | undefined\' is not assignable to parameter of type \'Controller | Machine | undefined\'.\\n  Type \'null\' is not assignable to type \'Controller | Machine | undefined\'.", "2087793957"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx:4294840152": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [44, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
@@ -133,8 +181,6 @@ exports[`stricter compilation`] = {
       [27, 30, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx:1181964408": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [31, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
@@ -145,8 +191,6 @@ exports[`stricter compilation`] = {
       [27, 11, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx:3510081411": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [26, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
@@ -154,23 +198,130 @@ exports[`stricter compilation`] = {
       [27, 58, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx:1476552216": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [27, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx:1150045171": [
       [18, 11, 3, "Object is possibly \'undefined\'.", "193426238"],
       [22, 53, 3, "Object is possibly \'undefined\'.", "193426238"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx:2088103628": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [61, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [92, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [124, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:1283997989": [
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [74, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+      [94, 14, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [151, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
+      [165, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.test.tsx:250248640": [
+      [12, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [122, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [130, 11, 10, "Property \'processing\' is missing in type \'{ setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' but required in type \'Pick<Props, \\"setSelectedAction\\" | \\"processing\\" | \\"setProcessing\\">\'.", "2275379384"],
+      [136, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [137, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
+      [188, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [196, 11, 10, "Property \'processing\' is missing in type \'{ setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' but required in type \'Pick<Props, \\"setSelectedAction\\" | \\"processing\\" | \\"setProcessing\\">\'.", "2275379384"],
+      [201, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [202, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
+      [237, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [245, 11, 10, "Property \'processing\' is missing in type \'{ setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' but required in type \'Pick<Props, \\"setSelectedAction\\" | \\"processing\\" | \\"setProcessing\\">\'.", "2275379384"],
+      [250, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [251, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"],
+      [285, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [309, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [318, 11, 10, "Property \'processing\' is missing in type \'{ setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' but required in type \'Pick<Props, \\"setSelectedAction\\" | \\"processing\\" | \\"setProcessing\\">\'.", "2275379384"],
+      [326, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [327, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:3007455862": [
+      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
+      [57, 21, 17, "Property \'deployingSelected\' does not exist on type \'typeof machine\'.", "3830099655"],
+      [70, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
+      [93, 40, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
+      [110, 34, 6, "Property \'deploy\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1121484462"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx:2676976650": [
+      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [25, 28, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
+      [27, 25, 17, "Object is of type \'unknown\'.", "4281571837"],
+      [29, 28, 22, "Property \'getUbuntuKernelOptions\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "321954485"],
+      [46, 18, 17, "Object is of type \'unknown\'.", "4281571837"],
+      [46, 46, 17, "Object is of type \'unknown\'.", "4281571837"],
+      [47, 41, 17, "Object is of type \'unknown\'.", "4281571837"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx:2749085546": [
+      [116, 10, 19, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2609332470"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx:4246555145": [
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [19, 27, 4, "Binding element \'file\' implicitly has an \'any\' type.", "2087597251"],
+      [21, 4, 16, "Object is possibly \'null\'.", "4019370437"],
+      [26, 20, 23, "Argument of type \'\\"Reading file aborted.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2851093748"],
+      [30, 20, 21, "Argument of type \'\\"Error reading file.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2974791143"],
+      [53, 18, 6, "Argument of type \'string\' is not assignable to parameter of type \'SetStateAction<null>\'.", "1168132398"],
+      [102, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx:3260645888": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [30, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [48, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [112, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [146, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [180, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [208, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [248, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [249, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [250, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [251, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [252, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [256, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.tsx:3685558019": [
+      [36, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
+      [37, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
+      [52, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
+      [53, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:2793346443": [
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [78, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+      [122, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"]
+    ],
+    "src/app/utils/getCookie.ts:940992619": [
+      [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
+    ],
+    "src/app/utils/someInArray.ts:1012121545": [
+      [8, 4, 68, "Type \'boolean | 0\' is not assignable to type \'boolean\'.\\n  Type \'0\' is not assignable to type \'boolean\'.", "3447795550"]
+    ],
+    "src/app/utils/someNotAll.ts:3892711037": [
+      [7, 2, 71, "Type \'boolean | 0\' is not assignable to type \'boolean\'.\\n  Type \'0\' is not assignable to type \'boolean\'.", "1467649629"]
+    ],
+    "src/testing/factories.ts:3256654333": [
+      [61, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string | undefined> | Factory<string | undefined> | DerivedFunction<Device, string | undefined> | undefined\'.", "1898500505"],
+      [65, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | Factory<ModelRef> | AttributeFunction<ModelRef> | DerivedFunction<Device, ModelRef>\'.", "2088575771"],
+      [82, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | AttributeFunction<ModelRef | undefined> | Factory<ModelRef | undefined> | DerivedFunction<...> | undefined\'.", "2088098233"],
+      [102, 2, 3, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | AttributeFunction<ModelRef | undefined> | Factory<ModelRef | undefined> | DerivedFunction<...> | undefined\'.", "193426238"],
+      [113, 2, 4, "Type \'null\' is not assignable to type \'Vlan | ArrayFactory<never> | AttributeFunction<Vlan> | Factory<Vlan> | DerivedFunction<Machine, Vlan>\'.", "2088175728"],
+      [114, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | Factory<ModelRef> | AttributeFunction<ModelRef> | DerivedFunction<Machine, ModelRef>\'.", "2088575771"]
     ]
   }`
 };
+
 exports[`no TSFixMe types`] = {
-  timestamp: 1592774742679,
   value: `{
-    "src/app/base/selectors/pod/pod.ts:361290740": [
-      [2, 45, 8, "RegExp match", "1152173309"],
-      [46, 34, 8, "RegExp match", "1152173309"]
+    "src/app/base/selectors/auth/auth.ts:3861897180": [
+      [0, 19, 8, "RegExp match", "1152173309"],
+      [28, 34, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/base/selectors/pod/pod.ts:2742582221": [
+      [7, 12, 10, "RegExp match", "3033477015"],
+      [83, 34, 8, "RegExp match", "1152173309"]
     ],
     "src/app/base/selectors/resourcepool/resourcepool.ts:2909044297": [
       [2, 33, 8, "RegExp match", "1152173309"],
@@ -180,24 +331,20 @@ exports[`no TSFixMe types`] = {
       [2, 19, 8, "RegExp match", "1152173309"],
       [30, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/base/types.ts:2497027810": [
-      [8, 9, 8, "RegExp match", "1152173309"],
-      [38, 9, 8, "RegExp match", "1152173309"],
-      [55, 9, 8, "RegExp match", "1152173309"],
-      [77, 6, 8, "RegExp match", "1152173309"],
-      [78, 7, 8, "RegExp match", "1152173309"],
-      [95, 7, 8, "RegExp match", "1152173309"],
-      [96, 7, 8, "RegExp match", "1152173309"],
-      [100, 9, 8, "RegExp match", "1152173309"],
-      [144, 16, 8, "RegExp match", "1152173309"],
-      [154, 9, 8, "RegExp match", "1152173309"],
-      [175, 9, 8, "RegExp match", "1152173309"],
-      [191, 11, 8, "RegExp match", "1152173309"],
-      [205, 9, 8, "RegExp match", "1152173309"]
+    "src/app/base/types.ts:970215085": [
+      [0, 11, 8, "RegExp match", "1152173309"],
+      [54, 9, 8, "RegExp match", "1152173309"],
+      [63, 9, 8, "RegExp match", "1152173309"],
+      [72, 9, 8, "RegExp match", "1152173309"],
+      [82, 9, 8, "RegExp match", "1152173309"],
+      [98, 9, 8, "RegExp match", "1152173309"],
+      [118, 9, 8, "RegExp match", "1152173309"],
+      [127, 9, 8, "RegExp match", "1152173309"],
+      [193, 16, 8, "RegExp match", "1152173309"]
     ]
   }`
 };
+
 exports[`migrate js files to ts`] = {
-  timestamp: 1592468736035,
-  value: `712`
+  value: `697`
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,6 +5301,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -7531,6 +7536,13 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-versions@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
+  integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
+  dependencies:
+    semver-regex "^2.0.0"
+
 findup-sync@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-3.0.0.tgz#17b108f9ee512dfb7a5c7f3c8b27ea9e1a9c08d1"
@@ -8425,6 +8437,22 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+husky@4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.2.5.tgz#2b4f7622673a71579f901d9885ed448394b5fa36"
+  integrity sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==
+  dependencies:
+    chalk "^4.0.0"
+    ci-info "^2.0.0"
+    compare-versions "^3.6.0"
+    cosmiconfig "^6.0.0"
+    find-versions "^3.2.0"
+    opencollective-postinstall "^2.0.2"
+    pkg-dir "^4.2.0"
+    please-upgrade-node "^3.2.0"
+    slash "^3.0.0"
+    which-pm-runs "^1.0.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -11546,6 +11574,11 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
+
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -12062,6 +12095,13 @@ pkg-up@^2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
+
+please-upgrade-node@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
+  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+  dependencies:
+    semver-compare "^1.0.0"
 
 plur@^4.0.0:
   version "4.0.0"
@@ -14086,6 +14126,16 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
+semver-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
+  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -16073,6 +16123,11 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+  integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
 which@1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
In order to make the best use of betterer, and ensure that new typescript issues we introduce are immediately obvious, I'd like to try the [approach recommended by betterer maintainer](https://github.com/phenomnomnominal/betterer/issues/144) for a while. I know there's been some contention around git hooks in the past, but they do provide an immediacy which means we're more likely to try to address issues as we create them. That's the theory anyway :)

This means we would now have the following workflow:

1) Push some commits
2) Betterer runs and alerts us to any regressions moving us further from strict mode (or whatever other betterer tests we've defined). You will _only_ see issues that your commits have introduced as we're ensuring that results are updated with every PR (CI will now fail if the results file has not been updated).
3) Take the opportunity to fix the typescript errors, or decide that it's too hard for now.
4) If necessary, force update the results file for the issues you've decided to defer with `yarn betterer --update`.

## Done
- Add husky and a pre-push hook which runs betterer.
- Remove `continue-on-error` in CI to ensure that each PR has updated betterer results correctly.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Commit some junk, betterer should run. Unless you've introduce a new typescript issue, it should exit 0.
