### PR TITLE
Fix angular machine list parentClasses bug.

### DIFF
--- a/legacy/src/app/directives/machines_table.js
+++ b/legacy/src/app/directives/machines_table.js
@@ -43,15 +43,17 @@ function maasMachinesTable(
     },
     template: machinesTableTmpl,
     link: function(scope) {
-      scope.clickHandler = event => {
-        const targetClasses = event.target.classList || [];
-        const parentClasses = event.target.parentNode.classList || [];
+      scope.clickHandler = (event) => {
+        const targetClasses = event.target.classList;
+        const parentClasses = event.target.parentNode.classList;
 
         if (
-          targetClasses.contains("p-table-menu__toggle") ||
-          targetClasses.contains("p-double-row__icon-container") ||
-          parentClasses.contains("p-table-menu__dropdown") ||
-          parentClasses.contains("p-double-row__icon-container")
+          targetClasses &&
+          parentClasses &&
+          (targetClasses.contains("p-table-menu__toggle") ||
+            targetClasses.contains("p-double-row__icon-container") ||
+            parentClasses.contains("p-table-menu__dropdown") ||
+            parentClasses.contains("p-double-row__icon-container"))
         ) {
           return;
         }


### PR DESCRIPTION
## Done

- Fixed a bug where if a parentNode did not exist when clicking on the machine list, a console error would occur

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the angular version of a pod details page
- Click somewhere in the window and drag the cursor outside the browser window
- Let go of the click
- There should be no console error

## Fixes

Fixes #1401 

