### PR TITLE
Build SubnetSelect component for KVM compose form.

### DIFF
--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -68,6 +68,7 @@ const ContextualMenu = ({
               closePortal(evt);
             }
           }}
+          type="button"
         >
           {toggleLabelFirst ? labelNode : null}
           {hasToggleIcon ? (

--- a/ui/src/app/base/components/TableMenu/_index.scss
+++ b/ui/src/app/base/components/TableMenu/_index.scss
@@ -2,15 +2,6 @@
   $icon-size: map-get($icon-sizes, default);
   $icon-space: $icon-size + $sph-inner--small + $sph-inner;
 
-  .p-table-menu .p-contextual-menu__non-interactive {
-    border-bottom: 1px solid $color-mid-light;
-    color: $color-mid-dark;
-    font-size: 0.75rem;
-    font-weight: 400;
-    padding: $spv-inner--x-small $sph-inner;
-    text-transform: uppercase;
-  }
-
   .p-table-menu--hasIcon .p-contextual-menu__non-interactive {
     padding-left: $icon-space;
   }

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route } from "react-router-dom";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -26,7 +27,7 @@ import ComposeForm from "../ComposeForm";
 const mockStore = configureStore();
 
 describe("ComposeFormFields", () => {
-  let initialState = rootStateFactory();
+  let initialState: RootState;
 
   beforeEach(() => {
     initialState = rootStateFactory({

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -1,0 +1,173 @@
+import { act } from "react-dom/test-utils";
+import { mount } from "enzyme";
+import React from "react";
+import { MemoryRouter, Route } from "react-router-dom";
+import { Provider } from "react-redux";
+import configureStore, { MockStoreEnhanced } from "redux-mock-store";
+
+import type { MenuLink } from "./SubnetSelect";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import {
+  domainState as domainStateFactory,
+  fabricState as fabricStateFactory,
+  generalState as generalStateFactory,
+  podDetails as podDetailsFactory,
+  podState as podStateFactory,
+  podStatus as podStatusFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  space as spaceFactory,
+  spaceState as spaceStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlanState as vlanStateFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import ComposeForm from "../../ComposeForm";
+
+const mockStore = configureStore();
+
+const generateWrapper = (store: MockStoreEnhanced, pod: Pod) =>
+  mount(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
+      >
+        <Route
+          exact
+          path="/kvm/:id"
+          component={() => <ComposeForm setSelectedAction={jest.fn()} />}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+
+describe("SubnetSelect", () => {
+  let initialState: RootState;
+
+  beforeEach(() => {
+    const pod = podDetailsFactory({ id: 1 });
+
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+      }),
+      fabric: fabricStateFactory({
+        loaded: true,
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+          loaded: true,
+        }),
+      }),
+      pod: podStateFactory({
+        items: [pod],
+        loaded: true,
+        statuses: { [pod.id]: podStatusFactory() },
+      }),
+      resourcepool: resourcePoolStateFactory({
+        loaded: true,
+      }),
+      space: spaceStateFactory({
+        loaded: true,
+      }),
+      subnet: subnetStateFactory({
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        loaded: true,
+      }),
+      zone: zoneStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("groups subnets by space if a space is not yet selected", async () => {
+    const spaces = [
+      spaceFactory({ name: "Outer" }),
+      spaceFactory({ name: "Safe" }),
+    ];
+    const subnets = [
+      subnetFactory({ space: spaces[0].id, vlan: 1 }),
+      subnetFactory({ space: spaces[0].id, vlan: 1 }),
+      subnetFactory({ space: spaces[1].id, vlan: 1 }),
+    ];
+    const pod = podDetailsFactory({ attached_vlans: [1], id: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    state.space.items = spaces;
+    state.subnet.items = subnets;
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Click "Define" button
+    await act(async () => {
+      wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    });
+    wrapper.update();
+
+    const links = wrapper
+      .find("SubnetSelect ContextualMenu")
+      .prop("links") as MenuLink[];
+
+    // "Any" subnet + "Space: Outer" + outer subnets + "Space: Safe" + safe subnets
+    expect(links.length).toBe(6);
+    expect(links[1]).toBe("Space: Outer");
+    expect(links[4]).toBe("Space: Safe");
+  });
+
+  it("filters subnets by selected space", async () => {
+    const space = spaceFactory();
+    const [subnetInSpace, subnetNotInSpace] = [
+      subnetFactory({ space: space.id, vlan: 1 }),
+      subnetFactory({ space: null, vlan: 1 }),
+    ];
+    const pod = podDetailsFactory({ attached_vlans: [1], id: 1 });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    state.space.items = [space];
+    state.subnet.items = [subnetInSpace, subnetNotInSpace];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+    let links = [];
+    let filteredLinks = [];
+
+    // Click "Define" button
+    await act(async () => {
+      wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    });
+    wrapper.update();
+
+    links = wrapper
+      .find("SubnetSelect ContextualMenu")
+      .prop("links") as MenuLink[];
+    filteredLinks = links.filter((link) => typeof link !== "string");
+    expect(filteredLinks.length).toBe(3);
+
+    // Choose the space in state from the dropdown
+    // Only the subnet in the selected space + "Any" should be available
+    await act(async () => {
+      wrapper
+        .find("FormikField[name='interfaces[0].space']")
+        .props()
+        .onChange({
+          target: {
+            name: "interfaces[0].space",
+            value: `${space.id}`,
+          },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+
+    links = wrapper
+      .find("SubnetSelect ContextualMenu")
+      .prop("links") as MenuLink[];
+    filteredLinks = links.filter((link) => typeof link !== "string");
+    expect(filteredLinks.length).toBe(2);
+  });
+});

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import type { InterfaceField } from "../../ComposeForm";
+import type { Fabric } from "app/store/fabric/types";
+import type { PodDetails } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import type { Space } from "app/store/space/types";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
+import fabricSelectors from "app/store/fabric/selectors";
+import podSelectors from "app/store/pod/selectors";
+import spaceSelectors from "app/store/space/selectors";
+import subnetSelectors from "app/store/subnet/selectors";
+import vlanSelectors from "app/store/vlan/selectors";
+import { groupAsMap } from "app/utils";
+import { getPxeIconClass } from "../InterfacesTable";
+import ContextualMenu from "app/base/components/ContextualMenu";
+
+type Props = {
+  iface: InterfaceField;
+  selectSubnet: (subnetID?: number) => void;
+};
+
+export type MenuLink =
+  | string
+  | {
+      children: JSX.Element;
+      className: string;
+      onClick: Props["selectSubnet"];
+    };
+
+/**
+ * Filter subnets to those that are in a given space.
+ * @param {Subnet[]} subnets - The subnets to filter.
+ * @param {Space} space - The space by which to filter subnets.
+ * @returns {Subnet[]} Subnets filtered by space.
+ */
+const filterSubnetsBySpace = (subnets: Subnet[], space: Space): Subnet[] => {
+  if (!!space) {
+    return subnets.filter((subnet) => subnet.space === space.id);
+  }
+  return subnets;
+};
+
+/**
+ * Generate links for use in the select dropdown.
+ * @param {Subnet[]} subnets - Subnets in state.
+ * @param {VLAN[]} vlans - VLANs in state.
+ * @param {Fabric[]} fabrics - Fabrics in state.
+ * @param {PodDetails} pod - Pod used to determine PXE state.
+ * @param {Function} selectSubnet - Function to run on link click.
+ * @returns {MenuLink[]} Subnet links for select dropdown.
+ */
+const generateLinks = (
+  subnets: Subnet[],
+  vlans: VLAN[],
+  fabrics: Fabric[],
+  pod: PodDetails,
+  selectSubnet: Props["selectSubnet"]
+) =>
+  subnets.map((subnet) => {
+    const vlan = vlans.find((vlan) => vlan.id === subnet?.vlan);
+    const fabric = fabrics.find((fabric) => fabric.id === vlan?.fabric);
+
+    return {
+      children: (
+        <>
+          <div>{subnet?.name || "Any"}</div>
+          <div>{fabric?.name || <em>Auto-assign</em>}</div>
+          <div>{vlan?.name || <em>Auto-assign</em>}</div>
+          <div>
+            <i className={getPxeIconClass(pod, vlan)}></i>
+          </div>
+        </>
+      ),
+      className: "kvm-subnet-select__subnet",
+      onClick: () => selectSubnet(subnet.id),
+    };
+  });
+
+export const SubnetSelect = ({ iface, selectSubnet }: Props): JSX.Element => {
+  const { id } = useParams();
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  ) as PodDetails;
+  const podSubnets = useSelector((state: RootState) =>
+    subnetSelectors.getByPod(state, pod)
+  );
+  const fabrics = useSelector(fabricSelectors.all);
+  const spaces = useSelector(spaceSelectors.all);
+  const vlans = useSelector(vlanSelectors.all);
+
+  const selectedSpace = spaces.find(
+    (space) => space.id === parseInt(iface.space)
+  );
+  const selectedSubnet = podSubnets.find(
+    (subnet) => subnet.id === parseInt(iface.subnet)
+  );
+  let links: MenuLink[] = [
+    {
+      children: (
+        <>
+          <div>Any</div>
+          <div>
+            <em>Auto-assign</em>
+          </div>
+          <div>
+            <em>Auto-assign</em>
+          </div>
+          <div>
+            <i className="p-icon--power-unknown"></i>
+          </div>
+        </>
+      ),
+      className: "kvm-subnet-select__subnet",
+      onClick: () => selectSubnet(),
+    },
+  ];
+
+  if (selectedSpace) {
+    // If space is selected, just show subnets in that space without the space name
+    const filteredSubnets = filterSubnetsBySpace(podSubnets, selectedSpace);
+    links = links.concat(
+      generateLinks(filteredSubnets, vlans, fabrics, pod, selectSubnet)
+    );
+  } else {
+    // If space is not selected, show all subnets grouped by space.
+    const spaceGroups = Array.from(
+      groupAsMap(podSubnets, (subnet: Subnet) => subnet.space)
+    )
+      .map(([spaceID, subnets]) => {
+        const space = spaces.find((space) => space.id === spaceID);
+        return {
+          name: space ? `Space: ${space.name}` : "No space",
+          subnets,
+        };
+      })
+      .sort(
+        (a, b) => (a.name === "No space" && 1) || (b.name === "No space" && -1)
+      );
+    spaceGroups.forEach((space) => {
+      links = links.concat([
+        space.name,
+        ...generateLinks(space.subnets, vlans, fabrics, pod, selectSubnet),
+      ]);
+    });
+  }
+
+  return (
+    <ContextualMenu
+      className="kvm-subnet-select"
+      constrainPanelWidth
+      dropdownClassName="kvm-subnet-select__dropdown"
+      hasToggleIcon
+      links={links}
+      position="left"
+      toggleClassName="kvm-subnet-select__toggle"
+      toggleLabel={selectedSubnet?.name || "Any"}
+    />
+  );
+};
+
+export default SubnetSelect;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/_index.scss
@@ -1,0 +1,93 @@
+@import "../index.scss";
+
+$ratio-total: $subnet-col-ratio + $fabric-col-ratio + $vlan-col-ratio;
+$ratio-multiplier: $ratio-total / $subnet-col-ratio;
+$padding-multiplier: 100% + #{2 * $sph-inner--small};
+$pxe-col-compensation: $pxe-col-width - $sph-inner--small;
+
+@mixin KVMSubnetSelect {
+  .kvm-subnet-select {
+    display: block;
+    width: 100%;
+
+    .kvm-subnet-select__dropdown {
+      max-width: none;
+      min-width: 0;
+      width: calc(#{$ratio-multiplier} * (#{$padding-multiplier}) + #{$pxe-col-compensation});
+
+      @media only screen and (max-width: $breakpoint-medium) {
+        width: auto;
+      }
+    }
+
+    .kvm-subnet-select__toggle {
+      align-items: center;
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 0;
+      padding-left: $sph-inner--small;
+      width: 100%;
+
+      > :nth-child(1) {
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
+
+      > :nth-child(2) {
+        flex-shrink: 0;
+      }
+    }
+
+    .kvm-subnet-select__subnet {
+      align-items: center;
+      display: flex;
+      width: 100%;
+
+      & > * {
+        overflow: hidden;
+        overflow-wrap: anywhere;
+        white-space: break-spaces;
+
+        // Subnet
+        &:nth-child(1) {
+          width: calc(#{percentage($subnet-col-ratio / $ratio-total)} - #{2 * $sph-inner--small});
+        }
+
+        // Fabric
+        &:nth-child(2) {
+          width: percentage($fabric-col-ratio / $ratio-total);
+        }
+
+        // VLAN
+        &:nth-child(3) {
+          width: percentage($vlan-col-ratio / $ratio-total);
+        }
+
+        // PXE
+        &:nth-child(4) {
+          width: #{$pxe-col-width - #{3 * $sph-inner--small}};
+        }
+
+        &:not(:last-child) {
+          padding-right: $sph-inner--small;
+        }
+
+        @media only screen and (max-width: $breakpoint-medium) {
+          &:nth-child(1) {
+            width: 100%;
+          }
+
+          &:nth-child(2),
+          &:nth-child(3),
+          &:nth-child(4) {
+            display: none;
+          }
+        }
+      }
+    }
+
+    .p-contextual-menu__non-interactive {
+      padding-top: $spv-inner--small;
+    }
+  }
+}

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/index.ts
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetSelect";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
@@ -1,3 +1,10 @@
+// Values used to calculate width of subnet select dropdown.
+// When changing these, ensure column widths add to 100% + any rem widths.
+$subnet-col-ratio: 0.2;
+$fabric-col-ratio: 0.15;
+$vlan-col-ratio: 0.15;
+$pxe-col-width: 2.5rem;
+
 @mixin KVMComposeInterfacesTable {
   .kvm-compose-interfaces-table {
     td,
@@ -19,22 +26,22 @@
 
       // Subnet
       &:nth-child(4) {
-        width: 20%;
+        width: percentage($subnet-col-ratio / 1);
       }
 
       // Fabric
       &:nth-child(5) {
-        width: 15%;
+        width: percentage($fabric-col-ratio / 1);
       }
 
       // VLAN
       &:nth-child(6) {
-        width: 15%;
+        width: percentage($vlan-col-ratio / 1);
       }
 
       // PXE
       &:nth-child(7) {
-        width: 2.5rem;
+        width: $pxe-col-width;
       }
 
       // Actions

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -6,6 +6,7 @@ import { Provider } from "react-redux";
 import configureStore, { MockStoreEnhanced } from "redux-mock-store";
 
 import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -43,7 +44,7 @@ const generateWrapper = (store: MockStoreEnhanced, pod: Pod) =>
   );
 
 describe("StorageTable", () => {
-  let initialState = rootStateFactory();
+  let initialState: RootState;
 
   beforeEach(() => {
     const pod = podDetailsFactory({ id: 1 });

--- a/ui/src/app/machines/views/MachineList/MachineListControls/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/FilterAccordion/__snapshots__/FilterAccordion.test.js.snap
@@ -143,6 +143,7 @@ exports[`FilterAccordion renders 1`] = `
         className="p-contextual-menu__toggle filter-accordion__toggle"
         hasIcon={true}
         onClick={[Function]}
+        type="button"
       >
         <button
           aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
@@ -150,6 +151,7 @@ exports[`FilterAccordion renders 1`] = `
           aria-haspopup="true"
           className="p-button--neutral has-icon p-contextual-menu__toggle filter-accordion__toggle"
           onClick={[Function]}
+          type="button"
         >
           <span>
             Filters

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -88,6 +88,7 @@ exports[`OwnerColumn renders 1`] = `
                       aria-expanded="false"
                       aria-haspopup="true"
                       class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                      type="button"
                     >
                       <i
                         class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -136,6 +137,7 @@ exports[`OwnerColumn renders 1`] = `
                         aria-expanded="false"
                         aria-haspopup="true"
                         class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                        type="button"
                       >
                         <i
                           class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -159,6 +161,7 @@ exports[`OwnerColumn renders 1`] = `
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                   hasIcon={true}
                   onClick={[Function]}
+                  type="button"
                 >
                   <button
                     aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
@@ -166,6 +169,7 @@ exports[`OwnerColumn renders 1`] = `
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                     onClick={[Function]}
+                    type="button"
                   >
                     <i
                       className="p-icon--contextual-menu p-contextual-menu__indicator"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -117,6 +117,7 @@ exports[`PoolColumn renders 1`] = `
                       aria-expanded="false"
                       aria-haspopup="true"
                       class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                      type="button"
                     >
                       <i
                         class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -171,6 +172,7 @@ exports[`PoolColumn renders 1`] = `
                         aria-expanded="false"
                         aria-haspopup="true"
                         class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                        type="button"
                       >
                         <i
                           class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -194,6 +196,7 @@ exports[`PoolColumn renders 1`] = `
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                   hasIcon={true}
                   onClick={[Function]}
+                  type="button"
                 >
                   <button
                     aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
@@ -201,6 +204,7 @@ exports[`PoolColumn renders 1`] = `
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                     onClick={[Function]}
+                    type="button"
                   >
                     <i
                       className="p-icon--contextual-menu p-contextual-menu__indicator"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -117,6 +117,7 @@ exports[`PowerColumn renders 1`] = `
                       aria-expanded="false"
                       aria-haspopup="true"
                       class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                      type="button"
                     >
                       <i
                         class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -171,6 +172,7 @@ exports[`PowerColumn renders 1`] = `
                         aria-expanded="false"
                         aria-haspopup="true"
                         class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                        type="button"
                       >
                         <i
                           class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -194,6 +196,7 @@ exports[`PowerColumn renders 1`] = `
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                   hasIcon={true}
                   onClick={[Function]}
+                  type="button"
                 >
                   <button
                     aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
@@ -201,6 +204,7 @@ exports[`PowerColumn renders 1`] = `
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                     onClick={[Function]}
+                    type="button"
                   >
                     <i
                       className="p-icon--contextual-menu p-contextual-menu__indicator"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -324,6 +324,7 @@ exports[`StatusColumn renders 1`] = `
                       aria-expanded="false"
                       aria-haspopup="true"
                       class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                      type="button"
                     >
                       <i
                         class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -381,6 +382,7 @@ exports[`StatusColumn renders 1`] = `
                         aria-expanded="false"
                         aria-haspopup="true"
                         class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                        type="button"
                       >
                         <i
                           class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -404,6 +406,7 @@ exports[`StatusColumn renders 1`] = `
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                   hasIcon={true}
                   onClick={[Function]}
+                  type="button"
                 >
                   <button
                     aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
@@ -411,6 +414,7 @@ exports[`StatusColumn renders 1`] = `
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                     onClick={[Function]}
+                    type="button"
                   >
                     <i
                       className="p-icon--contextual-menu p-contextual-menu__indicator"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -102,6 +102,7 @@ exports[`ZoneColumn renders 1`] = `
                       aria-expanded="false"
                       aria-haspopup="true"
                       class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                      type="button"
                     >
                       <i
                         class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -155,6 +156,7 @@ exports[`ZoneColumn renders 1`] = `
                         aria-expanded="false"
                         aria-haspopup="true"
                         class="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                        type="button"
                       >
                         <i
                           class="p-icon--contextual-menu p-contextual-menu__indicator"
@@ -178,6 +180,7 @@ exports[`ZoneColumn renders 1`] = `
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                   hasIcon={true}
                   onClick={[Function]}
+                  type="button"
                 >
                   <button
                     aria-controls="Uakgb_J5m9g-0JDMbcJqLJ"
@@ -185,6 +188,7 @@ exports[`ZoneColumn renders 1`] = `
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
                     onClick={[Function]}
+                    type="button"
                   >
                     <i
                       className="p-icon--contextual-menu p-contextual-menu__indicator"

--- a/ui/src/scss/_patterns_contextual-menu.scss
+++ b/ui/src/scss/_patterns_contextual-menu.scss
@@ -1,0 +1,11 @@
+@mixin maas-contextual-menu {
+  // Used to add titles/group headers to the Vanilla contextual menu pattern.
+  .p-contextual-menu__non-interactive {
+    border-bottom: 1px solid $color-mid-light;
+    color: $color-mid-dark;
+    font-size: 0.75rem;
+    font-weight: 400;
+    padding: $spv-inner--x-small $sph-inner;
+    text-transform: uppercase;
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -22,6 +22,7 @@
 // Import and include MAAS global styles
 @import "./patterns_buttons";
 @import "./patterns_cards";
+@import "./patterns_contextual-menu";
 @import "./patterns_double-row";
 @import "./patterns_footer";
 @import "./patterns_forms";
@@ -36,6 +37,7 @@
 @import "./utilities";
 @include maas-buttons;
 @include maas-cards;
+@include maas-contextual-menu;
 @include maas-double-row;
 @include maas-footer;
 @include maas-forms;
@@ -74,12 +76,14 @@
 @import "~app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover";
 @import "~app/kvm/views/KVMList/KVMListTable";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable";
+@import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable";
 @include CPUPopover;
 @include RAMPopover;
 @include StoragePopover;
 @include KVMListTable;
 @include KVMComposeInterfacesTable;
+@include KVMSubnetSelect;
 @include KVMComposeStorageTable;
 
 // machines


### PR DESCRIPTION
## Done

- Built SubnetSelect component similar to the angular version

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM compose form
- Define an interface
- Click the Subnet dropdown and check that it shows information about the fabric, VLAN and PXE boot status associated with that subnet

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2061

## Screenshots
### No space selected
![0 0 0 0_8400_MAAS_r_kvm_190 (3)](https://user-images.githubusercontent.com/25733845/89272333-55fd2480-d681-11ea-8dd5-0d4f3870cf6b.png)



### Space selected
![0 0 0 0_8400_MAAS_r_kvm_190 (4)](https://user-images.githubusercontent.com/25733845/89272339-58f81500-d681-11ea-824b-487bca8a7803.png)


