### PR TITLE
Added cloud-init docs link

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -1,4 +1,5 @@
 import { Col, List, Row, Select } from "@canonical/react-components";
+import classNames from "classnames";
 import React, { useState } from "react";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
@@ -103,15 +104,28 @@ export const DeployFormFields = (): JSX.Element => {
             ]}
             inline
           />
-          <FormikField
-            label="Cloud-init user-data&hellip;"
-            name="includeUserData"
-            type="checkbox"
-            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-              handleChange(evt);
-              setUserDataVisible(evt.target.checked);
-            }}
-            wrapperClassName={userDataVisible ? "u-sv2" : null}
+          <List
+            items={[
+              <FormikField
+                label="Cloud-init user-data&hellip;"
+                name="includeUserData"
+                type="checkbox"
+                onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                  handleChange(evt);
+                  setUserDataVisible(evt.target.checked);
+                }}
+                wrapperClassName={classNames("u-display-inline-block", {
+                  "u-sv2 u-display-inline-block": userDataVisible,
+                })}
+              />,
+              <a
+                className="p-link--external"
+                href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+              >
+                Read more
+              </a>,
+            ]}
+            inline
           />
           {userDataVisible && <UserDataField />}
         </Col>


### PR DESCRIPTION
## Done

- Added cloud-init docs link to the deploy form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- From the machine list check a deployable machine.
- Click deploy in the take action menu.
- Next to the cloud-init option there should be a read more link which should take you to the docs.

## Fixes

Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/2038.