### PR TITLE
Set up scaffolding components and grid layouts for KVM resources cards.

### DIFF
--- a/ui/src/app/base/components/Switch/Switch.tsx
+++ b/ui/src/app/base/components/Switch/Switch.tsx
@@ -1,20 +1,17 @@
-import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
 type Props = {
   className?: string;
+  label?: string;
   // TODO: Investigate why this won't work with React.HTMLProps<HTMLInputElement>.
 } & React.PropsWithoutRef<JSX.IntrinsicElements["input"]>;
 
-const Switch = ({ className, ...inputProps }: Props): JSX.Element => {
+const Switch = ({ className, label, ...inputProps }: Props): JSX.Element => {
   return (
-    <label>
-      <input
-        className={classNames("p-switch", className)}
-        type="checkbox"
-        {...inputProps}
-      />
+    <label className={className}>
+      {label}
+      <input className="p-switch" type="checkbox" {...inputProps} />
       <div className="p-switch__slider"></div>
     </label>
   );
@@ -25,6 +22,10 @@ Switch.propTypes = {
    * Optional classes applied to the parent element.
    */
   className: PropTypes.string,
+  /**
+   * Label for switch.
+   */
+  label: PropTypes.node,
 };
 
 export default Switch;

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -1,0 +1,14 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import KVMResourcesCard from "./KVMResourcesCard";
+
+describe("KVMResourcesCard", () => {
+  it("can be given a title", () => {
+    const wrapper = shallow(<KVMResourcesCard title="Title" />);
+
+    expect(wrapper.find("[data-test='kvm-resources-card-title']").text()).toBe(
+      "Title"
+    );
+  });
+});

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -1,0 +1,80 @@
+import { Card } from "@canonical/react-components";
+import classNames from "classnames";
+import React from "react";
+
+import ContextualMenu from "app/base/components/ContextualMenu";
+import Meter from "app/base/components/Meter";
+
+type Props = {
+  className?: string;
+  title?: string;
+};
+
+const KVMResourcesCard = ({ className, title }: Props): JSX.Element => {
+  return (
+    <Card className={classNames("kvm-resources-card", className)}>
+      {title && (
+        <>
+          <h5
+            className="p-text--paragraph"
+            data-test="kvm-resources-card-title"
+          >
+            {title}
+          </h5>
+          <hr />
+        </>
+      )}
+      <div className="kvm-resources-card__section kvm-resources-card__ram">
+        <h4 className="p-heading--small">RAM</h4>
+        <table className="u-no-margin--bottom">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Allocated</th>
+              <th>Free</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>General</td>
+              <td>64GB</td>
+              <td>96GB</td>
+            </tr>
+            <tr>
+              <td>Hugepage</td>
+              <td>32GB</td>
+              <td>64GB</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div className="kvm-resources-card__section kvm-resources-card__cpu">
+        <h4 className="p-heading--small">CPU cores</h4>
+        <Meter data={[]} />
+      </div>
+      <div className="kvm-resources-card__section kvm-resources-card__vfs">
+        <h4 className="p-heading--small">Virtual functions</h4>
+        <div>
+          <Meter data={[]} />
+          <hr />
+          <div className="p-heading--small u-text--light">
+            Network interfaces
+          </div>
+          <span>eth0, eth1, eth2, eth3</span>
+        </div>
+      </div>
+      <div className="kvm-resources-card__section kvm-resources-card__vms">
+        <h4 className="p-heading--small">Total VMs</h4>
+        <ContextualMenu
+          dropdownContent={<></>}
+          hasToggleIcon
+          toggleAppearance="base"
+          toggleClassName="is-dense is-thin"
+          toggleLabel="4"
+        />
+      </div>
+    </Card>
+  );
+};
+
+export default KVMResourcesCard;

--- a/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
+++ b/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
@@ -1,0 +1,116 @@
+@mixin KVMResourcesCard {
+  // Base KVM resources card styling.
+  .kvm-resources-card__section {
+    @extend %base-grid;
+    grid:
+      [row1-start] "header" min-content [row1-end]
+      [row2-start] "content" min-content [row2-end]
+      / 1fr;
+    grid-template-rows: min-content;
+
+    > :nth-child(1) {
+      grid-area: header;
+    }
+
+    > :nth-child(2) {
+      grid-area: content;
+    }
+
+    &:not(:first-of-type) {
+      padding-top: $spv-inner--large;
+      position: relative;
+
+      &::after {
+        background-color: $color-mid-light;
+        content: "";
+        height: 1px;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: $spv-inner--small;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      grid:
+        [row1-start] "header content content content" min-content [row1-end]
+        / 1fr 1fr 1fr 1fr;
+    }
+  }
+
+  // Overwrites for aggregated view at large breakpoints
+  .kvm-resources-card--aggregate {
+    padding-top: $spv-inner--small;
+
+    .p-card__content {
+      @extend %base-grid;
+      display: block;
+
+      @media only screen and (min-width: $breakpoint-large) {
+        display: grid;
+        grid-template-areas: "ram ram ram ram ram cpu cpu cpu vfs vfs vfs vms";
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+        grid-template-rows: min-content;
+
+        .kvm-resources-card__section {
+          padding: 0;
+
+          &:not(:first-of-type)::after {
+            bottom: -$spv-inner--large;
+            height: inherit;
+            left: -$sph-inner;
+            right: inherit;
+            top: -$spv-inner--small;
+            width: 1px;
+          }
+        }
+
+        .kvm-resources-card__ram {
+          grid-area: ram;
+          grid-template-areas: "header content content content content";
+          grid-template-columns: repeat(5, minmax(0, 1fr));
+        }
+
+        .kvm-resources-card__cpu {
+          grid-area: cpu;
+          grid-template-areas:
+            "header header header"
+            "content content content";
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+
+        .kvm-resources-card__vfs {
+          grid-area: vfs;
+          grid-template-areas:
+            "header header header"
+            "content content content";
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+        }
+
+        .kvm-resources-card__vms {
+          grid-area: vms;
+          grid-template-areas:
+            "header"
+            "content";
+          grid-template-columns: 1fr;
+          text-align: right;
+        }
+      }
+
+      @media only screen and (min-width: $breakpoint-x-large) {
+        grid-template-areas: "ram ram ram ram cpu cpu cpu vfs vfs vfs vms vms";
+
+        .kvm-resources-card__ram {
+          grid-template-areas: "header content content content";
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+        }
+
+        .kvm-resources-card__vms {
+          grid-template-areas: "header content";
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          text-align: left;
+        }
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/components/KVMResourcesCard/index.ts
+++ b/ui/src/app/kvm/components/KVMResourcesCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMResourcesCard";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -61,7 +61,7 @@ const KVMDetailsHeader = (): JSX.Element => {
       tabLinks={[
         {
           active: location.pathname.endsWith(`/kvm/${id}`),
-          label: "KVM summary",
+          label: "Resources",
           path: `/kvm/${id}`,
         },
         {

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
+
+const KVMAggregateResources = (): JSX.Element => {
+  return <KVMResourcesCard className="kvm-resources-card--aggregate" />;
+};
+
+export default KVMAggregateResources;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMAggregateResources";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
+
+const fakeNumas = [{ index: 0 }, { index: 1 }];
+
+const KVMNumaResources = (): JSX.Element => {
+  return (
+    <div className="numa-resources-grid">
+      {fakeNumas.map((numa) => (
+        <KVMResourcesCard key={numa.index} title={`NUMA node ${numa.index}`} />
+      ))}
+    </div>
+  );
+};
+
+export default KVMNumaResources;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/_index.scss
@@ -1,0 +1,14 @@
+@mixin KVMNumaResources {
+  .numa-resources-grid {
+    @extend %base-grid;
+    grid-template-columns: 1fr;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    @media only screen and (min-width: $breakpoint-x-large) {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMNumaResources";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.test.tsx
@@ -10,11 +10,11 @@ import {
   podStoragePool as podStoragePoolFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import KVMSummaryStorage from "./KVMSummaryStorage";
+import KVMStorage from "./KVMStorage";
 
 const mockStore = configureStore();
 
-describe("KVMSummaryStorage", () => {
+describe("KVMStorage", () => {
   it("correctly chunks KVM storage pools into rows of 3", () => {
     const pod = podFactory({
       storage_pools: Array.from(Array(4)).map(() => podStoragePoolFactory()),
@@ -24,7 +24,7 @@ describe("KVMSummaryStorage", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm/2", key: "testKey" }]}>
-          <KVMSummaryStorage id={pod.id} />
+          <KVMStorage id={pod.id} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.tsx
@@ -10,7 +10,7 @@ import Meter from "app/base/components/Meter";
 
 type Props = { id: Pod["id"] };
 
-const KVMSummaryStorage = ({ id }: Props): JSX.Element | null => {
+const KVMStorage = ({ id }: Props): JSX.Element | null => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
@@ -20,6 +20,7 @@ const KVMSummaryStorage = ({ id }: Props): JSX.Element | null => {
 
     return (
       <>
+        <h4 className="u-sv1">Storage</h4>
         {chunkedPools.map((pools, i) => (
           <Row key={`pool-chunk-${i}`}>
             {pools.map((pool) => {
@@ -28,7 +29,7 @@ const KVMSummaryStorage = ({ id }: Props): JSX.Element | null => {
 
               return (
                 <Col key={`storage-card-${pool.id}`} size="4">
-                  <Card className="p-card--transparent">
+                  <Card>
                     <div className="p-grid-list">
                       <div className="p-grid-list__label">Name</div>
                       <div className="p-grid-list__value">{pool.name}</div>
@@ -74,4 +75,4 @@ const KVMSummaryStorage = ({ id }: Props): JSX.Element | null => {
   return <Spinner text="Loading" />;
 };
 
-export default KVMSummaryStorage;
+export default KVMStorage;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMStorage";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
@@ -1,0 +1,50 @@
+import { mount } from "enzyme";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import type { RootState } from "app/store/root/types";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import KVMSummary from "./KVMSummary";
+
+const mockStore = configureStore();
+
+describe("KVMSummary", () => {
+  let initialState: RootState;
+
+  beforeEach(() => {
+    initialState = rootStateFactory({
+      pod: podStateFactory({ items: [podFactory({ id: 1 })] }),
+    });
+  });
+
+  it("can view resources by NUMA node", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <Route exact path="/kvm/:id" component={() => <KVMSummary />} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("KVMAggregateResources").exists()).toBe(true);
+    expect(wrapper.find("KVMNumaResources").exists()).toBe(false);
+
+    act(() => {
+      wrapper.find("input[data-test='numa-switch']").prop("onChange")({
+        target: { checked: true },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    wrapper.update();
+
+    expect(wrapper.find("KVMAggregateResources").exists()).toBe(false);
+    expect(wrapper.find("KVMNumaResources").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -1,5 +1,5 @@
-import { Spinner, Strip } from "@canonical/react-components";
-import React, { useEffect } from "react";
+import { Spinner } from "@canonical/react-components";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
@@ -7,8 +7,10 @@ import type { RootState } from "app/store/root/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { useWindowTitle } from "app/base/hooks";
-import MachineListTable from "app/machines/views/MachineList/MachineListTable";
-import KVMSummaryStorage from "./KVMSummaryStorage";
+import KVMAggregateResources from "./KVMAggregateResources";
+import KVMNumaResources from "./KVMNumaResources";
+import KVMStorage from "./KVMStorage";
+import Switch from "app/base/components/Switch";
 
 const KVMSummary = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -16,6 +18,7 @@ const KVMSummary = (): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
+  const [viewByNuma, setViewByNuma] = useState(false);
 
   useWindowTitle(`KVM ${`${pod?.name} ` || ""} details`);
 
@@ -26,15 +29,20 @@ const KVMSummary = (): JSX.Element => {
   if (!!pod) {
     return (
       <>
-        <h4>Storage</h4>
-        <Strip className="u-sv3" shallow>
-          <KVMSummaryStorage id={pod.id} />
-        </Strip>
-        <hr />
-        <h4>Machines</h4>
-        <Strip shallow>
-          <MachineListTable filter={`pod-id:=${pod.id}`} showActions={false} />
-        </Strip>
+        <div className="u-flex--between">
+          <h4 className="u-sv1">Resources</h4>
+          <Switch
+            checked={viewByNuma}
+            className="p-switch--inline-label"
+            data-test="numa-switch"
+            label="View by NUMA node"
+            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+              setViewByNuma(evt.target.checked);
+            }}
+          />
+        </div>
+        {viewByNuma ? <KVMNumaResources /> : <KVMAggregateResources />}
+        <KVMStorage id={pod.id} />
       </>
     );
   }

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummaryStorage/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./KVMSummaryStorage";

--- a/ui/src/scss/_patterns_buttons.scss
+++ b/ui/src/scss/_patterns_buttons.scss
@@ -65,4 +65,13 @@
   .p-button--link:not(:last-of-type):not(:only-of-type) {
     margin-right: 0;
   }
+
+  button.is-thin {
+    padding-left: $sph-inner--small;
+    padding-right: $sph-inner--small;
+
+    &.has-icon {
+      padding-left: $sph-inner--small * 0.5;
+    }
+  }
 }

--- a/ui/src/scss/_patterns_grids.scss
+++ b/ui/src/scss/_patterns_grids.scss
@@ -1,0 +1,14 @@
+@mixin maas-grids {
+  %base-grid {
+    display: grid;
+    grid-column-gap: map-get($grid-gutter-widths, large);
+
+    @media only screen and (max-width: $breakpoint-medium) {
+      grid-column-gap: map-get($grid-gutter-widths, medium);
+    }
+
+    @media only screen and (max-width: $breakpoint-small) {
+      grid-column-gap: map-get($grid-gutter-widths, small);
+    }
+  }
+}

--- a/ui/src/scss/_patterns_switches.scss
+++ b/ui/src/scss/_patterns_switches.scss
@@ -1,0 +1,9 @@
+@mixin maas-switches {
+  .p-switch--inline-label {
+    display: flex;
+
+    .p-switch__slider {
+      margin-left: $sph-inner;
+    }
+  }
+}

--- a/ui/src/scss/_patterns_typography.scss
+++ b/ui/src/scss/_patterns_typography.scss
@@ -1,0 +1,13 @@
+@mixin maas-typography {
+  .p-heading--small {
+    @extend %table-header-label;
+    color: $color-dark;
+    text-transform: uppercase;
+  }
+
+  .p-text--paragraph {
+    @extend %paragraph;
+    font-size: 1rem;
+    font-weight: 300;
+  }
+}

--- a/ui/src/scss/_settings.scss
+++ b/ui/src/scss/_settings.scss
@@ -4,6 +4,7 @@ $grid-max-width: 1440 / 16 * 1rem; // express in rems for easier calculations
 $color-navigation-background: #666;
 $color-navigation-background--hover: darken($color-navigation-background, 3%);
 
+$breakpoint-x-large: 1300px;
 $breakpoint-navigation-threshold: 870px;
 $increase-font-size-on-larger-screens: false;
 

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -51,7 +51,7 @@
   }
 
   .u-text--light {
-    color: $color-mid-dark;
+    color: $color-mid-dark !important;
   }
 
   .u-upper-case--first:first-letter {

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -26,14 +26,17 @@
 @import "./patterns_double-row";
 @import "./patterns_footer";
 @import "./patterns_forms";
+@import "./patterns_grids";
 @import "./patterns_icons";
 @import "./patterns_links";
 @import "./patterns_lists";
 @import "./patterns_navigation";
 @import "./patterns_notifications";
+@import "./patterns_switches";
 @import "./patterns_table-actions";
 @import "./patterns_tables";
 @import "./patterns_tabs";
+@import "./patterns_typography";
 @import "./utilities";
 @include maas-buttons;
 @include maas-cards;
@@ -41,14 +44,17 @@
 @include maas-double-row;
 @include maas-footer;
 @include maas-forms;
+@include maas-grids;
 @include maas-icons;
 @include maas-links;
 @include maas-lists;
 @include maas-navigation;
 @include maas-notifications;
+@include maas-switches;
 @include maas-table-actions;
 @include maas-tables;
 @include maas-tabs;
+@include maas-typography;
 @include maas-utilities;
 
 // Import and include MAAS component styles
@@ -71,6 +77,7 @@
 @include TagSelector;
 
 // kvm
+@import "~app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources";
 @import "~app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover";
 @import "~app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover";
 @import "~app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover";
@@ -79,14 +86,17 @@
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect";
+@import "~app/kvm/components/KVMResourcesCard";
 @include CPUPopover;
+@include KVMComposeInterfacesTable;
+@include KVMComposeStorageTable;
+@include KVMListTable;
+@include KVMNumaResources;
+@include KVMPoolSelect;
+@include KVMSubnetSelect;
+@include KVMResourcesCard;
 @include RAMPopover;
 @include StoragePopover;
-@include KVMListTable;
-@include KVMComposeInterfacesTable;
-@include KVMSubnetSelect;
-@include KVMComposeStorageTable;
-@include KVMPoolSelect;
 
 // machines
 @import "~app/machines/views/MachineList";


### PR DESCRIPTION
## Done

- Added a few sass mixins (small bold header, thin button and grid placeholder).
- Added the switch that toggles the aggregated and NUMA resources views.
- Set up responsive grid layouts for the aggregated and NUMA resources views
- Created scaffolding components using baked in data for now.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- I wouldn't worry too much about the specific styling here (spacing, alignment, etc). This PR is more concerned about the responsiveness of the content blocks. We can tidy up the minor details when we work on building the content properly, with actual data.
- Check that the content blocks match [the designs](https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f36a6fd1124de23d57b637b) for both aggregate and NUMA views.
- Check that you agree with how the components have been broken up.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#1863
Fixes canonical-web-and-design/MAAS-squad#1968

## Screenshots
### Aggregate x-large
![0 0 0 0_8400_MAAS_r_kvm_190 (5)](https://user-images.githubusercontent.com/25733845/90479896-c1abbb00-e172-11ea-859c-7576e2adc43d.png)


### Aggregate large
![0 0 0 0_8400_MAAS_r_kvm_190 (6)](https://user-images.githubusercontent.com/25733845/90479909-c53f4200-e172-11ea-92fb-1d3a7e0dddf1.png)


### Aggregate medium
![0 0 0 0_8400_MAAS_r_kvm_190 (7)](https://user-images.githubusercontent.com/25733845/90479918-c8d2c900-e172-11ea-92b0-2c74e7a08343.png)


### Aggregate small
![0 0 0 0_8400_MAAS_r_kvm_190 (8)](https://user-images.githubusercontent.com/25733845/90479926-ccfee680-e172-11ea-95ea-179c8fe21308.png)


### NUMA x-large
![0 0 0 0_8400_MAAS_r_kvm_190 (9)](https://user-images.githubusercontent.com/25733845/90479933-d0926d80-e172-11ea-82e0-dbe931777881.png)


### NUMA large
![0 0 0 0_8400_MAAS_r_kvm_190 (10)](https://user-images.githubusercontent.com/25733845/90479949-d6884e80-e172-11ea-8f8b-d78119c48261.png)


### NUMA small
![0 0 0 0_8400_MAAS_r_kvm_190 (11)](https://user-images.githubusercontent.com/25733845/90479957-da1bd580-e172-11ea-8841-1484ebf6e966.png)

