### PR TITLE
Update KVM list popovers to latest design.

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -144,14 +144,14 @@ describe("PoolSelect", () => {
     // defaultPool should be selected by default
     expect(
       wrapper
-        .find(".kvm-pool-select__pool")
+        .find(".kvm-pool-select__button")
         .at(0)
         .find(".p-icon--tick")
         .exists()
     ).toBe(true);
     expect(
       wrapper
-        .find(".kvm-pool-select__pool")
+        .find(".kvm-pool-select__button")
         .at(1)
         .find(".p-icon--tick")
         .exists()
@@ -159,21 +159,21 @@ describe("PoolSelect", () => {
 
     // Select other pool
     await act(async () => {
-      wrapper.find("button.kvm-pool-select__pool").at(1).simulate("click");
+      wrapper.find("button.kvm-pool-select__button").at(1).simulate("click");
     });
     wrapper.update();
 
     // otherPool should now be selected
     expect(
       wrapper
-        .find(".kvm-pool-select__pool")
+        .find(".kvm-pool-select__button")
         .at(0)
         .find(".p-icon--tick")
         .exists()
     ).toBe(false);
     expect(
       wrapper
-        .find(".kvm-pool-select__pool")
+        .find(".kvm-pool-select__button")
         .at(1)
         .find(".p-icon--tick")
         .exists()
@@ -208,15 +208,15 @@ describe("PoolSelect", () => {
     wrapper.update();
 
     // poolWithSpace should not be disabled, but poolWithoutSpace should be
-    expect(wrapper.find(".kvm-pool-select__pool").at(0).prop("disabled")).toBe(
-      false
-    );
-    expect(wrapper.find(".kvm-pool-select__pool").at(1).prop("disabled")).toBe(
-      true
-    );
+    expect(
+      wrapper.find(".kvm-pool-select__button").at(0).prop("disabled")
+    ).toBe(false);
+    expect(
+      wrapper.find(".kvm-pool-select__button").at(1).prop("disabled")
+    ).toBe(true);
     expect(
       wrapper
-        .find(".kvm-pool-select__pool")
+        .find(".kvm-pool-select__button")
         .at(1)
         .find(".p-icon--warning")
         .exists()

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -37,13 +37,13 @@ const generateDropdownContent = (
 
   return (
     <>
-      <div className="kvm-pool-select__grid p-contextual-menu__non-interactive">
+      <div className="kvm-pool-select__header p-table__header">
         <div></div>
         <div>Storage</div>
         <div className="u-align--right">Type</div>
         <ul className="p-inline-list u-default-text u-no-margin--bottom">
           <li className="p-inline-list__item">
-            <i className="p-icon--assigned is-inline"></i>
+            <i className="p-icon--allocated is-inline"></i>
             Allocated
           </li>
           <li className="p-inline-list__item">
@@ -51,7 +51,7 @@ const generateDropdownContent = (
             Requested
           </li>
           <li className="p-inline-list__item">
-            <i className="p-icon--unassigned is-inline"></i>
+            <i className="p-icon--free is-inline"></i>
             Free
           </li>
         </ul>
@@ -70,13 +70,13 @@ const generateDropdownContent = (
 
         return (
           <button
-            className="kvm-pool-select__pool p-button--base"
+            className="kvm-pool-select__button p-button--base"
             disabled={free < 0}
             key={`${disk.id}-${pool.id}`}
             onClick={() => selectPool(pool.name)}
             type="button"
           >
-            <div className="kvm-pool-select__grid">
+            <div className="kvm-pool-select__row">
               <div>{isSelected && <i className="p-icon--tick"></i>}</div>
               <div>
                 <strong>
@@ -118,7 +118,7 @@ const generateDropdownContent = (
                   free >= 0 ? (
                     <ul className="p-inline-list u-no-margin--bottom">
                       <li className="p-inline-list__item" data-test="allocated">
-                        <i className="p-icon--assigned is-inline"></i>
+                        <i className="p-icon--allocated is-inline"></i>
                         {`${allocated}GB`}
                       </li>
                       {requested !== 0 && (
@@ -131,7 +131,7 @@ const generateDropdownContent = (
                         </li>
                       )}
                       <li className="p-inline-list__item" data-test="free">
-                        <i className="p-icon--unassigned is-inline"></i>
+                        <i className="p-icon--free is-inline"></i>
                         {`${available - requested}GB`}
                       </li>
                     </ul>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/_index.scss
@@ -1,4 +1,20 @@
 @mixin KVMPoolSelect {
+  %kvm-pool-select__grid {
+    display: grid;
+    grid-column-gap: $sph-inner;
+    grid-template-columns: #{$sph-inner * 0.75} 2fr 1fr 3fr;
+    word-break: break-word;
+
+    @media only screen and (max-width: $breakpoint-large) {
+      grid-template-columns: #{$sph-inner * 0.75} 1fr;
+
+      > :nth-child(3),
+      > :nth-child(4) {
+        display: none;
+      }
+    }
+  }
+
   .kvm-pool-select {
     display: block;
     width: 100%;
@@ -11,6 +27,12 @@
       @media only screen and (max-width: $breakpoint-large) {
         width: auto;
       }
+    }
+
+    .kvm-pool-select__header {
+      @extend %kvm-pool-select__grid;
+      padding-left: $sph-inner;
+      padding-right: $sph-inner;
     }
 
     .kvm-pool-select__toggle {
@@ -31,7 +53,7 @@
       }
     }
 
-    .kvm-pool-select__pool {
+    .kvm-pool-select__button {
       margin-bottom: 0;
       padding: $spv-inner--small $sph-inner;
       text-align: left;
@@ -42,20 +64,8 @@
       }
     }
 
-    .kvm-pool-select__grid {
-      display: grid;
-      grid-column-gap: $sph-inner;
-      grid-template-columns: #{$sph-inner * 0.75} 2fr 1fr 3fr;
-      word-break: break-word;
-
-      @media only screen and (max-width: $breakpoint-large) {
-        grid-template-columns: #{$sph-inner * 0.75} 1fr;
-
-        > :nth-child(3),
-        > :nth-child(4) {
-          display: none;
-        }
-      }
+    .kvm-pool-select__row {
+      @extend %kvm-pool-select__grid;
     }
   }
 }

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
@@ -38,7 +38,7 @@ describe("CPUColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "4 of 8 assigned"
+      "4 of 8 allocated"
     );
     expect(wrapper.find("Meter").props().max).toBe(8);
   });
@@ -53,7 +53,7 @@ describe("CPUColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "4 of 16 assigned"
+      "4 of 16 allocated"
     );
     expect(wrapper.find("Meter").props().max).toBe(16);
   });

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
@@ -17,7 +17,7 @@ const CPUColumn = ({ id }: Props): JSX.Element | null => {
     const availableCores = pod.total.cores * pod.cpu_over_commit_ratio;
     return (
       <CPUPopover
-        assigned={pod.used.cores}
+        allocated={pod.used.cores}
         physical={pod.total.cores}
         overcommit={pod.cpu_over_commit_ratio}
       >
@@ -31,7 +31,7 @@ const CPUColumn = ({ id }: Props): JSX.Element | null => {
           ]}
           label={
             <small className="u-text--light">
-              {`${pod.used.cores} of ${availableCores} assigned`}
+              {`${pod.used.cores} of ${availableCores} allocated`}
             </small>
           }
           labelClassName="u-align--right"

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.test.tsx
@@ -13,13 +13,13 @@ describe("CPUPopover", () => {
 
   it("correctly displays CPU core data", () => {
     const wrapper = mount(
-      <CPUPopover assigned={10} physical={6} overcommit={3}>
+      <CPUPopover allocated={10} physical={6} overcommit={3}>
         Child
       </CPUPopover>
     );
     wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-test='assigned']").text()).toBe("10");
-    expect(wrapper.find("[data-test='unassigned']").text()).toBe("8");
+    expect(wrapper.find("[data-test='allocated']").text()).toBe("10");
+    expect(wrapper.find("[data-test='free']").text()).toBe("8");
     expect(wrapper.find("[data-test='physical']").text()).toBe("6");
     expect(wrapper.find("[data-test='overcommit']").text()).toBe("3");
     expect(wrapper.find("[data-test='total']").text()).toBe("18");

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.tsx
@@ -4,52 +4,60 @@ import React from "react";
 import Popover from "app/base/components/Popover";
 
 type Props = {
-  assigned: number;
+  allocated: number;
   children: JSX.Element | string;
   physical: number;
   overcommit: number;
 };
 
 const CPUPopover = ({
-  assigned,
+  allocated,
   children,
   physical,
   overcommit,
 }: Props): JSX.Element => {
   const total = physical * overcommit;
-  const unassigned = total - assigned;
+  const free = total - allocated;
 
   return (
     <Popover
       className="cpu-popover"
       content={
         <>
+          <div className="cpu-popover__header p-table__header">CPU cores</div>
           <div className="cpu-popover__primary">
-            <div className="cpu-popover__value" data-test="assigned">
-              <i className="p-icon--assigned is-inline"></i>
-              {assigned}
+            <div className="u-align--right" data-test="allocated">
+              {allocated}
             </div>
-            <div>Assigned</div>
-            <div className="cpu-popover__value" data-test="unassigned">
-              <i className="p-icon--unassigned is-inline"></i>
-              {unassigned}
+            <div className="u-vertically-center">
+              <i className="p-icon--allocated"></i>
             </div>
-            <div>Unassigned</div>
+            <div>Allocated</div>
+            <div className="u-align--right" data-test="free">
+              {free}
+            </div>
+            <div className="u-vertically-center">
+              <i className="p-icon--free"></i>
+            </div>
+            <div>Free</div>
           </div>
           <div className="cpu-popover__secondary">
-            <div className="cpu-popover__value" data-test="physical">
+            <div className="u-align--right" data-test="physical">
               {physical}
             </div>
+            <div />
             <div>{`Physical core${physical === 1 ? "" : "s"}`}</div>
-            <div className="cpu-popover__value">
-              &times;&nbsp;&nbsp;
+            <div className="u-align--right">
+              &times;&nbsp;
               <span data-test="overcommit">{overcommit}</span>
             </div>
+            <div />
             <div>Overcommit ratio</div>
             <hr className="cpu-popover__separator" />
-            <div className="cpu-popover__value" data-test="total">
+            <div className="u-align--right" data-test="total">
               {total}
             </div>
+            <div />
             <div>Total</div>
           </div>
         </>
@@ -61,7 +69,7 @@ const CPUPopover = ({
 };
 
 CPUPopover.propTypes = {
-  assigned: PropTypes.number.isRequired,
+  allocated: PropTypes.number.isRequired,
   children: PropTypes.node.isRequired,
   physical: PropTypes.number.isRequired,
   overcommit: PropTypes.number.isRequired,

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/_index.scss
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/_index.scss
@@ -1,12 +1,17 @@
 @mixin CPUPopover {
   %cpu-popover-grid {
     display: grid;
-    grid-template-columns: 2.75rem auto;
+    grid-column-gap: $sph-inner--small;
+    grid-template-columns: 2rem $sph-inner--small auto;
     padding: $spv-inner--small $spv-outer--medium;
   }
 
   .cpu-popover {
-    width: 13.25rem;
+    width: 13.5rem;
+  }
+
+  .cpu-popover__header {
+    margin: 0 $sph-inner;
   }
 
   .cpu-popover__primary {
@@ -20,14 +25,7 @@
 
   .cpu-popover__separator {
     grid-column-start: 1;
-    grid-column-end: 3;
+    grid-column-end: 4;
     margin-top: $spv-outer--small;
-  }
-
-  .cpu-popover__value {
-    align-items: center;
-    display: flex;
-    justify-content: flex-end;
-    padding-right: $sph-inner--small;
   }
 }

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
@@ -38,7 +38,7 @@ describe("RAMColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "2 of 8 GiB assigned"
+      "2 of 8 GiB allocated"
     );
     expect(wrapper.find("Meter").props().max).toBe(8192);
   });
@@ -53,7 +53,7 @@ describe("RAMColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "2 of 16 GiB assigned"
+      "2 of 16 GiB allocated"
     );
     expect(wrapper.find("Meter").props().max).toBe(16384);
   });

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
@@ -27,7 +27,7 @@ const RAMColumn = ({ id }: Props): JSX.Element | null => {
 
     return (
       <RAMPopover
-        assigned={pod.used.memory}
+        allocated={pod.used.memory}
         overcommit={pod.memory_over_commit_ratio}
         physical={pod.total.memory}
       >
@@ -41,7 +41,7 @@ const RAMColumn = ({ id }: Props): JSX.Element | null => {
           ]}
           label={
             <small className="u-text--light">
-              {`${assignedMemory.value} of ${availableMemory.value} ${availableMemory.unit} assigned`}
+              {`${assignedMemory.value} of ${availableMemory.value} ${availableMemory.unit} allocated`}
             </small>
           }
           labelClassName="u-align--right"

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.test.tsx
@@ -13,13 +13,13 @@ describe("RAMPopover", () => {
 
   it("correctly displays RAM data", () => {
     const wrapper = mount(
-      <RAMPopover assigned={4096} physical={8192} overcommit={2}>
+      <RAMPopover allocated={4096} physical={8192} overcommit={2}>
         Child
       </RAMPopover>
     );
     wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-test='assigned']").text()).toBe("4 GiB");
-    expect(wrapper.find("[data-test='unassigned']").text()).toBe("12 GiB");
+    expect(wrapper.find("[data-test='allocated']").text()).toBe("4 GiB");
+    expect(wrapper.find("[data-test='free']").text()).toBe("12 GiB");
     expect(wrapper.find("[data-test='physical']").text()).toBe("8 GiB");
     expect(wrapper.find("[data-test='overcommit']").text()).toBe("2");
     expect(wrapper.find("[data-test='total']").text()).toBe("16 GiB");

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
@@ -5,14 +5,14 @@ import { formatBytes } from "app/utils";
 import Popover from "app/base/components/Popover";
 
 type Props = {
-  assigned: number;
+  allocated: number;
   children: JSX.Element | string;
   physical: number;
   overcommit: number;
 };
 
 const RAMPopover = ({
-  assigned,
+  allocated,
   children,
   physical,
   overcommit,
@@ -23,48 +23,52 @@ const RAMPopover = ({
   const physicalMemory = formatBytes(physical, "MiB", {
     binary: true,
   });
-  const assignedMemory = formatBytes(assigned, "MiB", {
+  const allocatedMemory = formatBytes(allocated, "MiB", {
     binary: true,
   });
-  const unassignedMemory = formatBytes(
-    physical * overcommit - assigned,
-    "MiB",
-    {
-      binary: true,
-    }
-  );
+  const freeMemory = formatBytes(physical * overcommit - allocated, "MiB", {
+    binary: true,
+  });
 
   return (
     <Popover
       className="ram-popover"
       content={
         <>
+          <div className="ram-popover__header p-table__header">RAM</div>
           <div className="ram-popover__primary">
-            <div className="ram-popover__value" data-test="assigned">
-              <i className="p-icon--assigned is-inline"></i>
-              {`${assignedMemory.value} ${assignedMemory.unit}`}
+            <div className="u-align--right" data-test="allocated">
+              {`${allocatedMemory.value} ${allocatedMemory.unit}`}
             </div>
-            <div>Assigned</div>
-            <div className="ram-popover__value" data-test="unassigned">
-              <i className="p-icon--unassigned is-inline"></i>
-              {`${unassignedMemory.value} ${unassignedMemory.unit}`}
+            <div className="u-vertically-center">
+              <i className="p-icon--allocated"></i>
             </div>
-            <div>Unassigned</div>
+            <div>Allocated</div>
+            <div className="u-align--right" data-test="free">
+              {`${freeMemory.value} ${freeMemory.unit}`}
+            </div>
+            <div className="u-vertically-center">
+              <i className="p-icon--free"></i>
+            </div>
+            <div>Free</div>
           </div>
           <div className="ram-popover__secondary">
-            <div className="ram-popover__value" data-test="physical">
+            <div className="u-align--right" data-test="physical">
               {`${physicalMemory.value} ${physicalMemory.unit}`}
             </div>
+            <div />
             <div>Physical RAM</div>
-            <div className="ram-popover__value">
-              &times;&nbsp;&nbsp;
+            <div className="u-align--right">
+              &times;&nbsp;
               <span data-test="overcommit">{overcommit}</span>
             </div>
+            <div />
             <div>Overcommit ratio</div>
             <hr className="ram-popover__separator" />
-            <div className="ram-popover__value" data-test="total">
+            <div className="u-align--right" data-test="total">
               {`${totalMemory.value} ${totalMemory.unit}`}
             </div>
+            <div />
             <div>Total</div>
           </div>
         </>
@@ -76,7 +80,7 @@ const RAMPopover = ({
 };
 
 RAMPopover.propTypes = {
-  assigned: PropTypes.number.isRequired,
+  allocated: PropTypes.number.isRequired,
   children: PropTypes.node.isRequired,
   physical: PropTypes.number.isRequired,
   overcommit: PropTypes.number.isRequired,

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/_index.scss
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/_index.scss
@@ -1,12 +1,17 @@
 @mixin RAMPopover {
   %ram-popover-grid {
     display: grid;
-    grid-template-columns: 6rem auto;
+    grid-column-gap: $sph-inner--small;
+    grid-template-columns: 5rem $sph-inner--small auto;
     padding: $spv-inner--small $spv-outer--medium;
   }
 
   .ram-popover {
     width: 16.5rem;
+  }
+
+  .ram-popover__header {
+    margin: 0 $sph-inner;
   }
 
   .ram-popover__primary {
@@ -20,14 +25,7 @@
 
   .ram-popover__separator {
     grid-column-start: 1;
-    grid-column-end: 3;
+    grid-column-end: 4;
     margin-top: $spv-outer--small;
-  }
-
-  .ram-popover__value {
-    align-items: center;
-    display: flex;
-    justify-content: flex-end;
-    padding-right: $sph-inner--small;
   }
 }

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
@@ -38,7 +38,7 @@ describe("StorageColumn", () => {
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "0.1 of 1 TB assigned"
+      "0.1 of 1 TB allocated"
     );
     expect(wrapper.find("Meter").props().max).toBe(1000000000000);
   });

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
@@ -16,12 +16,15 @@ const StorageColumn = ({ id }: Props): JSX.Element | null => {
 
   if (pod) {
     const availableStorage = formatBytes(pod.total.local_storage, "B");
-    const assignedStorage = formatBytes(pod.used.local_storage, "B", {
+    const allocatedStorage = formatBytes(pod.used.local_storage, "B", {
       convertTo: availableStorage.unit,
     });
 
     return (
-      <StoragePopover pools={pod.storage_pools}>
+      <StoragePopover
+        defaultPoolID={pod.default_storage_pool}
+        pools={pod.storage_pools}
+      >
         <Meter
           className="u-no-margin--bottom"
           data={[
@@ -32,7 +35,7 @@ const StorageColumn = ({ id }: Props): JSX.Element | null => {
           ]}
           label={
             <small className="u-text--light">
-              {`${assignedStorage.value} of ${availableStorage.value} ${availableStorage.unit} assigned`}
+              {`${allocatedStorage.value} of ${availableStorage.value} ${availableStorage.unit} allocated`}
             </small>
           }
           labelClassName="u-align--right"

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.test.tsx
@@ -17,29 +17,23 @@ describe("StoragePopover", () => {
       podStoragePoolFactory({
         name: "poolio",
         path: "/the/way",
-        total: 1000,
+        total: 15000,
         type: "o-negative",
-        used: 500,
+        used: 5000,
       }),
     ];
-    const wrapper = mount(<StoragePopover pools={pools}>Child</StoragePopover>);
+    const wrapper = mount(
+      <StoragePopover defaultPoolID={pools[0].id} pools={pools}>
+        Child
+      </StoragePopover>
+    );
     wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-test='pool-name']").text()).toBe("poolio");
+    expect(wrapper.find("[data-test='pool-name']").text()).toBe(
+      "poolio (default)"
+    );
     expect(wrapper.find("[data-test='pool-path']").text()).toBe("/the/way");
     expect(wrapper.find("[data-test='pool-type']").text()).toBe("o-negative");
-    expect(wrapper.find("[data-test='pool-space']").text()).toBe(
-      "0.5 of 1 KB assigned"
-    );
-  });
-
-  it("adds horizontal rules between pools", () => {
-    const pools = [
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-      podStoragePoolFactory(),
-    ];
-    const wrapper = mount(<StoragePopover pools={pools}>Child</StoragePopover>);
-    wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("hr").length).toBe(pools.length - 1);
+    expect(wrapper.find("[data-test='pool-allocated']").text()).toBe("5KB");
+    expect(wrapper.find("[data-test='pool-free']").text()).toBe("10KB");
   });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
@@ -8,57 +8,94 @@ import Popover from "app/base/components/Popover";
 
 type Props = {
   children: ReactNode;
+  defaultPoolID: Pod["default_storage_pool"];
   pools: Pod["storage_pools"];
 };
 
-const StoragePopover = ({ children, pools }: Props): JSX.Element => {
+const StoragePopover = ({
+  children,
+  defaultPoolID,
+  pools,
+}: Props): JSX.Element => {
+  const sortedPools = [
+    pools.find((pool) => pool.id === defaultPoolID),
+    ...pools.filter((pool) => pool.id !== defaultPoolID),
+  ].filter(Boolean);
+
   return (
     <Popover
       className="storage-popover"
       content={
         <>
-          {pools.map((pool, i) => {
-            const available = formatBytes(pool.total, "B");
-            const assigned = formatBytes(pool.used, "B", {
-              convertTo: available.unit,
-            });
+          <div className="storage-popover__header p-table__header">
+            <div>Storage</div>
+            <div className="u-align--right">Type</div>
+            <ul className="p-inline-list u-default-text u-no-margin--bottom">
+              <li className="p-inline-list__item">
+                <i className="p-icon--allocated is-inline"></i>
+                Allocated
+              </li>
+              <li className="p-inline-list__item">
+                <i className="p-icon--free is-inline"></i>
+                Free
+              </li>
+            </ul>
+          </div>
+          {sortedPools.map((pool) => {
+            const isDefaultPool = pool.id === defaultPoolID;
+            const allocated = formatBytes(pool.used, "B");
+            const free = formatBytes(pool.total - pool.used, "B");
+            const total = formatBytes(pool.total, "B");
 
             return (
               <React.Fragment key={pool.id}>
-                <div className="storage-popover__pool">
-                  <div className="p-grid-list">
-                    <div className="p-grid-list__label">Name</div>
-                    <div className="p-grid-list__value" data-test="pool-name">
-                      {pool.name}
+                <div className="storage-popover__row">
+                  <div>
+                    <div className="u-truncate" data-test="pool-name">
+                      <strong>
+                        {isDefaultPool ? `${pool.name} (default)` : pool.name}
+                      </strong>
                     </div>
-                    <div className="p-grid-list__label">Mount</div>
-                    <div className="p-grid-list__value" data-test="pool-path">
+                    <div
+                      className="u-text--light u-truncate"
+                      data-test="pool-path"
+                    >
                       {pool.path}
                     </div>
                   </div>
-                  <div className="p-grid-list">
-                    <div className="p-grid-list__label">Type</div>
-                    <div className="p-grid-list__value" data-test="pool-type">
-                      {pool.type}
-                    </div>
-                    <div className="p-grid-list__label">Space</div>
-                    <div className="p-grid-list__value" data-test="pool-space">
-                      <Meter
-                        className="u-no-margin--bottom"
-                        data={[
-                          {
-                            key: `${pool.id}-storage-popover-meter`,
-                            value: pool.used,
-                          },
-                        ]}
-                        label={`${assigned.value} of ${available.value} ${available.unit} assigned`}
-                        labelClassName="u-text--light"
-                        max={pool.total}
-                      />
-                    </div>
+                  <div className="u-align--right">
+                    <div data-test="pool-type">{pool.type}</div>
+                    <div>{`${total.value}${total.unit}`}</div>
                   </div>
+                  <Meter
+                    className="u-no-margin--bottom"
+                    data={[
+                      {
+                        key: `${pool.id}-storage-popover-meter`,
+                        value: allocated.value,
+                      },
+                    ]}
+                    label={
+                      <ul className="p-inline-list u-no-margin--bottom">
+                        <li
+                          className="p-inline-list__item"
+                          data-test="pool-allocated"
+                        >
+                          <i className="p-icon--allocated is-inline"></i>
+                          {`${allocated.value}${allocated.unit}`}
+                        </li>
+                        <li
+                          className="p-inline-list__item"
+                          data-test="pool-free"
+                        >
+                          <i className="p-icon--free is-inline"></i>
+                          {`${free.value}${free.unit}`}
+                        </li>
+                      </ul>
+                    }
+                    max={total.value}
+                  />
                 </div>
-                {i !== pools.length - 1 && <hr className="u-sv1" />}
               </React.Fragment>
             );
           })}

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/_index.scss
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/_index.scss
@@ -1,12 +1,31 @@
 @mixin StoragePopover {
+  %storage-popover-grid {
+    display: grid;
+    grid-column-gap: $sph-inner;
+    grid-template-columns: 1fr 5rem 1fr;
+    padding-left: $sph-inner;
+    padding-right: $sph-inner;
+  }
+
   .storage-popover {
-    padding: $spv-inner--small $spv-outer--medium;
     width: 35rem;
   }
 
-  .storage-popover__pool {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-column-gap: 1rem;
+  .storage-popover__header {
+    @extend %storage-popover-grid;
+  }
+
+  .storage-popover__row {
+    @extend %storage-popover-grid;
+    padding-bottom: $spv-inner--small;
+    padding-top: $spv-inner--small;
+
+    > * {
+      overflow: hidden;
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid #cdcdcd;
+    }
   }
 }

--- a/ui/src/app/utils/formatBytes.ts
+++ b/ui/src/app/utils/formatBytes.ts
@@ -1,4 +1,4 @@
-type Byte = { value: number; unit: string };
+export type Byte = { value: number; unit: string };
 
 type FormatBytesConfig = {
   binary?: boolean;

--- a/ui/src/scss/_patterns_icons.scss
+++ b/ui/src/scss/_patterns_icons.scss
@@ -38,17 +38,21 @@
 }
 
 @mixin maas-icons {
-  $color-assigned: $color-link;
+  $color-allocated: $color-link;
+  $color-free: #d3e4ed;
   $color-requested: $color-positive;
-  $color-unassigned: #d3e4ed;
 
-  .p-icon--assigned {
-    @include maas-icon-circle($color-assigned);
+  .p-icon--allocated {
+    @include maas-icon-circle($color-allocated);
   }
 
   .p-icon--edit {
     @extend %icon;
     @include maas-icon-edit($color-mid-dark);
+  }
+
+  .p-icon--free {
+    @include maas-icon-circle($color-free);
   }
 
   .p-icon--locked {
@@ -98,10 +102,6 @@
   .p-icon--timed-out {
     @extend %icon;
     background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8' standalone='no'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' width='16px' version='1.1' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 16 16'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Etimed out%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg id='Page-1' fill-rule='evenodd' fill='none'%3E%3Cg id='smoke-testing-status' transform='translate%28-62 -206%29'%3E%3Cg id='timed-out' transform='translate%2850 191%29'%3E%3Cg transform='translate%2812 15%29'%3E%3Crect id='rect4970' y='0.00002' x='0' height='16' width='16'/%3E%3Ccircle id='circle4972' stroke-width='1.5' cy='8' stroke='%23E95420' cx='8' r='7.25'/%3E%3Cpolyline id='path839' stroke='%23E95420' stroke-width='2' points='11.8 11.8 7.9999 8 7.9999 3'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
-  }
-
-  .p-icon--unassigned {
-    @include maas-icon-circle($color-unassigned);
   }
 
   [class*="p-icon--"].is-inline {

--- a/ui/src/scss/_patterns_tables.scss
+++ b/ui/src/scss/_patterns_tables.scss
@@ -32,4 +32,13 @@
       padding-bottom: 0;
     }
   }
+
+  .p-table__header {
+    @extend %table-header-label;
+    border-bottom: 1px solid $color-mid-light;
+    margin-bottom: 0;
+    padding-bottom: $spv-inner--medium;
+    padding-top: $spv-inner--medium;
+    text-transform: uppercase;
+  }
 }


### PR DESCRIPTION
## Done

- Updated KVM list popovers to the [latest design](https://app.zeplin.io/project/5f281ffc1be00d31ed6bc3a4/screen/5f28494c9dd2f2206894f93a)
- Updated popover language (and code) so "assigned" is now "allocated", and "unassigned" is now "free".
- Used common styling between this popover and the storage pool select dropdown

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and hover over the meters for CPU, RAM and Storage
- Check that the popovers match the [latest design](https://app.zeplin.io/project/5f281ffc1be00d31ed6bc3a4/screen/5f28494c9dd2f2206894f93a)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2067

## Screenshots
### CPU
![0 0 0 0_8400_MAAS_r_kvm (22)](https://user-images.githubusercontent.com/25733845/89500059-625dba80-d804-11ea-9b5b-b6443929d475.png)


### RAM
![0 0 0 0_8400_MAAS_r_kvm (23)](https://user-images.githubusercontent.com/25733845/89500072-67226e80-d804-11ea-9096-48c95d5f4fe0.png)


### Storage
![0 0 0 0_8400_MAAS_r_kvm (24)](https://user-images.githubusercontent.com/25733845/89500079-6c7fb900-d804-11ea-8f58-f67757175726.png)

