### PR TITLE
Add types for preferences models

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -368,6 +368,18 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 9, 8, "RegExp match", "1152173309"]
     ],
+    "src/app/store/sshkey/types.ts:2805027575": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [19, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/sslkey/types.ts:518217640": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [13, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/token/types.ts:4281996604": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [15, 9, 8, "RegExp match", "1152173309"]
+    ],
     "src/app/store/user/types.ts:1153084241": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [14, 9, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/preferences/selectors/sshkey/sshkey.test.js
+++ b/ui/src/app/preferences/selectors/sshkey/sshkey.test.js
@@ -1,22 +1,19 @@
+import {
+  sshKey as sshKeyFactory,
+  sshKeyState as sshKeyStateFactory,
+} from "testing/factories";
 import sshkey from "./sshkey";
 
 describe("sshkey selectors", () => {
   describe("all", () => {
     it("returns list of all MAAS configs", () => {
+      const items = [sshKeyFactory(), sshKeyFactory()];
       const state = {
-        sshkey: {
-          loading: false,
-          loaded: true,
-          items: [
-            { id: 1, key: "ssh-rsa aabb" },
-            { id: 2, key: "ssh-rsa ccdd" },
-          ],
-        },
+        sshkey: sshKeyStateFactory({
+          items,
+        }),
       };
-      expect(sshkey.all(state)).toStrictEqual([
-        { id: 1, key: "ssh-rsa aabb" },
-        { id: 2, key: "ssh-rsa ccdd" },
-      ]);
+      expect(sshkey.all(state)).toStrictEqual(items);
     });
   });
 

--- a/ui/src/app/preferences/selectors/sslkey/sslkey.test.js
+++ b/ui/src/app/preferences/selectors/sslkey/sslkey.test.js
@@ -1,22 +1,19 @@
+import {
+  sslKey as sslKeyFactory,
+  sslKeyState as sslKeyStateFactory,
+} from "testing/factories";
 import sslkey from "./sslkey";
 
 describe("sslkey selectors", () => {
   describe("all", () => {
     it("returns list of all MAAS configs", () => {
+      const items = [sslKeyFactory(), sslKeyFactory()];
       const state = {
-        sslkey: {
-          loading: false,
-          loaded: true,
-          items: [
-            { id: 1, key: "ssh-rsa aabb" },
-            { id: 2, key: "ssh-rsa ccdd" },
-          ],
-        },
+        sslkey: sslKeyStateFactory({
+          items,
+        }),
       };
-      expect(sslkey.all(state)).toStrictEqual([
-        { id: 1, key: "ssh-rsa aabb" },
-        { id: 2, key: "ssh-rsa ccdd" },
-      ]);
+      expect(sslkey.all(state)).toStrictEqual(items);
     });
   });
 

--- a/ui/src/app/preferences/selectors/token/token.test.js
+++ b/ui/src/app/preferences/selectors/token/token.test.js
@@ -1,22 +1,19 @@
+import {
+  token as tokenFactory,
+  tokenState as tokenStateFactory,
+} from "testing/factories";
 import token from "./token";
 
 describe("token selectors", () => {
   describe("all", () => {
     it("returns list of all MAAS configs", () => {
+      const items = [tokenFactory(), tokenFactory()];
       const state = {
-        token: {
-          loading: false,
-          loaded: true,
-          items: [
-            { id: 1, key: "ssh-rsa aabb" },
-            { id: 2, key: "ssh-rsa ccdd" },
-          ],
-        },
+        token: tokenStateFactory({
+          items,
+        }),
       };
-      expect(token.all(state)).toStrictEqual([
-        { id: 1, key: "ssh-rsa aabb" },
-        { id: 2, key: "ssh-rsa ccdd" },
-      ]);
+      expect(token.all(state)).toStrictEqual(items);
     });
   });
 

--- a/ui/src/app/store/sshkey/types.ts
+++ b/ui/src/app/store/sshkey/types.ts
@@ -1,0 +1,26 @@
+import type { Model } from "app/store/types/model";
+import type { User } from "app/store/user/types";
+import type { TSFixMe } from "app/base/types";
+
+export type KeySource = {
+  auth_id: string;
+  protocol: string;
+};
+
+export type SSHKey = Model & {
+  created: string;
+  display: string;
+  key: string;
+  keysource: KeySource;
+  updated: string;
+  user: User["id"];
+};
+
+export type SSHKeyState = {
+  errors: TSFixMe;
+  items: SSHKey[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/sslkey/types.ts
+++ b/ui/src/app/store/sslkey/types.ts
@@ -1,0 +1,20 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+import type { User } from "app/store/user/types";
+
+export type SSLKey = Model & {
+  created: string;
+  display: string;
+  key: string;
+  updated: string;
+  user: User["id"];
+};
+
+export type SSLKeyState = {
+  errors: TSFixMe;
+  items: SSLKey[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/token/types.ts
+++ b/ui/src/app/store/token/types.ts
@@ -1,0 +1,22 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type TokenConsumer = {
+  key: string;
+  name: string;
+};
+
+export type Token = Model & {
+  consumer: TokenConsumer;
+  key: string;
+  secret: string;
+};
+
+export type TokenState = {
+  errors: TSFixMe;
+  items: Token[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -3,9 +3,15 @@ export {
   messageState,
   notificationState,
   podState,
+  sshKeyState,
+  sslKeyState,
+  tokenState,
   userState,
 } from "./state";
 export { message } from "./message";
 export { notification } from "./notification";
+export { sshKey } from "./sshkey";
+export { sslKey } from "./sslkey";
+export { token } from "./token";
 export { user } from "./user";
 export { device, machine, controller, pod } from "./nodes";

--- a/ui/src/testing/factories/sshkey.ts
+++ b/ui/src/testing/factories/sshkey.ts
@@ -1,0 +1,19 @@
+import { define, extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { SSHKey, KeySource } from "app/store/sshkey/types";
+
+export const keySource = define<KeySource>({
+  auth_id: "test auth id",
+  protocol: "test protocol",
+});
+
+export const sshKey = extend<Model, SSHKey>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  display: "display key",
+  key: "test key",
+  keysource: keySource,
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+  user: random,
+});

--- a/ui/src/testing/factories/sslkey.ts
+++ b/ui/src/testing/factories/sslkey.ts
@@ -1,0 +1,13 @@
+import { extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { SSLKey } from "app/store/sslkey/types";
+
+export const sslKey = extend<Model, SSLKey>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  display: "test key display",
+  key: "test key",
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+  user: random,
+});

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -7,6 +7,9 @@ import type { AuthState, UserState } from "app/store/user/types";
 import type { MessageState } from "app/store/message/types";
 import type { NotificationState } from "app/store/notification/types";
 import type { PodState } from "app/store/pod/types";
+import type { SSHKeyState } from "app/store/sshkey/types";
+import type { SSLKeyState } from "app/store/sslkey/types";
+import type { TokenState } from "app/store/token/types";
 
 const defaultState = {
   errors: () => ({}),
@@ -23,6 +26,21 @@ export const authState = define<AuthState>({
   user,
 });
 
+export const sshKeyState = define<SSHKeyState>({
+  ...defaultState,
+  errors: null,
+});
+
+export const sslKeyState = define<SSLKeyState>({
+  ...defaultState,
+  errors: null,
+});
+
+export const tokenState = define<TokenState>({
+  ...defaultState,
+  errors: null,
+});
+
 export const userState = define<UserState>({
   ...defaultState,
   auth: authState,
@@ -36,12 +54,9 @@ export const podState = define<PodState>({
 });
 
 export const notificationState = define<NotificationState>({
+  ...defaultState,
   errors: null,
   items: array(notification),
-  loaded: true,
-  loading: false,
-  saved: true,
-  saving: false,
 });
 
 export const messageState = define<MessageState>({

--- a/ui/src/testing/factories/token.ts
+++ b/ui/src/testing/factories/token.ts
@@ -1,0 +1,16 @@
+import { define, extend } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { Token, TokenConsumer } from "app/store/token/types";
+
+export const tokenConsumer = define<TokenConsumer>({
+  key: "consumer key",
+  name: "consumer name",
+});
+
+export const token = extend<Model, Token>(model, {
+  consumer: tokenConsumer,
+  key: "token key",
+  secret: "secret key",
+});


### PR DESCRIPTION
## Done

- Add types and factories for sshkey, sslkey and token.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1354.