### PR TITLE
Add Storage configuration section to KVM compose form.

### DIFF
--- a/ui/src/app/base/components/TagSelector/TagSelector.js
+++ b/ui/src/app/base/components/TagSelector/TagSelector.js
@@ -38,10 +38,11 @@ const generateDropdownItems = ({
   if (
     allowNewTags &&
     filter &&
-    !tags.some((tag) => (tag.displayName || tag.name) === filter)
+    !tags.some((tag) => (tag.displayName || tag.name) === filter) &&
+    !selectedTags.some((tag) => (tag.displayName || tag.name) === filter)
   ) {
-    // Insert an extra item for creating a new tag if allowed, filter is present
-    // is not an already existing tag
+    // Insert an extra item for creating a new tag if allowed and filter is not
+    // an already existing tag
     const newTagItem = (
       <li className="tag-selector__dropdown-item" key={filter}>
         <Button
@@ -88,8 +89,8 @@ const generateDropdownItems = ({
         </Button>
       </li>
     ));
-  dropdownItems.push(existingTagItems);
-  return dropdownItems;
+
+  return dropdownItems.concat(existingTagItems);
 };
 
 const generateSelectedItems = ({ selectedTags, updateTags }) =>
@@ -107,6 +108,7 @@ const generateSelectedItems = ({ selectedTags, updateTags }) =>
             false
           )
         }
+        type="button"
       >
         <span>{tag.name}</span>
         <i className="p-icon--close" />
@@ -124,7 +126,7 @@ export const TagSelector = ({
   onTagsUpdate,
   placeholder = "Tags",
   required,
-  tags,
+  tags = [],
 }) => {
   const wrapperRef = useRef(null);
 
@@ -158,14 +160,24 @@ export const TagSelector = ({
     };
   }, []);
 
+  const dropdownItems = generateDropdownItems({
+    allowNewTags,
+    filter,
+    selectedTags,
+    tags,
+    updateTags,
+  });
+
   return (
     <Field
       error={error}
       help={help}
       label={
-        <span onClick={() => setDropdownOpen(true)} ref={wrapperRef}>
-          {label}
-        </span>
+        label ? (
+          <span onClick={() => setDropdownOpen(true)} ref={wrapperRef}>
+            {label}
+          </span>
+        ) : undefined
       }
     >
       <div className="tag-selector">
@@ -194,17 +206,9 @@ export const TagSelector = ({
           type="text"
           value={filter}
         />
-        {dropdownOpen && (
+        {dropdownOpen && dropdownItems.length >= 1 && (
           <div className="tag-selector__dropdown">
-            <ul className="tag-selector__dropdown-list">
-              {generateDropdownItems({
-                allowNewTags,
-                filter,
-                selectedTags,
-                tags,
-                updateTags,
-              })}
-            </ul>
+            <ul className="tag-selector__dropdown-list">{dropdownItems}</ul>
           </div>
         )}
       </div>

--- a/ui/src/app/base/components/TagSelector/_index.scss
+++ b/ui/src/app/base/components/TagSelector/_index.scss
@@ -78,9 +78,5 @@
 
   .tag-selector__selected-button {
     padding: 0 $sph-inner--small 0 0 !important;
-
-    .p-icon--close {
-      @include vf-icon-size(0.875rem);
-    }
   }
 }

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import type { Pod } from "app/store/pod/types";
+import type { ComposeFormDefaults } from "../ComposeForm";
 import FormikField from "app/base/components/FormikField";
 import domainSelectors from "app/store/domain/selectors";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
@@ -14,10 +15,7 @@ type Props = {
     cores: number;
     memory: number; // MiB
   };
-  defaults: {
-    cores: number;
-    memory: number; // MiB
-  };
+  defaults: ComposeFormDefaults;
 };
 
 export const ComposeFormFields = ({

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -130,7 +130,7 @@ describe("InterfacesTable", () => {
     expect(wrapper.find("[data-test='undefined-interface']").exists()).toBe(
       true
     );
-    expect(wrapper.find("tbody TableRow").length).toBe(1);
+    expect(wrapper.find("InterfacesTable tbody TableRow").length).toBe(1);
 
     // Click "Define" button - table row should change to a defined interface
     await act(async () => {
@@ -140,21 +140,21 @@ describe("InterfacesTable", () => {
     expect(wrapper.find("[data-test='undefined-interface']").exists()).toBe(
       false
     );
-    expect(wrapper.find("tbody TableRow").length).toBe(1);
+    expect(wrapper.find("InterfacesTable tbody TableRow").length).toBe(1);
 
     // Click "Add interface" - another defined interface should be added
     await act(async () => {
       wrapper.find("[data-test='define-interfaces'] button").simulate("click");
     });
     wrapper.update();
-    expect(wrapper.find("tbody TableRow").length).toBe(2);
+    expect(wrapper.find("InterfacesTable tbody TableRow").length).toBe(2);
 
     // Click delete button - a defined interface should be removed
     await act(async () => {
       wrapper.find("TableActions button").at(0).simulate("click");
     });
     wrapper.update();
-    expect(wrapper.find("tbody TableRow").length).toBe(1);
+    expect(wrapper.find("InterfacesTable tbody TableRow").length).toBe(1);
   });
 
   it("correctly displays fabric, vlan and PXE details of selected subnet", async () => {

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -121,7 +121,7 @@ export const InterfacesTable = (): JSX.Element => {
           </span>
         </Button>
       </div>
-      <Table className="kvm-compose-interfaces-table" responsive>
+      <Table className="kvm-compose-interfaces-table p-form--table" responsive>
         <thead>
           <TableRow>
             <TableHeader>Name</TableHeader>
@@ -200,18 +200,18 @@ export const InterfacesTable = (): JSX.Element => {
                       ]}
                     />
                   </TableCell>
-                  <TableCell aria-label="Fabric">
+                  <TableCell aria-label="Fabric" className="u-align-non-field">
                     {fabric?.name || <em>Auto-assign</em>}
                   </TableCell>
-                  <TableCell aria-label="VLAN">
+                  <TableCell aria-label="VLAN" className="u-align-non-field">
                     {vlan?.name || <em>Auto-assign</em>}
                   </TableCell>
-                  <TableCell aria-label="PXE">
+                  <TableCell aria-label="PXE" className="u-align-non-field">
                     <i className={getPxeIconClass(pod, vlan)}></i>
                   </TableCell>
                   <TableCell
                     aria-label="Actions"
-                    className="u-align--right u-no-padding--right"
+                    className="u-align--right u-no-padding--right u-align-non-field"
                   >
                     <TableActions
                       deleteDisabled={!!composingPods.length}

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
@@ -42,36 +42,5 @@
         width: 4.5rem;
       }
     }
-
-    input,
-    select {
-      margin-bottom: 0;
-      min-width: 0;
-    }
-
-    .p-form-validation__message {
-      margin-top: 0;
-    }
-
-    @media screen and (max-width: $breakpoint-medium) {
-      tr {
-        padding: calc(#{$spv-inner--small} - 1px) $sph-inner;
-        width: 100%;
-      }
-
-      td {
-        align-items: center;
-        padding-left: calc(33% + #{$sph-inner--small});
-
-        .p-form__group {
-          flex: 1;
-        }
-
-        &[aria-label="Actions"] > * {
-          left: calc(-#{$sph-inner--small} - 1px);
-          position: relative;
-        }
-      }
-    }
   }
 }

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -1,0 +1,248 @@
+import { act } from "react-dom/test-utils";
+import { mount } from "enzyme";
+import React from "react";
+import { MemoryRouter, Route } from "react-router-dom";
+import { Provider } from "react-redux";
+import configureStore, { MockStoreEnhanced } from "redux-mock-store";
+
+import type { Pod } from "app/store/pod/types";
+import {
+  domainState as domainStateFactory,
+  fabricState as fabricStateFactory,
+  generalState as generalStateFactory,
+  podDetails as podDetailsFactory,
+  podState as podStateFactory,
+  podStatus as podStatusFactory,
+  podStoragePool as podStoragePoolFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  spaceState as spaceStateFactory,
+  subnetState as subnetStateFactory,
+  vlanState as vlanStateFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import ComposeForm from "../ComposeForm";
+
+const mockStore = configureStore();
+
+const generateWrapper = (store: MockStoreEnhanced, pod: Pod) =>
+  mount(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
+      >
+        <Route
+          exact
+          path="/kvm/:id"
+          component={() => <ComposeForm setSelectedAction={jest.fn()} />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+describe("StorageTable", () => {
+  let initialState = rootStateFactory();
+
+  beforeEach(() => {
+    const pod = podDetailsFactory({ id: 1 });
+
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+      }),
+      fabric: fabricStateFactory({
+        loaded: true,
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+          loaded: true,
+        }),
+      }),
+      pod: podStateFactory({
+        items: [pod],
+        loaded: true,
+        statuses: { [pod.id]: podStatusFactory() },
+      }),
+      resourcepool: resourcePoolStateFactory({
+        loaded: true,
+      }),
+      space: spaceStateFactory({
+        loaded: true,
+      }),
+      subnet: subnetStateFactory({
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        loaded: true,
+      }),
+      zone: zoneStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("disables add disk button with tooltip if KVM type is LXD", () => {
+    const pod = podDetailsFactory({ id: 1, type: "lxd" });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    expect(wrapper.find("[data-test='add-disk'] button").prop("disabled")).toBe(
+      true
+    );
+    expect(wrapper.find("[data-test='add-disk']").prop("message")).toBe(
+      "For the Beta version of LXD VM hosts each VM can only be assigned a single block device."
+    );
+  });
+
+  it("disables add disk button if pod is composing a machine", () => {
+    const pod = podDetailsFactory({ id: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    state.pod.statuses = { [pod.id]: podStatusFactory({ composing: true }) };
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    expect(wrapper.find("[data-test='add-disk'] button").prop("disabled")).toBe(
+      true
+    );
+  });
+
+  it("can add disks and remove all but last disk if KVM type is not LXD", async () => {
+    const pod = podDetailsFactory({ id: 1, type: "virsh" });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // One disk should display by default and cannot be deleted
+    expect(wrapper.find("StorageTable tbody TableRow").length).toBe(1);
+    expect(
+      wrapper.find("[data-test='remove-disk'] button").prop("disabled")
+    ).toBe(true);
+
+    // Click "Add disk" - another disk should be added, and remove button should enable
+    await act(async () => {
+      wrapper.find("[data-test='add-disk'] button").simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("StorageTable tbody TableRow").length).toBe(2);
+    expect(
+      wrapper.find("[data-test='remove-disk'] button").at(0).prop("disabled")
+    ).toBe(false);
+
+    // Click delete button - a disk should be removed
+    await act(async () => {
+      wrapper.find("[data-test='remove-disk'] button").at(0).simulate("click");
+    });
+    wrapper.update();
+    expect(wrapper.find("StorageTable tbody TableRow").length).toBe(1);
+    expect(
+      wrapper.find("[data-test='remove-disk'] button").prop("disabled")
+    ).toBe(true);
+  });
+
+  it("displays a caution message if disk size is less than 8GB", async () => {
+    const pod = podDetailsFactory({ id: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Change the disk size to below 8
+    await act(async () => {
+      wrapper
+        .find("input[name='disks[0].size']")
+        .props()
+        .onChange({
+          target: { name: "disks[0].size", value: "4" },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find("FormikField[name='disks[0].size'] .p-form-validation__message")
+        .text()
+    ).toBe("Caution: Ubuntu typically requires 8GB minimum.");
+  });
+
+  it("displays an error message if disk size is higher than available storage in pool", async () => {
+    const pool = podStoragePoolFactory({ available: 20000000000 }); // 20GB
+    const pod = podDetailsFactory({
+      id: 1,
+      default_storage_pool: pool.id,
+      storage_pools: [pool],
+    });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Change the disk size to above 20GB
+    await act(async () => {
+      wrapper
+        .find("input[name='disks[0].size']")
+        .props()
+        .onChange({
+          target: { name: "disks[0].size", value: "21" },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+    expect(wrapper.find(".p-form-validation__message").text()).toBe(
+      `Error: Only 20GB available in ${pool.name}.`
+    );
+  });
+
+  it(`displays an error message if the sum of disk sizes from a pool is higher
+    than the available storage in that pool`, async () => {
+    const pool = podStoragePoolFactory({ available: 25000000000 }); // 25GB
+    const pod = podDetailsFactory({
+      id: 1,
+      default_storage_pool: pool.id,
+      storage_pools: [pool],
+      type: "virsh",
+    });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Add a disk
+    await act(async () => {
+      wrapper.find("[data-test='add-disk'] button").simulate("click");
+    });
+    wrapper.update();
+
+    // Change the first disk size to 15GB
+    await act(async () => {
+      wrapper
+        .find("input[name='disks[0].size']")
+        .props()
+        .onChange({
+          target: { name: "disks[0].size", value: "15" },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+
+    // Change the second disk size to 11GB
+    await act(async () => {
+      wrapper
+        .find("input[name='disks[1].size']")
+        .props()
+        .onChange({
+          target: { name: "disks[1].size", value: "11" },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+
+    // Each is lower than 25GB, but the sum is higher, so an error should show
+    expect(wrapper.find(".p-form-validation__message").text()).toBe(
+      `Error: Only 25GB available in ${pool.name}.`
+    );
+  });
+});

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -1,0 +1,195 @@
+import {
+  Button,
+  Select,
+  Spinner,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  Tooltip,
+} from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import React from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import type { Disk, ComposeFormValues } from "../ComposeForm";
+import type { RootState } from "app/store/root/types";
+import podSelectors from "app/store/pod/selectors";
+import FormikField from "app/base/components/FormikField";
+import TableActions from "app/base/components/TableActions";
+import TagSelector from "app/base/components/TagSelector";
+
+type Props = { defaultDisk: Disk };
+
+export const StorageTable = ({ defaultDisk }: Props): JSX.Element => {
+  const { id } = useParams();
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  );
+  const composingPods = useSelector(podSelectors.composing);
+  const {
+    handleChange,
+    setFieldTouched,
+    setFieldValue,
+    values,
+  } = useFormikContext<ComposeFormValues>();
+  const { bootDisk, disks } = values;
+
+  const addDisk = () => {
+    const ids = disks.map((disk) => disk.id);
+    let id = 0;
+    while (ids.includes(id)) {
+      id++;
+    }
+    setFieldTouched(`disks[${disks.length}].size`, true, true);
+    setFieldValue("disks", [...disks, { ...defaultDisk, id }], true);
+  };
+
+  const removeDisk = (id: number) => {
+    const filteredDisks = disks.filter((disk) => disk.id !== id);
+    setFieldValue("disks", filteredDisks);
+
+    // If boot disk is removed, set boot to first disk in the remaining array.
+    if (!filteredDisks.some((disk) => disk.id === bootDisk)) {
+      setFieldValue("bootDisk", filteredDisks[0]?.id);
+    }
+  };
+
+  if (!!pod) {
+    // For the Beta version of LXD VM hosts each VM can only be assigned a single block device.
+    const cannotHaveMultipleDisks = pod.type === "lxd";
+    const disabled = cannotHaveMultipleDisks || !!composingPods.length;
+
+    return (
+      <>
+        <div className="u-flex--between">
+          <h4>Storage configuration</h4>
+          <Button
+            className="u-hide--medium u-hide--large"
+            disabled={disabled}
+            hasIcon
+            onClick={addDisk}
+            type="button"
+          >
+            <i className="p-icon--plus"></i>
+            <span>Add disk</span>
+          </Button>
+        </div>
+        <Table className="kvm-compose-storage-table p-form--table" responsive>
+          <thead>
+            <TableRow>
+              <TableHeader>Size (GB)</TableHeader>
+              <TableHeader>Location</TableHeader>
+              <TableHeader>Tags</TableHeader>
+              <TableHeader>Boot</TableHeader>
+              <TableHeader className="u-align--right">Actions</TableHeader>
+            </TableRow>
+          </thead>
+          <tbody>
+            {disks.map((disk, i) => {
+              return (
+                <TableRow key={disk.id}>
+                  <TableCell aria-label="Size">
+                    <FormikField
+                      caution={
+                        disk.size < 8
+                          ? "Ubuntu typically requires 8GB minimum."
+                          : undefined
+                      }
+                      min="1"
+                      name={`disks[${i}].size`}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        handleChange(e);
+                        setFieldTouched(`disks[${i}].size`, true, true);
+                        setFieldValue(`disks[${i}].size`, e.target.value);
+                      }}
+                      type="number"
+                    />
+                  </TableCell>
+                  <TableCell aria-label="Location">
+                    <FormikField
+                      component={Select}
+                      name={`disks[${i}].location`}
+                      options={[
+                        { label: "Select location", value: "", disabled: true },
+                        ...pod.storage_pools.map((pool) => ({
+                          key: pool.id,
+                          label: pool.name,
+                          value: pool.name,
+                        })),
+                      ]}
+                    />
+                  </TableCell>
+                  <TableCell aria-label="Tags">
+                    <FormikField
+                      allowNewTags
+                      component={TagSelector}
+                      name={`disks[${i}].tags`}
+                      onTagsUpdate={(selectedTags: { name: string }[]) => {
+                        setFieldValue(
+                          `disks[${i}].tags`,
+                          selectedTags.map((tag) => tag.name)
+                        );
+                      }}
+                      placeholder="Add tags"
+                    />
+                  </TableCell>
+                  <TableCell aria-label="Boot" className="u-align-non-field">
+                    <FormikField
+                      checked={bootDisk === disk.id}
+                      label=" "
+                      name="bootDisk"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        handleChange(e);
+                        setFieldValue("bootDisk", disk.id);
+                      }}
+                      type="radio"
+                    />
+                  </TableCell>
+                  <TableCell
+                    aria-label="Actions"
+                    className="u-align--right u-no-padding--right u-align-non-field"
+                  >
+                    <TableActions
+                      data-test="remove-disk"
+                      deleteDisabled={
+                        disks.length === 1 || !!composingPods.length
+                      }
+                      deleteTooltip={
+                        disks.length === 1 && "At least one disk is required."
+                      }
+                      onDelete={() => removeDisk(disk.id)}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </tbody>
+        </Table>
+        <Tooltip
+          data-test="add-disk"
+          message={
+            cannotHaveMultipleDisks &&
+            "For the Beta version of LXD VM hosts each VM can only be assigned a single block device."
+          }
+          position="right"
+        >
+          <Button
+            className="u-hide--small"
+            disabled={disabled}
+            hasIcon
+            onClick={addDisk}
+            type="button"
+          >
+            <i className="p-icon--plus"></i>
+            <span>Add disk</span>
+          </Button>
+        </Tooltip>
+      </>
+    );
+  }
+  return <Spinner text="Loading..." />;
+};
+
+export default StorageTable;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/_index.scss
@@ -1,0 +1,57 @@
+@mixin KVMComposeStorageTable {
+  .kvm-compose-storage-table {
+    td,
+    th {
+      // Capacity
+      &:nth-child(1) {
+        width: 12rem;
+      }
+
+      // Location
+      &:nth-child(2) {
+        width: 50%;
+      }
+
+      // Tags
+      &:nth-child(3) {
+        overflow: visible;
+        width: 50%;
+      }
+
+      // Boot
+      &:nth-child(4) {
+        width: 3.5rem;
+      }
+
+      // Actions
+      &:nth-child(5) {
+        width: 4.5rem;
+      }
+    }
+
+    input[type="radio"] + label {
+      display: inline;
+      padding-top: 0;
+
+      &::before {
+        left: 0.5rem;
+        top: 0.125rem;
+      }
+
+      &::after {
+        left: 0.825rem;
+        top: 0.425rem;
+      }
+
+      @media screen and (max-width: $breakpoint-medium) {
+        &::before {
+          left: 0;
+        }
+
+        &::after {
+          left: 0.325rem;
+        }
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/index.ts
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StorageTable";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/KVMSummaryStorage.tsx
@@ -4,9 +4,9 @@ import { useSelector } from "react-redux";
 
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import podSelectors from "app/store/pod/selectors";
 import { chunk, formatBytes } from "app/utils";
 import Meter from "app/base/components/Meter";
-import podSelectors from "app/store/pod/selectors";
 
 type Props = { id: Pod["id"] };
 

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -36,4 +36,52 @@
       transform: none;
     }
   }
+
+  // Custom styling for form fields inside a table.
+  .p-form--table {
+    input,
+    select {
+      margin-bottom: 0;
+      min-width: 0;
+    }
+
+    td {
+      padding-bottom: $spv-inner--small;
+      padding-top: $spv-inner--small;
+    }
+
+    .p-form-validation__message {
+      margin-top: 0;
+    }
+
+    .tag-selector__dropdown {
+      top: initial;
+    }
+
+    // Align non-form fields with form fields
+    .u-align-non-field {
+      padding-top: $sp-unit * 1.75;
+    }
+
+    @media screen and (max-width: $breakpoint-medium) {
+      tr {
+        padding: $spv-inner--small $sph-inner;
+        width: 100%;
+      }
+
+      td {
+        align-items: center;
+        padding-left: calc(33% + #{$sph-inner--small});
+
+        .p-form__group {
+          flex: 1;
+        }
+
+        &[aria-label="Actions"] > * {
+          left: calc(-#{$sph-inner--small} - 1px);
+          position: relative;
+        }
+      }
+    }
+  }
 }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -18,21 +18,18 @@
 
 // 03-02-2020 Caleb: Cannot give label a className when using Input component.
 // https://github.com/canonical-web-and-design/react-components/issues/67
-input[type="checkbox"],
-input[type="radio"] {
-  &.has-inline-label + label {
-    display: inline;
-    padding-top: 0;
+input[type="checkbox"].has-inline-label + label {
+  display: inline;
+  padding-top: 0;
 
-    &::before {
-      left: 0rem;
-      top: 0.125rem;
-    }
+  &::before {
+    left: 0rem;
+    top: 0.125rem;
+  }
 
-    &::after {
-      left: 0.1875rem;
-      top: 0.375rem;
-    }
+  &::after {
+    left: 0.1875rem;
+    top: 0.375rem;
   }
 }
 

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -74,11 +74,13 @@
 @import "~app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover";
 @import "~app/kvm/views/KVMList/KVMListTable";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable";
+@import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable";
 @include CPUPopover;
 @include RAMPopover;
 @include StoragePopover;
 @include KVMListTable;
 @include KVMComposeInterfacesTable;
+@include KVMComposeStorageTable;
 
 // machines
 @import "~app/machines/views/MachineList";


### PR DESCRIPTION
## Done

- Added Storage configuration section to KVM compose form.
- Updated TagSelector so it can be properly styled without a label
- Rich select to be added in https://github.com/canonical-web-and-design/maas-squad/issues/2061

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and select a LXD KVM
- Open the compose dropdown and check that there is a "Storage configuration" section.
- Check that hovering over the "Add disk" button shows a tooltip explaining that you can only have one disk for LXD KVMs.
- Change "Size" to below 8 and check that a warning shows.
- Change "Size" to above what's available in the storage pool and check that en error shows.
- Enter a valid size and click "Compose machine" and check that a new machine shows up in the machine list with the correct storage.
- Go to the KVM details page of a virsh KVM and check that you can add multiple disks with different storage pools.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2043

## Screenshot
![0 0 0 0_8400_MAAS_r_kvm_190](https://user-images.githubusercontent.com/25733845/88752777-17a5c800-d19e-11ea-8661-ffbc5aeb3513.png)

