### PR TITLE
✨ (legacy): Add cloud-init support to legacy.

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -899,6 +899,12 @@ function NodeDetailsController(
         extra.distro_series = "bionic";
       }
       extra.install_kvm = installKVM;
+
+      // cloud-config
+      const userData = $scope.deployOptions.userData;
+      if (userData) {
+        extra.user_data = userData;
+      }
     } else if ($scope.action.option.name === "commission") {
       extra.enable_ssh = $scope.commissionOptions.enableSSH;
       extra.skip_bmc_config = $scope.commissionOptions.skipBMCConfig;

--- a/legacy/src/app/directives/nodedetails/deploy_options.js
+++ b/legacy/src/app/directives/nodedetails/deploy_options.js
@@ -1,0 +1,8 @@
+import deployOptionsTmpl from "../../partials/nodedetails/deploy-options.html";
+
+const deployOptions = () => ({
+  restrict: "E",
+  template: deployOptionsTmpl,
+});
+
+export default deployOptions;

--- a/legacy/src/app/directives/nodedetails/user_data_upload.js
+++ b/legacy/src/app/directives/nodedetails/user_data_upload.js
@@ -1,0 +1,18 @@
+const userDataUpload = () => ({
+  link: ($scope, element) => {
+    element.on("change", () => {
+      const files = element[0].files;
+      const reader = new FileReader();
+
+      reader.onload = function (e) {
+        const text = e.target.result;
+        $scope.$parent.deployOptions.userData = text;
+        $scope.$parent.$apply();
+      };
+
+      reader.readAsText(files[0]);
+    });
+  },
+});
+
+export default userDataUpload;

--- a/legacy/src/app/directives/os_select.js
+++ b/legacy/src/app/directives/os_select.js
@@ -5,74 +5,7 @@
  */
 import angular from "angular";
 
-/* @ngInject */
-export function cacheOsSelect($templateCache) {
-  // Inject the os-select.html into the template cache.
-  $templateCache.put(
-    "directive/templates/os-select.html",
-    [
-      '<label class="p-form__label">Choose your image</label>',
-      '<div class="p-form__control"> ',
-      '<select name="os" ',
-      'data-ng-model="ngModel.osystem" ',
-      'data-ng-change="selectedOSChanged()" ',
-      'data-ng-disabled="maasOsSelect.osystems.length <= 1" ',
-      'data-ng-options="',
-      "os[0] as os[1] disable when ",
-      "installKVMSelectedAndNotUbuntu(os) ",
-      'for os in maasOsSelect.osystems">',
-      "</select>",
-      '<select name="release" ',
-      'data-ng-model="ngModel.release" ',
-      'data-ng-change="selectedReleaseChanged()" ',
-      'data-ng-disabled="maasOsSelect.releases.length <= 1" ',
-      'data-ng-options="',
-      "release[0] as release[1] disable when osOutdated(release,",
-      "deployOptions)",
-      ' for release in releases">',
-      "</select>",
-      '<select name="hwe_kernel" data-ng-model="ngModel.hwe_kernel" ',
-      'data-ng-show="hwe_kernels.length"',
-      'data-ng-options="',
-      "hwe_kernel[0] as hwe_kernel[1] for hwe_kernel ",
-      'in hwe_kernels">',
-      '<option value="">Default kernel</option>',
-      "</select>",
-      "</div>",
-    ].join("")
-  );
-}
-
-const osSelectTmpl = [
-  '<label class="p-form__label">Choose your image</label>',
-  '<div class="p-form__control"> ',
-  '<select name="os" ',
-  'data-ng-model="ngModel.osystem" ',
-  'data-ng-change="selectedOSChanged()" ',
-  'data-ng-disabled="maasOsSelect.osystems.length <= 1" ',
-  'data-ng-options="',
-  "os[0] as os[1] disable when ",
-  "installKVMSelectedAndNotUbuntu(os) ",
-  'for os in maasOsSelect.osystems">',
-  "</select>",
-  '<select name="release" ',
-  'data-ng-model="ngModel.release" ',
-  'data-ng-change="selectedReleaseChanged()" ',
-  'data-ng-disabled="maasOsSelect.releases.length <= 1" ',
-  'data-ng-options="',
-  "release[0] as release[1] disable when osOutdated(release,",
-  "deployOptions)",
-  ' for release in releases">',
-  "</select>",
-  '<select name="hwe_kernel" data-ng-model="ngModel.hwe_kernel" ',
-  'data-ng-show="hwe_kernels.length"',
-  'data-ng-options="',
-  "hwe_kernel[0] as hwe_kernel[1] for hwe_kernel ",
-  'in hwe_kernels">',
-  '<option value="">Default kernel</option>',
-  "</select>",
-  "</div>",
-].join("");
+import osSelectTmpl from "../partials/directives/os-select.html";
 
 /* @ngInject */
 export function maasOsSelect(KVMDeployOSBlacklist) {

--- a/legacy/src/app/directives/tests/test_os_select.js
+++ b/legacy/src/app/directives/tests/test_os_select.js
@@ -113,7 +113,7 @@ describe("maasOsSelect", function () {
     var directive = compileDirective("osinfo", "selected");
     var select = directive.find('select[name="release"]');
     expect(select.attr("data-ng-options")).toBe(
-      "release[0] as release[1] disable when osOutdated(release," +
+      "release[0] as release[1] disable when osOutdated(release, " +
         "deployOptions) for release in releases"
     );
   });

--- a/legacy/src/app/entry.js
+++ b/legacy/src/app/entry.js
@@ -154,6 +154,8 @@ import ZonesListController from "./controllers/zones_list";
 // directives
 // prettier-ignore
 import loading from "./directives/loading";
+import deployOptions from "./directives/nodedetails/deploy_options";
+import userDataUpload from "./directives/nodedetails/user_data_upload";
 import storageDisksPartitions from "./directives/nodedetails/storage_disks_partitions";
 import storageFilesystems from "./directives/nodedetails/storage_filesystems";
 import storageDatastores from "./directives/nodedetails/storage_datastores";
@@ -465,6 +467,8 @@ MAAS.config(configureMaas)
   .controller("ZonesListController", ZonesListController)
   // directives
   .directive("ngLoading", loading)
+  .directive("deployOptions", deployOptions)
+  .directive("userDataUpload", userDataUpload)
   .directive("storageDisksPartitions", storageDisksPartitions)
   .directive("storageFilesystems", storageFilesystems)
   .directive("storageDatastores", storageDatastores)

--- a/legacy/src/app/partials/directives/os-select.html
+++ b/legacy/src/app/partials/directives/os-select.html
@@ -1,27 +1,36 @@
-<label class="p-form__label">Choose your image</label>
-<div class="p-form__control">
-  <select
-    name="os"
-    data-ng-model="ngModel.osystem"
-    data-ng-change="selectedOSChanged()"
-    data-ng-disabled="maasOsSelect.osystems.length <= 1"
-    data-ng-options="os[0] as os[1] disable when installKVMSelectedAndNotUbuntu(os) for os in maasOsSelect.osystems"
-  >
-  </select>
-  <select
-    name="release"
-    data-ng-model="ngModel.release"
-    data-ng-change="selectedReleaseChanged()"
-    data-ng-disabled="maasOsSelect.releases.length <= 1"
-    data-ng-options="release[0] as release[1] disable when osOutdated(release, deployOptions) for release in releases"
-  >
-  </select>
-  <select
-    name="hwe_kernel"
-    data-ng-model="ngModel.hwe_kernel"
-    data-ng-show="hwe_kernels.length"
-    data-ng-options="hwe_kernel[0] as hwe_kernel[1] for hwe_kernel in hwe_kernels"
-  >
-    <option value="">Default kernel</option>
-  </select>
+<div class="row">
+  <div class="col-3">
+    <label class="p-form__label">OS</label>
+      <select
+        name="os"
+        data-ng-model="ngModel.osystem"
+        data-ng-change="selectedOSChanged()"
+        data-ng-disabled="maasOsSelect.osystems.length <= 1"
+        data-ng-options="os[0] as os[1] disable when installKVMSelectedAndNotUbuntu(os) for os in maasOsSelect.osystems"
+      >
+      </select>
+    </div>
+    <div class="col-3">
+    <label class="p-form__label">Release</label>
+      <select
+        name="release"
+        data-ng-model="ngModel.release"
+        data-ng-change="selectedReleaseChanged()"
+        data-ng-disabled="maasOsSelect.releases.length <= 1"
+        data-ng-options="release[0] as release[1] disable when osOutdated(release, deployOptions) for release in releases"
+      >
+      </select>
+    </div>
+    <div class="col-3">
+    <label class="p-form__label">Kernel</label>
+      <select
+        name="hwe_kernel"
+        data-ng-model="ngModel.hwe_kernel"
+        data-ng-show="hwe_kernels.length"
+        data-ng-options="hwe_kernel[0] as hwe_kernel[1] for hwe_kernel in hwe_kernels"
+      >
+        <option value="">Default kernel</option>
+      </select>
+    </div>
+  </div>
 </div>

--- a/legacy/src/app/partials/directives/os-select.html
+++ b/legacy/src/app/partials/directives/os-select.html
@@ -29,7 +29,7 @@
         data-ng-show="hwe_kernels.length"
         data-ng-options="hwe_kernel[0] as hwe_kernel[1] for hwe_kernel in hwe_kernels"
       >
-        <option value="">Default kernel</option>
+        <option value="">No minimum kernel</option>
       </select>
     </div>
   </div>

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -99,23 +99,7 @@
                                             </div>
                                         </div>
                                         <div data-ng-if="isSuperUser()" class="p-strip is-shallow u-no-padding--top">
-                                            <div class="p-form__group">
-                                                <label class="p-form__label u-no-padding--top">Additional installs</label>
-                                                <div class="p-form__control" style="width: 70%">
-                                                    <input id="installKVM" type="checkbox" data-ng-model="deployOptions.installKVM" ng-disabled="!nodesManager.canBeKvmHost(osSelection)">
-                                                    <label for="installKVM" class="u-float--left" style="width: auto; margin-right: 1rem;">
-                                                        Register as MAAS KVM host
-                                                    </label>
-                                                    <p class="u-sv-1 u-no-max-width" ng-if="!nodesManager.canBeKvmHost(osSelection)">
-                                                        <i class="p-icon--warning"></i>&nbsp;Ubuntu 18.04 is required to create a KVM host.
-                                                    </p>
-                                                    <p class="u-no-max-width u-no-margin--bottom">
-                                                        <a class="p-link--external" href="https://maas.io/docs/kvm-introduction" target="_blank">
-                                                            About MAAS KVM hosts
-                                                        </a>
-                                                    </p>
-                                                </div>
-                                            </div>
+<tab>                                       <deploy-options></deploy-options>
                                         </div>
                                     </div>
                                 </div>

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -1,3722 +1,6432 @@
 <div data-ng-if="!loaded">
-    <header class="p-strip--light is-shallow u-no-padding--bottom page-header">
-        <div class="row">
-            <h1 class="page-header__title">Loading...</h1>
-        </div>
-    </header>
+  <header class="p-strip--light is-shallow u-no-padding--bottom page-header">
+    <div class="row">
+      <h1 class="page-header__title">Loading...</h1>
+    </div>
+  </header>
 </div>
 <div data-ng-if="loaded">
-    <header class="p-strip--light is-shallow page-header u-no-padding--bottom">
-        <div class="row">
-            <div class="col-medium-4 col-8">
-                <h1 class="page-header__title">
-                    <span contenteditable="true"
-                        data-ng-class="{ editable: canEdit(), 'is-error': editHeaderInvalid(), editmode: header.editing }"
-                        data-ng-show="canEdit()"
-                        data-ng-model="header.hostname.value"
-                        data-ng-disabled="!canEdit()"
-                        data-ng-keydown="$event.keyCode == 13 && $event.preventDefault()"
-                        data-ng-keyup="$event.keyCode == 13 && saveEditHeader()"
-                        data-maas-editing="editHeader()"></span>
-                    <span ng-click="editHeaderDomain()" data-ng-show="!canEdit()">{$ header.hostname.value $}</span>
-                    <span class="page-header__title-dot u-no-margin--top ng-hide" data-ng-show="header.editing || header.editing_domain">.</span>
-                    <select class="page-header__title-domain ng-hide"
-                        data-ng-show="header.editing || header.editing_domain"
-                        data-ng-model="header.domain.selected"
-                        data-ng-options="domain as domain.name for domain in header.domain.options">
-                    </select>
-                </h1>
-                <button class="p-button--base u-no-margin--top ng-hide"
-                    data-ng-show="header.editing || header.editing_domain"
-                    data-ng-click="cancelEditHeader()">Cancel</button>
-                <button class="p-button--positive ng-hide"
-                    data-ng-show="header.editing || header.editing_domain"
-                    data-ng-disabled="editHeaderInvalid()"
-                    data-ng-click="saveEditHeader(); sendAnalyticsEvent('Machine details', 'Edited name', 'Machine summary tab')">Save</button>
+  <header class="p-strip--light is-shallow page-header u-no-padding--bottom">
+    <div class="row">
+      <div class="col-medium-4 col-8">
+        <h1 class="page-header__title">
+          <span
+            contenteditable="true"
+            data-ng-class="{ editable: canEdit(), 'is-error': editHeaderInvalid(), editmode: header.editing }"
+            data-ng-show="canEdit()"
+            data-ng-model="header.hostname.value"
+            data-ng-disabled="!canEdit()"
+            data-ng-keydown="$event.keyCode == 13 && $event.preventDefault()"
+            data-ng-keyup="$event.keyCode == 13 && saveEditHeader()"
+            data-maas-editing="editHeader()"
+          ></span>
+          <span ng-click="editHeaderDomain()" data-ng-show="!canEdit()"
+            >{$ header.hostname.value $}</span
+          >
+          <span
+            class="page-header__title-dot u-no-margin--top ng-hide"
+            data-ng-show="header.editing || header.editing_domain"
+            >.</span
+          >
+          <select
+            class="page-header__title-domain ng-hide"
+            data-ng-show="header.editing || header.editing_domain"
+            data-ng-model="header.domain.selected"
+            data-ng-options="domain as domain.name for domain in header.domain.options"
+          >
+          </select>
+        </h1>
+        <button
+          class="p-button--base u-no-margin--top ng-hide"
+          data-ng-show="header.editing || header.editing_domain"
+          data-ng-click="cancelEditHeader()"
+        >
+          Cancel
+        </button>
+        <button
+          class="p-button--positive ng-hide"
+          data-ng-show="header.editing || header.editing_domain"
+          data-ng-disabled="editHeaderInvalid()"
+          data-ng-click="saveEditHeader(); sendAnalyticsEvent('Machine details', 'Edited name', 'Machine summary tab')"
+        >
+          Save
+        </button>
 
-                <ul class="p-inline-list page-header__status u-no-margin--top" data-ng-if="!isController && !isDevice && !header.editing && !header.editing_domain">
-                    <li class="p-inline-list__item">
-                        <span data-ng-if="node.locked" class="p-tooltip--top-left" aria-describedby="header-locked-state">
-                            <i class="p-icon--locked">Locked: </i>
-                            <span class="p-tooltip__message" role="tooltip" id="header-locked-state">This machine is locked. You have to unlock it to perform any actions.</span>
-                        </span>
-                        {$ node.status $}
-                    </li>
-                    <li class="p-inline-list__item u-no-wrap">
-                        <i class="p-icon--power-{$ getPowerStateClass() $}"></i> {$ getPowerStateText() $}
-                        <button class="p-button--base u-no-margin--bottom" data-ng-show="canCheckPowerState()"
-                            data-ng-click="checkPowerState(); sendAnalyticsEvent('Machine details', 'Check power state', 'Machine summary tab')">check
-                            now</button>
-                    </li>
-                </ul>
-            </div>
+        <ul
+          class="p-inline-list page-header__status u-no-margin--top"
+          data-ng-if="!isController && !isDevice && !header.editing && !header.editing_domain"
+        >
+          <li class="p-inline-list__item">
+            <span
+              data-ng-if="node.locked"
+              class="p-tooltip--top-left"
+              aria-describedby="header-locked-state"
+            >
+              <i class="p-icon--locked">Locked: </i>
+              <span
+                class="p-tooltip__message"
+                role="tooltip"
+                id="header-locked-state"
+                >This machine is locked. You have to unlock it to perform any
+                actions.</span
+              >
+            </span>
+            {$ node.status $}
+          </li>
+          <li class="p-inline-list__item u-no-wrap">
+            <i class="p-icon--power-{$ getPowerStateClass() $}"></i> {$
+            getPowerStateText() $}
+            <button
+              class="p-button--base u-no-margin--bottom"
+              data-ng-show="canCheckPowerState()"
+              data-ng-click="checkPowerState(); sendAnalyticsEvent('Machine details', 'Check power state', 'Machine summary tab')"
+            >
+              check now
+            </button>
+          </li>
+        </ul>
+      </div>
 
-            <div class="col-medium-2 col-4">
-                <div class="u-align--right" data-ng-show="!header.editing && action.availableOptions.length">
-                    <div data-maas-cta="action.availableOptions"
-                        data-ng-click="updateAvailableActions('machines')"
-                        data-ng-model="action.option"
-                        data-ng-change="actionOptionChanged()">
-                    </div>
-                </div>
-            </div>
+      <div class="col-medium-2 col-4">
+        <div
+          class="u-align--right"
+          data-ng-show="!header.editing && action.availableOptions.length"
+        >
+          <div
+            data-maas-cta="action.availableOptions"
+            data-ng-click="updateAvailableActions('machines')"
+            data-ng-model="action.option"
+            data-ng-change="actionOptionChanged()"
+          ></div>
         </div>
-        <div class="page-header__dropdown" data-ng-class="{ 'u-hide': !action.option }">
-            <hr />
-            <div class="row ng-hide" data-ng-if="!isDevice && !node.dhcp_on">
-                <div class="page-header__section col-12">
-                    <p class="page-header__message"><i class="p-icon--warning">Warning:</i> MAAS is not providing DHCP.</p>
-                </div>
+      </div>
+    </div>
+    <div
+      class="page-header__dropdown"
+      data-ng-class="{ 'u-hide': !action.option }"
+    >
+      <hr />
+      <div class="row ng-hide" data-ng-if="!isDevice && !node.dhcp_on">
+        <div class="page-header__section col-12">
+          <p class="page-header__message">
+            <i class="p-icon--warning">Warning:</i> MAAS is not providing DHCP.
+          </p>
+        </div>
+      </div>
+      <div
+        class="row ng-hide u-no-margin--top"
+        data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name)"
+      >
+        <div class="page-header__section">
+          <form class="p-form">
+            <div class="row">
+              <div
+                class="col-5 ng-hide"
+                data-ng-show="action.option.name === 'commission' || action.option.name === 'test'"
+              >
+                <input
+                  id="enableSSH"
+                  type="checkbox"
+                  data-ng-model="commissionOptions.enableSSH"
+                />
+                <label for="enableSSH"
+                  >Allow SSH access and prevent machine from powering off</label
+                >
+                <input
+                  id="skipBMCConfig"
+                  type="checkbox"
+                  data-ng-model="commissionOptions.skipBMCConfig"
+                />
+                <label for="skipBMCConfig"
+                  >Skip configuring supported BMC controllers with a MAAS
+                  generated username and password.</label
+                >
+                <input
+                  id="skipNetworking"
+                  type="checkbox"
+                  data-ng-model="commissionOptions.skipNetworking"
+                />
+                <label for="skipNetworking">Retain network configuration</label>
+              </div>
+              <div
+                class="col-5 ng-hide"
+                data-ng-show="action.option.name === 'commission' || action.option.name === 'test'"
+              >
+                <input
+                  id="skipStorage"
+                  type="checkbox"
+                  data-ng-model="commissionOptions.skipStorage"
+                />
+                <label for="skipStorage">Retain storage configuration</label>
+                <input
+                  id="updateFirmware"
+                  type="checkbox"
+                  data-ng-model="commissionOptions.updateFirmware"
+                />
+                <label for="updateFirmware">Update firmware</label>
+                <input
+                  id="configureHBA"
+                  type="checkbox"
+                  data-ng-model="commissionOptions.configureHBA"
+                />
+                <label for="configureHBA">Configure HBA</label>
+              </div>
             </div>
-            <div class="row ng-hide u-no-margin--top" data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name)">
-                <div class="page-header__section">
-                    <form class="p-form">
-                        <div class="row">
-                            <div class="col-5 ng-hide" data-ng-show="action.option.name === 'commission' || action.option.name === 'test'">
-                                <input id="enableSSH" type="checkbox" data-ng-model="commissionOptions.enableSSH">
-                                <label for="enableSSH">Allow SSH access and prevent machine from powering off</label>
-                                <input id="skipBMCConfig" type="checkbox" data-ng-model="commissionOptions.skipBMCConfig">
-                                <label for="skipBMCConfig">Skip configuring supported BMC controllers with a MAAS generated username and password.</label>
-                                <input id="skipNetworking" type="checkbox" data-ng-model="commissionOptions.skipNetworking">
-                                <label for="skipNetworking">Retain network configuration</label>
-                            </div>
-                            <div class="col-5 ng-hide" data-ng-show="action.option.name === 'commission' || action.option.name === 'test'">
-                                <input id="skipStorage" type="checkbox" data-ng-model="commissionOptions.skipStorage">
-                                <label for="skipStorage">Retain storage configuration</label>
-                                <input id="updateFirmware" type="checkbox" data-ng-model="commissionOptions.updateFirmware">
-                                <label for="updateFirmware">Update firmware</label>
-                                <input id="configureHBA" type="checkbox"data-ng-model="commissionOptions.configureHBA">
-                                <label for="configureHBA">Configure HBA</label>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-12" data-ng-show="action.option.name === 'deploy' || action.option.name === 'release'">
-                                <div class="p-form--stacked" >
-                                    <div class="ng-hide" data-ng-show="action.option.name === 'deploy'">
-                                        <div class="p-strip is-shallow u-no-padding--top">
-                                            <div class="p-form__group">
-                                                <div data-maas-os-select="osinfo" data-ng-model="osSelection" style="width: 100%"></div>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="isSuperUser()" class="p-strip is-shallow u-no-padding--top">
-<tab>                                       <deploy-options></deploy-options>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-12 u-no-margin--left" data-ng-show="action.option.name === 'deploy' || action.option.name === 'release'">
-                                <div data-ng-if="action.option.name === 'release'" class="u-no-margin--top">
-                                    <maas-release-options local-options="release.options"></maas-release-options>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-12 u-align--right">
-                                <div class="page-header__controls" data-ng-if="action.option.name !== 'commission' && action.option.name !== 'test' && !action.showing_confirmation">
-                                    <div class="u-space-between">
-                                        <div class="u-align--right">
-                                            <div data-ng-if="action.option.name !== 'commission' && action.option.name !== 'test'">
-                                                <button class="p-button--base" data-ng-click="actionCancel()">Cancel</button>
-                                                <button class="p-button--neutral u-no-margin--top" data-ng-class="action.option.name === 'delete' ? 'p-button--negative' : 'p-button--positive'" data-ng-click="actionGo('nodes')" data-ng-hide="hasActionsFailed('nodes')">
-                                                    <span data-ng-if="action.option.name === 'acquire'">Acquire {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'deploy'">Deploy {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'release'">Release {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'set-zone'">Set zone for {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'on'">Power on {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'off'">Power off {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'abort'">Abort action on {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'rescue-mode'">Rescue {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'exit-rescue-mode'">Exit rescue mode</span>
-                                                    <span data-ng-if="action.option.name === 'mark-broken'">Mark {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'mark-fixed'">Mark {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'override-failed-testing'">Override failed testing</span>
-                                                    <span data-ng-if="action.option.name === 'lock'">Lock {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'unlock'">Unlock {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'delete'">Delete {$ type_name $}</span>
-                                                    <span data-ng-if="action.option.name === 'import-images'">Import images</span>
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <div class="row ng-hide" data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || action.option.name !== 'commission'" data-ng-if="hasCustomCommissioningScripts()">
-                <div class="page-header__section">
-                    <form class="p-form row">
-                        <div class="col-8">
-                            <div class="p-form__group">
-                                <label for="commissioning-scripts">Additional commissioning scripts</label>
-                                <span id="commissioning-scripts" data-maas-script-select="script" data-script-type="0" data-ng-model="commissioningSelection" class="tags--inline"></span>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <div class="row u-no-margin--top ng-hide" data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || (action.option.name !== 'commission' && action.option.name !== 'test')">
-                <hr />
-                <div class="page-header__section">
-                    <form class="p-form row">
-                        <div class="col-8">
-                            <div class="p-form__group hide-create-tag-label">
-                                <label for="testing-scripts">Tests</label>
-                                <span id="testing-scripts" data-maas-script-select="script" data-script-type="2" data-ng-model="testSelection" class="tags--inline" check-test-parameter-values="checkTestParameterValues" set-default-values="setDefaultValues"></span>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <div class="u-no-margin--top row ng-hide"  data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name)" data-ng-if="action.option.name === 'commission' || action.option.name === 'test' && !action.showing_confirmation">
-                <hr />
-                <div class="page-header__section col-12">
-                    <form class="p-form">
-                        <div class="u-align--right">
-                            <button class="p-button--base" data-ng-click="actionCancel()">Cancel</button>
-                            <button class="u-no-margin--top" data-ng-class="action.option.name === 'delete' ? 'p-button--negative' : 'p-button--positive'" data-ng-click="actionGo('nodes')" data-ng-hide="hasActionsFailed('nodes')" data-ng-disabled="disableTestButton">
-                                <span data-ng-if="action.option.name === 'commission'">Commission {$ type_name $}</span>
-                                <span data-ng-if="action.option.name === 'test'">Test {$ type_name $}</span>
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <div class="row ng-hide" data-ng-show="action.showing_confirmation">
-                <div class="col-12">
-                    <p>
-                        <i class="p-icon--warning"></i><b>Confirm:</b> {$ action.confirmation_message $}
-                    </p>
-                    <div data-ng-repeat="confirmation_detail in action.confirmation_details">
-                        <span>{$ confirmation_detail $}</span>
+            <div class="row">
+              <div
+                class="col-12"
+                data-ng-show="action.option.name === 'deploy' || action.option.name === 'release'"
+              >
+                <div class="p-form--stacked">
+                  <div
+                    class="ng-hide"
+                    data-ng-show="action.option.name === 'deploy'"
+                  >
+                    <div class="p-strip is-shallow u-no-padding--top">
+                      <div class="p-form__group">
+                        <div
+                          data-maas-os-select="osinfo"
+                          data-ng-model="osSelection"
+                          style="width: 100%;"
+                        ></div>
+                      </div>
                     </div>
-            <div class="u-equal-height">
+                    <div
+                      data-ng-if="isSuperUser()"
+                      class="p-strip is-shallow u-no-padding--top"
+                    >
+                      <deploy-options></deploy-options>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div
+                class="col-12 u-no-margin--left"
+                data-ng-show="action.option.name === 'deploy' || action.option.name === 'release'"
+              >
+                <div
+                  data-ng-if="action.option.name === 'release'"
+                  class="u-no-margin--top"
+                >
+                  <maas-release-options
+                    local-options="release.options"
+                  ></maas-release-options>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-12 u-align--right">
+                <div
+                  class="page-header__controls"
+                  data-ng-if="action.option.name !== 'commission' && action.option.name !== 'test' && !action.showing_confirmation"
+                >
+                  <div class="u-space-between">
+                    <div class="u-align--right">
+                      <div
+                        data-ng-if="action.option.name !== 'commission' && action.option.name !== 'test'"
+                      >
+                        <button
+                          class="p-button--base"
+                          data-ng-click="actionCancel()"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          class="p-button--neutral u-no-margin--top"
+                          data-ng-class="action.option.name === 'delete' ? 'p-button--negative' : 'p-button--positive'"
+                          data-ng-click="actionGo('nodes')"
+                          data-ng-hide="hasActionsFailed('nodes')"
+                        >
+                          <span data-ng-if="action.option.name === 'acquire'"
+                            >Acquire {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'deploy'"
+                            >Deploy {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'release'"
+                            >Release {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'set-zone'"
+                            >Set zone for {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'on'"
+                            >Power on {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'off'"
+                            >Power off {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'abort'"
+                            >Abort action on {$ type_name $}</span
+                          >
+                          <span
+                            data-ng-if="action.option.name === 'rescue-mode'"
+                            >Rescue {$ type_name $}</span
+                          >
+                          <span
+                            data-ng-if="action.option.name === 'exit-rescue-mode'"
+                            >Exit rescue mode</span
+                          >
+                          <span
+                            data-ng-if="action.option.name === 'mark-broken'"
+                            >Mark {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'mark-fixed'"
+                            >Mark {$ type_name $}</span
+                          >
+                          <span
+                            data-ng-if="action.option.name === 'override-failed-testing'"
+                            >Override failed testing</span
+                          >
+                          <span data-ng-if="action.option.name === 'lock'"
+                            >Lock {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'unlock'"
+                            >Unlock {$ type_name $}</span
+                          >
+                          <span data-ng-if="action.option.name === 'delete'"
+                            >Delete {$ type_name $}</span
+                          >
+                          <span
+                            data-ng-if="action.option.name === 'import-images'"
+                            >Import images</span
+                          >
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div
+        class="row ng-hide"
+        data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || action.option.name !== 'commission'"
+        data-ng-if="hasCustomCommissioningScripts()"
+      >
+        <div class="page-header__section">
+          <form class="p-form row">
+            <div class="col-8">
+              <div class="p-form__group">
+                <label for="commissioning-scripts"
+                  >Additional commissioning scripts</label
+                >
+                <span
+                  id="commissioning-scripts"
+                  data-maas-script-select="script"
+                  data-script-type="0"
+                  data-ng-model="commissioningSelection"
+                  class="tags--inline"
+                ></span>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div
+        class="row u-no-margin--top ng-hide"
+        data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || (action.option.name !== 'commission' && action.option.name !== 'test')"
+      >
+        <hr />
+        <div class="page-header__section">
+          <form class="p-form row">
+            <div class="col-8">
+              <div class="p-form__group hide-create-tag-label">
+                <label for="testing-scripts">Tests</label>
+                <span
+                  id="testing-scripts"
+                  data-maas-script-select="script"
+                  data-script-type="2"
+                  data-ng-model="testSelection"
+                  class="tags--inline"
+                  check-test-parameter-values="checkTestParameterValues"
+                  set-default-values="setDefaultValues"
+                ></span>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div
+        class="u-no-margin--top row ng-hide"
+        data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name)"
+        data-ng-if="action.option.name === 'commission' || action.option.name === 'test' && !action.showing_confirmation"
+      >
+        <hr />
+        <div class="page-header__section col-12">
+          <form class="p-form">
+            <div class="u-align--right">
+              <button class="p-button--base" data-ng-click="actionCancel()">
+                Cancel
+              </button>
+              <button
+                class="u-no-margin--top"
+                data-ng-class="action.option.name === 'delete' ? 'p-button--negative' : 'p-button--positive'"
+                data-ng-click="actionGo('nodes')"
+                data-ng-hide="hasActionsFailed('nodes')"
+                data-ng-disabled="disableTestButton"
+              >
+                <span data-ng-if="action.option.name === 'commission'"
+                  >Commission {$ type_name $}</span
+                >
+                <span data-ng-if="action.option.name === 'test'"
+                  >Test {$ type_name $}</span
+                >
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="row ng-hide" data-ng-show="action.showing_confirmation">
+        <div class="col-12">
+          <p>
+            <i class="p-icon--warning"></i><b>Confirm:</b> {$
+            action.confirmation_message $}
+          </p>
+          <div
+            data-ng-repeat="confirmation_detail in action.confirmation_details"
+          >
+            <span>{$ confirmation_detail $}</span>
+          </div>
+          <div class="u-equal-height">
             <div class="col-9 u-vertically-center">
-                <p class="u-remove-max-width">
-                Are you sure you want to {$ action.actionOption.name $} this {$ type_name $}?
-                </p>
+              <p class="u-remove-max-width">
+                Are you sure you want to {$ action.actionOption.name $} this {$
+                type_name $}?
+              </p>
             </div>
             <div class="col-3">
-                <div class="u-align--right">
-                <button class="p-button--base" data-ng-click="actionCancel()">No</button>
-                <button class="p-button--negative" data-ng-click="actionGo()">Yes</button>
-                </div>
+              <div class="u-align--right">
+                <button class="p-button--base" data-ng-click="actionCancel()">
+                  No
+                </button>
+                <button class="p-button--negative" data-ng-click="actionGo()">
+                  Yes
+                </button>
+              </div>
             </div>
-                    </div>
-                </div>
-            </div>
-            <div class="row u-equal-height ng-hide" data-ng-show="isActionError()">
-                <div class="col-9 u-vertically-center">
-                    <p class="u-remove-max-width">
-                        <i class="p-icon--error">Error:</i> {$ getHardwareTestErrorText(action.error) $}
-                    </p>
-                </div>
-                <div class="col-3">
-                    <div class="u-align--right">
-                        <button class="p-button--base" data-ng-click="actionCancel()">Cancel</button>
-                        <button class="p-button--neutral" data-ng-click="actionGo()">Retry</button>
-                    </div>
-                </div>
-            </div>
-            <div class="row u-equal-height ng-hide" data-ng-show="isDeployError()">
-                <div class="col-9 u-vertically-center">
-                    <p class="u-remove-max-width">
-                        <i class="p-icon--error">Error:</i> Node cannot be {$ action.option.sentence $}, because the required boot images have not been imported. To import boot images, visit the <a href="images/">images page</a>.
-                    </p>
-                </div>
-                <div class="col-3">
-                    <div class="u-align--right">
-                        <button class="p-button--base" data-ng-click="actionCancel()">Cancel</button>
-                    </div>
-                </div>
-            </div>
-            <div class="row u-equal-height ng-hide" data-ng-show="hasActionPowerError(action.option.name)">
-                <div class="col-9 u-vertically-center">
-                    <p class="u-remove-max-width">
-                        <i class="p-icon--error">Error:</i> Node cannot be {$ action.option.sentence $}, because power control software for the node is missing from its rack controller. To proceed, install the {$ getPowerErrors() $} on the rack controller.
-                    </p>
-                </div>
-                <div class="col-3">
-                    <div class="u-align--right">
-                        <button class="p-button--base" data-ng-click="actionCancel()">Cancel</button>
-                    </div>
-                </div>
-            </div>
-            <div class="row u-equal-height ng-hide" data-ng-show="!isDeployError() && isSSHKeyError()">
-                <div class="col-9 u-vertically-center">
-                    <p class="u-remove-max-width">
-                        <i class="p-icon--error">Error:</i> Node cannot be {$ action.option.sentence $}, because an SSH key has not been added to your account. To add an SSH key, visit <a href="account/prefs/">your account page</a>.
-                    </p>
-                </div>
-                <div class="col-3">
-                    <div class="u-align--right">
-                        <button class="p-button--base" data-ng-click="actionCancel()">Cancel</button>
-                    </div>
-                </div>
-            </div>
+          </div>
         </div>
+      </div>
+      <div class="row u-equal-height ng-hide" data-ng-show="isActionError()">
+        <div class="col-9 u-vertically-center">
+          <p class="u-remove-max-width">
+            <i class="p-icon--error">Error:</i> {$
+            getHardwareTestErrorText(action.error) $}
+          </p>
+        </div>
+        <div class="col-3">
+          <div class="u-align--right">
+            <button class="p-button--base" data-ng-click="actionCancel()">
+              Cancel
+            </button>
+            <button class="p-button--neutral" data-ng-click="actionGo()">
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="row u-equal-height ng-hide" data-ng-show="isDeployError()">
+        <div class="col-9 u-vertically-center">
+          <p class="u-remove-max-width">
+            <i class="p-icon--error">Error:</i> Node cannot be {$
+            action.option.sentence $}, because the required boot images have not
+            been imported. To import boot images, visit the
+            <a href="images/">images page</a>.
+          </p>
+        </div>
+        <div class="col-3">
+          <div class="u-align--right">
+            <button class="p-button--base" data-ng-click="actionCancel()">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="row u-equal-height ng-hide"
+        data-ng-show="hasActionPowerError(action.option.name)"
+      >
+        <div class="col-9 u-vertically-center">
+          <p class="u-remove-max-width">
+            <i class="p-icon--error">Error:</i> Node cannot be {$
+            action.option.sentence $}, because power control software for the
+            node is missing from its rack controller. To proceed, install the {$
+            getPowerErrors() $} on the rack controller.
+          </p>
+        </div>
+        <div class="col-3">
+          <div class="u-align--right">
+            <button class="p-button--base" data-ng-click="actionCancel()">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="row u-equal-height ng-hide"
+        data-ng-show="!isDeployError() && isSSHKeyError()"
+      >
+        <div class="col-9 u-vertically-center">
+          <p class="u-remove-max-width">
+            <i class="p-icon--error">Error:</i> Node cannot be {$
+            action.option.sentence $}, because an SSH key has not been added to
+            your account. To add an SSH key, visit
+            <a href="account/prefs/">your account page</a>.
+          </p>
+        </div>
+        <div class="col-3">
+          <div class="u-align--right">
+            <button class="p-button--base" data-ng-click="actionCancel()">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
 
-        <nav class="p-tabs">
-            <div class="row">
-                <hr class="u-no-margin--bottom" />
-                <ul class="p-tabs__list" role="tablist" data-ng-class="{ 'u-hide': action.option }">
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="!isController && !isDevice"
-                            data-ng-class="{ 'is-active': section.area === 'summary'}"
-                            data-ng-click="openSection('summary')">Machine summary</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="isController"
-                            data-ng-class="{ 'is-active': section.area === 'summary'}"
-                            data-ng-click="openSection('summary')">Controller summary</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="isDevice"
-                            data-ng-class="{ 'is-active': section.area === 'summary'}"
-                            data-ng-click="openSection('summary')">Device summary</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="!isController && devices.length"
-                            data-ng-class="{ 'is-active': section.area === 'instances'}"
-                            data-ng-click="openSection('instances')">Instances</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="isController"
-                            data-ng-class="{ 'is-active': section.area === 'vlans'}"
-                            data-ng-click="openSection('vlans')">VLANs</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link"
-                            data-ng-class="{ 'is-active': section.area === 'network'}"
-                            data-ng-click="openSection('network')">Network</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="!isDevice && !(isController && node.status === 'New')"
-                            data-ng-class="{ 'is-active': section.area === 'storage'}"
-                            data-ng-click="openSection('storage')">Storage</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="node.commissioning_status.pending > 0 || node.commissioning_status.running > 0 || node.commissioning_status.passed > 0 || node.commissioning_status.failed > 0"
-                            data-ng-class="{ 'is-active': section.area === 'commissioning'}"
-                            data-ng-click="openSection('commissioning')"><span data-maas-script-status="script-status" data-script-status="node.commissioning_status.status"></span> Commissioning</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="node.testing_status.pending > 0 || node.testing_status.running > 0 || node.testing_status.passed > 0 || node.testing_status.failed > 0"
-                            data-ng-class="{ 'is-active': section.area === 'testing'}"
-                            data-ng-click="openSection('testing')"><span data-maas-script-status="script-status" data-script-status="node.testing_status.status"></span> Tests</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="node.has_logs"
-                            data-ng-class="{ 'is-active': section.area === 'logs'}"
-                            data-ng-click="openSection('logs')"><span data-maas-script-status="script-status" data-script-status="node.installation_status" data-ng-if="node.installation_status !== -1"></span> Logs</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="!isDevice"
-                            data-ng-class="{ 'is-active': section.area === 'events'}"
-                            data-ng-click="openSection('events')">Events</a>
-                    </li>
-                    <li class="p-tabs__item" role="presentation">
-                        <a role="tab" class="p-tabs__link" data-ng-if="canEdit()"
-                            data-ng-class="{ 'is-active': section.area === 'configuration'}"
-                            data-ng-click="openSection('configuration')">Configuration</a>
-                    </li>
-                </ul>
-            </div>
-        </nav>
-    </header>
+    <nav class="p-tabs">
+      <div class="row">
+        <hr class="u-no-margin--bottom" />
+        <ul
+          class="p-tabs__list"
+          role="tablist"
+          data-ng-class="{ 'u-hide': action.option }"
+        >
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="!isController && !isDevice"
+              data-ng-class="{ 'is-active': section.area === 'summary'}"
+              data-ng-click="openSection('summary')"
+              >Machine summary</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="isController"
+              data-ng-class="{ 'is-active': section.area === 'summary'}"
+              data-ng-click="openSection('summary')"
+              >Controller summary</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="isDevice"
+              data-ng-class="{ 'is-active': section.area === 'summary'}"
+              data-ng-click="openSection('summary')"
+              >Device summary</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="!isController && devices.length"
+              data-ng-class="{ 'is-active': section.area === 'instances'}"
+              data-ng-click="openSection('instances')"
+              >Instances</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="isController"
+              data-ng-class="{ 'is-active': section.area === 'vlans'}"
+              data-ng-click="openSection('vlans')"
+              >VLANs</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-class="{ 'is-active': section.area === 'network'}"
+              data-ng-click="openSection('network')"
+              >Network</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="!isDevice && !(isController && node.status === 'New')"
+              data-ng-class="{ 'is-active': section.area === 'storage'}"
+              data-ng-click="openSection('storage')"
+              >Storage</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="node.commissioning_status.pending > 0 || node.commissioning_status.running > 0 || node.commissioning_status.passed > 0 || node.commissioning_status.failed > 0"
+              data-ng-class="{ 'is-active': section.area === 'commissioning'}"
+              data-ng-click="openSection('commissioning')"
+              ><span
+                data-maas-script-status="script-status"
+                data-script-status="node.commissioning_status.status"
+              ></span>
+              Commissioning</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="node.testing_status.pending > 0 || node.testing_status.running > 0 || node.testing_status.passed > 0 || node.testing_status.failed > 0"
+              data-ng-class="{ 'is-active': section.area === 'testing'}"
+              data-ng-click="openSection('testing')"
+              ><span
+                data-maas-script-status="script-status"
+                data-script-status="node.testing_status.status"
+              ></span>
+              Tests</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="node.has_logs"
+              data-ng-class="{ 'is-active': section.area === 'logs'}"
+              data-ng-click="openSection('logs')"
+              ><span
+                data-maas-script-status="script-status"
+                data-script-status="node.installation_status"
+                data-ng-if="node.installation_status !== -1"
+              ></span>
+              Logs</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="!isDevice"
+              data-ng-class="{ 'is-active': section.area === 'events'}"
+              data-ng-click="openSection('events')"
+              >Events</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="canEdit()"
+              data-ng-class="{ 'is-active': section.area === 'configuration'}"
+              data-ng-click="openSection('configuration')"
+              >Configuration</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </header>
 
-    <section class="p-strip is-shallow u-no-padding--bottom" data-ng-if="showHighAvailabilityNotification()">
+  <section
+    class="p-strip is-shallow u-no-padding--bottom"
+    data-ng-if="showHighAvailabilityNotification()"
+  >
+    <div class="row">
+      <div class="p-notification--information u-no-margin--bottom">
+        <p class="p-notification__response">
+          You can now enable <strong>high availability DHCP</strong> on {$
+          node.vlan.fabric_name $} {$ getNotificationVLANText() $}.
+          <a
+            href="{$ legacyURLBase $}/vlan/{$ node.vlan.id $}?provide_dhcp=true"
+            >Reconfigure</a
+          >
+          the DHCP configuration.
+          <a
+            class="p-notification__action"
+            data-ng-click="dismissHighAvailabilityNotification()"
+            >Dismiss</a
+          >
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section data-ng-if="section.area === 'summary'">
+    <node-details-summary />
+  </section>
+
+  <section class="p-strip" data-ng-if="section.area === 'instances'">
+    <div class="row">
+      <table>
+        <thead>
+          <tr>
+            <th class="col-4">Name</th>
+            <th class="col-4">MAC</th>
+            <th class="col-4">IP Address</th>
+          </tr>
+        </thead>
+        <tbody data-selected-rows>
+          <tr data-ng-repeat="device in devices">
+            <td class="col-4">{$ device.name $}</td>
+            <td class="col-4">{$ device.mac_address $}</td>
+            <td class="col-4">{$ device.ip_address $}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+  <section data-ng-if="section.area === 'configuration'">
+    <div class="p-strip">
+      <div class="row">
+        <div class="col-10">
+          <h2 data-ng-if="!isController" class="p-heading--four">
+            {$ node.node_type_display $} configuration
+          </h2>
+          <h2 data-ng-if="isController" class="p-heading--four">
+            Controller configuration
+          </h2>
+        </div>
+        <div class="col-2 u-align--right" data-ng-if="!summary.editing">
+          <button
+            class="p-button--neutral u-float--right u-no-margin--bottom"
+            data-ng-if="canEdit()"
+            data-ng-click="editSummary()"
+          >
+            Edit
+          </button>
+        </div>
+      </div>
+      <form class="p-form p-form--stacked">
         <div class="row">
-            <div class="p-notification--information u-no-margin--bottom">
-                <p class="p-notification__response">
-                    You can now enable <strong>high availability DHCP</strong> on {$ node.vlan.fabric_name $} {$ getNotificationVLANText() $}. <a href="{$ legacyURLBase $}/vlan/{$ node.vlan.id $}?provide_dhcp=true">Reconfigure</a> the DHCP configuration. <a
-                        class="p-notification__action" data-ng-click="dismissHighAvailabilityNotification()">Dismiss</a>
-                </p>
+          <div class="col-6">
+            <div
+              class="p-form__group row"
+              data-ng-if="!isDevice && !isController"
+              data-ng-class="{ 'is-error': invalidArchitecture() }"
+            >
+              <label
+                for="architecture"
+                class="p-form__label col-2"
+                data-ng-class="{'is-disabled': !summary.editing }"
+                >Architecture</label
+              >
+              <div class="p-form__control col-4">
+                <select
+                  name="architecture"
+                  id="architecture"
+                  class="p-form-validation__input"
+                  data-ng-disabled="!summary.editing"
+                  data-ng-model="summary.architecture.selected"
+                  data-ng-options="arch for arch in summary.architecture.options"
+                >
+                  <option value="" disabled="disabled"
+                    >{$ getArchitecturePlaceholder() $}</option
+                  >
+                </select>
+              </div>
             </div>
+            <div
+              class="p-form__group row"
+              data-ng-if="!isDevice && !isController"
+            >
+              <label
+                for="min_hwe_kernel"
+                class="p-form__label col-2"
+                data-ng-class="{'is-disabled': !summary.editing }"
+                >Minimum Kernel</label
+              >
+              <div class="p-form__control col-4">
+                <select
+                  name="min_hwe_kernel"
+                  id="min_hwe_kernel"
+                  data-ng-disabled="!summary.editing"
+                  data-ng-model="summary.min_hwe_kernel.selected"
+                  data-ng-options="hwe_kernel[0] as hwe_kernel[1] for hwe_kernel in summary.min_hwe_kernel.options"
+                >
+                  <option value="">No minimum kernel</option>
+                </select>
+              </div>
+            </div>
+            <div class="p-form__group row">
+              <label
+                for="zone"
+                class="p-form__label col-2"
+                data-ng-class="{'is-disabled': !summary.editing }"
+                >Zone</label
+              >
+              <div class="p-form__control col-4">
+                <select
+                  name="zone"
+                  id="zone"
+                  data-ng-disabled="!summary.editing"
+                  data-ng-model="summary.zone.selected"
+                  data-ng-options="zone as zone.name for zone in summary.zone.options"
+                >
+                  <option value="" disabled="disabled">Choose a zone</option>
+                </select>
+              </div>
+            </div>
+            <div
+              class="p-form__group row"
+              data-ng-if="!isDevice && !isController"
+            >
+              <label
+                for="pool"
+                class="p-form__label col-2"
+                data-ng-class="{'is-disabled': !summary.editing }"
+                >Resource pool</label
+              >
+              <div class="p-form__control col-4">
+                <select
+                  name="pool"
+                  id="pool"
+                  data-ng-disabled="!summary.editing"
+                  data-ng-model="summary.pool.selected"
+                  data-ng-options="pool as pool.name for pool in summary.pool.options"
+                >
+                  <option value="" disabled="disabled"
+                    >Choose a resource pool</option
+                  >
+                </select>
+              </div>
+            </div>
+            <div
+              class="p-form__group row"
+              data-ng-if="!isDevice && !isController"
+            >
+              <label
+                for="pool"
+                class="p-form__label col-2"
+                data-ng-class="{'is-disabled': !summary.editing }"
+                >Note</label
+              >
+              <div class="p-form__control col-4">
+                <input
+                  name="note"
+                  id="note"
+                  type="text"
+                  data-ng-disabled="!summary.editing"
+                  data-ng-model="summary.description"
+                />
+              </div>
+            </div>
+            <div class="p-form__group row">
+              <label
+                class="p-form__label col-2"
+                data-ng-class="{'is-disabled': !summary.editing }"
+                >Tags</label
+              >
+              <div class="p-form__control col-4 tags--inline">
+                <span
+                  data-ng-repeat="tag in node.tags"
+                  data-ng-hide="summary.editing"
+                >
+                  <a href="{$ newURLBase $}/machines?q=tags:({$ tag $})"
+                    >{$ tag $}</a
+                  >
+                </span>
+                <tags-input
+                  data-ng-model="summary.tags"
+                  data-ng-hide="!summary.editing"
+                  allowed-tags-pattern="[\w-]+"
+                >
+                  <auto-complete
+                    source="tagsAutocomplete($query)"
+                  ></auto-complete>
+                </tags-input>
+              </div>
+            </div>
+          </div>
         </div>
-    </section>
-
-    <section data-ng-if="section.area === 'summary'">
-        <node-details-summary />
-    </section>
-
-    <section class="p-strip" data-ng-if="section.area === 'instances'">
         <div class="row">
-            <table>
-                <thead>
-                    <tr>
-                        <th class="col-4">Name</th>
-                        <th class="col-4">MAC</th>
-                        <th class="col-4">IP Address</th>
-                    </tr>
-                </thead>
-                <tbody data-selected-rows>
-                    <tr data-ng-repeat="device in devices">
-                        <td class="col-4">{$ device.name $}</td>
-                        <td class="col-4">{$ device.mac_address $}</td>
-                        <td class="col-4">{$ device.ip_address $}</td>
-                    </tr>
-                </tbody>
-            </table>
+          <div class="col-12 u-align--right" data-ng-if="summary.editing">
+            <button
+              class="p-button--base u-no-margin--bottom"
+              ng-click="cancelEditSummary()"
+            >
+              Cancel
+            </button>
+            <button
+              class="p-button--positive u-no-margin--bottom"
+              ng-click="saveEditSummary()"
+              ng-disabled="invalidArchitecture()"
+            >
+              Save changes
+            </button>
+          </div>
         </div>
-    </section>
-    <section data-ng-if="section.area === 'configuration'">
-        <div class="p-strip">
-            <div class="row">
-                <div class="col-10">
-                    <h2 data-ng-if="!isController" class="p-heading--four">{$ node.node_type_display $} configuration</h2>
-                    <h2 data-ng-if="isController" class="p-heading--four">Controller configuration</h2>
-                </div>
-                <div class="col-2 u-align--right" data-ng-if="!summary.editing">
-                    <button class="p-button--neutral u-float--right u-no-margin--bottom"
-                        data-ng-if="canEdit()"
-                        data-ng-click="editSummary()">Edit</button>
-                </div>
-            </div>
-            <form class="p-form p-form--stacked">
-                <div class="row">
-                    <div class="col-6">
-                        <div class="p-form__group row" data-ng-if="!isDevice && !isController"
-                            data-ng-class="{ 'is-error': invalidArchitecture() }">
-                            <label for="architecture"
-                                class="p-form__label col-2"
-                                data-ng-class="{'is-disabled': !summary.editing }">Architecture</label>
-                            <div class="p-form__control col-4">
-                                <select name="architecture" id="architecture" class="p-form-validation__input"
-                                    data-ng-disabled="!summary.editing"
-                                    data-ng-model="summary.architecture.selected"
-                                    data-ng-options="arch for arch in summary.architecture.options">
-                                    <option value="" disabled="disabled">{$ getArchitecturePlaceholder() $}</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="p-form__group row" data-ng-if="!isDevice && !isController">
-                            <label for="min_hwe_kernel"
-                                class="p-form__label col-2"
-                                data-ng-class="{'is-disabled': !summary.editing }">Minimum Kernel</label>
-                            <div class="p-form__control col-4">
-                                <select name="min_hwe_kernel" id="min_hwe_kernel"
-                                    data-ng-disabled="!summary.editing"
-                                    data-ng-model="summary.min_hwe_kernel.selected"
-                                    data-ng-options="hwe_kernel[0] as hwe_kernel[1] for hwe_kernel in summary.min_hwe_kernel.options">
-                                    <option value="">No minimum kernel</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="p-form__group row">
-                            <label for="zone"
-                                class="p-form__label col-2"
-                                data-ng-class="{'is-disabled': !summary.editing }">Zone</label>
-                            <div class="p-form__control col-4">
-                                <select name="zone" id="zone"
-                                    data-ng-disabled="!summary.editing"
-                                    data-ng-model="summary.zone.selected"
-                                    data-ng-options="zone as zone.name for zone in summary.zone.options">
-                                    <option value="" disabled="disabled">Choose a zone</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="p-form__group row" data-ng-if="!isDevice && !isController">
-                            <label for="pool"
-                                class="p-form__label col-2"
-                                data-ng-class="{'is-disabled': !summary.editing }">Resource pool</label>
-                            <div class="p-form__control col-4">
-                                <select name="pool" id="pool"
-                                    data-ng-disabled="!summary.editing"
-                                    data-ng-model="summary.pool.selected"
-                                    data-ng-options="pool as pool.name for pool in summary.pool.options">
-                                    <option value="" disabled="disabled">Choose a resource pool</option>
-                                </select>
-                            </div>
-                        </div>
-                        <div class="p-form__group row" data-ng-if="!isDevice && !isController">
-                            <label for="pool"
-                                class="p-form__label col-2"
-                                data-ng-class="{'is-disabled': !summary.editing }">Note</label>
-                            <div class="p-form__control col-4">
-                                <input name="note" id="note" type="text"
-                                    data-ng-disabled="!summary.editing"
-                                    data-ng-model="summary.description" />
-                            </div>
-                        </div>
-                        <div class="p-form__group row">
-                            <label class="p-form__label col-2"
-                                data-ng-class="{'is-disabled': !summary.editing }">Tags</label>
-                            <div class="p-form__control col-4 tags--inline">
-                                <span data-ng-repeat="tag in node.tags" data-ng-hide="summary.editing">
-                                    <a href="{$ newURLBase $}/machines?q=tags:({$ tag $})">{$ tag $}</a>
-                                </span>
-                                <tags-input data-ng-model="summary.tags"
-                                    data-ng-hide="!summary.editing" allowed-tags-pattern="[\w-]+">
-                                    <auto-complete source="tagsAutocomplete($query)"></auto-complete>
-                                </tags-input>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-12 u-align--right" data-ng-if="summary.editing">
-                        <button
-                            class="p-button--base u-no-margin--bottom"
-                            ng-click="cancelEditSummary()"
-                        >
-                            Cancel
-                        </button>
-                        <button
-                            class="p-button--positive u-no-margin--bottom"
-                            ng-click="saveEditSummary()"
-                            ng-disabled="invalidArchitecture()"
-                        >
-                            Save changes
-                        </button>
-                    </div>
-                </div>
-            </form>
+      </form>
+    </div>
+    <div class="p-strip">
+      <div class="row" data-ng-if="!isDevice">
+        <div class="col-10">
+          <h2 class="p-heading--four">Power configuration</h2>
         </div>
-        <div class="p-strip">
-            <div class="row" data-ng-if="!isDevice">
-                <div class="col-10">
-                    <h2 class="p-heading--four">Power configuration</h2>
-                </div>
-                <div class="col-2">
-                    <div class="u-align--right">
-                        <button class="p-button--neutral u-float--right"
-                            data-ng-show="canEdit() && power_types.length"
-                            data-ng-click="editPower()"
-                            data-ng-if="!power.editing">Edit</button>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-12" data-ng-if="!isDevice">
-                    <div class="p-notification--negative" data-ng-if="!isRackControllerConnected()">
-                        <p class="p-notification__response">
-                        <span class="p-notification__status">Error:</span> Editing is currently
-                        disabled because no rack controller is currently
-                        connected to the region.</p>
-                    </div>
-                    <div class="p-notification--negative"
-                        data-ng-if="isRackControllerConnected() && node.power_type == '' && !isController">
-                        <p class="p-notification__response">
-                        <span class="p-notification__status">Error:</span> This node does not
-                        have a power type set and MAAS will be unable to
-                        control it. Update the power information below.</p>
-                    </div>
-                    <div class="p-notification--caution"
-                        data-ng-if="isRackControllerConnected() && node.power_type == '' && isController">
-                        <p class="p-notification__response">
-                        <span class="p-notification__status">Warning:</span> This node does not
-                        have a power type set and MAAS will be unable to
-                        control it. Update the power information below.</p>
-                    </div>
-                    <div class="p-notification--negative" data-ng-if="failedUpdateError">
-                        <p class="p-notification__response">
-                            <span class="p-notification__status">Error:</span> {$ failedUpdateError $}
-                        </p>
-                    </div>
-                    <div class="p-notification--negative" data-ng-if="hasPowerError()">
-                        <p class="p-notification__response">
-                        <span class="p-notification__status">Error:</span> Power control
-                        software for this power type is missing from the rack
-                        controller.  To proceed, install the
-                        {$ getPowerErrors() $} on the rack controller.</p>
-                    </div>
-                    <div class="p-notification--negative" data-ng-if="hasPowerEventError()">
-                        <p class="p-notification__response">
-                        <span class="p-notification__status">Error:</span> {$ getPowerEventErrorText() $}</p>
-                    </div>
-                    <div class="p-notification" data-ng-if="power.type.name == 'manual'">
-                        <p class="p-notification__response">Power control for
-                        this power type will need to be handled manually.</p>
-                    </div>
-                    <div class="p-notification" data-ng-if="power.editing && node.power_bmc_node_count > 1">
-                        <p class="p-notification__response">This power controller
-                        manages {$ node.power_bmc_node_count - 1 $} other
-                        {$ node.power_bmc_node_count > 3 ? "nodes" : "node" $}.
-                        Changing the IP address or outlet delay will affect all these nodes.</p>
-                    </div>
-                </div>
-            </div>
-            <form class="p-form p-form--stacked" class="disabled" data-ng-if="!isDevice">
-                <div class="row">
-                    <div class="col-6 ng-hide"
-                        data-ng-show="power_types.length"
-                        data-ng-disabled="!power.editing"
-                        data-maas-power-parameters="power_types"
-                        data-ng-model="power">
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-12 u-align--right ng-hide" data-ng-show="power.editing">
-                        <button class="p-button--base" type="button"
-                            data-ng-click="cancelEditPower()">Cancel</button>
-                        <button class="p-button--positive"
-                            data-ng-class="{ secondary: invalidPowerType() }"
-                            data-ng-click="saveEditPower()"
-                            data-ng-disabled="!powerParametersValid(power)">Save changes</button>
-                    </div>
-                </div>
-            </form>
+        <div class="col-2">
+          <div class="u-align--right">
+            <button
+              class="p-button--neutral u-float--right"
+              data-ng-show="canEdit() && power_types.length"
+              data-ng-click="editPower()"
+              data-ng-if="!power.editing"
+            >
+              Edit
+            </button>
+          </div>
         </div>
-    </section>
-    <section class="p-strip" data-ng-if="section.area === 'services'">
-        <div class="row" data-ng-show="node.node_type == 3 || node.node_type == 4">
-            <div class="col-12">
-                <h3 class="p-heading--four">Region Controller</h3>
-                <ul class="p-list-tree" aria-multiselectable="true" role="tablist">
-                    <li class="p-list-tree__item">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.regiond) $}"></span>
-                            &nbsp;regiond
-                            <span data-ng-if="services.regiond.status_info"> &mdash; {$ services.regiond.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.bind9) $}"></span>
-                            &nbsp;bind9
-                            <span data-ng-if="services.bind9.status_info"> &mdash; {$ services.bind9.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item" data-ng-if="services.ntp_region">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.ntp_region) $}"></span>
-                            &nbsp;ntp
-                            <span data-ng-if="services.ntp_region.status_info"> &mdash; {$ services.ntp_region.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.proxy) $}"></span>
-                            &nbsp;proxy
-                            <span data-ng-if="services.proxy.status_info"> &mdash; {$ services.proxy.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item" data-ng-if="services.syslog_region">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.syslog_region) $}"></span>
-                            &nbsp;syslog
-                            <span data-ng-if="services.syslog_region.status_info"> &mdash; {$ services.syslog_region.status_info $}</span>
-                        </span>
-                    </li>
-                </ul>
-            </div>
+      </div>
+      <div class="row">
+        <div class="col-12" data-ng-if="!isDevice">
+          <div
+            class="p-notification--negative"
+            data-ng-if="!isRackControllerConnected()"
+          >
+            <p class="p-notification__response">
+              <span class="p-notification__status">Error:</span> Editing is
+              currently disabled because no rack controller is currently
+              connected to the region.
+            </p>
+          </div>
+          <div
+            class="p-notification--negative"
+            data-ng-if="isRackControllerConnected() && node.power_type == '' && !isController"
+          >
+            <p class="p-notification__response">
+              <span class="p-notification__status">Error:</span> This node does
+              not have a power type set and MAAS will be unable to control it.
+              Update the power information below.
+            </p>
+          </div>
+          <div
+            class="p-notification--caution"
+            data-ng-if="isRackControllerConnected() && node.power_type == '' && isController"
+          >
+            <p class="p-notification__response">
+              <span class="p-notification__status">Warning:</span> This node
+              does not have a power type set and MAAS will be unable to control
+              it. Update the power information below.
+            </p>
+          </div>
+          <div class="p-notification--negative" data-ng-if="failedUpdateError">
+            <p class="p-notification__response">
+              <span class="p-notification__status">Error:</span> {$
+              failedUpdateError $}
+            </p>
+          </div>
+          <div class="p-notification--negative" data-ng-if="hasPowerError()">
+            <p class="p-notification__response">
+              <span class="p-notification__status">Error:</span> Power control
+              software for this power type is missing from the rack controller.
+              To proceed, install the {$ getPowerErrors() $} on the rack
+              controller.
+            </p>
+          </div>
+          <div
+            class="p-notification--negative"
+            data-ng-if="hasPowerEventError()"
+          >
+            <p class="p-notification__response">
+              <span class="p-notification__status">Error:</span> {$
+              getPowerEventErrorText() $}
+            </p>
+          </div>
+          <div class="p-notification" data-ng-if="power.type.name == 'manual'">
+            <p class="p-notification__response">
+              Power control for this power type will need to be handled
+              manually.
+            </p>
+          </div>
+          <div
+            class="p-notification"
+            data-ng-if="power.editing && node.power_bmc_node_count > 1"
+          >
+            <p class="p-notification__response">
+              This power controller manages {$ node.power_bmc_node_count - 1 $}
+              other {$ node.power_bmc_node_count > 3 ? "nodes" : "node" $}.
+              Changing the IP address or outlet delay will affect all these
+              nodes.
+            </p>
+          </div>
         </div>
-        <div class="row" data-ng-show="node.node_type == 2 || node.node_type == 4">
-            <div class="col-12">
-                <h3 class="p-heading--four">Rack Controller</h3>
-                <ul class="p-list-tree" aria-multiselectable="true" role="tablist">
-                    <li class="p-list-tree__item p-list-tree__item--group">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.rackd) $}"></span>
-                            &nbsp;rackd
-                            <span data-ng-if="services.rackd.status_info"> &mdash; {$ services.rackd.status_info $}</span>
-                        </span>
-                        <ul class="p-list-tree" role="tabpanel" aria-hidden="true">
-                            <li class="p-list-tree__item">
-                                <span>
-                                    <span class="p-icon--{$ getServiceClass(services.http) $}"></span>
-                                    &nbsp;http
-                                    <span data-ng-if="services.http.status_info"> &mdash; {$ services.http.status_info $}</span>
-                                </span>
-                            </li>
-                            <li class="p-list-tree__item">
-                                <span>
-                                    <span class="p-icon--{$ getServiceClass(services.tftp) $}"></span>
-                                    &nbsp;tftp
-                                    <span data-ng-if="services.tftp.status_info"> &mdash; {$ services.tftp.status_info $}</span>
-                                </span>
-                            </li>
-                        </ul>
-                    </li>
-                    <li class="p-list-tree__item">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.dhcpd) $}"></span>
-                            &nbsp;dhcpd
-                            <span data-ng-if="services.dhcpd.status_info"> &mdash; {$ services.dhcpd.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.dhcpd6) $}"></span>
-                            &nbsp;dhcpd6
-                            <span data-ng-if="services.dhcpd6.status_info"> &mdash; {$ services.dhcpd6.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item" data-ng-if="services.dns_rack">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.dns_rack) $}"></span>
-                            &nbsp;dns
-                            <span data-ng-if="services.dns_rack.status_info"> &mdash; {$ services.dns_rack.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item" data-ng-if="services.ntp_rack">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.ntp_rack) $}"></span>
-                            &nbsp;ntp
-                            <span data-ng-if="services.ntp_rack.status_info"> &mdash; {$ services.ntp_rack.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item" data-ng-if="services.proxy_rack">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.proxy_rack) $}"></span>
-                            &nbsp;proxy
-                            <span data-ng-if="services.proxy_rack.status_info"> &mdash; {$ services.proxy_rack.status_info $}</span>
-                        </span>
-                    </li>
-                    <li class="p-list-tree__item" data-ng-if="services.syslog_rack">
-                        <span>
-                            <span class="p-icon--{$ getServiceClass(services.syslog_rack) $}"></span>
-                            &nbsp;syslog
-                            <span data-ng-if="services.syslog_rack.status_info"> &mdash; {$ services.syslog_rack.status_info $}</span>
-                        </span>
-                    </li>
-                </ul>
-            </div>
+      </div>
+      <form
+        class="p-form p-form--stacked"
+        class="disabled"
+        data-ng-if="!isDevice"
+      >
+        <div class="row">
+          <div
+            class="col-6 ng-hide"
+            data-ng-show="power_types.length"
+            data-ng-disabled="!power.editing"
+            data-maas-power-parameters="power_types"
+            data-ng-model="power"
+          ></div>
         </div>
-    </section>
-    <section class="u-no-margin--top" data-ng-if="section.area === 'vlans' || section.area === 'network'" data-ng-controller="NodeNetworkingController">
-        <div class="p-strip" data-ng-if="section.area === 'vlans'">
-            <div class="row" data-ng-if="!loaded">
-                <div class="col-12">
-                    <p class="u-text--loading"><i class="p-icon--spinner u-animation--spin"></i>&nbsp;&nbsp;Loading...</p>
-                </div>
-            </div>
-            <div class="row">
-                <form data-ng-if="loaded">
-                    <table class="p-table-expanding p-table--controller-vlans">
-                        <thead>
-                            <tr class="p-table__row">
-                                <th title="Fabric">Fabric</th>
-                                <th title="VLAN">VLAN</th>
-                                <th title="DHCP">DHCP</th>
-                                <th title="Subnets">Subnets</th>
-                                <th title="Primary rack">Primary rack</th>
-                                <th title="Secondary rack">Secondary rack</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr class="p-table__row" data-ng-repeat="vlanRow in vlanTable">
-                                <td title="{$ vlanRow['fabric'].name $}">
-                                    <a href="{$ legacyURLBase $}/fabric/{$ vlanRow['fabric'].id $}">{$ vlanRow['fabric'].name $}</a>
-                                </td>
-                                <td title="{$ getVLANText(vlanRow['vlan']) $}">
-                                    <a href="{$ legacyURLBase $}/vlan/{$ vlanRow['vlan'].id $}">{$ getVLANText(vlanRow['vlan']) $}</a>
-                                </td>
-                                <td>
-                                    <span data-ng-if="vlanRow.vlan.dhcp_on === true || vlanRow.vlan.relay_vlan !== null || vlanRow.vlan.external_dhcp === true" title="Enabled">Enabled</span>
-                                    <span data-ng-if="vlanRow.vlan.dhcp_on !== true && vlanRow.vlan.relay_vlan === null" title="Disabled">Disabled</span>
-                                </td>
-                                <td>
-                                    <div class="u-no-margin--top" data-ng-repeat="subnet in vlanRow['subnets']">
-                                        <a href="{$ legacyURLBase $}/subnet/{$ subnet.id $}" title="{$ getSubnetText(subnet) $}">{$ getSubnetText(subnet) $}</a>
-                                    </div>
-                                </td>
-                                <td>
-                                    <a href="{$ legacyURLBase $}/controller/{$ vlanRow['primary_rack'].system_id $}" title="{$ vlanRow['primary_rack'].fqdn $}">{$ vlanRow['primary_rack'].fqdn $}</a>
-                                </td>
-                                <td>
-                                    <a href="{$ legacyURLBase $}/controller/{$ vlanRow['secondary_rack'].system_id $}" title="{$ vlanRow['secondary_rack'].fqdn $}">{$ vlanRow['secondary_rack'].fqdn $}</a>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </form>
-            </div>
+        <div class="row">
+          <div
+            class="col-12 u-align--right ng-hide"
+            data-ng-show="power.editing"
+          >
+            <button
+              class="p-button--base"
+              type="button"
+              data-ng-click="cancelEditPower()"
+            >
+              Cancel
+            </button>
+            <button
+              class="p-button--positive"
+              data-ng-class="{ secondary: invalidPowerType() }"
+              data-ng-click="saveEditPower()"
+              data-ng-disabled="!powerParametersValid(power)"
+            >
+              Save changes
+            </button>
+          </div>
         </div>
-        <div class="p-strip" data-ng-if="section.area === 'network'">
-            <div class="row" data-ng-if="!loaded">
-                <div class="col-12">
-                    <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
-                </div>
-            </div>
-            <form data-ng-if="loaded">
-                <div class="row" data-ng-if="
+      </form>
+    </div>
+  </section>
+  <section class="p-strip" data-ng-if="section.area === 'services'">
+    <div class="row" data-ng-show="node.node_type == 3 || node.node_type == 4">
+      <div class="col-12">
+        <h3 class="p-heading--four">Region Controller</h3>
+        <ul class="p-list-tree" aria-multiselectable="true" role="tablist">
+          <li class="p-list-tree__item">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.regiond) $}"
+              ></span>
+              &nbsp;regiond
+              <span data-ng-if="services.regiond.status_info">
+                &mdash; {$ services.regiond.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.bind9) $}"
+              ></span>
+              &nbsp;bind9
+              <span data-ng-if="services.bind9.status_info">
+                &mdash; {$ services.bind9.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item" data-ng-if="services.ntp_region">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.ntp_region) $}"
+              ></span>
+              &nbsp;ntp
+              <span data-ng-if="services.ntp_region.status_info">
+                &mdash; {$ services.ntp_region.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.proxy) $}"
+              ></span>
+              &nbsp;proxy
+              <span data-ng-if="services.proxy.status_info">
+                &mdash; {$ services.proxy.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item" data-ng-if="services.syslog_region">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.syslog_region) $}"
+              ></span>
+              &nbsp;syslog
+              <span data-ng-if="services.syslog_region.status_info">
+                &mdash; {$ services.syslog_region.status_info $}</span
+              >
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="row" data-ng-show="node.node_type == 2 || node.node_type == 4">
+      <div class="col-12">
+        <h3 class="p-heading--four">Rack Controller</h3>
+        <ul class="p-list-tree" aria-multiselectable="true" role="tablist">
+          <li class="p-list-tree__item p-list-tree__item--group">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.rackd) $}"
+              ></span>
+              &nbsp;rackd
+              <span data-ng-if="services.rackd.status_info">
+                &mdash; {$ services.rackd.status_info $}</span
+              >
+            </span>
+            <ul class="p-list-tree" role="tabpanel" aria-hidden="true">
+              <li class="p-list-tree__item">
+                <span>
+                  <span
+                    class="p-icon--{$ getServiceClass(services.http) $}"
+                  ></span>
+                  &nbsp;http
+                  <span data-ng-if="services.http.status_info">
+                    &mdash; {$ services.http.status_info $}</span
+                  >
+                </span>
+              </li>
+              <li class="p-list-tree__item">
+                <span>
+                  <span
+                    class="p-icon--{$ getServiceClass(services.tftp) $}"
+                  ></span>
+                  &nbsp;tftp
+                  <span data-ng-if="services.tftp.status_info">
+                    &mdash; {$ services.tftp.status_info $}</span
+                  >
+                </span>
+              </li>
+            </ul>
+          </li>
+          <li class="p-list-tree__item">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.dhcpd) $}"
+              ></span>
+              &nbsp;dhcpd
+              <span data-ng-if="services.dhcpd.status_info">
+                &mdash; {$ services.dhcpd.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.dhcpd6) $}"
+              ></span>
+              &nbsp;dhcpd6
+              <span data-ng-if="services.dhcpd6.status_info">
+                &mdash; {$ services.dhcpd6.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item" data-ng-if="services.dns_rack">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.dns_rack) $}"
+              ></span>
+              &nbsp;dns
+              <span data-ng-if="services.dns_rack.status_info">
+                &mdash; {$ services.dns_rack.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item" data-ng-if="services.ntp_rack">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.ntp_rack) $}"
+              ></span>
+              &nbsp;ntp
+              <span data-ng-if="services.ntp_rack.status_info">
+                &mdash; {$ services.ntp_rack.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item" data-ng-if="services.proxy_rack">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.proxy_rack) $}"
+              ></span>
+              &nbsp;proxy
+              <span data-ng-if="services.proxy_rack.status_info">
+                &mdash; {$ services.proxy_rack.status_info $}</span
+              >
+            </span>
+          </li>
+          <li class="p-list-tree__item" data-ng-if="services.syslog_rack">
+            <span>
+              <span
+                class="p-icon--{$ getServiceClass(services.syslog_rack) $}"
+              ></span>
+              &nbsp;syslog
+              <span data-ng-if="services.syslog_rack.status_info">
+                &mdash; {$ services.syslog_rack.status_info $}</span
+              >
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+  <section
+    class="u-no-margin--top"
+    data-ng-if="section.area === 'vlans' || section.area === 'network'"
+    data-ng-controller="NodeNetworkingController"
+  >
+    <div class="p-strip" data-ng-if="section.area === 'vlans'">
+      <div class="row" data-ng-if="!loaded">
+        <div class="col-12">
+          <p class="u-text--loading">
+            <i class="p-icon--spinner u-animation--spin"></i
+            >&nbsp;&nbsp;Loading...
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <form data-ng-if="loaded">
+          <table class="p-table-expanding p-table--controller-vlans">
+            <thead>
+              <tr class="p-table__row">
+                <th title="Fabric">Fabric</th>
+                <th title="VLAN">VLAN</th>
+                <th title="DHCP">DHCP</th>
+                <th title="Subnets">Subnets</th>
+                <th title="Primary rack">Primary rack</th>
+                <th title="Secondary rack">Secondary rack</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="p-table__row" data-ng-repeat="vlanRow in vlanTable">
+                <td title="{$ vlanRow['fabric'].name $}">
+                  <a
+                    href="{$ legacyURLBase $}/fabric/{$ vlanRow['fabric'].id $}"
+                    >{$ vlanRow['fabric'].name $}</a
+                  >
+                </td>
+                <td title="{$ getVLANText(vlanRow['vlan']) $}">
+                  <a href="{$ legacyURLBase $}/vlan/{$ vlanRow['vlan'].id $}"
+                    >{$ getVLANText(vlanRow['vlan']) $}</a
+                  >
+                </td>
+                <td>
+                  <span
+                    data-ng-if="vlanRow.vlan.dhcp_on === true || vlanRow.vlan.relay_vlan !== null || vlanRow.vlan.external_dhcp === true"
+                    title="Enabled"
+                    >Enabled</span
+                  >
+                  <span
+                    data-ng-if="vlanRow.vlan.dhcp_on !== true && vlanRow.vlan.relay_vlan === null"
+                    title="Disabled"
+                    >Disabled</span
+                  >
+                </td>
+                <td>
+                  <div
+                    class="u-no-margin--top"
+                    data-ng-repeat="subnet in vlanRow['subnets']"
+                  >
+                    <a
+                      href="{$ legacyURLBase $}/subnet/{$ subnet.id $}"
+                      title="{$ getSubnetText(subnet) $}"
+                      >{$ getSubnetText(subnet) $}</a
+                    >
+                  </div>
+                </td>
+                <td>
+                  <a
+                    href="{$ legacyURLBase $}/controller/{$ vlanRow['primary_rack'].system_id $}"
+                    title="{$ vlanRow['primary_rack'].fqdn $}"
+                    >{$ vlanRow['primary_rack'].fqdn $}</a
+                  >
+                </td>
+                <td>
+                  <a
+                    href="{$ legacyURLBase $}/controller/{$ vlanRow['secondary_rack'].system_id $}"
+                    title="{$ vlanRow['secondary_rack'].fqdn $}"
+                    >{$ vlanRow['secondary_rack'].fqdn $}</a
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </form>
+      </div>
+    </div>
+    <div class="p-strip" data-ng-if="section.area === 'network'">
+      <div class="row" data-ng-if="!loaded">
+        <div class="col-12">
+          <p><i class="p-icon--spinner u-animation--spin"></i> Loading...</p>
+        </div>
+      </div>
+      <form data-ng-if="loaded">
+        <div
+          class="row"
+          data-ng-if="
                 !isDevice && ((!isController && isAllNetworkingDisabled() && canEdit()) ||
-                !node.on_network || (!isController && !isUbuntuOS()))">
-                    <div class="col-12">
-                        <div class="p-notification--negative" data-ng-if="!node.on_network">
-                            <p class="p-notification__response">
-                                <span class="p-notification__status">Error:</span> Node must be connected to a network.</p>
-                        </div>
-                        <div class="p-notification" data-ng-if="!isController && isAllNetworkingDisabled() && canEdit()">
-                            <p class="p-notification__response">Interface
-                                configuration cannot be modified unless the
-                                node is New, Ready, Allocated, or Broken.</p>
-                        </div>
-                        <div class="p-notification--caution" data-ng-if="!isController && isCustomOS()">
-                            <p class="p-notification__response">
-                                <span class="p-notification__status">Important:</span> Custom images may require special preparation to support custom network configuration.
-                            </p>
-                        </div>
-                        <div class="p-notification--negative" data-ng-if="createBondError">
-                            <p class="p-notification__response">
-                                <span class="p-notification__status">Error:</span> {$ createBondError $}
-                                <a class="p-notification__action" data-ng-click="clearCreateBondError()">Dismiss</a>
-                            </p>
-                        </div>
+                !node.on_network || (!isController && !isUbuntuOS()))"
+        >
+          <div class="col-12">
+            <div class="p-notification--negative" data-ng-if="!node.on_network">
+              <p class="p-notification__response">
+                <span class="p-notification__status">Error:</span> Node must be
+                connected to a network.
+              </p>
+            </div>
+            <div
+              class="p-notification"
+              data-ng-if="!isController && isAllNetworkingDisabled() && canEdit()"
+            >
+              <p class="p-notification__response">
+                Interface configuration cannot be modified unless the node is
+                New, Ready, Allocated, or Broken.
+              </p>
+            </div>
+            <div
+              class="p-notification--caution"
+              data-ng-if="!isController && isCustomOS()"
+            >
+              <p class="p-notification__response">
+                <span class="p-notification__status">Important:</span> Custom
+                images may require special preparation to support custom network
+                configuration.
+              </p>
+            </div>
+            <div class="p-notification--negative" data-ng-if="createBondError">
+              <p class="p-notification__response">
+                <span class="p-notification__status">Error:</span> {$
+                createBondError $}
+                <a
+                  class="p-notification__action"
+                  data-ng-click="clearCreateBondError()"
+                  >Dismiss</a
+                >
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div
+          data-ng-if="!isShowingCreateBridge() && !isShowingEdit() && !isShowingCreateBond()"
+        >
+          <div
+            class="row"
+            data-ng-if="!isController && !isDevice"
+            data-ng-hide="isAllNetworkingDisabled() || isShowingCreateBond() || isShowingCreatePhysical()"
+          >
+            <div class="col-8">
+              <button
+                class="p-button--neutral"
+                data-ng-click="showCreatePhysical(); sendAnalyticsEvent('Machine details', 'Add interface', 'Network tab')"
+                data-ng-disabled="selectedMode !== null"
+              >
+                Add interface
+              </button>
+              <button
+                class="p-button--neutral"
+                data-ng-click="showCreateBond(); sendAnalyticsEvent('Machine details', 'Create bond', 'Network tab')"
+                data-ng-disabled="!canCreateBond()"
+              >
+                Create bond
+              </button>
+              <button
+                class="p-button--neutral"
+                data-ng-disabled="!canCreateBridge()"
+                data-ng-click="showCreateBridge(); sendAnalyticsEvent('Machine details', 'Create bridge', 'Network tab')"
+              >
+                Create bridge
+              </button>
+            </div>
+            <div class="col-4 u-align--right">
+              <button
+                class="p-button--neutral"
+                data-ng-click="validateNetworkConfiguration(); sendAnalyticsEvent('Machine details', 'Validate network configuration', 'Network tab')"
+              >
+                Validate network configuration
+              </button>
+            </div>
+          </div>
+          <div
+            data-ng-if="isDevice"
+            class="row"
+            data-ng-hide="isAllNetworkingDisabled() || isShowingCreateBond() || isShowingCreatePhysical()"
+          >
+            <div class="col-8">
+              <button
+                class="p-button--neutral"
+                data-ng-disabled="selectedMode !== null"
+                data-ng-click="showCreatePhysical(); sendAnalyticsEvent('Machine details', 'Add interface', 'Network tab')"
+              >
+                Add interface
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="row" data-ng-if="isShowingCreateBridge()">
+          <div class="p-card--highlighted">
+            <h2 class="p-heading--four">Create bridge</h2>
+            <table class="p-table-interface">
+              <thead>
+                <tr>
+                  <th class="p-double-row">
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div>Name</div>
+                      <div>MAC</div>
                     </div>
-                </div>
-
-                <div data-ng-if="!isShowingCreateBridge() && !isShowingEdit() && !isShowingCreateBond()">
-                    <div class="row" data-ng-if="!isController && !isDevice"
-                        data-ng-hide="isAllNetworkingDisabled() || isShowingCreateBond() || isShowingCreatePhysical()">
-                        <div class="col-8">
-                            <button
-                                class="p-button--neutral"
-                                data-ng-click="showCreatePhysical(); sendAnalyticsEvent('Machine details', 'Add interface', 'Network tab')"
-                                data-ng-disabled="selectedMode !== null"
-                            >
-                                Add interface
-                            </button>
-                            <button
-                                class="p-button--neutral"
-                                data-ng-click="showCreateBond(); sendAnalyticsEvent('Machine details', 'Create bond', 'Network tab')"
-                                data-ng-disabled="!canCreateBond()"
-                            >
-                                Create bond
-                            </button>
-                            <button
-                                class="p-button--neutral"
-                                data-ng-disabled="!canCreateBridge()"
-                                data-ng-click="showCreateBridge(); sendAnalyticsEvent('Machine details', 'Create bridge', 'Network tab')"
-                            >
-                                Create bridge
-                            </button>
-                        </div>
-                        <div class="col-4 u-align--right">
-                            <button class="p-button--neutral"
-                                data-ng-click="validateNetworkConfiguration(); sendAnalyticsEvent('Machine details', 'Validate network configuration', 'Network tab')">Validate
-                                network configuration</button>
-                        </div>
+                  </th>
+                  <th>Primary</th>
+                  <th class="p-table__col--status p-double-row">
+                    <div class="p-double-row__icon-container">
+                      <i class="p-icon--placeholder"></i>
                     </div>
-                    <div data-ng-if="isDevice" class="row"
-                        data-ng-hide="isAllNetworkingDisabled() || isShowingCreateBond() || isShowingCreatePhysical()">
-                        <div class="col-8">
-                            <button class="p-button--neutral" data-ng-disabled="selectedMode !== null"
-                                data-ng-click="showCreatePhysical(); sendAnalyticsEvent('Machine details', 'Add interface', 'Network tab')">Add
-                                interface</button>
-                        </div>
+                    <div class="p-double-row__rows-container--icon">
+                      Link/interface speed
                     </div>
-                </div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Type</div>
+                    <div>NUMA node</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Fabric</div>
+                    <div>VLAN</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Subnet</div>
+                    <div>Name</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>IP address</div>
+                    <div>Status</div>
+                  </th>
+                  <th>DHCP</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  data-ng-repeat="interface in interfaces"
+                  data-ng-if="isInterfaceSelected(interface)"
+                >
+                  <td class="p-double-row" aria-label="Name">
+                    <div
+                      class="p-double-row__checkbox"
+                      data-ng-if="isShowingInterfaces"
+                    >
+                      <input
+                        type="checkbox"
+                        class="checkbox"
+                        id="{$ getUniqueKey(interface) $}"
+                        data-ng-checked="isInterfaceSelected(interface)"
+                        data-ng-click="toggleInterfaceSelect(interface)"
+                      />
+                      <label
+                        class="is-inline-label"
+                        for="{$ getUniqueKey(interface) $}"
+                      ></label>
+                    </div>
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div class="p-double-row__main-row">
+                        <div title="{$ interface.name $}">
+                          {$ interface.name $}
+                        </div>
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <div title="{$ interface.mac_address $}">
+                          {$ interface.mac_address $}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Primary">
+                    <input
+                      type="radio"
+                      name="bondPrimary"
+                      id="{$ parent.name $}"
+                      data-ng-model="newBondInterface.primary"
+                      data-ng-value="parent"
+                    />
+                    <label
+                      class="is-inline-label"
+                      for="{$ parent.name $}"
+                    ></label>
+                  </td>
+                  <td
+                    class="p-table__col--status p-double-row"
+                    aria-label="Link and interface speed"
+                  >
+                    <div class="p-double-row__icon-container">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        <span
+                          aria-describedby="not-connected-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="!isInterfaceConnected(interface)"
+                        >
+                          <i class="p-icon--disconnected"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="not-connected-tooltip"
+                            >This interface is disconnected.</span
+                          >
+                        </span>
+                        <span
+                          aria-describedby="link-speed-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                        >
+                          <i class="p-icon--warning"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="link-speed-tooltip"
+                            >Link connected to slow interface.</span
+                          >
+                        </span>
+                        <i
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed"
+                          class="p-icon--placeholder"
+                        >
+                        </i>
+                      </span>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        {$ formatSpeedUnits(interface.link_speed) $}/{$
+                        formatSpeedUnits(interface.interface_speed) $}
+                      </span>
+                    </div>
+                  </td>
+                  <td aria-label="Type, NUMA node" class="p-double-row">
+                    <div
+                      class="p-tooltip--top-left numa-tooltip"
+                      ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }"
+                    >
+                      <div class="p-double-row__rows-container">
+                        <div
+                          class="p-double-row__main-row"
+                          title="{$ getInterfaceTypeText(interface) $}"
+                        >
+                          {$ getInterfaceTypeText(interface) $}
+                        </div>
+                        <div class="p-double-row__muted-row">
+                          <span
+                            >{$ getInterfaceNumaNodes(interface).join(", ")
+                            $}</span
+                          >
+                        </div>
+                      </div>
+                      <span
+                        class="p-tooltip__message"
+                        ng-if="getInterfaceNumaNodes(interface).length > 1"
+                        >This bond is spread over multiple NUMA nodes.<br />This
+                        may lead to suboptimal performance.</span
+                      >
+                    </div>
+                  </td>
+                  <td class="p-double-row" aria-label="Fabric">
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row">
+                        <div
+                          title="{$ interface.fabric && interface.fabric.name || 'Disconnected' $}"
+                        >
+                          {$ interface.fabric && interface.fabric.name $}
+                          <span
+                            data-ng-if="!(interface.fabric && interface.fabric.name)"
+                            >Disconnected</span
+                          >
+                        </div>
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <div title="{$ getVLANText(interface.vlan) $}">
+                          {$ getVLANText(interface.vlan) $}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="p-double-row" aria-label="Subnet CIDR">
+                    <div
+                      class="p-double-row__main-row"
+                      aria-label="Subnet CIDR"
+                      title="{$ interface.subnet.cidr $}"
+                    >
+                      <span data-ng-if="interface.subnet.cidr">
+                        <a
+                          class="p-link--soft"
+                          href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                          >{$ interface.subnet.cidr $}</a
+                        >
+                      </span>
+                      <span data-ng-if="!interface.subnet.cidr"
+                        >Unconfigured</span
+                      >
+                    </div>
+                    <div
+                      data-ng-if="interface.subnet.name"
+                      class="p-double-row__muted-row"
+                      aria-label="Subnet name"
+                      title="{$ interface.subnet.name $}"
+                    >
+                      <a
+                        class="p-muted-text p-link--muted"
+                        href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                        >{$ interface.subnet.name $}</a
+                      >
+                    </div>
+                  </td>
+                  <td class="p-double-row">
+                    <div
+                      data-ng-if="!interface.discovered[0].ip_address && interface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ interface.ip_address $}"
+                      >
+                        <span data-ng-if="interface.ip_address"
+                          >{$ interface.ip_address $}</span
+                        >
+                        <span data-ng-if="!interface.ip_address"
+                          >{$ getLinkModeText(interface) $}</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="{$ getLinkModeText(interface) $}"
+                      >
+                        <span data-ng-if="interface.ip_address"
+                          >{$ getLinkModeText(interface) $}</span
+                        >
+                      </div>
+                    </div>
+                    <div
+                      data-ng-if="interface.discovered[0].ip_address && interface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ interface.discovered[0].ip_address $}"
+                      >
+                        <span data-ng-if="interface.discovered[0].ip_address"
+                          >{$ interface.discovered[0].ip_address $}</span
+                        >
+                        <span data-ng-if="!interface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="DHCP"
+                      >
+                        <span data-ng-if="interface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                    </div>
+                  </td>
+                  <td style="overflow: visible;">
+                    {$ getDHCPStatus(interface.vlan) $}
+                    <span
+                      class="p-tooltip--btm-right"
+                      ng-if="interface.vlan && interface.vlan.relay_vlan"
+                      style="margin-left: 0.25rem;"
+                    >
+                      <i class="p-icon--information" style="width: 0.875rem;"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</i
+                      >
+                      <span class="p-tooltip__message"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</span
+                      >
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
 
-
-                <div class="row" data-ng-if="isShowingCreateBridge()">
-                    <div class="p-card--highlighted">
-                        <h2 class="p-heading--four">Create bridge</h2>
-                        <table class="p-table-interface">
-                            <thead>
-                                <tr>
-                                    <th class="p-double-row">
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div>Name</div>
-                                            <div>MAC</div>
-                                        </div>
-                                    </th>
-                                    <th>Primary</th>
-                                    <th class="p-table__col--status p-double-row">
-                                        <div class="p-double-row__icon-container">
-                                            <i class="p-icon--placeholder"></i>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            Link/interface speed
-                                        </div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Type</div>
-                                        <div>NUMA node</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Fabric</div>
-                                        <div>VLAN</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Subnet</div>
-                                        <div>Name</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>IP address</div>
-                                        <div>Status</div>
-                                    </th>
-                                    <th>DHCP</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr data-ng-repeat="interface in interfaces" data-ng-if="isInterfaceSelected(interface)">
-                                    <td class="p-double-row" aria-label="Name">
-                                        <div class="p-double-row__checkbox" data-ng-if="isShowingInterfaces">
-                                            <input type="checkbox" class="checkbox" id="{$ getUniqueKey(interface) $}" data-ng-checked="isInterfaceSelected(interface)" data-ng-click="toggleInterfaceSelect(interface)">
-                                            <label class="is-inline-label" for="{$ getUniqueKey(interface) $}"></label>
-                                        </div>
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div class="p-double-row__main-row">
-                                                <div title="{$ interface.name $}">
-                                                    {$ interface.name $}
-                                                </div>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <div title="{$ interface.mac_address $}">
-                                                    {$ interface.mac_address $}
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Primary">
-                                        <input type="radio" name="bondPrimary" id="{$ parent.name $}" data-ng-model="newBondInterface.primary"
-                                            data-ng-value="parent">
-                                        <label class="is-inline-label" for="{$ parent.name $}"></label>
-                                    </td>
-                                    <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
-                                        <div class="p-double-row__icon-container">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                <span
-                                                    aria-describedby="not-connected-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="!isInterfaceConnected(interface)"
-                                                >
-                                                    <i class="p-icon--disconnected"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                                </span>
-                                                <span
-                                                    aria-describedby="link-speed-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
-                                                >
-                                                    <i class="p-icon--warning"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                                </span>
-                                                <i
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed"
-                                                    class="p-icon--placeholder">
-                                                </i>
-                                            </span>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                {$ formatSpeedUnits(interface.link_speed) $}/{$ formatSpeedUnits(interface.interface_speed) $}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Type, NUMA node" class="p-double-row">
-                                        <div class="p-tooltip--top-left numa-tooltip"
-                                            ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }">
-                                            <div class="p-double-row__rows-container">
-                                                <div class="p-double-row__main-row" title="{$ getInterfaceTypeText(interface) $}">
-                                                    {$ getInterfaceTypeText(interface) $}
-                                                </div>
-                                                <div class="p-double-row__muted-row">
-                                                    <span>{$ getInterfaceNumaNodes(interface).join(", ") $}</span>
-                                                </div>
-                                            </div>
-                                            <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(interface).length > 1">This bond is spread over
-                                                multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row" aria-label="Fabric">
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row">
-                                                <div title="{$ interface.fabric && interface.fabric.name || 'Disconnected' $}">
-                                                    {$ interface.fabric && interface.fabric.name $}
-                                                    <span data-ng-if="!(interface.fabric && interface.fabric.name)">Disconnected</span>
-                                                </div>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <div title="{$ getVLANText(interface.vlan) $}">
-                                                    {$ getVLANText(interface.vlan) $}
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row" aria-label="Subnet CIDR">
-                                        <div class="p-double-row__main-row" aria-label="Subnet CIDR" title="{$ interface.subnet.cidr $}">
-                                            <span data-ng-if="interface.subnet.cidr">
-                                                <a class="p-link--soft" href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}">{$ interface.subnet.cidr $}</a>
-                                            </span>
-                                            <span data-ng-if="!interface.subnet.cidr">Unconfigured</span>
-                                        </div>
-                                        <div data-ng-if="interface.subnet.name" class="p-double-row__muted-row" aria-label="Subnet name" title="{$ interface.subnet.name $}">
-                                            <a class="p-muted-text p-link--muted" href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}">{$ interface.subnet.name $}</a>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div data-ng-if="!interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address" title="{$ interface.ip_address $}">
-                                                <span data-ng-if="interface.ip_address">{$ interface.ip_address $}</span>
-                                                <span data-ng-if="!interface.ip_address">{$ getLinkModeText(interface) $}</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="{$ getLinkModeText(interface) $}">
-                                                <span data-ng-if="interface.ip_address">{$ getLinkModeText(interface) $}</span>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address" title="{$ interface.discovered[0].ip_address $}">
-                                                <span data-ng-if="interface.discovered[0].ip_address">{$ interface.discovered[0].ip_address $}</span>
-                                                <span data-ng-if="!interface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="DHCP">
-                                                <span data-ng-if="interface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td style="overflow: visible;">
-                                        {$ getDHCPStatus(interface.vlan) $}
-                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
-                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
-                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
-                                        </span>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-
-                        <div class="p-strip is--shallow p-form--stacked">
-                            <div class="row">
-                                <div class="col-6">
-                                    <h3 class="p-heading--five">Bridge details</h3>
-                                    <div class="p-form__group row u-vertically-center" data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBridgeInterface) }">
-                                        <label for="name" class="p-form__label col-2">Bridge name</label>
-                                        <div class="p-form__control col-4">
-                                            <input type="text" class="table__input editible" data-ng-model="newBridgeInterface.name">
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label for="bridge_type" class="p-form__label col-2">Bridge type</label>
-                                        <div class="p-form__control col-4">
-                                            <p>Standard</p>
-                                            <!-- Hidden until OVS becomes available -->
-                                            <!-- <select data-ng-model="newBridgeInterface.bridge_type">
+            <div class="p-strip is--shallow p-form--stacked">
+              <div class="row">
+                <div class="col-6">
+                  <h3 class="p-heading--five">Bridge details</h3>
+                  <div
+                    class="p-form__group row u-vertically-center"
+                    data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBridgeInterface) }"
+                  >
+                    <label for="name" class="p-form__label col-2"
+                      >Bridge name</label
+                    >
+                    <div class="p-form__control col-4">
+                      <input
+                        type="text"
+                        class="table__input editible"
+                        data-ng-model="newBridgeInterface.name"
+                      />
+                    </div>
+                  </div>
+                  <div class="p-form__group row u-vertically-center">
+                    <label for="bridge_type" class="p-form__label col-2"
+                      >Bridge type</label
+                    >
+                    <div class="p-form__control col-4">
+                      <p>Standard</p>
+                      <!-- Hidden until OVS becomes available -->
+                      <!-- <select data-ng-model="newBridgeInterface.bridge_type">
                                                 <option value="standard">Standard</option>
                                                 <option value="ovs">Open vSwitch (ovs)</option>
                                             </select> -->
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center" data-ng-class="{ 'is-error': isMACAddressInvalid(newBridgeInterface.mac_address) }">
-                                        <label for="mac" class="p-form__label col-2">MAC address</label>
-                                        <div class="p-form__control col-4">
-                                            <input type="text" name="mac" placeholder="00:00:00:00:00:00" data-ng-model="newBridgeInterface.mac_address" data-ng-value="newBridgeInterface.mac_address" data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi" maxlength="17" mac-address data-ng-placeholder="getInterfacePlaceholderMACAddress(newBridgeInterface)">
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label class="p-form__label col-2">Tags</label>
-                                        <div class="p-form__control col-4 tags--inline">
-                                            <tags-input data-ng-model="newBridgeInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-6">
-                                    <h3 class="p-heading--five">Network</h3>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label class="p-form__label col-2">Fabric</label>
-                                        <div class="p-form__control col-4">
-                                            <select
-                                                name="fabric"
-                                                data-ng-model="newBridgeInterface.fabric"
-                                                data-ng-options="fabric as fabric.name for fabric in fabrics"
-                                            >
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label class="p-form__label col-2">VLAN</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="vlan"
-                                                data-ng-model="newBridgeInterface.vlan"
-                                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | filterVLANNotOnFabric:newBridgeInterface.fabric.vlan_ids"
-                                            >
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label class="p-form__label col-2">Subnet</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="subnet"
-                                                data-ng-model="newBridgeInterface.subnet"
-                                                data-ng-change="subnetChanged(newBridgeInterface)"
-                                                data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newBridgeInterface.vlan">
-                                                <option value="" data-ng-hide="newBridgeInterface.type === 'alias'">Unconfigured</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="!isLinkModeDisabled(newBridgeInterface)">
-                                        <label for="link-mode" class="p-form__label col-2">IP mode</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="link-mode"
-                                                data-ng-model="newBridgeInterface.mode"
-                                                data-ng-change="modeChanged(newBridgeInterface)"
-                                                data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newBridgeInterface">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newBridgeInterface.mode == 'static'">
-                                        <label for="ip-address" class="p-form__label col-2">IP address</label>
-                                        <div class="p-form__control col-4"
-                                        data-ng-class="{ 'is-error': isIPAddressInvalid(newBridgeInterface) }">
-                                            <input name="ip-address" type="text" placeholder="IP address" data-ng-model="newBridgeInterface.ip_address">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="p-strip is--shallow p-form--stacked">
-                            <div class="row">
-                                <div class="col-6">
-                                    <h3 class="p-heading--five">Advanced options</h3>
-                                    <div class="p-form__group row u-vertically-center" style="min-height: 2.5rem;">
-                                        <label for="stp" class="p-form__label col-2">
-                                            STP
-                                            <span class="p-tooltip--right" aria-describedby="stp">
-                                                <i class="p-icon--question"></i>
-                                                <span class="p-tooltip__message" role="tooltip" id="stp">Controls the participation of this bridge in the spanning tree protocol.</span>
-                                            </span>
-                                        </label>
-                                        <div class="p-form__control col-4">
-                                            <div class="onoffswitch maas-p-switch">
-                                                <input id="bridge_stp" type="checkbox" name="bridge_stp" class="onoffswitch-checkbox maas-p-switch--input" data-ng-model="newBridgeInterface.bridge_stp">
-                                                <div class="maas-p-switch--mask"></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center" data-ng-if="newBridgeInterface.bridge_stp">
-                                        <label for="fd" class="p-form__label col-2">Forward delay (ms)</label>
-                                        <div class="p-form__control col-4">
-                                            <input type="text" name="fd" data-ng-model="newBridgeInterface.bridge_fd">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row u-sv1">
-                            <hr />
-                        </div>
-                        <div class="row">
-                            <div class="col-12 u-align--right">
-                                <button
-                                    class="p-button--base u-no-margin--bottom"
-                                    data-ng-click="cancel()"
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    class="p-button--positive u-no-margin--bottom"
-                                    data-ng-click="addBridge()"
-                                    data-ng-disabled="cannotAddBridge()"
-                                >
-                                    Save bridge
-                                </button>
-                            </div>
-                        </div>
                     </div>
+                  </div>
+                  <div
+                    class="p-form__group row u-vertically-center"
+                    data-ng-class="{ 'is-error': isMACAddressInvalid(newBridgeInterface.mac_address) }"
+                  >
+                    <label for="mac" class="p-form__label col-2"
+                      >MAC address</label
+                    >
+                    <div class="p-form__control col-4">
+                      <input
+                        type="text"
+                        name="mac"
+                        placeholder="00:00:00:00:00:00"
+                        data-ng-model="newBridgeInterface.mac_address"
+                        data-ng-value="newBridgeInterface.mac_address"
+                        data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi"
+                        maxlength="17"
+                        mac-address
+                        data-ng-placeholder="getInterfacePlaceholderMACAddress(newBridgeInterface)"
+                      />
+                    </div>
+                  </div>
+                  <div class="p-form__group row u-vertically-center">
+                    <label class="p-form__label col-2">Tags</label>
+                    <div class="p-form__control col-4 tags--inline">
+                      <tags-input
+                        data-ng-model="newBridgeInterface.tags"
+                        allow-tags-pattern="[\w-]+"
+                      ></tags-input>
+                    </div>
+                  </div>
                 </div>
+                <div class="col-6">
+                  <h3 class="p-heading--five">Network</h3>
+                  <div class="p-form__group row u-vertically-center">
+                    <label class="p-form__label col-2">Fabric</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="fabric"
+                        data-ng-model="newBridgeInterface.fabric"
+                        data-ng-options="fabric as fabric.name for fabric in fabrics"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div class="p-form__group row u-vertically-center">
+                    <label class="p-form__label col-2">VLAN</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="vlan"
+                        data-ng-model="newBridgeInterface.vlan"
+                        data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | filterVLANNotOnFabric:newBridgeInterface.fabric.vlan_ids"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div class="p-form__group row u-vertically-center">
+                    <label class="p-form__label col-2">Subnet</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="subnet"
+                        data-ng-model="newBridgeInterface.subnet"
+                        data-ng-change="subnetChanged(newBridgeInterface)"
+                        data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newBridgeInterface.vlan"
+                      >
+                        <option
+                          value=""
+                          data-ng-hide="newBridgeInterface.type === 'alias'"
+                          >Unconfigured</option
+                        >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="!isLinkModeDisabled(newBridgeInterface)"
+                  >
+                    <label for="link-mode" class="p-form__label col-2"
+                      >IP mode</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="link-mode"
+                        data-ng-model="newBridgeInterface.mode"
+                        data-ng-change="modeChanged(newBridgeInterface)"
+                        data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newBridgeInterface"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newBridgeInterface.mode == 'static'"
+                  >
+                    <label for="ip-address" class="p-form__label col-2"
+                      >IP address</label
+                    >
+                    <div
+                      class="p-form__control col-4"
+                      data-ng-class="{ 'is-error': isIPAddressInvalid(newBridgeInterface) }"
+                    >
+                      <input
+                        name="ip-address"
+                        type="text"
+                        placeholder="IP address"
+                        data-ng-model="newBridgeInterface.ip_address"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="p-strip is--shallow p-form--stacked">
+              <div class="row">
+                <div class="col-6">
+                  <h3 class="p-heading--five">Advanced options</h3>
+                  <div
+                    class="p-form__group row u-vertically-center"
+                    style="min-height: 2.5rem;"
+                  >
+                    <label for="stp" class="p-form__label col-2">
+                      STP
+                      <span class="p-tooltip--right" aria-describedby="stp">
+                        <i class="p-icon--question"></i>
+                        <span class="p-tooltip__message" role="tooltip" id="stp"
+                          >Controls the participation of this bridge in the
+                          spanning tree protocol.</span
+                        >
+                      </span>
+                    </label>
+                    <div class="p-form__control col-4">
+                      <div class="onoffswitch maas-p-switch">
+                        <input
+                          id="bridge_stp"
+                          type="checkbox"
+                          name="bridge_stp"
+                          class="onoffswitch-checkbox maas-p-switch--input"
+                          data-ng-model="newBridgeInterface.bridge_stp"
+                        />
+                        <div class="maas-p-switch--mask"></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row u-vertically-center"
+                    data-ng-if="newBridgeInterface.bridge_stp"
+                  >
+                    <label for="fd" class="p-form__label col-2"
+                      >Forward delay (ms)</label
+                    >
+                    <div class="p-form__control col-4">
+                      <input
+                        type="text"
+                        name="fd"
+                        data-ng-model="newBridgeInterface.bridge_fd"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row u-sv1">
+              <hr />
+            </div>
+            <div class="row">
+              <div class="col-12 u-align--right">
+                <button
+                  class="p-button--base u-no-margin--bottom"
+                  data-ng-click="cancel()"
+                >
+                  Cancel
+                </button>
+                <button
+                  class="p-button--positive u-no-margin--bottom"
+                  data-ng-click="addBridge()"
+                  data-ng-disabled="cannotAddBridge()"
+                >
+                  Save bridge
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
 
-                <div class="row" data-ng-repeat="interface in interfaces" data-ng-if="isInterfaceSelected(interface) && isShowingEdit() && interface.type === editInterface.type">
-                    <div class="p-card--highlighted">
-                        <h2 class="p-heading--four">Edit {$ getInterfaceTypeText(interface).toLowerCase() $}</h2>
-                        <table class="p-table-interface">
-                            <thead>
-                                <tr data-ng-if="isDevice" class="p-table--is-device">
-                                    <th class="p-double-row">
-                                        <div>Name</div>
-                                        <div>MAC</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Type</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Fabric</div>
-                                        <div>VLAN</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Subnet</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>IP Mode</div>
-                                    </th>
-                                </tr>
+        <div
+          class="row"
+          data-ng-repeat="interface in interfaces"
+          data-ng-if="isInterfaceSelected(interface) && isShowingEdit() && interface.type === editInterface.type"
+        >
+          <div class="p-card--highlighted">
+            <h2 class="p-heading--four">
+              Edit {$ getInterfaceTypeText(interface).toLowerCase() $}
+            </h2>
+            <table class="p-table-interface">
+              <thead>
+                <tr data-ng-if="isDevice" class="p-table--is-device">
+                  <th class="p-double-row">
+                    <div>Name</div>
+                    <div>MAC</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Type</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Fabric</div>
+                    <div>VLAN</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Subnet</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>IP Mode</div>
+                  </th>
+                </tr>
 
-                                <tr data-ng-if="!isDevice" class="p-table--is-not-device">
-                                    <th class="p-double-row">
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div>Name</div>
-                                            <div>MAC</div>
-                                        </div>
-                                    </th>
-                                    <th>
-                                        <div data-ng-if="!isController && !isBond(editInterface)">PXE</div>
-                                        <div data-ng-if="isBond(editInterface)">Primary</div>
-                                    </th>
-                                    <th class="p-table__col--status p-double-row">
-                                        <div class="p-double-row__icon-container">
-                                            <i class="p-icon--placeholder"></i>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            Link/interface speed
-                                        </div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Type</div>
-                                        <div>NUMA node</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Fabric</div>
-                                        <div>VLAN</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Subnet</div>
-                                        <div>Name</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>IP Address</div>
-                                        <div>IP Status</div>
-                                    </th>
-                                    <th>DHCP</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr data-ng-repeat="interface in interfaces" data-ng-if="isInterfaceSelected(interface) && !isBond(editInterface)">
-                                    <td class="p-double-row" aria-label="Name">
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row">
-                                                <div title="{$ interface.name $}">
-                                                    {$ interface.name $}
-                                                </div>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <div title="{$ interface.mac_address $}">
-                                                    {$ interface.mac_address $}
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Boot interface" ng-if="!isDevice">
-                                        <span class="u-align--center u-hide u-show--large">
-                                            <i class="p-icon--success" id="{$ interface.name $}" name="bootInterface" data-ng-if="!isController && isBootInterface(interface)"></i>
-                                        </span>
-                                        <span class="u-hide--large"
-                                            data-ng-if="!isController && isBootInterface(interface) && !isEditing(interface)">Yes</span>
-                                        <span class="u-hide--large"
-                                            data-ng-if="!isController && !isBootInterface(interface) && !isEditing(interface)">No</span>
-                                    </td>
-                                    <td class="p-table__col--status p-double-row" aria-label="Link and interface speed" ng-if="!isDevice">
-                                        <div class="p-double-row__icon-container">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                <span
-                                                    aria-describedby="not-connected-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="!isInterfaceConnected(interface)"
-                                                >
-                                                    <i class="p-icon--disconnected"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                                </span>
-                                                <span
-                                                    aria-describedby="link-speed-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
-                                                >
-                                                    <i class="p-icon--warning"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                                </span>
-                                                <i
-                                                    class="p-icon--placeholder"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
-                                                </i>
-                                            </span>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                {$ formatSpeedUnits(interface.link_speed) $}/{$ formatSpeedUnits(interface.interface_speed) $}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Type, NUMA node" class="p-double-row">
-                                        <div class="p-tooltip--top-left numa-tooltip"
-                                            ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }">
-                                            <div class="p-double-row__rows-container">
-                                                <div class="p-double-row__main-row" title="{$ getInterfaceTypeText(interface) $}">
-                                                    {$ getInterfaceTypeText(interface) $}
-                                                </div>
-                                                <div class="p-double-row__muted-row">
-                                                    <span>{$ getInterfaceNumaNodes(interface).join(", ") $}</span>
-                                                </div>
-                                            </div>
-                                            <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(interface).length > 1">This bond is spread over
-                                                multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="Fabric">
-                                                <span title="{$ interface.fabric.name || 'Disconnected' $}">
-                                                    <a class="p-link--soft" data-ng-if="interface.fabric" href="{$ legacyURLBase $}/fabric/{$ interface.fabric.id $}">{$
-                                                        interface.fabric.name $}</a>
-                                                    <span data-ng-if="!interface.fabric.name">Disconnected</span>
-                                                </span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="VLAN">
-                                                <span title="{$ getVLANText(interface.vlan) $}">
-                                                    <a class="p-muted-text p-link--muted" data-ng-if="interface.vlan"
-                                                        href="{$ legacyURLBase $}/vlan/{$ interface.vlan.id $}">
-                                                        {$ getVLANText(interface.vlan) $}
-                                                    </a>
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div data-ng-if="((isDevice && interface.subnet) || (interface.fabric && !interface.discovered[0].subnet_id))"
-                                            title="{$ getSubnetText(interface.subnet) $}" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="Subnet CIDR" title="{$ interface.subnet.cidr $}">
-                                                <span data-ng-if="interface.subnet.cidr">
-                                                    <a class="p-link--soft" href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}">{$ interface.subnet.cidr $}</a>
-                                                </span>
-                                                <span data-ng-if="!interface.subnet.cidr">Unconfigured</span>
-                                            </div>
-                                            <div data-ng-if="interface.subnet.name" class="p-double-row__muted-row" aria-label="Subnet name"
-                                                title="{$ interface.subnet.name $}">
-                                                <a class="p-muted-text p-link--muted" href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}">{$
-                                                    interface.subnet.name $}</a>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="isAllNetworkingDisabled() && interface.discovered[0].subnet_id"
-                                            class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="Subnet CIDR"
-                                                title="{$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}">
-                                                {$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Subnet name" title="">
-                                                &nbsp;
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div data-ng-if="!interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address" title="{$ interface.ip_address $}">
-                                                <span data-ng-if="interface.ip_address">{$ interface.ip_address $}</span>
-                                                <span data-ng-if="!interface.ip_address">{$ getLinkModeText(interface) $}</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="{$ getLinkModeText(interface) $}">
-                                                <span data-ng-if="interface.ip_address">{$ getLinkModeText(interface) $}</span>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address"
-                                                title="{$ interface.discovered[0].ip_address $}">
-                                                <span data-ng-if="interface.discovered[0].ip_address">{$ interface.discovered[0].ip_address $}</span>
-                                                <span data-ng-if="!interface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="DHCP">
-                                                <span data-ng-if="interface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td style="overflow: visible;">
-                                        {$ getDHCPStatus(interface.vlan) $}
-                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
-                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
-                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr data-ng-repeat="interface in editInterface.members" data-ng-if="isBond(editInterface)">
-                                    <td class=" p-double-row" aria-label="Name">
-                                        <div class="p-double-row__checkbox" data-ng-if="isShowingInterfaces">
-                                            <input type="checkbox" class="checkbox" id="{$ getUniqueKey(interface) $}"
-                                                data-ng-checked="isInterfaceSelected(interface)" data-ng-click="toggleEditInterfaceSelect(interface)">
-                                            <label class="is-inline-label" for="{$ getUniqueKey(interface) $}"></label>
-                                        </div>
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div class="p-double-row__main-row">
-                                                <div title="{$ interface.name $}">
-                                                    {$ interface.name $}
-                                                </div>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <div title="{$ interface.mac_address $}">
-                                                    {$ interface.mac_address $}
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Primary">
-                                        <input type="radio" name="bondPrimary" id="{$ interface.name $}" data-ng-model="editInterface.primary"
-                                            data-ng-value="interface">
-                                        <label class="is-inline-label" for="{$ interface.name $}"></label>
-                                    </td>
-                                    <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
-                                        <div class="p-double-row__icon-container">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                <span
-                                                    aria-describedby="not-connected-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="!isInterfaceConnected(interface)"
-                                                >
-                                                    <i class="p-icon--disconnected"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                                </span>
-                                                <span
-                                                    aria-describedby="link-speed-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
-                                                >
-                                                    <i class="p-icon--warning"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                                </span>
-                                                <i
-                                                    class="p-icon--placeholder"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
-                                                </i>
-                                            </span>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                {$ formatSpeedUnits(interface.link_speed) $}/{$ formatSpeedUnits(interface.interface_speed) $}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Type, NUMA node" class="p-double-row">
-                                        <div class="p-tooltip--top-left numa-tooltip"
-                                            ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }">
-                                            <div class="p-double-row__rows-container">
-                                                <div class="p-double-row__main-row" title="{$ getInterfaceTypeText(interface) $}">
-                                                    {$ getInterfaceTypeText(interface) $}
-                                                </div>
-                                                <div class="p-double-row__muted-row">
-                                                    <span>{$ getInterfaceNumaNodes(interface).join(", ") $}</span>
-                                                </div>
-                                            </div>
-                                            <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(interface).length > 1">This bond is spread over
-                                                multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="Fabric">
-                                                <span title="{$ editInterface.fabric.name || 'Disconnected' $}">
-                                                    <a class="p-link--soft" data-ng-if="editInterface.fabric"
-                                                        href="{$ legacyURLBase $}/fabric/{$ editInterface.fabric.id $}">{$
-                                                        editInterface.fabric.name $}</a>
-                                                    <span data-ng-if="!editInterface.fabric.name">Disconnected</span>
-                                                </span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="VLAN">
-                                                <span title="{$ getVLANText(editInterface.vlan) $}">
-                                                    <a class="p-muted-text p-link--muted" data-ng-if="editInterface.vlan"
-                                                        href="{$ legacyURLBase $}/vlan/{$ editInterface.vlan.id $}">
-                                                        {$ getVLANText(editInterface.vlan) $}
-                                                    </a>
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div data-ng-if="((isDevice && editInterface.subnet) || (editInterface.fabric && !editInterface.discovered[0].subnet_id))"
-                                            title="{$ getSubnetText(editInterface.subnet) $}" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="Subnet CIDR" title="{$ editInterface.subnet.cidr $}">
-                                                <span data-ng-if="editInterface.subnet.cidr">
-                                                    <a class="p-link--soft" href="{$ legacyURLBase $}/subnet/{$ editInterface.subnet.id $}">{$ editInterface.subnet.cidr
-                                                        $}</a>
-                                                </span>
-                                                <span data-ng-if="!editInterface.subnet.cidr">Unconfigured</span>
-                                            </div>
-                                            <div data-ng-if="editInterface.subnet.name" class="p-double-row__muted-row" aria-label="Subnet name"
-                                                title="{$ editInterface.subnet.name $}">
-                                                <a class="p-muted-text p-link--muted" href="{$ legacyURLBase $}/subnet/{$ editInterface.subnet.id $}">{$
-                                                    editInterface.subnet.name $}</a>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="isAllNetworkingDisabled() && editInterface.discovered[0].subnet_id"
-                                            class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="Subnet CIDR"
-                                                title="{$ getSubnetText(getSubnet(editInterface.discovered[0].subnet_id)) $}">
-                                                {$ getSubnetText(getSubnet(editInterface.discovered[0].subnet_id)) $}
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Subnet name" title="">
-                                                &nbsp;
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div data-ng-if="!editInterface.discovered[0].ip_address && editInterface.fabric"
-                                            class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address" title="{$ editInterface.ip_address $}">
-                                                <span data-ng-if="editInterface.ip_address">{$ editInterface.ip_address $}</span>
-                                                <span data-ng-if="!editInterface.ip_address">{$ getLinkModeText(editInterface) $}</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="{$ getLinkModeText(editInterface) $}">
-                                                <span data-ng-if="editInterface.ip_address">{$ getLinkModeText(editInterface) $}</span>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="editInterface.discovered[0].ip_address && editInterface.fabric"
-                                            class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address"
-                                                title="{$ editInterface.discovered[0].ip_address $}">
-                                                <span data-ng-if="editInterface.discovered[0].ip_address">{$ editInterface.discovered[0].ip_address
-                                                    $}</span>
-                                                <span data-ng-if="!editInterface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="DHCP">
-                                                <span data-ng-if="editInterface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td style="overflow: visible;">
-                                        {$ getDHCPStatus(interface.vlan) $}
-                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
-                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
-                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr class="p-table__row--muted"
-                                    data-ng-repeat="interface in interfaces | filterEditInterface:editInterface"
-                                    data-ng-if="isShowingInterfaces && isBond(editInterface) && isInterface(interface)">
-                                    <td class="p-double-row" aria-label="Name">
-                                        <div class="p-double-row__checkbox">
-                                            <input type="checkbox" class="checkbox" id="{$ getUniqueKey(interface) $}"
-                                                data-ng-checked="isInterfaceSelected(interface)" data-ng-click="toggleEditInterfaceSelect(interface)">
-                                            <label class="is-inline-label" for="{$ getUniqueKey(interface) $}"></label>
-                                        </div>
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div class="p-double-row__main-row">
-                                                {$ interface.name $}
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                {$ interface.mac_address $}
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Primary">
-                                        <input type="radio" name="bondPrimary" id="{$ interface.name $}" data-ng-model="editInterface.primary"
-                                            data-ng-value="interface">
-                                        <label class="is-inline-label" for="{$ interface.name $}"></label>
-                                    </td>
-                                    <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
-                                        <div class="p-double-row__icon-container">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                <span
-                                                    aria-describedby="not-connected-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="!isInterfaceConnected(interface)"
-                                                >
-                                                    <i class="p-icon--error"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                                </span>
-                                                <span
-                                                    aria-describedby="link-speed-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
-                                                >
-                                                    <i class="p-icon--warning"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                                </span>
-                                                <i
-                                                    class="p-icon--placeholder"
-                                                    ng-if="isInterfaceConnected(interface)d && interface.link_speed === interface.interface_speed">
-                                                </i>
-                                                </span>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                {$ formatSpeedUnits(interface.link_speed) $}/{$ formatSpeedUnits(interface.interface_speed) $}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Type, NUMA node" class="p-double-row">
-                                        <div class="p-tooltip--top-left numa-tooltip"
-                                            ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }">
-                                            <div class="p-double-row__rows-container">
-                                                <div class="p-double-row__main-row" title="{$ getInterfaceTypeText(interface) $}">
-                                                    {$ getInterfaceTypeText(interface) $}
-                                                </div>
-                                                <div class="p-double-row__muted-row">
-                                                    <span>{$ getInterfaceNumaNodes(interface).join(", ") $}</span>
-                                                </div>
-                                            </div>
-                                            <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(interface).length > 1">This bond is spread over
-                                                multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row" aria-label="Fabric">
-                                        <div class="p-double-row__main-row">
-                                            <span title="{$ interface.fabric.name || 'Disconnected' $}">
-                                                {$ interface.fabric.name $}
-                                                <span data-ng-if="!interface.fabric.name">Disconnected</span>
-                                            </span>
-                                        </div>
-                                        <div class="p-double-row__muted-row">
-                                            <span title="{$ getVLANText(interface.vlan) $}">
-                                                {$ getVLANText(interface.vlan) $}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Subnet CIDR">
-                                        <span title="{$ interface.subnet.cidr $}">
-                                            <span data-ng-if="interface.subnet.cidr">
-                                                {$ interface.subnet.cidr $}
-                                            </span>
-                                            <span data-ng-if="!interface.subnet.cidr">
-                                                Unconfigured
-                                            </span>
-                                        </span>
-                                    </td>
-                                    <td aria-label="IP address">
-                                        <div data-ng-if="!editInterface.discovered[0].ip_address && editInterface.fabric"
-                                            class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address" title="{$ editInterface.ip_address $}">
-                                                <span data-ng-if="editInterface.ip_address">{$ editInterface.ip_address $}</span>
-                                                <span data-ng-if="!editInterface.ip_address">{$ getLinkModeText(editInterface) $}</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="{$ getLinkModeText(editInterface) $}">
-                                                <span data-ng-if="editInterface.ip_address">{$ getLinkModeText(editInterface) $}</span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td style="overflow: visible;">
-                                        {$ getDHCPStatus(editInterface.vlan) $}
-                                        <span class="p-tooltip--btm-right" ng-if="editInterface.vlan && editInterface.vlan.relay_vlan" style="margin-left: .25rem;">
-                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(editInterface.vlan, true) $}</i>
-                                            <span class="p-tooltip__message">{$ getDHCPStatus(editInterface.vlan, true) $}</span>
-                                        </span>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                <tr data-ng-if="!isDevice" class="p-table--is-not-device">
+                  <th class="p-double-row">
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div>Name</div>
+                      <div>MAC</div>
+                    </div>
+                  </th>
+                  <th>
+                    <div data-ng-if="!isController && !isBond(editInterface)">
+                      PXE
+                    </div>
+                    <div data-ng-if="isBond(editInterface)">Primary</div>
+                  </th>
+                  <th class="p-table__col--status p-double-row">
+                    <div class="p-double-row__icon-container">
+                      <i class="p-icon--placeholder"></i>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      Link/interface speed
+                    </div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Type</div>
+                    <div>NUMA node</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Fabric</div>
+                    <div>VLAN</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Subnet</div>
+                    <div>Name</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>IP Address</div>
+                    <div>IP Status</div>
+                  </th>
+                  <th>DHCP</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  data-ng-repeat="interface in interfaces"
+                  data-ng-if="isInterfaceSelected(interface) && !isBond(editInterface)"
+                >
+                  <td class="p-double-row" aria-label="Name">
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row">
+                        <div title="{$ interface.name $}">
+                          {$ interface.name $}
+                        </div>
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <div title="{$ interface.mac_address $}">
+                          {$ interface.mac_address $}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Boot interface" ng-if="!isDevice">
+                    <span class="u-align--center u-hide u-show--large">
+                      <i
+                        class="p-icon--success"
+                        id="{$ interface.name $}"
+                        name="bootInterface"
+                        data-ng-if="!isController && isBootInterface(interface)"
+                      ></i>
+                    </span>
+                    <span
+                      class="u-hide--large"
+                      data-ng-if="!isController && isBootInterface(interface) && !isEditing(interface)"
+                      >Yes</span
+                    >
+                    <span
+                      class="u-hide--large"
+                      data-ng-if="!isController && !isBootInterface(interface) && !isEditing(interface)"
+                      >No</span
+                    >
+                  </td>
+                  <td
+                    class="p-table__col--status p-double-row"
+                    aria-label="Link and interface speed"
+                    ng-if="!isDevice"
+                  >
+                    <div class="p-double-row__icon-container">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        <span
+                          aria-describedby="not-connected-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="!isInterfaceConnected(interface)"
+                        >
+                          <i class="p-icon--disconnected"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="not-connected-tooltip"
+                            >This interface is disconnected.</span
+                          >
+                        </span>
+                        <span
+                          aria-describedby="link-speed-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                        >
+                          <i class="p-icon--warning"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="link-speed-tooltip"
+                            >Link connected to slow interface.</span
+                          >
+                        </span>
+                        <i
+                          class="p-icon--placeholder"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed"
+                        >
+                        </i>
+                      </span>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        {$ formatSpeedUnits(interface.link_speed) $}/{$
+                        formatSpeedUnits(interface.interface_speed) $}
+                      </span>
+                    </div>
+                  </td>
+                  <td aria-label="Type, NUMA node" class="p-double-row">
+                    <div
+                      class="p-tooltip--top-left numa-tooltip"
+                      ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }"
+                    >
+                      <div class="p-double-row__rows-container">
+                        <div
+                          class="p-double-row__main-row"
+                          title="{$ getInterfaceTypeText(interface) $}"
+                        >
+                          {$ getInterfaceTypeText(interface) $}
+                        </div>
+                        <div class="p-double-row__muted-row">
+                          <span
+                            >{$ getInterfaceNumaNodes(interface).join(", ")
+                            $}</span
+                          >
+                        </div>
+                      </div>
+                      <span
+                        class="p-tooltip__message"
+                        ng-if="getInterfaceNumaNodes(interface).length > 1"
+                        >This bond is spread over multiple NUMA nodes.<br />This
+                        may lead to suboptimal performance.</span
+                      >
+                    </div>
+                  </td>
+                  <td class="p-double-row">
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row" aria-label="Fabric">
+                        <span
+                          title="{$ interface.fabric.name || 'Disconnected' $}"
+                        >
+                          <a
+                            class="p-link--soft"
+                            data-ng-if="interface.fabric"
+                            href="{$ legacyURLBase $}/fabric/{$ interface.fabric.id $}"
+                            >{$ interface.fabric.name $}</a
+                          >
+                          <span data-ng-if="!interface.fabric.name"
+                            >Disconnected</span
+                          >
+                        </span>
+                      </div>
+                      <div class="p-double-row__muted-row" aria-label="VLAN">
+                        <span title="{$ getVLANText(interface.vlan) $}">
+                          <a
+                            class="p-muted-text p-link--muted"
+                            data-ng-if="interface.vlan"
+                            href="{$ legacyURLBase $}/vlan/{$ interface.vlan.id $}"
+                          >
+                            {$ getVLANText(interface.vlan) $}
+                          </a>
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="p-double-row">
+                    <div
+                      data-ng-if="((isDevice && interface.subnet) || (interface.fabric && !interface.discovered[0].subnet_id))"
+                      title="{$ getSubnetText(interface.subnet) $}"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="Subnet CIDR"
+                        title="{$ interface.subnet.cidr $}"
+                      >
+                        <span data-ng-if="interface.subnet.cidr">
+                          <a
+                            class="p-link--soft"
+                            href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                            >{$ interface.subnet.cidr $}</a
+                          >
+                        </span>
+                        <span data-ng-if="!interface.subnet.cidr"
+                          >Unconfigured</span
+                        >
+                      </div>
+                      <div
+                        data-ng-if="interface.subnet.name"
+                        class="p-double-row__muted-row"
+                        aria-label="Subnet name"
+                        title="{$ interface.subnet.name $}"
+                      >
+                        <a
+                          class="p-muted-text p-link--muted"
+                          href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                          >{$ interface.subnet.name $}</a
+                        >
+                      </div>
+                    </div>
+                    <div
+                      data-ng-if="isAllNetworkingDisabled() && interface.discovered[0].subnet_id"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="Subnet CIDR"
+                        title="{$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}"
+                      >
+                        {$
+                        getSubnetText(getSubnet(interface.discovered[0].subnet_id))
+                        $}
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Subnet name"
+                        title=""
+                      >
+                        &nbsp;
+                      </div>
+                    </div>
+                  </td>
+                  <td class="p-double-row">
+                    <div
+                      data-ng-if="!interface.discovered[0].ip_address && interface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ interface.ip_address $}"
+                      >
+                        <span data-ng-if="interface.ip_address"
+                          >{$ interface.ip_address $}</span
+                        >
+                        <span data-ng-if="!interface.ip_address"
+                          >{$ getLinkModeText(interface) $}</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="{$ getLinkModeText(interface) $}"
+                      >
+                        <span data-ng-if="interface.ip_address"
+                          >{$ getLinkModeText(interface) $}</span
+                        >
+                      </div>
+                    </div>
+                    <div
+                      data-ng-if="interface.discovered[0].ip_address && interface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ interface.discovered[0].ip_address $}"
+                      >
+                        <span data-ng-if="interface.discovered[0].ip_address"
+                          >{$ interface.discovered[0].ip_address $}</span
+                        >
+                        <span data-ng-if="!interface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="DHCP"
+                      >
+                        <span data-ng-if="interface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                    </div>
+                  </td>
+                  <td style="overflow: visible;">
+                    {$ getDHCPStatus(interface.vlan) $}
+                    <span
+                      class="p-tooltip--btm-right"
+                      ng-if="interface.vlan && interface.vlan.relay_vlan"
+                      style="margin-left: 0.25rem;"
+                    >
+                      <i class="p-icon--information" style="width: 0.875rem;"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</i
+                      >
+                      <span class="p-tooltip__message"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</span
+                      >
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  data-ng-repeat="interface in editInterface.members"
+                  data-ng-if="isBond(editInterface)"
+                >
+                  <td class="p-double-row" aria-label="Name">
+                    <div
+                      class="p-double-row__checkbox"
+                      data-ng-if="isShowingInterfaces"
+                    >
+                      <input
+                        type="checkbox"
+                        class="checkbox"
+                        id="{$ getUniqueKey(interface) $}"
+                        data-ng-checked="isInterfaceSelected(interface)"
+                        data-ng-click="toggleEditInterfaceSelect(interface)"
+                      />
+                      <label
+                        class="is-inline-label"
+                        for="{$ getUniqueKey(interface) $}"
+                      ></label>
+                    </div>
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div class="p-double-row__main-row">
+                        <div title="{$ interface.name $}">
+                          {$ interface.name $}
+                        </div>
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <div title="{$ interface.mac_address $}">
+                          {$ interface.mac_address $}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Primary">
+                    <input
+                      type="radio"
+                      name="bondPrimary"
+                      id="{$ interface.name $}"
+                      data-ng-model="editInterface.primary"
+                      data-ng-value="interface"
+                    />
+                    <label
+                      class="is-inline-label"
+                      for="{$ interface.name $}"
+                    ></label>
+                  </td>
+                  <td
+                    class="p-table__col--status p-double-row"
+                    aria-label="Link and interface speed"
+                  >
+                    <div class="p-double-row__icon-container">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        <span
+                          aria-describedby="not-connected-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="!isInterfaceConnected(interface)"
+                        >
+                          <i class="p-icon--disconnected"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="not-connected-tooltip"
+                            >This interface is disconnected.</span
+                          >
+                        </span>
+                        <span
+                          aria-describedby="link-speed-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                        >
+                          <i class="p-icon--warning"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="link-speed-tooltip"
+                            >Link connected to slow interface.</span
+                          >
+                        </span>
+                        <i
+                          class="p-icon--placeholder"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed"
+                        >
+                        </i>
+                      </span>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        {$ formatSpeedUnits(interface.link_speed) $}/{$
+                        formatSpeedUnits(interface.interface_speed) $}
+                      </span>
+                    </div>
+                  </td>
+                  <td aria-label="Type, NUMA node" class="p-double-row">
+                    <div
+                      class="p-tooltip--top-left numa-tooltip"
+                      ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }"
+                    >
+                      <div class="p-double-row__rows-container">
+                        <div
+                          class="p-double-row__main-row"
+                          title="{$ getInterfaceTypeText(interface) $}"
+                        >
+                          {$ getInterfaceTypeText(interface) $}
+                        </div>
+                        <div class="p-double-row__muted-row">
+                          <span
+                            >{$ getInterfaceNumaNodes(interface).join(", ")
+                            $}</span
+                          >
+                        </div>
+                      </div>
+                      <span
+                        class="p-tooltip__message"
+                        ng-if="getInterfaceNumaNodes(interface).length > 1"
+                        >This bond is spread over multiple NUMA nodes.<br />This
+                        may lead to suboptimal performance.</span
+                      >
+                    </div>
+                  </td>
+                  <td class="p-double-row">
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row" aria-label="Fabric">
+                        <span
+                          title="{$ editInterface.fabric.name || 'Disconnected' $}"
+                        >
+                          <a
+                            class="p-link--soft"
+                            data-ng-if="editInterface.fabric"
+                            href="{$ legacyURLBase $}/fabric/{$ editInterface.fabric.id $}"
+                            >{$ editInterface.fabric.name $}</a
+                          >
+                          <span data-ng-if="!editInterface.fabric.name"
+                            >Disconnected</span
+                          >
+                        </span>
+                      </div>
+                      <div class="p-double-row__muted-row" aria-label="VLAN">
+                        <span title="{$ getVLANText(editInterface.vlan) $}">
+                          <a
+                            class="p-muted-text p-link--muted"
+                            data-ng-if="editInterface.vlan"
+                            href="{$ legacyURLBase $}/vlan/{$ editInterface.vlan.id $}"
+                          >
+                            {$ getVLANText(editInterface.vlan) $}
+                          </a>
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td class="p-double-row">
+                    <div
+                      data-ng-if="((isDevice && editInterface.subnet) || (editInterface.fabric && !editInterface.discovered[0].subnet_id))"
+                      title="{$ getSubnetText(editInterface.subnet) $}"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="Subnet CIDR"
+                        title="{$ editInterface.subnet.cidr $}"
+                      >
+                        <span data-ng-if="editInterface.subnet.cidr">
+                          <a
+                            class="p-link--soft"
+                            href="{$ legacyURLBase $}/subnet/{$ editInterface.subnet.id $}"
+                            >{$ editInterface.subnet.cidr $}</a
+                          >
+                        </span>
+                        <span data-ng-if="!editInterface.subnet.cidr"
+                          >Unconfigured</span
+                        >
+                      </div>
+                      <div
+                        data-ng-if="editInterface.subnet.name"
+                        class="p-double-row__muted-row"
+                        aria-label="Subnet name"
+                        title="{$ editInterface.subnet.name $}"
+                      >
+                        <a
+                          class="p-muted-text p-link--muted"
+                          href="{$ legacyURLBase $}/subnet/{$ editInterface.subnet.id $}"
+                          >{$ editInterface.subnet.name $}</a
+                        >
+                      </div>
+                    </div>
+                    <div
+                      data-ng-if="isAllNetworkingDisabled() && editInterface.discovered[0].subnet_id"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="Subnet CIDR"
+                        title="{$ getSubnetText(getSubnet(editInterface.discovered[0].subnet_id)) $}"
+                      >
+                        {$
+                        getSubnetText(getSubnet(editInterface.discovered[0].subnet_id))
+                        $}
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Subnet name"
+                        title=""
+                      >
+                        &nbsp;
+                      </div>
+                    </div>
+                  </td>
+                  <td class="p-double-row">
+                    <div
+                      data-ng-if="!editInterface.discovered[0].ip_address && editInterface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ editInterface.ip_address $}"
+                      >
+                        <span data-ng-if="editInterface.ip_address"
+                          >{$ editInterface.ip_address $}</span
+                        >
+                        <span data-ng-if="!editInterface.ip_address"
+                          >{$ getLinkModeText(editInterface) $}</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="{$ getLinkModeText(editInterface) $}"
+                      >
+                        <span data-ng-if="editInterface.ip_address"
+                          >{$ getLinkModeText(editInterface) $}</span
+                        >
+                      </div>
+                    </div>
+                    <div
+                      data-ng-if="editInterface.discovered[0].ip_address && editInterface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ editInterface.discovered[0].ip_address $}"
+                      >
+                        <span
+                          data-ng-if="editInterface.discovered[0].ip_address"
+                          >{$ editInterface.discovered[0].ip_address $}</span
+                        >
+                        <span
+                          data-ng-if="!editInterface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="DHCP"
+                      >
+                        <span
+                          data-ng-if="editInterface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                    </div>
+                  </td>
+                  <td style="overflow: visible;">
+                    {$ getDHCPStatus(interface.vlan) $}
+                    <span
+                      class="p-tooltip--btm-right"
+                      ng-if="interface.vlan && interface.vlan.relay_vlan"
+                      style="margin-left: 0.25rem;"
+                    >
+                      <i class="p-icon--information" style="width: 0.875rem;"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</i
+                      >
+                      <span class="p-tooltip__message"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</span
+                      >
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="p-table__row--muted"
+                  data-ng-repeat="interface in interfaces | filterEditInterface:editInterface"
+                  data-ng-if="isShowingInterfaces && isBond(editInterface) && isInterface(interface)"
+                >
+                  <td class="p-double-row" aria-label="Name">
+                    <div class="p-double-row__checkbox">
+                      <input
+                        type="checkbox"
+                        class="checkbox"
+                        id="{$ getUniqueKey(interface) $}"
+                        data-ng-checked="isInterfaceSelected(interface)"
+                        data-ng-click="toggleEditInterfaceSelect(interface)"
+                      />
+                      <label
+                        class="is-inline-label"
+                        for="{$ getUniqueKey(interface) $}"
+                      ></label>
+                    </div>
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div class="p-double-row__main-row">
+                        {$ interface.name $}
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        {$ interface.mac_address $}
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Primary">
+                    <input
+                      type="radio"
+                      name="bondPrimary"
+                      id="{$ interface.name $}"
+                      data-ng-model="editInterface.primary"
+                      data-ng-value="interface"
+                    />
+                    <label
+                      class="is-inline-label"
+                      for="{$ interface.name $}"
+                    ></label>
+                  </td>
+                  <td
+                    class="p-table__col--status p-double-row"
+                    aria-label="Link and interface speed"
+                  >
+                    <div class="p-double-row__icon-container">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        <span
+                          aria-describedby="not-connected-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="!isInterfaceConnected(interface)"
+                        >
+                          <i class="p-icon--error"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="not-connected-tooltip"
+                            >This interface is disconnected.</span
+                          >
+                        </span>
+                        <span
+                          aria-describedby="link-speed-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                        >
+                          <i class="p-icon--warning"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="link-speed-tooltip"
+                            >Link connected to slow interface.</span
+                          >
+                        </span>
+                        <i
+                          class="p-icon--placeholder"
+                          ng-if="isInterfaceConnected(interface)d && interface.link_speed === interface.interface_speed"
+                        >
+                        </i>
+                      </span>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        {$ formatSpeedUnits(interface.link_speed) $}/{$
+                        formatSpeedUnits(interface.interface_speed) $}
+                      </span>
+                    </div>
+                  </td>
+                  <td aria-label="Type, NUMA node" class="p-double-row">
+                    <div
+                      class="p-tooltip--top-left numa-tooltip"
+                      ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }"
+                    >
+                      <div class="p-double-row__rows-container">
+                        <div
+                          class="p-double-row__main-row"
+                          title="{$ getInterfaceTypeText(interface) $}"
+                        >
+                          {$ getInterfaceTypeText(interface) $}
+                        </div>
+                        <div class="p-double-row__muted-row">
+                          <span
+                            >{$ getInterfaceNumaNodes(interface).join(", ")
+                            $}</span
+                          >
+                        </div>
+                      </div>
+                      <span
+                        class="p-tooltip__message"
+                        ng-if="getInterfaceNumaNodes(interface).length > 1"
+                        >This bond is spread over multiple NUMA nodes.<br />This
+                        may lead to suboptimal performance.</span
+                      >
+                    </div>
+                  </td>
+                  <td class="p-double-row" aria-label="Fabric">
+                    <div class="p-double-row__main-row">
+                      <span
+                        title="{$ interface.fabric.name || 'Disconnected' $}"
+                      >
+                        {$ interface.fabric.name $}
+                        <span data-ng-if="!interface.fabric.name"
+                          >Disconnected</span
+                        >
+                      </span>
+                    </div>
+                    <div class="p-double-row__muted-row">
+                      <span title="{$ getVLANText(interface.vlan) $}">
+                        {$ getVLANText(interface.vlan) $}
+                      </span>
+                    </div>
+                  </td>
+                  <td aria-label="Subnet CIDR">
+                    <span title="{$ interface.subnet.cidr $}">
+                      <span data-ng-if="interface.subnet.cidr">
+                        {$ interface.subnet.cidr $}
+                      </span>
+                      <span data-ng-if="!interface.subnet.cidr">
+                        Unconfigured
+                      </span>
+                    </span>
+                  </td>
+                  <td aria-label="IP address">
+                    <div
+                      data-ng-if="!editInterface.discovered[0].ip_address && editInterface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ editInterface.ip_address $}"
+                      >
+                        <span data-ng-if="editInterface.ip_address"
+                          >{$ editInterface.ip_address $}</span
+                        >
+                        <span data-ng-if="!editInterface.ip_address"
+                          >{$ getLinkModeText(editInterface) $}</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="{$ getLinkModeText(editInterface) $}"
+                      >
+                        <span data-ng-if="editInterface.ip_address"
+                          >{$ getLinkModeText(editInterface) $}</span
+                        >
+                      </div>
+                    </div>
+                  </td>
+                  <td style="overflow: visible;">
+                    {$ getDHCPStatus(editInterface.vlan) $}
+                    <span
+                      class="p-tooltip--btm-right"
+                      ng-if="editInterface.vlan && editInterface.vlan.relay_vlan"
+                      style="margin-left: 0.25rem;"
+                    >
+                      <i class="p-icon--information" style="width: 0.875rem;"
+                        >{$ getDHCPStatus(editInterface.vlan, true) $}</i
+                      >
+                      <span class="p-tooltip__message"
+                        >{$ getDHCPStatus(editInterface.vlan, true) $}</span
+                      >
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
 
-                        <button class="p-button--neutral" data-ng-click="toggleInterfaces()" data-ng-if="showEditButton(editInterface, interfaces)">
-                            <span data-ng-if="isShowingInterfaces">Hide interfaces</span>
-                            <span data-ng-if="!isShowingInterfaces"
-                                data-ng-click="sendAnalyticsEvent('Machine details', 'Edit bond members', 'Network tab')">Edit bond members</span>
-                        </button>
+            <button
+              class="p-button--neutral"
+              data-ng-click="toggleInterfaces()"
+              data-ng-if="showEditButton(editInterface, interfaces)"
+            >
+              <span data-ng-if="isShowingInterfaces">Hide interfaces</span>
+              <span
+                data-ng-if="!isShowingInterfaces"
+                data-ng-click="sendAnalyticsEvent('Machine details', 'Edit bond members', 'Network tab')"
+                >Edit bond members</span
+              >
+            </button>
 
-                        <div class="p-form p-form--stacked" data-ng-class="{ 'is-active': isEditing(interface) || isShowingAdd() }">
-                            <div class="row" data-ng-if="isShowingAdd()">
-                                <div class="col-6">
-                                    <div class="p-form__group row">
-                                        <label class="p-form__label col-2">Name</label>
-                                        <div class="p-form__control col-4">
-                                            {$ getAddName() $}
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row">
-                                        <label for="type" class="p-form__label col-2">Type</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="type" data-ng-model="newInterface.type" data-ng-change="addTypeChanged()">
-                                                <option value="alias" data-ng-show="canAddAlias(newInterface.parent)">Alias</option>
-                                                <option value="vlan" data-ng-show="canAddVLAN(newInterface.parent)">VLAN</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newInterface.type !== 'alias'">
-                                        <label class="p-form__label col-2">Tags</label>
-                                        <div class="p-form__control col-4 tags--inline">
-                                            <tags-input data-ng-model="newInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-6">
-                                    <div class="p-form__group row">
-                                        <label for="fabric" class="p-form__label col-2">Fabric</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="fabric"
-                                                data-ng-model="newInterface.parent.fabric"
-                                                data-ng-options="fabric as fabric.name for fabric in fabrics"
-                                                disabled="disabled">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newInterface.type === 'alias'">
-                                        <label for="vlan" class="p-form__label col-2">VLAN</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="vlan"
-                                                data-ng-model="newInterface.vlan"
-                                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans"
-                                                disabled="disabled">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newInterface.type === 'vlan'">
-                                        <label for="vlan" class="p-form__label col-2">VLAN</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="vlan"
-                                                data-ng-model="newInterface.vlan"
-                                                data-ng-change="vlanChanged(newInterface)"
-                                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | removeDefaultVLAN | filterByFabric:newInterface.parent.fabric | filterByUnusedForInterface:newInterface.parent:originalInterfaces">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row">
-                                        <label for="subnet" class="p-form__label col-2">Subnet</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="subnet"
-                                                data-ng-model="newInterface.subnet"
-                                                data-ng-change="subnetChanged(newInterface)"
-                                                data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newInterface.vlan">
-                                                <option value="" data-ng-hide="newInterface.type === 'alias'">Unconfigured</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="!isLinkModeDisabled(newInterface)">
-                                        <label for="link-mode" class="p-form__label col-2">IP mode</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="link-mode"
-                                                data-ng-model="newInterface.mode"
-                                                data-ng-change="modeChanged(newInterface)"
-                                                data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newInterface">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newInterface.mode == 'static'">
-                                        <label for="ip-address" class="p-form__label col-2">IP address</label>
-                                        <div class="p-form__control col-4"
-                                        data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }">
-                                            <input name="ip-address" type="text" placeholder="IP address" data-ng-model="newInterface.ip_address">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+            <div
+              class="p-form p-form--stacked"
+              data-ng-class="{ 'is-active': isEditing(interface) || isShowingAdd() }"
+            >
+              <div class="row" data-ng-if="isShowingAdd()">
+                <div class="col-6">
+                  <div class="p-form__group row">
+                    <label class="p-form__label col-2">Name</label>
+                    <div class="p-form__control col-4">
+                      {$ getAddName() $}
+                    </div>
+                  </div>
+                  <div class="p-form__group row">
+                    <label for="type" class="p-form__label col-2">Type</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="type"
+                        data-ng-model="newInterface.type"
+                        data-ng-change="addTypeChanged()"
+                      >
+                        <option
+                          value="alias"
+                          data-ng-show="canAddAlias(newInterface.parent)"
+                          >Alias</option
+                        >
+                        <option
+                          value="vlan"
+                          data-ng-show="canAddVLAN(newInterface.parent)"
+                          >VLAN</option
+                        >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newInterface.type !== 'alias'"
+                  >
+                    <label class="p-form__label col-2">Tags</label>
+                    <div class="p-form__control col-4 tags--inline">
+                      <tags-input
+                        data-ng-model="newInterface.tags"
+                        allow-tags-pattern="[\w-]+"
+                      ></tags-input>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-6">
+                  <div class="p-form__group row">
+                    <label for="fabric" class="p-form__label col-2"
+                      >Fabric</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="fabric"
+                        data-ng-model="newInterface.parent.fabric"
+                        data-ng-options="fabric as fabric.name for fabric in fabrics"
+                        disabled="disabled"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newInterface.type === 'alias'"
+                  >
+                    <label for="vlan" class="p-form__label col-2">VLAN</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="vlan"
+                        data-ng-model="newInterface.vlan"
+                        data-ng-options="vlan as getVLANText(vlan) for vlan in vlans"
+                        disabled="disabled"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newInterface.type === 'vlan'"
+                  >
+                    <label for="vlan" class="p-form__label col-2">VLAN</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="vlan"
+                        data-ng-model="newInterface.vlan"
+                        data-ng-change="vlanChanged(newInterface)"
+                        data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | removeDefaultVLAN | filterByFabric:newInterface.parent.fabric | filterByUnusedForInterface:newInterface.parent:originalInterfaces"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div class="p-form__group row">
+                    <label for="subnet" class="p-form__label col-2"
+                      >Subnet</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="subnet"
+                        data-ng-model="newInterface.subnet"
+                        data-ng-change="subnetChanged(newInterface)"
+                        data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newInterface.vlan"
+                      >
+                        <option
+                          value=""
+                          data-ng-hide="newInterface.type === 'alias'"
+                          >Unconfigured</option
+                        >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="!isLinkModeDisabled(newInterface)"
+                  >
+                    <label for="link-mode" class="p-form__label col-2"
+                      >IP mode</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="link-mode"
+                        data-ng-model="newInterface.mode"
+                        data-ng-change="modeChanged(newInterface)"
+                        data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newInterface"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newInterface.mode == 'static'"
+                  >
+                    <label for="ip-address" class="p-form__label col-2"
+                      >IP address</label
+                    >
+                    <div
+                      class="p-form__control col-4"
+                      data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }"
+                    >
+                      <input
+                        name="ip-address"
+                        type="text"
+                        placeholder="IP address"
+                        data-ng-model="newInterface.ip_address"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
 
-                            <div class="row" data-ng-if="isEditing(editInterface)">
-                                <div class="row" data-ng-if="editInterface.type !== 'bond'">
-                                    <maas-obj-form obj="editInterface" manager="nodesManager" manager-method="updateInterfaceForm"
-                                        table-form="true" save-on-blur="false" after-save="editSave" pre-process="preProcessInterface">
-                                        <div class="p-strip is-shallow">
-                                            <div class="row">
-                                                <div class="col-6">
-                                                    <h3 class="p-heading--five">{$ getInterfaceTypeText(interface) $} details</h3>
-                                                    <maas-obj-field type="text" key="name" label="Name"
-                                                        data-ng-if="interface.type !== 'alias' && interface.type !== 'vlan'" disable-label="false"
-                                                        label-width="2" input-width="4"
-                                                        input-class="table__input"></maas-obj-field>
-                                                    <div class="p-form__group row u-vertically-center" data-ng-if="interface.type === 'bridge'">
-                                                        <label for="bridge_type" class="p-form__label col-2">Bridge type</label>
-                                                        <div class="p-form__control col-4">
-                                                            <p>Standard</p>
-                                                            <!-- Hidden until OVS becomes available -->
-                                                            <!-- <select data-ng-model="editInterface.bridge_type">
+              <div class="row" data-ng-if="isEditing(editInterface)">
+                <div class="row" data-ng-if="editInterface.type !== 'bond'">
+                  <maas-obj-form
+                    obj="editInterface"
+                    manager="nodesManager"
+                    manager-method="updateInterfaceForm"
+                    table-form="true"
+                    save-on-blur="false"
+                    after-save="editSave"
+                    pre-process="preProcessInterface"
+                  >
+                    <div class="p-strip is-shallow">
+                      <div class="row">
+                        <div class="col-6">
+                          <h3 class="p-heading--five">
+                            {$ getInterfaceTypeText(interface) $} details
+                          </h3>
+                          <maas-obj-field
+                            type="text"
+                            key="name"
+                            label="Name"
+                            data-ng-if="interface.type !== 'alias' && interface.type !== 'vlan'"
+                            disable-label="false"
+                            label-width="2"
+                            input-width="4"
+                            input-class="table__input"
+                          ></maas-obj-field>
+                          <div
+                            class="p-form__group row u-vertically-center"
+                            data-ng-if="interface.type === 'bridge'"
+                          >
+                            <label for="bridge_type" class="p-form__label col-2"
+                              >Bridge type</label
+                            >
+                            <div class="p-form__control col-4">
+                              <p>Standard</p>
+                              <!-- Hidden until OVS becomes available -->
+                              <!-- <select data-ng-model="editInterface.bridge_type">
                                                                 <option value="standard">Standard</option>
                                                                 <option value="ovs">Open vSwitch (ovs)</option>
                                                             </select> -->
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row">
-                                                        <label for="mac" class="p-form__label col-2">MAC address</label>
-                                                        <div class="p-form__control col-4 p-form-validation"
-                                                            data-ng-class="{ 'is-error': isMACAddressInvalid(editInterface.mac_address) }">
-                                                            <input type="text" name="mac" class="p-form-validation__input"
-                                                                placeholder="00:00:00:00:00:00"
-                                                                data-ng-value="editInterface.mac_address"
-                                                                data-ng-model="editInterface.mac_address"
-                                                                data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi" mac-address maxlength="17"
-                                                                data-ng-placeholder="getInterfacePlaceholderMACAddress(editInterface)"
-                                                            >
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row" data-ng-if="!isAllNetworkingDisabled(interface)">
-                                                        <label class="p-form__label col-2">Tags</label>
-                                                        <div class="p-form__control col-4 tags--inline">
-                                                            <tags-input data-ng-model="editInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row p-form-validation" data-ng-class="{ 'is-error': !linkSpeedValid(editInterface) }" data-ng-if="editInterface.type === 'physical'">
-                                                        <label class="p-form__label col-2">Link speed (Gbps)</label>
-                                                        <div class="p-form__control col-4">
-                                                            <input type="text" name="link_speed" id="link_speed" data-ng-model="editInterface.formatted_link_speed"
-                                                                data-ng-disabled="!editInterface.link_connected" class="p-form-validation__input">
-                                                            <p class="p-form-validation__message u-no-margin--top" data-ng-if="!linkSpeedValid(editInterface)">
-                                                                <strong>Error:</strong> Link speed cannot be higher than interface speed
-                                                            </p>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row" data-ng-if="editInterface.type === 'physical'">
-                                                        <label class="p-form__label col-2">Interface speed (Gbps)</label>
-                                                        <div class="p-form__control col-4">
-                                                            <input type="text" name="interface_speed" id="interface_speed" data-ng-model="editInterface.formatted_interface_speed" data-ng-disabled="!editInterface.link_connected">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-6" data-ng-if="!isAllNetworkingDisabled(interface)">
-                                                    <h3 class="p-heading--five">Network</h3>
-                                                    <maas-obj-field type="options" key="fabric" label="Fabric"
-                                                        disable-label="false"
-                                                        placeholder="Disconnected" placeholder-enabled="true"
-                                                        on-change="fabricChangedForm"
-                                                        options="fabric as fabric.name for fabric in fabrics"
-                                                        label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4"></maas-obj-field>
-                                                    <maas-obj-field type="options" key="vlan" label="VLAN"
-                                                        disable-label="false"
-                                                        data-ng-show="!isController && editInterface.$maasForm.getValue('fabric')"
-                                                        on-change="vlanChangedForm"
-                                                        options="vlan as getVLANText(vlan) for vlan in vlans | removeDefaultVLANIfVLAN:interface.type | filterByFabric:editInterface.$maasForm.getValue('fabric')"
-                                                        label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4">
-                                                    </maas-obj-field>
-                                                    <maas-obj-field type="options" key="subnet" label="Subnet" placeholder="Unconfigured" placeholder-enabled="true"
-                                                        disable-label="false"
-                                                        data-ng-show="!isController && editInterface.$maasForm.getValue('fabric')"
-                                                        on-change="subnetChangedForm"
-                                                        options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:editInterface.$maasForm.getValue('vlan')"
-                                                        label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4">
-                                                        </maas-obj-field>
-                                                    <maas-obj-field type="options" key="subnet" label="Subnet" placeholder="Unconfigured" placeholder-enabled="true"
-                                                        data-ng-init="editInterface.subnet = editInterface.defaultSubnet"
-                                                        data-ng-if="!isController && editInterface.$maasForm.getValue('ip_assignment') === 'static'"
-                                                        on-change="subnetChangedForm"
-                                                        disable-label="false"
-                                                        options="subnet as getSubnetText(subnet) for subnet in subnets"
-                                                        label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4"></maas-obj-field>
-                                                    <maas-obj-field type="options" key="mode" label="IP mode"
-                                                        disable-label="false"
-                                                        data-ng-if="!isController && editInterface.$maasForm.getValue('fabric') && !isLinkModeDisabled(editInterface.$maasForm)"
-                                                        options="mode.mode as mode.text for mode in modes | filterLinkModes:editInterface.$maasForm"
-                                                        on-change="modeChangedForm"
-                                                        label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4">
-                                                        </maas-obj-field>
-                                                    <maas-obj-field type="text" key="ip_address" label="IP address" placeholder="IP Address"
-                                                        disable-label="false" input-class="table__input"
-                                                        data-ng-if="!isController && editInterface.$maasForm.getValue('fabric') && editInterface.$maasForm.getValue('mode') == 'static'"
-                                                        label-width="2" label-width-tablet="2" input-width="4" input-width-tablet="4">
-                                                        </maas-obj-field>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="p-strip is-shallow" data-ng-if="editInterface.type !== 'physical'">
-                                            <div class="row">
-                                                <div class="col-6">
-                                                    <h3 class="p-heading--five">Advanced options</h3>
-                                                    <div class="p-form__group row u-vertically-center" style="min-height: 2.5rem;">
-                                                        <label for="stp" class="p-form__label col-2">
-                                                            STP
-                                                            <span class="p-tooltip--right" aria-describedby="stp">
-                                                                <i class="p-icon--question"></i>
-                                                                <span class="p-tooltip__message" role="tooltip" id="stp">Controls the participation of this bridge in the spanning tree protocol.</span>
-                                                            </span>
-                                                        </label>
-                                                        <div class="p-form__control col-4">
-                                                            <div class="onoffswitch maas-p-switch">
-                                                                <input id="bridge_stp" type="checkbox" name="bridge_stp" class="onoffswitch-checkbox maas-p-switch--input" data-ng-model="editInterface.bridge_stp">
-                                                                <div class="maas-p-switch--mask"></div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group u-vertically-center" data-ng-if="editInterface.bridge_stp">
-                                                        <label for="fd" class="p-form__label col-2">Forward delay (ms)</label>
-                                                        <div class="p-form__control col-4">
-                                                            <input type="text" name="fd" data-ng-model="editInterface.bridge_fd">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <hr />
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-6">
-                                                <maas-obj-errors></maas-obj-errors>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="u-align--right">
-                                                    <button class="p-button--base u-no-margin--bottom"
-                                                        data-ng-click="editCancel()">Cancel</button>
-                                                    <button class="p-button--positive u-no-margin--bottom"
-                                                    data-ng-disabled="cannotEditBond(editInterface)"
-                                                    maas-obj-save>Save {$ getInterfaceTypeText(interface).toLowerCase() $}</button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </maas-obj-form>
-                                </div>
-
-                                <div class="row" data-ng-if="editInterface.type === 'bond'">
-                                    <maas-obj-form obj="editInterface" manager="nodesManager" manager-method="updateInterfaceForm" table-form="true" save-on-blur="false" after-save="editSave" pre-process="preProcessInterface">
-                                        <div class="p-strip is-shallow">
-                                            <div class="row p-form--stacked">
-                                                <div class="col-6">
-                                                    <h3 class="p-heading--five">Bond details</h3>
-                                                    <div class="p-form__group row">
-                                                        <label for="bond-mode" class="p-form__label col-2">Bond mode</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select
-                                                                name="bond-mode"
-                                                                ng-change="handleEditBondMode(editInterface.bond_mode)"
-                                                                ng-model="editInterface.bond_mode"
-                                                                ng-options="mode[0] as mode[1] for mode in bondOptions.modes"
-                                                            >
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row p-form-validation" data-ng-if="showXMITHashPolicy()"
-                                                        data-ng-class="{ 'is-caution': showLACPRate() && modeAndPolicyCompliant() }">
-                                                        <label for="xmit-hash-policy" class="p-form__label col-2">Hash policy</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select name="xmit-hash-policy"
-                                                                class="p-form-validation__input"
-                                                                data-ng-model="editInterface.bond_xmit_hash_policy"
-                                                                data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies">
-                                                            </select>
-                                                            <p class="p-form-validation__message" data-ng-if="showLACPRate() && modeAndPolicyCompliant()">
-                                                                <strong>Warning:</strong> This hash policy is not fully 802.3ad compliant.
-                                                            </p>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row" data-ng-if="showLACPRate()">
-                                                        <label for="lacp-rate" class="p-form__label col-2">LACP rate</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select name="lacp-rate"
-                                                                data-ng-model="editInterface.bond_lacp_rate"
-                                                                data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates">
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row">
-                                                        <label for="bond-name" class="p-form__label col-2">Bond name</label>
-                                                        <div
-                                                            class="p-form__control p-form-validation col-4"
-                                                            data-ng-class="{ 'is-error': isInterfaceNameInvalid(editInterface) }"
-                                                        >
-                                                            <input
-                                                                type="text"
-                                                                name="name"
-                                                                id="bond-name"
-                                                                class="p-form-validation__input"
-                                                                data-ng-model="editInterface.name"
-                                                            >
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row">
-                                                        <label class="p-form__label col-2">Tags</label>
-                                                        <div class="p-form__control col-4 tags--inline">
-                                                            <tags-input data-ng-model="editInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-6">
-                                                    <h3 class="p-heading--five">Network</h3>
-                                                    <div class="p-form__group row u-vertically-center">
-                                                        <label class="p-form__label col-2">Fabric</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select
-                                                                name="fabric"
-                                                                data-ng-model="editInterface.fabric"
-                                                                data-ng-options="fabric as fabric.name for fabric in fabrics"
-                                                                data-ng-change="updateVLAN(editInterface)"
-                                                            >
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row u-vertically-center">
-                                                        <label class="p-form__label col-2">VLAN</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select name="vlan"
-                                                                data-ng-model="editInterface.vlan"
-                                                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | filterVLANNotOnFabric:editInterface.fabric.vlan_ids"
-                                                            >
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row u-vertically-center">
-                                                        <label class="p-form__label col-2">Subnet</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select name="subnet"
-                                                                data-ng-model="editInterface.subnet"
-                                                                data-ng-change="subnetChanged(editInterface)"
-                                                                data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:editInterface.vlan">
-                                                                <option value="" data-ng-hide="editInterface.type === 'alias'">Unconfigured</option>
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row" data-ng-if="!isLinkModeDisabled(editInterface)">
-                                                        <label for="link-mode" class="p-form__label col-2">IP mode</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select name="link-mode"
-                                                                data-ng-model="editInterface.mode"
-                                                                data-ng-change="modeChanged(editInterface)"
-                                                                data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:editInterface">
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row" data-ng-if="editInterface.mode == 'static'">
-                                                        <label for="ip-address" class="p-form__label col-2">IP address</label>
-                                                        <div class="p-form__control col-4" data-ng-class="{ 'is-error': isIPAddressInvalid(editInterface) }">
-                                                            <input name="ip-address" type="text" placeholder="IP address" data-ng-model="editInterface.ip_address">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <div class="p-strip is-shallow">
-                                            <div class="row p-form--stacked">
-                                                <div class="col-6">
-                                                    <h3 class="p-heading--five">Advanced options</h3>
-                                                    <div class="p-form__group row">
-                                                        <label for="mac" class="p-form__label col-2">MAC address</label>
-                                                        <div class="p-form__control col-4 p-form-validation"
-                                                            data-ng-class="{ 'is-error': isMACAddressInvalid(editInterface.mac_address) }">
-                                                            <input type="text" name="mac" class="p-form-validation__input"
-                                                                placeholder="00:00:00:00:00:00"
-                                                                data-ng-model="editInterface.mac_address"
-                                                                data-ng-value="editInterface.mac_address"
-                                                                data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi" mac-address maxlength="17"
-                                                                data-ng-placeholder="getInterfacePlaceholderMACAddress(editInterface)"
-                                                            >
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row">
-                                                        <label for="link-monitoring" class="p-form__label col-2">Link monitoring</label>
-                                                        <div class="p-form__control col-4">
-                                                            <select
-                                                                id="link-monitoring"
-                                                                name="link-monitoring"
-                                                                ng-change="handleEditLinkMonitoring(editInterfaceLinkMonitoring)"
-                                                                ng-model="editInterfaceLinkMonitoring"
-                                                            >
-                                                                <option value="">No link monitoring</option>
-                                                                <option value="mii">MII link monitoring</option>
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row" data-ng-if="editInterfaceLinkMonitoring === 'mii'">
-                                                        <label for="monitoring-frequency" class="p-form__label col-2 u-no-padding--top">Monitoring frequency (ms)</label>
-                                                        <div class="p-form__control col-4">
-                                                            <input type="text" name="monitoring-frequency" id="monitoring-frequency"
-                                                                data-ng-model="editInterface.bond_miimon">
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row" data-ng-if="editInterfaceLinkMonitoring === 'mii'">
-                                                        <label for="updelay" class="p-form__label col-2">Updelay (ms)</label>
-                                                        <div class="p-form__control col-4">
-                                                            <input type="text" name="updelay" id="updelay" data-ng-model="editInterface.bond_updelay">
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group row"  data-ng-if="editInterfaceLinkMonitoring === 'mii'">
-                                                        <label for="downdelay" class="p-form__label col-2">Downdelay (ms)</label>
-                                                        <div class="p-form__control col-4">
-                                                            <input type="text" name="downdelay" id="downdelay" data-ng-model="editInterface.bond_downdelay">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="row u-sv2">
-                                            <hr />
-                                        </div>
-                                        <div class="row">
-                                            <maas-obj-errors></maas-obj-errors>
-                                            <div class="u-align--right">
-                                                <button class="p-button--base u-no-margin--bottom"
-                                                    data-ng-click="editCancel()">Cancel</button>
-                                                <span class="p-tooltip--top-right" aria-describedby="save-bond-tooltip"
-                                                    data-ng-if="editInterface.members && editInterface.members.length < 2">
-                                                    <button class="p-button--positive u-no-margin--bottom" disabled>Save {$ getInterfaceTypeText(interface).toLowerCase() $}</button>
-                                                    <span class="p-tooltip__message" role="tooltip" id="save-bond-tooltip">A bond must have at least two interfaces</span>
-                                                </span>
-                                                <button class="p-button--positive u-no-margin--bottom"
-                                                data-ng-disabled="(isInterfaceNameInvalid(editInterface)) || isIPAddressInvalid(editInterface) || isMACAddressInvalid(editInterface.mac_address, true)" data-ng-if="editInterface.members && editInterface.members.length >= 2"
-                                                maas-obj-save>
-                                                    <span data-ng-if="isSaving">
-                                                        <i class="p-icon--spinner is-light u-animation--spin"></i>
-                                                        &nbsp;
-                                                        Saving {$ getInterfaceTypeText(interface).toLowerCase() $}
-                                                    </span>
-                                                    <span data-ng-if="!isSaving">
-                                                        Save {$ getInterfaceTypeText(interface).toLowerCase() $}
-                                                    </span>
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </maas-obj-form>
-                                </div>
                             </div>
+                          </div>
+                          <div class="p-form__group row">
+                            <label for="mac" class="p-form__label col-2"
+                              >MAC address</label
+                            >
+                            <div
+                              class="p-form__control col-4 p-form-validation"
+                              data-ng-class="{ 'is-error': isMACAddressInvalid(editInterface.mac_address) }"
+                            >
+                              <input
+                                type="text"
+                                name="mac"
+                                class="p-form-validation__input"
+                                placeholder="00:00:00:00:00:00"
+                                data-ng-value="editInterface.mac_address"
+                                data-ng-model="editInterface.mac_address"
+                                data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi"
+                                mac-address
+                                maxlength="17"
+                                data-ng-placeholder="getInterfacePlaceholderMACAddress(editInterface)"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="!isAllNetworkingDisabled(interface)"
+                          >
+                            <label class="p-form__label col-2">Tags</label>
+                            <div class="p-form__control col-4 tags--inline">
+                              <tags-input
+                                data-ng-model="editInterface.tags"
+                                allow-tags-pattern="[\w-]+"
+                              ></tags-input>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row p-form-validation"
+                            data-ng-class="{ 'is-error': !linkSpeedValid(editInterface) }"
+                            data-ng-if="editInterface.type === 'physical'"
+                          >
+                            <label class="p-form__label col-2"
+                              >Link speed (Gbps)</label
+                            >
+                            <div class="p-form__control col-4">
+                              <input
+                                type="text"
+                                name="link_speed"
+                                id="link_speed"
+                                data-ng-model="editInterface.formatted_link_speed"
+                                data-ng-disabled="!editInterface.link_connected"
+                                class="p-form-validation__input"
+                              />
+                              <p
+                                class="p-form-validation__message u-no-margin--top"
+                                data-ng-if="!linkSpeedValid(editInterface)"
+                              >
+                                <strong>Error:</strong> Link speed cannot be
+                                higher than interface speed
+                              </p>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="editInterface.type === 'physical'"
+                          >
+                            <label class="p-form__label col-2"
+                              >Interface speed (Gbps)</label
+                            >
+                            <div class="p-form__control col-4">
+                              <input
+                                type="text"
+                                name="interface_speed"
+                                id="interface_speed"
+                                data-ng-model="editInterface.formatted_interface_speed"
+                                data-ng-disabled="!editInterface.link_connected"
+                              />
+                            </div>
+                          </div>
                         </div>
-                        <div class="row is-active" data-ng-if="isShowingDeleteConfirm() && isInterfaceSelected(interface)">
-                            <hr />
-                            <div class="row">
-                                <div class="col-8">
-                                    <p class="u-no-margin--bottom"><span class="p-icon--warning">Warning:</span> Are you sure you want to remove this {$ getRemoveTypeText(interface) $}?</p>
-                                </div>
-                                <div class="col-4">
-                                    <div class="u-align--right">
-                                        <button class="p-button--base" data-ng-click="editCancel()">Cancel</button>
-                                        <button class="p-button--negative u-no-margin--top" data-ng-click="confirmRemove(interface)">Remove</button>
-                                    </div>
-                                </div>
-                            </div>
+                        <div
+                          class="col-6"
+                          data-ng-if="!isAllNetworkingDisabled(interface)"
+                        >
+                          <h3 class="p-heading--five">Network</h3>
+                          <maas-obj-field
+                            type="options"
+                            key="fabric"
+                            label="Fabric"
+                            disable-label="false"
+                            placeholder="Disconnected"
+                            placeholder-enabled="true"
+                            on-change="fabricChangedForm"
+                            options="fabric as fabric.name for fabric in fabrics"
+                            label-width="2"
+                            label-width-tablet="2"
+                            input-width="4"
+                            input-width-tablet="4"
+                          ></maas-obj-field>
+                          <maas-obj-field
+                            type="options"
+                            key="vlan"
+                            label="VLAN"
+                            disable-label="false"
+                            data-ng-show="!isController && editInterface.$maasForm.getValue('fabric')"
+                            on-change="vlanChangedForm"
+                            options="vlan as getVLANText(vlan) for vlan in vlans | removeDefaultVLANIfVLAN:interface.type | filterByFabric:editInterface.$maasForm.getValue('fabric')"
+                            label-width="2"
+                            label-width-tablet="2"
+                            input-width="4"
+                            input-width-tablet="4"
+                          >
+                          </maas-obj-field>
+                          <maas-obj-field
+                            type="options"
+                            key="subnet"
+                            label="Subnet"
+                            placeholder="Unconfigured"
+                            placeholder-enabled="true"
+                            disable-label="false"
+                            data-ng-show="!isController && editInterface.$maasForm.getValue('fabric')"
+                            on-change="subnetChangedForm"
+                            options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:editInterface.$maasForm.getValue('vlan')"
+                            label-width="2"
+                            label-width-tablet="2"
+                            input-width="4"
+                            input-width-tablet="4"
+                          >
+                          </maas-obj-field>
+                          <maas-obj-field
+                            type="options"
+                            key="subnet"
+                            label="Subnet"
+                            placeholder="Unconfigured"
+                            placeholder-enabled="true"
+                            data-ng-init="editInterface.subnet = editInterface.defaultSubnet"
+                            data-ng-if="!isController && editInterface.$maasForm.getValue('ip_assignment') === 'static'"
+                            on-change="subnetChangedForm"
+                            disable-label="false"
+                            options="subnet as getSubnetText(subnet) for subnet in subnets"
+                            label-width="2"
+                            label-width-tablet="2"
+                            input-width="4"
+                            input-width-tablet="4"
+                          ></maas-obj-field>
+                          <maas-obj-field
+                            type="options"
+                            key="mode"
+                            label="IP mode"
+                            disable-label="false"
+                            data-ng-if="!isController && editInterface.$maasForm.getValue('fabric') && !isLinkModeDisabled(editInterface.$maasForm)"
+                            options="mode.mode as mode.text for mode in modes | filterLinkModes:editInterface.$maasForm"
+                            on-change="modeChangedForm"
+                            label-width="2"
+                            label-width-tablet="2"
+                            input-width="4"
+                            input-width-tablet="4"
+                          >
+                          </maas-obj-field>
+                          <maas-obj-field
+                            type="text"
+                            key="ip_address"
+                            label="IP address"
+                            placeholder="IP Address"
+                            disable-label="false"
+                            input-class="table__input"
+                            data-ng-if="!isController && editInterface.$maasForm.getValue('fabric') && editInterface.$maasForm.getValue('mode') == 'static'"
+                            label-width="2"
+                            label-width-tablet="2"
+                            input-width="4"
+                            input-width-tablet="4"
+                          >
+                          </maas-obj-field>
                         </div>
-                        <hr data-ng-if="isShowingAdd() && !newInterface.saving" />
-                        <div class="row" data-ng-if="isShowingAdd() && !newInterface.saving">
-                            <div class="col-6">
-                                <button class="p-button--neutral"
-                                    data-ng-click="addInterface('alias')"
-                                    data-ng-show="canAddAlias(interface)">Add <span data-ng-show="newInterface.type === 'alias'">another </span>alias</button>
-                                <button class="p-button--neutral u-no-margin--top"
-                                    data-ng-click="addInterface('vlan')"
-                                    data-ng-show="canAddAnotherVLAN(interface)">Add <span data-ng-show="newInterface.type === 'vlan'">another </span>VLAN</button>
-                            </div>
-                            <div class="col-6">
-                                <div class="u-align--right">
-                                    <button class="p-button--base" data-ng-click="editCancel()">Cancel</button>
-                                    <button class="p-button--positive u-no-margin--top" data-ng-click="addInterface()">Add</button>
-                                </div>
-                            </div>
-                        </div>
+                      </div>
                     </div>
+                    <div
+                      class="p-strip is-shallow"
+                      data-ng-if="editInterface.type !== 'physical'"
+                    >
+                      <div class="row">
+                        <div class="col-6">
+                          <h3 class="p-heading--five">Advanced options</h3>
+                          <div
+                            class="p-form__group row u-vertically-center"
+                            style="min-height: 2.5rem;"
+                          >
+                            <label for="stp" class="p-form__label col-2">
+                              STP
+                              <span
+                                class="p-tooltip--right"
+                                aria-describedby="stp"
+                              >
+                                <i class="p-icon--question"></i>
+                                <span
+                                  class="p-tooltip__message"
+                                  role="tooltip"
+                                  id="stp"
+                                  >Controls the participation of this bridge in
+                                  the spanning tree protocol.</span
+                                >
+                              </span>
+                            </label>
+                            <div class="p-form__control col-4">
+                              <div class="onoffswitch maas-p-switch">
+                                <input
+                                  id="bridge_stp"
+                                  type="checkbox"
+                                  name="bridge_stp"
+                                  class="onoffswitch-checkbox maas-p-switch--input"
+                                  data-ng-model="editInterface.bridge_stp"
+                                />
+                                <div class="maas-p-switch--mask"></div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group u-vertically-center"
+                            data-ng-if="editInterface.bridge_stp"
+                          >
+                            <label for="fd" class="p-form__label col-2"
+                              >Forward delay (ms)</label
+                            >
+                            <div class="p-form__control col-4">
+                              <input
+                                type="text"
+                                name="fd"
+                                data-ng-model="editInterface.bridge_fd"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row">
+                      <hr />
+                    </div>
+                    <div class="row">
+                      <div class="col-6">
+                        <maas-obj-errors></maas-obj-errors>
+                      </div>
+                      <div class="col-6">
+                        <div class="u-align--right">
+                          <button
+                            class="p-button--base u-no-margin--bottom"
+                            data-ng-click="editCancel()"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            class="p-button--positive u-no-margin--bottom"
+                            data-ng-disabled="cannotEditBond(editInterface)"
+                            maas-obj-save
+                          >
+                            Save {$
+                            getInterfaceTypeText(interface).toLowerCase() $}
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </maas-obj-form>
                 </div>
 
+                <div class="row" data-ng-if="editInterface.type === 'bond'">
+                  <maas-obj-form
+                    obj="editInterface"
+                    manager="nodesManager"
+                    manager-method="updateInterfaceForm"
+                    table-form="true"
+                    save-on-blur="false"
+                    after-save="editSave"
+                    pre-process="preProcessInterface"
+                  >
+                    <div class="p-strip is-shallow">
+                      <div class="row p-form--stacked">
+                        <div class="col-6">
+                          <h3 class="p-heading--five">Bond details</h3>
+                          <div class="p-form__group row">
+                            <label for="bond-mode" class="p-form__label col-2"
+                              >Bond mode</label
+                            >
+                            <div class="p-form__control col-4">
+                              <select
+                                name="bond-mode"
+                                ng-change="handleEditBondMode(editInterface.bond_mode)"
+                                ng-model="editInterface.bond_mode"
+                                ng-options="mode[0] as mode[1] for mode in bondOptions.modes"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row p-form-validation"
+                            data-ng-if="showXMITHashPolicy()"
+                            data-ng-class="{ 'is-caution': showLACPRate() && modeAndPolicyCompliant() }"
+                          >
+                            <label
+                              for="xmit-hash-policy"
+                              class="p-form__label col-2"
+                              >Hash policy</label
+                            >
+                            <div class="p-form__control col-4">
+                              <select
+                                name="xmit-hash-policy"
+                                class="p-form-validation__input"
+                                data-ng-model="editInterface.bond_xmit_hash_policy"
+                                data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies"
+                              >
+                              </select>
+                              <p
+                                class="p-form-validation__message"
+                                data-ng-if="showLACPRate() && modeAndPolicyCompliant()"
+                              >
+                                <strong>Warning:</strong> This hash policy is
+                                not fully 802.3ad compliant.
+                              </p>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="showLACPRate()"
+                          >
+                            <label for="lacp-rate" class="p-form__label col-2"
+                              >LACP rate</label
+                            >
+                            <div class="p-form__control col-4">
+                              <select
+                                name="lacp-rate"
+                                data-ng-model="editInterface.bond_lacp_rate"
+                                data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div class="p-form__group row">
+                            <label for="bond-name" class="p-form__label col-2"
+                              >Bond name</label
+                            >
+                            <div
+                              class="p-form__control p-form-validation col-4"
+                              data-ng-class="{ 'is-error': isInterfaceNameInvalid(editInterface) }"
+                            >
+                              <input
+                                type="text"
+                                name="name"
+                                id="bond-name"
+                                class="p-form-validation__input"
+                                data-ng-model="editInterface.name"
+                              />
+                            </div>
+                          </div>
+                          <div class="p-form__group row">
+                            <label class="p-form__label col-2">Tags</label>
+                            <div class="p-form__control col-4 tags--inline">
+                              <tags-input
+                                data-ng-model="editInterface.tags"
+                                allow-tags-pattern="[\w-]+"
+                              ></tags-input>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-6">
+                          <h3 class="p-heading--five">Network</h3>
+                          <div class="p-form__group row u-vertically-center">
+                            <label class="p-form__label col-2">Fabric</label>
+                            <div class="p-form__control col-4">
+                              <select
+                                name="fabric"
+                                data-ng-model="editInterface.fabric"
+                                data-ng-options="fabric as fabric.name for fabric in fabrics"
+                                data-ng-change="updateVLAN(editInterface)"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div class="p-form__group row u-vertically-center">
+                            <label class="p-form__label col-2">VLAN</label>
+                            <div class="p-form__control col-4">
+                              <select
+                                name="vlan"
+                                data-ng-model="editInterface.vlan"
+                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | filterVLANNotOnFabric:editInterface.fabric.vlan_ids"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div class="p-form__group row u-vertically-center">
+                            <label class="p-form__label col-2">Subnet</label>
+                            <div class="p-form__control col-4">
+                              <select
+                                name="subnet"
+                                data-ng-model="editInterface.subnet"
+                                data-ng-change="subnetChanged(editInterface)"
+                                data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:editInterface.vlan"
+                              >
+                                <option
+                                  value=""
+                                  data-ng-hide="editInterface.type === 'alias'"
+                                  >Unconfigured</option
+                                >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="!isLinkModeDisabled(editInterface)"
+                          >
+                            <label for="link-mode" class="p-form__label col-2"
+                              >IP mode</label
+                            >
+                            <div class="p-form__control col-4">
+                              <select
+                                name="link-mode"
+                                data-ng-model="editInterface.mode"
+                                data-ng-change="modeChanged(editInterface)"
+                                data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:editInterface"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="editInterface.mode == 'static'"
+                          >
+                            <label for="ip-address" class="p-form__label col-2"
+                              >IP address</label
+                            >
+                            <div
+                              class="p-form__control col-4"
+                              data-ng-class="{ 'is-error': isIPAddressInvalid(editInterface) }"
+                            >
+                              <input
+                                name="ip-address"
+                                type="text"
+                                placeholder="IP address"
+                                data-ng-model="editInterface.ip_address"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
 
-                <div class="row" data-ng-if="isShowingCreateBond() && !isAllNetworkingDisabled()">
-                    <div class="p-card--highlighted">
-                        <h2 class="p-heading--four">Create bond</h2>
-                        <table class="p-table-interface">
-                            <thead>
-                                <tr>
-                                    <th class="p-double-row">
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div>Name,</div>
-                                            <div>MAC</div>
-                                        </div>
-                                    </th>
-                                    <th>Primary</th>
-                                    <th class="p-table__col--status p-double-row">
-                                        <div class="p-double-row__icon-container">
-                                            <i class="p-icon--placeholder"></i>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            Link/interface speed
-                                        </div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Type</div>
-                                        <div>NUMA node</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Fabric,</div>
-                                        <div>VLAN</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>Subnet,</div>
-                                        <div>Name</div>
-                                    </th>
-                                    <th class="p-double-row">
-                                        <div>IP Address,</div>
-                                        <div>Status</div>
-                                    </th>
-                                    <th>DHCP</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr data-ng-repeat="parent in newBondInterface.parents | orderBy:'name'">
-                                    <td class="p-double-row" aria-label="Name">
-                                        <div class="p-double-row__checkbox" data-ng-if="isShowingInterfaces">
-                                            <input type="checkbox" class="checkbox" id="{$ getUniqueKey(parent) $}" data-ng-checked="isInterfaceSelected(parent)" data-ng-click="toggleInterfaceSelect(parent)">
-                                            <label class="is-inline-label" for="{$ getUniqueKey(parent) $}"></label>
-                                        </div>
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div class="p-double-row__main-row">
-                                                {$ parent.name $}
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                {$ parent.mac_address $}
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Primary">
-                                        <input type="radio" name="bondPrimary" id="{$ parent.name $}" data-ng-model="newBondInterface.primary" data-ng-value="parent">
-                                        <label class="is-inline-label" for="{$ parent.name $}"></label>
-                                    </td>
-                                    <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
-                                        <div class="p-double-row__icon-container">
-                                            <span ng-if="!isBond(parent) && !isBridge(parent)">
-                                                <span
-                                                    aria-describedby="not-connected-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="!isInterfaceConnected(parent)"
-                                                >
-                                                    <i class="p-icon--error"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                                </span>
-                                                <span
-                                                    aria-describedby="link-speed-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="isInterfaceConnected(parent) && parent.link_speed < parent.interface_speed"
-                                                >
-                                                    <i class="p-icon--warning"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                                </span>
-                                                <i
-                                                    class="p-icon--placeholder"
-                                                    ng-if="isInterfaceConnected(parent) && parent.link_speed === parent.interface_speed">
-                                                </i>
-                                            </span>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            <span ng-if="!isBond(parent) && !isBridge(parent)">
-                                                {$ formatSpeedUnits(parent.link_speed) $}/{$ formatSpeedUnits(parent.interface_speed) $}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Type, NUMA node" class="p-double-row">
-                                        <div class="p-tooltip--top-left numa-tooltip"
-                                            ng-class="{ 'show-warning': getInterfaceNumaNodes(parent).length > 1 }">
-                                            <div class="p-double-row__rows-container">
-                                                <div class="p-double-row__main-row" title="{$ getInterfaceTypeText(parent) $}">
-                                                    {$ getInterfaceTypeText(parent) $}
-                                                </div>
-                                                <div class="p-double-row__muted-row">
-                                                    <span>{$ getInterfaceNumaNodes(parent).join(", ") $}</span>
-                                                </div>
-                                            </div>
-                                            <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(parent).length > 1">This bond is spread over
-                                                multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row" aria-label="Fabric">
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row">
-                                                <span title="{$ parent.fabric.name || 'Disconnected' $}">
-                                                    {$ parent.fabric.name $}
-                                                    <span data-ng-if="!parent.fabric.name">Disconnected</span>
-                                                </span>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <span title="{$ getVLANText(parent.vlan) $}">
-                                                    {$ getVLANText(parent.vlan) $}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Subnet CIDR">
-                                        <span title="{$ parent.subnet.cidr $}">
-                                            <span data-ng-if="parent.subnet.cidr">
-                                                {$ parent.subnet.cidr $}
-                                            </span>
-                                            <span data-ng-if="!parent.subnet.cidr">
-                                                Unconfigured
-                                            </span>
-                                        </span>
-                                    </td>
-                                    <td aria-label="IP address">
-                                        <span title="{$ parent.ip_address $}">
-                                            <span data-ng-if="parent.ip_address">
-                                                {$ parent.ip_address $}
-                                            </span>
-                                            <span data-ng-if="!parent.ip_address">
-                                                {$ getLinkModeText(parent) $}
-                                            </span>
-                                        </span>
-                                    </td>
-                                    <td style="overflow: visible;">
-                                        {$ getDHCPStatus(parent.vlan) $}
-                                        <span class="p-tooltip--btm-right" ng-if="parent.vlan && parent.vlan.relay_vlan" style="margin-left: .25rem;">
-                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(parent.vlan, true) $}</i>
-                                            <span class="p-tooltip__message">{$ getDHCPStatus(parent.vlan, true) $}</span>
-                                        </span>
-                                    </td>
-                                </tr>
-                                <tr class="p-table__row--muted" data-ng-repeat="interface in interfaces | filterSelectedInterfaces:selectedInterfaces:newBondInterface" data-ng-if="isShowingInterfaces">
-                                    <td class="p-double-row" aria-label="Name">
-                                        <div class="p-double-row__checkbox">
-                                            <input type="checkbox" class="checkbox" id="{$ getUniqueKey(interface) $}" data-ng-checked="isInterfaceSelected(interface)" data-ng-click="toggleInterfaceSelect(interface)">
-                                            <label class="is-inline-label" for="{$ getUniqueKey(interface) $}"></label>
-                                        </div>
-                                        <div class="p-double-row__rows-container--checkbox">
-                                            <div class="p-double-row__main-row">
-                                                {$ interface.name $}
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                {$ interface.mac_address $}
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Primary">
-                                        <input type="radio" name="bondPrimary" id="{$ interface.name $}" data-ng-model="newBondInterface.primary" data-ng-value="interface">
-                                        <label class="is-inline-label" for="{$ interface.name $}"></label>
-                                    </td>
-                                    <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
-                                        <div class="p-double-row__icon-container">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                <span
-                                                    aria-describedby="not-connected-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="!isInterfaceConnected(interface)"
-                                                >
-                                                    <i class="p-icon--error"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                                </span>
-                                                <span
-                                                    aria-describedby="link-speed-tooltip"
-                                                    class="p-tooltip--top-left"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
-                                                >
-                                                    <i class="p-icon--warning"></i>
-                                                    <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                                </span>
-                                                <i
-                                                    class="p-icon--placeholder"
-                                                    ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
-                                                </i>
-                                            </span>
-                                        </div>
-                                        <div class="p-double-row__rows-container--icon">
-                                            <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                                {$ formatSpeedUnits(interface.link_speed) $}/{$ formatSpeedUnits(interface.interface_speed) $}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Type, NUMA node" class="p-double-row">
-                                        <div class="p-tooltip--top-left numa-tooltip"
-                                            ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }">
-                                            <div class="p-double-row__rows-container">
-                                                <div class="p-double-row__main-row" title="{$ getInterfaceTypeText(interface) $}">
-                                                    {$ getInterfaceTypeText(interface) $}
-                                                </div>
-                                                <div class="p-double-row__muted-row">
-                                                    <span>{$ getInterfaceNumaNodes(interface).join(", ") $}</span>
-                                                </div>
-                                            </div>
-                                            <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(interface).length > 1">This bond is spread over
-                                                multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                        </div>
-                                    </td>
-                                    <td class="p-double-row" aria-label="Fabric">
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row">
-                                                <span title="{$ interface.fabric.name || 'Disconnected' $}">
-                                                    {$ interface.fabric.name $}
-                                                    <span data-ng-if="!interface.fabric.name">Disconnected</span>
-                                                </span>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <span title="{$ getVLANText(interface.vlan) $}">
-                                                    {$ getVLANText(interface.vlan) $}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td aria-label="Subnet CIDR">
-                                        <span title="{$ interface.subnet.cidr $}">
-                                            <span data-ng-if="interface.subnet.cidr">
-                                                {$ interface.subnet.cidr $}
-                                            </span>
-                                            <span data-ng-if="!interface.subnet.cidr">
-                                                Unconfigured
-                                            </span>
-                                        </span>
-                                    </td>
-                                    <td class="p-double-row">
-                                        <div data-ng-if="!interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address" title="{$ interface.ip_address $}">
-                                                <span data-ng-if="interface.ip_address">{$ interface.ip_address $}</span>
-                                                <span data-ng-if="!interface.ip_address">{$ getLinkModeText(interface) $}</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="{$ getLinkModeText(interface) $}">
-                                                <span data-ng-if="interface.ip_address">{$ getLinkModeText(interface) $}</span>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row" aria-label="IP address" title="{$ interface.discovered[0].ip_address $}">
-                                                <span data-ng-if="interface.discovered[0].ip_address">{$ interface.discovered[0].ip_address $}</span>
-                                                <span data-ng-if="!interface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row" aria-label="Link mode" title="DHCP">
-                                                <span data-ng-if="interface.discovered[0].ip_address">DHCP</span>
-                                            </div>
-                                        </div>
-                                    </td>
-                                    <td style="overflow: visible;">
-                                        {$ getDHCPStatus(interface.vlan) $}
-                                        <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
-                                            <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
-                                            <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
-                                        </span>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-
-                        <button class="p-button--neutral" data-ng-click="toggleInterfaces()" data-ng-if="showCreateEditButton()">
-                            <span data-ng-if="isShowingInterfaces">Hide interfaces</span>
-                            <span data-ng-if="!isShowingInterfaces" data-ng-click="sendAnalyticsEvent('Machine details', 'Edit bond', 'Network tab')">Edit bond members</span>
+                    <div class="p-strip is-shallow">
+                      <div class="row p-form--stacked">
+                        <div class="col-6">
+                          <h3 class="p-heading--five">Advanced options</h3>
+                          <div class="p-form__group row">
+                            <label for="mac" class="p-form__label col-2"
+                              >MAC address</label
+                            >
+                            <div
+                              class="p-form__control col-4 p-form-validation"
+                              data-ng-class="{ 'is-error': isMACAddressInvalid(editInterface.mac_address) }"
+                            >
+                              <input
+                                type="text"
+                                name="mac"
+                                class="p-form-validation__input"
+                                placeholder="00:00:00:00:00:00"
+                                data-ng-model="editInterface.mac_address"
+                                data-ng-value="editInterface.mac_address"
+                                data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi"
+                                mac-address
+                                maxlength="17"
+                                data-ng-placeholder="getInterfacePlaceholderMACAddress(editInterface)"
+                              />
+                            </div>
+                          </div>
+                          <div class="p-form__group row">
+                            <label
+                              for="link-monitoring"
+                              class="p-form__label col-2"
+                              >Link monitoring</label
+                            >
+                            <div class="p-form__control col-4">
+                              <select
+                                id="link-monitoring"
+                                name="link-monitoring"
+                                ng-change="handleEditLinkMonitoring(editInterfaceLinkMonitoring)"
+                                ng-model="editInterfaceLinkMonitoring"
+                              >
+                                <option value="">No link monitoring</option>
+                                <option value="mii">MII link monitoring</option>
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="editInterfaceLinkMonitoring === 'mii'"
+                          >
+                            <label
+                              for="monitoring-frequency"
+                              class="p-form__label col-2 u-no-padding--top"
+                              >Monitoring frequency (ms)</label
+                            >
+                            <div class="p-form__control col-4">
+                              <input
+                                type="text"
+                                name="monitoring-frequency"
+                                id="monitoring-frequency"
+                                data-ng-model="editInterface.bond_miimon"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="editInterfaceLinkMonitoring === 'mii'"
+                          >
+                            <label for="updelay" class="p-form__label col-2"
+                              >Updelay (ms)</label
+                            >
+                            <div class="p-form__control col-4">
+                              <input
+                                type="text"
+                                name="updelay"
+                                id="updelay"
+                                data-ng-model="editInterface.bond_updelay"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group row"
+                            data-ng-if="editInterfaceLinkMonitoring === 'mii'"
+                          >
+                            <label for="downdelay" class="p-form__label col-2"
+                              >Downdelay (ms)</label
+                            >
+                            <div class="p-form__control col-4">
+                              <input
+                                type="text"
+                                name="downdelay"
+                                id="downdelay"
+                                data-ng-model="editInterface.bond_downdelay"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row u-sv2">
+                      <hr />
+                    </div>
+                    <div class="row">
+                      <maas-obj-errors></maas-obj-errors>
+                      <div class="u-align--right">
+                        <button
+                          class="p-button--base u-no-margin--bottom"
+                          data-ng-click="editCancel()"
+                        >
+                          Cancel
                         </button>
-
-                        <div class="p-strip is-shallow">
-                            <div class="row p-form--stacked">
-                                <div class="col-6">
-                                    <h3 class="p-heading--five">Bond details</h3>
-                                    <div class="p-form__group row">
-                                        <label for="bond-mode" class="p-form__label col-2">Bond mode</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="bond-mode"
-                                                data-ng-model="newBondInterface.bond_mode"
-                                                data-ng-options="mode[0] as mode[1] for mode in bondOptions.modes">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row p-form-validation"
-                                        data-ng-if="showXMITHashPolicy()"
-                                        data-ng-class="{ 'is-caution': showLACPRate() && modeAndPolicyCompliant() }">
-                                        <label for="xmit-hash-policy" class="p-form__label col-2">Hash policy</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="xmit-hash-policy"
-                                                class="p-form-validation__input"
-                                                data-ng-model="newBondInterface.bond_xmit_hash_policy"
-                                                data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies">
-                                            </select>
-                                            <p class="p-form-validation__message" data-ng-if="showLACPRate() && modeAndPolicyCompliant()">
-                                                <strong>Warning:</strong> This hash policy is not fully 802.3ad compliant.
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="showLACPRate()">
-                                        <label for="lacp-rate" class="p-form__label col-2">LACP rate</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="lacp-rate"
-                                                data-ng-model="newBondInterface.bond_lacp_rate"
-                                                data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row">
-                                        <label for="bond-name" class="p-form__label col-2">Bond name</label>
-                                        <div
-                                            class="p-form__control p-form-validation col-4"
-                                            data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBondInterface) }"
-                                        >
-                                            <input
-                                                type="text"
-                                                name="name"
-                                                id="bond-name"
-                                                class="p-form-validation__input"
-                                                data-ng-model="newBondInterface.name"
-                                            >
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row">
-                                        <label class="p-form__label col-2">Tags</label>
-                                        <div class="p-form__control tags--inline col-4">
-                                            <tags-input data-ng-model="newBondInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="col-6">
-                                    <h3 class="p-heading--five">Network</h3>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label class="p-form__label col-2">Fabric</label>
-                                        <div class="p-form__control col-4">
-                                            <select
-                                                name="fabric"
-                                                data-ng-model="newBondInterface.fabric"
-                                                data-ng-options="fabric as fabric.name for fabric in fabrics"
-                                            >
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label class="p-form__label col-2">VLAN</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="vlan"
-                                                data-ng-model="newBondInterface.vlan"
-                                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | filterVLANNotOnFabric:newBondInterface.fabric.vlan_ids"
-                                            >
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center">
-                                        <label class="p-form__label col-2">Subnet</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="subnet"
-                                                data-ng-model="newBondInterface.subnet"
-                                                data-ng-change="subnetChanged(newBondInterface)"
-                                                data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newBondInterface.vlan">
-                                                <option value="" data-ng-hide="newBondInterface.type === 'alias'">Unconfigured</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center" data-ng-if="!isLinkModeDisabled(newBondInterface)">
-                                        <label for="link-mode" class="p-form__label col-2">IP mode</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="link-mode"
-                                                data-ng-model="newBondInterface.mode"
-                                                data-ng-change="modeChanged(newBondInterface)"
-                                                data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newBondInterface">
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row u-vertically-center" data-ng-if="newBondInterface.mode == 'static'">
-                                        <label for="ip-address" class="p-form__label col-2">IP address</label>
-                                        <div class="p-form__control col-4" data-ng-class="{ 'is-error': isIPAddressInvalid(newBondInterface) }">
-                                            <input name="ip-address" type="text" placeholder="IP address" data-ng-model="newBondInterface.ip_address">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="p-strip is-shallow">
-                            <div class="row p-form--stacked">
-                                <div class="col-6">
-                                    <h3 class="p-heading--five">Advanced options</h3>
-                                    <div class="p-form__group row">
-                                        <label for="mac" class="p-form__label col-2">MAC address</label>
-                                        <div class="p-form__control p-form-validation col-4"
-                                            data-ng-class="{ 'is-error': isMACAddressInvalid(newBondInterface.mac_address) }">
-                                            <input type="text" name="mac" class="p-form-validation__input"
-                                                placeholder="00:00:00:00:00:00"
-                                                data-ng-value="newBondInterface.mac_address"
-                                                data-ng-model="newBondInterface.mac_address"
-                                                data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi" mac-address maxlength="17"
-                                                data-ng-placeholder="getInterfacePlaceholderMACAddress(newBondInterface)"
-                                            >
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row">
-                                        <label for="link-monitoring" class="p-form__label col-2">Link monitoring</label>
-                                        <div class="p-form__control col-4">
-                                            <select name="link-monitoring" id="link-monitoring" data-ng-model="newInterfaceLinkMonitoring">
-                                                <option value="">No link monitoring</option>
-                                                <option value="mii">MII link monitoring</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newInterfaceLinkMonitoring === 'mii'">
-                                        <label for="monitoring-frequency" class="p-form__label u-no-padding--top col-2">Monitoring frequency (ms)</label>
-                                        <div class="p-form__control col-4">
-                                            <input type="text" name="monitoring-frequency" id="monitoring-frequency"
-                                                data-ng-model="newBondInterface.bond_miimon">
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newInterfaceLinkMonitoring === 'mii'">
-                                        <label for="updelay" class="p-form__label col-2">Updelay (ms)</label>
-                                        <div class="p-form__control col-4">
-                                            <input type="text" name="updelay" id="updelay" data-ng-model="newBondInterface.bond_updelay">
-                                        </div>
-                                    </div>
-                                    <div class="p-form__group row" data-ng-if="newInterfaceLinkMonitoring === 'mii'">
-                                        <label for="downdelay" class="p-form__label col-2">Downdelay (ms)</label>
-                                        <div class="p-form__control col-4">
-                                            <input type="text" name="downdelay" id="downdelay" data-ng-model="newBondInterface.bond_downdelay">
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="row u-sv1">
-                            <hr />
-                        </div>
-                        <div class="row">
-                            <div class="col-12 u-align--right">
-                                <button class="p-button--base u-no-margin--bottom" type="button" data-ng-click="cancel()">Cancel</button>
-                                <span class="p-tooltip--top-right" aria-describedby="save-bond-tooltip"
-                                    data-ng-if="newBondInterface.parents && newBondInterface.parents.length < 2">
-                                    <button class="p-button--positive u-no-margin--bottom" disabled>Save bond</button>
-                                    <span class="p-tooltip__message" role="tooltip" id="save-bond-tooltip">A bond must have at least two interfaces</span>
-                                </span>
-                                <button class="p-button--positive u-no-margin--bottom" data-ng-if="newBondInterface.parents && newBondInterface.parents.length >= 2" data-ng-click="addBond()" data-ng-disabled="cannotAddBond()">
-                                    <span data-ng-if="isSaving">
-                                        <i class="p-icon--spinner is-light u-animation--spin"></i>
-                                        &nbsp;
-                                        Saving bond
-                                    </span>
-                                    <span data-ng-if="!isSaving">
-                                        Save bond
-                                    </span>
-                                </button>
-                            </div>
-                        </div>
+                        <span
+                          class="p-tooltip--top-right"
+                          aria-describedby="save-bond-tooltip"
+                          data-ng-if="editInterface.members && editInterface.members.length < 2"
+                        >
+                          <button
+                            class="p-button--positive u-no-margin--bottom"
+                            disabled
+                          >
+                            Save {$
+                            getInterfaceTypeText(interface).toLowerCase() $}
+                          </button>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="save-bond-tooltip"
+                            >A bond must have at least two interfaces</span
+                          >
+                        </span>
+                        <button
+                          class="p-button--positive u-no-margin--bottom"
+                          data-ng-disabled="(isInterfaceNameInvalid(editInterface)) || isIPAddressInvalid(editInterface) || isMACAddressInvalid(editInterface.mac_address, true)"
+                          data-ng-if="editInterface.members && editInterface.members.length >= 2"
+                          maas-obj-save
+                        >
+                          <span data-ng-if="isSaving">
+                            <i
+                              class="p-icon--spinner is-light u-animation--spin"
+                            ></i>
+                            &nbsp; Saving {$
+                            getInterfaceTypeText(interface).toLowerCase() $}
+                          </span>
+                          <span data-ng-if="!isSaving">
+                            Save {$
+                            getInterfaceTypeText(interface).toLowerCase() $}
+                          </span>
+                        </button>
+                      </div>
                     </div>
+                  </maas-obj-form>
                 </div>
+              </div>
+            </div>
+            <div
+              class="row is-active"
+              data-ng-if="isShowingDeleteConfirm() && isInterfaceSelected(interface)"
+            >
+              <hr />
+              <div class="row">
+                <div class="col-8">
+                  <p class="u-no-margin--bottom">
+                    <span class="p-icon--warning">Warning:</span> Are you sure
+                    you want to remove this {$ getRemoveTypeText(interface) $}?
+                  </p>
+                </div>
+                <div class="col-4">
+                  <div class="u-align--right">
+                    <button class="p-button--base" data-ng-click="editCancel()">
+                      Cancel
+                    </button>
+                    <button
+                      class="p-button--negative u-no-margin--top"
+                      data-ng-click="confirmRemove(interface)"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <hr data-ng-if="isShowingAdd() && !newInterface.saving" />
+            <div
+              class="row"
+              data-ng-if="isShowingAdd() && !newInterface.saving"
+            >
+              <div class="col-6">
+                <button
+                  class="p-button--neutral"
+                  data-ng-click="addInterface('alias')"
+                  data-ng-show="canAddAlias(interface)"
+                >
+                  Add
+                  <span data-ng-show="newInterface.type === 'alias'"
+                    >another </span
+                  >alias
+                </button>
+                <button
+                  class="p-button--neutral u-no-margin--top"
+                  data-ng-click="addInterface('vlan')"
+                  data-ng-show="canAddAnotherVLAN(interface)"
+                >
+                  Add
+                  <span data-ng-show="newInterface.type === 'vlan'"
+                    >another </span
+                  >VLAN
+                </button>
+              </div>
+              <div class="col-6">
+                <div class="u-align--right">
+                  <button class="p-button--base" data-ng-click="editCancel()">
+                    Cancel
+                  </button>
+                  <button
+                    class="p-button--positive u-no-margin--top"
+                    data-ng-click="addInterface()"
+                  >
+                    Add
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
 
-                <div class="row" data-ng-if="!isShowingCreateBridge() && !isShowingEdit() && !isShowingCreateBond()">
-                    <table class="p-table-expanding p-table--controller-interfaces">
-                        <thead>
-                            <tr data-ng-if="isDevice" class="p-table--is-device">
-                                <th>MAC</th>
-                                <th>Subnet</th>
-                                <th>IP Address</th>
-                                <th><div class="u-align--right">Actions</div></th>
-                                <th class="u-hide"></th>
-                            </tr>
+        <div
+          class="row"
+          data-ng-if="isShowingCreateBond() && !isAllNetworkingDisabled()"
+        >
+          <div class="p-card--highlighted">
+            <h2 class="p-heading--four">Create bond</h2>
+            <table class="p-table-interface">
+              <thead>
+                <tr>
+                  <th class="p-double-row">
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div>Name,</div>
+                      <div>MAC</div>
+                    </div>
+                  </th>
+                  <th>Primary</th>
+                  <th class="p-table__col--status p-double-row">
+                    <div class="p-double-row__icon-container">
+                      <i class="p-icon--placeholder"></i>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      Link/interface speed
+                    </div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Type</div>
+                    <div>NUMA node</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Fabric,</div>
+                    <div>VLAN</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>Subnet,</div>
+                    <div>Name</div>
+                  </th>
+                  <th class="p-double-row">
+                    <div>IP Address,</div>
+                    <div>Status</div>
+                  </th>
+                  <th>DHCP</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  data-ng-repeat="parent in newBondInterface.parents | orderBy:'name'"
+                >
+                  <td class="p-double-row" aria-label="Name">
+                    <div
+                      class="p-double-row__checkbox"
+                      data-ng-if="isShowingInterfaces"
+                    >
+                      <input
+                        type="checkbox"
+                        class="checkbox"
+                        id="{$ getUniqueKey(parent) $}"
+                        data-ng-checked="isInterfaceSelected(parent)"
+                        data-ng-click="toggleInterfaceSelect(parent)"
+                      />
+                      <label
+                        class="is-inline-label"
+                        for="{$ getUniqueKey(parent) $}"
+                      ></label>
+                    </div>
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div class="p-double-row__main-row">
+                        {$ parent.name $}
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        {$ parent.mac_address $}
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Primary">
+                    <input
+                      type="radio"
+                      name="bondPrimary"
+                      id="{$ parent.name $}"
+                      data-ng-model="newBondInterface.primary"
+                      data-ng-value="parent"
+                    />
+                    <label
+                      class="is-inline-label"
+                      for="{$ parent.name $}"
+                    ></label>
+                  </td>
+                  <td
+                    class="p-table__col--status p-double-row"
+                    aria-label="Link and interface speed"
+                  >
+                    <div class="p-double-row__icon-container">
+                      <span ng-if="!isBond(parent) && !isBridge(parent)">
+                        <span
+                          aria-describedby="not-connected-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="!isInterfaceConnected(parent)"
+                        >
+                          <i class="p-icon--error"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="not-connected-tooltip"
+                            >This interface is disconnected.</span
+                          >
+                        </span>
+                        <span
+                          aria-describedby="link-speed-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="isInterfaceConnected(parent) && parent.link_speed < parent.interface_speed"
+                        >
+                          <i class="p-icon--warning"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="link-speed-tooltip"
+                            >Link connected to slow interface.</span
+                          >
+                        </span>
+                        <i
+                          class="p-icon--placeholder"
+                          ng-if="isInterfaceConnected(parent) && parent.link_speed === parent.interface_speed"
+                        >
+                        </i>
+                      </span>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      <span ng-if="!isBond(parent) && !isBridge(parent)">
+                        {$ formatSpeedUnits(parent.link_speed) $}/{$
+                        formatSpeedUnits(parent.interface_speed) $}
+                      </span>
+                    </div>
+                  </td>
+                  <td aria-label="Type, NUMA node" class="p-double-row">
+                    <div
+                      class="p-tooltip--top-left numa-tooltip"
+                      ng-class="{ 'show-warning': getInterfaceNumaNodes(parent).length > 1 }"
+                    >
+                      <div class="p-double-row__rows-container">
+                        <div
+                          class="p-double-row__main-row"
+                          title="{$ getInterfaceTypeText(parent) $}"
+                        >
+                          {$ getInterfaceTypeText(parent) $}
+                        </div>
+                        <div class="p-double-row__muted-row">
+                          <span
+                            >{$ getInterfaceNumaNodes(parent).join(", ")
+                            $}</span
+                          >
+                        </div>
+                      </div>
+                      <span
+                        class="p-tooltip__message"
+                        ng-if="getInterfaceNumaNodes(parent).length > 1"
+                        >This bond is spread over multiple NUMA nodes.<br />This
+                        may lead to suboptimal performance.</span
+                      >
+                    </div>
+                  </td>
+                  <td class="p-double-row" aria-label="Fabric">
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row">
+                        <span
+                          title="{$ parent.fabric.name || 'Disconnected' $}"
+                        >
+                          {$ parent.fabric.name $}
+                          <span data-ng-if="!parent.fabric.name"
+                            >Disconnected</span
+                          >
+                        </span>
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <span title="{$ getVLANText(parent.vlan) $}">
+                          {$ getVLANText(parent.vlan) $}
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Subnet CIDR">
+                    <span title="{$ parent.subnet.cidr $}">
+                      <span data-ng-if="parent.subnet.cidr">
+                        {$ parent.subnet.cidr $}
+                      </span>
+                      <span data-ng-if="!parent.subnet.cidr">
+                        Unconfigured
+                      </span>
+                    </span>
+                  </td>
+                  <td aria-label="IP address">
+                    <span title="{$ parent.ip_address $}">
+                      <span data-ng-if="parent.ip_address">
+                        {$ parent.ip_address $}
+                      </span>
+                      <span data-ng-if="!parent.ip_address">
+                        {$ getLinkModeText(parent) $}
+                      </span>
+                    </span>
+                  </td>
+                  <td style="overflow: visible;">
+                    {$ getDHCPStatus(parent.vlan) $}
+                    <span
+                      class="p-tooltip--btm-right"
+                      ng-if="parent.vlan && parent.vlan.relay_vlan"
+                      style="margin-left: 0.25rem;"
+                    >
+                      <i class="p-icon--information" style="width: 0.875rem;"
+                        >{$ getDHCPStatus(parent.vlan, true) $}</i
+                      >
+                      <span class="p-tooltip__message"
+                        >{$ getDHCPStatus(parent.vlan, true) $}</span
+                      >
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="p-table__row--muted"
+                  data-ng-repeat="interface in interfaces | filterSelectedInterfaces:selectedInterfaces:newBondInterface"
+                  data-ng-if="isShowingInterfaces"
+                >
+                  <td class="p-double-row" aria-label="Name">
+                    <div class="p-double-row__checkbox">
+                      <input
+                        type="checkbox"
+                        class="checkbox"
+                        id="{$ getUniqueKey(interface) $}"
+                        data-ng-checked="isInterfaceSelected(interface)"
+                        data-ng-click="toggleInterfaceSelect(interface)"
+                      />
+                      <label
+                        class="is-inline-label"
+                        for="{$ getUniqueKey(interface) $}"
+                      ></label>
+                    </div>
+                    <div class="p-double-row__rows-container--checkbox">
+                      <div class="p-double-row__main-row">
+                        {$ interface.name $}
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        {$ interface.mac_address $}
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Primary">
+                    <input
+                      type="radio"
+                      name="bondPrimary"
+                      id="{$ interface.name $}"
+                      data-ng-model="newBondInterface.primary"
+                      data-ng-value="interface"
+                    />
+                    <label
+                      class="is-inline-label"
+                      for="{$ interface.name $}"
+                    ></label>
+                  </td>
+                  <td
+                    class="p-table__col--status p-double-row"
+                    aria-label="Link and interface speed"
+                  >
+                    <div class="p-double-row__icon-container">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        <span
+                          aria-describedby="not-connected-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="!isInterfaceConnected(interface)"
+                        >
+                          <i class="p-icon--error"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="not-connected-tooltip"
+                            >This interface is disconnected.</span
+                          >
+                        </span>
+                        <span
+                          aria-describedby="link-speed-tooltip"
+                          class="p-tooltip--top-left"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                        >
+                          <i class="p-icon--warning"></i>
+                          <span
+                            class="p-tooltip__message"
+                            role="tooltip"
+                            id="link-speed-tooltip"
+                            >Link connected to slow interface.</span
+                          >
+                        </span>
+                        <i
+                          class="p-icon--placeholder"
+                          ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed"
+                        >
+                        </i>
+                      </span>
+                    </div>
+                    <div class="p-double-row__rows-container--icon">
+                      <span
+                        ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                      >
+                        {$ formatSpeedUnits(interface.link_speed) $}/{$
+                        formatSpeedUnits(interface.interface_speed) $}
+                      </span>
+                    </div>
+                  </td>
+                  <td aria-label="Type, NUMA node" class="p-double-row">
+                    <div
+                      class="p-tooltip--top-left numa-tooltip"
+                      ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }"
+                    >
+                      <div class="p-double-row__rows-container">
+                        <div
+                          class="p-double-row__main-row"
+                          title="{$ getInterfaceTypeText(interface) $}"
+                        >
+                          {$ getInterfaceTypeText(interface) $}
+                        </div>
+                        <div class="p-double-row__muted-row">
+                          <span
+                            >{$ getInterfaceNumaNodes(interface).join(", ")
+                            $}</span
+                          >
+                        </div>
+                      </div>
+                      <span
+                        class="p-tooltip__message"
+                        ng-if="getInterfaceNumaNodes(interface).length > 1"
+                        >This bond is spread over multiple NUMA nodes.<br />This
+                        may lead to suboptimal performance.</span
+                      >
+                    </div>
+                  </td>
+                  <td class="p-double-row" aria-label="Fabric">
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row">
+                        <span
+                          title="{$ interface.fabric.name || 'Disconnected' $}"
+                        >
+                          {$ interface.fabric.name $}
+                          <span data-ng-if="!interface.fabric.name"
+                            >Disconnected</span
+                          >
+                        </span>
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <span title="{$ getVLANText(interface.vlan) $}">
+                          {$ getVLANText(interface.vlan) $}
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                  <td aria-label="Subnet CIDR">
+                    <span title="{$ interface.subnet.cidr $}">
+                      <span data-ng-if="interface.subnet.cidr">
+                        {$ interface.subnet.cidr $}
+                      </span>
+                      <span data-ng-if="!interface.subnet.cidr">
+                        Unconfigured
+                      </span>
+                    </span>
+                  </td>
+                  <td class="p-double-row">
+                    <div
+                      data-ng-if="!interface.discovered[0].ip_address && interface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ interface.ip_address $}"
+                      >
+                        <span data-ng-if="interface.ip_address"
+                          >{$ interface.ip_address $}</span
+                        >
+                        <span data-ng-if="!interface.ip_address"
+                          >{$ getLinkModeText(interface) $}</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="{$ getLinkModeText(interface) $}"
+                      >
+                        <span data-ng-if="interface.ip_address"
+                          >{$ getLinkModeText(interface) $}</span
+                        >
+                      </div>
+                    </div>
+                    <div
+                      data-ng-if="interface.discovered[0].ip_address && interface.fabric"
+                      class="p-double-row__rows-container"
+                    >
+                      <div
+                        class="p-double-row__main-row"
+                        aria-label="IP address"
+                        title="{$ interface.discovered[0].ip_address $}"
+                      >
+                        <span data-ng-if="interface.discovered[0].ip_address"
+                          >{$ interface.discovered[0].ip_address $}</span
+                        >
+                        <span data-ng-if="!interface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                      <div
+                        class="p-double-row__muted-row"
+                        aria-label="Link mode"
+                        title="DHCP"
+                      >
+                        <span data-ng-if="interface.discovered[0].ip_address"
+                          >DHCP</span
+                        >
+                      </div>
+                    </div>
+                  </td>
+                  <td style="overflow: visible;">
+                    {$ getDHCPStatus(interface.vlan) $}
+                    <span
+                      class="p-tooltip--btm-right"
+                      ng-if="interface.vlan && interface.vlan.relay_vlan"
+                      style="margin-left: 0.25rem;"
+                    >
+                      <i class="p-icon--information" style="width: 0.875rem;"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</i
+                      >
+                      <span class="p-tooltip__message"
+                        >{$ getDHCPStatus(interface.vlan, true) $}</span
+                      >
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
 
-                            <tr data-ng-if="!isDevice" class="p-table--is-not-device">
-                                <th class="p-double-row">
-                                    <div class="p-double-row__checkbox">
-                                        <span data-ng-if="!isController">&nbsp;</span>
-                                    </div>
-                                    <div class="p-double-row__rows-container--checkbox">
-                                        <div>Name</div>
-                                        <div>MAC</div>
-                                    </div>
-                                </th>
-                                <th>
-                                    <div data-ng-if="!isController">PXE</div>
-                                </th>
-                                <th class="p-table__col--status p-double-row">
-                                    <div class="p-double-row__icon-container">
-                                        <i class="p-icon--placeholder"></i>
-                                    </div>
-                                    <div class="p-double-row__rows-container--icon">
-                                        Link/interface speed
-                                    </div>
-                                </th>
-                                <th class="p-double-row">
-                                    <div>Type</div>
-                                    <div>NUMA node</div>
-                                </th>
-                                <th class="p-double-row">
-                                    <div>Fabric</div>
-                                    <div>VLAN</div>
-                                </th>
-                                <th class="p-double-row">
-                                    <div>Subnet</div>
-                                    <div>Name</div>
-                                </th>
-                                <th class="p-double-row">
-                                    <div>IP Address</div>
-                                    <div>Status</div>
-                                </th>
-                                <th>DHCP</th>
-                                <th class="u-align--right">Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody data-selected-rows>
-                            <tr data-ng-if="isDevice" class="p-table--is-device" data-ng-class="{ disabled: isDisabled(), 'is-active': isInterfaceSelected(interface) && (!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)), noEdit: cannotEditInterface(interface) }" data-ng-repeat="interface in interfaces | removeInterfaceParents:newBondInterface:isAllNetworkingDisabled() | removeInterfaceParents:newBridgeInterface:isAllNetworkingDisabled()">
-                                <td>{$ interface.mac_address $}</td>
-                                <td aria-label="Subnet">
-                                    <span data-ng-if="!isEditing(interface) && (interface.subnet || (interface.fabric && !interface.discovered[0].subnet_id))">{$ getSubnetText(interface.subnet) $}</span>
-                                    <span data-ng-if="isAllNetworkingDisabled() && interface.discovered[0].subnet_id" title="{$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}">
-                                        {$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}
-                                    </span>
-                                </td>
-                                <td aria-label="IP Address">{$ interface.ip_address $}</td>
-                                <td class="p-table--action-cell">
-                                    <div class="u-align--right">
-                                        <div class="p-contextual-menu" toggle-ctrl data-ng-if="!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)">
-                                            <button
-                                                class="p-button--base is-small p-contextual-menu__toggle u-no-margin--right"
-                                                data-ng-click="toggleMenu()"
-                                                data-ng-if="!(isShowingDeleteConfirm() && isInterfaceSelected(interface))"
-                                            >
-                                                <i class="p-icon--contextual-menu u-no-margin--right">Actions</i>
-                                            </button>
-                                            <div class="p-contextual-menu__dropdown" role="menu" data-ng-if="isToggled">
-                                                <button class="p-contextual-menu__link"
-                                                    data-ng-if="!cannotEditInterface(interface)"
-                                                    aria-label="Edit"
-                                                    data-ng-click="toggleMenu(); edit(interface); sendAnalyticsEvent('Machine details', 'Edit interface', 'Network tab')">Edit {$ getInterfaceTypeText(interface) $}</button>
-                                                <button class="p-contextual-menu__link"
-                                                    data-ng-if="canBeRemoved()"
-                                                    aria-label="Remove"
-                                                    data-ng-click="toggleMenu(); quickRemove(interface); sendAnalyticsEvent('Machine details', 'Remove interface', 'Network tab')">Remove {$ getInterfaceTypeText(interface) $}&hellip;</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="p-table-expanding__panel col-12" data-ng-if="isShowingMembers(interface)">
-                                    <div class="row" data-ng-class="{ 'is-active': isShowingMembers(interface) }"
-                                        data-ng-repeat="member in interface.members"
-                                        data-ng-show="isShowingMembers(interface)">
-                                        <div class="col-1"></div>
-                                        <div class="col-2" data-ng-show="tableInfo.column == 'name'">{$ member.name $}</div>
-                                        <div class="col-2 ng-hide"data-ng-show="tableInfo.column == 'mac'">{$ member.mac_address $}</div>
-                                        <div class="col-2">{$ getInterfaceTypeText(member) $}</div>
-                                        <div class="col-7"></div>
-                                    </div>
-                                </td>
-                                <td ng-if="isShowingDeleteConfirm() && isInterfaceSelected(interface)">
-                                    <div class="row">
-                                        <hr />
-                                        <div class="col-8">
-                                            <p class="u-no-margin--bottom"><span class="p-icon--warning">Warning:</span> Are you sure you want to remove this {$ getRemoveTypeText(interface) $}?</p>
-                                        </div>
-                                        <div class="col-4">
-                                            <div class="u-align--right">
-                                                <button class="p-button--base" data-ng-click="cancel()">Cancel</button>
-                                                <button class="p-button--negative u-no-margin--top" data-ng-click="confirmRemove(interface)">Remove</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
+            <button
+              class="p-button--neutral"
+              data-ng-click="toggleInterfaces()"
+              data-ng-if="showCreateEditButton()"
+            >
+              <span data-ng-if="isShowingInterfaces">Hide interfaces</span>
+              <span
+                data-ng-if="!isShowingInterfaces"
+                data-ng-click="sendAnalyticsEvent('Machine details', 'Edit bond', 'Network tab')"
+                >Edit bond members</span
+              >
+            </button>
 
-                            <!--
+            <div class="p-strip is-shallow">
+              <div class="row p-form--stacked">
+                <div class="col-6">
+                  <h3 class="p-heading--five">Bond details</h3>
+                  <div class="p-form__group row">
+                    <label for="bond-mode" class="p-form__label col-2"
+                      >Bond mode</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="bond-mode"
+                        data-ng-model="newBondInterface.bond_mode"
+                        data-ng-options="mode[0] as mode[1] for mode in bondOptions.modes"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row p-form-validation"
+                    data-ng-if="showXMITHashPolicy()"
+                    data-ng-class="{ 'is-caution': showLACPRate() && modeAndPolicyCompliant() }"
+                  >
+                    <label for="xmit-hash-policy" class="p-form__label col-2"
+                      >Hash policy</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="xmit-hash-policy"
+                        class="p-form-validation__input"
+                        data-ng-model="newBondInterface.bond_xmit_hash_policy"
+                        data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies"
+                      >
+                      </select>
+                      <p
+                        class="p-form-validation__message"
+                        data-ng-if="showLACPRate() && modeAndPolicyCompliant()"
+                      >
+                        <strong>Warning:</strong> This hash policy is not fully
+                        802.3ad compliant.
+                      </p>
+                    </div>
+                  </div>
+                  <div class="p-form__group row" data-ng-if="showLACPRate()">
+                    <label for="lacp-rate" class="p-form__label col-2"
+                      >LACP rate</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="lacp-rate"
+                        data-ng-model="newBondInterface.bond_lacp_rate"
+                        data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div class="p-form__group row">
+                    <label for="bond-name" class="p-form__label col-2"
+                      >Bond name</label
+                    >
+                    <div
+                      class="p-form__control p-form-validation col-4"
+                      data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBondInterface) }"
+                    >
+                      <input
+                        type="text"
+                        name="name"
+                        id="bond-name"
+                        class="p-form-validation__input"
+                        data-ng-model="newBondInterface.name"
+                      />
+                    </div>
+                  </div>
+                  <div class="p-form__group row">
+                    <label class="p-form__label col-2">Tags</label>
+                    <div class="p-form__control tags--inline col-4">
+                      <tags-input
+                        data-ng-model="newBondInterface.tags"
+                        allow-tags-pattern="[\w-]+"
+                      ></tags-input>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-6">
+                  <h3 class="p-heading--five">Network</h3>
+                  <div class="p-form__group row u-vertically-center">
+                    <label class="p-form__label col-2">Fabric</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="fabric"
+                        data-ng-model="newBondInterface.fabric"
+                        data-ng-options="fabric as fabric.name for fabric in fabrics"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div class="p-form__group row u-vertically-center">
+                    <label class="p-form__label col-2">VLAN</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="vlan"
+                        data-ng-model="newBondInterface.vlan"
+                        data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | filterVLANNotOnFabric:newBondInterface.fabric.vlan_ids"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div class="p-form__group row u-vertically-center">
+                    <label class="p-form__label col-2">Subnet</label>
+                    <div class="p-form__control col-4">
+                      <select
+                        name="subnet"
+                        data-ng-model="newBondInterface.subnet"
+                        data-ng-change="subnetChanged(newBondInterface)"
+                        data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newBondInterface.vlan"
+                      >
+                        <option
+                          value=""
+                          data-ng-hide="newBondInterface.type === 'alias'"
+                          >Unconfigured</option
+                        >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row u-vertically-center"
+                    data-ng-if="!isLinkModeDisabled(newBondInterface)"
+                  >
+                    <label for="link-mode" class="p-form__label col-2"
+                      >IP mode</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="link-mode"
+                        data-ng-model="newBondInterface.mode"
+                        data-ng-change="modeChanged(newBondInterface)"
+                        data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newBondInterface"
+                      >
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row u-vertically-center"
+                    data-ng-if="newBondInterface.mode == 'static'"
+                  >
+                    <label for="ip-address" class="p-form__label col-2"
+                      >IP address</label
+                    >
+                    <div
+                      class="p-form__control col-4"
+                      data-ng-class="{ 'is-error': isIPAddressInvalid(newBondInterface) }"
+                    >
+                      <input
+                        name="ip-address"
+                        type="text"
+                        placeholder="IP address"
+                        data-ng-model="newBondInterface.ip_address"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="p-strip is-shallow">
+              <div class="row p-form--stacked">
+                <div class="col-6">
+                  <h3 class="p-heading--five">Advanced options</h3>
+                  <div class="p-form__group row">
+                    <label for="mac" class="p-form__label col-2"
+                      >MAC address</label
+                    >
+                    <div
+                      class="p-form__control p-form-validation col-4"
+                      data-ng-class="{ 'is-error': isMACAddressInvalid(newBondInterface.mac_address) }"
+                    >
+                      <input
+                        type="text"
+                        name="mac"
+                        class="p-form-validation__input"
+                        placeholder="00:00:00:00:00:00"
+                        data-ng-value="newBondInterface.mac_address"
+                        data-ng-model="newBondInterface.mac_address"
+                        data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi"
+                        mac-address
+                        maxlength="17"
+                        data-ng-placeholder="getInterfacePlaceholderMACAddress(newBondInterface)"
+                      />
+                    </div>
+                  </div>
+                  <div class="p-form__group row">
+                    <label for="link-monitoring" class="p-form__label col-2"
+                      >Link monitoring</label
+                    >
+                    <div class="p-form__control col-4">
+                      <select
+                        name="link-monitoring"
+                        id="link-monitoring"
+                        data-ng-model="newInterfaceLinkMonitoring"
+                      >
+                        <option value="">No link monitoring</option>
+                        <option value="mii">MII link monitoring</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newInterfaceLinkMonitoring === 'mii'"
+                  >
+                    <label
+                      for="monitoring-frequency"
+                      class="p-form__label u-no-padding--top col-2"
+                      >Monitoring frequency (ms)</label
+                    >
+                    <div class="p-form__control col-4">
+                      <input
+                        type="text"
+                        name="monitoring-frequency"
+                        id="monitoring-frequency"
+                        data-ng-model="newBondInterface.bond_miimon"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newInterfaceLinkMonitoring === 'mii'"
+                  >
+                    <label for="updelay" class="p-form__label col-2"
+                      >Updelay (ms)</label
+                    >
+                    <div class="p-form__control col-4">
+                      <input
+                        type="text"
+                        name="updelay"
+                        id="updelay"
+                        data-ng-model="newBondInterface.bond_updelay"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="p-form__group row"
+                    data-ng-if="newInterfaceLinkMonitoring === 'mii'"
+                  >
+                    <label for="downdelay" class="p-form__label col-2"
+                      >Downdelay (ms)</label
+                    >
+                    <div class="p-form__control col-4">
+                      <input
+                        type="text"
+                        name="downdelay"
+                        id="downdelay"
+                        data-ng-model="newBondInterface.bond_downdelay"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row u-sv1">
+              <hr />
+            </div>
+            <div class="row">
+              <div class="col-12 u-align--right">
+                <button
+                  class="p-button--base u-no-margin--bottom"
+                  type="button"
+                  data-ng-click="cancel()"
+                >
+                  Cancel
+                </button>
+                <span
+                  class="p-tooltip--top-right"
+                  aria-describedby="save-bond-tooltip"
+                  data-ng-if="newBondInterface.parents && newBondInterface.parents.length < 2"
+                >
+                  <button
+                    class="p-button--positive u-no-margin--bottom"
+                    disabled
+                  >
+                    Save bond
+                  </button>
+                  <span
+                    class="p-tooltip__message"
+                    role="tooltip"
+                    id="save-bond-tooltip"
+                    >A bond must have at least two interfaces</span
+                  >
+                </span>
+                <button
+                  class="p-button--positive u-no-margin--bottom"
+                  data-ng-if="newBondInterface.parents && newBondInterface.parents.length >= 2"
+                  data-ng-click="addBond()"
+                  data-ng-disabled="cannotAddBond()"
+                >
+                  <span data-ng-if="isSaving">
+                    <i class="p-icon--spinner is-light u-animation--spin"></i>
+                    &nbsp; Saving bond
+                  </span>
+                  <span data-ng-if="!isSaving">
+                    Save bond
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="row"
+          data-ng-if="!isShowingCreateBridge() && !isShowingEdit() && !isShowingCreateBond()"
+        >
+          <table class="p-table-expanding p-table--controller-interfaces">
+            <thead>
+              <tr data-ng-if="isDevice" class="p-table--is-device">
+                <th>MAC</th>
+                <th>Subnet</th>
+                <th>IP Address</th>
+                <th><div class="u-align--right">Actions</div></th>
+                <th class="u-hide"></th>
+              </tr>
+
+              <tr data-ng-if="!isDevice" class="p-table--is-not-device">
+                <th class="p-double-row">
+                  <div class="p-double-row__checkbox">
+                    <span data-ng-if="!isController">&nbsp;</span>
+                  </div>
+                  <div class="p-double-row__rows-container--checkbox">
+                    <div>Name</div>
+                    <div>MAC</div>
+                  </div>
+                </th>
+                <th>
+                  <div data-ng-if="!isController">PXE</div>
+                </th>
+                <th class="p-table__col--status p-double-row">
+                  <div class="p-double-row__icon-container">
+                    <i class="p-icon--placeholder"></i>
+                  </div>
+                  <div class="p-double-row__rows-container--icon">
+                    Link/interface speed
+                  </div>
+                </th>
+                <th class="p-double-row">
+                  <div>Type</div>
+                  <div>NUMA node</div>
+                </th>
+                <th class="p-double-row">
+                  <div>Fabric</div>
+                  <div>VLAN</div>
+                </th>
+                <th class="p-double-row">
+                  <div>Subnet</div>
+                  <div>Name</div>
+                </th>
+                <th class="p-double-row">
+                  <div>IP Address</div>
+                  <div>Status</div>
+                </th>
+                <th>DHCP</th>
+                <th class="u-align--right">Actions</th>
+              </tr>
+            </thead>
+            <tbody data-selected-rows>
+              <tr
+                data-ng-if="isDevice"
+                class="p-table--is-device"
+                data-ng-class="{ disabled: isDisabled(), 'is-active': isInterfaceSelected(interface) && (!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)), noEdit: cannotEditInterface(interface) }"
+                data-ng-repeat="interface in interfaces | removeInterfaceParents:newBondInterface:isAllNetworkingDisabled() | removeInterfaceParents:newBridgeInterface:isAllNetworkingDisabled()"
+              >
+                <td>{$ interface.mac_address $}</td>
+                <td aria-label="Subnet">
+                  <span
+                    data-ng-if="!isEditing(interface) && (interface.subnet || (interface.fabric && !interface.discovered[0].subnet_id))"
+                    >{$ getSubnetText(interface.subnet) $}</span
+                  >
+                  <span
+                    data-ng-if="isAllNetworkingDisabled() && interface.discovered[0].subnet_id"
+                    title="{$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}"
+                  >
+                    {$
+                    getSubnetText(getSubnet(interface.discovered[0].subnet_id))
+                    $}
+                  </span>
+                </td>
+                <td aria-label="IP Address">{$ interface.ip_address $}</td>
+                <td class="p-table--action-cell">
+                  <div class="u-align--right">
+                    <div
+                      class="p-contextual-menu"
+                      toggle-ctrl
+                      data-ng-if="!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)"
+                    >
+                      <button
+                        class="p-button--base is-small p-contextual-menu__toggle u-no-margin--right"
+                        data-ng-click="toggleMenu()"
+                        data-ng-if="!(isShowingDeleteConfirm() && isInterfaceSelected(interface))"
+                      >
+                        <i class="p-icon--contextual-menu u-no-margin--right"
+                          >Actions</i
+                        >
+                      </button>
+                      <div
+                        class="p-contextual-menu__dropdown"
+                        role="menu"
+                        data-ng-if="isToggled"
+                      >
+                        <button
+                          class="p-contextual-menu__link"
+                          data-ng-if="!cannotEditInterface(interface)"
+                          aria-label="Edit"
+                          data-ng-click="toggleMenu(); edit(interface); sendAnalyticsEvent('Machine details', 'Edit interface', 'Network tab')"
+                        >
+                          Edit {$ getInterfaceTypeText(interface) $}
+                        </button>
+                        <button
+                          class="p-contextual-menu__link"
+                          data-ng-if="canBeRemoved()"
+                          aria-label="Remove"
+                          data-ng-click="toggleMenu(); quickRemove(interface); sendAnalyticsEvent('Machine details', 'Remove interface', 'Network tab')"
+                        >
+                          Remove {$ getInterfaceTypeText(interface) $}&hellip;
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="p-table-expanding__panel col-12"
+                  data-ng-if="isShowingMembers(interface)"
+                >
+                  <div
+                    class="row"
+                    data-ng-class="{ 'is-active': isShowingMembers(interface) }"
+                    data-ng-repeat="member in interface.members"
+                    data-ng-show="isShowingMembers(interface)"
+                  >
+                    <div class="col-1"></div>
+                    <div
+                      class="col-2"
+                      data-ng-show="tableInfo.column == 'name'"
+                    >
+                      {$ member.name $}
+                    </div>
+                    <div
+                      class="col-2 ng-hide"
+                      data-ng-show="tableInfo.column == 'mac'"
+                    >
+                      {$ member.mac_address $}
+                    </div>
+                    <div class="col-2">{$ getInterfaceTypeText(member) $}</div>
+                    <div class="col-7"></div>
+                  </div>
+                </td>
+                <td
+                  ng-if="isShowingDeleteConfirm() && isInterfaceSelected(interface)"
+                >
+                  <div class="row">
+                    <hr />
+                    <div class="col-8">
+                      <p class="u-no-margin--bottom">
+                        <span class="p-icon--warning">Warning:</span> Are you
+                        sure you want to remove this {$
+                        getRemoveTypeText(interface) $}?
+                      </p>
+                    </div>
+                    <div class="col-4">
+                      <div class="u-align--right">
+                        <button class="p-button--base" data-ng-click="cancel()">
+                          Cancel
+                        </button>
+                        <button
+                          class="p-button--negative u-no-margin--top"
+                          data-ng-click="confirmRemove(interface)"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+
+              <!--
                                 "False" row added to allow ng-repeat of interfaces as well as their
                                 immediate members (if any) while at the same level in the DOM.
                             -->
-                            <tr
-                                ng-if="false"
-                                ng-repeat-start="interface in interfaces | removeInterfaceParents:newBondInterface:isAllNetworkingDisabled() | removeInterfaceParents:newBridgeInterface:isAllNetworkingDisabled()"
-                            ></tr>
-                            <tr
-                                class="p-table--is-not-device"
-                                ng-class="{
+              <tr
+                ng-if="false"
+                ng-repeat-start="interface in interfaces | removeInterfaceParents:newBondInterface:isAllNetworkingDisabled() | removeInterfaceParents:newBridgeInterface:isAllNetworkingDisabled()"
+              ></tr>
+              <tr
+                class="p-table--is-not-device"
+                ng-class="{
                                     'disabled': isDisabled(),
                                     'is-active': isInterfaceSelected(interface) && (!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)),
                                     'noEdit': cannotEditInterface(interface)
                                 }"
-                                ng-if="!isDevice"
-                            >
-                                <td class="p-double-row" aria-label="Name" data-ng-class="{ 'is-error': isInterfaceNameInvalid(editInterface) }">
-                                    <div class="p-double-row__checkbox" data-ng-if="!isController && !isEditing(interface)">
-                                        <input type="checkbox" class="checkbox" id="{$ getUniqueKey(interface) $}"
-                                            data-ng-checked="isInterfaceSelected(interface)"
-                                            data-ng-click="toggleInterfaceSelect(interface)"
-                                            data-ng-disabled="isDisabled() || isAllNetworkingDisabled()">
-                                        <label class="is-inline-label" for="{$ getUniqueKey(interface) $}"></label>
-                                    </div>
-                                    <div class="p-double-row__rows-container--checkbox">
-                                        <div class="p-double-row__main-row">
-                                            <div data-ng-if="!isEditing(interface) || (!isEditing(interface) && interface.type === 'vlan')" title="{$ interface.name $}">
-                                                {$ interface.name $}
-                                            </div>
-                                        </div>
-                                        <div class="p-double-row__muted-row">
-                                            <div data-ng-if="!isEditing(interface) || (!isEditing(interface) && interface.type === 'vlan')" title="{$ interface.mac_address $}">
-                                                {$ interface.mac_address $}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td aria-label="Boot interface">
-                                    <span class="u-align--center">
-                                        <i class="p-icon--success" id="{$ interface.name $}" name="bootInterface" data-ng-if="!isController && isBootInterface(interface)"></i>
-                                    </span>
-                                </td>
-                                <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
-                                    <div class="p-double-row__icon-container">
-                                        <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                            <span
-                                                aria-describedby="not-connected-tooltip"
-                                                class="p-tooltip--top-left"
-                                                ng-if="!isInterfaceConnected(interface)"
-                                            >
-                                                <i class="p-icon--disconnected"></i>
-                                                <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                            </span>
-                                            <span
-                                                aria-describedby="link-speed-tooltip"
-                                                class="p-tooltip--top-left"
-                                                ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
-                                            >
-                                                <i class="p-icon--warning"></i>
-                                                <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                            </span>
-                                            <i
-                                                class="p-icon--placeholder"
-                                                ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed">
-                                            </i>
-                                        </span>
-                                    </div>
-                                    <div class="p-double-row__rows-container--icon">
-                                        <span ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)">
-                                            {$ formatSpeedUnits(interface.link_speed) $}/{$ formatSpeedUnits(interface.interface_speed) $}
-                                        </span>
-                                    </div>
-                                </td>
-                                <td aria-label="Type, NUMA node" class="p-double-row">
-                                    <div
-                                        class="p-tooltip--top-left numa-tooltip"
-                                        ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }"
-                                    >
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row">
-                                                <span data-ng-if="!isEditing(interface)" title="{$ getInterfaceTypeText(interface) $}">{$ getInterfaceTypeText(interface) $}</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <span>{$ getInterfaceNumaNodes(interface).join(", ") $}</span>
-                                            </div>
-                                        </div>
-                                        <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(interface).length > 1">This bond is spread over multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                    </div>
-                                </td>
-                                <td class="p-double-row">
-                                    <div class="p-double-row__rows-container">
-                                        <div class="p-double-row__main-row" aria-label="Fabric">
-                                            <span data-ng-if="!isEditing(interface)" title="{$ interface.fabric.name || 'Disconnected' $}">
-                                                <a class="p-link--soft" data-ng-if="interface.fabric" href="{$ legacyURLBase $}/fabric/{$ interface.fabric.id $}">{$ interface.fabric.name $}</a>
-                                                <span data-ng-if="!interface.fabric.name">Disconnected</span>
-                                            </span>
-                                        </div>
-                                        <div class="p-double-row__muted-row" aria-label="VLAN">
-                                            <span data-ng-if="!isEditing(interface)" title="{$ getVLANText(interface.vlan) $}">
-                                                <a class="p-muted-text p-link--muted" data-ng-if="interface.vlan" href="{$ legacyURLBase $}/vlan/{$ interface.vlan.id $}">
-                                                    {$ getVLANText(interface.vlan) $}
-                                                </a>
-                                            </span>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="p-double-row">
-                                    <div data-ng-if="!isEditing(interface) && ((isDevice && interface.subnet) || (interface.fabric && !interface.discovered[0].subnet_id))" title="{$ getSubnetText(interface.subnet) $}" class="p-double-row__rows-container">
-                                        <div class="p-double-row__main-row" aria-label="Subnet CIDR" title="{$ interface.subnet.cidr $}">
-                                            <div class="u-text-overflow">
-                                                <span data-ng-if="interface.subnet.cidr">
-                                                    <a class="p-link--soft" href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}">{$ interface.subnet.cidr $}</a>
-                                                </span>
-                                                <span data-ng-if="!interface.subnet.cidr">Unconfigured</span>
-                                            </div>
-                                        </div>
-                                        <div data-ng-if="interface.subnet.name" class="p-double-row__muted-row" aria-label="Subnet name" title="{$ interface.subnet.name $}">
-                                            <div class="u-text-overflow">
-                                                <a class="p-muted-text p-link--muted" href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}">{$ interface.subnet.name $}</a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div data-ng-if="isAllNetworkingDisabled() && interface.discovered[0].subnet_id" class="p-double-row__rows-container">
-                                        <div class="p-double-row__main-row" aria-label="Subnet CIDR" title="{$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}">
-                                            <div class="u-text-overflow">
-                                                {$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}
-                                            </div>
-                                        </div>
-                                        <div class="p-double-row__muted-row" aria-label="Subnet name" title="">
-                                            &nbsp;
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="p-double-row">
-                                    <div data-ng-if="!isEditing(interface) && !interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                        <div class="p-double-row__main-row" aria-label="IP address" title="{$ interface.ip_address $}">
-                                            <div class="u-text-overflow">
-                                                <span data-ng-if="interface.ip_address">{$ interface.ip_address $}</span>
-                                                <span data-ng-if="!interface.ip_address">{$ getLinkModeText(interface) $}</span>
-                                            </div>
-                                        </div>
-                                        <div class="p-double-row__muted-row" aria-label="Status" title="{$ getNetworkTestingStatus(interface) $}">
-                                            <div class="u-text-overflow">
-                                                {$ getNetworkTestingStatus(interface) $}
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div data-ng-if="!isEditing(interface) && interface.discovered[0].ip_address && interface.fabric" class="p-double-row__rows-container">
-                                        <div class="p-double-row__main-row" aria-label="IP address" title="{$ interface.discovered[0].ip_address $}">
-                                            <span data-ng-if="interface.discovered[0].ip_address">{$ interface.discovered[0].ip_address $}</span>
-                                            <span data-ng-if="!interface.discovered[0].ip_address">DHCP</span>
-                                        </div>
-                                        <div class="p-double-row__muted-row" aria-label="Link mode" title="DHCP">
-                                            <span data-ng-if="interface.discovered[0].ip_address">DHCP</span>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td style="overflow: visible;">
-                                    {$ getDHCPStatus(interface.vlan) $}
-                                    <span class="p-tooltip--btm-right" ng-if="interface.vlan && interface.vlan.relay_vlan" style="margin-left: .25rem;">
-                                        <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(interface.vlan, true) $}</i>
-                                        <span class="p-tooltip__message">{$ getDHCPStatus(interface.vlan, true) $}</span>
-                                    </span>
-                                </td>
-                                <td class="p-table--action-cell u-vertically-center u-align--right">
-                                    <div class="p-contextual-menu" toggle-ctrl data-ng-if="(!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)) && !isEditing(interface) && !(isShowingDeleteConfirm() && isInterfaceSelected(interface))">
-                                        <button class="p-button--base is-small p-contextual-menu__toggle u-no-margin--right" data-ng-click="toggleMenu()"><i class="p-icon--contextual-menu u-no-margin--right">Actions</i></button>
-                                        <div class="p-contextual-menu__dropdown" role="menu" data-ng-show="isToggled">
-                                            <button class="p-contextual-menu__link" role="menu" data-ng-show="isToggled" data-ng-if="canMarkAsConnected(interface)"
-                                                aria-label="Mark as connected"
-                                                data-ng-click="toggleMenu(); changeConnectionStatus(interface); sendAnalyticsEvent('Machine details', 'Mark interface as connected', 'Network tab')">
-                                                Mark as connected
-                                            </button>
-                                            <button class="p-contextual-menu__link" role="menu" data-ng-show="isToggled"
-                                                data-ng-if="canMarkAsDisconnected(interface)" aria-label="Mark as disconnected"
-                                                data-ng-click="toggleMenu(); changeConnectionStatus(interface); sendAnalyticsEvent('Machine details', 'Mark interface as disconnected', 'Network tab')">
-                                                Mark as disconnected
-                                            </button>
-                                            <button class="p-contextual-menu__link"
-                                                aria-label="Add Alias or VLAN"
-                                                data-ng-if="canAddAliasOrVLAN(interface)"
-                                                data-ng-click="toggleMenu(); quickAdd(interface); sendAnalyticsEvent('Machine details', 'Add alias or VLAN', 'Network tab')">Add alias or VLAN</button>
-                                            <button class="p-contextual-menu__link"
-                                                data-ng-if="!cannotEditInterface(interface)"
-                                                aria-label="Edit"
-                                                data-ng-click="toggleMenu(); handleEdit(interface); sendAnalyticsEvent('Machine details', 'Edit interface', 'Network tab')">Edit {$ getInterfaceTypeText(interface) $}</button>
-                                            <button class="p-contextual-menu__link"
-                                                data-ng-if="canBeRemoved()"
-                                                aria-label="Remove"
-                                                data-ng-click="toggleMenu(); quickRemove(interface); sendAnalyticsEvent('Machine details', 'Remove interface', 'Network tab')">Remove {$ getInterfaceTypeText(interface) $}&hellip;</button>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="p-table-expanding__panel col-12" data-ng-if="isInterfaceSelected(interface) && showEditWarning">
-                                    <div class="row">
-                                        <div class="p-warning-message">
-                                            <i class="p-icon--warning p-warning-message__icon"></i>
-                                            <div>
-                                                This interface is <strong>disconnected</strong>, it cannot be configured unless a cable is connected.
-                                                <br>
-                                                If this is no longer true, <a href="" data-ng-click="changeConnectionStatus(interface)">mark cable as connected</a>.
-                                            </div>
-                                        </div>
-                                        <div class="u-align--right">
-                                            <button class="p-button--base" data-ng-click="cancel()">Cancel</button>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="p-table-expanding__panel col-12"  data-ng-if="isInterfaceSelected(interface) && (isShowingAdd() || isEditing(interface) || isShowingDeleteConfirm() || isChangingConnectionStatus || isShowingAdd() && !newInterface.saving)">
-                                    <div class="row">
-                                        <div class="u-position-relative u-clearfix" data-ng-if="windowWidth <= 772">
-                                            <h2 data-ng-click="cancel()" class="u-float--left p-heading--four">
-                                                <span data-ng-if="canAddAlias(newInterface.parent)">Adding alias</span>
-                                                <span data-ng-if="canAddVLAN(newInterface.parent)">Adding VLAN</span>
-                                                <span data-ng-if="isEditing(interface)">Editing {$ interface.name $}</span>
-                                                <span data-ng-if="isShowingDeleteConfirm()">Removing {$ interface.name $}</span>
-                                            </h2>
-                                            <button data-ng-click="cancel()" class="p-button--base u-float--right p-button--close">
-                                                <i class="p-icon--remove">Cancel</i>
-                                            </button>
-                                        </div>
-                                        <hr />
-                                        <div class="row" data-ng-if="isChangingConnectionStatus">
-                                            <div class="p-warning-message">
-                                                <i class="p-icon--warning p-warning-message__icon"></i>
-                                                <div data-ng-if="isInterfaceConnected(interface)">
-                                                    This interface was detected as <strong>connected</strong>. Are you sure you want to mark it as disconnected?
-                                                    <br>
-                                                    When the interface is disconnected, it cannot be configured.
-                                                </div>
-                                                <div data-ng-if="!isInterfaceConnected(interface)">
-                                                    This interface was detected as <strong>disconnected</strong>. Are you sure you want to mark it as connected?
-                                                </div>
-                                            </div>
-                                            <div class="u-align--right">
-                                                <button class="p-button--base" data-ng-click="cancel()">Cancel</button>
-                                                <button class="u-no-margin--top" data-ng-click="saveConnectionStatus(interface)" data-ng-class="{'p-button--positive': !isInterfaceConnected(interface), 'p-button--negative': isInterfaceConnected(interface)}">
-                                                    Mark as <span data-ng-if="isInterfaceConnected(interface)">disconnected</span><span data-ng-if="!isInterfaceConnected(interface)">connected</span>
-                                                </button>
-                                            </div>
-                                        </div>
-                                        <div class="p-form p-form--stacked" data-ng-class="{ 'is-active': isEditing(interface) || isShowingAdd() }">
-                                            <div class="row" data-ng-if="isShowingAdd()">
-                                                <div class="col-6">
-                                                    <div class="p-form__group">
-                                                        <label class="p-form__label">Name</label>
-                                                        <div class="p-form__control">
-                                                            <span class="col-4">{$ getAddName() $}</span>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group">
-                                                        <label for="type" class="p-form__label">Type</label>
-                                                        <div class="p-form__control">
-                                                            <select name="type" data-ng-model="newInterface.type" data-ng-change="addTypeChanged()">
-                                                                <option value="alias" data-ng-show="canAddAlias(newInterface.parent)">Alias</option>
-                                                                <option value="vlan" data-ng-show="canAddVLAN(newInterface.parent)">VLAN</option>
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group" data-ng-if="newInterface.type !== 'alias'">
-                                                        <label class="p-form__label">Tags</label>
-                                                        <div class="p-form__control tags--inline">
-                                                            <tags-input data-ng-model="newInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-6">
-                                                    <div class="p-form__group">
-                                                        <label for="fabric" class="p-form__label">Fabric</label>
-                                                        <div class="p-form__control">
-                                                            <select name="fabric"
-                                                                data-ng-model="newInterface.parent.fabric"
-                                                                data-ng-options="fabric as fabric.name for fabric in fabrics"
-                                                                disabled="disabled">
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group" data-ng-if="newInterface.type === 'alias'">
-                                                        <label for="vlan" class="p-form__label">VLAN</label>
-                                                        <div class="p-form__control">
-                                                            <select name="vlan"
-                                                                data-ng-model="newInterface.vlan"
-                                                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans"
-                                                                disabled="disabled">
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group" data-ng-if="newInterface.type === 'vlan'">
-                                                        <label for="vlan" class="p-form__label">VLAN</label>
-                                                        <div class="p-form__control">
-                                                            <select name="vlan"
-                                                                data-ng-model="newInterface.vlan"
-                                                                data-ng-change="vlanChanged(newInterface)"
-                                                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | removeDefaultVLAN | filterByFabric:newInterface.parent.fabric | filterByUnusedForInterface:newInterface.parent:originalInterfaces">
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group">
-                                                        <label for="subnet" class="p-form__label">Subnet</label>
-                                                        <div class="p-form__control">
-                                                            <select name="subnet"
-                                                                data-ng-model="newInterface.subnet"
-                                                                data-ng-change="subnetChanged(newInterface)"
-                                                                data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newInterface.vlan">
-                                                                <option value="" data-ng-hide="newInterface.type === 'alias'">Unconfigured</option>
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group" data-ng-if="!isLinkModeDisabled(newInterface)">
-                                                        <label for="link-mode" class="p-form__label">IP mode</label>
-                                                        <div class="p-form__control">
-                                                            <select name="link-mode"
-                                                                data-ng-model="newInterface.mode"
-                                                                data-ng-change="modeChanged(newInterface)"
-                                                                data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newInterface">
-                                                            </select>
-                                                        </div>
-                                                    </div>
-                                                    <div class="p-form__group" data-ng-if="newInterface.mode == 'static'">
-                                                        <label for="ip-address" class="p-form__label">IP address</label>
-                                                        <div class="p-form__control" data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }">
-                                                            <input name="ip-address" type="text" placeholder="IP address" data-ng-model="newInterface.ip_address">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <maas-obj-form obj="editInterface" manager="nodesManager" manager-method="updateInterfaceForm"
-                                                table-form="true" save-on-blur="false" after-save="editSave" pre-process="preProcessInterface"
-                                                data-ng-if="isEditing(editInterface)">
-                                                <div class="row">
-                                                    <div class="col-6">
-                                                        <maas-obj-field type="text" key="mac_address" label="MAC address"
-                                                            data-ng-if="interface.type !== 'alias' && interface.type !== 'vlan'" disable-label="false"
-                                                            input-class="table__input" placeholder="00:00:00:00:00:00"></maas-obj-field>
-                                                        <maas-obj-field type="tags" key="tags" label="Tags"
-                                                            placeholder="Add a tag"
-                                                            data-ng-if="!isAllNetworkingDisabled(interface) && interface.type !== 'alias'"
-                                                            disable-label="false"></maas-obj-field>
-                                                    </div>
-                                                    <div class="col-6" data-ng-if="!isAllNetworkingDisabled(interface)">
-                                                        <maas-obj-field type="options" key="ip_assignment" label="IP Assignment" label-width="2" input-width="5"
-                                                            disable-label="false"
-                                                            options="assignment.name as assignment.text for assignment in ipAssignments"></maas-obj-field>
-                                                        <maas-obj-field type="options" key="subnet" label="Subnet" placeholder="Unconfigured" placeholder-enabled="true"
-                                                            data-ng-init="editInterface.subnet = editInterface.defaultSubnet" label-width="2" input-width="5"
-                                                            data-ng-if="editInterface.$maasForm.getValue('ip_assignment') === 'static'"
-                                                            on-change="subnetChangedForm"
-                                                            disable-label="false"
-                                                            options="subnet as getSubnetText(subnet) for subnet in subnets"></maas-obj-field>
-                                                        <maas-obj-field type="text" key="ip_address" label="IP address" placeholder="IP Address" label-width="two" input-width="three"
-                                                            disable-label="false" input-class="table__input u-margin--none"
-                                                            data-ng-if="editInterface.$maasForm.getValue('ip_assignment') === 'external'">
-                                                            </maas-obj-field>
-                                                        <maas-obj-field type="text" key="ip_address" label="IP Address" placeholder="IP Address (optional)"
-                                                            data-ng-if="editInterface.$maasForm.getValue('ip_assignment') === 'static'" label-width="2" input-width="5"
-                                                            disable-label="false"></maas-obj-field>
-                                                    </div>
-                                                </div>
-                                                <div class="row u-no-margin--top">
-                                                    <hr />
-                                                    <maas-obj-errors></maas-obj-errors>
-                                                    <div class="u-align--right u-no-margin--top">
-                                                        <button class="p-button--base"
-                                                            data-ng-click="editCancel()">Cancel</button>
-                                                        <button class="p-button--positive u-no-margin--top"
-                                                        data-ng-disabled="isIPAddressInvalid(editInterface) || isMACAddressInvalid(editInterface.mac_address, true)"
-                                                        maas-obj-save>Save</button>
-                                                    </div>
-                                                </div>
-                                            </maas-obj-form>
-                                        </div>
-                                        <div class="row is-active" data-ng-if="isShowingDeleteConfirm() && isInterfaceSelected(interface)">
-                                            <div class="col-8">
-                                                <p class="u-no-margin--bottom"><span class="p-icon--warning">Warning:</span> Are you sure you want to remove this {$ getRemoveTypeText(interface) $}?</p>
-                                            </div>
-                                            <div class="col-4">
-                                                <div class="u-align--right">
-                                                    <button class="p-button--base" data-ng-click="cancel()">Cancel</button>
-                                                    <button class="p-button--negative u-no-margin--top" data-ng-click="confirmRemove(interface)">Remove</button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <hr data-ng-if="isShowingAdd() && !newInterface.saving" />
-                                        <div class="row" data-ng-if="isShowingAdd() && !newInterface.saving">
-                                            <div class="col-6">
-                                                <button class="p-button--neutral"
-                                                    data-ng-click="addInterface('alias')"
-                                                    data-ng-show="canAddAlias(interface)">Add <span data-ng-show="newInterface.type === 'alias'">another </span>alias</button>
-                                                <button class="p-button--neutral u-no-margin--top"
-                                                    data-ng-click="addInterface('vlan')"
-                                                    data-ng-show="canAddAnotherVLAN(interface)">Add <span data-ng-show="newInterface.type === 'vlan'">another </span>VLAN</button>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="u-align--right">
-                                                    <button class="p-button--base" data-ng-click="cancel()">Cancel</button>
-                                                    <button class="p-button--positive u-no-margin--top" data-ng-click="addInterface()">Add</button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td class="p-table-expanding__panel col-12" data-ng-if="isShowingMembers(interface)">
-                                    <div class="row" data-ng-class="{ 'is-active': isShowingMembers(interface) }"
-                                        data-ng-repeat="member in interface.members"
-                                        data-ng-show="isShowingMembers(interface)">
-                                        <div class="col-1"></div>
-                                        <div class="col-2" data-ng-show="tableInfo.column == 'name'">{$ member.name $}</div>
-                                        <div class="col-2 ng-hide"data-ng-show="tableInfo.column == 'mac'">{$ member.mac_address $}</div>
-                                        <div class="col-2">{$ getInterfaceTypeText(member) $}</div>
-                                        <div class="col-7"></div>
-                                    </div>
-                                </td>
-                            </tr>
-
-                            <tr
-                                class="p-table--is-not-device indented-border"
-                                ng-if="interface.members && interface.members.length > 0 && interface.type !== 'alias'"
-                                ng-repeat="member in interface.members"
-                            >
-                                <td class="p-double-row" aria-label="Name">
-                                    <div class="p-double-row__checkbox">
-                                        <label></label>
-                                    </div>
-                                    <div class="p-double-row__rows-container--checkbox">
-                                        <div class="p-double-row__main-row">
-                                            <div title="{$ member.name $}">
-                                                {$ member.name $}
-                                            </div>
-                                        </div>
-                                        <div class="p-double-row__muted-row">
-                                            <div title="{$ member.mac_address $}">
-                                                {$ member.mac_address $}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </td>
-                                <td aria-label="Boot interface">
-                                    &nbsp;
-                                </td>
-                                <td class="p-table__col--status p-double-row" aria-label="Link and interface speed">
-                                    <div class="p-double-row__icon-container">
-                                        <span ng-if="!isBond(member) && !isBridge(member)">
-                                            <span
-                                                aria-describedby="not-connected-tooltip"
-                                                class="p-tooltip--top-left"
-                                                ng-if="!isInterfaceConnected(member)"
-                                            >
-                                                <i class="p-icon--disconnected"></i>
-                                                <span class="p-tooltip__message" role="tooltip" id="not-connected-tooltip">This interface is disconnected.</span>
-                                            </span>
-                                            <span
-                                                aria-describedby="link-speed-tooltip"
-                                                class="p-tooltip--top-left"
-                                                ng-if="isInterfaceConnected(member) && member.link_speed < member.interface_speed"
-                                            >
-                                                <i class="p-icon--warning"></i>
-                                                <span class="p-tooltip__message" role="tooltip" id="link-speed-tooltip">Link connected to slow interface.</span>
-                                            </span>
-                                            <i
-                                                ng-if="isInterfaceConnected(member) && member.link_speed === member.interface_speed"
-                                                class="p-icon--placeholder"
-                                            ></i>
-                                        </span>
-                                    </div>
-                                    <div class="p-double-row__rows-container--icon">
-                                        <span ng-if="!isBond(member) && !isBridge(member)">
-                                            {$ formatSpeedUnits(member.link_speed) $}/{$ formatSpeedUnits(member.interface_speed) $}
-                                        </span>
-                                    </div>
-                                </td>
-                                <td aria-label="Type, NUMA node" class="p-double-row">
-                                    <div
-                                        class="p-tooltip--top-left numa-tooltip"
-                                        ng-class="{ 'show-warning': getInterfaceNumaNodes(member).length > 1 }"
-                                    >
-                                        <div class="p-double-row__rows-container">
-                                            <div class="p-double-row__main-row">
-                                                <span title="{$ getInterfaceTypeText(member) $}">{$ getInterfaceTypeText(interface, member) $}</span>
-                                            </div>
-                                            <div class="p-double-row__muted-row">
-                                                <span>{$ getInterfaceNumaNodes(member).join(", ") $}</span>
-                                            </div>
-                                        </div>
-                                        <span class="p-tooltip__message" ng-if="getInterfaceNumaNodes(member).length > 1">This bond is spread over multiple NUMA nodes.<br>This may lead to suboptimal performance.</span>
-                                    </div>
-                                </td>
-                                <td class="p-double-row">
-                                    &nbsp;
-                                </td>
-                                <td class="p-double-row">
-                                    &nbsp;
-                                </td>
-                                <td class="p-double-row">
-                                    &nbsp;
-                                </td>
-                                <td class="p-double-row">
-                                    &nbsp;
-                                </td>
-                                <td class="p-double-row">
-                                    &nbsp;
-                                </td>
-                            </tr>
-                            <tr ng-if="false" ng-repeat-end></tr>
-
-                            <tr class="is-active" data-ng-if="isShowingCreateBond() && !isAllNetworkingDisabled()">
-                                <td>
-                                    <div class="row" data-ng-if="windowWidth > 772">
-                                        <table class="u-no-margin--top">
-                                            <tr class="u-no-padding">
-                                                <td class="table-col--16">
-                                                    <input type="checkbox" class="checkbox u-float--left" id="bond-create" disabled="disabled" checked style="margin-top: 0.5rem;" />
-                                                    <label for="bond-create"></label>
-                                                    <span data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBondInterface) }" style="padding-left: 2rem;">
-                                                        <input type="text" name="name" class="editible p-form-validation__input u-no-margin--bottom" data-ng-model="newBondInterface.name" style="width: 82%;">
-                                                    </span>
-                                                </td>
-                                                <td class="table-col--7 u-align--center">
-                                                    <input type="radio" name="bondBootInterface" checked id="{$ newBondInterface $}" data-ng-if="hasBootInterface(newBondInterface)">
-                                                </td>
-                                                <td class="table-col--77">&nbsp;</td>
-                                            </tr>
-                                        </table>
-                                        <hr>
-                                    </div>
-                                    <div class="row" data-ng-if="windowWidth <= 772">
-                                        <h2 class="u-float--left">Create bond</h2>
-                                        <button data-ng-click="cancel()" class="p-button--base u-float--right p-button--close">
-                                            <i class="p-icon--close">Cancel</i>
-                                        </button>
-                                    </div>
-                                </td>
-                                <td class="p-table-expanding__panel col-12 u-no-padding--top">
-                                    <div class="p-form p-form--stacked is-active">
-                                        <div class="row">
-                                            <div class="col-6">
-                                                <div class="p-form__group" data-ng-if="windowWidth <= 772">
-                                                    <label for="bond-name" class="p-form__label">Name</label>
-                                                    <div class="p-form__control p-form-validation"
-                                                        data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBondInterface) }">
-                                                        <input type="text" name="name" id="bond-name" class="p-form-validation__input"
-                                                            data-ng-model="newBondInterface.name">
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group">
-                                                    <label for="bond-mode" class="p-form__label">Bond mode</label>
-                                                    <div class="p-form__control">
-                                                        <select name="bond-mode"
-                                                            data-ng-model="newBondInterface.mode"
-                                                            data-ng-options="mode[0] as mode[1] for mode in bondOptions.modes">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group">
-                                                    <label for="mac" class="p-form__label">MAC address</label>
-                                                    <div class="p-form__control p-form-validation"
-                                                        data-ng-class="{ 'is-error': isMACAddressInvalid(newBondInterface.mac_address) }">
-                                                        <input type="text" name="mac" class="p-form-validation__input"
-                                                            placeholder="00:00:00:00:00:00"
-                                                            data-ng-model="newBondInterface.mac_address"
-                                                            data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi" mac-address maxlength="17"
-                                                            data-ng-placeholder="getInterfacePlaceholderMACAddress(newBondInterface)">
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group u-vertically-center">
-                                                    <label class="p-form__label">Tags</label>
-                                                    <div class="p-form__control tags--inline">
-                                                        <tags-input data-ng-model="newBondInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="p-form__group" data-ng-if="showLACPRate()">
-                                                    <label for="lacp-rate" class="p-form__label">LACP rate</label>
-                                                    <div class="p-form__control">
-                                                        <select name="lacp-rate"
-                                                            data-ng-model="newBondInterface.bond_lacp_rate"
-                                                            data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group" data-ng-if="showXMITHashPolicy()">
-                                                    <label for="xmit-hash-policy" class="p-form__label">XMIT hash policy</label>
-                                                    <div class="p-form__control">
-                                                        <select name="xmit-hash-policy"
-                                                            data-ng-model="newBondInterface.bond_xmit_hash_policy"
-                                                            data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div data-ng-if="newBondInterface.parents.length > 0">
-                                        <hr>
-                                        <table class="row">
-                                            <tr>
-                                                <th class="table-col--16">Name</th>
-                                                <th class="table-col--16">Type</th>
-                                                <th class="table-col--16">Primary</th>
-                                            </tr>
-                                            <tr data-ng-repeat="parent in newBondInterface.parents | orderBy:'name'">
-                                                <td class="table-col--16" aria-label="Name">{$ parent.name $}</td>
-                                                <td class="table-col--16" aria-label="Type">{$ getInterfaceTypeText(parent) $}</td>
-                                                <td class="table-col--16" aria-label="Primary">
-                                                    <input type="radio" name="bondPrimary" id="{$ parent.name $}" data-ng-model="newBondInterface.primary" data-ng-value="parent">
-                                                    <label class="is-inline-label" for="{$ parent.name $}"></label>
-                                                </td>
-                                            </tr>
-                                        </table>
-                                    </div>
-                                    <div class="row">
-                                        <hr />
-                                        <div class="col-12 u-align--right">
-                                            <button class="p-button--base" type="button" data-ng-click="cancel()">Cancel</button>
-                                            <button class="p-button--positive u-no-margin--top"
-                                                data-ng-click="addBond()"
-                                                data-ng-disabled="cannotAddBond()">Save</button>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="is-active ng-hide" data-ng-show="isShowingCreatePhysical()">
-                                <td class="p-table-expanding__panel">
-                                    <div class="row u-hide--medium u-hide--small">
-                                        <div class="col-6">
-                                            <div class="p-form-validation" data-ng-if="!isDevice"
-                                                data-ng-class="{ 'is-error': isInterfaceNameInvalid(newInterface) }">
-                                                <input type="text" class="p-form-validation__input"
-                                                    data-ng-model="newInterface.name">
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <hr data-ng-if="!isDevice" class="u-hide--medium u-hide--small">
-                                    <div class="row" data-ng-if="windowWidth <= 772">
-                                        <div class="u-flex--no-wrap">
-                                            <h2 data-ng-click="cancel()" class="p-heading--four">New interface</h2>
-                                            <button class="p-button--close" data-ng-click="cancel()" ><i class="p-icon--close">Cancel</i></button>
-                                        </div>
-                                    </div>
-                                    <div class="p-form p-form--stacked" data-ng-if="!isDevice">
-                                        <div class="row">
-                                            <div class="col-6" data-ng-if="!isDevice">
-                                                <div class="p-form__group row p-form-validation u-hide--large"
-                                                    data-ng-class="{ 'is-error': isInterfaceNameInvalid(newInterface) }">
-                                                    <label for="new-interface-name" class="p-form__label col-2">Name</label>
-                                                    <div class="p-form__control col-4">
-                                                        <input type="text" class="p-form-validation__input" id="new-interface-name"
-                                                            data-ng-model="newInterface.name">
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group row u-no-margin--top">
-                                                    <label class="p-form__label col-2">Type</label>
-                                                    <div class="p-form__control col-4">
-                                                        <p>Physical</p>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group row p-form-validation u-no-margin--top"
-                                                    data-ng-class="{ 'is-error': isMACAddressInvalid(newInterface.mac_address, false) || newInterface.macError }">
-                                                    <label for="mac" class="p-form__label col-2">MAC address</label>
-                                                    <div class="p-form__control col-4">
-                                                        <input type="text" name="mac" class="p-form-validation__input"
-                                                            placeholder="00:00:00:00:00:00"
-                                                            data-ng-model="newInterface.mac_address"
-                                                            data-ng-keydown="$event.keyCode == 13 && $event.preventDefault()"
-                                                            data-ng-keyup="$event.keyCode == 13 && addPhysicalInterface()"
-                                                            data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi" mac-address maxlength="17">
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group u-no-margin--top row u-vertically-center" style="min-height: 2.5rem;">
-                                                    <label class="p-form__label col-2">Tags</label>
-                                                    <div class="p-form__control col-4 tags--inline">
-                                                        <tags-input data-ng-model="newInterface.tags" allow-tags-pattern="[\w-]+"></tags-input>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="p-form__group row">
-                                                    <label for="fabric" class="p-form__label col-2">Fabric</label>
-                                                    <div class="p-form__control col-4">
-                                                        <select name="fabric"
-                                                            data-ng-model="newInterface.fabric"
-                                                            data-ng-change="fabricChanged(newInterface)"
-                                                            data-ng-options="fabric as fabric.name for fabric in fabrics">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group row u-no-margin--top">
-                                                    <label for="vlan" class="p-form__label col-2">VLAN</label>
-                                                    <div class="p-form__control col-4">
-                                                        <select name="vlan"
-                                                            data-ng-model="newInterface.vlan"
-                                                            data-ng-options="vlan as getVLANText(vlan) for vlan in vlans">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group row u-no-margin--top">
-                                                    <label for="subnet" class="p-form__label col-2">Subnet</label>
-                                                    <div class="p-form__control col-4">
-                                                        <select name="subnet"
-                                                            data-ng-model="newInterface.subnet"
-                                                            data-ng-change="subnetChanged(newInterface)"
-                                                            data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newInterface.vlan">
-                                                            <option value="" data-ng-hide="newInterface.type === 'alias'">Unconfigured</option>
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group row u-no-margin--top" data-ng-if="!isLinkModeDisabled(newInterface)">
-                                                    <label for="link-mode" class="p-form__label col-2">IP mode</label>
-                                                    <div class="p-form__control col-4">
-                                                        <select name="link-mode"
-                                                            data-ng-model="newInterface.mode"
-                                                            data-ng-change="modeChanged(newInterface)"
-                                                            data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newInterface">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group row u-no-margin--top p-form-validation" data-ng-if="newInterface.mode == 'static'"
-                                                    data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }">
-                                                    <label for="ip-address" class="p-form__label col-2">IP address</label>
-                                                    <div class="p-form__control col-4">
-                                                        <input name="ip-address" type="text"
-                                                            class="p-form-validation__input"
-                                                            placeholder="IP address (optional)"
-                                                            data-ng-model="newInterface.ip_address">
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="p-form p-form--stacked">
-                                        <div class="row" data-ng-if="isDevice">
-                                            <div class="col-6">
-                                                <div class="p-form__group p-form-validation"
-                                                    data-ng-class="{ 'is-error': isMACAddressInvalid(newInterface.mac_address, true) }">
-                                                    <label for="mac" class="p-form__label">MAC address</label>
-                                                    <div class="p-form__control">
-                                                        <input name="mac" type="text"
-                                                            class="p-form-validation__input"
-                                                            placeholder="00:00:00:00:00:00"
-                                                            data-ng-model="newInterface.mac_address"
-                                                            data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi" mac-address maxlength="17">
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="col-6" data-ng-if="!isAllNetworkingDisabled(interface)">
-                                                <div class="p-form__group">
-                                                    <label for="ip-assignment" class="p-form__label">IP Assignment</label>
-                                                    <div class="p-form__control">
-                                                        <select name="ip-assignment"
-                                                            data-ng-model="newInterface.ip_assignment"
-                                                            data-ng-options="assignment.name as assignment.text for assignment in ipAssignments">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group" data-ng-if="newInterface.ip_assignment === 'static'">
-                                                    <label for="subnet" class="p-form__label">Subnet</label>
-                                                    <div class="p-form__control">
-                                                        <select name="subnet"
-                                                            data-ng-init="newInterface.subnet = subnets[0]"
-                                                            data-ng-model="newInterface.subnet"
-                                                            data-ng-change="subnetChanged(newInterface)"
-                                                            data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets">
-                                                        </select>
-                                                    </div>
-                                                </div>
-                                                <div class="p-form__group p-form-validation" data-ng-if="newInterface.ip_assignment !== 'dynamic'"
-                                                    data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }">
-                                                    <label for="ip-address" class="p-form__label">IP address</label>
-                                                    <div class="p-form__control">
-                                                        <input name="ip-address" type="text"
-                                                            class="p-form-validation__input"
-                                                            data-ng-if="newInterface.ip_assignment === 'static'"
-                                                            placeholder="IP address (optional)"
-                                                            data-ng-model="newInterface.ip_address">
-                                                        <input name="ip-address" type="text"
-                                                            class="p-form-validation__input"
-                                                            data-ng-if="newInterface.ip_assignment !== 'static'"
-                                                            placeholder="IP address"
-                                                            data-ng-model="newInterface.ip_address">
-                                                        <p class="p-form-validation__message" role="alert"
-                                                            data-ng-if="getInterfaceError(newInterface)">
-                                                            <strong>Error:</strong> {$ getInterfaceError(newInterface) $}
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <hr />
-                                        <div class="u-float--left" data-ng-show="newInterface.errorMsg">
-                                            <span class="p-icon--error">Error:</span> {$ newInterface.errorMsg $}
-                                        </div>
-                                        <div class="u-align--right">
-                                            <button class="p-button--base" data-ng-click="cancel()">Cancel</button>
-                                            <button class="p-button--positive"
-                                                data-ng-click="addPhysicalInterface()"
-                                                data-ng-disabled="cannotAddPhysicalInterface()">Save interface</button>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </form>
-        </div>
-        <div class="row" data-ng-if="filteredSnippets.length && !isShowingCreateBridge() && !isShowingEdit() && !isShowingCreateBond()">
-            <div class="col-12">
-                <h2 class="p-heading--four">DHCP snippets</h2>
-                <maas-dhcp-snippets-table snippets="filteredSnippets"></maas-dhcp-snippets-table>
-            </div>
-        </div>
-    </section>
-
-    <section class="p-strip is-shallow u-no-padding--bottom" data-ng-if="section.area === 'storage'" data-ng-controller="NodeStorageController">
-        <div class="row">
-            <div class="col-12">
-                <div class="p-notification--negative" data-ng-if="!has_disks">
-                    <p class="p-notification__response">
-                        <span class="p-notification__status">Error:</span> No storage information. Commissioning this node will gather the storage information.
-                    </p>
-                </div>
-                <div class="p-notification" data-ng-if="isAllStorageDisabled() && $parent.canEdit()">
-                    <p class="p-notification__response">Storage configuration cannot be modified unless the machine is Ready or Allocated.</p>
-                </div>
-                <div class="p-notification" data-ng-if="!isUbuntuOS() && !isCentOS()">
-                    <p class="p-notification__response">Custom storage configuration is only supported on Ubuntu, CentOS, and RHEL.</p>
-                </div>
-                <div class="p-notification" data-ng-if="!isUbuntuOS()">
-                    <p class="p-notification__response">Bcache and ZFS are only supported on Ubuntu.</p>
-                </div>
-                <div data-ng-repeat="issue in node.storage_layout_issues" class="p-notification--negative" data-ng-if="hasStorageLayoutIssues()">
-                    <p class="p-notification__response">
-                        <span class="p-notification__status">Error:</span> {$ issue $}
-                    </p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <section data-ng-if="section.area === 'storage'" data-ng-controller="NodeStorageController">
-        <form class="p-strip">
-            <div data-ng-if="canEdit() && (node.status_code === 4 || node.status_code === 10)">
-                <div class="u-fixed-width" data-ng-if="!confirmStorageLayout">
-                    <div class="p-form__group u-align--right">
-                        <div data-ng-if="storageLayoutIsDisabled(osFamily.layouts) && storageLayoutIsDisabled(osFamily.layouts)">
-                            <button class="p-button--neutral" disabled>Change storage layout</button>
-                        </div>
-                        <div data-ng-if="!(storageLayoutIsDisabled(osFamily.layouts) && storageLayoutIsDisabled(osFamily.layouts))">
-                            <div class="p-contextual-menu" toggle-ctrl>
-                                <button class="p-button--neutral p-contextual-menu__toggle u-no-margin--bottom u-no-margin--right" data-ng-click="toggleMenu()">
-                                    <span data-ng-if="!updatingStorageLayout">
-                                        Change storage layout&nbsp;
-                                        <i class="p-icon--chevron" data-ng-class="{'u-rotate':isToggled}"></i>
-                                    </span>
-
-                                    <span data-ng-if="updatingStorageLayout">
-                                        <i class="p-icon--spinner u-animation--spin"></i>
-                                        &nbsp;
-                                        Updating storage layout&hellip;
-                                    </span>
-                                </button>
-                                <div class="p-contextual-menu__dropdown" role="menu" data-ng-show="isToggled">
-                                    <button class="p-contextual-menu__link" data-ng-click="toggleMenu(); openStorageLayoutConfirm('flat')">Flat</button>
-                                    <button class="p-contextual-menu__link" data-ng-click="toggleMenu(); openStorageLayoutConfirm('lvm')">LVM</button>
-                                    <button class="p-contextual-menu__link" data-ng-click="toggleMenu(); openStorageLayoutConfirm('bcache')">bcache</button>
-                                    <hr class="u-no-margin--bottom"/>
-                                    <button class="p-contextual-menu__link" data-ng-click="toggleMenu(); openStorageLayoutConfirm('vmfs6')">VMFS6 (VMware ESXi)</button>
-                                    <hr class="u-no-margin--bottom"/>
-                                    <button class="p-contextual-menu__link" data-ng-click="toggleMenu(); openStorageLayoutConfirm('blank')">No storage (blank) layout</button>
-                                </div>
-                            </div>
-                        </div>
+                ng-if="!isDevice"
+              >
+                <td
+                  class="p-double-row"
+                  aria-label="Name"
+                  data-ng-class="{ 'is-error': isInterfaceNameInvalid(editInterface) }"
+                >
+                  <div
+                    class="p-double-row__checkbox"
+                    data-ng-if="!isController && !isEditing(interface)"
+                  >
+                    <input
+                      type="checkbox"
+                      class="checkbox"
+                      id="{$ getUniqueKey(interface) $}"
+                      data-ng-checked="isInterfaceSelected(interface)"
+                      data-ng-click="toggleInterfaceSelect(interface)"
+                      data-ng-disabled="isDisabled() || isAllNetworkingDisabled()"
+                    />
+                    <label
+                      class="is-inline-label"
+                      for="{$ getUniqueKey(interface) $}"
+                    ></label>
+                  </div>
+                  <div class="p-double-row__rows-container--checkbox">
+                    <div class="p-double-row__main-row">
+                      <div
+                        data-ng-if="!isEditing(interface) || (!isEditing(interface) && interface.type === 'vlan')"
+                        title="{$ interface.name $}"
+                      >
+                        {$ interface.name $}
+                      </div>
                     </div>
-                </div>
-                <div class="row" data-ng-if="confirmStorageLayout">
-                    <div class="p-card--highlighted">
-                        <div class="col-6 u-no-margin--left">
-                            <div class="p-notification--caution is-subtle" data-ng-if="newLayout.id === 'vmfs6'">
-                                <p class="p-notification__response">
-                                    <strong>Are you sure you want to change the storage layout to VMFS6?</strong><br />
-                                    Any changes done already will be discarded.<br />
-                                    This layout allows only for the deployment of <strong>VMware ESXi</strong> images.<br />
-                                    The storage layout will be applied to a node when it is deployed.
-                                </p>
-                            </div>
-                            <div class="p-notification--caution is-subtle" data-ng-if="newLayout.id === 'lvm'">
-                                <p class="p-notification__response">
-                                    <strong>Are you sure you want to change the storage layout to LVM?</strong><br />
-                                    Any changes done already will be lost.<br />
-                                    The storage layout will be applied to a node when it is deployed.
-                                </p>
-                            </div>
-                            <div class="p-notification--caution is-subtle" data-ng-if="newLayout.id === 'blank'">
-                                <p class="p-notification__response">
-                                    <strong>Are you sure you want to change this storage layout to blank?</strong><br />
-                                    Used disks will be returned to available, and any volume groups, raid sets,  caches, and filesystems removed.<br />
-                                    The storage layout will be applied to a node when it is deployed.
-                                </p>
-                            </div>
-                            <div class="p-notification--caution is-subtle" data-ng-if="newLayout.id !== 'lvm' && newLayout.id !== 'vmfs6' && newLayout.id !== 'blank'">
-                                <p class="p-notification__response" style="margin-left: -1rem">
-                                    <strong>Are you sure you want to change the storage layout to {$ newLayout.id $}?</strong><br />
-                                    Any changes done already will be lost.<br />
-                                    The storage layout will be applied to a node when it is deployed.
-                                </p>
-                            </div>
+                    <div class="p-double-row__muted-row">
+                      <div
+                        data-ng-if="!isEditing(interface) || (!isEditing(interface) && interface.type === 'vlan')"
+                        title="{$ interface.mac_address $}"
+                      >
+                        {$ interface.mac_address $}
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td aria-label="Boot interface">
+                  <span class="u-align--center">
+                    <i
+                      class="p-icon--success"
+                      id="{$ interface.name $}"
+                      name="bootInterface"
+                      data-ng-if="!isController && isBootInterface(interface)"
+                    ></i>
+                  </span>
+                </td>
+                <td
+                  class="p-table__col--status p-double-row"
+                  aria-label="Link and interface speed"
+                >
+                  <div class="p-double-row__icon-container">
+                    <span
+                      ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                    >
+                      <span
+                        aria-describedby="not-connected-tooltip"
+                        class="p-tooltip--top-left"
+                        ng-if="!isInterfaceConnected(interface)"
+                      >
+                        <i class="p-icon--disconnected"></i>
+                        <span
+                          class="p-tooltip__message"
+                          role="tooltip"
+                          id="not-connected-tooltip"
+                          >This interface is disconnected.</span
+                        >
+                      </span>
+                      <span
+                        aria-describedby="link-speed-tooltip"
+                        class="p-tooltip--top-left"
+                        ng-if="isInterfaceConnected(interface) && interface.link_speed < interface.interface_speed"
+                      >
+                        <i class="p-icon--warning"></i>
+                        <span
+                          class="p-tooltip__message"
+                          role="tooltip"
+                          id="link-speed-tooltip"
+                          >Link connected to slow interface.</span
+                        >
+                      </span>
+                      <i
+                        class="p-icon--placeholder"
+                        ng-if="isInterfaceConnected(interface) && interface.link_speed === interface.interface_speed"
+                      >
+                      </i>
+                    </span>
+                  </div>
+                  <div class="p-double-row__rows-container--icon">
+                    <span
+                      ng-if="!isBond(interface) && !isBridge(interface) && !isVLAN(interface)"
+                    >
+                      {$ formatSpeedUnits(interface.link_speed) $}/{$
+                      formatSpeedUnits(interface.interface_speed) $}
+                    </span>
+                  </div>
+                </td>
+                <td aria-label="Type, NUMA node" class="p-double-row">
+                  <div
+                    class="p-tooltip--top-left numa-tooltip"
+                    ng-class="{ 'show-warning': getInterfaceNumaNodes(interface).length > 1 }"
+                  >
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row">
+                        <span
+                          data-ng-if="!isEditing(interface)"
+                          title="{$ getInterfaceTypeText(interface) $}"
+                          >{$ getInterfaceTypeText(interface) $}</span
+                        >
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <span
+                          >{$ getInterfaceNumaNodes(interface).join(", ")
+                          $}</span
+                        >
+                      </div>
+                    </div>
+                    <span
+                      class="p-tooltip__message"
+                      ng-if="getInterfaceNumaNodes(interface).length > 1"
+                      >This bond is spread over multiple NUMA nodes.<br />This
+                      may lead to suboptimal performance.</span
+                    >
+                  </div>
+                </td>
+                <td class="p-double-row">
+                  <div class="p-double-row__rows-container">
+                    <div class="p-double-row__main-row" aria-label="Fabric">
+                      <span
+                        data-ng-if="!isEditing(interface)"
+                        title="{$ interface.fabric.name || 'Disconnected' $}"
+                      >
+                        <a
+                          class="p-link--soft"
+                          data-ng-if="interface.fabric"
+                          href="{$ legacyURLBase $}/fabric/{$ interface.fabric.id $}"
+                          >{$ interface.fabric.name $}</a
+                        >
+                        <span data-ng-if="!interface.fabric.name"
+                          >Disconnected</span
+                        >
+                      </span>
+                    </div>
+                    <div class="p-double-row__muted-row" aria-label="VLAN">
+                      <span
+                        data-ng-if="!isEditing(interface)"
+                        title="{$ getVLANText(interface.vlan) $}"
+                      >
+                        <a
+                          class="p-muted-text p-link--muted"
+                          data-ng-if="interface.vlan"
+                          href="{$ legacyURLBase $}/vlan/{$ interface.vlan.id $}"
+                        >
+                          {$ getVLANText(interface.vlan) $}
+                        </a>
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td class="p-double-row">
+                  <div
+                    data-ng-if="!isEditing(interface) && ((isDevice && interface.subnet) || (interface.fabric && !interface.discovered[0].subnet_id))"
+                    title="{$ getSubnetText(interface.subnet) $}"
+                    class="p-double-row__rows-container"
+                  >
+                    <div
+                      class="p-double-row__main-row"
+                      aria-label="Subnet CIDR"
+                      title="{$ interface.subnet.cidr $}"
+                    >
+                      <div class="u-text-overflow">
+                        <span data-ng-if="interface.subnet.cidr">
+                          <a
+                            class="p-link--soft"
+                            href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                            >{$ interface.subnet.cidr $}</a
+                          >
+                        </span>
+                        <span data-ng-if="!interface.subnet.cidr"
+                          >Unconfigured</span
+                        >
+                      </div>
+                    </div>
+                    <div
+                      data-ng-if="interface.subnet.name"
+                      class="p-double-row__muted-row"
+                      aria-label="Subnet name"
+                      title="{$ interface.subnet.name $}"
+                    >
+                      <div class="u-text-overflow">
+                        <a
+                          class="p-muted-text p-link--muted"
+                          href="{$ legacyURLBase $}/subnet/{$ interface.subnet.id $}"
+                          >{$ interface.subnet.name $}</a
+                        >
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    data-ng-if="isAllNetworkingDisabled() && interface.discovered[0].subnet_id"
+                    class="p-double-row__rows-container"
+                  >
+                    <div
+                      class="p-double-row__main-row"
+                      aria-label="Subnet CIDR"
+                      title="{$ getSubnetText(getSubnet(interface.discovered[0].subnet_id)) $}"
+                    >
+                      <div class="u-text-overflow">
+                        {$
+                        getSubnetText(getSubnet(interface.discovered[0].subnet_id))
+                        $}
+                      </div>
+                    </div>
+                    <div
+                      class="p-double-row__muted-row"
+                      aria-label="Subnet name"
+                      title=""
+                    >
+                      &nbsp;
+                    </div>
+                  </div>
+                </td>
+                <td class="p-double-row">
+                  <div
+                    data-ng-if="!isEditing(interface) && !interface.discovered[0].ip_address && interface.fabric"
+                    class="p-double-row__rows-container"
+                  >
+                    <div
+                      class="p-double-row__main-row"
+                      aria-label="IP address"
+                      title="{$ interface.ip_address $}"
+                    >
+                      <div class="u-text-overflow">
+                        <span data-ng-if="interface.ip_address"
+                          >{$ interface.ip_address $}</span
+                        >
+                        <span data-ng-if="!interface.ip_address"
+                          >{$ getLinkModeText(interface) $}</span
+                        >
+                      </div>
+                    </div>
+                    <div
+                      class="p-double-row__muted-row"
+                      aria-label="Status"
+                      title="{$ getNetworkTestingStatus(interface) $}"
+                    >
+                      <div class="u-text-overflow">
+                        {$ getNetworkTestingStatus(interface) $}
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    data-ng-if="!isEditing(interface) && interface.discovered[0].ip_address && interface.fabric"
+                    class="p-double-row__rows-container"
+                  >
+                    <div
+                      class="p-double-row__main-row"
+                      aria-label="IP address"
+                      title="{$ interface.discovered[0].ip_address $}"
+                    >
+                      <span data-ng-if="interface.discovered[0].ip_address"
+                        >{$ interface.discovered[0].ip_address $}</span
+                      >
+                      <span data-ng-if="!interface.discovered[0].ip_address"
+                        >DHCP</span
+                      >
+                    </div>
+                    <div
+                      class="p-double-row__muted-row"
+                      aria-label="Link mode"
+                      title="DHCP"
+                    >
+                      <span data-ng-if="interface.discovered[0].ip_address"
+                        >DHCP</span
+                      >
+                    </div>
+                  </div>
+                </td>
+                <td style="overflow: visible;">
+                  {$ getDHCPStatus(interface.vlan) $}
+                  <span
+                    class="p-tooltip--btm-right"
+                    ng-if="interface.vlan && interface.vlan.relay_vlan"
+                    style="margin-left: 0.25rem;"
+                  >
+                    <i class="p-icon--information" style="width: 0.875rem;"
+                      >{$ getDHCPStatus(interface.vlan, true) $}</i
+                    >
+                    <span class="p-tooltip__message"
+                      >{$ getDHCPStatus(interface.vlan, true) $}</span
+                    >
+                  </span>
+                </td>
+                <td
+                  class="p-table--action-cell u-vertically-center u-align--right"
+                >
+                  <div
+                    class="p-contextual-menu"
+                    toggle-ctrl
+                    data-ng-if="(!isAllNetworkingDisabled() || isLimitedEditingAllowed(interface)) && !isEditing(interface) && !(isShowingDeleteConfirm() && isInterfaceSelected(interface))"
+                  >
+                    <button
+                      class="p-button--base is-small p-contextual-menu__toggle u-no-margin--right"
+                      data-ng-click="toggleMenu()"
+                    >
+                      <i class="p-icon--contextual-menu u-no-margin--right"
+                        >Actions</i
+                      >
+                    </button>
+                    <div
+                      class="p-contextual-menu__dropdown"
+                      role="menu"
+                      data-ng-show="isToggled"
+                    >
+                      <button
+                        class="p-contextual-menu__link"
+                        role="menu"
+                        data-ng-show="isToggled"
+                        data-ng-if="canMarkAsConnected(interface)"
+                        aria-label="Mark as connected"
+                        data-ng-click="toggleMenu(); changeConnectionStatus(interface); sendAnalyticsEvent('Machine details', 'Mark interface as connected', 'Network tab')"
+                      >
+                        Mark as connected
+                      </button>
+                      <button
+                        class="p-contextual-menu__link"
+                        role="menu"
+                        data-ng-show="isToggled"
+                        data-ng-if="canMarkAsDisconnected(interface)"
+                        aria-label="Mark as disconnected"
+                        data-ng-click="toggleMenu(); changeConnectionStatus(interface); sendAnalyticsEvent('Machine details', 'Mark interface as disconnected', 'Network tab')"
+                      >
+                        Mark as disconnected
+                      </button>
+                      <button
+                        class="p-contextual-menu__link"
+                        aria-label="Add Alias or VLAN"
+                        data-ng-if="canAddAliasOrVLAN(interface)"
+                        data-ng-click="toggleMenu(); quickAdd(interface); sendAnalyticsEvent('Machine details', 'Add alias or VLAN', 'Network tab')"
+                      >
+                        Add alias or VLAN
+                      </button>
+                      <button
+                        class="p-contextual-menu__link"
+                        data-ng-if="!cannotEditInterface(interface)"
+                        aria-label="Edit"
+                        data-ng-click="toggleMenu(); handleEdit(interface); sendAnalyticsEvent('Machine details', 'Edit interface', 'Network tab')"
+                      >
+                        Edit {$ getInterfaceTypeText(interface) $}
+                      </button>
+                      <button
+                        class="p-contextual-menu__link"
+                        data-ng-if="canBeRemoved()"
+                        aria-label="Remove"
+                        data-ng-click="toggleMenu(); quickRemove(interface); sendAnalyticsEvent('Machine details', 'Remove interface', 'Network tab')"
+                      >
+                        Remove {$ getInterfaceTypeText(interface) $}&hellip;
+                      </button>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="p-table-expanding__panel col-12"
+                  data-ng-if="isInterfaceSelected(interface) && showEditWarning"
+                >
+                  <div class="row">
+                    <div class="p-warning-message">
+                      <i class="p-icon--warning p-warning-message__icon"></i>
+                      <div>
+                        This interface is <strong>disconnected</strong>, it
+                        cannot be configured unless a cable is connected.
+                        <br />
+                        If this is no longer true,
+                        <a
+                          href=""
+                          data-ng-click="changeConnectionStatus(interface)"
+                          >mark cable as connected</a
+                        >.
+                      </div>
+                    </div>
+                    <div class="u-align--right">
+                      <button class="p-button--base" data-ng-click="cancel()">
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="p-table-expanding__panel col-12"
+                  data-ng-if="isInterfaceSelected(interface) && (isShowingAdd() || isEditing(interface) || isShowingDeleteConfirm() || isChangingConnectionStatus || isShowingAdd() && !newInterface.saving)"
+                >
+                  <div class="row">
+                    <div
+                      class="u-position-relative u-clearfix"
+                      data-ng-if="windowWidth <= 772"
+                    >
+                      <h2
+                        data-ng-click="cancel()"
+                        class="u-float--left p-heading--four"
+                      >
+                        <span data-ng-if="canAddAlias(newInterface.parent)"
+                          >Adding alias</span
+                        >
+                        <span data-ng-if="canAddVLAN(newInterface.parent)"
+                          >Adding VLAN</span
+                        >
+                        <span data-ng-if="isEditing(interface)"
+                          >Editing {$ interface.name $}</span
+                        >
+                        <span data-ng-if="isShowingDeleteConfirm()"
+                          >Removing {$ interface.name $}</span
+                        >
+                      </h2>
+                      <button
+                        data-ng-click="cancel()"
+                        class="p-button--base u-float--right p-button--close"
+                      >
+                        <i class="p-icon--remove">Cancel</i>
+                      </button>
+                    </div>
+                    <hr />
+                    <div class="row" data-ng-if="isChangingConnectionStatus">
+                      <div class="p-warning-message">
+                        <i class="p-icon--warning p-warning-message__icon"></i>
+                        <div data-ng-if="isInterfaceConnected(interface)">
+                          This interface was detected as
+                          <strong>connected</strong>. Are you sure you want to
+                          mark it as disconnected?
+                          <br />
+                          When the interface is disconnected, it cannot be
+                          configured.
                         </div>
-                        <div class="col-6 u-align--right">
-                            <hr>
-                            <button class="p-button--base u-no-margin--bottom"
-                                data-ng-click="closeStorageLayoutConfirm()">Cancel</button>
-                            <button class="p-button--negative u-no-margin--bottom"
-                                data-ng-click="updateStorageLayout(storageLayout); sendAnalyticsEvent('Machine details', 'Change storage layout to ' + storageLayout.name, 'Storage tab')">
-                                Change storage layout
+                        <div data-ng-if="!isInterfaceConnected(interface)">
+                          This interface was detected as
+                          <strong>disconnected</strong>. Are you sure you want
+                          to mark it as connected?
+                        </div>
+                      </div>
+                      <div class="u-align--right">
+                        <button class="p-button--base" data-ng-click="cancel()">
+                          Cancel
+                        </button>
+                        <button
+                          class="u-no-margin--top"
+                          data-ng-click="saveConnectionStatus(interface)"
+                          data-ng-class="{'p-button--positive': !isInterfaceConnected(interface), 'p-button--negative': isInterfaceConnected(interface)}"
+                        >
+                          Mark as
+                          <span data-ng-if="isInterfaceConnected(interface)"
+                            >disconnected</span
+                          ><span data-ng-if="!isInterfaceConnected(interface)"
+                            >connected</span
+                          >
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      class="p-form p-form--stacked"
+                      data-ng-class="{ 'is-active': isEditing(interface) || isShowingAdd() }"
+                    >
+                      <div class="row" data-ng-if="isShowingAdd()">
+                        <div class="col-6">
+                          <div class="p-form__group">
+                            <label class="p-form__label">Name</label>
+                            <div class="p-form__control">
+                              <span class="col-4">{$ getAddName() $}</span>
+                            </div>
+                          </div>
+                          <div class="p-form__group">
+                            <label for="type" class="p-form__label">Type</label>
+                            <div class="p-form__control">
+                              <select
+                                name="type"
+                                data-ng-model="newInterface.type"
+                                data-ng-change="addTypeChanged()"
+                              >
+                                <option
+                                  value="alias"
+                                  data-ng-show="canAddAlias(newInterface.parent)"
+                                  >Alias</option
+                                >
+                                <option
+                                  value="vlan"
+                                  data-ng-show="canAddVLAN(newInterface.parent)"
+                                  >VLAN</option
+                                >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group"
+                            data-ng-if="newInterface.type !== 'alias'"
+                          >
+                            <label class="p-form__label">Tags</label>
+                            <div class="p-form__control tags--inline">
+                              <tags-input
+                                data-ng-model="newInterface.tags"
+                                allow-tags-pattern="[\w-]+"
+                              ></tags-input>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-6">
+                          <div class="p-form__group">
+                            <label for="fabric" class="p-form__label"
+                              >Fabric</label
+                            >
+                            <div class="p-form__control">
+                              <select
+                                name="fabric"
+                                data-ng-model="newInterface.parent.fabric"
+                                data-ng-options="fabric as fabric.name for fabric in fabrics"
+                                disabled="disabled"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group"
+                            data-ng-if="newInterface.type === 'alias'"
+                          >
+                            <label for="vlan" class="p-form__label">VLAN</label>
+                            <div class="p-form__control">
+                              <select
+                                name="vlan"
+                                data-ng-model="newInterface.vlan"
+                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans"
+                                disabled="disabled"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group"
+                            data-ng-if="newInterface.type === 'vlan'"
+                          >
+                            <label for="vlan" class="p-form__label">VLAN</label>
+                            <div class="p-form__control">
+                              <select
+                                name="vlan"
+                                data-ng-model="newInterface.vlan"
+                                data-ng-change="vlanChanged(newInterface)"
+                                data-ng-options="vlan as getVLANText(vlan) for vlan in vlans | removeDefaultVLAN | filterByFabric:newInterface.parent.fabric | filterByUnusedForInterface:newInterface.parent:originalInterfaces"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div class="p-form__group">
+                            <label for="subnet" class="p-form__label"
+                              >Subnet</label
+                            >
+                            <div class="p-form__control">
+                              <select
+                                name="subnet"
+                                data-ng-model="newInterface.subnet"
+                                data-ng-change="subnetChanged(newInterface)"
+                                data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newInterface.vlan"
+                              >
+                                <option
+                                  value=""
+                                  data-ng-hide="newInterface.type === 'alias'"
+                                  >Unconfigured</option
+                                >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group"
+                            data-ng-if="!isLinkModeDisabled(newInterface)"
+                          >
+                            <label for="link-mode" class="p-form__label"
+                              >IP mode</label
+                            >
+                            <div class="p-form__control">
+                              <select
+                                name="link-mode"
+                                data-ng-model="newInterface.mode"
+                                data-ng-change="modeChanged(newInterface)"
+                                data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newInterface"
+                              >
+                              </select>
+                            </div>
+                          </div>
+                          <div
+                            class="p-form__group"
+                            data-ng-if="newInterface.mode == 'static'"
+                          >
+                            <label for="ip-address" class="p-form__label"
+                              >IP address</label
+                            >
+                            <div
+                              class="p-form__control"
+                              data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }"
+                            >
+                              <input
+                                name="ip-address"
+                                type="text"
+                                placeholder="IP address"
+                                data-ng-model="newInterface.ip_address"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <maas-obj-form
+                        obj="editInterface"
+                        manager="nodesManager"
+                        manager-method="updateInterfaceForm"
+                        table-form="true"
+                        save-on-blur="false"
+                        after-save="editSave"
+                        pre-process="preProcessInterface"
+                        data-ng-if="isEditing(editInterface)"
+                      >
+                        <div class="row">
+                          <div class="col-6">
+                            <maas-obj-field
+                              type="text"
+                              key="mac_address"
+                              label="MAC address"
+                              data-ng-if="interface.type !== 'alias' && interface.type !== 'vlan'"
+                              disable-label="false"
+                              input-class="table__input"
+                              placeholder="00:00:00:00:00:00"
+                            ></maas-obj-field>
+                            <maas-obj-field
+                              type="tags"
+                              key="tags"
+                              label="Tags"
+                              placeholder="Add a tag"
+                              data-ng-if="!isAllNetworkingDisabled(interface) && interface.type !== 'alias'"
+                              disable-label="false"
+                            ></maas-obj-field>
+                          </div>
+                          <div
+                            class="col-6"
+                            data-ng-if="!isAllNetworkingDisabled(interface)"
+                          >
+                            <maas-obj-field
+                              type="options"
+                              key="ip_assignment"
+                              label="IP Assignment"
+                              label-width="2"
+                              input-width="5"
+                              disable-label="false"
+                              options="assignment.name as assignment.text for assignment in ipAssignments"
+                            ></maas-obj-field>
+                            <maas-obj-field
+                              type="options"
+                              key="subnet"
+                              label="Subnet"
+                              placeholder="Unconfigured"
+                              placeholder-enabled="true"
+                              data-ng-init="editInterface.subnet = editInterface.defaultSubnet"
+                              label-width="2"
+                              input-width="5"
+                              data-ng-if="editInterface.$maasForm.getValue('ip_assignment') === 'static'"
+                              on-change="subnetChangedForm"
+                              disable-label="false"
+                              options="subnet as getSubnetText(subnet) for subnet in subnets"
+                            ></maas-obj-field>
+                            <maas-obj-field
+                              type="text"
+                              key="ip_address"
+                              label="IP address"
+                              placeholder="IP Address"
+                              label-width="two"
+                              input-width="three"
+                              disable-label="false"
+                              input-class="table__input u-margin--none"
+                              data-ng-if="editInterface.$maasForm.getValue('ip_assignment') === 'external'"
+                            >
+                            </maas-obj-field>
+                            <maas-obj-field
+                              type="text"
+                              key="ip_address"
+                              label="IP Address"
+                              placeholder="IP Address (optional)"
+                              data-ng-if="editInterface.$maasForm.getValue('ip_assignment') === 'static'"
+                              label-width="2"
+                              input-width="5"
+                              disable-label="false"
+                            ></maas-obj-field>
+                          </div>
+                        </div>
+                        <div class="row u-no-margin--top">
+                          <hr />
+                          <maas-obj-errors></maas-obj-errors>
+                          <div class="u-align--right u-no-margin--top">
+                            <button
+                              class="p-button--base"
+                              data-ng-click="editCancel()"
+                            >
+                              Cancel
                             </button>
+                            <button
+                              class="p-button--positive u-no-margin--top"
+                              data-ng-disabled="isIPAddressInvalid(editInterface) || isMACAddressInvalid(editInterface.mac_address, true)"
+                              maas-obj-save
+                            >
+                              Save
+                            </button>
+                          </div>
                         </div>
+                      </maas-obj-form>
                     </div>
-                </div>
-            </div>
-
-            <div class="row" data-ng-if="storageLayout.id === 'vmfs6'">
-                <div data-ng-controller="NodeFilesystemsController">
-                    <storage-datastores></storage-datastores>
-                </div>
-            </div>
-
-            <div class="row">
-                <div data-ng-controller="NodeFilesystemsController" data-ng-if="storageLayout.id !== 'vmfs6'">
-                    <storage-filesystems canEdit="canEdit()"></storage-filesystems>
-                </div>
-                <div data-ng-show="cachesets.length">
-                    <div class="row">
-                        <h3 class="p-heading--four">Available cache sets</h3>
-                    </div>
-                    <div class="row">
-                        <table class="p-table-expanding">
-                            <thead>
-                                <tr>
-                                    <th class="col-2">Name</th>
-                                    <th class="col-3">Size</th>
-                                    <th class="col-4">Used by</th>
-                                    <th class="col-2">
-                                        <div class="u-align--right">Actions</div>
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr data-ng-repeat="cacheset in cachesets" data-ng-class="{ 'is-active': cacheset.$selected }">
-                                    <td class="col-2" aria-label="Name" title="{$ cacheset.name $}">{$ cacheset.name $}</td>
-                                    <td class="col-3" aria-label="Size" title="{$ cacheset.size_human $}">{$ cacheset.size_human $}</td>
-                                    <td class="col-4" aria-label="Used by" title="{$ cacheset.used_by $}">{$ cacheset.used_by $}</td>
-                                    <td class="col-2 p-table--action-cell">
-                                        <div class="u-align--right">
-                                        <div class="p-contextual-menu" toggle-ctrl data-ng-if="canDeleteCacheSet(cacheset) && !cacheset.$selected">
-                                            <button class="p-button--base is-small p-contextual-menu__toggle" data-ng-click="toggleMenu()">
-                                                <i class="p-icon--contextual-menu u-no-margin--right">Actions</i>
-                                            </button>
-                                            <div class="p-contextual-menu__dropdown" role="menu" data-ng-show="isToggled">
-                                                <button class="p-contextual-menu__link"
-                                                    aria-label="Remove"
-                                                    data-ng-show="canDeleteCacheSet(cacheset)"
-                                                    data-ng-click="toggleMenu(); quickCacheSetDelete(cacheset)">Remove&hellip;</button>
-                                            </div>
-                                        </div>
-                                        </div>
-                                    </td>
-                                    <td class="p-table-expanding__panel col-12" data-ng-if="cacheset.$selected && cachesetsMode === 'delete'">
-                                        <div class="row" data-ng-if="windowWidth <= 772">
-                                            <div class="col-8">
-                                                <h2 data-ng-click="filesystemCancel()" class="p-heading--four">
-                                                    <span data-ng-if="cachesetsMode === 'delete'">Removing {$ cacheset.name $}</span>
-                                                </h2>
-                                            </div>
-                                        </div>
-                                        <div class="row" data-ng-class="{ 'is-active': cachesetsMode !== null && cachesetsMode !== 'multi' }">
-                                            <div data-ng-show="cachesetsMode === 'single' && canDeleteCacheSet(cacheset)">
-                                                <button class="p-button--base"
-                                                    data-ng-show="canDeleteCacheSet(cacheset)"
-                                                    data-ng-click="cacheSetDelete()">Remove</button>
-                                            </div>
-                                            <div class="row ng-hide" data-ng-show="cachesetsMode === 'delete'">
-                                                <div class="col-8">
-                                                    <p><span class="p-icon--warning">Warning:</span> Are you sure you want to delete this cache set?</p>
-                                                </div>
-                                                <div class="col-4">
-                                                    <div class="u-align--right">
-                                                        <button class="p-button--base" type="button" data-ng-click="cacheSetCancel()">Cancel</button>
-                                                        <button class="p-button--negative u-no-margin--top" data-ng-click="cacheSetConfirmDelete(cacheset)">Remove cache set</button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div>
-                    <storage-disks-partitions></storage-disks-partitions>
-                </div>
-            </div>
-        </form>
-    </section>
-    <section class="p-strip" data-ng-if="section.area === 'events'">
-        <div class="row">
-            <div class="col-12 u-align--right" data-ng-if="node.events.length">
-                <a href="{$ legacyURLBase $}/{$ type_name $}/{$ node.system_id $}/events">View full history</a>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-12">
-                <div class="p-notification" data-ng-if="!node.events.length">
-                    <p class="p-notification__response">
-                        No events found.
-                    </p>
-                </div>
-                <table data-ng-if="node.events.length">
-                    <thead>
-                        <tr>
-                            <th class="col-3">Time</th>
-                            <th class="col-9">Event</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr
-                            data-ng-repeat="event in node.events | orderByDate:'created':'id' | limitTo:events.limit">
-                            <td class="col-3" aria-label="Created" title="{$ event.created $}">
-                                <span class="p-icon--{$ event.type.level $}"></span>&nbsp;
-                                {$ event.created $}
-                            </td>
-                            <td class="col-9" aria-label="Event" title="{$ getEventText(event) $}">{$ getEventText(event) $}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-12 u-align--center">
-                <button class="p-button--neutral" data-ng-show="allowShowMoreEvents()" data-ng-click="showMoreEvents()">Load next 10 events</button>
-            </div>
-        </div>
-    </section>
-    <section class="p-strip" data-ng-if="section.area === 'logs'">
-        <div data-ng-controller="NodeResultsController">
-            <div class="row" data-ng-if="!resultsLoaded">
-                <div class="col-12">
-                    <p class="u-text--loading"><i class="p-icon--spinner u-animation--spin"></i>&nbsp;&nbsp;Loading...</p>
-                </div>
-            </div>
-            <div data-ng-if="resultsLoaded">
-                <div class="row">
-                    <div class="col-12">
-                        <div class="u-sv2">
-                            <div data-maas-cta="logs.availableOptions" data-ng-model="logs.option" data-ng-change="updateLogOutput()"></div>
+                    <div
+                      class="row is-active"
+                      data-ng-if="isShowingDeleteConfirm() && isInterfaceSelected(interface)"
+                    >
+                      <div class="col-8">
+                        <p class="u-no-margin--bottom">
+                          <span class="p-icon--warning">Warning:</span> Are you
+                          sure you want to remove this {$
+                          getRemoveTypeText(interface) $}?
+                        </p>
+                      </div>
+                      <div class="col-4">
+                        <div class="u-align--right">
+                          <button
+                            class="p-button--base"
+                            data-ng-click="cancel()"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            class="p-button--negative u-no-margin--top"
+                            data-ng-click="confirmRemove(interface)"
+                          >
+                            Remove
+                          </button>
                         </div>
+                      </div>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="col-12">
-                        <pre class="p-code-numbered is-copyable" data-maas-code-lines="logOutput" data-ng-if="logOutput !== null && logOutput !== ''"></pre>
-                        <div class="p-notification" data-ng-if="logOutput === null || logOutput === ''">
-                            <p class="p-notification__response">
-                                No logs found.
+                    <hr data-ng-if="isShowingAdd() && !newInterface.saving" />
+                    <div
+                      class="row"
+                      data-ng-if="isShowingAdd() && !newInterface.saving"
+                    >
+                      <div class="col-6">
+                        <button
+                          class="p-button--neutral"
+                          data-ng-click="addInterface('alias')"
+                          data-ng-show="canAddAlias(interface)"
+                        >
+                          Add
+                          <span data-ng-show="newInterface.type === 'alias'"
+                            >another </span
+                          >alias
+                        </button>
+                        <button
+                          class="p-button--neutral u-no-margin--top"
+                          data-ng-click="addInterface('vlan')"
+                          data-ng-show="canAddAnotherVLAN(interface)"
+                        >
+                          Add
+                          <span data-ng-show="newInterface.type === 'vlan'"
+                            >another </span
+                          >VLAN
+                        </button>
+                      </div>
+                      <div class="col-6">
+                        <div class="u-align--right">
+                          <button
+                            class="p-button--base"
+                            data-ng-click="cancel()"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            class="p-button--positive u-no-margin--top"
+                            data-ng-click="addInterface()"
+                          >
+                            Add
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="p-table-expanding__panel col-12"
+                  data-ng-if="isShowingMembers(interface)"
+                >
+                  <div
+                    class="row"
+                    data-ng-class="{ 'is-active': isShowingMembers(interface) }"
+                    data-ng-repeat="member in interface.members"
+                    data-ng-show="isShowingMembers(interface)"
+                  >
+                    <div class="col-1"></div>
+                    <div
+                      class="col-2"
+                      data-ng-show="tableInfo.column == 'name'"
+                    >
+                      {$ member.name $}
+                    </div>
+                    <div
+                      class="col-2 ng-hide"
+                      data-ng-show="tableInfo.column == 'mac'"
+                    >
+                      {$ member.mac_address $}
+                    </div>
+                    <div class="col-2">{$ getInterfaceTypeText(member) $}</div>
+                    <div class="col-7"></div>
+                  </div>
+                </td>
+              </tr>
+
+              <tr
+                class="p-table--is-not-device indented-border"
+                ng-if="interface.members && interface.members.length > 0 && interface.type !== 'alias'"
+                ng-repeat="member in interface.members"
+              >
+                <td class="p-double-row" aria-label="Name">
+                  <div class="p-double-row__checkbox">
+                    <label></label>
+                  </div>
+                  <div class="p-double-row__rows-container--checkbox">
+                    <div class="p-double-row__main-row">
+                      <div title="{$ member.name $}">
+                        {$ member.name $}
+                      </div>
+                    </div>
+                    <div class="p-double-row__muted-row">
+                      <div title="{$ member.mac_address $}">
+                        {$ member.mac_address $}
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td aria-label="Boot interface">
+                  &nbsp;
+                </td>
+                <td
+                  class="p-table__col--status p-double-row"
+                  aria-label="Link and interface speed"
+                >
+                  <div class="p-double-row__icon-container">
+                    <span ng-if="!isBond(member) && !isBridge(member)">
+                      <span
+                        aria-describedby="not-connected-tooltip"
+                        class="p-tooltip--top-left"
+                        ng-if="!isInterfaceConnected(member)"
+                      >
+                        <i class="p-icon--disconnected"></i>
+                        <span
+                          class="p-tooltip__message"
+                          role="tooltip"
+                          id="not-connected-tooltip"
+                          >This interface is disconnected.</span
+                        >
+                      </span>
+                      <span
+                        aria-describedby="link-speed-tooltip"
+                        class="p-tooltip--top-left"
+                        ng-if="isInterfaceConnected(member) && member.link_speed < member.interface_speed"
+                      >
+                        <i class="p-icon--warning"></i>
+                        <span
+                          class="p-tooltip__message"
+                          role="tooltip"
+                          id="link-speed-tooltip"
+                          >Link connected to slow interface.</span
+                        >
+                      </span>
+                      <i
+                        ng-if="isInterfaceConnected(member) && member.link_speed === member.interface_speed"
+                        class="p-icon--placeholder"
+                      ></i>
+                    </span>
+                  </div>
+                  <div class="p-double-row__rows-container--icon">
+                    <span ng-if="!isBond(member) && !isBridge(member)">
+                      {$ formatSpeedUnits(member.link_speed) $}/{$
+                      formatSpeedUnits(member.interface_speed) $}
+                    </span>
+                  </div>
+                </td>
+                <td aria-label="Type, NUMA node" class="p-double-row">
+                  <div
+                    class="p-tooltip--top-left numa-tooltip"
+                    ng-class="{ 'show-warning': getInterfaceNumaNodes(member).length > 1 }"
+                  >
+                    <div class="p-double-row__rows-container">
+                      <div class="p-double-row__main-row">
+                        <span title="{$ getInterfaceTypeText(member) $}"
+                          >{$ getInterfaceTypeText(interface, member) $}</span
+                        >
+                      </div>
+                      <div class="p-double-row__muted-row">
+                        <span
+                          >{$ getInterfaceNumaNodes(member).join(", ") $}</span
+                        >
+                      </div>
+                    </div>
+                    <span
+                      class="p-tooltip__message"
+                      ng-if="getInterfaceNumaNodes(member).length > 1"
+                      >This bond is spread over multiple NUMA nodes.<br />This
+                      may lead to suboptimal performance.</span
+                    >
+                  </div>
+                </td>
+                <td class="p-double-row">
+                  &nbsp;
+                </td>
+                <td class="p-double-row">
+                  &nbsp;
+                </td>
+                <td class="p-double-row">
+                  &nbsp;
+                </td>
+                <td class="p-double-row">
+                  &nbsp;
+                </td>
+                <td class="p-double-row">
+                  &nbsp;
+                </td>
+              </tr>
+              <tr ng-if="false" ng-repeat-end></tr>
+
+              <tr
+                class="is-active"
+                data-ng-if="isShowingCreateBond() && !isAllNetworkingDisabled()"
+              >
+                <td>
+                  <div class="row" data-ng-if="windowWidth > 772">
+                    <table class="u-no-margin--top">
+                      <tr class="u-no-padding">
+                        <td class="table-col--16">
+                          <input
+                            type="checkbox"
+                            class="checkbox u-float--left"
+                            id="bond-create"
+                            disabled="disabled"
+                            checked
+                            style="margin-top: 0.5rem;"
+                          />
+                          <label for="bond-create"></label>
+                          <span
+                            data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBondInterface) }"
+                            style="padding-left: 2rem;"
+                          >
+                            <input
+                              type="text"
+                              name="name"
+                              class="editible p-form-validation__input u-no-margin--bottom"
+                              data-ng-model="newBondInterface.name"
+                              style="width: 82%;"
+                            />
+                          </span>
+                        </td>
+                        <td class="table-col--7 u-align--center">
+                          <input
+                            type="radio"
+                            name="bondBootInterface"
+                            checked
+                            id="{$ newBondInterface $}"
+                            data-ng-if="hasBootInterface(newBondInterface)"
+                          />
+                        </td>
+                        <td class="table-col--77">&nbsp;</td>
+                      </tr>
+                    </table>
+                    <hr />
+                  </div>
+                  <div class="row" data-ng-if="windowWidth <= 772">
+                    <h2 class="u-float--left">Create bond</h2>
+                    <button
+                      data-ng-click="cancel()"
+                      class="p-button--base u-float--right p-button--close"
+                    >
+                      <i class="p-icon--close">Cancel</i>
+                    </button>
+                  </div>
+                </td>
+                <td class="p-table-expanding__panel col-12 u-no-padding--top">
+                  <div class="p-form p-form--stacked is-active">
+                    <div class="row">
+                      <div class="col-6">
+                        <div
+                          class="p-form__group"
+                          data-ng-if="windowWidth <= 772"
+                        >
+                          <label for="bond-name" class="p-form__label"
+                            >Name</label
+                          >
+                          <div
+                            class="p-form__control p-form-validation"
+                            data-ng-class="{ 'is-error': isInterfaceNameInvalid(newBondInterface) }"
+                          >
+                            <input
+                              type="text"
+                              name="name"
+                              id="bond-name"
+                              class="p-form-validation__input"
+                              data-ng-model="newBondInterface.name"
+                            />
+                          </div>
+                        </div>
+                        <div class="p-form__group">
+                          <label for="bond-mode" class="p-form__label"
+                            >Bond mode</label
+                          >
+                          <div class="p-form__control">
+                            <select
+                              name="bond-mode"
+                              data-ng-model="newBondInterface.mode"
+                              data-ng-options="mode[0] as mode[1] for mode in bondOptions.modes"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                        <div class="p-form__group">
+                          <label for="mac" class="p-form__label"
+                            >MAC address</label
+                          >
+                          <div
+                            class="p-form__control p-form-validation"
+                            data-ng-class="{ 'is-error': isMACAddressInvalid(newBondInterface.mac_address) }"
+                          >
+                            <input
+                              type="text"
+                              name="mac"
+                              class="p-form-validation__input"
+                              placeholder="00:00:00:00:00:00"
+                              data-ng-model="newBondInterface.mac_address"
+                              data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi"
+                              mac-address
+                              maxlength="17"
+                              data-ng-placeholder="getInterfacePlaceholderMACAddress(newBondInterface)"
+                            />
+                          </div>
+                        </div>
+                        <div class="p-form__group u-vertically-center">
+                          <label class="p-form__label">Tags</label>
+                          <div class="p-form__control tags--inline">
+                            <tags-input
+                              data-ng-model="newBondInterface.tags"
+                              allow-tags-pattern="[\w-]+"
+                            ></tags-input>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-6">
+                        <div class="p-form__group" data-ng-if="showLACPRate()">
+                          <label for="lacp-rate" class="p-form__label"
+                            >LACP rate</label
+                          >
+                          <div class="p-form__control">
+                            <select
+                              name="lacp-rate"
+                              data-ng-model="newBondInterface.bond_lacp_rate"
+                              data-ng-options="rate[0] as rate[1] for rate in bondOptions.lacp_rates"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                        <div
+                          class="p-form__group"
+                          data-ng-if="showXMITHashPolicy()"
+                        >
+                          <label for="xmit-hash-policy" class="p-form__label"
+                            >XMIT hash policy</label
+                          >
+                          <div class="p-form__control">
+                            <select
+                              name="xmit-hash-policy"
+                              data-ng-model="newBondInterface.bond_xmit_hash_policy"
+                              data-ng-options="xmit[0] as xmit[1] for xmit in bondOptions.xmit_hash_policies"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-ng-if="newBondInterface.parents.length > 0">
+                    <hr />
+                    <table class="row">
+                      <tr>
+                        <th class="table-col--16">Name</th>
+                        <th class="table-col--16">Type</th>
+                        <th class="table-col--16">Primary</th>
+                      </tr>
+                      <tr
+                        data-ng-repeat="parent in newBondInterface.parents | orderBy:'name'"
+                      >
+                        <td class="table-col--16" aria-label="Name">
+                          {$ parent.name $}
+                        </td>
+                        <td class="table-col--16" aria-label="Type">
+                          {$ getInterfaceTypeText(parent) $}
+                        </td>
+                        <td class="table-col--16" aria-label="Primary">
+                          <input
+                            type="radio"
+                            name="bondPrimary"
+                            id="{$ parent.name $}"
+                            data-ng-model="newBondInterface.primary"
+                            data-ng-value="parent"
+                          />
+                          <label
+                            class="is-inline-label"
+                            for="{$ parent.name $}"
+                          ></label>
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+                  <div class="row">
+                    <hr />
+                    <div class="col-12 u-align--right">
+                      <button
+                        class="p-button--base"
+                        type="button"
+                        data-ng-click="cancel()"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        class="p-button--positive u-no-margin--top"
+                        data-ng-click="addBond()"
+                        data-ng-disabled="cannotAddBond()"
+                      >
+                        Save
+                      </button>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="is-active ng-hide"
+                data-ng-show="isShowingCreatePhysical()"
+              >
+                <td class="p-table-expanding__panel">
+                  <div class="row u-hide--medium u-hide--small">
+                    <div class="col-6">
+                      <div
+                        class="p-form-validation"
+                        data-ng-if="!isDevice"
+                        data-ng-class="{ 'is-error': isInterfaceNameInvalid(newInterface) }"
+                      >
+                        <input
+                          type="text"
+                          class="p-form-validation__input"
+                          data-ng-model="newInterface.name"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <hr
+                    data-ng-if="!isDevice"
+                    class="u-hide--medium u-hide--small"
+                  />
+                  <div class="row" data-ng-if="windowWidth <= 772">
+                    <div class="u-flex--no-wrap">
+                      <h2 data-ng-click="cancel()" class="p-heading--four">
+                        New interface
+                      </h2>
+                      <button class="p-button--close" data-ng-click="cancel()">
+                        <i class="p-icon--close">Cancel</i>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="p-form p-form--stacked" data-ng-if="!isDevice">
+                    <div class="row">
+                      <div class="col-6" data-ng-if="!isDevice">
+                        <div
+                          class="p-form__group row p-form-validation u-hide--large"
+                          data-ng-class="{ 'is-error': isInterfaceNameInvalid(newInterface) }"
+                        >
+                          <label
+                            for="new-interface-name"
+                            class="p-form__label col-2"
+                            >Name</label
+                          >
+                          <div class="p-form__control col-4">
+                            <input
+                              type="text"
+                              class="p-form-validation__input"
+                              id="new-interface-name"
+                              data-ng-model="newInterface.name"
+                            />
+                          </div>
+                        </div>
+                        <div class="p-form__group row u-no-margin--top">
+                          <label class="p-form__label col-2">Type</label>
+                          <div class="p-form__control col-4">
+                            <p>Physical</p>
+                          </div>
+                        </div>
+                        <div
+                          class="p-form__group row p-form-validation u-no-margin--top"
+                          data-ng-class="{ 'is-error': isMACAddressInvalid(newInterface.mac_address, false) || newInterface.macError }"
+                        >
+                          <label for="mac" class="p-form__label col-2"
+                            >MAC address</label
+                          >
+                          <div class="p-form__control col-4">
+                            <input
+                              type="text"
+                              name="mac"
+                              class="p-form-validation__input"
+                              placeholder="00:00:00:00:00:00"
+                              data-ng-model="newInterface.mac_address"
+                              data-ng-keydown="$event.keyCode == 13 && $event.preventDefault()"
+                              data-ng-keyup="$event.keyCode == 13 && addPhysicalInterface()"
+                              data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi"
+                              mac-address
+                              maxlength="17"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="p-form__group u-no-margin--top row u-vertically-center"
+                          style="min-height: 2.5rem;"
+                        >
+                          <label class="p-form__label col-2">Tags</label>
+                          <div class="p-form__control col-4 tags--inline">
+                            <tags-input
+                              data-ng-model="newInterface.tags"
+                              allow-tags-pattern="[\w-]+"
+                            ></tags-input>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-6">
+                        <div class="p-form__group row">
+                          <label for="fabric" class="p-form__label col-2"
+                            >Fabric</label
+                          >
+                          <div class="p-form__control col-4">
+                            <select
+                              name="fabric"
+                              data-ng-model="newInterface.fabric"
+                              data-ng-change="fabricChanged(newInterface)"
+                              data-ng-options="fabric as fabric.name for fabric in fabrics"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                        <div class="p-form__group row u-no-margin--top">
+                          <label for="vlan" class="p-form__label col-2"
+                            >VLAN</label
+                          >
+                          <div class="p-form__control col-4">
+                            <select
+                              name="vlan"
+                              data-ng-model="newInterface.vlan"
+                              data-ng-options="vlan as getVLANText(vlan) for vlan in vlans"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                        <div class="p-form__group row u-no-margin--top">
+                          <label for="subnet" class="p-form__label col-2"
+                            >Subnet</label
+                          >
+                          <div class="p-form__control col-4">
+                            <select
+                              name="subnet"
+                              data-ng-model="newInterface.subnet"
+                              data-ng-change="subnetChanged(newInterface)"
+                              data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets | filterByVLAN:newInterface.vlan"
+                            >
+                              <option
+                                value=""
+                                data-ng-hide="newInterface.type === 'alias'"
+                                >Unconfigured</option
+                              >
+                            </select>
+                          </div>
+                        </div>
+                        <div
+                          class="p-form__group row u-no-margin--top"
+                          data-ng-if="!isLinkModeDisabled(newInterface)"
+                        >
+                          <label for="link-mode" class="p-form__label col-2"
+                            >IP mode</label
+                          >
+                          <div class="p-form__control col-4">
+                            <select
+                              name="link-mode"
+                              data-ng-model="newInterface.mode"
+                              data-ng-change="modeChanged(newInterface)"
+                              data-ng-options="mode.mode as mode.text for mode in modes | filterLinkModes:newInterface"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                        <div
+                          class="p-form__group row u-no-margin--top p-form-validation"
+                          data-ng-if="newInterface.mode == 'static'"
+                          data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }"
+                        >
+                          <label for="ip-address" class="p-form__label col-2"
+                            >IP address</label
+                          >
+                          <div class="p-form__control col-4">
+                            <input
+                              name="ip-address"
+                              type="text"
+                              class="p-form-validation__input"
+                              placeholder="IP address (optional)"
+                              data-ng-model="newInterface.ip_address"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="p-form p-form--stacked">
+                    <div class="row" data-ng-if="isDevice">
+                      <div class="col-6">
+                        <div
+                          class="p-form__group p-form-validation"
+                          data-ng-class="{ 'is-error': isMACAddressInvalid(newInterface.mac_address, true) }"
+                        >
+                          <label for="mac" class="p-form__label"
+                            >MAC address</label
+                          >
+                          <div class="p-form__control">
+                            <input
+                              name="mac"
+                              type="text"
+                              class="p-form-validation__input"
+                              placeholder="00:00:00:00:00:00"
+                              data-ng-model="newInterface.mac_address"
+                              data-ng-pattern="/^([0-9A-F]{2}[::]){5}([0-9A-F]{2})$/gmi"
+                              mac-address
+                              maxlength="17"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="col-6"
+                        data-ng-if="!isAllNetworkingDisabled(interface)"
+                      >
+                        <div class="p-form__group">
+                          <label for="ip-assignment" class="p-form__label"
+                            >IP Assignment</label
+                          >
+                          <div class="p-form__control">
+                            <select
+                              name="ip-assignment"
+                              data-ng-model="newInterface.ip_assignment"
+                              data-ng-options="assignment.name as assignment.text for assignment in ipAssignments"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                        <div
+                          class="p-form__group"
+                          data-ng-if="newInterface.ip_assignment === 'static'"
+                        >
+                          <label for="subnet" class="p-form__label"
+                            >Subnet</label
+                          >
+                          <div class="p-form__control">
+                            <select
+                              name="subnet"
+                              data-ng-init="newInterface.subnet = subnets[0]"
+                              data-ng-model="newInterface.subnet"
+                              data-ng-change="subnetChanged(newInterface)"
+                              data-ng-options="subnet as getSubnetText(subnet) for subnet in subnets"
+                            >
+                            </select>
+                          </div>
+                        </div>
+                        <div
+                          class="p-form__group p-form-validation"
+                          data-ng-if="newInterface.ip_assignment !== 'dynamic'"
+                          data-ng-class="{ 'is-error': isIPAddressInvalid(newInterface) }"
+                        >
+                          <label for="ip-address" class="p-form__label"
+                            >IP address</label
+                          >
+                          <div class="p-form__control">
+                            <input
+                              name="ip-address"
+                              type="text"
+                              class="p-form-validation__input"
+                              data-ng-if="newInterface.ip_assignment === 'static'"
+                              placeholder="IP address (optional)"
+                              data-ng-model="newInterface.ip_address"
+                            />
+                            <input
+                              name="ip-address"
+                              type="text"
+                              class="p-form-validation__input"
+                              data-ng-if="newInterface.ip_assignment !== 'static'"
+                              placeholder="IP address"
+                              data-ng-model="newInterface.ip_address"
+                            />
+                            <p
+                              class="p-form-validation__message"
+                              role="alert"
+                              data-ng-if="getInterfaceError(newInterface)"
+                            >
+                              <strong>Error:</strong> {$
+                              getInterfaceError(newInterface) $}
                             </p>
+                          </div>
                         </div>
+                      </div>
                     </div>
-                </div>
-            </div>
+                  </div>
+                  <div class="row">
+                    <hr />
+                    <div
+                      class="u-float--left"
+                      data-ng-show="newInterface.errorMsg"
+                    >
+                      <span class="p-icon--error">Error:</span> {$
+                      newInterface.errorMsg $}
+                    </div>
+                    <div class="u-align--right">
+                      <button class="p-button--base" data-ng-click="cancel()">
+                        Cancel
+                      </button>
+                      <button
+                        class="p-button--positive"
+                        data-ng-click="addPhysicalInterface()"
+                        data-ng-disabled="cannotAddPhysicalInterface()"
+                      >
+                        Save interface
+                      </button>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
-    </section>
-    <section class="p-strip" data-ng-if="section.area === 'commissioning'">
-        <div data-maas-script-results-list="script-results"></div>
-    </section>
-    <section class="p-strip" data-ng-if="section.area === 'testing'">
-        <div data-maas-script-results-list="script-results"></div>
-    </section>
+      </form>
+    </div>
+    <div
+      class="row"
+      data-ng-if="filteredSnippets.length && !isShowingCreateBridge() && !isShowingEdit() && !isShowingCreateBond()"
+    >
+      <div class="col-12">
+        <h2 class="p-heading--four">DHCP snippets</h2>
+        <maas-dhcp-snippets-table
+          snippets="filteredSnippets"
+        ></maas-dhcp-snippets-table>
+      </div>
+    </div>
+  </section>
+
+  <section
+    class="p-strip is-shallow u-no-padding--bottom"
+    data-ng-if="section.area === 'storage'"
+    data-ng-controller="NodeStorageController"
+  >
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification--negative" data-ng-if="!has_disks">
+          <p class="p-notification__response">
+            <span class="p-notification__status">Error:</span> No storage
+            information. Commissioning this node will gather the storage
+            information.
+          </p>
+        </div>
+        <div
+          class="p-notification"
+          data-ng-if="isAllStorageDisabled() && $parent.canEdit()"
+        >
+          <p class="p-notification__response">
+            Storage configuration cannot be modified unless the machine is Ready
+            or Allocated.
+          </p>
+        </div>
+        <div class="p-notification" data-ng-if="!isUbuntuOS() && !isCentOS()">
+          <p class="p-notification__response">
+            Custom storage configuration is only supported on Ubuntu, CentOS,
+            and RHEL.
+          </p>
+        </div>
+        <div class="p-notification" data-ng-if="!isUbuntuOS()">
+          <p class="p-notification__response">
+            Bcache and ZFS are only supported on Ubuntu.
+          </p>
+        </div>
+        <div
+          data-ng-repeat="issue in node.storage_layout_issues"
+          class="p-notification--negative"
+          data-ng-if="hasStorageLayoutIssues()"
+        >
+          <p class="p-notification__response">
+            <span class="p-notification__status">Error:</span> {$ issue $}
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section
+    data-ng-if="section.area === 'storage'"
+    data-ng-controller="NodeStorageController"
+  >
+    <form class="p-strip">
+      <div
+        data-ng-if="canEdit() && (node.status_code === 4 || node.status_code === 10)"
+      >
+        <div class="u-fixed-width" data-ng-if="!confirmStorageLayout">
+          <div class="p-form__group u-align--right">
+            <div
+              data-ng-if="storageLayoutIsDisabled(osFamily.layouts) && storageLayoutIsDisabled(osFamily.layouts)"
+            >
+              <button class="p-button--neutral" disabled>
+                Change storage layout
+              </button>
+            </div>
+            <div
+              data-ng-if="!(storageLayoutIsDisabled(osFamily.layouts) && storageLayoutIsDisabled(osFamily.layouts))"
+            >
+              <div class="p-contextual-menu" toggle-ctrl>
+                <button
+                  class="p-button--neutral p-contextual-menu__toggle u-no-margin--bottom u-no-margin--right"
+                  data-ng-click="toggleMenu()"
+                >
+                  <span data-ng-if="!updatingStorageLayout">
+                    Change storage layout&nbsp;
+                    <i
+                      class="p-icon--chevron"
+                      data-ng-class="{'u-rotate':isToggled}"
+                    ></i>
+                  </span>
+
+                  <span data-ng-if="updatingStorageLayout">
+                    <i class="p-icon--spinner u-animation--spin"></i>
+                    &nbsp; Updating storage layout&hellip;
+                  </span>
+                </button>
+                <div
+                  class="p-contextual-menu__dropdown"
+                  role="menu"
+                  data-ng-show="isToggled"
+                >
+                  <button
+                    class="p-contextual-menu__link"
+                    data-ng-click="toggleMenu(); openStorageLayoutConfirm('flat')"
+                  >
+                    Flat
+                  </button>
+                  <button
+                    class="p-contextual-menu__link"
+                    data-ng-click="toggleMenu(); openStorageLayoutConfirm('lvm')"
+                  >
+                    LVM
+                  </button>
+                  <button
+                    class="p-contextual-menu__link"
+                    data-ng-click="toggleMenu(); openStorageLayoutConfirm('bcache')"
+                  >
+                    bcache
+                  </button>
+                  <hr class="u-no-margin--bottom" />
+                  <button
+                    class="p-contextual-menu__link"
+                    data-ng-click="toggleMenu(); openStorageLayoutConfirm('vmfs6')"
+                  >
+                    VMFS6 (VMware ESXi)
+                  </button>
+                  <hr class="u-no-margin--bottom" />
+                  <button
+                    class="p-contextual-menu__link"
+                    data-ng-click="toggleMenu(); openStorageLayoutConfirm('blank')"
+                  >
+                    No storage (blank) layout
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row" data-ng-if="confirmStorageLayout">
+          <div class="p-card--highlighted">
+            <div class="col-6 u-no-margin--left">
+              <div
+                class="p-notification--caution is-subtle"
+                data-ng-if="newLayout.id === 'vmfs6'"
+              >
+                <p class="p-notification__response">
+                  <strong
+                    >Are you sure you want to change the storage layout to
+                    VMFS6?</strong
+                  ><br />
+                  Any changes done already will be discarded.<br />
+                  This layout allows only for the deployment of
+                  <strong>VMware ESXi</strong> images.<br />
+                  The storage layout will be applied to a node when it is
+                  deployed.
+                </p>
+              </div>
+              <div
+                class="p-notification--caution is-subtle"
+                data-ng-if="newLayout.id === 'lvm'"
+              >
+                <p class="p-notification__response">
+                  <strong
+                    >Are you sure you want to change the storage layout to
+                    LVM?</strong
+                  ><br />
+                  Any changes done already will be lost.<br />
+                  The storage layout will be applied to a node when it is
+                  deployed.
+                </p>
+              </div>
+              <div
+                class="p-notification--caution is-subtle"
+                data-ng-if="newLayout.id === 'blank'"
+              >
+                <p class="p-notification__response">
+                  <strong
+                    >Are you sure you want to change this storage layout to
+                    blank?</strong
+                  ><br />
+                  Used disks will be returned to available, and any volume
+                  groups, raid sets,  caches, and filesystems removed.<br />
+                  The storage layout will be applied to a node when it is
+                  deployed.
+                </p>
+              </div>
+              <div
+                class="p-notification--caution is-subtle"
+                data-ng-if="newLayout.id !== 'lvm' && newLayout.id !== 'vmfs6' && newLayout.id !== 'blank'"
+              >
+                <p class="p-notification__response" style="margin-left: -1rem;">
+                  <strong
+                    >Are you sure you want to change the storage layout to {$
+                    newLayout.id $}?</strong
+                  ><br />
+                  Any changes done already will be lost.<br />
+                  The storage layout will be applied to a node when it is
+                  deployed.
+                </p>
+              </div>
+            </div>
+            <div class="col-6 u-align--right">
+              <hr />
+              <button
+                class="p-button--base u-no-margin--bottom"
+                data-ng-click="closeStorageLayoutConfirm()"
+              >
+                Cancel
+              </button>
+              <button
+                class="p-button--negative u-no-margin--bottom"
+                data-ng-click="updateStorageLayout(storageLayout); sendAnalyticsEvent('Machine details', 'Change storage layout to ' + storageLayout.name, 'Storage tab')"
+              >
+                Change storage layout
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row" data-ng-if="storageLayout.id === 'vmfs6'">
+        <div data-ng-controller="NodeFilesystemsController">
+          <storage-datastores></storage-datastores>
+        </div>
+      </div>
+
+      <div class="row">
+        <div
+          data-ng-controller="NodeFilesystemsController"
+          data-ng-if="storageLayout.id !== 'vmfs6'"
+        >
+          <storage-filesystems canEdit="canEdit()"></storage-filesystems>
+        </div>
+        <div data-ng-show="cachesets.length">
+          <div class="row">
+            <h3 class="p-heading--four">Available cache sets</h3>
+          </div>
+          <div class="row">
+            <table class="p-table-expanding">
+              <thead>
+                <tr>
+                  <th class="col-2">Name</th>
+                  <th class="col-3">Size</th>
+                  <th class="col-4">Used by</th>
+                  <th class="col-2">
+                    <div class="u-align--right">Actions</div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  data-ng-repeat="cacheset in cachesets"
+                  data-ng-class="{ 'is-active': cacheset.$selected }"
+                >
+                  <td
+                    class="col-2"
+                    aria-label="Name"
+                    title="{$ cacheset.name $}"
+                  >
+                    {$ cacheset.name $}
+                  </td>
+                  <td
+                    class="col-3"
+                    aria-label="Size"
+                    title="{$ cacheset.size_human $}"
+                  >
+                    {$ cacheset.size_human $}
+                  </td>
+                  <td
+                    class="col-4"
+                    aria-label="Used by"
+                    title="{$ cacheset.used_by $}"
+                  >
+                    {$ cacheset.used_by $}
+                  </td>
+                  <td class="col-2 p-table--action-cell">
+                    <div class="u-align--right">
+                      <div
+                        class="p-contextual-menu"
+                        toggle-ctrl
+                        data-ng-if="canDeleteCacheSet(cacheset) && !cacheset.$selected"
+                      >
+                        <button
+                          class="p-button--base is-small p-contextual-menu__toggle"
+                          data-ng-click="toggleMenu()"
+                        >
+                          <i class="p-icon--contextual-menu u-no-margin--right"
+                            >Actions</i
+                          >
+                        </button>
+                        <div
+                          class="p-contextual-menu__dropdown"
+                          role="menu"
+                          data-ng-show="isToggled"
+                        >
+                          <button
+                            class="p-contextual-menu__link"
+                            aria-label="Remove"
+                            data-ng-show="canDeleteCacheSet(cacheset)"
+                            data-ng-click="toggleMenu(); quickCacheSetDelete(cacheset)"
+                          >
+                            Remove&hellip;
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td
+                    class="p-table-expanding__panel col-12"
+                    data-ng-if="cacheset.$selected && cachesetsMode === 'delete'"
+                  >
+                    <div class="row" data-ng-if="windowWidth <= 772">
+                      <div class="col-8">
+                        <h2
+                          data-ng-click="filesystemCancel()"
+                          class="p-heading--four"
+                        >
+                          <span data-ng-if="cachesetsMode === 'delete'"
+                            >Removing {$ cacheset.name $}</span
+                          >
+                        </h2>
+                      </div>
+                    </div>
+                    <div
+                      class="row"
+                      data-ng-class="{ 'is-active': cachesetsMode !== null && cachesetsMode !== 'multi' }"
+                    >
+                      <div
+                        data-ng-show="cachesetsMode === 'single' && canDeleteCacheSet(cacheset)"
+                      >
+                        <button
+                          class="p-button--base"
+                          data-ng-show="canDeleteCacheSet(cacheset)"
+                          data-ng-click="cacheSetDelete()"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                      <div
+                        class="row ng-hide"
+                        data-ng-show="cachesetsMode === 'delete'"
+                      >
+                        <div class="col-8">
+                          <p>
+                            <span class="p-icon--warning">Warning:</span> Are
+                            you sure you want to delete this cache set?
+                          </p>
+                        </div>
+                        <div class="col-4">
+                          <div class="u-align--right">
+                            <button
+                              class="p-button--base"
+                              type="button"
+                              data-ng-click="cacheSetCancel()"
+                            >
+                              Cancel
+                            </button>
+                            <button
+                              class="p-button--negative u-no-margin--top"
+                              data-ng-click="cacheSetConfirmDelete(cacheset)"
+                            >
+                              Remove cache set
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div>
+          <storage-disks-partitions></storage-disks-partitions>
+        </div>
+      </div>
+    </form>
+  </section>
+  <section class="p-strip" data-ng-if="section.area === 'events'">
+    <div class="row">
+      <div class="col-12 u-align--right" data-ng-if="node.events.length">
+        <a
+          href="{$ legacyURLBase $}/{$ type_name $}/{$ node.system_id $}/events"
+          >View full history</a
+        >
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <div class="p-notification" data-ng-if="!node.events.length">
+          <p class="p-notification__response">
+            No events found.
+          </p>
+        </div>
+        <table data-ng-if="node.events.length">
+          <thead>
+            <tr>
+              <th class="col-3">Time</th>
+              <th class="col-9">Event</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              data-ng-repeat="event in node.events | orderByDate:'created':'id' | limitTo:events.limit"
+            >
+              <td
+                class="col-3"
+                aria-label="Created"
+                title="{$ event.created $}"
+              >
+                <span class="p-icon--{$ event.type.level $}"></span>&nbsp; {$
+                event.created $}
+              </td>
+              <td
+                class="col-9"
+                aria-label="Event"
+                title="{$ getEventText(event) $}"
+              >
+                {$ getEventText(event) $}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12 u-align--center">
+        <button
+          class="p-button--neutral"
+          data-ng-show="allowShowMoreEvents()"
+          data-ng-click="showMoreEvents()"
+        >
+          Load next 10 events
+        </button>
+      </div>
+    </div>
+  </section>
+  <section class="p-strip" data-ng-if="section.area === 'logs'">
+    <div data-ng-controller="NodeResultsController">
+      <div class="row" data-ng-if="!resultsLoaded">
+        <div class="col-12">
+          <p class="u-text--loading">
+            <i class="p-icon--spinner u-animation--spin"></i
+            >&nbsp;&nbsp;Loading...
+          </p>
+        </div>
+      </div>
+      <div data-ng-if="resultsLoaded">
+        <div class="row">
+          <div class="col-12">
+            <div class="u-sv2">
+              <div
+                data-maas-cta="logs.availableOptions"
+                data-ng-model="logs.option"
+                data-ng-change="updateLogOutput()"
+              ></div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-12">
+            <pre
+              class="p-code-numbered is-copyable"
+              data-maas-code-lines="logOutput"
+              data-ng-if="logOutput !== null && logOutput !== ''"
+            ></pre>
+            <div
+              class="p-notification"
+              data-ng-if="logOutput === null || logOutput === ''"
+            >
+              <p class="p-notification__response">
+                No logs found.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section class="p-strip" data-ng-if="section.area === 'commissioning'">
+    <div data-maas-script-results-list="script-results"></div>
+  </section>
+  <section class="p-strip" data-ng-if="section.area === 'testing'">
+    <div data-maas-script-results-list="script-results"></div>
+  </section>
 </div>

--- a/legacy/src/app/partials/nodedetails/deploy-options.html
+++ b/legacy/src/app/partials/nodedetails/deploy-options.html
@@ -1,0 +1,102 @@
+<div class="row">
+  <div class="col-3">
+    <p>Customise options</p>
+  </div>
+  <div class="col-9">
+    <ul class="p-list p-inline-list">
+      <li class="p-inline-list__item">
+        <div
+          class="p-form-group p-form-validation u-sv-1 u-display-inline-block"
+        >
+          <div class="p-form__control u-clearfix">
+            <input
+              id="installKVM"
+              type="checkbox"
+              data-ng-model="deployOptions.installKVM"
+              ng-disabled="!nodesManager.canBeKvmHost(osSelection)"
+            />
+            <label
+              for="installKVM"
+              class="u-float--left"
+              style="width: auto; margin-right: 1rem;"
+            >
+              Register as MAAS KVM host (Ubuntu 18.04 LTS required)
+            </label>
+
+            <p
+              class="u-sv-1 u-no-max-width"
+              ng-if="!nodesManager.canBeKvmHost(osSelection)"
+            >
+              <i class="p-icon--warning"></i>&nbsp;Ubuntu 18.04 is required to
+              create a KVM host.
+            </p>
+          </div>
+        </div>
+      </li>
+      <li class="p-inline-list__item">
+        <a
+          class="p-link--external"
+          href="https://maas.io/docs/kvm-introduction"
+          target="_blank"
+        >
+          Read more
+        </a>
+      </li>
+    </ul>
+
+    <ul class="p-list p-inline-list">
+      <li class="p-inline-list__item">
+        <div
+          class="p-form-group p-form-validation u-sv-1 u-display-inline-block"
+        >
+          <div class="p-form__control u-clearfix">
+            <input
+              id="showCloudInit"
+              type="checkbox"
+              ng-model="showCloudInitChecked"
+            />
+            <label
+              for="showCloudInit"
+              class="u-float--left"
+              style="width: auto; margin-right: 1rem;"
+            >
+              Cloud-init user-data&hellip;
+            </label>
+          </div>
+        </div>
+      </li>
+      <li class="p-inline-list__item">
+        <a
+          class="p-link--external"
+          href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+          target="_blank"
+        >
+          Read more
+        </a>
+      </li>
+    </ul>
+
+    <div data-ng-if="showCloudInitChecked">
+      <textarea
+        class="p-form-validation__input u-sv2"
+        data-ng-model="deployOptions.userData"
+        name="userData"
+        autocapitalize="off"
+        autocomplete="off"
+        autocorrect="off"
+        placeholder="Paste script here"
+        spellcheck="false"
+        style="min-height: 15rem;"
+      ></textarea>
+      <input
+        user-data-upload
+        id="userDataFiles"
+        type="file"
+        autocomplete="off"
+        accept="text/*,
+application/x-csh, application/x-sh, application/x-shellscript,
+application/json, application/ld+json, application/x-yaml"
+      />
+    </div>
+  </div>
+</div>

--- a/legacy/src/app/partials/nodedetails/deploy-options.html
+++ b/legacy/src/app/partials/nodedetails/deploy-options.html
@@ -1,4 +1,5 @@
 <div class="row">
+  <hr />
   <div class="col-3">
     <p>Customise options</p>
   </div>
@@ -99,4 +100,5 @@ application/json, application/ld+json, application/x-yaml"
       />
     </div>
   </div>
+  <hr />
 </div>


### PR DESCRIPTION
## Done

* Add support for cloud-init to deploy form on machine details view.
* Fix styles to make deploy form better aligned with the react version on machine list.

*Note*: the **actual** diff is not that large, `node-details.html` has been reformatted here (curious that prettier missed that earlier...). Apologies for the heart attack.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

from machine details:
- Select "Take action" ... "Deploy"
- Tick "Cloud-init user-data…"
- Add a cloud config file via the file picker from "Customise options", it should populate the text area.
- Submit the form with your network inspector open, the deploy payload should contain extra data `user_data`.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2041

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
