### PR TITLE
fix(ui): adjust spacing around deploy options

### DIFF
--- a/legacy/src/app/partials/nodedetails/deploy-options.html
+++ b/legacy/src/app/partials/nodedetails/deploy-options.html
@@ -4,9 +4,7 @@
     <p>Customise options</p>
   </div>
   <div class="col-9">
-    <div
-      class="p-form-group p-form-validation"
-    >
+    <div class="p-form-group p-form-validation">
       <div class="p-form__control u-clearfix">
         <input
           id="installKVM"
@@ -28,19 +26,9 @@
             Read more
           </a>
         </label>
-
-        <p
-          class="u-sv-1 u-no-max-width"
-          ng-if="!nodesManager.canBeKvmHost(osSelection)"
-        >
-          <i class="p-icon--warning"></i>&nbsp;Ubuntu 18.04 is required to
-          create a KVM host.
-        </p>
       </div>
     </div>
-    <div
-      class="p-form-group p-form-validation u-sv2"
-    >
+    <div class="p-form-group p-form-validation u-sv2">
       <div class="p-form__control u-clearfix">
         <input
           id="showCloudInit"

--- a/legacy/src/app/partials/nodedetails/deploy-options.html
+++ b/legacy/src/app/partials/nodedetails/deploy-options.html
@@ -4,78 +4,65 @@
     <p>Customise options</p>
   </div>
   <div class="col-9">
-    <ul class="p-list p-inline-list">
-      <li class="p-inline-list__item">
-        <div
-          class="p-form-group p-form-validation u-sv-1 u-display-inline-block"
+    <div
+      class="p-form-group p-form-validation"
+    >
+      <div class="p-form__control u-clearfix">
+        <input
+          id="installKVM"
+          type="checkbox"
+          data-ng-model="deployOptions.installKVM"
+          ng-disabled="!nodesManager.canBeKvmHost(osSelection)"
+        />
+        <label
+          for="installKVM"
+          class="u-float--left"
+          style="width: auto; margin-right: 1rem;"
         >
-          <div class="p-form__control u-clearfix">
-            <input
-              id="installKVM"
-              type="checkbox"
-              data-ng-model="deployOptions.installKVM"
-              ng-disabled="!nodesManager.canBeKvmHost(osSelection)"
-            />
-            <label
-              for="installKVM"
-              class="u-float--left"
-              style="width: auto; margin-right: 1rem;"
-            >
-              Register as MAAS KVM host (Ubuntu 18.04 LTS required)
-            </label>
+          Register as MAAS KVM host (Ubuntu 18.04 LTS required).&nbsp;
+          <a
+            class="p-link--external"
+            href="https://maas.io/docs/kvm-introduction"
+            target="_blank"
+          >
+            Read more
+          </a>
+        </label>
 
-            <p
-              class="u-sv-1 u-no-max-width"
-              ng-if="!nodesManager.canBeKvmHost(osSelection)"
-            >
-              <i class="p-icon--warning"></i>&nbsp;Ubuntu 18.04 is required to
-              create a KVM host.
-            </p>
-          </div>
-        </div>
-      </li>
-      <li class="p-inline-list__item">
-        <a
-          class="p-link--external"
-          href="https://maas.io/docs/kvm-introduction"
-          target="_blank"
+        <p
+          class="u-sv-1 u-no-max-width"
+          ng-if="!nodesManager.canBeKvmHost(osSelection)"
         >
-          Read more
-        </a>
-      </li>
-    </ul>
-
-    <ul class="p-list p-inline-list">
-      <li class="p-inline-list__item">
-        <div
-          class="p-form-group p-form-validation u-sv-1 u-display-inline-block"
+          <i class="p-icon--warning"></i>&nbsp;Ubuntu 18.04 is required to
+          create a KVM host.
+        </p>
+      </div>
+    </div>
+    <div
+      class="p-form-group p-form-validation u-sv2"
+    >
+      <div class="p-form__control u-clearfix">
+        <input
+          id="showCloudInit"
+          type="checkbox"
+          ng-model="showCloudInitChecked"
+        />
+        <label
+          for="showCloudInit"
+          class="u-float--left"
+          style="width: auto; margin-right: 1rem;"
         >
