### PR TITLE
Create types and factories for remaining models

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -195,7 +195,7 @@ exports[`stricter compilation`] = {
       [92, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [131, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:3217432980": [
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:3618445959": [
       [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [72, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [82, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
@@ -214,12 +214,12 @@ exports[`stricter compilation`] = {
       [250, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [251, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:3049974690": [
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:3879941606": [
       [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
-      [46, 21, 17, "Property \'deployingSelected\' does not exist on type \'typeof machine\'.", "3830099655"],
-      [60, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
-      [69, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
-      [80, 34, 6, "Property \'deploy\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1121484462"]
+      [47, 21, 17, "Property \'deployingSelected\' does not exist on type \'typeof machine\'.", "3830099655"],
+      [61, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
+      [70, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
+      [81, 34, 6, "Property \'deploy\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1121484462"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx:162052981": [
       [128, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"],
@@ -268,16 +268,16 @@ exports[`stricter compilation`] = {
       [252, 11, 5, "Object is of type \'unknown\'.", "173192470"],
       [256, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.tsx:1626104059": [
-      [36, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
-      [37, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
-      [52, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
-      [53, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"]
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.tsx:2618150815": [
+      [37, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
+      [38, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
+      [53, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
+      [54, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:2932673855": [
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:2669831063": [
       [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [82, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
-      [126, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"]
+      [79, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+      [123, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"]
     ],
     "src/app/utils/getCookie.ts:940992619": [
       [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
@@ -290,6 +290,9 @@ exports[`stricter compilation`] = {
     ],
     "src/testing/factories/notification.ts:2660496186": [
       [10, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
+    ],
+    "src/testing/factories/state.ts:2971454815": [
+      [151, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"]
     ]
   }`
 };
@@ -324,18 +327,35 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [13, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/dhcpsnippet/types.ts:4267311850": [
+    "src/app/store/dhcpsnippet/types.ts:2041796238": [
       [4, 13, 8, "RegExp match", "1152173309"],
-      [18, 9, 8, "RegExp match", "1152173309"],
       [24, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/domain/types.ts:2438698325": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [16, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/general/types.ts:1987535520": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [5, 9, 8, "RegExp match", "1152173309"],
+      [14, 9, 8, "RegExp match", "1152173309"],
+      [23, 9, 8, "RegExp match", "1152173309"],
+      [32, 9, 8, "RegExp match", "1152173309"],
+      [47, 9, 8, "RegExp match", "1152173309"],
+      [61, 9, 8, "RegExp match", "1152173309"],
+      [72, 9, 8, "RegExp match", "1152173309"],
+      [95, 9, 8, "RegExp match", "1152173309"],
+      [104, 9, 8, "RegExp match", "1152173309"],
+      [138, 9, 8, "RegExp match", "1152173309"],
+      [147, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/licensekeys/types.ts:2257386395": [
       [1, 13, 8, "RegExp match", "1152173309"],
       [11, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:730274029": [
+    "src/app/store/machine/types.ts:33334270": [
       [2, 13, 8, "RegExp match", "1152173309"],
-      [50, 9, 8, "RegExp match", "1152173309"]
+      [43, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/notification/types.ts:910911970": [
       [1, 13, 8, "RegExp match", "1152173309"],
@@ -354,17 +374,38 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 9, 8, "RegExp match", "1152173309"]
     ],
+    "src/app/store/scriptresults/types.ts:1509395648": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [30, 9, 8, "RegExp match", "1152173309"]
+    ],
     "src/app/store/scripts/types.ts:2264904018": [
       [1, 13, 8, "RegExp match", "1152173309"],
       [15, 14, 8, "RegExp match", "1152173309"],
       [20, 14, 8, "RegExp match", "1152173309"],
       [52, 9, 8, "RegExp match", "1152173309"]
     ],
+    "src/app/store/service/types.ts:3748751936": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [10, 9, 8, "RegExp match", "1152173309"]
+    ],
     "src/app/store/sshkey/types.ts:2805027575": [
       [2, 13, 8, "RegExp match", "1152173309"],
       [19, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/sslkey/types.ts:518217640": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [13, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/status/types.ts:3358556468": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [5, 22, 8, "RegExp match", "1152173309"],
+      [8, 8, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/subnet/types.ts:587705301": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [46, 9, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/tag/types.ts:2533761736": [
       [1, 13, 8, "RegExp match", "1152173309"],
       [13, 9, 8, "RegExp match", "1152173309"]
     ],

--- a/ui/src/app/base/selectors/domain/domain.test.js
+++ b/ui/src/app/base/selectors/domain/domain.test.js
@@ -1,13 +1,18 @@
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+} from "testing/factories";
 import domain from "./domain";
 
 describe("domain selectors", () => {
   it("can get all items", () => {
+    const items = [domainFactory()];
     const state = {
-      domain: {
-        items: [{ name: "maas.test" }],
-      },
+      domain: domainStateFactory({
+        items,
+      }),
     };
-    expect(domain.all(state)).toEqual([{ name: "maas.test" }]);
+    expect(domain.all(state)).toEqual(items);
   });
 
   it("can get the loading state", () => {

--- a/ui/src/app/base/selectors/service/service.test.js
+++ b/ui/src/app/base/selectors/service/service.test.js
@@ -1,25 +1,16 @@
+import {
+  service as serviceFactory,
+  serviceState as serviceStateFactory,
+} from "testing/factories";
 import service from "./service";
 
 describe("service selectors", () => {
   it("can get all items", () => {
-    const items = [
-      {
-        id: 1,
-        name: "ntp_rack",
-        status: "dead",
-        status_info: "",
-      },
-      {
-        id: 2,
-        name: "http",
-        status: "unknown",
-        status_info: "",
-      },
-    ];
+    const items = [serviceFactory(), serviceFactory()];
     const state = {
-      service: {
+      service: serviceStateFactory({
         items,
-      },
+      }),
     };
     expect(service.all(state)).toEqual(items);
   });

--- a/ui/src/app/base/selectors/status/status.test.js
+++ b/ui/src/app/base/selectors/status/status.test.js
@@ -1,13 +1,14 @@
+import { statusState as statusStateFactory } from "testing/factories";
 import status from "./status";
 
 describe("status", () => {
   it("can get the connected status", () => {
     const state = {
-      status: {
-        connected: false,
-      },
+      status: statusStateFactory({
+        connected: true,
+      }),
     };
-    expect(status.connected(state)).toBe(false);
+    expect(status.connected(state)).toBe(true);
   });
 
   it("can get the error status", () => {

--- a/ui/src/app/base/selectors/subnet/subnet.test.js
+++ b/ui/src/app/base/selectors/subnet/subnet.test.js
@@ -1,13 +1,18 @@
+import {
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+} from "testing/factories";
 import subnet from "./subnet";
 
 describe("subnet selectors", () => {
   it("can get all items", () => {
+    const items = [subnetFactory(), subnetFactory()];
     const state = {
-      subnet: {
-        items: [{ name: "maas.test" }],
-      },
+      subnet: subnetStateFactory({
+        items,
+      }),
     };
-    expect(subnet.all(state)).toEqual([{ name: "maas.test" }]);
+    expect(subnet.all(state)).toEqual(items);
   });
 
   it("can get the loading state", () => {

--- a/ui/src/app/base/selectors/tag/tag.test.js
+++ b/ui/src/app/base/selectors/tag/tag.test.js
@@ -1,22 +1,16 @@
+import {
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
 import tag from "./tag";
 
 describe("tag selectors", () => {
   it("can get all items", () => {
-    const items = [
-      {
-        id: 1,
-        created: "Mon, 16 Sep. 2019 12:22:36",
-        updated: "Mon, 16 Sep. 2019 12:22:36",
-        name: "virtual",
-        definition: "",
-        comment: "",
-        kernel_opts: null,
-      },
-    ];
+    const items = [tagFactory(), tagFactory()];
     const state = {
-      tag: {
+      tag: tagStateFactory({
         items,
-      },
+      }),
     };
     expect(tag.all(state)).toEqual(items);
   });

--- a/ui/src/app/base/selectors/zone/zone.test.js
+++ b/ui/src/app/base/selectors/zone/zone.test.js
@@ -1,23 +1,16 @@
+import {
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 import zone from "./zone";
 
 describe("zone selectors", () => {
   it("can get all items", () => {
-    const items = [
-      {
-        id: 1,
-        created: "Mon, 16 Sep. 2019 12:19:56",
-        updated: "Mon, 16 Sep. 2019 12:19:56",
-        name: "default",
-        description: "",
-        devices_count: 15,
-        machines_count: 0,
-        controllers_count: 0,
-      },
-    ];
+    const items = [zoneFactory(), zoneFactory()];
     const state = {
-      zone: {
+      zone: zoneStateFactory({
         items,
-      },
+      }),
     };
     expect(zone.all(state)).toEqual(items);
   });

--- a/ui/src/app/store/dhcpsnippet/types.ts
+++ b/ui/src/app/store/dhcpsnippet/types.ts
@@ -1,6 +1,7 @@
 import type { Device } from "app/store/device/types";
 import type { Host } from "app/store/types/host";
 import type { Model } from "app/store/types/model";
+import type { Subnet } from "app/store/subnet/types";
 import type { TSFixMe } from "app/base/types";
 
 export type DHCPSnippetHistory = Model & {
@@ -15,7 +16,7 @@ export type DHCPSnippet = Model & {
   history: DHCPSnippetHistory[];
   name: string;
   node: Host | Device | null;
-  subnet: TSFixMe | null; // Replace with Subnet["id"] when the Subnet type has been defined.
+  subnet: Subnet["id"] | null;
   updated: string;
   value: string;
 };

--- a/ui/src/app/store/domain/types.ts
+++ b/ui/src/app/store/domain/types.ts
@@ -1,0 +1,23 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type Domain = Model & {
+  created: string;
+  updated: string;
+  name: string;
+  authoritative: boolean;
+  ttl: number | null;
+  hosts: number;
+  resource_count: number;
+  displayname: string;
+  is_default: boolean;
+};
+
+export type DomainState = {
+  errors: TSFixMe;
+  items: Domain[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/scriptresults/types.ts
+++ b/ui/src/app/store/scriptresults/types.ts
@@ -1,0 +1,37 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type ScriptResultResult = {
+  name: string;
+  title: string;
+  description: string;
+  value: string;
+  surfaced: boolean;
+};
+
+export type ScriptResult = Model & {
+  endtime: number;
+  estimated_runtime: string;
+  hardware_type: 0 | 1 | 2 | 3 | 4;
+  name: string;
+  result_type: 0 | 1 | 2;
+  results: ScriptResultResult[];
+  runtime: string;
+  starttime: number;
+  status_name: string;
+  suppressed: boolean;
+  tags: string;
+};
+
+export type ScriptResults = {
+  [x: string]: ScriptResult[];
+};
+
+export type ScriptResultsState = {
+  errors: TSFixMe;
+  items: ScriptResults;
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/service/types.ts
+++ b/ui/src/app/store/service/types.ts
@@ -1,0 +1,17 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type Service = Model & {
+  name: string;
+  status: string;
+  status_info: string;
+};
+
+export type ServiceState = {
+  errors: TSFixMe;
+  items: Service[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/status/types.ts
+++ b/ui/src/app/store/status/types.ts
@@ -1,0 +1,13 @@
+import type { TSFixMe } from "app/base/types";
+
+export type StatusState = {
+  authenticated: boolean;
+  authenticating: boolean;
+  authenticationError: TSFixMe;
+  connected: boolean;
+  connecting: boolean;
+  error: TSFixMe;
+  externalAuthURL: string;
+  externalLoginURL: string;
+  noUsers: boolean;
+};

--- a/ui/src/app/store/subnet/types.ts
+++ b/ui/src/app/store/subnet/types.ts
@@ -1,0 +1,53 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type SubnetStatisticsRange = {
+  end: string;
+  num_addresses: number;
+  purpose: string[];
+  start: string;
+};
+
+export type SubnetStatistics = {
+  available_string: string;
+  first_address: string;
+  ip_version: number;
+  largest_available: number;
+  last_address: string;
+  num_available: number;
+  num_unavailable: number;
+  ranges: SubnetStatisticsRange[];
+  suggested_dynamic_range: SubnetStatisticsRange;
+  suggested_gateway: string | null;
+  total_addresses: number;
+  usage_string: string;
+  usage: number;
+};
+
+export type Subnet = Model & {
+  active_discovery: boolean;
+  allow_dns: boolean;
+  allow_proxy: boolean;
+  cidr: string;
+  created: string;
+  description: string;
+  dns_servers: string;
+  gateway_ip: string | null;
+  managed: boolean;
+  name: string;
+  rdns_mode: number;
+  space: number | null;
+  statistics: SubnetStatistics;
+  updated: string;
+  version: number;
+  vlan: number;
+};
+
+export type SubnetState = {
+  errors: TSFixMe;
+  items: Subnet[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/app/store/tag/types.ts
+++ b/ui/src/app/store/tag/types.ts
@@ -1,0 +1,20 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+
+export type Tag = Model & {
+  created: string;
+  updated: string;
+  name: string;
+  definition: string;
+  comment: string;
+  kernel_opts: string | null;
+};
+
+export type TagState = {
+  errors: TSFixMe;
+  items: Tag[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};

--- a/ui/src/testing/factories/domain.ts
+++ b/ui/src/testing/factories/domain.ts
@@ -1,0 +1,17 @@
+import { extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Domain } from "app/store/domain/types";
+import type { Model } from "app/store/types/model";
+
+export const domain = extend<Model, Domain>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+  name: "test name",
+  authoritative: false,
+  ttl: null,
+  hosts: random,
+  resource_count: random,
+  displayname: "test display",
+  is_default: false,
+});

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -5,6 +5,7 @@ export {
   configState,
   defaultMinHweKernelState,
   dhcpSnippetState,
+  domainState,
   generalState,
   hweKernelsState,
   knownArchitecturesState,
@@ -18,14 +19,22 @@ export {
   pocketsToDisableState,
   podState,
   powerTypesState,
+  resourcePoolState,
+  scriptResultsState,
   scriptsState,
+  serviceState,
   sshKeyState,
   sslKeyState,
+  statusState,
+  subnetState,
+  tagState,
   tokenState,
   userState,
   versionState,
+  zoneState,
 } from "./state";
 export { config } from "./config";
+export { domain } from "./domain";
 export { device, machine, controller, pod } from "./nodes";
 export { dhcpSnippet } from "./dhcpsnippet";
 export { licenseKeys } from "./licensekeys";
@@ -49,8 +58,18 @@ export {
 export { message } from "./message";
 export { notification } from "./notification";
 export { packageRepository } from "./packagerepository";
+export { resourcePool } from "./resourcepool";
+export {
+  scriptResult,
+  scriptResultResult,
+  scriptResults,
+} from "./scriptresults";
 export { scripts } from "./scripts";
+export { service } from "./service";
 export { sshKey } from "./sshkey";
 export { sslKey } from "./sslkey";
+export { subnet, subnetStatistics, subnetStatisticsRange } from "./subnet";
+export { tag } from "./tag";
 export { token } from "./token";
 export { user } from "./user";
+export { zone } from "./zone";

--- a/ui/src/testing/factories/resourcepool.ts
+++ b/ui/src/testing/factories/resourcepool.ts
@@ -1,0 +1,16 @@
+import { extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { ResourcePool } from "app/store/resourcepool/types";
+
+export const resourcePool = extend<Model, ResourcePool>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  description: "test description",
+  is_default: false,
+  machine_ready_count: random,
+  machine_total_count: random,
+  name: "test name",
+  permissions: () => [],
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+});

--- a/ui/src/testing/factories/scriptresults.ts
+++ b/ui/src/testing/factories/scriptresults.ts
@@ -1,0 +1,35 @@
+import { array, define, extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type {
+  ScriptResult,
+  ScriptResultResult,
+  ScriptResults,
+} from "app/store/scriptresults/types";
+
+export const scriptResultResult = define<ScriptResultResult>({
+  name: "test name",
+  title: "test title",
+  description: "test description",
+  value: "test value",
+  surfaced: false,
+});
+
+export const scriptResult = extend<Model, ScriptResult>(model, {
+  endtime: random,
+  estimated_runtime: "test runtime",
+  hardware_type: 3,
+  name: "test name",
+  result_type: 1,
+  results: array(scriptResultResult),
+  runtime: "test runtime",
+  starttime: random,
+  status_name: "test status",
+  suppressed: false,
+  tags: "test, tags",
+});
+
+export const scriptResults = define<ScriptResults>({
+  testResult: array(scriptResult),
+});

--- a/ui/src/testing/factories/service.ts
+++ b/ui/src/testing/factories/service.ts
@@ -1,0 +1,11 @@
+import { extend } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { Service } from "app/store/service/types";
+
+export const service = extend<Model, Service>(model, {
+  name: "test name",
+  status: "test status",
+  status_info: "test info",
+});

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -6,15 +6,23 @@ import { user } from "./user";
 import type { AuthState, UserState } from "app/store/user/types";
 import type { ConfigState } from "app/store/config/types";
 import type { DHCPSnippetState } from "app/store/dhcpsnippet/types";
+import type { DomainState } from "app/store/domain/types";
 import type { LicenseKeysState } from "app/store/licensekeys/types";
 import type { MessageState } from "app/store/message/types";
 import type { NotificationState } from "app/store/notification/types";
 import type { PackageRepositoryState } from "app/store/packagerepository/types";
 import type { PodState } from "app/store/pod/types";
+import type { ResourcePoolState } from "app/store/resourcepool/types";
+import type { ScriptResultsState } from "app/store/scriptresults/types";
 import type { ScriptsState } from "app/store/scripts/types";
+import type { ServiceState } from "app/store/service/types";
 import type { SSHKeyState } from "app/store/sshkey/types";
 import type { SSLKeyState } from "app/store/sslkey/types";
+import type { StatusState } from "app/store/status/types";
+import type { SubnetState } from "app/store/subnet/types";
+import type { TagState } from "app/store/tag/types";
 import type { TokenState } from "app/store/token/types";
+import type { ZoneState } from "app/store/zone/types";
 import type {
   ArchitecturesState,
   ComponentsToDisableState,
@@ -169,4 +177,45 @@ export const generalState = define<GeneralState>({
   pocketsToDisable: pocketsToDisableState,
   powerTypes: powerTypesState,
   version: versionState,
+});
+
+export const statusState = define<StatusState>({
+  authenticated: false,
+  authenticating: false,
+  authenticationError: () => ({}),
+  connected: false,
+  connecting: false,
+  error: () => ({}),
+  externalAuthURL: "http://example.com/auth",
+  externalLoginURL: "http://example.com/login",
+  noUsers: false,
+});
+
+export const domainState = define<DomainState>({
+  ...defaultState,
+});
+
+export const resourcePoolState = define<ResourcePoolState>({
+  ...defaultState,
+});
+
+export const scriptResultsState = define<ScriptResultsState>({
+  ...defaultState,
+  items: () => ({}),
+});
+
+export const serviceState = define<ServiceState>({
+  ...defaultState,
+});
+
+export const subnetState = define<SubnetState>({
+  ...defaultState,
+});
+
+export const tagState = define<TagState>({
+  ...defaultState,
+});
+
+export const zoneState = define<ZoneState>({
+  ...defaultState,
 });

--- a/ui/src/testing/factories/subnet.ts
+++ b/ui/src/testing/factories/subnet.ts
@@ -1,0 +1,51 @@
+import { array, define, extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type {
+  Subnet,
+  SubnetStatistics,
+  SubnetStatisticsRange,
+} from "app/store/subnet/types";
+
+export const subnetStatisticsRange = define<SubnetStatisticsRange>({
+  end: "172.16.2.1",
+  num_addresses: random,
+  purpose: () => [],
+  start: "172.16.2.1",
+});
+
+export const subnetStatistics = define<SubnetStatistics>({
+  available_string: "99%",
+  first_address: "172.16.1.1",
+  ip_version: random,
+  largest_available: random,
+  last_address: "172.16.1.254",
+  num_available: random,
+  num_unavailable: random,
+  ranges: array(subnetStatisticsRange),
+  suggested_dynamic_range: subnetStatisticsRange,
+  suggested_gateway: null,
+  total_addresses: random,
+  usage_string: "1%",
+  usage: random,
+});
+
+export const subnet = extend<Model, Subnet>(model, {
+  active_discovery: false,
+  allow_dns: false,
+  allow_proxy: false,
+  cidr: "172.16.1.0/24",
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  description: "test description",
+  dns_servers: "fd89:8724:81f1:5512:557f:99c3:6967:8d63",
+  gateway_ip: null,
+  managed: false,
+  name: "test-name",
+  rdns_mode: random,
+  space: null,
+  statistics: subnetStatistics,
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+  version: random,
+  vlan: random,
+});

--- a/ui/src/testing/factories/tag.ts
+++ b/ui/src/testing/factories/tag.ts
@@ -1,0 +1,14 @@
+import { extend } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { Tag } from "app/store/tag/types";
+
+export const tag = extend<Model, Tag>(model, {
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+  name: "test name",
+  definition: "test definition",
+  comment: "test comment",
+  kernel_opts: null,
+});

--- a/ui/src/testing/factories/zone.ts
+++ b/ui/src/testing/factories/zone.ts
@@ -1,0 +1,15 @@
+import { extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type { Zone } from "app/store/zone/types";
+
+export const zone = extend<Model, Zone>(model, {
+  controllers_count: random,
+  created: "Wed, 08 Jul. 2020 05:35:4",
+  description: "test description",
+  devices_count: random,
+  machines_count: random,
+  name: "test name",
+  updated: "Wed, 08 Jul. 2020 05:35:4",
+});


### PR DESCRIPTION
## Done

- Create types and factories for domain, resourcepool, scriptresults, service, status, subnet, tag and zone.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1360.