### PR TITLE
Test scripts aren't mandatory.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -29,16 +29,13 @@ const CommissionFormSchema = Yup.object().shape({
       description: Yup.string(),
     })
   ),
-  testingScripts: Yup.array()
-    .of(
-      Yup.object().shape({
-        name: Yup.string().required(),
-        displayName: Yup.string(),
-        description: Yup.string(),
-      })
-    )
-    .min(1, "You must select at least one script.")
-    .required(),
+  testingScripts: Yup.array().of(
+    Yup.object().shape({
+      name: Yup.string().required(),
+      displayName: Yup.string(),
+      description: Yup.string(),
+    })
+  )
 });
 
 export const CommissionForm = ({ setSelectedAction }) => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -35,7 +35,7 @@ const CommissionFormSchema = Yup.object().shape({
       displayName: Yup.string(),
       description: Yup.string(),
     })
-  )
+  ),
 });
 
 export const CommissionForm = ({ setSelectedAction }) => {


### PR DESCRIPTION
## Done

- Changed the form schema for `CommissioningForm` to remove mandatory testing scripts

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- From machine list, select a machine to commission
- In the comissioning form, remove the default smartctl-validate test
- Should be able to submit the form.

## Fixes
 #1374 
## Launchpad issue

Fixes LP#1884278

## Backports