-          <div class="p-form__control u-clearfix">
-            <input
-              id="showCloudInit"
-              type="checkbox"
-              ng-model="showCloudInitChecked"
-            />
-            <label
-              for="showCloudInit"
-              class="u-float--left"
-              style="width: auto; margin-right: 1rem;"
-            >
-              Cloud-init user-data&hellip;
-            </label>
-          </div>
-        </div>
-      </li>
-      <li class="p-inline-list__item">
-        <a
-          class="p-link--external"
-          href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
-          target="_blank"
-        >
-          Read more
-        </a>
-      </li>
-    </ul>
+          Cloud-init user-data&hellip;&nbsp;
+          <a
+            class="p-link--external"
+            href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+            target="_blank"
+          >
+            Read more
+          </a>
+        </label>
+      </div>
+    </div>
 
     <div data-ng-if="showCloudInitChecked">
       <textarea

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -115,7 +115,6 @@ export const DeployFormFields = (): JSX.Element => {
               }
               name="installKVM"
               type="checkbox"
-              wrapperClassName="u-display-inline-block"
             />
             <FormikField
               disabled={noImages}
@@ -136,8 +135,8 @@ export const DeployFormFields = (): JSX.Element => {
                 handleChange(evt);
                 setUserDataVisible(evt.target.checked);
               }}
-              wrapperClassName={classNames("u-display-inline-block", {
-                "u-sv2 u-display-inline-block": userDataVisible,
+              wrapperClassName={classNames({
+                "u-sv2": userDataVisible,
               })}
             />
             {userDataVisible && <UserDataField />}

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -1,10 +1,4 @@
-import {
-  Col,
-  List,
-  Notification,
-  Row,
-  Select,
-} from "@canonical/react-components";
+import { Col, Notification, Row, Select } from "@canonical/react-components";
 import classNames from "classnames";
 import React, { useState } from "react";
 import { useFormikContext } from "formik";
@@ -106,47 +100,45 @@ export const DeployFormFields = (): JSX.Element => {
             <p>Customise options</p>
           </Col>
           <Col size="9">
-            <List
-              items={[
-                <FormikField
-                  disabled={!canBeKVMHost || noImages}
-                  label="Register as MAAS KVM host (Ubuntu 18.04 LTS required)."
-                  name="installKVM"
-                  type="checkbox"
-                  wrapperClassName="u-sv-1 u-display-inline-block"
-                />,
-                <a
-                  className="p-link--external"
-                  href="https://maas.io/docs/kvm-introduction"
-                >
-                  Read more
-                </a>,
-              ]}
-              inline
+            <FormikField
+              disabled={!canBeKVMHost || noImages}
+              label={
+                <>
+                  Register as MAAS KVM host (Ubuntu 18.04 LTS required).{" "}
+                  <a
+                    className="p-link--external"
+                    href="https://maas.io/docs/kvm-introduction"
+                  >
+                    Read more
+                  </a>
+                </>
+              }
+              name="installKVM"
+              type="checkbox"
+              wrapperClassName="u-display-inline-block"
             />
-            <List
-              items={[
-                <FormikField
-                  disabled={noImages}
-                  label="Cloud-init user-data&hellip;"
-                  name="includeUserData"
-                  type="checkbox"
-                  onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-                    handleChange(evt);
-                    setUserDataVisible(evt.target.checked);
-                  }}
-                  wrapperClassName={classNames("u-display-inline-block", {
-                    "u-sv2 u-display-inline-block": userDataVisible,
-                  })}
-                />,
-                <a
-                  className="p-link--external"
-                  href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
-                >
-                  Read more
-                </a>,
-              ]}
-              inline
+            <FormikField
+              disabled={noImages}
+              label={
+                <>
+                  Cloud-init user-data&hellip;{" "}
+                  <a
+                    className="p-link--external"
+                    href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+                  >
+                    Read more
+                  </a>
+                </>
+              }
+              name="includeUserData"
+              type="checkbox"
+              onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                handleChange(evt);
+                setUserDataVisible(evt.target.checked);
+              }}
+              wrapperClassName={classNames("u-display-inline-block", {
+                "u-sv2 u-display-inline-block": userDataVisible,
+              })}
             />
             {userDataVisible && <UserDataField />}
           </Col>


### PR DESCRIPTION
## Done

- Fix the spacing around the deploy options.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- Visit the machine list, check a deployable machine and open the deploy form via the take action menu.
- Check that there is a nice amount of space between the two checkbox options.
- Reduce the size of your window until the labels wrap onto a new line. The wrapping text should be indented to match the label (and clear the checkbox).
- Now visit a deployable machine's details page and open the deploy form via the take action menu.
- Check that there is a nice amount of space between the two checkbox options.
- Reduce the size of your window until the labels wrap onto a new line. The wrapping text should be indented to match the label (and clear the checkbox).

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2040.
