### PR TITLE
Add interfaces table to KVM compose form.

### DIFF
--- a/ui/src/app/base/actions/pod/pod.test.ts
+++ b/ui/src/app/base/actions/pod/pod.test.ts
@@ -1,7 +1,7 @@
 import pod from "./pod";
 
 describe("pod actions", () => {
-  it("should handle fetching pods", () => {
+  it("can create an action for fetching pods", () => {
     expect(pod.fetch()).toEqual({
       type: "FETCH_POD",
       meta: {
@@ -11,7 +11,7 @@ describe("pod actions", () => {
     });
   });
 
-  it("can handle creating pods", () => {
+  it("can create an action for creating a pod", () => {
     expect(pod.create({ name: "pod1", description: "a pod" })).toEqual({
       type: "CREATE_POD",
       meta: {
@@ -27,7 +27,22 @@ describe("pod actions", () => {
     });
   });
 
-  it("can handle updating pods", () => {
+  it("can create an action for getting a pod", () => {
+    expect(pod.get(1)).toEqual({
+      type: "GET_POD",
+      meta: {
+        model: "pod",
+        method: "get",
+      },
+      payload: {
+        params: {
+          id: 1,
+        },
+      },
+    });
+  });
+
+  it("can create an action for updating a pod", () => {
     expect(pod.update({ name: "pod1", description: "a pod" })).toEqual({
       type: "UPDATE_POD",
       meta: {
@@ -43,7 +58,7 @@ describe("pod actions", () => {
     });
   });
 
-  it("can handle deleting pods", () => {
+  it("can create an action for deleting a pod", () => {
     expect(pod.delete(1)).toEqual({
       type: "DELETE_POD",
       meta: {
@@ -58,7 +73,7 @@ describe("pod actions", () => {
     });
   });
 
-  it("can handle refreshing pods", () => {
+  it("can create an action for refreshing a pod", () => {
     expect(pod.refresh(1)).toEqual({
       type: "REFRESH_POD",
       meta: {
@@ -73,7 +88,7 @@ describe("pod actions", () => {
     });
   });
 
-  it("can handle composing pods", () => {
+  it("can create an action for composing a pod", () => {
     const params = { id: 1 };
     expect(pod.compose(params)).toEqual({
       type: "COMPOSE_POD",
@@ -87,14 +102,14 @@ describe("pod actions", () => {
     });
   });
 
-  it("can handle selecting pods", () => {
+  it("can create an action for selecting pods", () => {
     expect(pod.setSelected([1, 2, 4])).toEqual({
       type: "SET_SELECTED_PODS",
       payload: [1, 2, 4],
     });
   });
 
-  it("can handle cleaning pods", () => {
+  it("can create an action for pods cleanup", () => {
     expect(pod.cleanup()).toEqual({
       type: "CLEANUP_POD",
     });

--- a/ui/src/app/base/actions/pod/pod.ts
+++ b/ui/src/app/base/actions/pod/pod.ts
@@ -14,6 +14,19 @@ pod.compose = (params) => {
   };
 };
 
+pod.get = (podID: Pod["id"]) => {
+  return {
+    type: "GET_POD",
+    meta: {
+      model: "pod",
+      method: "get",
+    },
+    payload: {
+      params: { id: podID },
+    },
+  };
+};
+
 pod.refresh = (podID: Pod["id"]) => {
   return {
     type: "REFRESH_POD",

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from "react";
 import React, { useState } from "react";
 
-import { useProcessing } from "app/base/hooks";
 import type { TSFixMe } from "app/base/types";
+import { useProcessing } from "app/base/hooks";
 import { formatErrors } from "app/utils";
 import FormikForm from "app/base/components/FormikForm";
 import FormCardButtons from "app/base/components/FormCardButtons";
@@ -87,7 +88,7 @@ const getLabel = (
 type Props = {
   actionName?: string;
   allowUnchanged?: boolean;
-  children?: JSX.Element;
+  children?: ReactNode;
   cleanup?: () => void;
   clearSelectedAction?: (...args: unknown[]) => void;
   disabled?: boolean;

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -2,6 +2,7 @@ import { Formik } from "formik";
 import { Redirect } from "react-router";
 import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
+import type { ReactNode } from "react";
 import React, { useEffect } from "react";
 
 import { useSendAnalytics } from "app/base/hooks";
@@ -14,7 +15,7 @@ type Props = {
   Buttons?: JSX.Element;
   buttonsBordered?: boolean;
   cleanup?: () => void;
-  children?: JSX.Element;
+  children?: ReactNode;
   errors?: TSFixMe;
   initialValues: TSFixMe;
   loading?: boolean;

--- a/ui/src/app/base/components/TableActions/TableActions.js
+++ b/ui/src/app/base/components/TableActions/TableActions.js
@@ -38,6 +38,7 @@ const TableActions = ({
           disabled={deleteDisabled}
           hasIcon
           onClick={() => onDelete()}
+          type="button"
         >
           <i className="p-icon--delete">Delete</i>
         </Button>

--- a/ui/src/app/base/reducers/pod/pod.test.ts
+++ b/ui/src/app/base/reducers/pod/pod.test.ts
@@ -1,5 +1,6 @@
 import {
   pod as podFactory,
+  podDetails as podDetailsFactory,
   podState as podStateFactory,
   podStatus as podStatusFactory,
 } from "testing/factories";
@@ -77,6 +78,54 @@ describe("pod reducer", () => {
       selected: [],
       statuses: {},
     });
+  });
+
+  it("should correctly reduce GET_POD_START", () => {
+    const podState = podStateFactory({ items: [], loading: false });
+
+    expect(
+      pod(podState, {
+        type: "GET_POD_START",
+        params: { id: 1 },
+      })
+    ).toEqual(podStateFactory({ loading: true }));
+  });
+
+  it("should correctly reduce GET_POD_SUCCESS", () => {
+    const newPod = podDetailsFactory();
+    const podState = podStateFactory({
+      items: [],
+      loading: true,
+    });
+
+    expect(
+      pod(podState, {
+        type: "GET_POD_SUCCESS",
+        payload: newPod,
+      })
+    ).toEqual(
+      podStateFactory({
+        items: [newPod],
+        loading: false,
+        statuses: { [newPod.id]: podStatusFactory() },
+      })
+    );
+  });
+
+  it("should correctly reduce GET_POD_ERROR", () => {
+    const podState = podStateFactory({ loading: true });
+
+    expect(
+      pod(podState, {
+        error: "Could not get pod",
+        type: "GET_POD_ERROR",
+      })
+    ).toEqual(
+      podStateFactory({
+        errors: "Could not get pod",
+        loading: false,
+      })
+    );
   });
 
   it("should correctly reduce CREATE_POD_START", () => {

--- a/ui/src/app/base/reducers/pod/pod.ts
+++ b/ui/src/app/base/reducers/pod/pod.ts
@@ -49,7 +49,7 @@ const pod = createNextState((draft, action) => {
           draft.items[existingIdx] = newItem;
         } else {
           draft.items.push(newItem);
-          // Set up the statuses for this machine.
+          // Set up the statuses for this pod.
           draft.statuses[newItem.id] = DEFAULT_STATUSES;
         }
       });
@@ -67,10 +67,31 @@ const pod = createNextState((draft, action) => {
       draft.saved = true;
       draft.saving = false;
       break;
+    case "GET_POD_START":
+      draft.loading = true;
+      break;
+    case "GET_POD_SUCCESS":
+      const pod = action.payload;
+      // If the item already exists, update it, otherwise
+      // add it to the store.
+      const i = draft.items.findIndex(
+        (draftItem: Pod) => draftItem.id === pod.id
+      );
+      if (i !== -1) {
+        draft.items[i] = pod;
+      } else {
+        draft.items.push(pod);
+        // Set up the statuses for this pod.
+        draft.statuses[pod.id] = DEFAULT_STATUSES;
+      }
+      draft.loading = false;
+      break;
     case "FETCH_POD_ERROR":
+    case "GET_POD_ERROR":
     case "CREATE_POD_ERROR":
     case "UPDATE_POD_ERROR":
       draft.errors = action.error;
+      draft.loading = false;
       draft.saving = false;
       break;
     case "CREATE_POD_NOTIFY":

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.test.js
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.test.js
@@ -9,19 +9,21 @@ import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
   generalState as generalStateFactory,
-  pod as podFactory,
+  podDetails as podDetailsFactory,
   podState as podStateFactory,
   podStatus as podStatusFactory,
   powerTypesState as powerTypesStateFactory,
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
+  space as spaceFactory,
   spaceState as spaceStateFactory,
+  subnet as subnetFactory,
   subnetState as subnetStateFactory,
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
-import ComposeForm from "./ComposeForm";
+import ComposeForm, { createInterfaceConstraints } from "./ComposeForm";
 
 const mockStore = configureStore();
 
@@ -40,7 +42,7 @@ describe("ComposeForm", () => {
         powerTypes: powerTypesStateFactory({ loaded: true }),
       }),
       pod: podStateFactory({
-        items: [podFactory({ id: 1 })],
+        items: [podDetailsFactory({ id: 1 })],
         loaded: true,
         statuses: { 1: podStatusFactory() },
       }),
@@ -76,12 +78,12 @@ describe("ComposeForm", () => {
       "FETCH_DOMAIN",
       "FETCH_FABRIC",
       "FETCH_GENERAL_POWER_TYPES",
-      "FETCH_POD",
       "FETCH_RESOURCEPOOL",
       "FETCH_SPACE",
       "FETCH_SUBNET",
       "FETCH_VLAN",
       "FETCH_ZONE",
+      "GET_POD",
     ];
     const actions = store.getActions();
     expectedActions.forEach((expectedAction) => {
@@ -104,7 +106,11 @@ describe("ComposeForm", () => {
   });
 
   it("can handle composing a machine", () => {
+    const space = spaceFactory({ id: 1, name: "outer" });
+    const subnet = subnetFactory({ id: 10, cidr: "192.168.1.1/24" });
     const state = { ...initialState };
+    state.space.items = [space];
+    state.subnet.items = [subnet];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -115,16 +121,28 @@ describe("ComposeForm", () => {
     );
 
     act(() =>
-      wrapper.find("Formik").props().onSubmit({
-        architecture: "amd64/generic",
-        cores: 5,
-        domain: "0",
-        hostname: "mean-bean-machine",
-        id: "1",
-        memory: 4096,
-        pool: "2",
-        zone: "3",
-      })
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          architecture: "amd64/generic",
+          cores: 5,
+          domain: "0",
+          hostname: "mean-bean-machine",
+          id: "1",
+          interfaces: [
+            {
+              id: 1,
+              ipAddress: "192.168.1.1",
+              name: "eth0",
+              space: "1",
+              subnet: "10",
+            },
+          ],
+          memory: 4096,
+          pool: "2",
+          zone: "3",
+        })
     );
     expect(
       store.getActions().find((action) => action.type === "COMPOSE_POD")
@@ -141,13 +159,84 @@ describe("ComposeForm", () => {
           domain: 0,
           hostname: "mean-bean-machine",
           id: 1,
-          interfaces: undefined,
+          interfaces:
+            "eth0:ip=192.168.1.1,space=outer,subnet_cidr=192.168.1.1/24",
           memory: 4096,
           pool: 2,
           storage: undefined,
           zone: 3,
         },
       },
+    });
+  });
+
+  describe("createInterfacesConstraint", () => {
+    it("returns an empty string if no interfaces are given", () => {
+      const interfaceFields = [];
+      expect(createInterfaceConstraints(interfaceFields, [], [])).toEqual("");
+    });
+
+    it("returns an empty string if no constraints are given", () => {
+      const interfaceFields = [
+        {
+          id: 1,
+          ipAddress: "",
+          name: "eth0",
+          space: "",
+          subnet: "",
+        },
+      ];
+      expect(createInterfaceConstraints(interfaceFields, [], [])).toEqual("");
+    });
+
+    it("can create a single interface constraint", () => {
+      const space = spaceFactory();
+      const subnet = subnetFactory();
+      const interfaceFields = [
+        {
+          id: 1,
+          ipAddress: "192.168.1.1",
+          name: "eth0",
+          space: `${space.id}`,
+          subnet: `${subnet.id}`,
+        },
+      ];
+      expect(
+        createInterfaceConstraints(interfaceFields, [space], [subnet])
+      ).toEqual(
+        `eth0:ip=${interfaceFields[0].ipAddress},space=${space.name},subnet_cidr=${subnet.cidr}`
+      );
+    });
+
+    it("can create multiple interface constraints", () => {
+      const [space1, space2] = [spaceFactory(), spaceFactory()];
+      const [subnet1, subnet2] = [subnetFactory(), subnetFactory()];
+      const [interface1, interface2] = [
+        {
+          id: 1,
+          ipAddress: "192.168.1.1",
+          name: "eth0",
+          space: `${space1.id}`,
+          subnet: `${subnet1.id}`,
+        },
+        {
+          id: 2,
+          ipAddress: "192.168.1.2",
+          name: "eth1",
+          space: `${space2.id}`,
+          subnet: `${subnet2.id}`,
+        },
+      ];
+      expect(
+        createInterfaceConstraints(
+          [interface1, interface2],
+          [space1, space2],
+          [subnet1, subnet2]
+        )
+      ).toEqual(
+        `eth0:ip=${interface1.ipAddress},space=${space1.name},subnet_cidr=${subnet1.cidr};` +
+          `eth1:ip=${interface2.ipAddress},space=${space2.name},subnet_cidr=${subnet2.cidr}`
+      );
     });
   });
 });

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
@@ -72,12 +72,14 @@ export const createInterfaceConstraints = (
         constraints.push(`ip=${iface.ipAddress}`);
       }
       if (iface.space !== "") {
-        const space = spaces.find((space) => space.id === Number(iface.space));
+        const space = spaces.find(
+          (space) => space.id === parseInt(iface.space)
+        );
         !!space && constraints.push(`space=${space.name}`);
       }
       if (iface.subnet !== "") {
         const subnet = subnets.find(
-          (subnet) => subnet.id === Number(iface.subnet)
+          (subnet) => subnet.id === parseInt(iface.subnet)
         );
         !!subnet && constraints.push(`subnet_cidr=${subnet?.cidr}`);
       }

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -86,14 +86,14 @@ describe("ComposeFormFields", () => {
     // 10 * 3 - 8 = 22
     expect(
       wrapper.find("FormikField[name='cores'] .p-form-help-text").text()
-    ).toEqual("22 cores available");
+    ).toEqual("22 cores available.");
   });
 
   it("correctly displays the available memory", () => {
     const state = { ...initialState };
     const pod = state.pod.items[0];
-    pod.total.memory = 8;
-    pod.used.memory = 5;
+    pod.total.memory = 8000;
+    pod.used.memory = 5000;
     pod.memory_over_commit_ratio = 2;
     const store = mockStore(state);
     const wrapper = mount(
@@ -107,10 +107,10 @@ describe("ComposeFormFields", () => {
         </MemoryRouter>
       </Provider>
     );
-    // 8 * 2 - 5 = 11
+    // 8000 * 2 - 5000 = 11000
     expect(
       wrapper.find("FormikField[name='memory'] .p-form-help-text").text()
-    ).toEqual("11 MiB available");
+    ).toEqual("11000 MiB available.");
   });
 
   it("shows warnings if available cores/memory is less than the default", () => {
@@ -144,12 +144,12 @@ describe("ComposeFormFields", () => {
     );
     expect(
       wrapper
-        .find("FormikField[name='cores'] + .p-form-validation__message")
+        .find("FormikField[name='cores'] .p-form-validation__message")
         .exists()
     ).toBe(true);
     expect(
       wrapper
-        .find("FormikField[name='memory'] + .p-form-validation__message")
+        .find("FormikField[name='memory'] .p-form-validation__message")
         .exists()
     ).toBe(true);
   });

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -29,6 +29,9 @@ export const ComposeFormFields = ({
   const resourcePools = useSelector(resourcePoolSelectors.all);
   const zones = useSelector(zoneSelectors.all);
 
+  const coresCaution = available.cores < defaults.cores;
+  const memoryCaution = available.memory < defaults.memory;
+
   return (
     <Row>
       <Col size="5">
@@ -93,7 +96,15 @@ export const ComposeFormFields = ({
           ]}
         />
         <FormikField
-          help={`${available.cores} cores available`}
+          caution={
+            coresCaution
+              ? `The available cores (${available.cores}) is less than the
+                recommended default (${defaults.cores}).`
+              : undefined
+          }
+          help={
+            coresCaution ? undefined : `${available.cores} cores available.`
+          }
           label="Cores"
           max={`${available.cores}`}
           min="1"
@@ -102,15 +113,16 @@ export const ComposeFormFields = ({
           step="1"
           type="number"
         />
-        {available.cores < defaults.cores && (
-          <p className="p-form-validation__message">
-            <i className="p-icon--warning" />
-            <strong className="p-icon__text">Caution:</strong> The available
-            cores is less than the recommended default.
-          </p>
-        )}
         <FormikField
-          help={`${available.memory} MiB available`}
+          caution={
+            memoryCaution
+              ? `The available memory (${available.memory}MiB) is less than the
+                recommended default (${defaults.memory}MiB).`
+              : undefined
+          }
+          help={
+            memoryCaution ? undefined : `${available.memory} MiB available.`
+          }
           label="RAM (MiB)"
           max={`${available.memory}`}
           min="1024"
@@ -118,13 +130,6 @@ export const ComposeFormFields = ({
           placeholder={`${defaults.memory} (default)`}
           type="number"
         />
-        {available.memory < defaults.memory && (
-          <p className="p-form-validation__message">
-            <i className="p-icon--warning" />
-            <strong className="p-icon__text">Caution:</strong> The available
-            memory is less than the recommended default.
-          </p>
-        )}
       </Col>
     </Row>
   );

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -1,0 +1,255 @@
+import { act } from "react-dom/test-utils";
+import { mount } from "enzyme";
+import React from "react";
+import { MemoryRouter, Route } from "react-router-dom";
+import { Provider } from "react-redux";
+import configureStore, { MockStoreEnhanced } from "redux-mock-store";
+
+import type { Pod } from "app/store/pod/types";
+import {
+  domainState as domainStateFactory,
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  generalState as generalStateFactory,
+  podDetails as podDetailsFactory,
+  podState as podStateFactory,
+  podStatus as podStatusFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  space as spaceFactory,
+  spaceState as spaceStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import ComposeForm from "../ComposeForm";
+
+const mockStore = configureStore();
+
+const generateWrapper = (store: MockStoreEnhanced, pod: Pod) =>
+  mount(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
+      >
+        <Route
+          exact
+          path="/kvm/:id"
+          component={() => <ComposeForm setSelectedAction={jest.fn()} />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+describe("InterfacesTable", () => {
+  let initialState = rootStateFactory();
+
+  beforeEach(() => {
+    const pod = podDetailsFactory({ id: 1 });
+
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+      }),
+      fabric: fabricStateFactory({
+        loaded: true,
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+          loaded: true,
+        }),
+      }),
+      pod: podStateFactory({
+        items: [pod],
+        loaded: true,
+        statuses: { [pod.id]: podStatusFactory() },
+      }),
+      resourcepool: resourcePoolStateFactory({
+        loaded: true,
+      }),
+      space: spaceStateFactory({
+        loaded: true,
+      }),
+      subnet: subnetStateFactory({
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        loaded: true,
+      }),
+      zone: zoneStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("disables add interface button with tooltip if KVM has no available subnets", () => {
+    const pod = podDetailsFactory({ attached_vlans: [], id: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    expect(
+      wrapper.find("[data-test='define-interfaces'] button").prop("disabled")
+    ).toBe(true);
+    expect(
+      wrapper.find("[data-test='define-interfaces']").prop("message")
+    ).toBe("There are no available subnets on this KVM's attached VLANs.");
+  });
+
+  it("disables add interface button if pod is composing a machine", () => {
+    const pod = podDetailsFactory({ attached_vlans: [1], id: 1 });
+    const subnet = subnetFactory({ vlan: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    state.pod.statuses = { [pod.id]: podStatusFactory({ composing: true }) };
+    state.subnet.items = [subnet];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    expect(
+      wrapper.find("[data-test='define-interfaces'] button").prop("disabled")
+    ).toBe(true);
+  });
+
+  it("can add and remove interfaces if KVM has available subnets", async () => {
+    const pod = podDetailsFactory({ attached_vlans: [1], id: 1 });
+    const subnet = subnetFactory({ vlan: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    state.subnet.items = [subnet];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Undefined interface row displays by default
+    expect(wrapper.find("[data-test='undefined-interface']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("tbody TableRow").length).toBe(1);
+
+    // Click "Define" button - table row should change to a defined interface
+    await act(async () => {
+      wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("[data-test='undefined-interface']").exists()).toBe(
+      false
+    );
+    expect(wrapper.find("tbody TableRow").length).toBe(1);
+
+    // Click "Add interface" - another defined interface should be added
+    await act(async () => {
+      wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("tbody TableRow").length).toBe(2);
+
+    // Click delete button - a defined interface should be removed
+    await act(async () => {
+      wrapper.find("TableActions button").at(0).simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("tbody TableRow").length).toBe(1);
+  });
+
+  it("correctly displays fabric, vlan and PXE details of selected subnet", async () => {
+    const fabric = fabricFactory();
+    const vlan = vlanFactory({ fabric: fabric.id });
+    const subnet = subnetFactory({ vlan: vlan.id });
+    const pod = podDetailsFactory({
+      attached_vlans: [vlan.id],
+      boot_vlans: [vlan.id],
+      id: 1,
+    });
+    const state = { ...initialState };
+    state.fabric.items = [fabric];
+    state.pod.items = [pod];
+    state.subnet.items = [subnet];
+    state.vlan.items = [vlan];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Click "Define" button
+    // Fabric and VLAN should be auto assigned, PXE should be unknown
+    await act(async () => {
+      wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("TableCell[aria-label='Fabric']").text()).toBe(
+      "Auto-assign"
+    );
+    expect(wrapper.find("TableCell[aria-label='VLAN']").text()).toBe(
+      "Auto-assign"
+    );
+    expect(
+      wrapper.find("TableCell[aria-label='PXE'] i").prop("className")
+    ).toBe("p-icon--power-unknown");
+
+    // Choose the subnet in state from the dropdown
+    // Fabric and VLAN nams should display, PXE should be true
+    await act(async () => {
+      wrapper
+        .find("select[name='interfaces[0].subnet']")
+        .props()
+        .onChange({
+          target: { name: "interfaces[0].subnet", value: `${subnet.id}` },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+    expect(wrapper.find("TableCell[aria-label='Fabric']").text()).toBe(
+      fabric.name
+    );
+    expect(wrapper.find("TableCell[aria-label='VLAN']").text()).toBe(vlan.name);
+    expect(
+      wrapper.find("TableCell[aria-label='PXE'] i").prop("className")
+    ).toBe("p-icon--success");
+  });
+
+  it("filters subnets by selected space", async () => {
+    const space = spaceFactory();
+    const [subnetInSpace, subnetNotInSpace] = [
+      subnetFactory({ space: space.id, vlan: 1 }),
+      subnetFactory({ space: null, vlan: 1 }),
+    ];
+    const pod = podDetailsFactory({ attached_vlans: [1], id: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    state.space.items = [space];
+    state.subnet.items = [subnetInSpace, subnetNotInSpace];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Click "Define" button
+    // Both subnets + "Any" option should be available
+    await act(async () => {
+      wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(
+      wrapper.find("select[name='interfaces[0].subnet'] option").length
+    ).toBe(3);
+
+    // Choose the space in state from the dropdown
+    // Only the subnet in the selected space + "Any" should be available
+    await act(async () => {
+      wrapper
+        .find("FormikField[name='interfaces[0].space']")
+        .props()
+        .onChange({
+          target: {
+            name: "interfaces[0].space",
+            value: `${space.id}`,
+          },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+    expect(
+      wrapper.find("select[name='interfaces[0].subnet'] option").length
+    ).toBe(2);
+  });
+});

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -138,10 +138,10 @@ export const InterfacesTable = (): JSX.Element => {
           <tbody>
             {interfaces.map((iface, i) => {
               const space = spaces.find(
-                (space) => space.id === Number(iface.space)
+                (space) => space.id === parseInt(iface.space)
               );
               const subnet = podSubnets.find(
-                (subnet) => subnet.id === Number(iface.subnet)
+                (subnet) => subnet.id === parseInt(iface.subnet)
               );
               const vlan = vlans.find((vlan) => vlan.id === subnet?.vlan);
               const fabric = fabrics.find(

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -1,0 +1,263 @@
+import {
+  Button,
+  Select,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  Tooltip,
+} from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import React from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import type { ComposeFormValues, InterfaceField } from "../ComposeForm";
+import type { PodDetails } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import type { Space } from "app/store/space/types";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
+import fabricSelectors from "app/store/fabric/selectors";
+import podSelectors from "app/store/pod/selectors";
+import spaceSelectors from "app/store/space/selectors";
+import subnetSelectors from "app/store/subnet/selectors";
+import vlanSelectors from "app/store/vlan/selectors";
+import FormikField from "app/base/components/FormikField";
+import TableActions from "app/base/components/TableActions";
+
+/**
+ * Filter subnets to those that are in a given space.
+ * @param {Subnet[]} subnets - The subnets to filter.
+ * @param {Space} space - The space by which to filter subnets.
+ * @returns {Subnet[]} Subnets filtered by space.
+ */
+const filterSubnetsBySpace = (subnets: Subnet[], space: Space): Subnet[] => {
+  if (!!space) {
+    return subnets.filter((subnet) => subnet.space === space.id);
+  }
+  return subnets;
+};
+
+/**
+ * Generate a new InterfaceField with a given id.
+ * @param {number} id - The id to give the new InterfaceField.
+ * @returns {InterfaceField} Generated InterfaceField.
+ */
+const generateNewInterface = (id: number): InterfaceField => {
+  return {
+    id,
+    ipAddress: "",
+    name: `eth${id}`,
+    space: "",
+    subnet: "",
+  };
+};
+
+/**
+ * Get the icon class name for the interface's PXE column.
+ * @param {PodDetails} pod - The pod whose boot VLANs are to be checked.
+ * @param {VLAN} vlan - The VLAN of the interface's selected subnet.
+ * @returns {string} The class name of the PXE column icon.
+ */
+const getPxeIconClass = (pod: PodDetails, vlan: VLAN): string => {
+  if (!vlan || !pod) {
+    return "p-icon--power-unknown";
+  }
+  return pod.boot_vlans?.includes(vlan.id)
+    ? "p-icon--success"
+    : "p-icon--error";
+};
+
+export const InterfacesTable = (): JSX.Element => {
+  const { id } = useParams();
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  ) as PodDetails;
+  const podSubnets = useSelector((state: RootState) =>
+    subnetSelectors.getByPod(state, pod)
+  );
+  const composingPods = useSelector(podSelectors.composing);
+  const fabrics = useSelector(fabricSelectors.all);
+  const spaces = useSelector(spaceSelectors.all);
+  const vlans = useSelector(vlanSelectors.all);
+
+  const { handleChange, setFieldValue, values } = useFormikContext<
+    ComposeFormValues
+  >();
+  const { interfaces } = values;
+  const cannotDefineInterfaces = podSubnets.length === 0;
+
+  const addInterface = () => {
+    const ids = interfaces.map((iface) => iface.id);
+    let id = 0;
+    while (ids.includes(id)) {
+      id++;
+    }
+    setFieldValue("interfaces", [...interfaces, generateNewInterface(id)]);
+  };
+
+  const removeInterface = (id: number) => {
+    setFieldValue(
+      "interfaces",
+      interfaces.filter((iface) => iface.id !== id)
+    );
+  };
+
+  return (
+    <>
+      <div className="u-flex--between">
+        <h4>Interfaces</h4>
+        <Button
+          className="u-hide--medium u-hide--large"
+          disabled={cannotDefineInterfaces || !!composingPods.length}
+          hasIcon
+          onClick={addInterface}
+          type="button"
+        >
+          <i className="p-icon--plus"></i>
+          <span>
+            {interfaces.length === 0 ? "Define (optional)" : "Add interface"}
+          </span>
+        </Button>
+      </div>
+      <Table className="kvm-compose-interfaces-table" responsive>
+        <thead>
+          <TableRow>
+            <TableHeader>Name</TableHeader>
+            <TableHeader>IP address</TableHeader>
+            <TableHeader>Space</TableHeader>
+            <TableHeader>Subnet</TableHeader>
+            <TableHeader>Fabric</TableHeader>
+            <TableHeader>VLAN</TableHeader>
+            <TableHeader>PXE</TableHeader>
+            <TableHeader className="u-align--right">Actions</TableHeader>
+          </TableRow>
+        </thead>
+        {interfaces.length >= 1 ? (
+          <tbody>
+            {interfaces.map((iface, i) => {
+              const space = spaces.find(
+                (space) => space.id === Number(iface.space)
+              );
+              const subnet = podSubnets.find(
+                (subnet) => subnet.id === Number(iface.subnet)
+              );
+              const vlan = vlans.find((vlan) => vlan.id === subnet?.vlan);
+              const fabric = fabrics.find(
+                (fabric) => fabric.id === vlan?.fabric
+              );
+              const subnetsBySpace = filterSubnetsBySpace(podSubnets, space);
+
+              return (
+                <TableRow key={iface.id}>
+                  <TableCell aria-label="Name">
+                    <FormikField name={`interfaces[${i}].name`} type="text" />
+                  </TableCell>
+                  <TableCell aria-label="IP address">
+                    <FormikField
+                      name={`interfaces[${i}].ipAddress`}
+                      placeholder="Leave empty to auto-assign"
+                      type="text"
+                    />
+                  </TableCell>
+                  <TableCell aria-label="Space">
+                    <FormikField
+                      component={Select}
+                      name={`interfaces[${i}].space`}
+                      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                        handleChange(e);
+                        setFieldValue(`interfaces[${i}].subnet`, "");
+                      }}
+                      options={[
+                        {
+                          label: "Any",
+                          value: "",
+                        },
+                        ...spaces.map((space) => ({
+                          key: space.id,
+                          label: space.name,
+                          value: space.id,
+                        })),
+                      ]}
+                    />
+                  </TableCell>
+                  <TableCell aria-label="Subnet">
+                    <FormikField
+                      className="u-no-margin--bottom"
+                      component={Select}
+                      name={`interfaces[${i}].subnet`}
+                      options={[
+                        {
+                          label: "Any",
+                          value: "",
+                        },
+                        ...subnetsBySpace.map((subnet) => ({
+                          key: subnet.id,
+                          label: subnet.name,
+                          value: subnet.id,
+                        })),
+                      ]}
+                    />
+                  </TableCell>
+                  <TableCell aria-label="Fabric">
+                    {fabric?.name || <em>Auto-assign</em>}
+                  </TableCell>
+                  <TableCell aria-label="VLAN">
+                    {vlan?.name || <em>Auto-assign</em>}
+                  </TableCell>
+                  <TableCell aria-label="PXE">
+                    <i className={getPxeIconClass(pod, vlan)}></i>
+                  </TableCell>
+                  <TableCell
+                    aria-label="Actions"
+                    className="u-align--right u-no-padding--right"
+                  >
+                    <TableActions
+                      deleteDisabled={!!composingPods.length}
+                      onDelete={() => removeInterface(iface.id)}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </tbody>
+        ) : (
+          <tbody>
+            <TableRow data-test="undefined-interface">
+              <TableCell aria-label="Name">
+                <em>default</em>
+              </TableCell>
+              <TableCell aria-label="IP address" colSpan="7">
+                Created by hypervisor at compose time
+              </TableCell>
+            </TableRow>
+          </tbody>
+        )}
+      </Table>
+      <Tooltip
+        data-test="define-interfaces"
+        message={
+          cannotDefineInterfaces &&
+          "There are no available subnets on this KVM's attached VLANs."
+        }
+        position="right"
+      >
+        <Button
+          className="u-hide--small"
+          disabled={cannotDefineInterfaces || !!composingPods.length}
+          hasIcon
+          onClick={addInterface}
+          type="button"
+        >
+          <i className="p-icon--plus"></i>
+          <span>
+            {interfaces.length === 0 ? "Define (optional)" : "Add interface"}
+          </span>
+        </Button>
+      </Tooltip>
+    </>
+  );
+};
+
+export default InterfacesTable;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
@@ -1,0 +1,77 @@
+@mixin KVMComposeInterfacesTable {
+  .kvm-compose-interfaces-table {
+    td,
+    th {
+      // Name
+      &:nth-child(1) {
+        width: 11%;
+      }
+
+      // IP address
+      &:nth-child(2) {
+        width: 24%;
+      }
+
+      // Space
+      &:nth-child(3) {
+        width: 15%;
+      }
+
+      // Subnet
+      &:nth-child(4) {
+        width: 20%;
+      }
+
+      // Fabric
+      &:nth-child(5) {
+        width: 15%;
+      }
+
+      // VLAN
+      &:nth-child(6) {
+        width: 15%;
+      }
+
+      // PXE
+      &:nth-child(7) {
+        width: 2.5rem;
+      }
+
+      // Actions
+      &:nth-child(8) {
+        width: 4.5rem;
+      }
+    }
+
+    input,
+    select {
+      margin-bottom: 0;
+      min-width: 0;
+    }
+
+    .p-form-validation__message {
+      margin-top: 0;
+    }
+
+    @media screen and (max-width: $breakpoint-medium) {
+      tr {
+        padding: calc(#{$spv-inner--small} - 1px) $sph-inner;
+        width: 100%;
+      }
+
+      td {
+        align-items: center;
+        padding-left: calc(33% + #{$sph-inner--small});
+
+        .p-form__group {
+          flex: 1;
+        }
+
+        &[aria-label="Actions"] > * {
+          left: calc(-#{$sph-inner--small} - 1px);
+          position: relative;
+        }
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/index.ts
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InterfacesTable";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -21,8 +21,8 @@ const KVMDetails = (): JSX.Element => {
   const podsLoaded = useSelector(podSelectors.loaded);
 
   useEffect(() => {
-    dispatch(podActions.fetch());
-  }, [dispatch]);
+    dispatch(podActions.get(id));
+  }, [dispatch, id]);
 
   // If KVM has been deleted, redirect to KVM list.
   if (podsLoaded && !pod) {

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -25,7 +25,7 @@ export type PodStoragePool = Model & {
   used: number;
 };
 
-export type Pod = Model & {
+export type BasePod = Model & {
   architectures: string[];
   available: PodHint;
   capabilities: string[];
@@ -54,6 +54,13 @@ export type Pod = Model & {
   used: PodHint;
   zone: number;
 };
+
+export type PodDetails = BasePod & {
+  attached_vlans: number[];
+  boot_vlans: number[];
+};
+
+export type Pod = BasePod | PodDetails;
 
 export type PodStatus = {
   composing: boolean;

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -25,6 +25,9 @@ export type PodStoragePool = Model & {
   used: number;
 };
 
+// BasePod is returned from the server when using "pod.list", and is used in the
+// pod list pages. This type is missing some properties due to an optimisation
+// on the backend to reduce the amount of database queries on list pages.
 export type BasePod = Model & {
   architectures: string[];
   available: PodHint;
@@ -55,11 +58,15 @@ export type BasePod = Model & {
   zone: number;
 };
 
+// PodDetails is returned from the server when using "pod.get", and is used in the
+// pod details pages. This type contains all possible properties of a pod model.
 export type PodDetails = BasePod & {
   attached_vlans: number[];
   boot_vlans: number[];
 };
 
+// Depending on where the user has navigated in the app, pods in state can
+// either be of type Pod or PodDetails.
 export type Pod = BasePod | PodDetails;
 
 export type PodStatus = {

--- a/ui/src/app/store/subnet/selectors.test.ts
+++ b/ui/src/app/store/subnet/selectors.test.ts
@@ -1,4 +1,5 @@
 import {
+  podDetails as podDetailsFactory,
   rootState as rootStateFactory,
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
@@ -42,5 +43,20 @@ describe("subnet selectors", () => {
       }),
     });
     expect(subnet.getById(state, 909)).toStrictEqual(items[1]);
+  });
+
+  it("can get subnets that are available to a given pod", () => {
+    const subnets = [
+      subnetFactory({ vlan: 1 }),
+      subnetFactory({ vlan: 2 }),
+      subnetFactory({ vlan: 3 }),
+    ];
+    const pod = podDetailsFactory({ attached_vlans: [1, 2] });
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: subnets,
+      }),
+    });
+    expect(subnet.getByPod(state, pod)).toStrictEqual([subnets[0], subnets[1]]);
   });
 });

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -1,13 +1,37 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 import { generateBaseSelectors } from "app/store/utils";
+import type { PodDetails } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import type { Subnet, SubnetState } from "app/store/subnet/types";
 
 const searchFunction = (subnet: Subnet, term: string) =>
   subnet.name.includes(term);
 
-const selectors = generateBaseSelectors<SubnetState, Subnet, "id">(
+const defaultSelectors = generateBaseSelectors<SubnetState, Subnet, "id">(
   "subnet",
   "id",
   searchFunction
 );
+
+/**
+ * Get subnets that are available to a given pod.
+ * @param {RootState} state - The redux state.
+ * @param {Pod} pod - The pod to query.
+ * @returns {Subnet[]} Subnets that are available to a given pod.
+ */
+const getByPod = createSelector(
+  [defaultSelectors.all, (_state: RootState, pod: PodDetails) => pod],
+  (subnets, pod) => {
+    if (!pod) {
+      return [];
+    }
+    return subnets.filter((subnet) =>
+      pod.attached_vlans?.includes(subnet.vlan)
+    );
+  }
+);
+
+const selectors = { ...defaultSelectors, getByPod };
 
 export default selectors;

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -51,6 +51,7 @@ input[type="radio"] {
 }
 .p-form-help-text,
 .p-form-validation__message {
+  line-height: 1.5rem;
   margin-bottom: 0.8rem;
   margin-top: -0.5rem;
 }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -69,8 +69,10 @@
 // kvm
 @import "~app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover";
 @import "~app/kvm/views/KVMList/KVMListTable";
+@import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable";
 @include CPUPopover;
 @include KVMListTable;
+@include KVMComposeInterfacesTable;
 
 // machines
 @import "~app/machines/views/MachineList";

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -51,6 +51,7 @@ export {
   machine,
   controller,
   pod,
+  podDetails,
   podHint,
   podStoragePool,
 } from "./nodes";

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -5,6 +5,7 @@ import type { Device } from "app/store/device/types";
 import type { Machine } from "app/store/machine/types";
 import type {
   Pod,
+  PodDetails,
   PodHint,
   PodHintExtras,
   PodStoragePool,
@@ -182,4 +183,9 @@ export const pod = extend<Model, Pod>(model, {
   updated: "Fri, 03 Jul. 2020 02:44:12",
   used: podHint,
   zone: 1,
+});
+
+export const podDetails = extend<Pod, PodDetails>(pod, {
+  attached_vlans: () => [],
+  boot_vlans: () => [],
 });


### PR DESCRIPTION
## Done

- Added interfaces table to KVM compose form, which is used to construct the interface constraints string.
- Updated warning styling for cores and memory fields

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM details page of a KVM and open the Compose dropdown.
- Check that there is an Interfaces section.
- Click "Define (optional)" and define some interface constraints.
- Check that the list of subnets is filtered depending on the selected space.
- Check that the values for fabric, vlan and PXE update correctly.
- Compose the machine and wait a minute or so for MAAS to set it up.
- Check that the newly created machine has interfaces as defined in the KVM compose form.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2042

## Screenshot
### Undefined interface
![0 0 0 0_8400_MAAS_r_kvm_185 (7)](https://user-images.githubusercontent.com/25733845/88360248-64615b80-cdb8-11ea-9331-e945e64bb5f5.png)



### Defined interface
![0 0 0 0_8400_MAAS_r_kvm_185 (8)](https://user-images.githubusercontent.com/25733845/88360262-67f4e280-cdb8-11ea-87eb-f1797ec00fc6.png)



### Mobile view
![0 0 0 0_8400_MAAS_r_kvm_185 (12)](https://user-images.githubusercontent.com/25733845/88364932-cd040480-cdc7-11ea-8c60-267123d1e9ca.png)



