### PR TITLE
Add "Storage" section to KVM summary page.

### DIFF
--- a/shared/src/components/Header/Header.js
+++ b/shared/src/components/Header/Header.js
@@ -101,7 +101,6 @@ export const Header = ({
     },
     {
       inHardwareMenu: true,
-      isLegacy: true,
       label: "KVM",
       url: "/kvm",
     },

--- a/shared/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/shared/src/components/Header/__snapshots__/Header.test.js.snap
@@ -128,7 +128,7 @@ exports[`Header renders 1`] = `
             role="menuitem"
           >
             <a
-              href="/MAAS/l/kvm"
+              href="/kvm"
               onClick={[Function]}
             >
               KVM

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -106,8 +106,11 @@ exports[`stricter compilation`] = {
       [81, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [94, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx:173402218": [
+    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx:990639268": [
       [0, 31, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+    ],
+    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx:19770221": [
+      [0, 40, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:879073754": [
       [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
@@ -398,9 +401,9 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [20, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/pod/types.ts:2359527267": [
+    "src/app/store/pod/types.ts:299495599": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [59, 9, 8, "RegExp match", "1152173309"]
+      [58, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/resourcepool/types.ts:4045616415": [
       [0, 13, 8, "RegExp match", "1152173309"],
@@ -458,5 +461,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `980`
+  value: `986`
 };

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -29,17 +29,17 @@ exports[`stricter compilation`] = {
       [123, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
     "src/app/base/components/FormikField/FormikField.tsx:4232142994": [
-      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/base/components/FormikForm/FormikForm.tsx:4136491328": [
       [70, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/SectionHeader/SectionHeader.tsx:2251696534": [
-      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [59, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
     ],
     "src/app/base/components/Slider/Slider.tsx:753275532": [
-      [0, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"]
+      [0, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"]
     ],
     "src/app/base/reducers/pod/pod.test.ts:1670915466": [
       [44, 10, 8, "Argument of type \'PodState\' is not assignable to parameter of type \'{ readonly errors: {}; readonly items: readonly never[]; readonly loaded: boolean; readonly loading: boolean; readonly saved: boolean; readonly saving: boolean; readonly selected: readonly never[]; readonly statuses: {}; }\'.\\n  Types of property \'items\' are incompatible.\\n    Type \'Pod[]\' is not assignable to type \'readonly never[]\'.\\n      Type \'Pod\' is not assignable to type \'never\'.", "604104617"],
@@ -83,8 +83,8 @@ exports[`stricter compilation`] = {
       [160, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
     ],
     "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfiguration.tsx:3273586287": [
-      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [4, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [4, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],
     "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.test.tsx:2293033710": [
       [15, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -92,7 +92,7 @@ exports[`stricter compilation`] = {
       [83, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMDetails/KVMConfiguration/KVMConfigurationFields/KVMConfigurationFields.tsx:1512800423": [
-      [0, 40, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 40, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:2892838463": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -106,16 +106,19 @@ exports[`stricter compilation`] = {
       [81, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [94, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
+    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx:173402218": [
+      [0, 31, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+    ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx:879073754": [
-      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
-      [4, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
+      [0, 24, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [4, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:475451368": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [129, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx:4073178480": [
-      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 33, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx:2184902936": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -132,11 +135,11 @@ exports[`stricter compilation`] = {
       [108, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:641984635": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [45, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
       [65, 6, 11, "Type \'\\"\\" | Element | null\' is not assignable to type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3453098368"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx:3190792186": [
+    "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx:2263649754": [
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [46, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
@@ -158,7 +161,7 @@ exports[`stricter compilation`] = {
       [418, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:4207317122": [
-      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 43, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [67, 13, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'Pod\'.\\n  No index signature with a parameter of type \'string\' was found on type \'Pod\'.", "2363910037"],
       [101, 57, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
       [116, 24, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[any?], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<...>; cleanup: Acti...\'.", "1023496814"]
@@ -169,7 +172,7 @@ exports[`stricter compilation`] = {
       [41, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx:248496192": [
-      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
+      [0, 22, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx:2366141448": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -198,12 +201,12 @@ exports[`stricter compilation`] = {
     "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:3463297505": [
       [19, 32, 3, "Argument of type \'Pod | undefined\' is not assignable to parameter of type \'Pod\'.\\n  Type \'undefined\' is not assignable to type \'Pod\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "193426238"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx:411821159": [
+    "src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx:1892145639": [
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [46, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx:1445496861": [
+    "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx:2518478478": [
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [31, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
@@ -222,7 +225,7 @@ exports[`stricter compilation`] = {
       [131, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:3618445959": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [72, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [82, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
       [105, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
@@ -241,7 +244,7 @@ exports[`stricter compilation`] = {
       [251, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:3879941606": [
-      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/multipass/code/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
+      [1, 21, 5, "Could not find a declaration file for module \'yup\'. \'/home/caleb/Projects/maas-ui/node_modules/yup/lib/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/yup\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'yup\';\`", "95899385"],
       [47, 21, 17, "Property \'deployingSelected\' does not exist on type \'typeof machine\'.", "3830099655"],
       [61, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction | undefined\'.", "2087897566"],
       [70, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
@@ -257,7 +260,7 @@ exports[`stricter compilation`] = {
       [282, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx:1262012646": [
-      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 39, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [25, 28, 16, "Property \'getAllOsReleases\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "3763145524"],
       [27, 25, 17, "Object is of type \'unknown\'.", "4281571837"],
       [29, 28, 22, "Property \'getUbuntuKernelOptions\' does not exist on type \'{ get(state: any): any; loading(state: any): any; loaded(state: any): any; errors(state: any): any; }\'.", "321954485"],
@@ -270,7 +273,7 @@ exports[`stricter compilation`] = {
       [150, 12, 10, "Type \'{ processing: boolean; setProcessing: Mock<any, any>; setSelectedAction: Mock<any, any>; }\' is not assignable to type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.\\n  Property \'processing\' does not exist on type \'IntrinsicAttributes & Pick<Props, \\"setSelectedAction\\"> & Pick<InferProps<{ setSelectedAction: Validator<(...args: any[]) => any>; }>, never> & Pick<...>\'.", "3107157038"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx:4246555145": [
-      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 34, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [19, 27, 4, "Binding element \'file\' implicitly has an \'any\' type.", "2087597251"],
       [21, 4, 16, "Object is possibly \'null\'.", "4019370437"],
       [26, 20, 23, "Argument of type \'\\"Reading file aborted.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2851093748"],
@@ -301,7 +304,7 @@ exports[`stricter compilation`] = {
       [54, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:2669831063": [
-      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
+      [0, 23, 29, "Could not find a declaration file for module \'@canonical/react-components\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components\';\`", "1034255216"],
       [79, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [123, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"]
     ],
@@ -383,7 +386,7 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [11, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:1408384200": [
+    "src/app/store/machine/types.ts:1807720510": [
       [2, 13, 8, "RegExp match", "1152173309"],
       [68, 9, 8, "RegExp match", "1152173309"]
     ],
@@ -395,10 +398,9 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [20, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/pod/types.ts:3027397456": [
+    "src/app/store/pod/types.ts:2359527267": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [39, 16, 8, "RegExp match", "1152173309"],
-      [49, 9, 8, "RegExp match", "1152173309"]
+      [59, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/resourcepool/types.ts:4045616415": [
       [0, 13, 8, "RegExp match", "1152173309"],
@@ -456,5 +458,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `672`
+  value: `980`
 };

--- a/ui/src/app/base/components/Meter/Meter.test.tsx
+++ b/ui/src/app/base/components/Meter/Meter.test.tsx
@@ -33,8 +33,8 @@ describe("Meter", () => {
     const wrapper = shallow(
       <Meter
         data={[
-          { key: "datum-1", label: "One", value: 1 },
-          { key: "datum-2", label: "Two", value: 3 },
+          { key: "datum-1", value: 1 },
+          { key: "datum-2", value: 3 },
         ]}
       />
     );
@@ -46,17 +46,17 @@ describe("Meter", () => {
     expect(wrapper.find("div").at(0).props().className).toBe("p-meter--small");
   });
 
-  it("can be given labels", () => {
+  it("can be given a label", () => {
     const wrapper = shallow(
       <Meter
         data={[
-          { key: "datum-1", label: "One", value: 1 },
-          { key: "datum-2", label: "Two", value: 3 },
+          { key: "datum-1", value: 1 },
+          { key: "datum-2", value: 3 },
         ]}
+        label="Meter label"
       />
     );
-    expect(wrapper.find(".p-meter__labels div").at(0).text()).toBe("One");
-    expect(wrapper.find(".p-meter__labels div").at(1).text()).toBe("Two");
+    expect(wrapper.find(".p-meter__label").at(0).text()).toBe("Meter label");
   });
 
   it("can be given a custom empty colour", () => {

--- a/ui/src/app/base/components/Meter/Meter.tsx
+++ b/ui/src/app/base/components/Meter/Meter.tsx
@@ -35,7 +35,6 @@ const updateWidths = (
 type MeterDatum = {
   color?: string;
   key: string;
-  label?: string;
   value: number;
 };
 
@@ -43,7 +42,8 @@ type Props = {
   className?: string;
   data: MeterDatum[];
   emptyColor?: string;
-  labelsClassName?: string;
+  label?: string | JSX.Element;
+  labelClassName?: string;
   max?: number;
   overColor?: string;
   segmented?: boolean;
@@ -55,7 +55,8 @@ const Meter = ({
   className,
   data,
   emptyColor = DEFAULT_EMPTY_COLOR,
-  labelsClassName,
+  label,
+  labelClassName,
   max,
   overColor = DEFAULT_OVER_COLOR,
   segmented = false,
@@ -63,7 +64,6 @@ const Meter = ({
   small = false,
 }: Props): JSX.Element => {
   const el = useRef(null);
-  const hasLabels = data.some((datum) => datum.label);
   const valueSum = data.reduce((sum, datum) => sum + datum.value, 0);
   const maximum = max || valueSum;
   const datumWidths = data.map((datum) => (datum.value / maximum) * 100);
@@ -136,22 +136,9 @@ const Meter = ({
           />
         )}
       </div>
-      {hasLabels && (
-        <div className={classNames("p-meter__labels", labelsClassName)}>
-          {data.map((datum) => {
-            if (!datum.label) {
-              return null;
-            }
-            return (
-              <div key={`${datum.key}-label`}>
-                {small ? (
-                  <small className="u-text--light">{datum.label}</small>
-                ) : (
-                  datum.label
-                )}
-              </div>
-            );
-          })}
+      {label && (
+        <div className={classNames("p-meter__label", labelClassName)}>
+          {label}
         </div>
       )}
     </div>
@@ -164,12 +151,12 @@ Meter.propTypes = {
     PropTypes.shape({
       color: PropTypes.string,
       key: PropTypes.string.isRequired,
-      label: PropTypes.node,
       value: PropTypes.number,
     })
   ).isRequired,
   emptyColor: PropTypes.string,
-  labelsClassName: PropTypes.string,
+  label: PropTypes.node,
+  labelClassName: PropTypes.string,
   max: PropTypes.number,
   overColor: PropTypes.string,
   segmented: PropTypes.bool,

--- a/ui/src/app/base/components/Meter/__snapshots__/Meter.test.tsx.snap
+++ b/ui/src/app/base/components/Meter/__snapshots__/Meter.test.tsx.snap
@@ -38,19 +38,5 @@ exports[`Meter renders 1`] = `
       }
     />
   </div>
