### PR TITLE
fix(legacy): Pass operational functions to commissioning scripts selector

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -320,6 +320,8 @@
                   data-script-type="0"
                   data-ng-model="commissioningSelection"
                   class="tags--inline"
+                  check-test-parameter-values="checkTestParameterValues"
+                  set-default-values="setDefaultValues"
                 ></span>
               </div>
             </div>


### PR DESCRIPTION
## Done

- Pass checkTestParameterValues and setDefaultValues to commissioning scripts selector

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a ready machine details
- Click the Action menu and select Commission
- You should see the script called set_scale.sh
- Remove that and see there are no console errors
- Add the script back again and check it works with no errors
- Do all the above on bolla and see there are errors

## Fixes

Fixes: #1477 

## Launchpad issue

lp#1891924

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
