### PR TITLE
Update opt-out menu to send API request

### DIFF
--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
@@ -37,7 +37,7 @@ describe("NotificationGroupNotification", () => {
   });
 
   it("renders", () => {
-    const notification = notificationFactory();
+    const notification = notificationFactory({ id: 1 });
     const state = rootStateFactory({
       config,
       notification: notificationStateFactory({

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -4,10 +4,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { Notification } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
+import { config as configActions } from "app/settings/actions";
 import { isReleaseNotification } from "app/store/utils";
 import { MessageType } from "app/store/message/types";
 import { notification as notificationActions } from "app/base/actions";
 import authSelectors from "app/store/auth/selectors";
+import configSelectors from "app/store/config/selectors";
 import ContextualMenu from "app/base/components/ContextualMenu";
 import notificationSelectors from "app/store/notification/selectors";
 import Switch from "app/base/components/Switch";
@@ -24,6 +26,9 @@ const NotificationGroupNotification = ({ id, type }: Props): JSX.Element => {
   const authUser = useSelector(authSelectors.get);
   const notification = useSelector((state: RootState) =>
     notificationSelectors.getById(state, id)
+  );
+  const releaseNotifications = useSelector(
+    configSelectors.releaseNotifications
   );
   const showMenu =
     isReleaseNotification(notification) && authUser?.is_superuser;
@@ -49,7 +54,16 @@ const NotificationGroupNotification = ({ id, type }: Props): JSX.Element => {
             <>
               <div className="u-flex--between">
                 <div className="u-sv1">Enable new release notifications</div>
-                <Switch disabled={true} checked={true} />
+                <Switch
+                  defaultChecked={Boolean(releaseNotifications)}
+                  onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                    dispatch(
+                      configActions.update({
+                        release_notifications: evt.target.checked,
+                      })
+                    );
+                  }}
+                />
               </div>
               <Link to="/settings/configuration/general">See settings</Link>
             </>

--- a/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`NotificationGroupNotification renders 1`] = `
 <NotificationGroupNotification
-  id={1}
+  id={7}
   type="negative"
 >
   <Notification

--- a/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`NotificationGroupNotification renders 1`] = `
 <NotificationGroupNotification
-  id={7}
+  id={1}
   type="negative"
 >
   <Notification

--- a/ui/src/app/base/components/Switch/Switch.tsx
+++ b/ui/src/app/base/components/Switch/Switch.tsx
@@ -9,14 +9,14 @@ type Props = {
 
 const Switch = ({ className, ...inputProps }: Props): JSX.Element => {
   return (
-    <span>
+    <label>
       <input
         className={classNames("p-switch", className)}
         type="checkbox"
         {...inputProps}
       />
       <div className="p-switch__slider"></div>
-    </span>
+    </label>
   );
 };
 

--- a/ui/src/app/base/components/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/ui/src/app/base/components/Switch/__snapshots__/Switch.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch renders 1`] = `
-<span>
+<label>
   <input
     className="p-switch"
     type="checkbox"
@@ -9,5 +9,5 @@ exports[`Switch renders 1`] = `
   <div
     className="p-switch__slider"
   />
-</span>
+</label>
 `;


### PR DESCRIPTION
## Done

- Update the opt-out menu to show the value from the API, and send the updated value.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local edge snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- Create a release notification:
```shell
maas $PROFILE notifications create ident='release_notification' category='info' users=true admins=true message='<strong>We’ve released MAAS 2.8.</strong> This version supports LXD VM hosts, faster UI and many bug fixes. Find out <a href="https://maas.io/docs/release-notes">what’s new in 2.8</a>.'
```
- If you dismiss the notification and want to be able to see it again you can run:
```shell
make harness
from maasserver.models.notification import Notification, NotificationDismissal
NotificationDismissal.objects.filter(notification=Notification.objects.get(ident='release_notification')).delete()
```
- In the release notification open the opt-out menu and click the toggle. The notification should disappear.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/2053.