-  <div
-    className="p-meter__labels"
-  >
-    <div
-      key="datum-1-label"
-    >
-      One
-    </div>
-    <div
-      key="datum-2-label"
-    >
-      Two
-    </div>
-  </div>
 </div>
 `;

--- a/ui/src/app/base/components/Meter/_index.scss
+++ b/ui/src/app/base/components/Meter/_index.scss
@@ -1,10 +1,10 @@
 @mixin Meter {
-  $meter-height: $sp-unit * 2;
+  $meter-height: $sp-unit * 1.75;
   $meter-height--small: $sp-unit * 1.5;
 
   .p-meter {
     margin-bottom: $sp-unit * 1.5;
-    padding-top: $spv-inner--x-small;
+    padding-top: $sp-unit * 0.75;
   }
 
   .p-meter__bar {
@@ -14,11 +14,11 @@
     position: relative;
   }
 
-  .p-meter__labels {
+  .p-meter__label {
     display: flex;
     justify-content: space-between;
     margin-bottom: -#{$sp-unit * .25};
-    padding-top: $sp-unit * 1.25;
+    padding-top: $sp-unit * 1;
   }
 
   .p-meter__filled {
@@ -44,7 +44,7 @@
       margin-bottom: $sp-unit * .75;
     }
 
-    .p-meter__labels {
+    .p-meter__label {
       margin-bottom: 0;
       padding-top: 0;
     }

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -2,17 +2,16 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import type { RootState } from "app/store/root/types";
 import { pod as podActions } from "app/base/actions";
 import { pod as podSelectors } from "app/base/selectors";
 import { useWindowTitle } from "app/base/hooks";
-
-import type { RootState } from "app/store/root/types";
 import MachineListTable from "app/machines/views/MachineList/MachineListTable";
+import KVMSummaryStorage from "./KVMSummaryStorage";
 
-const KVMSummary = (): JSX.Element => {
+const KVMSummary = (): JSX.Element | null => {
   const dispatch = useDispatch();
   const { id } = useParams();
-
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
@@ -23,7 +22,18 @@ const KVMSummary = (): JSX.Element => {
     dispatch(podActions.fetch());
   }, [dispatch]);
 
-  return <MachineListTable filter={`pod-id:=${id}`} showActions={false} />;
+  if (!!pod) {
+    return (
+      <>
+        <h4>Storage</h4>
+        <KVMSummaryStorage id={pod.id} />
+        <hr />
+        <h4>Machines</h4>
+        <MachineListTable filter={`pod-id:=${pod.id}`} showActions={false} />
+      </>
+    );
+  }
+  return null;
 };
 
 export default KVMSummary;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -1,3 +1,4 @@
+import { Spinner, Strip } from "@canonical/react-components";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
@@ -9,7 +10,7 @@ import { useWindowTitle } from "app/base/hooks";
 import MachineListTable from "app/machines/views/MachineList/MachineListTable";
 import KVMSummaryStorage from "./KVMSummaryStorage";
 
-const KVMSummary = (): JSX.Element | null => {
+const KVMSummary = (): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams();
   const pod = useSelector((state: RootState) =>
@@ -26,14 +27,18 @@ const KVMSummary = (): JSX.Element | null => {
     return (
       <>
         <h4>Storage</h4>
-        <KVMSummaryStorage id={pod.id} />
+        <Strip className="u-sv3" shallow>
+          <KVMSummaryStorage id={pod.id} />
+        </Strip>
         <hr />
         <h4>Machines</h4>
-        <MachineListTable filter={`pod-id:=${pod.id}`} showActions={false} />
+        <Strip shallow>
+          <MachineListTable filter={`pod-id:=${pod.id}`} showActions={false} />
+        </Strip>
       </>
     );
   }
-  return null;
+  return <Spinner text="Loading" />;
 };
 
 export default KVMSummary;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.test.tsx
@@ -29,7 +29,7 @@ describe("KVMSummaryStorage", () => {
       </Provider>
     );
     expect(wrapper.find("Row")).toHaveLength(2);
-    expect(wrapper.find("Row").at(0).props()?.children).toHaveLength(3);
-    expect(wrapper.find("Row").at(1).props()?.children).toHaveLength(1);
+    expect(wrapper.find("Row").at(0).props().children).toHaveLength(3);
+    expect(wrapper.find("Row").at(1).props().children).toHaveLength(1);
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import configureStore from "redux-mock-store";
+import { mount } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  podStoragePool as podStoragePoolFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import KVMSummaryStorage from "./KVMSummaryStorage";
+
+const mockStore = configureStore();
+
+describe("KVMSummaryStorage", () => {
+  it("correctly chunks KVM storage pools into rows of 3", () => {
+    const pod = podFactory({
+      storage_pools: Array.from(Array(4)).map(() => podStoragePoolFactory()),
+    });
+    const state = rootStateFactory({ pod: podStateFactory({ items: [pod] }) });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/2", key: "testKey" }]}>
+          <KVMSummaryStorage id={pod.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Row")).toHaveLength(2);
+    expect(wrapper.find("Row").at(0).props()?.children).toHaveLength(3);
+    expect(wrapper.find("Row").at(1).props()?.children).toHaveLength(1);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx
@@ -1,4 +1,4 @@
-import { Card, Col, Row } from "@canonical/react-components";
+import { Card, Col, Row, Spinner } from "@canonical/react-components";
 import React from "react";
 import { useSelector } from "react-redux";
 
@@ -28,7 +28,7 @@ const KVMSummaryStorage = ({ id }: Props): JSX.Element | null => {
 
               return (
                 <Col key={`storage-card-${pool.id}`} size="4">
-                  <Card>
+                  <Card className="p-card--transparent">
                     <div className="p-grid-list">
                       <div className="p-grid-list__label">Name</div>
                       <div className="p-grid-list__value">{pool.name}</div>
@@ -71,7 +71,7 @@ const KVMSummaryStorage = ({ id }: Props): JSX.Element | null => {
       </>
     );
   }
-  return null;
+  return <Spinner text="Loading" />;
 };
 
 export default KVMSummaryStorage;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx
@@ -1,0 +1,77 @@
+import { Card, Col, Row } from "@canonical/react-components";
+import React from "react";
+import { useSelector } from "react-redux";
+
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import { pod as podSelectors } from "app/base/selectors";
+import { chunk, formatBytes } from "app/utils";
+import Meter from "app/base/components/Meter";
+
+type Props = { id: Pod["id"] };
+
+const KVMSummaryStorage = ({ id }: Props): JSX.Element | null => {
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  );
+
+  if (!!pod) {
+    const chunkedPools = chunk(pod.storage_pools, 3);
+
+    return (
+      <>
+        {chunkedPools.map((pools, i) => (
+          <Row key={`pool-chunk-${i}`}>
+            {pools.map((pool) => {
+              const available = formatBytes(pool.total - pool.used, "B");
+              const used = formatBytes(pool.used, "B");
+
+              return (
+                <Col key={`storage-card-${pool.id}`} size="4">
+                  <Card>
+                    <div className="p-grid-list">
+                      <div className="p-grid-list__label">Name</div>
+                      <div className="p-grid-list__value">{pool.name}</div>
+                      <div className="p-grid-list__label">Mount</div>
+                      <div className="p-grid-list__value">{pool.path}</div>
+                      <div className="p-grid-list__label">Type</div>
+                      <div className="p-grid-list__value">{pool.type}</div>
+                      <div className="p-grid-list__label">Space</div>
+                      <div className="p-grid-list__value">
+                        <Meter
+                          className="u-no-margin--bottom"
+                          data={[
+                            {
+                              key: `pool-${pool.id}-meter`,
+                              value: pool.used,
+                            },
+                          ]}
+                          label={
+                            <>
+                              <div>
+                                <div>{`${used.value} ${used.unit}`}</div>
+                                <div className="u-text--light">Used</div>
+                              </div>
+                              <div className="u-align--right">
+                                <div>{`${available.value} ${available.unit}`}</div>
+                                <div className="u-text--light">Available</div>
+                              </div>
+                            </>
+                          }
+                          max={pool.total}
+                        />
+                      </div>
+                    </div>
+                  </Card>
+                </Col>
+              );
+            })}
+          </Row>
+        ))}
+      </>
+    );
+  }
+  return null;
+};
+
+export default KVMSummaryStorage;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMSummaryStorage";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
@@ -37,7 +37,7 @@ describe("CPUColumn", () => {
         <CPUColumn id={1} />
       </Provider>
     );
-    expect(wrapper.find("Meter").find(".p-meter__labels").text()).toBe(
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
       "4 of 8 assigned"
     );
     expect(wrapper.find("Meter").props().max).toBe(8);
@@ -52,7 +52,7 @@ describe("CPUColumn", () => {
         <CPUColumn id={1} />
       </Provider>
     );
-    expect(wrapper.find("Meter").find(".p-meter__labels").text()).toBe(
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
       "4 of 16 assigned"
     );
     expect(wrapper.find("Meter").props().max).toBe(16);

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
@@ -26,11 +26,15 @@ const CPUColumn = ({ id }: Props): JSX.Element | null => {
           data={[
             {
               key: `${pod.name}-cpu-meter`,
-              label: `${pod.used.cores} of ${availableCores} assigned`,
               value: pod.used.cores,
             },
           ]}
-          labelsClassName="u-align--right"
+          label={
+            <small className="u-text--light">
+              {`${pod.used.cores} of ${availableCores} assigned`}
+            </small>
+          }
+          labelClassName="u-align--right"
           max={availableCores}
           segmented
           small

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
@@ -37,7 +37,7 @@ describe("RAMColumn", () => {
         <RAMColumn id={1} />
       </Provider>
     );
-    expect(wrapper.find("Meter").find(".p-meter__labels").text()).toBe(
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
       "2 of 8 GiB assigned"
     );
     expect(wrapper.find("Meter").props().max).toBe(8192);
@@ -52,7 +52,7 @@ describe("RAMColumn", () => {
         <RAMColumn id={1} />
       </Provider>
     );
-    expect(wrapper.find("Meter").find(".p-meter__labels").text()).toBe(
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
       "2 of 16 GiB assigned"
     );
     expect(wrapper.find("Meter").props().max).toBe(16384);

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
@@ -30,11 +30,15 @@ const RAMColumn = ({ id }: Props): JSX.Element | null => {
         data={[
           {
             key: `${pod.name}-memory-meter`,
-            label: `${assignedMemory.value} of ${availableMemory.value} ${availableMemory.unit} assigned`,
             value: pod.used.memory,
           },
         ]}
-        labelsClassName="u-align--right"
+        label={
+          <small className="u-text--light">
+            {`${assignedMemory.value} of ${availableMemory.value} ${availableMemory.unit} assigned`}
+          </small>
+        }
+        labelClassName="u-align--right"
         max={pod.total.memory * pod.memory_over_commit_ratio}
         small
       />

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
@@ -36,7 +36,7 @@ describe("StorageColumn", () => {
         <StorageColumn id={1} />
       </Provider>
     );
-    expect(wrapper.find("Meter").find(".p-meter__labels").text()).toBe(
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
       "0.1 of 1 TB assigned"
     );
     expect(wrapper.find("Meter").props().max).toBe(1000000000000);

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
@@ -25,11 +25,15 @@ const StorageColumn = ({ id }: Props): JSX.Element | null => {
         data={[
           {
             key: `${pod.name}-storage-meter`,
-            label: `${assignedStorage.value} of ${availableStorage.value} ${availableStorage.unit} assigned`,
             value: pod.used.local_storage,
           },
         ]}
-        labelsClassName="u-align--right"
+        label={
+          <small className="u-text--light">
+            {`${assignedStorage.value} of ${availableStorage.value} ${availableStorage.unit} assigned`}
+          </small>
+        }
+        labelClassName="u-align--right"
         max={pod.total.local_storage}
         small
       />

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/_index.scss
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/_index.scss
@@ -4,7 +4,7 @@
     th {
       // FQDN
       &:nth-child(1) {
-        @include breakpoint-widths(60%, 30%, 20%, 25%);
+        @include breakpoint-widths(60%, 30%, 20%, 24%);
       }
 
       // Power
@@ -19,7 +19,7 @@
 
       // VMs / Owners
       &:nth-child(4) {
-        @include breakpoint-widths(0, 0, 0% 8%);
+        @include breakpoint-widths(0, 0, 0%, 9%);
       }
 
       // OS

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -16,9 +16,8 @@ export type PodHintExtras = {
   local_disks: number;
 };
 
-export type PodStoragePool = {
+export type PodStoragePool = Model & {
   available: number;
-  id: number;
   name: string;
   path: string;
   total: number;

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -16,6 +16,16 @@ export type PodHintExtras = {
   local_disks: number;
 };
 
+export type PodStoragePool = {
+  available: number;
+  id: number;
+  name: string;
+  path: string;
+  total: number;
+  type: string;
+  used: number;
+};
+
 export type Pod = Model & {
   architectures: string[];
   available: PodHint;
@@ -37,7 +47,7 @@ export type Pod = Model & {
   power_address: string;
   power_pass?: string;
   owners_count: number;
-  storage_pools: TSFixMe[];
+  storage_pools: PodStoragePool[];
   tags: string[];
   total: PodHint;
   type: string;

--- a/ui/src/app/utils/chunk.test.ts
+++ b/ui/src/app/utils/chunk.test.ts
@@ -1,0 +1,18 @@
+import { chunk } from "./chunk";
+
+describe("chunk", () => {
+  it("correctly chunks an array", () => {
+    expect(chunk([1, 2, 3], 1)).toStrictEqual([[1], [2], [3]]);
+    expect(chunk([1, 2, 3, 4], 2)).toStrictEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(chunk([1, 2, 3], 3)).toStrictEqual([[1, 2, 3]]);
+  });
+
+  it("can handle uneven chunks", () => {
+    expect(chunk([1, 2, 3], 2)).toStrictEqual([[1, 2], [3]]);
+    expect(chunk([1, 2, 3, 4], 3)).toStrictEqual([[1, 2, 3], [4]]);
+    expect(chunk([1, 2], 3)).toStrictEqual([[1, 2]]);
+  });
+});

--- a/ui/src/app/utils/chunk.ts
+++ b/ui/src/app/utils/chunk.ts
@@ -1,0 +1,7 @@
+export const chunk = <T extends unknown>(array: T[], size: number): T[][] => {
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+};

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -1,4 +1,5 @@
 export { capitaliseFirst } from "./capitaliseFirst";
+export { chunk } from "./chunk";
 export { formatBytes } from "./formatBytes";
 export { formatErrors } from "./formatErrors";
 export { formatMacAddress } from "./formatMacAddress";

--- a/ui/src/scss/_breakpoint-widths.scss
+++ b/ui/src/scss/_breakpoint-widths.scss
@@ -8,7 +8,7 @@
   $breakpoint-first: 600px;
   $breakpoint-second: 900px;
   $breakpoint-third: 1030px;
-  $breakpoint-fourth: 1360px;
+  $breakpoint-fourth: 1300px;
 
   @media (max-width: $breakpoint-first - 1px) {
     @if $width-one == 0 {

--- a/ui/src/scss/_patterns_cards.scss
+++ b/ui/src/scss/_patterns_cards.scss
@@ -1,0 +1,7 @@
+@mixin maas-cards {
+  // Button styles that make it look like a link
+  .p-card--transparent {
+    @extend %vf-card;
+    background-color: transparent;
+  }
+}

--- a/ui/src/scss/_patterns_lists.scss
+++ b/ui/src/scss/_patterns_lists.scss
@@ -1,0 +1,24 @@
+@mixin maas-lists {
+  .p-grid-list {
+    display: grid;
+    grid-column-gap: $sph-inner;
+    grid-template-columns: min-content auto;
+  }
+
+  .p-grid-list__label {
+    color: $color-mid-dark;
+    text-align: right;
+    
+    &:not(:nth-last-child(2)) {
+      margin-bottom: $spv-outer--small-scaleable;
+    }
+  }
+
+  .p-grid-list__value {
+    word-break: break-word;
+
+    &:not(:last-child) {
+      margin-bottom: $spv-outer--small-scaleable;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -26,6 +26,7 @@
 @import "./patterns_forms";
 @import "./patterns_icons";
 @import "./patterns_links";
+@import "./patterns_lists";
 @import "./patterns_navigation";
 @import "./patterns_notifications";
 @import "./patterns_table-actions";
@@ -38,6 +39,7 @@
 @include maas-forms;
 @include maas-icons;
 @include maas-links;
+@include maas-lists;
 @include maas-navigation;
 @include maas-notifications;
 @include maas-table-actions;

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -21,6 +21,7 @@
 
 // Import and include MAAS global styles
 @import "./patterns_buttons";
+@import "./patterns_cards";
 @import "./patterns_double-row";
 @import "./patterns_footer";
 @import "./patterns_forms";
@@ -34,6 +35,7 @@
 @import "./patterns_tabs";
 @import "./utilities";
 @include maas-buttons;
+@include maas-cards;
 @include maas-double-row;
 @include maas-footer;
 @include maas-forms;

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -39,7 +39,7 @@ export {
 } from "./state";
 export { config } from "./config";
 export { domain } from "./domain";
-export { device, machine, controller, pod } from "./nodes";
+export { device, machine, controller, pod, podStoragePool } from "./nodes";
 export { dhcpSnippet } from "./dhcpsnippet";
 export { licenseKeys } from "./licensekeys";
 export {

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -1,9 +1,14 @@
-import { define, extend, random } from "cooky-cutter";
+import { define, extend, random, sequence } from "cooky-cutter";
 
 import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
 import type { Machine } from "app/store/machine/types";
-import type { Pod, PodHint, PodHintExtras } from "app/store/pod/types";
+import type {
+  Pod,
+  PodHint,
+  PodHintExtras,
+  PodStoragePool,
+} from "app/store/pod/types";
 import type { Model } from "app/store/types/model";
 import { BaseNode, SimpleNode, TestStatus } from "app/store/types/node";
 import { model, modelRef } from "./model";
@@ -31,7 +36,7 @@ const link_speeds = () => [];
 const permissions = () => ["edit", "delete", "compose"];
 const service_ids = () => [];
 const spaces = () => [];
-const storage_pools = () => [];
+const storage_pools = () => [podStoragePool(), podStoragePool()];
 const storage_tags = () => [];
 const subnets = () => [];
 const tags = () => [];
@@ -138,6 +143,16 @@ const podHintExtras = define<PodHintExtras>({
   iscsi_storage: -1,
   iscsi_storage_gb: "-0.0",
   local_disks: -1,
+});
+
+export const podStoragePool = define<PodStoragePool>({
+  available: 700000000000,
+  total: 1000000000000,
+  used: 300000000000,
+  name: () => `storage-pool-${random()}`,
+  path: () => `/path/to/${random()}`,
+  id: sequence,
+  type: "lvm",
 });
 
 export const pod = extend<Model, Pod>(model, {


### PR DESCRIPTION
## Done

- Added storage cards to KVM summary page. I've done it mostly according to [the design](https://app.zeplin.io/project/5e538f1156434564ebb73903/screen/5ec783846b27e649abd0406a), except I've made it 3 per row instead of 4 otherwise the mount paths + storage meter get really cramped near the medium breakpoint.
- Updated the Meter component to only accept a single `label` prop, instead of having a label per datum. I think how we plan to use meter labels is too varied, so it's easier to just have complete control over how the label looks from a single JSX element.
- Changed the Header component to route to /r/kvm instead of /l/kvm
- Fixed a css bug that prevented the VMs header rendering

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click "KVM" in the header nav and check that it takes you to the react KVM list
- Check that the KVM list has a VMs/Owners column
- Click on a KVM and check that the Storage sections matches [the design](https://app.zeplin.io/project/5e538f1156434564ebb73903/screen/5ec783846b27e649abd0406a) (except 3 per row instead of 4)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#1958

## Screenshot
![0 0 0 0_8400_MAAS_r_kvm_180](https://user-images.githubusercontent.com/25733845/87495930-df7a9180-c695-11ea-8015-d42b24a8e1ba.png)

