### PR TITLE
Add MachineListTable to KVM summary page.

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -29,14 +29,14 @@ exports[`stricter compilation`] = {
       [123, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
     "src/app/base/components/FormikField/FormikField.tsx:1946634864": [
-      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/base/components/FormikForm/FormikForm.tsx:4136491328": [
       [70, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
-    "src/app/base/components/SectionHeader/SectionHeader.tsx:1828886231": [
-      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [60, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
+    "src/app/base/components/SectionHeader/SectionHeader.tsx:2251696534": [
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [59, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
     ],
     "src/app/base/reducers/pod/pod.test.ts:1670915466": [
       [44, 10, 8, "Argument of type \'PodState\' is not assignable to parameter of type \'{ readonly errors: {}; readonly items: readonly never[]; readonly loaded: boolean; readonly loading: boolean; readonly saved: boolean; readonly saving: boolean; readonly selected: readonly never[]; readonly statuses: {}; }\'.\\n  Types of property \'items\' are incompatible.\\n    Type \'Pod[]\' is not assignable to type \'readonly never[]\'.\\n      Type \'Pod\' is not assignable to type \'never\'.", "604104617"],
@@ -81,15 +81,15 @@ exports[`stricter compilation`] = {
       [94, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:1453319310": [
-      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [3, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [3, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:475451368": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [129, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx:4073178480": [
-      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx:2184902936": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -106,7 +106,7 @@ exports[`stricter compilation`] = {
       [108, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:641984635": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [45, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
       [65, 6, 11, "Type \'\\"\\" | Element | null\' is not assignable to type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3453098368"]
     ],
@@ -132,7 +132,7 @@ exports[`stricter compilation`] = {
       [418, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:4207317122": [
-      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [67, 13, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'Pod\'.\\n  No index signature with a parameter of type \'string\' was found on type \'Pod\'.", "2363910037"],
       [101, 57, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
       [116, 24, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
@@ -143,7 +143,7 @@ exports[`stricter compilation`] = {
       [41, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx:248496192": [
-      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx:2366141448": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -196,7 +196,7 @@ exports[`stricter compilation`] = {
       [131, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:3618445959": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [72, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [82, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
       [105, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
@@ -215,7 +215,7 @@ exports[`stricter compilation`] = {
       [251, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:3879941606": [
-      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
+      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
       [47, 21, 17, "Property \'deployingSelected\' does not exist on type \'typeof machine\'.", "3830099655"],
       [61, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
       [70, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
@@ -231,7 +231,7 @@ exports[`stricter compilation`] = {
       [282, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx:1262012646": [
-      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [25, 28, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
       [27, 25, 17, "Object is of type \'unknown\'.", "4281571837"],
       [29, 28, 22, "Property \'getUbuntuKernelOptions\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "321954485"],
@@ -244,7 +244,7 @@ exports[`stricter compilation`] = {
       [150, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx:4246555145": [
-      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [19, 27, 4, "Binding element \'file\' implicitly has an \'any\' type.", "2087597251"],
       [21, 4, 16, "Object is possibly \'null\'.", "4019370437"],
       [26, 20, 23, "Argument of type \'\\"Reading file aborted.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2851093748"],
@@ -275,7 +275,7 @@ exports[`stricter compilation`] = {
       [54, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:2669831063": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [79, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [123, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"]
     ],
@@ -426,5 +426,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `672`
+  value: `870`
 };

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -7,6 +7,7 @@ import { pod as podSelectors } from "app/base/selectors";
 import { useWindowTitle } from "app/base/hooks";
 
 import type { RootState } from "app/store/root/types";
+import MachineListTable from "app/machines/views/MachineList/MachineListTable";
 
 const KVMSummary = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -22,7 +23,7 @@ const KVMSummary = (): JSX.Element => {
     dispatch(podActions.fetch());
   }, [dispatch]);
 
-  return <></>;
+  return <MachineListTable filter={`pod-id:=${id}`} showActions={false} />;
 };
 
 export default KVMSummary;

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -89,10 +89,12 @@ const generateRows = ({
   machines,
   onToggleMenu,
   selectedIDs,
+  showActions,
   showMAC,
   sortRows,
 }) => {
   const sortedMachines = sortRows(machines);
+  const menuCallback = showActions ? onToggleMenu : undefined;
   return sortedMachines.map((row) => {
     const isActive = activeRow === row.system_id;
 
@@ -105,8 +107,10 @@ const generateRows = ({
         {
           content: (
             <NameColumn
-              handleCheckbox={() =>
-                handleRowCheckbox(row.system_id, selectedIDs)
+              handleCheckbox={
+                showActions
+                  ? () => handleRowCheckbox(row.system_id, selectedIDs)
+                  : undefined
               }
               selected={someInArray(row.system_id, selectedIDs)}
               showMAC={showMAC}
@@ -116,30 +120,30 @@ const generateRows = ({
         },
         {
           content: (
-            <PowerColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+            <PowerColumn onToggleMenu={menuCallback} systemId={row.system_id} />
           ),
         },
         {
           content: (
             <StatusColumn
-              onToggleMenu={onToggleMenu}
+              onToggleMenu={menuCallback}
               systemId={row.system_id}
             />
           ),
         },
         {
           content: (
-            <OwnerColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+            <OwnerColumn onToggleMenu={menuCallback} systemId={row.system_id} />
           ),
         },
         {
           content: (
-            <PoolColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+            <PoolColumn onToggleMenu={menuCallback} systemId={row.system_id} />
           ),
         },
         {
           content: (
-            <ZoneColumn onToggleMenu={onToggleMenu} systemId={row.system_id} />
+            <ZoneColumn onToggleMenu={menuCallback} systemId={row.system_id} />
           ),
         },
         {
@@ -291,6 +295,7 @@ const generateGroupRows = ({
   hiddenGroups,
   selectedIDs,
   setHiddenGroups,
+  showActions,
   ...rowProps
 }) => {
   let rows = [];
@@ -308,24 +313,31 @@ const generateGroupRows = ({
               <DoubleRow
                 data-test="group-cell"
                 primary={
-                  <Input
-                    checked={someInArray(machineIDs, selectedIDs)}
-                    className={classNames("has-inline-label", {
-                      "p-checkbox--mixed": someNotAll(machineIDs, selectedIDs),
-                    })}
-                    disabled={false}
-                    id={label}
-                    label={<strong>{label}</strong>}
-                    onChange={() =>
-                      handleGroupCheckbox(machineIDs, selectedIDs)
-                    }
-                    type="checkbox"
-                    wrapperClassName="u-no-margin--bottom"
-                  />
+                  showActions ? (
+                    <Input
+                      checked={someInArray(machineIDs, selectedIDs)}
+                      className={classNames("has-inline-label", {
+                        "p-checkbox--mixed": someNotAll(
+                          machineIDs,
+                          selectedIDs
+                        ),
+                      })}
+                      disabled={false}
+                      id={label}
+                      label={<strong>{label}</strong>}
+                      onChange={() =>
+                        handleGroupCheckbox(machineIDs, selectedIDs)
+                      }
+                      type="checkbox"
+                      wrapperClassName="u-no-margin--bottom"
+                    />
+                  ) : (
+                    <strong>{label}</strong>
+                  )
                 }
-                primaryTextClassName="u-nudge--checkbox"
+                primaryTextClassName={showActions && "u-nudge--checkbox"}
                 secondary={getGroupSecondaryString(machineIDs, selectedIDs)}
-                secondaryClassName="u-nudge--secondary-row"
+                secondaryClassName={showActions && "u-nudge--secondary-row"}
               />
             ),
           },
@@ -371,6 +383,7 @@ const generateGroupRows = ({
         generateRows({
           machines: visibleMachines,
           selectedIDs,
+          showActions,
           ...rowProps,
         })
       );
@@ -379,11 +392,12 @@ const generateGroupRows = ({
 };
 
 export const MachineListTable = ({
-  filter,
-  grouping,
-  hiddenGroups,
+  filter = "",
+  grouping = "none",
+  hiddenGroups = [],
   setHiddenGroups,
   setSearchFilter,
+  showActions = true,
 }) => {
   const dispatch = useDispatch();
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
@@ -405,7 +419,7 @@ export const MachineListTable = ({
   const removeSelectedFilter = () => {
     const filters = getCurrentFilters(filter);
     const newFilters = toggleFilter(filters, "in", "selected", false, false);
-    setSearchFilter(filtersToString(newFilters));
+    setSearchFilter && setSearchFilter(filtersToString(newFilters));
   };
 
   useEffect(() => {
@@ -449,6 +463,7 @@ export const MachineListTable = ({
     activeRow,
     handleRowCheckbox,
     onToggleMenu,
+    showActions,
     showMAC,
     sortRows,
   };
@@ -463,22 +478,31 @@ export const MachineListTable = ({
           headers={[
             {
               content: (
-                <div className="u-flex u-nudge--checkbox">
-                  <Input
-                    checked={someInArray(machineIDs, selectedIDs)}
-                    className={classNames("has-inline-label", {
-                      "p-checkbox--mixed": someNotAll(machineIDs, selectedIDs),
-                    })}
-                    data-test="all-machines-checkbox"
-                    disabled={machines.length === 0}
-                    id="all-machines-checkbox"
-                    label={" "}
-                    onChange={() =>
-                      handleGroupCheckbox(machineIDs, selectedIDs)
-                    }
-                    type="checkbox"
-                    wrapperClassName="u-no-margin--bottom"
-                  />
+                <div
+                  className={classNames("u-flex", {
+                    "u-nudge--checkbox": showActions,
+                  })}
+                >
+                  {showActions && (
+                    <Input
+                      checked={someInArray(machineIDs, selectedIDs)}
+                      className={classNames("has-inline-label", {
+                        "p-checkbox--mixed": someNotAll(
+                          machineIDs,
+                          selectedIDs
+                        ),
+                      })}
+                      data-test="all-machines-checkbox"
+                      disabled={machines.length === 0}
+                      id="all-machines-checkbox"
+                      label={" "}
+                      onChange={() =>
+                        handleGroupCheckbox(machineIDs, selectedIDs)
+                      }
+                      type="checkbox"
+                      wrapperClassName="u-no-margin--bottom"
+                    />
+                  )}
                   <div>
                     <TableHeader
                       currentSort={currentSort}
@@ -679,7 +703,8 @@ MachineListTable.propTypes = {
   hiddenGroups: PropTypes.arrayOf(PropTypes.string),
   filter: PropTypes.string,
   setHiddenGroups: PropTypes.func,
-  setSearchFilter: PropTypes.func.isRequired,
+  setSearchFilter: PropTypes.func,
+  showActions: PropTypes.bool,
 };
 
 export default React.memo(MachineListTable);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
@@ -897,4 +897,25 @@ describe("MachineListTable", () => {
       });
     expect(setSearchFilter).toHaveBeenCalledWith("");
   });
+
+  it("does not show checkboxes if showActions is false", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MachineListTable showActions={false} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='all-machines-checkbox'] input").exists()
+    ).toBe(false);
+    expect(wrapper.find("[data-test='group-cell'] input").exists()).toBe(false);
+    expect(wrapper.find("[data-test='name-column'] input").exists()).toBe(
+      false
+    );
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -126,19 +126,23 @@ export const NameColumn = ({ handleCheckbox, selected, showMAC, systemId }) => {
     <DoubleRow
       data-test="name-column"
       primary={
-        <Input
-          checked={selected}
-          className="has-inline-label keep-label-opacity"
-          id={systemId}
-          label={primaryRow}
-          onChange={handleCheckbox}
-          type="checkbox"
-          wrapperClassName="u-no-margin--bottom machine-list--inline-input"
-        />
+        handleCheckbox ? (
+          <Input
+            checked={selected}
+            className="has-inline-label keep-label-opacity"
+            id={systemId}
+            label={primaryRow}
+            onChange={handleCheckbox}
+            type="checkbox"
+            wrapperClassName="u-no-margin--bottom machine-list--inline-input"
+          />
+        ) : (
+          primaryRow
+        )
       }
-      primaryTextClassName="u-nudge--checkbox"
+      primaryTextClassName={handleCheckbox && "u-nudge--checkbox"}
       secondary={secondaryRow}
-      secondaryClassName="u-nudge--secondary-row"
+      secondaryClassName={handleCheckbox && "u-nudge--secondary-row"}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
@@ -46,7 +46,7 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn systemId="abc123" />
+          <NameColumn handleCheckbox={jest.fn()} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -249,5 +249,19 @@ describe("NameColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Input").props().checked).toBe(true);
+  });
+
+  it("does not render checkbox if onToggleMenu not provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <NameColumn handleCheckbox={undefined} systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Input").exists()).toBe(false);
   });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`NameColumn renders 1`] = `
 <NameColumn
+  handleCheckbox={[MockFunction]}
   systemId="abc123"
 >
   <DoubleRow
@@ -26,6 +27,7 @@ exports[`NameColumn renders 1`] = `
             </small>
           </a>
         }
+        onChange={[MockFunction]}
         type="checkbox"
         wrapperClassName="u-no-margin--bottom machine-list--inline-input"
       />
@@ -65,6 +67,7 @@ exports[`NameColumn renders 1`] = `
                   </small>
                 </a>
               }
+              onChange={[MockFunction]}
               type="checkbox"
               wrapperClassName="u-no-margin--bottom machine-list--inline-input"
             >
@@ -98,6 +101,7 @@ exports[`NameColumn renders 1`] = `
                     <input
                       className="p-form-validation__input has-inline-label keep-label-opacity"
                       id="abc123"
+                      onChange={[MockFunction]}
                       type="checkbox"
                     />
                     <Label

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
@@ -35,7 +35,7 @@ export const OwnerColumn = ({ onToggleMenu, systemId }) => {
 
   return (
     <DoubleRow
-      menuLinks={menuLinks}
+      menuLinks={onToggleMenu && menuLinks}
       menuTitle="Take action:"
       onToggleMenu={toggleMenu}
       primary={
@@ -58,7 +58,7 @@ export const OwnerColumn = ({ onToggleMenu, systemId }) => {
 };
 
 OwnerColumn.propTypes = {
-  onToggleMenu: PropTypes.func.isRequired,
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.js
@@ -141,4 +141,19 @@ describe("OwnerColumn", () => {
       "No owner actions available"
     );
   });
+
+  it("does not render table menu if onToggleMenu not provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <OwnerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableMenu").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
@@ -48,7 +48,7 @@ export const PoolColumn = ({ onToggleMenu, systemId }) => {
 
   return (
     <DoubleRow
-      menuLinks={poolLinks}
+      menuLinks={onToggleMenu && poolLinks}
       menuTitle="Change pool:"
       onToggleMenu={toggleMenu}
       primary={
@@ -75,7 +75,7 @@ export const PoolColumn = ({ onToggleMenu, systemId }) => {
 };
 
 PoolColumn.propTypes = {
-  onToggleMenu: PropTypes.func.isRequired,
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
@@ -189,4 +189,19 @@ describe("PoolColumn", () => {
     wrapper.update();
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
+
+  it("does not render table menu if onToggleMenu not provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PoolColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableMenu").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
@@ -95,7 +95,7 @@ export const PowerColumn = ({ onToggleMenu, systemId }) => {
       }
       iconSpace={true}
       menuClassName="p-table-menu--hasIcon"
-      menuLinks={menuLinks}
+      menuLinks={onToggleMenu && menuLinks}
       menuTitle="Take action:"
       onToggleMenu={toggleMenu}
       primary={
@@ -119,7 +119,7 @@ export const PowerColumn = ({ onToggleMenu, systemId }) => {
 };
 
 PowerColumn.propTypes = {
-  onToggleMenu: PropTypes.func.isRequired,
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.js
@@ -164,4 +164,19 @@ describe("PowerColumn", () => {
       "No power actions available"
     );
   });
+
+  it("does not render table menu if onToggleMenu not provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <PowerColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableMenu").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
@@ -120,7 +120,7 @@ export const StatusColumn = ({ onToggleMenu, systemId }) => {
     <DoubleRow
       icon={getStatusIcon(machine)}
       iconSpace={true}
-      menuLinks={menuLinks}
+      menuLinks={onToggleMenu && menuLinks}
       menuTitle="Take action:"
       onToggleMenu={toggleMenu}
       primary={
@@ -141,7 +141,7 @@ export const StatusColumn = ({ onToggleMenu, systemId }) => {
 };
 
 StatusColumn.propTypes = {
-  onToggleMenu: PropTypes.func.isRequired,
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.js
@@ -260,4 +260,19 @@ describe("StatusColumn", () => {
     wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
     expect(wrapper.find(".p-contextual-menu__dropdown")).toMatchSnapshot();
   });
+
+  it("does not render table menu if onToggleMenu not provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableMenu").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
@@ -66,7 +66,7 @@ export const ZoneColumn = ({ onToggleMenu, systemId }) => {
 
   return (
     <DoubleRow
-      menuLinks={zoneLinks}
+      menuLinks={onToggleMenu && zoneLinks}
       menuTitle="Change AZ:"
       onToggleMenu={toggleMenu}
       primary={
@@ -93,7 +93,7 @@ export const ZoneColumn = ({ onToggleMenu, systemId }) => {
 };
 
 ZoneColumn.propTypes = {
-  onToggleMenu: PropTypes.func.isRequired,
+  onToggleMenu: PropTypes.func,
   systemId: PropTypes.string.isRequired,
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
@@ -198,4 +198,19 @@ describe("ZoneColumn", () => {
     wrapper.update();
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
+
+  it("does not render table menu if onToggleMenu not provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ZoneColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableMenu").exists()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Done

- Added `showActions` prop to MachineListTable (default=true) which determines whether checkboxes and in-table actions will show
- Added MachineListTable to KVM summary page (with showActions=false).
- I was going to convert some files to TS but it would have required converting the machines selector file to TS too. I'll tackle that as a separate ticket.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/kvm and click on a KVM.
- Check that a machine list displays with a correctly filtered list of machines.
- Check that the machine list does not have any checkboxes, and you cannot perform any in-table actions.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#1959

## Screenshot
![0 0 0 0_8400_MAAS_r_kvm_27 (1)](https://user-images.githubusercontent.com/25733845/87280960-176ac300-c536-11ea-8f45-00eeadb26130.png)

