### PR TITLE
Build KVM configuration form.

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -79,7 +79,7 @@ exports[`stricter compilation`] = {
       [100, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [104, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:355991143": [
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:1892683038": [
       [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [5, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -38,7 +38,7 @@ exports[`stricter compilation`] = {
       [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [59, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
     ],
-    "src/app/base/components/Slider/Slider.tsx:3550275385": [
+    "src/app/base/components/Slider/Slider.tsx:753275532": [
       [0, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"]
     ],
     "src/app/base/reducers/pod/pod.test.ts:1670915466": [
@@ -357,6 +357,20 @@ exports[`no TSFixMe types`] = {
     "src/app/store/domain/types.ts:2438698325": [
       [1, 13, 8, "RegExp match", "1152173309"],
       [16, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/general/types.ts:1987535520": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [5, 9, 8, "RegExp match", "1152173309"],
+      [14, 9, 8, "RegExp match", "1152173309"],
+      [23, 9, 8, "RegExp match", "1152173309"],
+      [32, 9, 8, "RegExp match", "1152173309"],
+      [47, 9, 8, "RegExp match", "1152173309"],
+      [61, 9, 8, "RegExp match", "1152173309"],
+      [72, 9, 8, "RegExp match", "1152173309"],
+      [95, 9, 8, "RegExp match", "1152173309"],
+      [104, 9, 8, "RegExp match", "1152173309"],
+      [138, 9, 8, "RegExp match", "1152173309"],
+      [147, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/general/types.ts:1987535520": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -38,6 +38,9 @@ exports[`stricter compilation`] = {
       [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [59, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
     ],
+    "src/app/base/components/Slider/Slider.tsx:3550275385": [
+      [0, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"]
+    ],
     "src/app/base/reducers/pod/pod.test.ts:1670915466": [
       [44, 10, 8, "Argument of type \'PodState\' is not assignable to parameter of type \'{ readonly errors: {}; readonly items: readonly never[]; readonly loaded: boolean; readonly loading: boolean; readonly saved: boolean; readonly saving: boolean; readonly selected: readonly never[]; readonly statuses: {}; }\'.\\n  Types of property \'items\' are incompatible.\\n    Type \'Pod[]\' is not assignable to type \'readonly never[]\'.\\n      Type \'Pod\' is not assignable to type \'never\'.", "604104617"],
       [64, 10, 8, "Argument of type \'PodState\' is not assignable to parameter of type \'{ readonly errors: {}; readonly items: readonly never[]; readonly loaded: boolean; readonly loading: boolean; readonly saved: boolean; readonly saving: boolean; readonly selected: readonly never[]; readonly statuses: {}; }\'.", "604104617"],
@@ -76,16 +79,16 @@ exports[`stricter compilation`] = {
       [100, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [104, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:4096304743": [
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:355991143": [
       [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [5, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx:1085219694": [
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx:2293033710": [
       [15, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [40, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [77, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+      [83, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx:3757238586": [
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx:1512800423": [
       [0, 40, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:2892838463": [
@@ -385,7 +388,7 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [20, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/pod/types.ts:3311872753": [
+    "src/app/store/pod/types.ts:3027397456": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [39, 16, 8, "RegExp match", "1152173309"],
       [49, 9, 8, "RegExp match", "1152173309"]

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -28,7 +28,7 @@ exports[`stricter compilation`] = {
       [23, 13, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [123, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
-    "src/app/base/components/FormikField/FormikField.tsx:1946634864": [
+    "src/app/base/components/FormikField/FormikField.tsx:4232142994": [
       [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/base/components/FormikForm/FormikForm.tsx:4136491328": [
@@ -71,7 +71,7 @@ exports[`stricter compilation`] = {
     "src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx:4039034563": [
       [30, 30, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx:1827624353": [
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx:2470520871": [
       [17, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
@@ -452,5 +452,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `870`
+  value: `879`
 };

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -71,17 +71,20 @@ exports[`stricter compilation`] = {
     "src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx:4039034563": [
       [30, 30, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx:3820128401": [
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx:1827624353": [
       [17, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [83, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [100, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [104, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
+      [104, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"],
+      [139, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [156, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [160, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:1892683038": [
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:3273586287": [
       [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [5, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+      [4, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],
     "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx:2293033710": [
       [15, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -103,9 +106,9 @@ exports[`stricter compilation`] = {
       [81, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [94, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:1453319310": [
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:879073754": [
       [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [3, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+      [4, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:475451368": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -357,20 +360,6 @@ exports[`no TSFixMe types`] = {
     "src/app/store/domain/types.ts:2438698325": [
       [1, 13, 8, "RegExp match", "1152173309"],
       [16, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/general/types.ts:1987535520": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [5, 9, 8, "RegExp match", "1152173309"],
-      [14, 9, 8, "RegExp match", "1152173309"],
-      [23, 9, 8, "RegExp match", "1152173309"],
-      [32, 9, 8, "RegExp match", "1152173309"],
-      [47, 9, 8, "RegExp match", "1152173309"],
-      [61, 9, 8, "RegExp match", "1152173309"],
-      [72, 9, 8, "RegExp match", "1152173309"],
-      [95, 9, 8, "RegExp match", "1152173309"],
-      [104, 9, 8, "RegExp match", "1152173309"],
-      [138, 9, 8, "RegExp match", "1152173309"],
-      [147, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/general/types.ts:1987535520": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -53,7 +53,7 @@ exports[`stricter compilation`] = {
       [335, 10, 8, "Argument of type \'PodState\' is not assignable to parameter of type \'{ readonly errors: {}; readonly items: readonly never[]; readonly loaded: boolean; readonly loading: boolean; readonly saved: boolean; readonly saving: boolean; readonly selected: readonly never[]; readonly statuses: {}; }\'.", "604104617"],
       [373, 10, 8, "Argument of type \'PodState\' is not assignable to parameter of type \'{ readonly errors: {}; readonly items: readonly never[]; readonly loaded: boolean; readonly loading: boolean; readonly saved: boolean; readonly saving: boolean; readonly selected: readonly never[]; readonly statuses: {}; }\'.", "604104617"]
     ],
-    "src/app/base/reducers/pod/pod.ts:3778994122": [
+    "src/app/base/reducers/pod/pod.ts:2323457215": [
       [27, 2, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2764002661"]
     ],
     "src/app/base/selectors/pod/pod.ts:3260989378": [
@@ -65,8 +65,28 @@ exports[`stricter compilation`] = {
       [54, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx:114114633": [
-      [29, 30, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"]
+    "src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx:4039034563": [
+      [30, 30, 7, "Property \'refresh\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1380666520"]
+    ],
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx:3820128401": [
+      [17, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [83, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [100, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [104, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
+    ],
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:4096304743": [
+      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [5, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+    ],
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx:1085219694": [
+      [15, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [40, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [77, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    ],
+    "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx:3757238586": [
+      [0, 40, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:2892838463": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -367,8 +387,8 @@ exports[`no TSFixMe types`] = {
     ],
     "src/app/store/pod/types.ts:3311872753": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [38, 16, 8, "RegExp match", "1152173309"],
-      [48, 9, 8, "RegExp match", "1152173309"]
+      [39, 16, 8, "RegExp match", "1152173309"],
+      [49, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/resourcepool/types.ts:4045616415": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/base/components/FormCard/_index.scss
+++ b/ui/src/app/base/components/FormCard/_index.scss
@@ -1,4 +1,8 @@
 @mixin FormCard {
+  .form-card {
+    overflow: visible; // Allows absolutely positioned elements to extend beyond bottom of card
+  }
+
   .form-card__buttons {
     display: flex;
     justify-content: flex-end;

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
@@ -2,7 +2,6 @@ import { ActionButton, Button } from "@canonical/react-components";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
-import { useHistory } from "react-router-dom";
 
 export const FormCardButtons = ({
   bordered = true,
@@ -16,8 +15,6 @@ export const FormCardButtons = ({
   submitLabel,
   success,
 }) => {
-  const history = useHistory();
-
   return (
     <>
       {bordered && <hr />}
@@ -26,21 +23,17 @@ export const FormCardButtons = ({
           "is-bordered": bordered,
         })}
       >
-        <Button
-          appearance="base"
-          className={classNames({ "u-no-margin--bottom": bordered })}
-          data-test="cancel-action"
-          onClick={() => {
-            if (onCancel) {
-              onCancel();
-            } else {
-              history.goBack();
-            }
-          }}
-          type="button"
-        >
-          Cancel
-        </Button>
+        {onCancel && (
+          <Button
+            appearance="base"
+            className={classNames({ "u-no-margin--bottom": bordered })}
+            data-test="cancel-action"
+            onClick={onCancel}
+            type="button"
+          >
+            Cancel
+          </Button>
+        )}
         {secondarySubmit && secondarySubmitLabel && (
           <Button
             appearance="neutral"

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.js
@@ -67,4 +67,14 @@ describe("FormCardButtons ", () => {
       "Be patient!"
     );
   });
+
+  it("does not show cancel button if no onCancel prop", () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+        <FormCardButtons onCancel={undefined} submitLabel="Save" />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find('[data-test="cancel-action"]').exists()).toBe(false);
+  });
 });

--- a/ui/src/app/base/components/FormCardButtons/__snapshots__/FormCardButtons.test.js.snap
+++ b/ui/src/app/base/components/FormCardButtons/__snapshots__/FormCardButtons.test.js.snap
@@ -8,22 +8,6 @@ exports[`FormCardButtons  renders 1`] = `
   <div
     className="form-card__buttons is-bordered"
   >
-    <Button
-      appearance="base"
-      className="u-no-margin--bottom"
-      data-test="cancel-action"
-      onClick={[Function]}
-      type="button"
-    >
-      <button
-        className="p-button--base u-no-margin--bottom"
-        data-test="cancel-action"
-        onClick={[Function]}
-        type="button"
-      >
-        Cancel
-      </button>
-    </Button>
     <ActionButton
       appearance="positive"
       className="u-no-margin--bottom"

--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -9,7 +9,7 @@ import type { TSFixMe } from "app/base/types";
 type Props = {
   Component?: JSX.Element;
   name: string;
-  value?: string;
+  value?: number | string;
   [x: string]: TSFixMe;
 };
 
@@ -34,7 +34,7 @@ const FormikField = ({
 FormikField.propTypes = {
   component: PropTypes.func,
   name: PropTypes.string.isRequired,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 export default FormikField;

--- a/ui/src/app/base/components/Slider/Slider.test.tsx
+++ b/ui/src/app/base/components/Slider/Slider.test.tsx
@@ -4,20 +4,26 @@ import React from "react";
 import Slider from "./Slider";
 
 describe("Slider", () => {
-  it("renders without number input", () => {
+  it("renders correctly", () => {
     const wrapper = shallow(
-      <Slider max={10} min={0} onChange={jest.fn()} value={5} />
+      <Slider max={10} min={0} onChange={jest.fn()} showInput value={5} />
     );
     // Snapshot should not include extra number input beside the slider.
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("renders with number input", () => {
+  it("can render without an additional number input", () => {
     const wrapper = shallow(
-      <Slider max={10} min={0} onChange={jest.fn()} showInput value={5} />
+      <Slider
+        max={10}
+        min={0}
+        onChange={jest.fn()}
+        showInput={false}
+        value={5}
+      />
     );
     // Snapshot should include extra number input beside the slider.
-    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find("input[type='number']").exists()).toBe(false);
   });
 
   it("correctly displays filled portion", () => {

--- a/ui/src/app/base/components/Slider/Slider.test.tsx
+++ b/ui/src/app/base/components/Slider/Slider.test.tsx
@@ -24,7 +24,7 @@ describe("Slider", () => {
     );
     const backgroundStyle = wrapper.find(".p-slider").props().style
       ?.background as string;
-    const trimmed = backgroundStyle.replace(/\s\s+/g, " ");
+    const trimmed = backgroundStyle?.replace(/\s\s+/g, " ");
     const expectedPercentage = "25%"; // ((4 - 2) / (10 - 2)) * 100 = (2 / 8) * 100 = 25
     expect(trimmed.includes(expectedPercentage)).toBe(true);
   });

--- a/ui/src/app/base/components/Slider/Slider.test.tsx
+++ b/ui/src/app/base/components/Slider/Slider.test.tsx
@@ -8,7 +8,6 @@ describe("Slider", () => {
     const wrapper = shallow(
       <Slider max={10} min={0} onChange={jest.fn()} showInput value={5} />
     );
-    // Snapshot should not include extra number input beside the slider.
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -22,7 +21,6 @@ describe("Slider", () => {
         value={5}
       />
     );
-    // Snapshot should include extra number input beside the slider.
     expect(wrapper.find("input[type='number']").exists()).toBe(false);
   });
 

--- a/ui/src/app/base/components/Slider/Slider.test.tsx
+++ b/ui/src/app/base/components/Slider/Slider.test.tsx
@@ -8,6 +8,7 @@ describe("Slider", () => {
     const wrapper = shallow(
       <Slider max={10} min={0} onChange={jest.fn()} value={5} />
     );
+    // Snapshot should not include extra number input beside the slider.
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -15,6 +16,7 @@ describe("Slider", () => {
     const wrapper = shallow(
       <Slider max={10} min={0} onChange={jest.fn()} showInput value={5} />
     );
+    // Snapshot should include extra number input beside the slider.
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/ui/src/app/base/components/Slider/Slider.test.tsx
+++ b/ui/src/app/base/components/Slider/Slider.test.tsx
@@ -1,0 +1,48 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import Slider from "./Slider";
+
+describe("Slider", () => {
+  it("renders without number input", () => {
+    const wrapper = shallow(
+      <Slider max={10} min={0} onChange={jest.fn()} value={5} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders with number input", () => {
+    const wrapper = shallow(
+      <Slider max={10} min={0} onChange={jest.fn()} showInput value={5} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("correctly displays filled portion", () => {
+    const wrapper = shallow(
+      <Slider max={10} min={2} onChange={jest.fn()} showInput value={4} />
+    );
+    const backgroundStyle = wrapper.find(".p-slider").props().style
+      ?.background as string;
+    const trimmed = backgroundStyle.replace(/\s\s+/g, " ");
+    const expectedPercentage = "25%"; // ((4 - 2) / (10 - 2)) * 100 = (2 / 8) * 100 = 25
+    expect(trimmed.includes(expectedPercentage)).toBe(true);
+  });
+
+  it("can be given a custom filled color", () => {
+    const wrapper = shallow(
+      <Slider
+        filledColor="#abc123"
+        max={8}
+        min={2}
+        onChange={jest.fn()}
+        showInput
+        value={4}
+      />
+    );
+    const backgroundStyle = wrapper.find(".p-slider").props().style
+      ?.background as string;
+    const trimmed = backgroundStyle.replace(/\s\s+/g, " ");
+    expect(trimmed.includes("#abc123")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/Slider/Slider.tsx
+++ b/ui/src/app/base/components/Slider/Slider.tsx
@@ -1,0 +1,81 @@
+import Field from "@canonical/react-components/dist/components/Field";
+import React from "react";
+
+const DEFAULT_FILLED_COLOR = "#0066CC";
+
+type Props = {
+  disabled?: boolean;
+  emptyColor?: string;
+  error?: string;
+  filledColor?: string;
+  help?: string;
+  inputDisabled?: boolean;
+  label?: string;
+  max: number;
+  min: number;
+  onChange: (e: React.FormEvent<HTMLInputElement>) => void;
+  required?: boolean;
+  showInput?: boolean;
+  step?: number;
+  value: number;
+};
+
+export const Slider = ({
+  disabled = false,
+  emptyColor = "transparent",
+  error,
+  filledColor = DEFAULT_FILLED_COLOR,
+  help,
+  inputDisabled = false,
+  label,
+  max,
+  min,
+  onChange,
+  required = false,
+  showInput = false,
+  step = 1,
+  value,
+}: Props): JSX.Element => {
+  const filledPercentage = `${((value - min) / (max - min)) * 100}%`;
+
+  return (
+    <Field error={error} help={help} label={label}>
+      <div className="p-slider__wrapper">
+        <input
+          className="p-slider"
+          disabled={disabled}
+          max={max}
+          min={min}
+          onChange={onChange}
+          required={required}
+          step={step}
+          style={{
+            background: `linear-gradient(
+              to right,
+              ${filledColor} 0%,
+              ${filledColor} ${filledPercentage},
+              ${emptyColor} ${filledPercentage},
+              ${emptyColor} 100%
+            )`,
+          }}
+          type="range"
+          value={value}
+        />
+        {showInput && (
+          <input
+            className="p-slider__input"
+            disabled={disabled || inputDisabled}
+            max={max}
+            min={min}
+            onChange={onChange}
+            step={step}
+            type="number"
+            value={value}
+          />
+        )}
+      </div>
+    </Field>
+  );
+};
+
+export default Slider;

--- a/ui/src/app/base/components/Slider/Slider.tsx
+++ b/ui/src/app/base/components/Slider/Slider.tsx
@@ -36,8 +36,21 @@ export const Slider = ({
   step = 1,
   value,
 }: Props): JSX.Element => {
-  const filledPercentage = `${((value - min) / (max - min)) * 100}%`;
-
+  let style = {};
+  if (navigator?.userAgent?.includes("AppleWebKit")) {
+    // Range inputs on Webkit browsers don't have a built-in "filled" portion,
+    // so instead it is handled here as a background.
+    const filledPercentage = `${((value - min) / (max - min)) * 100}%`;
+    style = {
+      background: `linear-gradient(
+        to right,
+        ${filledColor} 0%,
+        ${filledColor} ${filledPercentage},
+        ${emptyColor} ${filledPercentage},
+        ${emptyColor} 100%
+      )`,
+    };
+  }
   return (
     <Field error={error} help={help} label={label}>
       <div className="p-slider__wrapper">
@@ -49,15 +62,7 @@ export const Slider = ({
           onChange={onChange}
           required={required}
           step={step}
-          style={{
-            background: `linear-gradient(
-              to right,
-              ${filledColor} 0%,
-              ${filledColor} ${filledPercentage},
-              ${emptyColor} ${filledPercentage},
-              ${emptyColor} 100%
-            )`,
-          }}
+          style={style}
           type="range"
           value={value}
         />

--- a/ui/src/app/base/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/ui/src/app/base/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Slider renders with number input 1`] = `
+<Field>
+  <div
+    className="p-slider__wrapper"
+  >
+    <input
+      className="p-slider"
+      disabled={false}
+      max={10}
+      min={0}
+      onChange={[MockFunction]}
+      required={false}
+      step={1}
+      style={
+        Object {
+          "background": "linear-gradient(
+              to right,
+              #0066CC 0%,
+              #0066CC 50%,
+              transparent 50%,
+              transparent 100%
+            )",
+        }
+      }
+      type="range"
+      value={5}
+    />
+    <input
+      className="p-slider__input"
+      disabled={false}
+      max={10}
+      min={0}
+      onChange={[MockFunction]}
+      step={1}
+      type="number"
+      value={5}
+    />
+  </div>
+</Field>
+`;
+
+exports[`Slider renders without number input 1`] = `
+<Field>
+  <div
+    className="p-slider__wrapper"
+  >
+    <input
+      className="p-slider"
+      disabled={false}
+      max={10}
+      min={0}
+      onChange={[MockFunction]}
+      required={false}
+      step={1}
+      style={
+        Object {
+          "background": "linear-gradient(
+              to right,
+              #0066CC 0%,
+              #0066CC 50%,
+              transparent 50%,
+              transparent 100%
+            )",
+        }
+      }
+      type="range"
+      value={5}
+    />
+  </div>
+</Field>
+`;

--- a/ui/src/app/base/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/ui/src/app/base/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -16,12 +16,12 @@ exports[`Slider renders with number input 1`] = `
       style={
         Object {
           "background": "linear-gradient(
-              to right,
-              #0066CC 0%,
-              #0066CC 50%,
-              transparent 50%,
-              transparent 100%
-            )",
+        to right,
+        #0066CC 0%,
+        #0066CC 50%,
+        transparent 50%,
+        transparent 100%
+      )",
         }
       }
       type="range"
@@ -57,12 +57,12 @@ exports[`Slider renders without number input 1`] = `
       style={
         Object {
           "background": "linear-gradient(
-              to right,
-              #0066CC 0%,
-              #0066CC 50%,
-              transparent 50%,
-              transparent 100%
-            )",
+        to right,
+        #0066CC 0%,
+        #0066CC 50%,
+        transparent 50%,
+        transparent 100%
+      )",
         }
       }
       type="range"

--- a/ui/src/app/base/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/ui/src/app/base/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Slider renders with number input 1`] = `
+exports[`Slider renders correctly 1`] = `
 <Field>
   <div
     className="p-slider__wrapper"
@@ -35,37 +35,6 @@ exports[`Slider renders with number input 1`] = `
       onChange={[MockFunction]}
       step={1}
       type="number"
-      value={5}
-    />
-  </div>
-</Field>
-`;
-
-exports[`Slider renders without number input 1`] = `
-<Field>
-  <div
-    className="p-slider__wrapper"
-  >
-    <input
-      className="p-slider"
-      disabled={false}
-      max={10}
-      min={0}
-      onChange={[MockFunction]}
-      required={false}
-      step={1}
-      style={
-        Object {
-          "background": "linear-gradient(
-        to right,
-        #0066CC 0%,
-        #0066CC 50%,
-        transparent 50%,
-        transparent 100%
-      )",
-        }
-      }
-      type="range"
       value={5}
     />
   </div>

--- a/ui/src/app/base/components/Slider/index.ts
+++ b/ui/src/app/base/components/Slider/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Slider";

--- a/ui/src/app/base/components/TagSelector/TagSelector.js
+++ b/ui/src/app/base/components/TagSelector/TagSelector.js
@@ -1,4 +1,4 @@
-import { Button, Input, Label } from "@canonical/react-components";
+import { Button, Input } from "@canonical/react-components";
 import Field from "@canonical/react-components/dist/components/Field";
 import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
@@ -159,12 +159,16 @@ export const TagSelector = ({
   }, []);
 
   return (
-    <div className="tag-selector" ref={wrapperRef}>
-      <Field
-        error={error}
-        help={help}
-        label={<Label onClick={() => setDropdownOpen(true)}>{label}</Label>}
-      >
+    <Field
+      error={error}
+      help={help}
+      label={
+        <span onClick={() => setDropdownOpen(true)} ref={wrapperRef}>
+          {label}
+        </span>
+      }
+    >
+      <div className="tag-selector">
         {selectedTags.length > 0 && (
           <ul className="tag-selector__selected-list">
             {generateSelectedItems({ selectedTags, updateTags })}
@@ -203,8 +207,8 @@ export const TagSelector = ({
             </ul>
           </div>
         )}
-      </Field>
-    </div>
+      </div>
+    </Field>
   );
 };
 

--- a/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.js.snap
+++ b/ui/src/app/base/components/TagSelector/__snapshots__/TagSelector.test.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TagSelector renders and matches the snapshot when closed 1`] = `
-<div
-  className="tag-selector"
+<Field
+  label={
+    <span
+      onClick={[Function]}
+    >
+      Tags
+    </span>
+  }
 >
-  <Field
-    label={
-      <Label
-        onClick={[Function]}
-      >
-        Tags
-      </Label>
-    }
+  <div
+    className="tag-selector"
   >
     <Input
       className="tag-selector__input"
@@ -22,8 +22,8 @@ exports[`TagSelector renders and matches the snapshot when closed 1`] = `
       type="text"
       value=""
     />
-  </Field>
-</div>
+  </div>
+</Field>
 `;
 
 exports[`TagSelector renders and matches the snapshot when opened 1`] = `
@@ -44,39 +44,34 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
     ]
   }
 >
-  <div
-    className="tag-selector"
-  >
-    <Field
-      label={
-        <Label
-          onClick={[Function]}
-        >
-          Tags
-        </Label>
-      }
-    >
-      <div
-        className="p-form__group p-form-validation"
+  <Field
+    label={
+      <span
+        onClick={[Function]}
       >
-        <Label>
-          <label
-            className="p-form__label"
+        Tags
+      </span>
+    }
+  >
+    <div
+      className="p-form__group p-form-validation"
+    >
+      <Label>
+        <label
+          className="p-form__label"
+        >
+          <span
+            onClick={[Function]}
           >
-            <Label
-              onClick={[Function]}
-            >
-              <label
-                className="p-form__label"
-                onClick={[Function]}
-              >
-                Tags
-              </label>
-            </Label>
-          </label>
-        </Label>
+            Tags
+          </span>
+        </label>
+      </Label>
+      <div
+        className="p-form__control u-clearfix"
+      >
         <div
-          className="p-form__control u-clearfix"
+          className="tag-selector"
         >
           <Input
             className="tag-selector__input"
@@ -111,8 +106,8 @@ exports[`TagSelector renders and matches the snapshot when opened 1`] = `
           </Input>
         </div>
       </div>
-    </Field>
-  </div>
+    </div>
+  </Field>
 </TagSelector>
 `;
 
@@ -136,39 +131,34 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
     ]
   }
 >
-  <div
-    className="tag-selector"
-  >
-    <Field
-      label={
-        <Label
-          onClick={[Function]}
-        >
-          Tags
-        </Label>
-      }
-    >
-      <div
-        className="p-form__group p-form-validation"
+  <Field
+    label={
+      <span
+        onClick={[Function]}
       >
-        <Label>
-          <label
-            className="p-form__label"
+        Tags
+      </span>
+    }
+  >
+    <div
+      className="p-form__group p-form-validation"
+    >
+      <Label>
+        <label
+          className="p-form__label"
+        >
+          <span
+            onClick={[Function]}
           >
-            <Label
-              onClick={[Function]}
-            >
-              <label
-                className="p-form__label"
-                onClick={[Function]}
-              >
-                Tags
-              </label>
-            </Label>
-          </label>
-        </Label>
+            Tags
+          </span>
+        </label>
+      </Label>
+      <div
+        className="p-form__control u-clearfix"
+      >
         <div
-          className="p-form__control u-clearfix"
+          className="tag-selector"
         >
           <Input
             className="tag-selector__input"
@@ -203,7 +193,7 @@ exports[`TagSelector renders and matches the snapshot with tag descriptions 1`] 
           </Input>
         </div>
       </div>
-    </Field>
-  </div>
+    </div>
+  </Field>
 </TagSelector>
 `;

--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -1,8 +1,9 @@
 import { Button } from "@canonical/react-components";
-import { useSelector } from "react-redux";
-import * as Yup from "yup";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import { auth as authSelectors } from "app/base/selectors";
 import { status as statusSelectors } from "app/base/selectors";
@@ -63,6 +64,7 @@ export const UserForm = ({
   user,
 }) => {
   const editing = !!user;
+  const history = useHistory();
   const [passwordVisible, showPassword] = useState(!editing);
   const saving = useSelector(userSelectors.saving);
   const saved = useSelector(userSelectors.saved);
@@ -99,6 +101,7 @@ export const UserForm = ({
       cleanup={cleanup}
       errors={errors}
       initialValues={initialValues}
+      onCancel={() => history.goBack()}
       onSaveAnalytics={onSaveAnalytics}
       onSubmit={(values, { resetForm }) => {
         const params = {

--- a/ui/src/app/base/reducers/pod/pod.ts
+++ b/ui/src/app/base/reducers/pod/pod.ts
@@ -53,16 +53,19 @@ const pod = createNextState((draft, action) => {
       draft.loading = false;
       break;
     case "CREATE_POD_START":
+    case "UPDATE_POD_START":
       draft.saved = false;
       draft.saving = true;
       break;
     case "CREATE_POD_SUCCESS":
+    case "UPDATE_POD_SUCCESS":
       draft.errors = {};
       draft.saved = true;
       draft.saving = false;
       break;
     case "FETCH_POD_ERROR":
     case "CREATE_POD_ERROR":
+    case "UPDATE_POD_ERROR":
       draft.errors = action.error;
       draft.saving = false;
       break;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -15,6 +15,7 @@ const RefreshForm = ({ setSelectedAction }: Props): JSX.Element | null => {
   const { id } = useParams();
   const errors = useSelector(podSelectors.errors);
   const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const refreshing = useSelector(podSelectors.refreshing);
   const refreshingSelected = useSelector(podSelectors.refreshingSelected);
   const podsToRefresh = id ? [Number(id)] : selectedPodIDs;
 
@@ -30,7 +31,7 @@ const RefreshForm = ({ setSelectedAction }: Props): JSX.Element | null => {
           dispatch(podActions.refresh(podID));
         });
       }}
-      processingCount={refreshingSelected.length}
+      processingCount={id ? refreshing.length : refreshingSelected.length}
       selectedCount={podsToRefresh.length}
     >
       <p>

--- a/ui/src/app/kvm/utils.ts
+++ b/ui/src/app/kvm/utils.ts
@@ -1,0 +1,10 @@
+export const formatHostType = (type: string): string => {
+  switch (type) {
+    case "lxd":
+      return "LXD";
+    case "virsh":
+      return "Virsh";
+    default:
+      return type;
+  }
+};

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
@@ -80,7 +80,7 @@ describe("KVMConfiguration", () => {
     expect(wrapper.find("Spinner").length).toBe(1);
   });
 
-  it("can handle updating a KVM", () => {
+  it("can handle updating a lxd KVM", () => {
     const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
@@ -129,6 +129,62 @@ describe("KVMConfiguration", () => {
           pool: "1",
           power_address: "192.168.1.1",
           power_pass: undefined,
+          tags: "tag1,tag2",
+          zone: "2",
+        },
+      },
+    });
+  });
+
+  it("can handle updating a virsh KVM", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/kvm/:id/edit"
+            component={() => <KVMConfiguration />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          cpu_over_commit_ratio: 2,
+          memory_over_commit_ratio: 2,
+          password: "password",
+          pool: "1",
+          power_address: "192.168.1.1",
+          tags: ["tag1", "tag2"],
+          type: "lxd",
+          zone: "2",
+        })
+    );
+    expect(
+      store.getActions().find((action) => action.type === "UPDATE_POD")
+    ).toStrictEqual({
+      type: "UPDATE_POD",
+      meta: {
+        method: "update",
+        model: "pod",
+      },
+      payload: {
+        params: {
+          cpu_over_commit_ratio: 2,
+          id: 1,
+          memory_over_commit_ratio: 2,
+          password: undefined,
+          pool: "1",
+          power_address: "192.168.1.1",
+          power_pass: "password", // virsh uses power_pass key
           tags: "tag1,tag2",
           zone: "2",
         },

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
@@ -164,7 +164,7 @@ describe("KVMConfiguration", () => {
           pool: "1",
           power_address: "192.168.1.1",
           tags: ["tag1", "tag2"],
-          type: "lxd",
+          type: "virsh",
           zone: "2",
         })
     );

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.test.tsx
@@ -1,0 +1,138 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter, Route } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+} from "testing/factories";
+
+import KVMConfiguration from "./KVMConfiguration";
+
+const mockStore = configureStore();
+
+describe("KVMConfiguration", () => {
+  let initialState;
+
+  beforeEach(() => {
+    const pods = [podFactory({ id: 1, name: "pod1" })];
+    const podState = podStateFactory({ items: pods, loaded: true });
+    initialState = {
+      config: {
+        items: [],
+      },
+      pod: podState,
+      resourcepool: {
+        items: [],
+        loaded: true,
+      },
+      tag: {
+        items: [],
+        loaded: true,
+      },
+      zone: {
+        items: [],
+        loaded: true,
+      },
+    };
+  });
+
+  it("fetches the necessary data on load", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <KVMConfiguration />
+        </MemoryRouter>
+      </Provider>
+    );
+    const expectedActions = [
+      "FETCH_POD",
+      "FETCH_RESOURCEPOOL",
+      "FETCH_TAG",
+      "FETCH_ZONE",
+    ];
+    const actions = store.getActions();
+    expectedActions.forEach((expectedAction) => {
+      expect(actions.some((action) => action.type === expectedAction));
+    });
+  });
+
+  it("displays a spinner if data has not loaded", () => {
+    const state = { ...initialState };
+    state.pod.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <KVMConfiguration />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").length).toBe(1);
+  });
+
+  it("can handle updating a KVM", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/kvm/:id/edit"
+            component={() => <KVMConfiguration />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          cpu_over_commit_ratio: 2,
+          memory_over_commit_ratio: 2,
+          password: "password",
+          pool: "1",
+          power_address: "192.168.1.1",
+          tags: ["tag1", "tag2"],
+          type: "lxd",
+          zone: "2",
+        })
+    );
+    expect(
+      store.getActions().find((action) => action.type === "UPDATE_POD")
+    ).toStrictEqual({
+      type: "UPDATE_POD",
+      meta: {
+        method: "update",
+        model: "pod",
+      },
+      payload: {
+        params: {
+          cpu_over_commit_ratio: 2,
+          id: 1,
+          memory_over_commit_ratio: 2,
+          password: "password", // lxd uses password key
+          pool: "1",
+          power_address: "192.168.1.1",
+          power_pass: undefined,
+          tags: "tag1,tag2",
+          zone: "2",
+        },
+      },
+    });
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
@@ -87,7 +87,7 @@ const KVMConfiguration = (): JSX.Element => {
           initialValues={{
             cpu_over_commit_ratio: pod.cpu_over_commit_ratio,
             memory_over_commit_ratio: pod.memory_over_commit_ratio,
-            password: podPassword,
+            password: podPassword || "",
             pool: `${pod.pool}`, // Convert to string for valid options HTML, also API expects string
             power_address: pod.power_address,
             tags: pod.tags,
@@ -104,10 +104,11 @@ const KVMConfiguration = (): JSX.Element => {
               cpu_over_commit_ratio: values.cpu_over_commit_ratio,
               id: pod.id,
               memory_over_commit_ratio: values.memory_over_commit_ratio,
-              password: values.type === "lxd" ? values.password : undefined,
+              password: (values.type === "lxd" && values.password) || undefined,
               pool: values.pool,
               power_address: values.power_address,
-              power_pass: values.type === "lxd" ? undefined : values.password,
+              power_pass:
+                (values.type === "virsh" && values.password) || undefined,
               tags: values.tags.join(","), // API expects comma-separated string
               zone: values.zone,
             };

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
@@ -1,28 +1,133 @@
+import { Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-
-import { pod as podActions } from "app/base/actions";
-import { pod as podSelectors } from "app/base/selectors";
-import { useWindowTitle } from "app/base/hooks";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import type { RootState } from "app/store/root/types";
+import type { Pod } from "app/store/pod/types";
+import {
+  pod as podActions,
+  resourcepool as resourcePoolActions,
+  tag as tagActions,
+  zone as zoneActions,
+} from "app/base/actions";
+import {
+  pod as podSelectors,
+  resourcepool as resourcePoolSelectors,
+  tag as tagSelectors,
+  zone as zoneSelectors,
+} from "app/base/selectors";
+import { useWindowTitle } from "app/base/hooks";
+import { formatErrors } from "app/utils";
+import FormCard from "app/base/components/FormCard";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import KVMConfigurationFields from "./KVMConfigurationFields";
+
+const KVMConfigurationSchema = Yup.object().shape({
+  cpu_over_commit_ratio: Yup.number().required("CPU overcommit ratio required"),
+  memory_over_commit_ratio: Yup.number().required(
+    "Memory overcommit ratio required"
+  ),
+  pool: Yup.string().required("Resource pool required"),
+  power_address: Yup.string().required("Address required"),
+  password: Yup.string(),
+  tags: Yup.array().of(Yup.string()),
+  type: Yup.string().required("Type required"),
+  zone: Yup.string().required("Zone required"),
+});
+
+export type KVMConfigurationValues = {
+  cpu_over_commit_ratio: Pod["cpu_over_commit_ratio"];
+  memory_over_commit_ratio: Pod["memory_over_commit_ratio"];
+  pool: Pod["pool"];
+  power_address: Pod["power_address"];
+  password: Pod["password"] | Pod["power_pass"];
+  tags: Pod["tags"];
+  type: Pod["type"];
+  zone: Pod["zone"];
+};
 
 const KVMConfiguration = (): JSX.Element => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const { id } = useParams();
-
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
+  const podErrors = useSelector(podSelectors.errors);
+  const podSaved = useSelector(podSelectors.saved);
+  const podSaving = useSelector(podSelectors.saving);
+  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
+  const tagsLoaded = useSelector(tagSelectors.loaded);
+  const zonesLoaded = useSelector(zoneSelectors.loaded);
+
+  const errors = formatErrors(podErrors);
 
   useWindowTitle(`KVM ${`${pod?.name} ` || ""} configuration`);
 
   useEffect(() => {
     dispatch(podActions.fetch());
+    dispatch(resourcePoolActions.fetch());
+    dispatch(tagActions.fetch());
+    dispatch(zoneActions.fetch());
   }, [dispatch]);
 
-  return <></>;
+  const loaded =
+    Boolean(pod) && resourcePoolsLoaded && tagsLoaded && zonesLoaded;
+
+  if (loaded) {
+    const podPassword = pod.type === "lxd" ? pod.password : pod.power_pass;
+
+    return (
+      <FormCard sidebar={false} title="KVM configuration">
+        <FormikForm
+          buttons={FormCardButtons}
+          cleanup={podActions.cleanup}
+          errors={errors}
+          initialValues={{
+            cpu_over_commit_ratio: pod.cpu_over_commit_ratio,
+            memory_over_commit_ratio: pod.memory_over_commit_ratio,
+            password: podPassword,
+            pool: `${pod.pool}`, // Convert to string for valid HTML, also API expects string
+            power_address: pod.power_address,
+            tags: pod.tags,
+            type: pod.type,
+            zone: `${pod.zone}`, // Convert to string for valid HTML, also API expects string
+          }}
+          onCancel={() => history.push({ pathname: `/kvm/${id}` })}
+          onSaveAnalytics={{
+            action: "Edit KVM",
+            category: "KVM",
+            label: "KVM configuration form",
+          }}
+          onSubmit={(values: KVMConfigurationValues) => {
+            const params = {
+              cpu_over_commit_ratio: values.cpu_over_commit_ratio,
+              id: pod.id,
+              memory_over_commit_ratio: values.memory_over_commit_ratio,
+              password: values.type === "lxd" ? values.password : undefined,
+              pool: values.pool,
+              power_address: values.power_address,
+              power_pass: values.type === "lxd" ? undefined : values.password,
+              tags: values.tags.join(","), // API expects comma-separated string
+              zone: values.zone,
+            };
+            dispatch(podActions.update(params));
+          }}
+          saving={podSaving}
+          saved={podSaved}
+          submitLabel="Save changes"
+          validationSchema={KVMConfigurationSchema}
+        >
+          <KVMConfigurationFields />
+        </FormikForm>
+      </FormCard>
+    );
+  }
+  return <Spinner text="Loading" />;
 };
 
 export default KVMConfiguration;

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
@@ -2,7 +2,6 @@ import { Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import type { RootState } from "app/store/root/types";
@@ -52,7 +51,6 @@ export type KVMConfigurationValues = {
 
 const KVMConfiguration = (): JSX.Element => {
   const dispatch = useDispatch();
-  const history = useHistory();
   const { id } = useParams();
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
@@ -77,7 +75,7 @@ const KVMConfiguration = (): JSX.Element => {
 
   const loaded = resourcePoolsLoaded && tagsLoaded && zonesLoaded;
 
-  if (typeof pod === "object" && loaded) {
+  if (!!pod && loaded) {
     const podPassword = pod.type === "lxd" ? pod.password : pod.power_pass;
 
     return (
@@ -96,7 +94,6 @@ const KVMConfiguration = (): JSX.Element => {
             type: pod.type,
             zone: `${pod.zone}`, // Convert to string for valid options HTML, also API expects string
           }}
-          onCancel={() => history.push({ pathname: `/kvm/${id}` })}
           onSaveAnalytics={{
             action: "Edit KVM",
             category: "KVM",
@@ -118,6 +115,7 @@ const KVMConfiguration = (): JSX.Element => {
           }}
           saving={podSaving}
           saved={podSaved}
+          showCancel={false}
           submitLabel="Save changes"
           validationSchema={KVMConfigurationSchema}
         >

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
@@ -75,10 +75,9 @@ const KVMConfiguration = (): JSX.Element => {
     dispatch(zoneActions.fetch());
   }, [dispatch]);
 
-  const loaded =
-    Boolean(pod) && resourcePoolsLoaded && tagsLoaded && zonesLoaded;
+  const loaded = resourcePoolsLoaded && tagsLoaded && zonesLoaded;
 
-  if (loaded) {
+  if (typeof pod === "object" && loaded) {
     const podPassword = pod.type === "lxd" ? pod.password : pod.power_pass;
 
     return (

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx
@@ -90,11 +90,11 @@ const KVMConfiguration = (): JSX.Element => {
             cpu_over_commit_ratio: pod.cpu_over_commit_ratio,
             memory_over_commit_ratio: pod.memory_over_commit_ratio,
             password: podPassword,
-            pool: `${pod.pool}`, // Convert to string for valid HTML, also API expects string
+            pool: `${pod.pool}`, // Convert to string for valid options HTML, also API expects string
             power_address: pod.power_address,
             tags: pod.tags,
             type: pod.type,
-            zone: `${pod.zone}`, // Convert to string for valid HTML, also API expects string
+            zone: `${pod.zone}`, // Convert to string for valid options HTML, also API expects string
           }}
           onCancel={() => history.push({ pathname: `/kvm/${id}` })}
           onSaveAnalytics={{

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
@@ -8,7 +8,6 @@ import {
   pod as podFactory,
   podState as podStateFactory,
 } from "testing/factories";
-import { formatHostType } from "app/kvm/utils";
 import KVMConfiguration from "../KVMConfiguration";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
@@ -1,0 +1,114 @@
+import { MemoryRouter, Route } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+} from "testing/factories";
+import { formatHostType } from "app/kvm/utils";
+import KVMConfiguration from "../KVMConfiguration";
+
+const mockStore = configureStore();
+
+describe("KVMConfigurationFields", () => {
+  let initialState;
+
+  beforeEach(() => {
+    const podState = podStateFactory({ items: [], loaded: true });
+    initialState = {
+      config: {
+        items: [],
+      },
+      pod: podState,
+      resourcepool: {
+        items: [],
+        loaded: true,
+      },
+      tag: {
+        items: [],
+        loaded: true,
+      },
+      zone: {
+        items: [],
+        loaded: true,
+      },
+    };
+  });
+
+  it("correctly sets initial values for virsh pods", () => {
+    const state = { ...initialState };
+    const pod = podFactory({ id: 1, type: "virsh", power_pass: "maxpower" });
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/kvm/:id/edit"
+            component={() => <KVMConfiguration />}
+          />
+          <KVMConfiguration />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Input[name='type']").props().value).toBe("Virsh");
+    expect(wrapper.find("Select[name='zone']").props().value).toEqual(
+      pod.zone.toString()
+    );
+    expect(wrapper.find("Select[name='pool']").props().value).toEqual(
+      pod.pool.toString()
+    );
+    expect(wrapper.find("TagSelector[name='tags']").props().value).toEqual(
+      pod.tags
+    );
+    expect(wrapper.find("Input[name='power_address']").props().value).toBe(
+      pod.power_address
+    );
+    expect(wrapper.find("Input[name='password']").props().value).toBe(
+      pod.power_pass
+    );
+  });
+
+  it("correctly sets initial values for lxd pods", () => {
+    const state = { ...initialState };
+    const pod = podFactory({ id: 1, type: "lxd", password: "powerranger" });
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/kvm/:id/edit"
+            component={() => <KVMConfiguration />}
+          />
+          <KVMConfiguration />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Input[name='type']").props().value).toBe("LXD");
+    expect(wrapper.find("Select[name='zone']").props().value).toEqual(
+      pod.zone.toString()
+    );
+    expect(wrapper.find("Select[name='pool']").props().value).toEqual(
+      pod.pool.toString()
+    );
+    expect(wrapper.find("TagSelector[name='tags']").props().value).toEqual(
+      pod.tags
+    );
+    expect(wrapper.find("Input[name='power_address']").props().value).toBe(
+      pod.power_address
+    );
+    expect(wrapper.find("Input[name='password']").props().value).toBe(
+      pod.password
+    );
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx
@@ -72,6 +72,12 @@ describe("KVMConfigurationFields", () => {
     expect(wrapper.find("Input[name='password']").props().value).toBe(
       pod.power_pass
     );
+    expect(
+      wrapper.find("Slider[name='cpu_over_commit_ratio']").props().value
+    ).toBe(pod.cpu_over_commit_ratio);
+    expect(
+      wrapper.find("Slider[name='memory_over_commit_ratio']").props().value
+    ).toBe(pod.memory_over_commit_ratio);
   });
 
   it("correctly sets initial values for lxd pods", () => {
@@ -109,5 +115,11 @@ describe("KVMConfigurationFields", () => {
     expect(wrapper.find("Input[name='password']").props().value).toBe(
       pod.password
     );
+    expect(
+      wrapper.find("Slider[name='cpu_over_commit_ratio']").props().value
+    ).toBe(pod.cpu_over_commit_ratio);
+    expect(
+      wrapper.find("Slider[name='memory_over_commit_ratio']").props().value
+    ).toBe(pod.memory_over_commit_ratio);
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx
@@ -11,6 +11,7 @@ import {
 } from "app/base/selectors";
 import { formatHostType } from "app/kvm/utils";
 import FormikField from "app/base/components/FormikField";
+import Slider from "app/base/components/Slider";
 import TagSelector from "app/base/components/TagSelector";
 
 const KVMConfigurationFields = (): JSX.Element => {
@@ -92,6 +93,40 @@ const KVMConfigurationFields = (): JSX.Element => {
           label="Password (optional)"
           name="password"
           type="password"
+        />
+        <FormikField
+          component={Slider}
+          inputDisabled
+          label="CPU overcommit"
+          max={10}
+          min={0.1}
+          name="cpu_over_commit_ratio"
+          onChange={(e: React.FormEvent<HTMLInputElement>) =>
+            setFieldValue(
+              "cpu_over_commit_ratio",
+              Number(e.currentTarget.value)
+            )
+          }
+          showInput
+          step={0.1}
+          value={values.cpu_over_commit_ratio}
+        />
+        <FormikField
+          component={Slider}
+          inputDisabled
+          label="Memory overcommit"
+          max={10}
+          min={0.1}
+          name="memory_over_commit_ratio"
+          onChange={(e: React.FormEvent<HTMLInputElement>) =>
+            setFieldValue(
+              "memory_over_commit_ratio",
+              Number(e.currentTarget.value)
+            )
+          }
+          showInput
+          step={0.1}
+          value={values.memory_over_commit_ratio}
         />
       </Col>
     </Row>

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx
@@ -1,0 +1,101 @@
+import { Col, Input, Row, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import React from "react";
+import { useSelector } from "react-redux";
+
+import type { KVMConfigurationValues } from "../KVMConfiguration";
+import {
+  resourcepool as resourcePoolSelectors,
+  tag as tagSelectors,
+  zone as zoneSelectors,
+} from "app/base/selectors";
+import { formatHostType } from "app/kvm/utils";
+import FormikField from "app/base/components/FormikField";
+import TagSelector from "app/base/components/TagSelector";
+
+const KVMConfigurationFields = (): JSX.Element => {
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const allTags = useSelector(tagSelectors.all);
+  const zones = useSelector(zoneSelectors.all);
+  const { initialValues, setFieldValue, values } = useFormikContext<
+    KVMConfigurationValues
+  >();
+  // Tags in state is an array of objects
+  const allTagsSorted = [...allTags].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  // pod.tags is an array of strings, so needs to be converted into objects
+  const initialTags = [...initialValues.tags]
+    .sort()
+    .map((tag) => ({ name: tag }));
+
+  return (
+    <Row>
+      <Col size="5">
+        <Input
+          disabled
+          label="KVM host type"
+          name="type"
+          value={formatHostType(values.type)}
+          type="text"
+        />
+        <FormikField
+          component={Select}
+          label="Zone"
+          name="zone"
+          options={[
+            { label: "Select your zone", value: "", disabled: true },
+            ...zones.map((zone) => ({
+              key: `zone-${zone.id}`,
+              label: zone.name,
+              value: zone.id,
+            })),
+          ]}
+        />
+        <FormikField
+          component={Select}
+          label="Resource pool"
+          name="pool"
+          options={[
+            {
+              label: "Select your resource pool",
+              value: "",
+              disabled: true,
+            },
+            ...resourcePools.map((pool) => ({
+              key: `pool-${pool.id}`,
+              label: pool.name,
+              value: pool.id,
+            })),
+          ]}
+        />
+        <FormikField
+          allowNewTags
+          component={TagSelector}
+          initialSelected={initialTags}
+          label="Tags"
+          name="tags"
+          onTagsUpdate={(selectedTags: { name: string }[]) => {
+            setFieldValue(
+              "tags",
+              // Convert back to array of strings
+              selectedTags.map((tag) => tag.name)
+            );
+          }}
+          placeholder="Select or create tags"
+          tags={allTagsSorted}
+        />
+      </Col>
+      <Col size="5">
+        <FormikField label="Address" name="power_address" type="text" />
+        <FormikField
+          label="Password (optional)"
+          name="password"
+          type="password"
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default KVMConfigurationFields;

--- a/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMConfigurationFields";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -6,7 +6,6 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import type { RootState } from "app/store/root/types";
 import { pod as podActions } from "app/base/actions";
 import { pod as podSelectors } from "app/base/selectors";
-import { useWindowTitle } from "app/base/hooks";
 import Section from "app/base/components/Section";
 import KVMConfiguration from "./KVMConfiguration";
 import KVMDetailsHeader from "./KVMDetailsHeader";
@@ -20,8 +19,6 @@ const KVMDetails = (): JSX.Element => {
     podSelectors.getById(state, Number(id))
   );
   const podsLoaded = useSelector(podSelectors.loaded);
-
-  useWindowTitle(`KVM ${`${pod?.name} ` || ""} details`);
 
   useEffect(() => {
     dispatch(podActions.fetch());
@@ -37,14 +34,16 @@ const KVMDetails = (): JSX.Element => {
       header={<KVMDetailsHeader />}
       headerClassName="u-no-padding--bottom"
     >
-      <Switch>
-        <Route exact path="/kvm/:id">
-          <KVMSummary />
-        </Route>
-        <Route exact path="/kvm/:id/edit">
-          <KVMConfiguration />
-        </Route>
-      </Switch>
+      {pod && (
+        <Switch>
+          <Route exact path="/kvm/:id">
+            <KVMSummary />
+          </Route>
+          <Route exact path="/kvm/:id/edit">
+            <KVMConfiguration />
+          </Route>
+        </Switch>
+      )}
     </Section>
   );
 };

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from "@canonical/react-components";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import {
@@ -42,6 +43,7 @@ export type AddKVMFormValues = { [x: string]: TSFixMe };
 
 export const AddKVMForm = (): JSX.Element => {
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const podSaved = useSelector(podSelectors.saved);
   const podSaving = useSelector(podSelectors.saving);
@@ -112,6 +114,7 @@ export const AddKVMForm = (): JSX.Element => {
               type: initialHostType,
               zone: zones.length ? zones[0].id : "",
             }}
+            onCancel={() => history.push({ pathname: "/kvm" })}
             onSaveAnalytics={{
               action: "Save",
               category: "KVM",

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
@@ -3,18 +3,8 @@ import { useSelector } from "react-redux";
 
 import { pod as podSelectors } from "app/base/selectors";
 import type { RootState } from "app/store/root/types";
+import { formatHostType } from "app/kvm/utils";
 import DoubleRow from "app/base/components/DoubleRow";
-
-const formatHostType = (type: string) => {
-  switch (type) {
-    case "lxd":
-      return "LXD";
-    case "virsh":
-      return "Virsh";
-    default:
-      return type;
-  }
-};
 
 type Props = { id: number };
 

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
@@ -1,6 +1,7 @@
 import { Spinner } from "@canonical/react-components";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import {
@@ -34,6 +35,7 @@ const generateChassisSchema = (parametersSchema) =>
 
 export const AddChassisForm = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const chassisPowerTypes = useSelector(generalSelectors.powerTypes.chassis);
   const domains = useSelector(domainSelectors.all);
@@ -99,6 +101,7 @@ export const AddChassisForm = () => {
               power_parameters: allPowerParameters,
               power_type: "",
             }}
+            onCancel={() => history.push({ pathname: "/machines" })}
             onSaveAnalytics={{
               action: resetOnSave ? "Save and add another" : "Save",
               category: "Chassis",

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -1,6 +1,7 @@
 import { Spinner } from "@canonical/react-components";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import {
@@ -55,6 +56,7 @@ const generateMachineSchema = (parametersSchema) =>
 
 export const AddMachineForm = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const architectures = useSelector(generalSelectors.architectures.get);
   const architecturesLoaded = useSelector(
@@ -156,6 +158,7 @@ export const AddMachineForm = () => {
               pxe_mac: "",
               zone: (zones.length && zones[0].name) || "",
             }}
+            onCancel={() => history.push({ pathname: "/machines" })}
             onSaveAnalytics={{
               action: resetOnSave ? "Save and add another" : "Save",
               category: "Machine",

--- a/ui/src/app/machines/views/AddRSD/AddRSDForm/AddRSDForm.js
+++ b/ui/src/app/machines/views/AddRSD/AddRSDForm/AddRSDForm.js
@@ -1,6 +1,7 @@
 import { Spinner } from "@canonical/react-components";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import {
@@ -30,6 +31,7 @@ const AddRSDSchema = Yup.object().shape({
 
 export const AddRSDForm = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const podSaved = useSelector(podSelectors.saved);
   const podSaving = useSelector(podSelectors.saving);
@@ -90,6 +92,7 @@ export const AddRSDForm = () => {
               power_user: "",
               zone: (zones.length && zones[0].id) || 0,
             }}
+            onCancel={() => history.push({ pathname: "/machines" })}
             onSaveAnalytics={{
               action: resetOnSave ? "Save and add another" : "Save",
               category: "Pod",

--- a/ui/src/app/pools/views/PoolForm/PoolForm.js
+++ b/ui/src/app/pools/views/PoolForm/PoolForm.js
@@ -1,6 +1,7 @@
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import { resourcepool as poolActions } from "app/base/actions";
 import { resourcepool as poolSelectors } from "app/base/selectors";
@@ -18,6 +19,7 @@ const PoolSchema = Yup.object().shape({
 
 export const PoolForm = ({ pool }) => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const saved = useSelector(poolSelectors.saved);
   const saving = useSelector(poolSelectors.saving);
   const errors = useSelector(poolSelectors.errors);
@@ -52,10 +54,10 @@ export const PoolForm = ({ pool }) => {
     <FormCard sidebar={false} title={title}>
       <FormikForm
         buttons={FormCardButtons}
-        errors={errors}
         cleanup={poolActions.cleanup}
+        errors={errors}
         initialValues={initialValues}
-        submitLabel="Save pool"
+        onCancel={() => history.push({ pathname: "/pools" })}
         onSaveAnalytics={{
           action: "Saved",
           category: "Resource pool",
@@ -71,9 +73,10 @@ export const PoolForm = ({ pool }) => {
           }
           setSaving(values.name);
         }}
-        saving={saving}
         saved={saved}
         savedRedirect="/pools"
+        saving={saving}
+        submitLabel="Save pool"
         validationSchema={PoolSchema}
       >
         <FormikField type="text" name="name" label="Name (required)" />

--- a/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.js
+++ b/ui/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.js
@@ -1,8 +1,9 @@
 import { Col, Row } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import PropTypes from "prop-types";
 import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import { token as tokenActions } from "app/preferences/actions";
 import { token as tokenSelectors } from "app/preferences/selectors";
@@ -24,6 +25,7 @@ const APIKeyEditSchema = Yup.object().shape({
 export const APIKeyForm = ({ token }) => {
   const editing = !!token;
   const dispatch = useDispatch();
+  const history = useHistory();
   const errors = useSelector(tokenSelectors.errors);
   const saved = useSelector(tokenSelectors.saved);
   const saving = useSelector(tokenSelectors.saving);
@@ -46,6 +48,7 @@ export const APIKeyForm = ({ token }) => {
         initialValues={{
           name: token ? token.consumer.name : "",
         }}
+        onCancel={() => history.push({ pathname: "/account/prefs/api-keys" })}
         onSaveAnalytics={{
           action: "Saved",
           category: "API keys preferences",

--- a/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.js
+++ b/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.js
@@ -1,6 +1,7 @@
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import { sshkey as sshkeyActions } from "app/preferences/actions";
 import { sshkey as sshkeySelectors } from "app/preferences/selectors";
@@ -25,6 +26,7 @@ const SSHKeySchema = Yup.object().shape({
 
 export const AddSSHKey = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const errors = useSelector(sshkeySelectors.errors);
   const saved = useSelector(sshkeySelectors.saved);
   const saving = useSelector(sshkeySelectors.saving);
@@ -40,6 +42,7 @@ export const AddSSHKey = () => {
         cleanup={sshkeyActions.cleanup}
         errors={errors}
         initialValues={{ auth_id: "", protocol: "", key: "" }}
+        onCancel={() => history.push({ pathname: "/account/prefs/ssh-keys" })}
         onSaveAnalytics={{
           action: "Saved",
           category: "SSH keys preferences",

--- a/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.js
+++ b/ui/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.js
@@ -1,7 +1,8 @@
 import { Col, Row, Textarea } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import { sslkey as sslkeyActions } from "app/preferences/actions";
 import { sslkey as sslkeySelectors } from "app/preferences/selectors";
@@ -17,10 +18,11 @@ const SSLKeySchema = Yup.object().shape({
 });
 
 export const AddSSLKey = () => {
+  const dispatch = useDispatch();
+  const history = useHistory();
   const saving = useSelector(sslkeySelectors.saving);
   const saved = useSelector(sslkeySelectors.saved);
   const errors = useSelector(sslkeySelectors.errors);
-  const dispatch = useDispatch();
 
   useWindowTitle("Add SSL key");
 
@@ -33,6 +35,7 @@ export const AddSSLKey = () => {
         cleanup={sslkeyActions.cleanup}
         errors={errors}
         initialValues={{ key: "" }}
+        onCancel={() => history.push({ pathname: "/account/prefs/ssl-keys" })}
         onSaveAnalytics={{
           action: "Saved",
           category: "SSL keys preferences",

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
@@ -1,7 +1,8 @@
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import {
   controller as controllerActions,
@@ -35,12 +36,13 @@ const DhcpSchema = Yup.object().shape({
 });
 
 export const DhcpForm = ({ dhcpSnippet }) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
   const [savingDhcp, setSaving] = useState();
   const [name, setName] = useState();
   const errors = useSelector(dhcpsnippetSelectors.errors);
   const saved = useSelector(dhcpsnippetSelectors.saved);
   const saving = useSelector(dhcpsnippetSelectors.saving);
-  const dispatch = useDispatch();
   const editing = !!dhcpSnippet;
   const { loading, loaded, type } = useDhcpTarget(
     editing ? dhcpSnippet.node : null,
@@ -88,6 +90,7 @@ export const DhcpForm = ({ dhcpSnippet }) => {
           type: dhcpSnippet ? type : "",
           value: dhcpSnippet ? dhcpSnippet.value : "",
         }}
+        onCancel={() => history.push({ pathname: "/settings/dhcp" })}
         onSaveAnalytics={{
           action: "Saved",
           category: "DHCP snippet settings",

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.js
@@ -1,7 +1,8 @@
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
 
 import { general as generalActions } from "app/base/actions";
 import { general as generalSelectors } from "app/base/selectors";
@@ -21,13 +22,14 @@ const LicenseKeySchema = Yup.object().shape({
 });
 
 export const LicenseKeyForm = ({ licenseKey }) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
   const [savingLicenseKey, setSaving] = useState();
   const saving = useSelector(licenseKeysSelectors.saving);
   const saved = useSelector(licenseKeysSelectors.saved);
   const errors = useSelector(licenseKeysSelectors.errors);
   const osInfoLoaded = useSelector(generalSelectors.osInfo.loaded);
   const licenseKeysLoaded = useSelector(licenseKeysSelectors.loaded);
-  const dispatch = useDispatch();
   const releases = useSelector(generalSelectors.osInfo.getLicensedOsReleases);
   const osystems = useSelector(generalSelectors.osInfo.getLicensedOsystems);
   const isLoaded = licenseKeysLoaded && osInfoLoaded;
@@ -70,6 +72,7 @@ export const LicenseKeyForm = ({ licenseKey }) => {
               : releases[osystems[0][0]][0].value,
             license_key: licenseKey ? licenseKey.license_key : "",
           }}
+          onCancel={() => history.push({ pathname: "/settings/license-keys" })}
           onSaveAnalytics={{
             action: "Saved",
             category: "License keys settings",

--- a/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.js
+++ b/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.js
@@ -1,7 +1,8 @@
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import {
@@ -36,8 +37,9 @@ const RepositorySchema = Yup.object().shape({
 });
 
 export const RepositoryForm = ({ type, repository }) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
   const [savedRepo, setSavedRepo] = useState();
-
   const componentsToDisableLoaded = useSelector(
     generalSelectors.componentsToDisable.loaded
   );
@@ -56,8 +58,6 @@ export const RepositoryForm = ({ type, repository }) => {
     knownArchitecturesLoaded &&
     pocketsToDisableLoaded &&
     repositoriesLoaded;
-
-  const dispatch = useDispatch();
 
   useAddMessage(
     repositoriesSaved,
@@ -124,6 +124,9 @@ export const RepositoryForm = ({ type, repository }) => {
             cleanup={repositoryActions.cleanup}
             errors={errors}
             initialValues={initialValues}
+            onCancel={() =>
+              history.push({ pathname: "/settings/repositories" })
+            }
             onSaveAnalytics={{
               action: "Saved",
               category: "Package repos settings",

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -31,10 +31,11 @@ export type Pod = Model & {
   ip_address: number | string;
   memory_over_commit_ratio: number;
   name: string;
+  password?: string;
   permissions: string[];
   pool: number;
   power_address: string;
-  power_pass: string;
+  power_pass?: string;
   owners_count: number;
   storage_pools: TSFixMe[];
   tags: string[];

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -54,3 +54,21 @@ input[type="radio"] {
   margin-bottom: 0.8rem;
   margin-top: -0.5rem;
 }
+
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+.p-slider__input[type=number] {
+  -moz-appearance: textfield;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -55,16 +55,20 @@ input[type="radio"] {
   margin-top: -0.5rem;
 }
 
-/* Chrome, Safari, Edge, Opera */
+// 10-07-2020 Caleb: Slider input misaligned when using type="number" + wrapper
+// should mirror normal form field spacing.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3163
+.p-slider__wrapper {
+  margin-bottom: $input-margin-bottom;
+}
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
-
-/* Firefox */
-.p-slider__input[type=number] {
+.p-slider__input {
   -moz-appearance: textfield;
+  height: auto;
 
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {


### PR DESCRIPTION
## Done

- Added KVM configuration form.
- Changed FormikForm buttons so that "Cancel" button is only displayed if `onCancel` prop is provided.
- Drive by fix for refresh form in KVM details so that form closes when successfully completed.
- Drive by fix for TagSelector spacing

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/kvm and click on a KVM
- Click on the "Configuration" tab and check that the config form shows up
- Check that you can change and save the values, and the saved values persist

## Fixes

Fixes canonical-web-and-design/MAAS-squad#1960
Fixes canonical-web-and-design/MAAS-squad#2039


## Screenshot
![0 0 0 0_8400_MAAS_r_kvm_180_edit (1)](https://user-images.githubusercontent.com/25733845/87118501-ec2a6e80-c2be-11ea-8e5e-a89a9f853b62.png)



