### PR TITLE
Add vscode betterer config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     "cSpell.words": [
         "lifecycles",
         "unmount"
-    ]
+    ],
+    "betterer.configPath": "./ui/.betterer.ts",
+    "betterer.resultsPath": "./ui/.betterer.results",
+    "betterer.tsconfigPath": "./ui/tsconfig.json"
 }

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -323,7 +323,7 @@ exports[`stricter compilation`] = {
     "src/app/utils/someNotAll.ts:3892711037": [
       [7, 2, 71, "Type \'boolean | 0\' is not assignable to type \'boolean\'.\\n  Type \'0\' is not assignable to type \'boolean\'.", "1467649629"]
     ],
-    "src/testing/factories.ts:1289488080": [
+    "src/testing/factories/nodes.ts:1289488080": [
       [56, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string | undefined> | Factory<string | undefined> | DerivedFunction<Device, string | undefined> | undefined\'.", "1898500505"],
       [60, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | Factory<ModelRef> | AttributeFunction<ModelRef> | DerivedFunction<Device, ModelRef>\'.", "2088575771"],
       [77, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | AttributeFunction<ModelRef | undefined> | Factory<ModelRef | undefined> | DerivedFunction<...> | undefined\'.", "2088098233"],
@@ -385,5 +385,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `679`
+  value: `676`
 };


### PR DESCRIPTION
## Done

- Add vs code workspace config for betterer extension
- Remove js file count test, as it [appears to be failing](https://github.com/phenomnomnominal/betterer/issues/149) when run in the extension context. This test isn't as valuable as having immediate feedback in the IDE for "stricter compilation", so I think dropping it isn't a huge loss.


![image](https://user-images.githubusercontent.com/130286/86689274-f3514280-c05a-11ea-908e-e9c6161a5a58.png)

![image](https://user-images.githubusercontent.com/130286/86689308-fb10e700-c05a-11ea-9834-cc1c1bc77950.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Install the betterer vs code extension.
- Rename a js file to ts, wait a bit (can take a while for problems to appear), check the problems tab and you should hopefully see some betterer output. You should also get some red squiggles in the IDE (just as we do for ts compiler errors and eslint).

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
