### PR TITLE
feat(ui): Build redesigned KVM storage cards.

### DIFF
--- a/ui/src/app/base/components/Meter/Meter.test.tsx
+++ b/ui/src/app/base/components/Meter/Meter.test.tsx
@@ -30,14 +30,7 @@ const mockClientRect = ({
 
 describe("Meter", () => {
   it("renders", () => {
-    const wrapper = shallow(
-      <Meter
-        data={[
-          { key: "datum-1", value: 1 },
-          { key: "datum-2", value: 3 },
-        ]}
-      />
-    );
+    const wrapper = shallow(<Meter data={[{ value: 1 }, { value: 3 }]} />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -48,13 +41,7 @@ describe("Meter", () => {
 
   it("can be given a label", () => {
     const wrapper = shallow(
-      <Meter
-        data={[
-          { key: "datum-1", value: 1 },
-          { key: "datum-2", value: 3 },
-        ]}
-        label="Meter label"
-      />
+      <Meter data={[{ value: 1 }, { value: 3 }]} label="Meter label" />
     );
     expect(wrapper.find(".p-meter__label").at(0).text()).toBe("Meter label");
   });
@@ -70,9 +57,9 @@ describe("Meter", () => {
     const wrapper = shallow(
       <Meter
         data={[
-          { color: "#AAA", key: "aaa", value: 1 },
-          { color: "#BBB", key: "bbb", value: 2 },
-          { color: "#CCC", key: "ccc", value: 3 },
+          { color: "#AAA", value: 1 },
+          { color: "#BBB", value: 2 },
+          { color: "#CCC", value: 3 },
         ]}
       />
     );
@@ -89,11 +76,7 @@ describe("Meter", () => {
 
   it("changes colour if values exceed given maximum value", () => {
     const wrapper = shallow(
-      <Meter
-        data={[{ color: "#ABC", key: "key", value: 100 }]}
-        max={10}
-        overColor="#DEF"
-      />
+      <Meter data={[{ color: "#ABC", value: 100 }]} max={10} overColor="#DEF" />
     );
     expect(
       wrapper.find(".p-meter__filled").props().style?.backgroundColor
@@ -104,10 +87,10 @@ describe("Meter", () => {
     const wrapper = shallow(
       <Meter
         data={[
-          { key: "ten", value: 10 }, // 10/100 = 10%
-          { key: "twenty", value: 20 }, // 20/100 = 20%
-          { key: "thirty", value: 30 }, // 30/100 = 30%
-          { key: "forty", value: 40 }, // 40/100 = 40%
+          { value: 10 }, // 10/100 = 10%
+          { value: 20 }, // 20/100 = 20%
+          { value: 30 }, // 30/100 = 30%
+          { value: 40 }, // 40/100 = 40%
         ]}
       />
     );
@@ -129,10 +112,10 @@ describe("Meter", () => {
     const wrapper = shallow(
       <Meter
         data={[
-          { key: "ten", value: 10 }, // 1st = 0%
-          { key: "twenty", value: 20 }, // 2nd = 1st width = 10%
-          { key: "thirty", value: 30 }, // 3rd = 1st + 2nd width = 30%
-          { key: "forty", value: 40 }, // 4th = 1st + 2nd + 3rd width = 60%
+          { value: 10 }, // 1st = 0%
+          { value: 20 }, // 2nd = 1st width = 10%
+          { value: 30 }, // 3rd = 1st + 2nd width = 30%
+          { value: 40 }, // 4th = 1st + 2nd + 3rd width = 60%
         ]}
       />
     );
@@ -151,16 +134,14 @@ describe("Meter", () => {
   });
 
   it("can be made segmented", () => {
-    const wrapper = mount(
-      <Meter data={[{ key: "filled", value: 2 }]} max={10} segmented />
-    );
+    const wrapper = mount(<Meter data={[{ value: 2 }]} max={10} segmented />);
     expect(wrapper.find(".p-meter__separators").exists()).toBe(true);
   });
 
   it("can set the segment separator color", () => {
     const wrapper = mount(
       <Meter
-        data={[{ key: "filled", value: 2 }]}
+        data={[{ value: 2 }]}
         max={10}
         segmented
         separatorColor="#abc123"
@@ -177,9 +158,7 @@ describe("Meter", () => {
     Element.prototype.getBoundingClientRect = mockClientRect({
       width: 128,
     });
-    const wrapper = mount(
-      <Meter data={[{ key: "filled", value: 10 }]} segmented max={100} />
-    );
+    const wrapper = mount(<Meter data={[{ value: 10 }]} segmented max={100} />);
 
     const backgroundStyle = wrapper.find(".p-meter__separators").props().style
       ?.background as string;
@@ -194,9 +173,7 @@ describe("Meter", () => {
     Element.prototype.getBoundingClientRect = mockClientRect({
       width: 200,
     });
-    const wrapper = mount(
-      <Meter data={[{ key: "filled", value: 10 }]} segmented max={100} />
-    );
+    const wrapper = mount(<Meter data={[{ value: 10 }]} segmented max={100} />);
 
     const barWidth = wrapper.find(".p-meter__bar").props().style?.width;
     expect(barWidth).toBe(128);

--- a/ui/src/app/base/components/Meter/Meter.tsx
+++ b/ui/src/app/base/components/Meter/Meter.tsx
@@ -35,7 +35,6 @@ const updateWidths = (
 
 type MeterDatum = {
   color?: string;
-  key: string;
   value: number;
 };
 
@@ -104,7 +103,7 @@ const Meter = ({
           data.map((datum, i) => (
             <div
               className="p-meter__filled"
-              key={`${datum.key}-bar`}
+              key={`meter-${i}`}
               style={{
                 backgroundColor:
                   datum.color ||
@@ -151,7 +150,6 @@ Meter.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       color: PropTypes.string,
-      key: PropTypes.string.isRequired,
       value: PropTypes.number,
     })
   ).isRequired,

--- a/ui/src/app/base/components/Meter/__snapshots__/Meter.test.tsx.snap
+++ b/ui/src/app/base/components/Meter/__snapshots__/Meter.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Meter renders 1`] = `
   >
     <div
       className="p-meter__filled"
-      key="datum-1-bar"
+      key="meter-0"
       style={
         Object {
           "backgroundColor": "#0066CC",
@@ -27,7 +27,7 @@ exports[`Meter renders 1`] = `
     />
     <div
       className="p-meter__filled"
-      key="datum-2-bar"
+      key="meter-1"
       style={
         Object {
           "backgroundColor": "#0E8420",

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -95,22 +95,18 @@ const generateDropdownContent = (
                 data={[
                   {
                     color: COLOURS.LINK,
-                    key: `pool-${pool.id}-allocated`,
                     value: allocated,
                   },
                   {
                     color: COLOURS.POSITIVE,
-                    key: `pool-${pool.id}-requested`,
                     value: requested,
                   },
                   {
                     color: COLOURS.POSITIVE_FADED,
-                    key: `pool-${pool.id}-pending-request`,
                     value: pendingRequest,
                   },
                   {
                     color: COLOURS.LINK_FADED,
-                    key: `pool-${pool.id}-free`,
                     value: free >= 0 ? free : 0,
                   },
                 ]}

--- a/ui/src/app/kvm/components/KVMMeter/KVMMeter.test.tsx
+++ b/ui/src/app/kvm/components/KVMMeter/KVMMeter.test.tsx
@@ -1,0 +1,14 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import KVMMeter from "./KVMMeter";
+
+describe("KVMMeter", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <KVMMeter allocated={2} free={1} total={3} unit="GB" />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
+++ b/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import Meter from "app/base/components/Meter";
+
+type Props = {
+  allocated: number;
+  free: number;
+  segmented?: boolean;
+  total: number;
+  unit?: string;
+};
+
+const KVMMeter = ({
+  allocated,
+  free,
+  segmented = false,
+  total,
+  unit = "",
+}: Props): JSX.Element | null => {
+  return (
+    <div className="kvm-meter">
+      <div>
+        <p className="p-heading--small u-text--light">Total</p>
+        <div>{`${total}${unit}`}</div>
+      </div>
+      <div className="u-align--right">
+        <p className="p-heading--small u-text--light">
+          Allocated
+          <span className="u-nudge-left--small">
+            <i className="p-icon--allocated"></i>
+          </span>
+        </p>
+        <div className="u-nudge-left">{`${allocated}${unit}`}</div>
+      </div>
+      <div className="u-align--right">
+        <p className="p-heading--small u-text--light">
+          Free
+          <span className="u-nudge-left--small">
+            <i className="p-icon--free"></i>
+          </span>
+        </p>
+        <div className="u-nudge-left">{`${free}${unit}`}</div>
+      </div>
+      <div style={{ gridArea: "meter" }}>
+        <Meter
+          className="u-no-margin--bottom"
+          data={[
+            {
+              value: allocated,
+            },
+          ]}
+          max={total}
+          segmented={segmented}
+          small
+        />
+      </div>
+    </div>
+  );
+};
+
+export default KVMMeter;

--- a/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KVMMeter renders 1`] = `
+<div
+  className="kvm-meter"
+>
+  <div>
+    <p
+      className="p-heading--small u-text--light"
+    >
+      Total
+    </p>
+    <div>
+      3GB
+    </div>
+  </div>
+  <div
+    className="u-align--right"
+  >
+    <p
+      className="p-heading--small u-text--light"
+    >
+      Allocated
+      <span
+        className="u-nudge-left--small"
+      >
+        <i
+          className="p-icon--allocated"
+        />
+      </span>
+    </p>
+    <div
+      className="u-nudge-left"
+    >
+      2GB
+    </div>
+  </div>
+  <div
+    className="u-align--right"
+  >
+    <p
+      className="p-heading--small u-text--light"
+    >
+      Free
+      <span
+        className="u-nudge-left--small"
+      >
+        <i
+          className="p-icon--free"
+        />
+      </span>
+    </p>
+    <div
+      className="u-nudge-left"
+    >
+      1GB
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "gridArea": "meter",
+      }
+    }
+  >
+    <Meter
+      className="u-no-margin--bottom"
+      data={
+        Array [
+          Object {
+            "value": 2,
+          },
+        ]
+      }
+      max={3}
+      segmented={false}
+      small={true}
+    />
+  </div>
+</div>
+`;

--- a/ui/src/app/kvm/components/KVMMeter/_index.scss
+++ b/ui/src/app/kvm/components/KVMMeter/_index.scss
@@ -1,0 +1,11 @@
+@mixin KVMMeter {
+  .kvm-meter {
+    display: grid;
+    grid-column-gap: $sph-inner;
+    grid-template-areas:
+      "total allocated free"
+      "meter meter meter";
+    grid-template-columns: repeat(3, minmax(1fr, max-content));
+    grid-template-rows: min-content;
+  }
+}

--- a/ui/src/app/kvm/components/KVMMeter/index.ts
+++ b/ui/src/app/kvm/components/KVMMeter/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KVMMeter";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.test.tsx
@@ -15,21 +15,35 @@ import KVMStorage from "./KVMStorage";
 const mockStore = configureStore();
 
 describe("KVMStorage", () => {
-  it("correctly chunks KVM storage pools into rows of 3", () => {
+  it("sorts pools by id, with default first", () => {
+    const [defaultPool, pool1, pool2] = [
+      podStoragePoolFactory({ id: "a" }),
+      podStoragePoolFactory({ id: "b" }),
+      podStoragePoolFactory({ id: "c" }),
+    ];
     const pod = podFactory({
-      storage_pools: Array.from(Array(4)).map(() => podStoragePoolFactory()),
+      default_storage_pool: defaultPool.id,
+      id: 1,
+      storage_pools: [pool2, defaultPool, pool1],
     });
     const state = rootStateFactory({ pod: podStateFactory({ items: [pod] }) });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm/2", key: "testKey" }]}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
           <KVMStorage id={pod.id} />
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Row")).toHaveLength(2);
-    expect(wrapper.find("Row").at(0).props().children).toHaveLength(3);
-    expect(wrapper.find("Row").at(1).props().children).toHaveLength(1);
+
+    expect(wrapper.find("[data-test='pool-name']").at(0).text()).toBe(
+      defaultPool.name
+    );
+    expect(wrapper.find("[data-test='pool-name']").at(1).text()).toBe(
+      pool1.name
+    );
+    expect(wrapper.find("[data-test='pool-name']").at(2).text()).toBe(
+      pool2.name
+    );
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/_index.scss
@@ -1,0 +1,25 @@
+@mixin KVMStorage {
+  .kvm-storage-grid {
+    @extend %base-grid;
+    grid-template-columns: 1fr;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    @media only screen and (min-width: $breakpoint-x-large) {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+  }
+
+  .kvm-storage-meter-grid {
+    display: grid;
+    grid-column-gap: $sph-inner;
+    grid-template-columns: 1fr;
+    grid-template-rows: min-content;
+
+    @media only screen and (min-width: $breakpoint-small) {
+      grid-template-columns: 1fr 3fr;
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
@@ -25,7 +25,6 @@ const CPUColumn = ({ id }: Props): JSX.Element | null => {
           className="u-flex--column-align-end u-no-margin--bottom"
           data={[
             {
-              key: `${pod.name}-cpu-meter`,
               value: pod.used.cores,
             },
           ]}

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
@@ -35,7 +35,6 @@ const RAMColumn = ({ id }: Props): JSX.Element | null => {
           className="u-no-margin--bottom"
           data={[
             {
-              key: `${pod.name}-memory-meter`,
               value: pod.used.memory,
             },
           ]}

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
@@ -29,7 +29,6 @@ const StorageColumn = ({ id }: Props): JSX.Element | null => {
           className="u-no-margin--bottom"
           data={[
             {
-              key: `${pod.name}-storage-meter`,
               value: pod.used.local_storage,
             },
           ]}

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
@@ -71,7 +71,6 @@ const StoragePopover = ({
                     className="u-no-margin--bottom"
                     data={[
                       {
-                        key: `${pool.id}-storage-popover-meter`,
                         value: allocated.value,
                       },
                     ]}

--- a/ui/src/scss/_patterns_typography.scss
+++ b/ui/src/scss/_patterns_typography.scss
@@ -2,6 +2,7 @@
   .p-heading--small {
     @extend %table-header-label;
     color: $color-dark;
+    margin-bottom: $sp-unit * 0.25;
     text-transform: uppercase;
   }
 

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -42,6 +42,14 @@
     text-transform: none !important;
   }
 
+  .u-nudge-left {
+    padding-right: $sph-inner !important;
+  }
+
+  .u-nudge-left--small {
+    padding-left: $sph-inner--small !important;
+  }
+
   .u-nudge-right {
     padding-left: $sph-inner !important;
   }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -78,6 +78,7 @@
 
 // kvm
 @import "~app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources";
+@import "~app/kvm/views/KVMDetails/KVMSummary/KVMStorage";
 @import "~app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover";
 @import "~app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover";
 @import "~app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover";
@@ -86,15 +87,18 @@
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect";
+@import "~app/kvm/components/KVMMeter";
 @import "~app/kvm/components/KVMResourcesCard";
 @include CPUPopover;
 @include KVMComposeInterfacesTable;
 @include KVMComposeStorageTable;
 @include KVMListTable;
+@include KVMMeter;
 @include KVMNumaResources;
 @include KVMPoolSelect;
-@include KVMSubnetSelect;
 @include KVMResourcesCard;
+@include KVMStorage;
+@include KVMSubnetSelect;
 @include RAMPopover;
 @include StoragePopover;
 


### PR DESCRIPTION
## Done

- Built redesigned KVM storage cards.
- Built KVMMeter component which just wraps Meter with some specific styling for total/allocated/free data. We should be able to use it in other parts of the KVM resources summary.
- Removed `key` prop from Meter data. It was only used because the component maps over the data array - all it needs to be is a unique string so it probably didn't need to be included in the prop.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM details page and check that the storage cards match [the design](https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f33dc5944a05220896e857a)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2072

## Screenshot
![0 0 0 0_8400_MAAS_r_kvm_190 (12)](https://user-images.githubusercontent.com/25733845/90625725-60144b00-e25d-11ea-9cf6-9481d0cecf68.png)

