### PR TITLE
Add maas.version tag to Sentry reports.

### DIFF
--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -253,7 +253,7 @@ function configureMaas(
   $locationProvider,
   $compileProvider,
   tagsInputConfigProvider,
-  $urlRouterProvider,
+  $urlRouterProvider
 ) {
   // Disable debugInfo unless in a Jest context.
   // Re-enable debugInfo in development by running
@@ -336,6 +336,7 @@ Sentry.init({
 /* @ngInject */
 const configureSentry = ($window) => {
   Sentry.setExtra("maasVersion", $window.CONFIG.version);
+  Sentry.setTag("maas.version", $window.CONFIG.version);
 };
 
 const maasModule = "MAAS";

--- a/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.js
+++ b/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.js
@@ -21,6 +21,7 @@ class ErrorBoundary extends React.Component {
     if (analyticsEnabled) {
       Sentry.withScope((scope) => {
         scope.setExtras({ ...errorInfo, maasVersion });
+        scope.setTag("maas.version", maasVersion);
         const eventId = Sentry.captureException(error);
         this.setState({ eventId });
       });


### PR DESCRIPTION
## Done

- Add `maas.version` tag to Sentry reports as per https://docs.sentry.io/platforms/javascript/

## QA
n/a

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

n/a

## Fixes

n/a

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
