### PR TITLE
Filter out notifications if they are disabled

### DIFF
--- a/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -4,10 +4,12 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import {
-  notification as notificationFactory,
-  notificationState as notificationStateFactory,
+  config as configFactory,
+  configState as configStateFactory,
   message as messageFactory,
   messageState as messageStateFactory,
+  notification as notificationFactory,
+  notificationState as notificationStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 import NotificationList from "./NotificationList";
@@ -29,6 +31,9 @@ describe("NotificationList", () => {
       }),
     ];
     state = rootStateFactory({
+      config: configStateFactory({
+        items: [configFactory({ name: "release_notifications", value: false })],
+      }),
       messages: messageStateFactory({
         items: [messageFactory({ id: 1, message: "User deleted" })],
       }),

--- a/ui/src/app/store/notification/selectors.test.ts
+++ b/ui/src/app/store/notification/selectors.test.ts
@@ -1,8 +1,11 @@
 import {
+  config as configFactory,
+  configState as configStateFactory,
   notification as notificationFactory,
   notificationState as notificationStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { NotificationIdent } from "app/store/notification/types";
 import notification from "./selectors";
 
 describe("notification selectors", () => {
@@ -13,6 +16,23 @@ describe("notification selectors", () => {
       }),
     });
     const items = notification.all(state);
+    expect(items.length).toEqual(1);
+    expect(items[0].message).toEqual("Test message");
+  });
+
+  it("can get all enabled items", () => {
+    const state = rootStateFactory({
+      config: configStateFactory({
+        items: [configFactory({ name: "release_notifications", value: false })],
+      }),
+      notification: notificationStateFactory({
+        items: [
+          notificationFactory({ message: "Test message" }),
+          notificationFactory({ ident: NotificationIdent.release }),
+        ],
+      }),
+    });
+    const items = notification.allEnabled(state);
     expect(items.length).toEqual(1);
     expect(items[0].message).toEqual("Test message");
   });

--- a/ui/src/app/store/notification/selectors.ts
+++ b/ui/src/app/store/notification/selectors.ts
@@ -1,6 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import { generateBaseSelectors } from "app/store/utils";
+import configSelectors from "app/store/config/selectors";
+import { NotificationIdent } from "app/store/notification/types";
 import type {
   Notification,
   NotificationState,
@@ -17,7 +19,25 @@ const defaultSelectors = generateBaseSelectors<
  * @param {RootState} state - The redux state.
  * @returns {Notification[]} Warning notifications.
  */
-const warnings = createSelector([defaultSelectors.all], (notifications) =>
+const allEnabled = createSelector(
+  [defaultSelectors.all, configSelectors.releaseNotifications],
+  (notifications, releaseNotificationsEnabled) => {
+    if (!releaseNotificationsEnabled) {
+      return notifications.filter(
+        (notification: Notification) =>
+          notification.ident !== NotificationIdent.release
+      );
+    }
+    return notifications;
+  }
+);
+
+/**
+ * Returns notifications of type 'warning'
+ * @param {RootState} state - The redux state.
+ * @returns {Notification[]} Warning notifications.
+ */
+const warnings = createSelector([allEnabled], (notifications) =>
   notifications.filter(
     (notification: Notification) => notification.category === "warning"
   )
@@ -28,7 +48,7 @@ const warnings = createSelector([defaultSelectors.all], (notifications) =>
  * @param {RootState} state - The redux state.
  * @returns {Notification[]} Error notifications.
  */
-const errors = createSelector([defaultSelectors.all], (notifications) =>
+const errors = createSelector([allEnabled], (notifications) =>
   notifications.filter(
     (notification: Notification) => notification.category === "error"
   )
@@ -39,7 +59,7 @@ const errors = createSelector([defaultSelectors.all], (notifications) =>
  * @param {RootState} state - The redux state.
  * @returns {Notification[]} Success notifications.
  */
-const success = createSelector([defaultSelectors.all], (notifications) =>
+const success = createSelector([allEnabled], (notifications) =>
   notifications.filter(
     (notification: Notification) => notification.category === "success"
   )
@@ -50,7 +70,7 @@ const success = createSelector([defaultSelectors.all], (notifications) =>
  * @param {RootState} state - The redux state.
  * @returns {Notification[]} Info notifications.
  */
-const info = createSelector([defaultSelectors.all], (notifications) =>
+const info = createSelector([allEnabled], (notifications) =>
   notifications.filter(
     (notification: Notification) => notification.category === "info"
   )
@@ -58,6 +78,7 @@ const info = createSelector([defaultSelectors.all], (notifications) =>
 
 const selectors = {
   ...defaultSelectors,
+  allEnabled,
   errors,
   info,
   success,

--- a/ui/src/app/store/notification/selectors.ts
+++ b/ui/src/app/store/notification/selectors.ts
@@ -15,9 +15,9 @@ const defaultSelectors = generateBaseSelectors<
 >("notification", "id");
 
 /**
- * Returns notifications of type 'warning'
+ * Returns notifications that haven't been disabled.
  * @param {RootState} state - The redux state.
- * @returns {Notification[]} Warning notifications.
+ * @returns {Notification[]} Notifications that can be shown to the user.
  */
 const allEnabled = createSelector(
   [defaultSelectors.all, configSelectors.releaseNotifications],


### PR DESCRIPTION
## Done

- Filter notifications to remove release notifications if the option is turned off.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local edge snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- Create a release notification:
```shell
maas $PROFILE notifications create ident='release_notification' category='info' users=true admins=true message='<strong>We’ve released MAAS 2.8.</strong> This version supports LXD VM hosts, faster UI and many bug fixes. Find out <a href="https://maas.io/docs/release-notes">what’s new in 2.8</a>.'
```
- If you dismiss the notification and want to be able to see it again you can run:
```shell
make harness
from maasserver.models.notification import Notification, NotificationDismissal
NotificationDismissal.objects.filter(notification=Notification.objects.get(ident='release_notification')).delete()
```
- Load the general settings page you should see the release notification (assuming you haven't turned the option off).
- Turn the option off, the notification should no longer be visible.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/2050.
Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/2052.