### PR TITLE
feat(ui): add a copyable ip address to pod details

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
@@ -47,4 +47,27 @@ describe("KVMSummary", () => {
     expect(wrapper.find("KVMAggregateResources").exists()).toBe(false);
     expect(wrapper.find("KVMNumaResources").exists()).toBe(true);
   });
+
+  it("can display the ip address", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            power_address: "qemu+ssh://ubuntu@171.16.4.28/system",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <Route exact path="/kvm/:id" component={() => <KVMSummary />} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Code").exists()).toBe(true);
+    expect(wrapper.find("Code input").prop("value")).toBe("171.16.4.28");
+  });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
@@ -48,7 +48,7 @@ describe("KVMSummary", () => {
     expect(wrapper.find("KVMNumaResources").exists()).toBe(true);
   });
 
-  it("can display the ip address", () => {
+  it("can display the power address", () => {
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [
@@ -68,6 +68,8 @@ describe("KVMSummary", () => {
       </Provider>
     );
     expect(wrapper.find("Code").exists()).toBe(true);
-    expect(wrapper.find("Code input").prop("value")).toBe("171.16.4.28");
+    expect(wrapper.find("Code input").prop("value")).toBe(
+      "qemu+ssh://ubuntu@171.16.4.28/system"
+    );
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -82,7 +82,9 @@ const KVMSummary = (): JSX.Element => {
     return (
       <>
         <div className="u-flex">
-          <p className="u-nudge-left">LXD URL:</p>
+          <p className="u-nudge-left">
+            {pod.type === "virsh" ? "Virsh:" : "LXD URL:"}
+          </p>
           <Code copyable className="u-flex--grow">
             {ip_address}
           </Code>

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@canonical/react-components";
+import { Code, Spinner } from "@canonical/react-components";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
@@ -76,8 +76,18 @@ const KVMSummary = (): JSX.Element => {
   }, [dispatch]);
 
   if (!!pod) {
+    // Fetch the IP address that is contained in the power_address. This is the
+    // only place the IP address is exposed.
+    const ip_address = pod.power_address.match(/[\d.]+/)[0];
     return (
       <>
+        <div className="u-flex">
+          <p className="u-nudge-left">LXD URL:</p>
+          <Code copyable className="u-flex--grow">
+            {ip_address}
+          </Code>
+        </div>
+        <hr className="u-sv1" />
         <div className="u-flex--between">
           <h4 className="u-sv1">Resources</h4>
           <Switch

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -76,9 +76,6 @@ const KVMSummary = (): JSX.Element => {
   }, [dispatch]);
 
   if (!!pod) {
-    // Fetch the IP address that is contained in the power_address. This is the
-    // only place the IP address is exposed.
-    const ip_address = pod.power_address.match(/[\d.]+/)[0];
     return (
       <>
         <div className="u-flex">
@@ -86,7 +83,7 @@ const KVMSummary = (): JSX.Element => {
             {pod.type === "virsh" ? "Virsh:" : "LXD URL:"}
           </p>
           <Code copyable className="u-flex--grow">
-            {ip_address}
+            {pod.power_address}
           </Code>
         </div>
         <hr className="u-sv1" />

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -18,6 +18,10 @@
     display: flex;
   }
 
+  .u-flex--grow {
+    flex: 1;
+  }
+
   .u-flex--between {
     display: flex;
     justify-content: space-between;
@@ -54,8 +58,16 @@
     padding-left: $sph-inner !important;
   }
 
+  .u-nudge-left {
+    padding-right: $sph-inner !important;
+  }
+
   .u-nudge-right--small {
     padding-left: $sph-inner--small !important;
+  }
+
+  .u-nudge-left--small {
+    padding-right: $sph-inner--small !important;
   }
 
   .u-text--light {


### PR DESCRIPTION
Add a copyable code component containing a Pod's IP address to the pod details page.

## Done

- Add a copyable code component containing a Pod's IP address to the pod details page.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- Navigate to the details page for a pod.
- There should be a code box at the top with the ip address, à la: https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f315c75b688551f4783d49b

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2071.