### PR TITLE
fix(legacy): Correctly redirect to legacy for user intro.

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -18,7 +18,6 @@ import {
   Footer,
   Header,
   navigateToLegacy,
-  navigateToNew,
 } from "@maas-ui/maas-ui-shared";
 import { status as statusActions } from "app/base/actions";
 import { websocket } from "./base/actions";
@@ -104,7 +103,7 @@ export const App = () => {
     if (completedIntro === false) {
       navigateToLegacy("/intro");
     } else if (authUser && !authUser.completed_intro) {
-      navigateToNew("/intro/user");
+      navigateToLegacy("/intro/user");
     }
   }
 


### PR DESCRIPTION
## Done
- Fix user intro route. Some recent refactoring inadvertently redirected the UI to a non existent react route (r/user/intro), instead of the correct legacy route (l/user/intro), which caused an infinite redirect loop of death. :skull: :fire:

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

In a clean focal container:

- Steps for QA.
-  sudo snap install maas--channel=latest/edge
-  sudo snap install maas-test-db
- sudo maas init region+rack
- sudo maas createadmin
- login, you should see the user intro view, rather than being stuck in an infinite redirect loop

## Fixes

fixes: [lp#1891149](https://bugs.launchpad.net/maas/+bug/1891149)


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
