### PR TITLE
Change cypress MAAS snap from latest/edge to 2.8/edge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: Install MAAS snap and set up postgres database
           command: |
             sudo systemctl enable snapd
-            sudo snap install maas --channel=latest/edge
+            sudo snap install maas --channel=2.8/edge
             sudo -iu postgres psql -c "CREATE USER \"$MAAS_DBUSER\" WITH ENCRYPTED PASSWORD '$MAAS_DBPASS'" >/dev/null
             sudo -iu postgres createdb -O "$MAAS_DBUSER" "$MAAS_DBNAME" >/dev/null
             pg_hba="/etc/postgresql/$POSTGRES_VERSION/main/pg_hba.conf"


### PR DESCRIPTION
## Done

- Changed cypress MAAS snap from latest/edge to 2.8/edge for the 2.8 branch,

## QA
### QA steps

- `test_cypress` should pass