### PR TITLE
Block CI on betterer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: CYPRESS_INSTALL_BINARY=0 yarn install
       - run: yarn betterer > results.txt
-        continue-on-error: true
         env:
           CI: true
       - name: Upload betterer results
@@ -49,4 +48,3 @@ jobs:
         with:
           name: betterer-report
           path: results.txt
-

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,16 +1,39 @@
 # Hacking
 
-- [Development setup](#maas-ui-development-setup)
-- [Running a branch](#running-a-branch)
-- [Setting up or connecting to a MAAS](#maas-deployments)
-- [Creating a Multipass instance](#creating-a-multipass-instance)
-- [Creating a LXD instance](#creating-a-lxd-instance)
-- [Building for production](#building)
-- [Creating a fake windows image](#creating-a-fake-windows-image)
-- [Testing with Cypress](#testing-with-cypress)
-- [Adding a new yarn workspace](#adding-a-new-yarn-workspace)
+- Project conventions
+  - [TypeScript](#Typescript)
+    - [Dealing with problems](#dealing-with-problems)
+    - [Betterer](#betterer)
+- Development setup
+  - [Development setup](#development-setup)
+  - [Running a branch](#running-a-branch)
+  - [Setting up or connecting to a MAAS](#maas-deployments)
+  - [Creating a Multipass instance](#creating-a-multipass-instance)
+  - [Creating a LXD instance](#creating-a-lxd-instance)
+  - [Building a production bundle](#building)
+  - [Creating a fake windows image](#creating-a-fake-windows-image)
+  - [Testing with Cypress](#testing-with-cypress)
+  - [Adding a new yarn workspace](#adding-a-new-yarn-workspace)
 
-# maas-ui development setup
+# Project conventions
+
+## TypeScript
+
+maas-ui is in the process of migrating `ui` to TypeScript. Any new modules in `ui` should be written in [TypeScript](https://www.typescriptlang.org/), however `legacy` is exempt.
+
+If your branch touches an existing js module in `ui`, it should be converted to TypeScript. The maas-ui maintainers are happy to help with any issues you might encounter.
+
+### Dealing with problems
+
+There are cases where determining a type for a particular object can be difficult. We provide an "escape hatch" type called `TSFixMe` (aliased to `any`) which you can use, but please make a best effort to avoid this and determine the correct types where possible.
+
+### Betterer
+
+maas-ui uses [betterer](https://github.com/phenomnomnominal/betterer) to assist with our goal of enabling TypeScript's `strict` compile option. Once you are ready to create a PR against maas-ui, please run `yarn betterer`, and make a best effort to correct any TypeScript issues your branch may have introduced. CI will block your PR if you have introduced a `strict` mode regression.
+
+If you are unable to address the compiler errors, you can as a last resort run `yarn betterer --update` to force an update of the betterer snapshot. Please do not do this as a matter of course, but seek help if you are having trouble satisfying the compiler.
+
+# Development setup
 
 **Note: You will need access to a running instance of MAAS in order to run maas-ui.**
 
@@ -454,10 +477,10 @@ Ensure both node (current LTS) and yarn are installed.
 From the root of the MAAS UI project run:
 
 ```shell
-dotrun build-all
+yarn build-all
 ```
 
-Optimised production bundles for both `ui` and `legacy` will be built, and output to `./build`.
+An optimised production bundle will be built, and output to `./build`.
 
 # Creating a fake windows image
 
@@ -522,11 +545,13 @@ Then you should be able to visit `<your-maas-url>:5240/MAAS/l/images` and your W
 If you're testing license keys the format is: `XXXXX-XXXXX-XXXXX-XXXXX-XXXXX`.
 
 # Testing with Cypress
+
 [Cypress](https://www.cypress.io/) is an end-to-end Javascript testing framework that executes in the browser, and therefore in the same run loop as the device under test. It includes features such as time travel (through the use of UI snapshots), real-time reloads and automatic/intuitive waiting.
 
 ## Running headless tests
 
 ### Note
+
 ⚠️ Cypress tests assume that the user `admin` with password `test` exists on the maas server.
 
 To run headless Cypress tests, enter the following command from the root of the project:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [License](#license)
 
 ## About
+
 MAAS is an open-source tool that lets you build a data centre from bare-metal servers. You can discover, commission, deploy, and dynamically reconfigure a large network of individual units.
 
 ![screenshot](https://user-images.githubusercontent.com/130286/80558424-738d7300-8a2e-11ea-9777-4d5fc72788b3.png)
@@ -20,48 +21,57 @@ This repository contains the sourcecode for the [MAAS](https://maas.io) web app,
 
 It is comprised of the following [yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/):
 
-  - *ui*: the react maas client (all new work should be in this workspace).
-  - *legacy*: the angularjs maas client.
-  - *root*: a single-spa app, providing top-level routing between both *ui* and *legacy*.
-  - *shared*: code shared between both legacy and ui.
-  - *proxy*: a proxying express project, used for serving both legacy and ui projects in development.
+- _ui_: the react maas client (all new work should be in this workspace).
+- _legacy_: the angularjs maas client.
+- _root_: a single-spa app, providing top-level routing between both _ui_ and _legacy_.
+- _shared_: code shared between both legacy and ui.
+- _proxy_: a proxying express project, used for serving both legacy and ui projects in development.
 
 ## Contributing
+
 Community contributions are most welcome, and there are a number of ways to participate:
 
-* [Submit bugs and feature requests](https://github.com/canonical-web-and-design/maas-ui/issues)
-* [Assist with code review](https://github.com/canonical-web-and-design/maas-ui/pulls)
-* [Submit bugs for the MAAS website](https://github.com/canonical-web-and-design/maas.io)
-* [Contribute to MAAS documentation](https://maas.io/docs/writing-guide)
+- [Submit bugs and feature requests](https://github.com/canonical-web-and-design/maas-ui/issues)
+- [Assist with code review](https://github.com/canonical-web-and-design/maas-ui/pulls)
+- [Submit bugs for the MAAS website](https://github.com/canonical-web-and-design/maas.io)
+- [Contribute to MAAS documentation](https://maas.io/docs/writing-guide)
 
 Please see [HACKING](HACKING.md) for details on setting up a MAAS UI development environment.
 
 ## Feedback
-  * Ask a question about MAAS on [Discourse](https://discourse.maas.io/).
-  * File a [MAAS UI issue](https://github.com/canonical-web-and-design/maas-ui/issues/new/choose).
-  * File a [MAAS issue](https://bugs.launchpad.net/maas/+filebug).
+
+- Ask a question about MAAS on [Discourse](https://discourse.maas.io/).
+- File a [MAAS UI issue](https://github.com/canonical-web-and-design/maas-ui/issues/new/choose).
+- File a [MAAS issue](https://bugs.launchpad.net/maas/+filebug).
 
 ## Related Projects
 
 ### MAAS
+
 MAAS server source and issue tracking [can be found on Launchpad](https://launchpad.net/maas).
 
 ### LXD
+
 [LXD](https://github.com/lxc/lxd) is a next generation system container and virtual machine manager, used extensively by MAAS.
 
 ## Built With
-  * [React](https://reactjs.org/)
-  * [Redux](https://redux.js.org/)
-  * [single-spa](https://single-spa.js.org/)
-  * [Angularjs](https://angularjs.org/) (legacy)
+
+- [React](https://reactjs.org/)
+- [Redux](https://redux.js.org/)
+- [single-spa](https://single-spa.js.org/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Angularjs](https://angularjs.org/) (legacy)
 
 ## Team Members
+
 [MAAS UI](https://github.com/orgs/canonical/teams/maas-ui/members) and [Canonical Web & Design](https://github.com/orgs/canonical/teams/web-and-design/members)
 
 ## Code of Conduct
+
 This project adopts the [Ubuntu Code of Conduct](https://ubuntu.com/community/code-of-conduct).
 
 ## License
+
 Code licensed AGPLv3 by Canonical Ltd.
 
 With ♥ from Canonical

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,130 +1,198 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
-    "src/app/base/reducers/pod/pod.test.ts:1930988215": [
-      [144, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
-      [144, 27, 4, "Type \'string\' is not assignable to type \'never\'.", "2087876002"]
+    "src/app/base/actions/pod/pod.test.ts:2464677720": [
+      [61, 15, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"],
+      [76, 15, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
     ],
-    "src/app/base/selectors/pod/pod.ts:361290740": [
-      [66, 23, 17, "No overload matches this call.\\n  Overload 1 of 3, \'(callbackfn: (previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod, initialValue: Pod): Pod\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod\'.\\n      Types of parameters \'hosts\' and \'previousValue\' are incompatible.\\n        Type \'Pod\' is missing the following properties from type \'never[]\': length, pop, push, concat, and 28 more.\\n  Overload 2 of 3, \'(callbackfn: (previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[], initialValue: never[]): never[]\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[]\'.\\n      Type \'Controller[] | Machine[]\' is not assignable to type \'never[]\'.\\n        Type \'Controller[]\' is not assignable to type \'never[]\'.\\n          Type \'Controller\' is not assignable to type \'never\'.", "4184440056"]
+    "src/app/base/actions/pod/pod.ts:3144177006": [
+      [5, 4, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"],
+      [18, 4, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
     ],
-    "src/app/kvm/views/KVM.tsx:2802410770": [
-      [1, 30, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"]
+    "src/app/base/components/ActionForm/ActionForm.test.tsx:2440224413": [
+      [35, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [35, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [49, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [63, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [63, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [74, 21, 6, "Binding element \'errors\' implicitly has an \'any\' type.", "1168132398"],
+      [74, 29, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [89, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [89, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:1684615486": [
-      [1, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
-      [2, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [3, 36, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
+    "src/app/base/components/ActionForm/ActionForm.tsx:3995516374": [
+      [14, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
+      [18, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
+      [21, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
+      [21, 22, 15, "Object is possibly \'undefined\'.", "1847077069"],
+      [23, 13, 13, "Object is possibly \'undefined\'.", "3155939599"],
+      [123, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
+    ],
+    "src/app/base/components/FormikField/FormikField.tsx:1946634864": [
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+    ],
+    "src/app/base/components/FormikForm/FormikForm.tsx:4136491328": [
+      [70, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
+    ],
+    "src/app/base/components/SectionHeader/SectionHeader.tsx:1828886231": [
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [60, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
+    ],
+    "src/app/base/reducers/pod/pod.test.ts:1336984638": [
+      [163, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [163, 27, 4, "Type \'string\' is not assignable to type \'never\'.", "2087876002"],
+      [196, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [230, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [264, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [299, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [299, 31, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [334, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [368, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [368, 27, 9, "Type \'number\' is not assignable to type \'never\'.", "56784379"],
+      [403, 20, 2, "Type \'number\' is not assignable to type \'never\'.", "5861160"],
+      [403, 27, 9, "Type \'number\' is not assignable to type \'never\'.", "56784379"]
+    ],
+    "src/app/base/reducers/pod/pod.ts:3778994122": [
+      [27, 2, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2764002661"]
+    ],
+    "src/app/base/selectors/pod/pod.ts:3015115511": [
+      [109, 23, 17, "No overload matches this call.\\n  Overload 1 of 3, \'(callbackfn: (previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod, initialValue: Pod): Pod\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: Pod, currentValue: Pod, currentIndex: number, array: Pod[]) => Pod\'.\\n      Types of parameters \'hosts\' and \'previousValue\' are incompatible.\\n        Type \'Pod\' is missing the following properties from type \'never[]\': length, pop, push, concat, and 28 more.\\n  Overload 2 of 3, \'(callbackfn: (previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[], initialValue: never[]): never[]\', gave the following error.\\n    Argument of type \'(hosts: never[], pod: Pod) => Controller[] | Machine[]\' is not assignable to parameter of type \'(previousValue: never[], currentValue: Pod, currentIndex: number, array: Pod[]) => never[]\'.\\n      Type \'Controller[] | Machine[]\' is not assignable to type \'never[]\'.\\n        Type \'Controller[]\' is not assignable to type \'never[]\'.\\n          Type \'Controller\' is not assignable to type \'never\'.", "4184440056"]
+    ],
+    "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:2847492569": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [33, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [47, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [56, 24, 5, "Parameter \'props\' implicitly has an \'any\' type.", "187023499"],
-      [65, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [74, 24, 5, "Parameter \'props\' implicitly has an \'any\' type.", "187023499"]
+      [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [76, 24, 5, "Parameter \'props\' implicitly has an \'any\' type.", "187023499"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMDetails.tsx:3694518590": [
-      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [1, 22, 11, "Could not find a declaration file for module \'pluralize\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/pluralize/pluralize.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/pluralize\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'pluralize\';\`", "1850933701"],
-      [4, 26, 14, "Could not find a declaration file for module \'react-router\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router\';\`", "1913807490"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx:2826559237": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 29, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [3, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [23, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [37, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:3132221287": [
+    "src/app/kvm/views/KVMDetails/KVMDetails.tsx:1424820812": [
       [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:1453319310": [
+      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [3, 21, 5, "Could not find a declaration file for module \'yup\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+    ],
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:475451368": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [129, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx:4073178480": [
+      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx:4285699560": [
+      [21, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx:88432150": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [36, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [54, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/KVMActionFormWrapper.tsx:284015728": [
+      [15, 4, 12, "Type \'null\' is not assignable to type \'Element\'.", "3224621615"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx:1426299611": [
+      [21, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'string\'.", "2087897566"],
+      [26, 30, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx:2184902936": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [22, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx:2739913947": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [28, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [42, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [58, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [75, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [92, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [108, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:426034803": [
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [39, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'SetStateAction<string>\'.", "2087897566"],
+      [45, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
+      [65, 6, 11, "Type \'\\"\\" | Element\' is not assignable to type \'Element | undefined\'.\\n  Type \'\\"\\"\' is not assignable to type \'Element | undefined\'.", "3453098368"]
+    ],
     "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx:2065549093": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [44, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx:1073164979": [
+    "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx:510481832": [
       [19, 18, 3, "Object is possibly \'undefined\'.", "193426238"],
       [20, 20, 3, "Object is possibly \'undefined\'.", "193426238"],
       [21, 17, 3, "Object is possibly \'undefined\'.", "193426238"],
       [25, 11, 3, "Object is possibly \'undefined\'.", "193426238"],
       [25, 29, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:1754334357": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 29, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [3, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:2374633436": [
       [12, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [110, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [129, 27, 6, "Parameter \'action\' implicitly has an \'any\' type.", "1314712411"],
-      [134, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [153, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [205, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [252, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [303, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+      [111, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [135, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [146, 6, 88, "Object is possibly \'undefined\'.", "465871270"],
+      [154, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [206, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [253, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [304, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [349, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [363, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
+      [371, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [385, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
+      [393, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [418, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:2888575480": [
-      [0, 36, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [71, 15, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'Pod\'.\\n  No index signature with a parameter of type \'string\' was found on type \'Pod\'.", "2363910037"],
-      [125, 57, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
-      [281, 48, 8, "Argument of type \'Pod\' is not assignable to parameter of type \'(Controller | Machine)[]\'.\\n  Type \'Pod\' is missing the following properties from type \'(Controller | Machine)[]\': length, pop, push, concat, and 28 more.", "612212173"]
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:4176304522": [
+      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [67, 13, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'Pod\'.\\n  No index signature with a parameter of type \'string\' was found on type \'Pod\'.", "2363910037"],
+      [101, 57, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
+      [116, 24, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx:1102421723": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 29, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [3, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
+    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx:2529226174": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [26, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+      [27, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [41, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx:2333705587": [
-      [2, 21, 18, "Could not find a declaration file for module \'react-router-dom\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/react-router-dom/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/react-router-dom\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'react-router-dom\';\`", "578327337"],
-      [18, 26, 3, "Object is possibly \'undefined\'.", "193426238"],
-      [19, 19, 3, "Object is possibly \'undefined\'.", "193426238"]
+    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx:3688026520": [
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [31, 23, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx:2642544460": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [55, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [89, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:189060714": [
-      [20, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.", "193426238"],
+    "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:2019834130": [
+      [20, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "193426238"],
       [23, 28, 13, "Property \'getOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "1772678613"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx:2138170176": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx:2848158544": [
+    "src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx:3465902379": [
       [18, 33, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2973346775"],
       [21, 33, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "2973147829"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx:3552592969": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
-      [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [36, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [48, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx:2627892494": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [39, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [52, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:1354181980": [
-      [19, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.", "193426238"],
-      [25, 33, 4, "Argument of type \'Controller | Machine | null | undefined\' is not assignable to parameter of type \'Object\'.\\n  Type \'undefined\' is not assignable to type \'Object\'.", "2087793957"]
+    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:3802016292": [
+      [19, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "193426238"],
+      [25, 33, 4, "Argument of type \'Controller | Machine | null | undefined\' is not assignable to parameter of type \'Controller | Machine | undefined\'.\\n  Type \'null\' is not assignable to type \'Controller | Machine | undefined\'.", "2087793957"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx:4294840152": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [44, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx:1614008088": [
+    "src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx:4244075939": [
       [14, 33, 3, "Object is possibly \'undefined\'.", "193426238"],
       [21, 18, 3, "Object is possibly \'undefined\'.", "193426238"],
       [23, 17, 3, "Object is possibly \'undefined\'.", "193426238"],
@@ -132,59 +200,190 @@ exports[`stricter compilation`] = {
       [27, 30, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx:1181964408": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [31, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx:2231352096": [
+    "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx:172021915": [
       [14, 34, 3, "Object is possibly \'undefined\'.", "193426238"],
       [21, 18, 3, "Object is possibly \'undefined\'.", "193426238"],
       [23, 17, 3, "Object is possibly \'undefined\'.", "193426238"],
       [27, 11, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx:3510081411": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [26, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx:1944168975": [
+    "src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx:1957225268": [
       [27, 58, 3, "Object is possibly \'undefined\'.", "193426238"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx:1476552216": [
-      [0, 22, 8, "Could not find a declaration file for module \'enzyme\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/enzyme/build/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/enzyme\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'enzyme\';\`", "1025042757"],
-      [2, 27, 18, "Could not find a declaration file for module \'redux-mock-store\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/redux-mock-store/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/redux-mock-store\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'redux-mock-store\';\`", "1001964238"],
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [27, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx:1150045171": [
+    "src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx:3749948392": [
       [18, 11, 3, "Object is possibly \'undefined\'.", "193426238"],
       [22, 53, 3, "Object is possibly \'undefined\'.", "193426238"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx:2715595244": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [61, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [92, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [131, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:3217432980": [
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [72, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+      [82, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [105, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
+      [119, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.test.tsx:2276870095": [
+      [12, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [122, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [136, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [137, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
+      [188, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [201, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [202, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
+      [237, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [250, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [251, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:3049974690": [
+      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
+      [46, 21, 17, "Property \'deployingSelected\' does not exist on type \'typeof machine\'.", "3830099655"],
+      [60, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
+      [69, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
+      [80, 34, 6, "Property \'deploy\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1121484462"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx:162052981": [
+      [128, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"],
+      [148, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"],
+      [168, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"],
+      [189, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"],
+      [220, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"],
+      [262, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"],
+      [282, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx:1262012646": [
+      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [25, 28, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
+      [27, 25, 17, "Object is of type \'unknown\'.", "4281571837"],
+      [29, 28, 22, "Property \'getUbuntuKernelOptions\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "321954485"],
+      [46, 18, 17, "Object is of type \'unknown\'.", "4281571837"],
+      [46, 46, 17, "Object is of type \'unknown\'.", "4281571837"],
+      [47, 41, 17, "Object is of type \'unknown\'.", "4281571837"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx:2749085546": [
+      [116, 10, 19, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2609332470"],
+      [150, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx:4246555145": [
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [19, 27, 4, "Binding element \'file\' implicitly has an \'any\' type.", "2087597251"],
+      [21, 4, 16, "Object is possibly \'null\'.", "4019370437"],
+      [26, 20, 23, "Argument of type \'\\"Reading file aborted.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2851093748"],
+      [30, 20, 21, "Argument of type \'\\"Error reading file.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2974791143"],
+      [53, 18, 6, "Argument of type \'string\' is not assignable to parameter of type \'SetStateAction<null>\'.", "1168132398"],
+      [102, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx:3260645888": [
+      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [30, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [48, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [112, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [146, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [180, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [208, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [248, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [249, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [250, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [251, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [252, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [256, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.tsx:1626104059": [
+      [36, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
+      [37, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
+      [52, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
+      [53, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:2932673855": [
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [82, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+      [126, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"]
+    ],
+    "src/app/utils/getCookie.ts:940992619": [
+      [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
+    ],
+    "src/app/utils/someInArray.ts:1012121545": [
+      [8, 4, 68, "Type \'boolean | 0\' is not assignable to type \'boolean\'.\\n  Type \'0\' is not assignable to type \'boolean\'.", "3447795550"]
+    ],
+    "src/app/utils/someNotAll.ts:3892711037": [
+      [7, 2, 71, "Type \'boolean | 0\' is not assignable to type \'boolean\'.\\n  Type \'0\' is not assignable to type \'boolean\'.", "1467649629"]
+    ],
+    "src/testing/factories.ts:1289488080": [
+      [56, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string | undefined> | Factory<string | undefined> | DerivedFunction<Device, string | undefined> | undefined\'.", "1898500505"],
+      [60, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | Factory<ModelRef> | AttributeFunction<ModelRef> | DerivedFunction<Device, ModelRef>\'.", "2088575771"],
+      [77, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | AttributeFunction<ModelRef | undefined> | Factory<ModelRef | undefined> | DerivedFunction<...> | undefined\'.", "2088098233"],
+      [97, 2, 3, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | AttributeFunction<ModelRef | undefined> | Factory<ModelRef | undefined> | DerivedFunction<...> | undefined\'.", "193426238"],
+      [108, 2, 4, "Type \'null\' is not assignable to type \'Vlan | ArrayFactory<never> | AttributeFunction<Vlan> | Factory<Vlan> | DerivedFunction<Machine, Vlan>\'.", "2088175728"],
+      [109, 2, 4, "Type \'null\' is not assignable to type \'ModelRef | ArrayFactory<never> | Factory<ModelRef> | AttributeFunction<ModelRef> | DerivedFunction<Machine, ModelRef>\'.", "2088575771"]
     ]
   }`
 };
 
 exports[`no TSFixMe types`] = {
   value: `{
-    "src/app/base/selectors/pod/pod.ts:361290740": [
-      [2, 45, 8, "RegExp match", "1152173309"],
-      [46, 34, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/base/selectors/resourcepool/resourcepool.ts:2909044297": [
-      [2, 33, 8, "RegExp match", "1152173309"],
+    "src/app/base/selectors/auth/auth.ts:3918254483": [
+      [1, 13, 8, "RegExp match", "1152173309"],
       [30, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/base/selectors/zone/zone.ts:3222253233": [
-      [2, 19, 8, "RegExp match", "1152173309"],
-      [30, 34, 8, "RegExp match", "1152173309"]
+    "src/app/base/selectors/pod/pod.ts:3015115511": [
+      [6, 13, 8, "RegExp match", "1152173309"],
+      [80, 34, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/base/selectors/resourcepool/resourcepool.ts:4021278305": [
+      [4, 13, 8, "RegExp match", "1152173309"],
+      [32, 34, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/base/selectors/zone/zone.ts:3530283409": [
+      [3, 13, 8, "RegExp match", "1152173309"],
+      [32, 34, 8, "RegExp match", "1152173309"]
     ],
     "src/app/base/types.ts:3778456340": [
       [0, 11, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/controller/types.ts:3342242320": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [13, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/machine/types.ts:90613066": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [50, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/pod/types.ts:3311872753": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [38, 16, 8, "RegExp match", "1152173309"],
+      [48, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/resourcepool/types.ts:4045616415": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [15, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/user/types.ts:1153084241": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [14, 9, 8, "RegExp match", "1152173309"],
+      [24, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/zone/types.ts:80244761": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [14, 9, 8, "RegExp match", "1152173309"]
     ]
   }`
 };
 
 exports[`migrate js files to ts`] = {
-  value: `688`
+  value: `679`
 };


### PR DESCRIPTION
## Done

- Block CI on betterer.
- Add 'project conventions' section to HACKING.
- Update 'build with' section to include link to TypeScript.
- Manually update betterer snapshot.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- n/a

## Fixes

Fixes: n/a

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
