### PR TITLE
Fix add rack controller help

### DIFF
--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -714,11 +714,14 @@
             <hr />
             <h4 class="page-header__dropdown-title">Add rack controller</h4>
             <pre><code># To add a new rack controller, SSH into the rack controller.
-# Install the maas-rack-controller package.
-sudo apt install maas-rack-controller
-# Register the rack controller with this MAAS. If the rack controller (and machines)
-# don't have access to the URL, use a different IP address to allow connection.
-sudo maas-rack register --url {$ tabs.controllers.registerUrl $} --secret {$ tabs.controllers.registerSecret $}</code></pre>
+# Install the maas snap.
+sudo snap install maas
+# Initialize the rack controller with this MAAS.
+sudo maas init rack
+
+# You will be asked for the following input:
+#  - MAAS URL: The MAAS URL for the region controller: http://[region_controller_ip]:5240/MAAS/
+#  - Secret: The a secret stored on the controller: {$ tabs.controllers.registerSecret $}</code></pre>
         </div>
         <div class="u-align--right ng-hide" data-ng-show="tabs.controllers.addController">
                 <a href="" class="p-button--neutral"


### PR DESCRIPTION
The current version of MAAS does not support 'maas rack-register'
anymore. The rack controller must be registered with 'maas init'.

## Done

- Itemised list of what was changed by this PR.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
