### PR TITLE
Add types and factories for settings models

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -29,13 +29,13 @@ exports[`stricter compilation`] = {
       [123, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
     "src/app/base/components/FormikField/FormikField.tsx:1946634864": [
-      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/base/components/FormikForm/FormikForm.tsx:4136491328": [
       [70, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/SectionHeader/SectionHeader.tsx:1828886231": [
-      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [60, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
     ],
     "src/app/base/reducers/pod/pod.test.ts:1670915466": [
@@ -81,15 +81,15 @@ exports[`stricter compilation`] = {
       [94, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:1453319310": [
-      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [3, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [3, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:475451368": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [129, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx:4073178480": [
-      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx:2184902936": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -106,7 +106,7 @@ exports[`stricter compilation`] = {
       [108, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:641984635": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [45, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
       [65, 6, 11, "Type \'\\"\\" | Element | null\' is not assignable to type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3453098368"]
     ],
@@ -132,7 +132,7 @@ exports[`stricter compilation`] = {
       [418, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:4207317122": [
-      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [67, 13, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'Pod\'.\\n  No index signature with a parameter of type \'string\' was found on type \'Pod\'.", "2363910037"],
       [101, 57, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
       [116, 24, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
@@ -143,7 +143,7 @@ exports[`stricter compilation`] = {
       [41, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx:248496192": [
-      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx:2366141448": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -196,7 +196,7 @@ exports[`stricter compilation`] = {
       [131, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:3217432980": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [72, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [82, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
       [105, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
@@ -215,7 +215,7 @@ exports[`stricter compilation`] = {
       [251, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:3049974690": [
-      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
+      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
       [46, 21, 17, "Property \'deployingSelected\' does not exist on type \'typeof machine\'.", "3830099655"],
       [60, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
       [69, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
@@ -231,7 +231,7 @@ exports[`stricter compilation`] = {
       [282, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx:1262012646": [
-      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [25, 28, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
       [27, 25, 17, "Object is of type \'unknown\'.", "4281571837"],
       [29, 28, 22, "Property \'getUbuntuKernelOptions\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "321954485"],
@@ -244,7 +244,7 @@ exports[`stricter compilation`] = {
       [150, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx:4246555145": [
-      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [19, 27, 4, "Binding element \'file\' implicitly has an \'any\' type.", "2087597251"],
       [21, 4, 16, "Object is possibly \'null\'.", "4019370437"],
       [26, 20, 23, "Argument of type \'\\"Reading file aborted.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2851093748"],
@@ -275,7 +275,7 @@ exports[`stricter compilation`] = {
       [53, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:2932673855": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [82, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [126, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"]
     ],
@@ -316,9 +316,22 @@ exports[`no TSFixMe types`] = {
     "src/app/base/types.ts:3778456340": [
       [0, 11, 8, "RegExp match", "1152173309"]
     ],
+    "src/app/store/config/types.ts:3756472347": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [9, 9, 8, "RegExp match", "1152173309"]
+    ],
     "src/app/store/controller/types.ts:3342242320": [
       [1, 13, 8, "RegExp match", "1152173309"],
       [13, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/dhcpsnippet/types.ts:4267311850": [
+      [4, 13, 8, "RegExp match", "1152173309"],
+      [18, 9, 8, "RegExp match", "1152173309"],
+      [24, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/licensekeys/types.ts:2257386395": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [11, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/machine/types.ts:730274029": [
       [2, 13, 8, "RegExp match", "1152173309"],
@@ -328,6 +341,10 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [19, 9, 8, "RegExp match", "1152173309"]
     ],
+    "src/app/store/packagerepository/types.ts:3950087859": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [20, 9, 8, "RegExp match", "1152173309"]
+    ],
     "src/app/store/pod/types.ts:3311872753": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [38, 16, 8, "RegExp match", "1152173309"],
@@ -336,6 +353,11 @@ exports[`no TSFixMe types`] = {
     "src/app/store/resourcepool/types.ts:4045616415": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/scripts/types.ts:3202102268": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [11, 14, 8, "RegExp match", "1152173309"],
+      [43, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/sshkey/types.ts:2805027575": [
       [2, 13, 8, "RegExp match", "1152173309"],
@@ -362,5 +384,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `706`
+  value: `671`
 };

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -354,12 +354,11 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scripts/types.ts:1395981335": [
+    "src/app/store/scripts/types.ts:2264904018": [
       [1, 13, 8, "RegExp match", "1152173309"],
-      [11, 14, 8, "RegExp match", "1152173309"],
-      [16, 14, 8, "RegExp match", "1152173309"],
-      [21, 14, 8, "RegExp match", "1152173309"],
-      [53, 9, 8, "RegExp match", "1152173309"]
+      [15, 14, 8, "RegExp match", "1152173309"],
+      [20, 14, 8, "RegExp match", "1152173309"],
+      [52, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/sshkey/types.ts:2805027575": [
       [2, 13, 8, "RegExp match", "1152173309"],
@@ -386,5 +385,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `671`
+  value: `672`
 };

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -354,10 +354,12 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scripts/types.ts:3202102268": [
+    "src/app/store/scripts/types.ts:1395981335": [
       [1, 13, 8, "RegExp match", "1152173309"],
       [11, 14, 8, "RegExp match", "1152173309"],
-      [43, 9, 8, "RegExp match", "1152173309"]
+      [16, 14, 8, "RegExp match", "1152173309"],
+      [21, 14, 8, "RegExp match", "1152173309"],
+      [53, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/sshkey/types.ts:2805027575": [
       [2, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/base/selectors/dhcpsnippet/dhcpsnippet.test.js
+++ b/ui/src/app/base/selectors/dhcpsnippet/dhcpsnippet.test.js
@@ -1,13 +1,18 @@
+import {
+  dhcpSnippet as dhcpSnippetFactory,
+  dhcpSnippetState as dhcpSnippetStateFactory,
+} from "testing/factories";
 import dhcpsnippet from "./dhcpsnippet";
 
 describe("dhcpsnippet selectors", () => {
   it("can get all items", () => {
+    const items = [dhcpSnippetFactory(), dhcpSnippetFactory()];
     const state = {
-      dhcpsnippet: {
-        items: [{ name: "lease" }],
-      },
+      dhcpsnippet: dhcpSnippetStateFactory({
+        items,
+      }),
     };
-    expect(dhcpsnippet.all(state)).toEqual([{ name: "lease" }]);
+    expect(dhcpsnippet.all(state)).toEqual(items);
   });
 
   it("can get the loading state", () => {

--- a/ui/src/app/base/selectors/licensekeys/licensekeys.js
+++ b/ui/src/app/base/selectors/licensekeys/licensekeys.js
@@ -56,8 +56,8 @@ licensekeys.hasErrors = createSelector(
  */
 licensekeys.search = createSelector(
   [licensekeys.all, (state, term) => term],
-  (licencekeyItems, term) =>
-    licencekeyItems.filter(
+  (licensekeyItems, term) =>
+    licensekeyItems.filter(
       (item) => item.osystem.includes(term) || item.distro_series.includes(term)
     )
 );
@@ -79,8 +79,8 @@ licensekeys.getByOsystemAndDistroSeries = createSelector(
     licensekeys.all,
     (state, osystem, distro_series) => ({ osystem, distro_series }),
   ],
-  (licencekeyItems, { osystem, distro_series }) =>
-    licencekeyItems.filter(
+  (licensekeyItems, { osystem, distro_series }) =>
+    licensekeyItems.filter(
       (item) => item.osystem === osystem && item.distro_series === distro_series
     )[0]
 );

--- a/ui/src/app/base/selectors/licensekeys/licensekeys.test.js
+++ b/ui/src/app/base/selectors/licensekeys/licensekeys.test.js
@@ -1,24 +1,17 @@
+import {
+  licenseKeys as licenseKeysFactory,
+  licenseKeysState as licenseKeysStateFactory,
+} from "testing/factories";
 import licensekeys from "./licensekeys";
 
 describe("licensekeys selectors", () => {
   describe("all", () => {
     it("returns all license keys", () => {
-      const items = [
-        {
-          osystem: "windows",
-          license_key: "foo",
-        },
-        {
-          osystem: "redhat",
-          license_key: "bar",
-        },
-      ];
+      const items = [licenseKeysFactory(), licenseKeysFactory()];
       const state = {
-        licensekeys: {
-          loading: false,
-          loaded: true,
+        licensekeys: licenseKeysStateFactory({
           items,
-        },
+        }),
       };
 
       expect(licensekeys.all(state)).toStrictEqual(items);

--- a/ui/src/app/base/selectors/packagerepository/packagerepository.test.js
+++ b/ui/src/app/base/selectors/packagerepository/packagerepository.test.js
@@ -1,13 +1,18 @@
+import {
+  packageRepository as packageRepositoryFactory,
+  packageRepositoryState as packageRepositoryStateFactory,
+} from "testing/factories";
 import packagerepository from "./packagerepository";
 
 describe("packagerepository selectors", () => {
   it("can get repository items", () => {
+    const items = [packageRepositoryFactory(), packageRepositoryFactory()];
     const state = {
-      packagerepository: {
-        items: [{ name: "default" }],
-      },
+      packagerepository: packageRepositoryStateFactory({
+        items,
+      }),
     };
-    expect(packagerepository.all(state)).toEqual([{ name: "default" }]);
+    expect(packagerepository.all(state)).toEqual(items);
   });
 
   it("can get the loading state", () => {

--- a/ui/src/app/base/selectors/scripts/scripts.test.js
+++ b/ui/src/app/base/selectors/scripts/scripts.test.js
@@ -1,26 +1,17 @@
+import {
+  scripts as scriptsFactory,
+  scriptsState as scriptsStateFactory,
+} from "testing/factories";
 import scripts from "./scripts";
 
 describe("scripts selectors", () => {
   describe("all", () => {
     it("returns all scripts", () => {
-      const items = [
-        {
-          name: "commissioning script",
-          description: "a commissioning script",
-          type: 0,
-        },
-        {
-          name: "testing script",
-          description: "a testing script",
-          type: 2,
-        },
-      ];
+      const items = [scriptsFactory(), scriptsFactory()];
       const state = {
-        scripts: {
-          loading: false,
-          loaded: true,
+        scripts: scriptsStateFactory({
           items,
-        },
+        }),
       };
 
       expect(scripts.all(state)).toStrictEqual(items);

--- a/ui/src/app/settings/selectors/config/config.test.js
+++ b/ui/src/app/settings/selectors/config/config.test.js
@@ -1,18 +1,17 @@
+import {
+  config as configFactory,
+  configState as configStateFactory,
+} from "testing/factories";
 import config from "./config";
 
 describe("config selectors", () => {
   describe("all", () => {
     it("returns list of all MAAS configs", () => {
-      const allConfigs = [
-        { name: "default_storage_layout", value: "bcache" },
-        { name: "enable_disk_erasing_on_release", value: "foo" },
-      ];
+      const allConfigs = [configFactory(), configFactory()];
       const state = {
-        config: {
-          loading: false,
-          loaded: true,
+        config: configStateFactory({
           items: allConfigs,
-        },
+        }),
       };
       expect(config.all(state)).toStrictEqual(allConfigs);
     });

--- a/ui/src/app/store/config/types.ts
+++ b/ui/src/app/store/config/types.ts
@@ -1,0 +1,16 @@
+import type { TSFixMe } from "app/base/types";
+
+export type Config = {
+  name: string;
+  value: string | boolean | number | null;
+  choices?: [string | number, string][];
+};
+
+export type ConfigState = {
+  errors: TSFixMe;
+  items: Config[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/dhcpsnippet/types.ts
+++ b/ui/src/app/store/dhcpsnippet/types.ts
@@ -1,0 +1,31 @@
+import type { Controller } from "app/store/controller/types";
+import type { Device } from "app/store/device/types";
+import type { Machine } from "app/store/machine/types";
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type DHCPSnippetHistory = Model & {
+  created: string;
+  value: string;
+};
+
+export type DHCPSnippet = Model & {
+  created: string;
+  description: string;
+  enabled: boolean;
+  history: DHCPSnippetHistory[];
+  name: string;
+  node: Controller | Machine | Device | null;
+  subnet: TSFixMe | null; // Replace with Subnet["id"] when the Subnet type has been defined.
+  updated: string;
+  value: string;
+};
+
+export type DHCPSnippetState = {
+  errors: TSFixMe;
+  items: DHCPSnippet[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/dhcpsnippet/types.ts
+++ b/ui/src/app/store/dhcpsnippet/types.ts
@@ -1,6 +1,5 @@
-import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
-import type { Machine } from "app/store/machine/types";
+import type { Host } from "app/store/types/host";
 import type { Model } from "app/store/types/model";
 import type { TSFixMe } from "app/base/types";
 
@@ -15,7 +14,7 @@ export type DHCPSnippet = Model & {
   enabled: boolean;
   history: DHCPSnippetHistory[];
   name: string;
-  node: Controller | Machine | Device | null;
+  node: Host | Device | null;
   subnet: TSFixMe | null; // Replace with Subnet["id"] when the Subnet type has been defined.
   updated: string;
   value: string;

--- a/ui/src/app/store/licensekeys/types.ts
+++ b/ui/src/app/store/licensekeys/types.ts
@@ -1,0 +1,18 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type LicenseKeys = Model & {
+  distro_series: string;
+  license_key: string;
+  osystem: string;
+  resource_uri: string;
+};
+
+export type LicenseKeysState = {
+  errors: TSFixMe;
+  items: LicenseKeys[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/packagerepository/types.ts
+++ b/ui/src/app/store/packagerepository/types.ts
@@ -1,0 +1,27 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type PackageRepository = Model & {
+  arches: string[];
+  components: string[];
+  created: string;
+  default: boolean;
+  disable_sources: boolean;
+  disabled_components: string[];
+  disabled_pockets: string[];
+  distributions: string[];
+  enabled: boolean;
+  key: string;
+  name: string;
+  updated: string;
+  url: string;
+};
+
+export type PackageRepositoryState = {
+  errors: TSFixMe;
+  items: PackageRepository[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/scripts/types.ts
+++ b/ui/src/app/store/scripts/types.ts
@@ -1,0 +1,50 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type ScriptsHistory = Model & {
+  comment: string | null;
+  created: string;
+  data: string;
+};
+
+export type JSONObject = {
+  // Data from a Django JSONObjectField.
+  [x: string]: TSFixMe;
+};
+
+export type Scripts = Model & {
+  apply_configured_networking: boolean;
+  default: boolean;
+  description: string;
+  destructive: boolean;
+  for_hardware: string[];
+  hardware_type_name: "Node" | "CPU" | "Memory" | "Storage" | "Network";
+  hardware_type: number;
+  history: ScriptsHistory[];
+  may_reboot: boolean;
+  name: string;
+  packages: JSONObject;
+  parallel_name:
+    | "Disabled"
+    | "Run along other instances of this script"
+    | "Run along any other script.";
+  parallel: number;
+  parameters: JSONObject;
+  recommission: boolean;
+  resource_uri: string;
+  results: JSONObject;
+  tags: string[];
+  timeout: string;
+  title: string;
+  type_name: "Commissioning script" | "Testing script";
+  type: number;
+};
+
+export type ScriptsState = {
+  errors: TSFixMe;
+  items: Scripts[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/scripts/types.ts
+++ b/ui/src/app/store/scripts/types.ts
@@ -8,8 +8,7 @@ export type ScriptsHistory = Model & {
 };
 
 export type ScriptsPackages = {
-  // Data from a Django JSONObjectField that could have any validly parsed JSON structure.
-  [x: string]: TSFixMe;
+  [x: string]: string[];
 };
 
 export type ScriptsParameters = {

--- a/ui/src/app/store/scripts/types.ts
+++ b/ui/src/app/store/scripts/types.ts
@@ -7,8 +7,18 @@ export type ScriptsHistory = Model & {
   data: string;
 };
 
-export type JSONObject = {
-  // Data from a Django JSONObjectField.
+export type ScriptsPackages = {
+  // Data from a Django JSONObjectField that could have any validly parsed JSON structure.
+  [x: string]: TSFixMe;
+};
+
+export type ScriptsParameters = {
+  // Data from a Django JSONObjectField that could have any validly parsed JSON structure.
+  [x: string]: TSFixMe;
+};
+
+export type ScriptsResults = {
+  // Data from a Django JSONObjectField that could have any validly parsed JSON structure.
   [x: string]: TSFixMe;
 };
 
@@ -23,16 +33,16 @@ export type Scripts = Model & {
   history: ScriptsHistory[];
   may_reboot: boolean;
   name: string;
-  packages: JSONObject;
+  packages: ScriptsPackages;
   parallel_name:
     | "Disabled"
     | "Run along other instances of this script"
     | "Run along any other script.";
   parallel: number;
-  parameters: JSONObject;
+  parameters: ScriptsParameters;
   recommission: boolean;
   resource_uri: string;
-  results: JSONObject;
+  results: ScriptsResults;
   tags: string[];
   timeout: string;
   title: string;

--- a/ui/src/testing/factories/config.ts
+++ b/ui/src/testing/factories/config.ts
@@ -1,0 +1,8 @@
+import { define } from "cooky-cutter";
+
+import type { Config } from "app/store/config/types";
+
+export const config = define<Config>({
+  name: "test name",
+  value: null,
+});

--- a/ui/src/testing/factories/dhcpsnippet.ts
+++ b/ui/src/testing/factories/dhcpsnippet.ts
@@ -1,0 +1,25 @@
+import { array, extend } from "cooky-cutter";
+
+import { model } from "./model";
+import type {
+  DHCPSnippet,
+  DHCPSnippetHistory,
+} from "app/store/dhcpsnippet/types";
+import type { Model } from "app/store/types/model";
+
+export const dhcpSnippetHistory = extend<Model, DHCPSnippetHistory>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  value: "test value",
+});
+
+export const dhcpSnippet = extend<Model, DHCPSnippet>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  description: "test description",
+  enabled: false,
+  history: array(dhcpSnippetHistory),
+  name: "test snippet",
+  node: null,
+  subnet: null,
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+  value: "test value",
+});

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -1,17 +1,27 @@
 export {
   authState,
+  configState,
+  dhcpSnippetState,
+  licenseKeysState,
   messageState,
   notificationState,
+  packageRepositoryState,
   podState,
+  scriptsState,
   sshKeyState,
   sslKeyState,
   tokenState,
   userState,
 } from "./state";
+export { config } from "./config";
+export { device, machine, controller, pod } from "./nodes";
+export { dhcpSnippet } from "./dhcpsnippet";
+export { licenseKeys } from "./licensekeys";
 export { message } from "./message";
 export { notification } from "./notification";
+export { packageRepository } from "./packagerepository";
+export { scripts } from "./scripts";
 export { sshKey } from "./sshkey";
 export { sslKey } from "./sslkey";
 export { token } from "./token";
 export { user } from "./user";
-export { device, machine, controller, pod } from "./nodes";

--- a/ui/src/testing/factories/licensekeys.ts
+++ b/ui/src/testing/factories/licensekeys.ts
@@ -1,0 +1,12 @@
+import { extend } from "cooky-cutter";
+
+import { model } from "./model";
+import type { LicenseKeys } from "app/store/licensekeys/types";
+import type { Model } from "app/store/types/model";
+
+export const licenseKeys = extend<Model, LicenseKeys>(model, {
+  distro_series: "win2012",
+  license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX",
+  osystem: "windows",
+  resource_uri: "/MAAS/api/2.0/license-key/windows/win2012",
+});

--- a/ui/src/testing/factories/packagerepository.ts
+++ b/ui/src/testing/factories/packagerepository.ts
@@ -1,0 +1,21 @@
+import { extend } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { PackageRepository } from "app/store/packagerepository/types";
+
+export const packageRepository = extend<Model, PackageRepository>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+  name: "test repo",
+  url: "test url",
+  distributions: () => [],
+  disabled_pockets: () => [],
+  disabled_components: () => [],
+  disable_sources: false,
+  components: () => [],
+  arches: () => [],
+  key: "",
+  default: false,
+  enabled: false,
+});

--- a/ui/src/testing/factories/scripts.ts
+++ b/ui/src/testing/factories/scripts.ts
@@ -1,0 +1,36 @@
+import { array, extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { Scripts, ScriptsHistory } from "app/store/scripts/types";
+
+export const scriptsHistory = extend<Model, ScriptsHistory>(model, {
+  comment: null,
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  data: "test history data",
+});
+
+export const scripts = extend<Model, Scripts>(model, {
+  apply_configured_networking: false,
+  default: false,
+  description: "test description",
+  destructive: false,
+  for_hardware: () => [],
+  hardware_type_name: "Node",
+  hardware_type: random,
+  history: array(scriptsHistory),
+  may_reboot: false,
+  name: "test name",
+  packages: () => ({}),
+  parallel_name: "Disabled",
+  parallel: random,
+  parameters: () => ({}),
+  recommission: false,
+  resource_uri: "/MAAS/api/2.0/scripts/test",
+  results: () => ({}),
+  tags: () => [],
+  timeout: "00:30:00",
+  title: "test title",
+  type_name: "Commissioning script",
+  type: random,
+});

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -4,9 +4,14 @@ import { message } from "./message";
 import { notification } from "./notification";
 import { user } from "./user";
 import type { AuthState, UserState } from "app/store/user/types";
+import type { ConfigState } from "app/store/config/types";
+import type { DHCPSnippetState } from "app/store/dhcpsnippet/types";
+import type { LicenseKeysState } from "app/store/licensekeys/types";
 import type { MessageState } from "app/store/message/types";
 import type { NotificationState } from "app/store/notification/types";
+import type { PackageRepositoryState } from "app/store/packagerepository/types";
 import type { PodState } from "app/store/pod/types";
+import type { ScriptsState } from "app/store/scripts/types";
 import type { SSHKeyState } from "app/store/sshkey/types";
 import type { SSLKeyState } from "app/store/sslkey/types";
 import type { TokenState } from "app/store/token/types";
@@ -26,6 +31,22 @@ export const authState = define<AuthState>({
   user,
 });
 
+export const configState = define<ConfigState>({
+  ...defaultState,
+});
+
+export const dhcpSnippetState = define<DHCPSnippetState>({
+  ...defaultState,
+});
+
+export const licenseKeysState = define<LicenseKeysState>({
+  ...defaultState,
+});
+
+export const scriptsState = define<ScriptsState>({
+  ...defaultState,
+});
+
 export const sshKeyState = define<SSHKeyState>({
   ...defaultState,
   errors: null,
@@ -39,6 +60,10 @@ export const sslKeyState = define<SSLKeyState>({
 export const tokenState = define<TokenState>({
   ...defaultState,
   errors: null,
+});
+
+export const packageRepositoryState = define<PackageRepositoryState>({
+  ...defaultState,
 });
 
 export const userState = define<UserState>({


### PR DESCRIPTION
## Done

- Add types and factories for dhcpsnippets, licensekeys, packagerepositories scripts and config.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1355.