### PR TITLE
Add error message to deploy form if no images have been downloaded.

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -55,7 +55,7 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
   }, [dispatch]);
 
   // Default OS+release is set in the backend even if the image has not yet been
-  // downloaded. The following condiionals check whether the OS+release actually
+  // downloaded. The following conditionals check whether the OS+release actually
   // exist in state before setting initial values in the form.
   let initialOS = "";
   let initialRelease = "";

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -43,7 +43,9 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
   const defaultMinHweKernel = useSelector(
     generalSelectors.defaultMinHweKernel.get
   );
-  const osInfo = useSelector(generalSelectors.osInfo.get);
+  const { default_osystem, default_release, osystems, releases } = useSelector(
+    generalSelectors.osInfo.get
+  );
   const deployingSelected = useSelector(machineSelectors.deployingSelected);
 
   useEffect(() => {
@@ -52,16 +54,33 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
     dispatch(machineActions.fetch());
   }, [dispatch]);
 
+  // Default OS+release is set in the backend even if the image has not yet been
+  // downloaded. The following condiionals check whether the OS+release actually
+  // exist in state before setting initial values in the form.
+  let initialOS = "";
+  let initialRelease = "";
+  if (osystems.some((osChoice) => osChoice[0] === default_osystem)) {
+    initialOS = default_osystem;
+  }
+  if (
+    releases.some((releaseChoice) => {
+      const split = releaseChoice[0].split("/");
+      return split.length > 1 && split[1] === default_release;
+    })
+  ) {
+    initialRelease = default_release;
+  }
+
   return (
     <ActionForm
       actionName="deploy"
-      allowUnchanged
+      allowUnchanged={osystems.length !== 0 && releases.length !== 0}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}
       errors={errors}
       initialValues={{
-        oSystem: osInfo.default_osystem,
-        release: osInfo.default_release,
+        oSystem: initialOS,
+        release: initialRelease,
         kernel: defaultMinHweKernel || "",
         installKVM: false,
       }}

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -125,11 +125,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            processing={false}
-            setProcessing={jest.fn()}
-            setSelectedAction={jest.fn()}
-          />
+          <DeployForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -145,11 +141,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            processing={false}
-            setProcessing={jest.fn()}
-            setSelectedAction={jest.fn()}
-          />
+          <DeployForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -165,11 +157,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            processing={false}
-            setProcessing={jest.fn()}
-            setSelectedAction={jest.fn()}
-          />
+          <DeployForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -186,11 +174,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            processing={false}
-            setProcessing={jest.fn()}
-            setSelectedAction={jest.fn()}
-          />
+          <DeployForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -217,11 +201,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            processing={false}
-            setProcessing={jest.fn()}
-            setSelectedAction={jest.fn()}
-          />
+          <DeployForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -259,15 +239,28 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            processing={false}
-            setProcessing={jest.fn()}
-            setSelectedAction={jest.fn()}
-          />
+          <DeployForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("[data-test='sshkeys-warning']").exists()).toBe(true);
+  });
+
+  it("displays an error if there are no OSes or releases to choose from", () => {
+    const state = { ...initialState };
+    state.general.osInfo.data.osystems = [];
+    state.general.osInfo.data.releases = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+        >
+          <DeployForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='images-error']").exists()).toBe(true);
   });
 
   it("can display the user data input", async () => {
@@ -279,11 +272,7 @@ describe("DeployFormFields", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <DeployForm
-            processing={false}
-            setProcessing={jest.fn()}
-            setSelectedAction={jest.fn()}
-          />
+          <DeployForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -246,7 +246,8 @@ describe("DeployFormFields", () => {
     expect(wrapper.find("[data-test='sshkeys-warning']").exists()).toBe(true);
   });
 
-  it("displays an error if there are no OSes or releases to choose from", () => {
+  it(`displays an error and disables form fields if there are no OSes or
+    releases to choose from`, () => {
     const state = { ...initialState };
     state.general.osInfo.data.osystems = [];
     state.general.osInfo.data.releases = [];
@@ -261,6 +262,15 @@ describe("DeployFormFields", () => {
       </Provider>
     );
     expect(wrapper.find("[data-test='images-error']").exists()).toBe(true);
+    expect(wrapper.find("FormikField[name='oSystem']").props().disabled).toBe(
+      true
+    );
+    expect(wrapper.find("FormikField[name='release']").props().disabled).toBe(
+      true
+    );
+    expect(
+      wrapper.find("FormikField[name='installKVM']").props().disabled
+    ).toBe(true);
   });
 
   it("can display the user data input", async () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -1,4 +1,10 @@
-import { Col, List, Row, Select } from "@canonical/react-components";
+import {
+  Col,
+  List,
+  Notification,
+  Row,
+  Select,
+} from "@canonical/react-components";
 import classNames from "classnames";
 import React, { useState } from "react";
 import { useFormikContext } from "formik";
@@ -12,7 +18,6 @@ import configSelectors from "app/store/config/selectors";
 import FormikField from "app/base/components/FormikField";
 import generalSelectors from "app/store/general/selectors";
 import type { RootState } from "app/store/root/types";
-import type { User } from "app/store/user/types";
 import UserDataField from "./UserDataField";
 
 export const DeployFormFields = (): JSX.Element => {
@@ -20,7 +25,7 @@ export const DeployFormFields = (): JSX.Element => {
   const formikProps = useFormikContext<DeployFormValues>();
   const { handleChange, setFieldValue, values } = formikProps;
 
-  const user: User = useSelector(authSelectors.get);
+  const user = useSelector(authSelectors.get);
   const osOptions = useSelector(configSelectors.defaultOSystemOptions);
   const { osystems, releases } = useSelector(generalSelectors.osInfo.get);
   const allReleaseOptions = useSelector(
@@ -33,140 +38,144 @@ export const DeployFormFields = (): JSX.Element => {
   const canBeKVMHost =
     values.oSystem === "ubuntu" && values.release === "bionic";
   const imagesURL = generateLegacyURL("/images");
+  const noImages = osystems.length === 0 || releases.length === 0;
 
   return (
-    <div className="u-sv2">
-      <Row>
-        <Col size="3">
-          <FormikField
-            component={Select}
-            label="OS"
-            name="oSystem"
-            options={osOptions}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              handleChange(e);
-              const value = e.target.value;
-              if (allReleaseOptions[value] && allReleaseOptions[value].length) {
-                setFieldValue("release", allReleaseOptions[value][0].value);
-              }
-              if (value !== "ubuntu") {
-                setFieldValue("installKVM", false);
-              }
+    <>
+      {noImages && (
+        <Notification data-test="images-error" type="negative">
+          You will not be able to deploy a machine until at least one valid
+          image has been downloaded. To download an image, visit the{" "}
+          <a
+            href={imagesURL}
+            onClick={(evt) => {
+              evt.preventDefault();
+              window.history.pushState(null, null, imagesURL);
             }}
-          />
-        </Col>
-        <Col size="3">
-          <FormikField
-            component={Select}
-            label="Release"
-            name="release"
-            options={releaseOptions}
-            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-              handleChange(e);
-              if (e.target.value !== "bionic") {
-                setFieldValue("installKVM", false);
-              }
-            }}
-          />
-        </Col>
-        <Col size="3">
-          {values.oSystem === "ubuntu" && (
+          >
+            images page
+          </a>
+          .
+        </Notification>
+      )}
+      <div className="u-sv2">
+        <Row>
+          <Col size="3">
             <FormikField
               component={Select}
-              label="Kernel"
-              name="kernel"
-              options={kernelOptions}
+              disabled={noImages}
+              label="OS"
+              name="oSystem"
+              options={osOptions}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                handleChange(e);
+                const value = e.target.value;
+                if (
+                  allReleaseOptions[value] &&
+                  allReleaseOptions[value].length
+                ) {
+                  setFieldValue("release", allReleaseOptions[value][0].value);
+                }
+                if (value !== "ubuntu") {
+                  setFieldValue("installKVM", false);
+                }
+              }}
             />
-          )}
-        </Col>
-      </Row>
-      <div className="u-sv2">
-        <hr className="u-sv2" />
+          </Col>
+          <Col size="3">
+            <FormikField
+              component={Select}
+              disabled={noImages}
+              label="Release"
+              name="release"
+              options={releaseOptions}
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                handleChange(e);
+                if (e.target.value !== "bionic") {
+                  setFieldValue("installKVM", false);
+                }
+              }}
+            />
+          </Col>
+          <Col size="3">
+            {values.oSystem === "ubuntu" && (
+              <FormikField
+                component={Select}
+                label="Kernel"
+                name="kernel"
+                options={kernelOptions}
+              />
+            )}
+          </Col>
+        </Row>
+        <div className="u-sv2">
+          <hr className="u-sv2" />
+        </div>
+        <Row>
+          <Col size="3">
+            <p>Customise options</p>
+          </Col>
+          <Col size="9">
+            <List
+              items={[
+                <FormikField
+                  disabled={!canBeKVMHost || noImages}
+                  label="Register as MAAS KVM host (Ubuntu 18.04 LTS required)."
+                  name="installKVM"
+                  type="checkbox"
+                  wrapperClassName="u-sv-1 u-display-inline-block"
+                />,
+                <a
+                  className="p-link--external"
+                  href="https://maas.io/docs/kvm-introduction"
+                >
+                  Read more
+                </a>,
+              ]}
+              inline
+            />
+            <List
+              items={[
+                <FormikField
+                  disabled={noImages}
+                  label="Cloud-init user-data&hellip;"
+                  name="includeUserData"
+                  type="checkbox"
+                  onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                    handleChange(evt);
+                    setUserDataVisible(evt.target.checked);
+                  }}
+                  wrapperClassName={classNames("u-display-inline-block", {
+                    "u-sv2 u-display-inline-block": userDataVisible,
+                  })}
+                />,
+                <a
+                  className="p-link--external"
+                  href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+                >
+                  Read more
+                </a>,
+              ]}
+              inline
+            />
+            {userDataVisible && <UserDataField />}
+          </Col>
+        </Row>
+        {user.sshkeys_count === 0 && (
+          <Row>
+            <Col size="12">
+              <p className="u-no-max-width" data-test="sshkeys-warning">
+                <i className="p-icon--warning is-inline"></i>
+                Login will not be possible because no SSH keys have been added
+                to your account. To add an SSH key, visit your{" "}
+                <Link to="/account/prefs/ssh-keys">account page</Link>.
+              </p>
+            </Col>
+          </Row>
+        )}
+        <hr className="u-sv1" />
       </div>
-      <Row>
-        <Col size="3">
-          <p>Customise options</p>
-        </Col>
-        <Col size="9">
-          <List
-            items={[
-              <FormikField
-                disabled={!canBeKVMHost}
-                label="Register as MAAS KVM host (Ubuntu 18.04 LTS required)."
-                name="installKVM"
-                type="checkbox"
-                wrapperClassName="u-sv-1 u-display-inline-block"
-              />,
-              <a
-                className="p-link--external"
-                href="https://maas.io/docs/kvm-introduction"
-              >
-                Read more
-              </a>,
-            ]}
-            inline
-          />
-          <List
-            items={[
-              <FormikField
-                label="Cloud-init user-data&hellip;"
-                name="includeUserData"
-                type="checkbox"
-                onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-                  handleChange(evt);
-                  setUserDataVisible(evt.target.checked);
-                }}
-                wrapperClassName={classNames("u-display-inline-block", {
-                  "u-sv2 u-display-inline-block": userDataVisible,
-                })}
-              />,
-              <a
-                className="p-link--external"
-                href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
-              >
-                Read more
-              </a>,
-            ]}
-            inline
-          />
-          {userDataVisible && <UserDataField />}
-        </Col>
-      </Row>
-      {(osystems.length === 0 || releases.length === 0) && (
-        <Row>
-          <Col size="12">
-            <p className="u-no-max-width" data-test="images-error">
-              <i className="p-icon--error is-inline"></i>
-              You will not be able to deploy a machine until at least one valid
-              image has been downloaded. To download an image, visit the{" "}
-              <a
-                href={imagesURL}
-                onClick={(evt) => {
-                  evt.preventDefault();
-                  window.history.pushState(null, null, imagesURL);
-                }}
-              >
-                images page
-              </a>
-              .
-            </p>
-          </Col>
-        </Row>
-      )}
-      {user.sshkeys_count === 0 && (
-        <Row>
-          <Col size="12">
-            <p className="u-no-max-width" data-test="sshkeys-warning">
-              <i className="p-icon--warning is-inline"></i>
-              Login will not be possible because no SSH keys have been added to
-              your account. To add an SSH key, visit your{" "}
-              <Link to="/account/prefs/ssh-keys">account page</Link>.
-            </p>
-          </Col>
-        </Row>
-      )}
-      <hr className="u-sv1" />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Done

- Disable and add an error message to the deploy form if no OSes/releases are detected in state.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Spin up a new MAAS and do not download any images when prompted to. I don't think this will work if you try to delete all the images from an existing MAAS, as MAAS prevents users from deleting the default commissioning/deployment image.
- Select one or more machines and choose the "Deploy" action.
- The deploy form should be disabled with an error message that asks you to visit the images page.

## Fixes

Fixes #1393 

## Screenshot
![0 0 0 0_8400_MAAS_r_machines (2)](https://user-images.githubusercontent.com/25733845/87901941-ac703d80-ca9b-11ea-9961-93fe710bf744.png)

