### PR TITLE
Add CPU and VFs meters to KVM resources page.

### DIFF
--- a/ui/src/app/base/components/Meter/Meter.test.tsx
+++ b/ui/src/app/base/components/Meter/Meter.test.tsx
@@ -167,15 +167,4 @@ describe("Meter", () => {
       `repeating-linear-gradient( to right, transparent 0, transparent 1px, ${DEFAULT_SEPARATOR_COLOR} 1px, ${DEFAULT_SEPARATOR_COLOR} 2px )`
     );
   });
-
-  it("snaps to floor base 2 width if segmented", () => {
-    // Width of container is 200px, so floor base 2 number (e.g 2, 4, 8, 16, etc) is 128
-    Element.prototype.getBoundingClientRect = mockClientRect({
-      width: 200,
-    });
-    const wrapper = mount(<Meter data={[{ value: 10 }]} segmented max={100} />);
-
-    const barWidth = wrapper.find(".p-meter__bar").props().style?.width;
-    expect(barWidth).toBe(128);
-  });
 });

--- a/ui/src/app/base/components/Meter/Meter.tsx
+++ b/ui/src/app/base/components/Meter/Meter.tsx
@@ -14,6 +14,8 @@ export const DEFAULT_FILLED_COLORS = [
 export const DEFAULT_EMPTY_COLOR = COLOURS.LINK_FADED;
 export const DEFAULT_OVER_COLOR = COLOURS.CAUTION;
 export const DEFAULT_SEPARATOR_COLOR = COLOURS.LIGHT;
+const MINIMUM_SEGMENT_WIDTH = 2;
+const SEPARATOR_WIDTH = 1;
 
 const updateWidths = (
   el: React.MutableRefObject<Element | null>,
@@ -22,14 +24,11 @@ const updateWidths = (
   setSegmentWidth: (size: number) => void
 ) => {
   const boundingWidth = el?.current?.getBoundingClientRect()?.width || 0;
-  // Because we're dealing with single pixel separators, we set the bar width to
-  // the nearest floor base 2 number to help with anti-aliasing.
-  const base2Width = Math.pow(
-    2,
-    Math.floor(Math.log(boundingWidth) / Math.log(2))
-  );
-  const segmentWidth = base2Width > maximum * 2 ? base2Width / maximum : 2;
-  setBarWidth(base2Width);
+  const segmentWidth =
+    boundingWidth > maximum * MINIMUM_SEGMENT_WIDTH
+      ? boundingWidth / maximum
+      : MINIMUM_SEGMENT_WIDTH;
+  setBarWidth(boundingWidth);
   setSegmentWidth(segmentWidth);
 };
 
@@ -128,8 +127,8 @@ const Meter = ({
               background: `repeating-linear-gradient(
                 to right,
                 transparent 0,
-                transparent ${segmentWidth - 1}px,
-                ${separatorColor} ${segmentWidth - 1}px,
+                transparent ${segmentWidth - SEPARATOR_WIDTH}px,
+                ${separatorColor} ${segmentWidth - SEPARATOR_WIDTH}px,
                 ${separatorColor} ${segmentWidth}px
               )`,
             }}

--- a/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
+++ b/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
@@ -21,29 +21,31 @@ const KVMMeter = ({
     <div className="kvm-meter">
       <div>
         <p className="p-heading--small u-text--light">Total</p>
-        <div>{`${total}${unit}`}</div>
+        <div data-test="total">{`${total}${unit}`}</div>
       </div>
       <div className="u-align--right">
         <p className="p-heading--small u-text--light">
           Allocated
           <span className="u-nudge-left--small">
-            <i className="p-circle--link"></i>
+            <i className="p-circle--link u-no-margin--top"></i>
           </span>
         </p>
-        <div className="u-nudge-left">{`${allocated}${unit}`}</div>
+        <div
+          className="u-nudge-left"
+          data-test="allocated"
+        >{`${allocated}${unit}`}</div>
       </div>
       <div className="u-align--right">
         <p className="p-heading--small u-text--light">
           Free
           <span className="u-nudge-left--small">
-            <i className="p-circle--link-faded"></i>
+            <i className="p-circle--link-faded u-no-margin--top"></i>
           </span>
         </p>
-        <div className="u-nudge-left">{`${free}${unit}`}</div>
+        <div className="u-nudge-left" data-test="free">{`${free}${unit}`}</div>
       </div>
       <div style={{ gridArea: "meter" }}>
         <Meter
-          className="u-no-margin--bottom"
           data={[
             {
               value: allocated,

--- a/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
@@ -10,7 +10,9 @@ exports[`KVMMeter renders 1`] = `
     >
       Total
     </p>
-    <div>
+    <div
+      data-test="total"
+    >
       3GB
     </div>
   </div>
@@ -25,12 +27,13 @@ exports[`KVMMeter renders 1`] = `
         className="u-nudge-left--small"
       >
         <i
-          className="p-circle--link"
+          className="p-circle--link u-no-margin--top"
         />
       </span>
     </p>
     <div
       className="u-nudge-left"
+      data-test="allocated"
     >
       2GB
     </div>
@@ -46,12 +49,13 @@ exports[`KVMMeter renders 1`] = `
         className="u-nudge-left--small"
       >
         <i
-          className="p-circle--link-faded"
+          className="p-circle--link-faded u-no-margin--top"
         />
       </span>
     </p>
     <div
       className="u-nudge-left"
+      data-test="free"
     >
       1GB
     </div>
@@ -64,7 +68,6 @@ exports[`KVMMeter renders 1`] = `
     }
   >
     <Meter
-      className="u-no-margin--bottom"
       data={
         Array [
           Object {

--- a/ui/src/app/kvm/components/KVMMeter/_index.scss
+++ b/ui/src/app/kvm/components/KVMMeter/_index.scss
@@ -5,7 +5,7 @@
     grid-template-areas:
       "total allocated free"
       "meter meter meter";
-    grid-template-columns: repeat(3, minmax(1fr, max-content));
+    grid-template-columns: 1fr max-content 1fr;
     grid-template-rows: min-content;
   }
 }

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -4,8 +4,30 @@ import React from "react";
 import KVMResourcesCard from "./KVMResourcesCard";
 
 describe("KVMResourcesCard", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <KVMResourcesCard
+        cores={{ allocated: 1, free: 2, total: 3 }}
+        nics={[]}
+        ram={{ general: { allocated: 2, free: 3, total: 5 } }}
+        vfs={{ allocated: 100, free: 156, total: 256 }}
+        title="Title"
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it("can be given a title", () => {
-    const wrapper = shallow(<KVMResourcesCard title="Title" />);
+    const wrapper = shallow(
+      <KVMResourcesCard
+        cores={{ allocated: 1, free: 2, total: 3 }}
+        nics={[]}
+        ram={{ general: { allocated: 2, free: 3, total: 5 } }}
+        vfs={{ allocated: 100, free: 156, total: 256 }}
+        title="Title"
+      />
+    );
 
     expect(wrapper.find("[data-test='kvm-resources-card-title']").text()).toBe(
       "Title"

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -3,14 +3,35 @@ import classNames from "classnames";
 import React from "react";
 
 import ContextualMenu from "app/base/components/ContextualMenu";
-import Meter from "app/base/components/Meter";
+import KVMMeter from "app/kvm/components/KVMMeter";
+
+type ChartValues = {
+  allocated: number;
+  free: number;
+  total: number;
+  unit?: string;
+};
 
 type Props = {
   className?: string;
+  cores: ChartValues;
+  nics: string[];
+  ram: {
+    general: ChartValues;
+    hugepage?: ChartValues & { pagesize: number };
+  };
   title?: string;
+  vfs: ChartValues;
 };
 
-const KVMResourcesCard = ({ className, title }: Props): JSX.Element => {
+const KVMResourcesCard = ({
+  className,
+  cores,
+  nics,
+  ram,
+  title,
+  vfs,
+}: Props): JSX.Element => {
   return (
     <Card className={classNames("kvm-resources-card", className)}>
       {title && (
@@ -42,55 +63,76 @@ const KVMResourcesCard = ({ className, title }: Props): JSX.Element => {
             <tr>
               <td>General</td>
               <td className="u-align--right">
-                64GB
+                <span data-test="ram-general-allocated">
+                  {ram.general.allocated}
+                  {ram.general.unit}
+                </span>
                 <span className="u-nudge-left--small">
                   <i className="p-circle--link"></i>
                 </span>
               </td>
               <td className="u-align--right">
-                96GB
+                <span data-test="ram-general-free">
+                  {ram.general.free}
+                  {ram.general.unit}
+                </span>
                 <span className="u-nudge-left--small">
                   <i className="p-circle--link-faded"></i>
                 </span>
               </td>
             </tr>
-            <tr>
-              <td>
-                Hugepage
-                <br />
-                <strong className="p-text--x-small u-text--light">
-                  (Size: 2048KB)
-                </strong>
-              </td>
-              <td className="u-align--right">
-                32GB
-                <span className="u-nudge-left--small">
-                  <i className="p-circle--positive"></i>
-                </span>
-              </td>
-              <td className="u-align--right">
-                64GB
-                <span className="u-nudge-left--small">
-                  <i className="p-circle--positive-faded"></i>
-                </span>
-              </td>
-            </tr>
+            {ram.hugepage && (
+              <tr>
+                <td>
+                  Hugepage
+                  <br />
+                  <strong className="p-text--x-small u-text--light">
+                    {`(Size: ${ram.hugepage.pagesize}KB)`}
+                  </strong>
+                </td>
+                <td className="u-align--right">
+                  {ram.hugepage.allocated}
+                  {ram.hugepage.unit}
+                  <span className="u-nudge-left--small">
+                    <i className="p-circle--positive"></i>
+                  </span>
+                </td>
+                <td className="u-align--right">
+                  {ram.hugepage.free}
+                  {ram.hugepage.unit}
+                  <span className="u-nudge-left--small">
+                    <i className="p-circle--positive-faded"></i>
+                  </span>
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
       <div className="kvm-resources-card__section kvm-resources-card__cpu">
-        <h4 className="p-heading--small">CPU cores</h4>
-        <Meter data={[]} />
+        <h4 className="p-heading--small u-sv1">CPU cores</h4>
+        <KVMMeter
+          allocated={cores.allocated}
+          data-test="cpu-meter"
+          free={cores.free}
+          segmented
+          total={cores.total}
+        />
       </div>
       <div className="kvm-resources-card__section kvm-resources-card__vfs">
-        <h4 className="p-heading--small">Virtual functions</h4>
+        <h4 className="p-heading--small u-sv1">Virtual functions</h4>
         <div>
-          <Meter data={[]} />
+          <KVMMeter
+            allocated={vfs.allocated}
+            data-test="vfs-meter"
+            free={vfs.free}
+            total={vfs.total}
+          />
           <hr />
           <div className="p-heading--small u-text--light">
             Network interfaces
           </div>
-          <span>eth0, eth1, eth2, eth3</span>
+          <span>{nics.join(", ")}</span>
         </div>
       </div>
       <div className="kvm-resources-card__section kvm-resources-card__vms">

--- a/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KVMResourcesCard renders 1`] = `
+<Card
+  className="kvm-resources-card"
+>
+  <h5
+    className="p-text--paragraph"
+    data-test="kvm-resources-card-title"
+  >
+    Title
+  </h5>
+  <hr />
+  <div
+    className="kvm-resources-card__section kvm-resources-card__ram"
+  >
+    <h4
+      className="p-heading--small"
+    >
+      RAM
+    </h4>
+    <table
+      className="kvm-resources-card__ram-table"
+    >
+      <thead>
+        <tr>
+          <th />
+          <th
+            className="u-align--right"
+          >
+            <span
+              className="u-nudge-left"
+            >
+              Allocated
+            </span>
+          </th>
+          <th
+            className="u-align--right"
+          >
+            <span
+              className="u-nudge-left"
+            >
+              Free
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            General
+          </td>
+          <td
+            className="u-align--right"
+          >
+            <span
+              data-test="ram-general-allocated"
+            >
+              2
+            </span>
+            <span
+              className="u-nudge-left--small"
+            >
+              <i
+                className="p-circle--link"
+              />
+            </span>
+          </td>
+          <td
+            className="u-align--right"
+          >
+            <span
+              data-test="ram-general-free"
+            >
+              3
+            </span>
+            <span
+              className="u-nudge-left--small"
+            >
+              <i
+                className="p-circle--link-faded"
+              />
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div
+    className="kvm-resources-card__section kvm-resources-card__cpu"
+  >
+    <h4
+      className="p-heading--small u-sv1"
+    >
+      CPU cores
+    </h4>
+    <KVMMeter
+      allocated={1}
+      data-test="cpu-meter"
+      free={2}
+      segmented={true}
+      total={3}
+    />
+  </div>
+  <div
+    className="kvm-resources-card__section kvm-resources-card__vfs"
+  >
+    <h4
+      className="p-heading--small u-sv1"
+    >
+      Virtual functions
+    </h4>
+    <div>
+      <KVMMeter
+        allocated={100}
+        data-test="vfs-meter"
+        free={156}
+        total={256}
+      />
+      <hr />
+      <div
+        className="p-heading--small u-text--light"
+      >
+        Network interfaces
+      </div>
+      <span />
+    </div>
+  </div>
+  <div
+    className="kvm-resources-card__section kvm-resources-card__vms"
+  >
+    <h4
+      className="p-heading--small"
+    >
+      Total VMs
+    </h4>
+    <ContextualMenu
+      dropdownContent={<React.Fragment />}
+      hasToggleIcon={true}
+      toggleAppearance="base"
+      toggleClassName="is-dense is-thin"
+      toggleLabel="4"
+    />
+  </div>
+</Card>
+`;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import configureStore from "redux-mock-store";
+import { mount } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+
+import {
+  pod as podFactory,
+  podHint as podHintFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import KVMAggregateResources from "./KVMAggregateResources";
+
+const mockStore = configureStore();
+
+describe("KVMAggregateResources", () => {
+  it("correctly displays cpu core information", () => {
+    const pod = podFactory({
+      cpu_over_commit_ratio: 3,
+      id: 1,
+      total: podHintFactory({ cores: 4 }),
+      used: podHintFactory({ cores: 2 }),
+    });
+    const state = rootStateFactory({ pod: podStateFactory({ items: [pod] }) });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <KVMAggregateResources id={pod.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='cpu-meter'] [data-test='total']").text()
+    ).toBe("12");
+    expect(
+      wrapper.find("[data-test='cpu-meter'] [data-test='allocated']").text()
+    ).toBe("2");
+    expect(
+      wrapper.find("[data-test='cpu-meter'] [data-test='free']").text()
+    ).toBe("10");
+  });
+
+  it("correctly displays general RAM information", () => {
+    const pod = podFactory({
+      memory_over_commit_ratio: 2,
+      id: 1,
+      total: podHintFactory({ memory: 2 }),
+      used: podHintFactory({ memory: 1 }),
+    });
+    const state = rootStateFactory({ pod: podStateFactory({ items: [pod] }) });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <KVMAggregateResources id={pod.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='ram-general-allocated']").text()).toBe(
+      "1MiB"
+    );
+    expect(wrapper.find("[data-test='ram-general-free']").text()).toBe("3MiB");
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
@@ -1,8 +1,77 @@
-import React from "react";
-import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
+import { Spinner } from "@canonical/react-components";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
-const KVMAggregateResources = (): JSX.Element => {
-  return <KVMResourcesCard className="kvm-resources-card--aggregate" />;
+import type { RootState } from "app/store/root/types";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
+import { formatBytes } from "app/utils";
+
+const fakeHugepageRAM = {
+  allocated: 10,
+  free: 2,
+  total: 12,
+  pagesize: 2048,
+  unit: "GiB",
+};
+const fakeNICs = ["eth0", "eth1", "eth2", "eth3"];
+const fakeVFs = {
+  allocated: 32,
+  free: 224,
+  total: 256,
+};
+
+type Props = { id: number };
+
+const KVMAggregateResources = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  );
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
+  }, [dispatch]);
+
+  if (!!pod) {
+    const totalCores = pod.total.cores * pod.cpu_over_commit_ratio;
+    const totalGeneralRAM = formatBytes(
+      pod.total.memory * pod.memory_over_commit_ratio,
+      "MiB",
+      { binary: true }
+    );
+
+    return (
+      <KVMResourcesCard
+        className="kvm-resources-card--aggregate"
+        cores={{
+          allocated: pod.used.cores,
+          free: totalCores - pod.used.cores,
+          total: totalCores,
+        }}
+        nics={fakeNICs}
+        ram={{
+          general: {
+            allocated: formatBytes(pod.used.memory, "MiB", {
+              binary: true,
+              convertTo: totalGeneralRAM.unit,
+            }).value,
+            free: formatBytes(
+              pod.total.memory * pod.memory_over_commit_ratio - pod.used.memory,
+              "MiB",
+              { binary: true, convertTo: totalGeneralRAM.unit }
+            ).value,
+            total: totalGeneralRAM.value,
+            unit: totalGeneralRAM.unit,
+          },
+          hugepage: fakeHugepageRAM,
+        }}
+        vfs={fakeVFs}
+      />
+    );
+  }
+  return <Spinner text="Loading" />;
 };
 
 export default KVMAggregateResources;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -2,13 +2,63 @@ import React from "react";
 
 import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
 
-const fakeNumas = [{ index: 0 }, { index: 1 }];
+const fakeNumas = [
+  {
+    cores: { allocated: 1, free: 2, total: 3 },
+    index: 0,
+    nics: ["eth0", "eth2"],
+    ram: {
+      general: {
+        allocated: 12,
+        free: 12,
+        total: 24,
+        unit: "GiB",
+      },
+      hugepage: {
+        allocated: 540,
+        free: 420,
+        pagesize: 4068,
+        total: 960,
+        unit: "MiB",
+      },
+    },
+    vfs: { allocated: 13, free: 1, total: 14 },
+  },
+  {
+    cores: { allocated: 200, free: 100, total: 300 },
+    index: 1,
+    nics: ["eth1", "eth3"],
+    ram: {
+      general: {
+        allocated: 3,
+        free: 1,
+        total: 4,
+        unit: "GiB",
+      },
+      hugepage: {
+        allocated: 1,
+        free: 1,
+        pagesize: 2048,
+        total: 2,
+        unit: "GiB",
+      },
+    },
+    vfs: { allocated: 18, free: 226, total: 242 },
+  },
+];
 
 const KVMNumaResources = (): JSX.Element => {
   return (
     <div className="numa-resources-grid">
       {fakeNumas.map((numa) => (
-        <KVMResourcesCard key={numa.index} title={`NUMA node ${numa.index}`} />
+        <KVMResourcesCard
+          cores={numa.cores}
+          key={numa.index}
+          nics={numa.nics}
+          ram={numa.ram}
+          title={`NUMA node ${numa.index}`}
+          vfs={numa.vfs}
+        />
       ))}
     </div>
   );

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.tsx
@@ -45,7 +45,7 @@ const KVMStorage = ({ id }: Props): JSX.Element | null => {
             });
 
             return (
-              <Card key={pool.id}>
+              <Card className="u-no-padding--bottom" key={pool.id}>
                 <h5>
                   <span data-test="pool-name">{pool.name}</span>
                   <br />

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -41,7 +41,11 @@ const KVMSummary = (): JSX.Element => {
             }}
           />
         </div>
-        {viewByNuma ? <KVMNumaResources /> : <KVMAggregateResources />}
+        {viewByNuma ? (
+          <KVMNumaResources />
+        ) : (
+          <KVMAggregateResources id={pod.id} />
+        )}
         <KVMStorage id={pod.id} />
       </>
     );


### PR DESCRIPTION
## Done

- Added meters for aggregate CPU and VFs, and NUMA CPU and VFs.
- Used real data for aggregate RAM and CPU, and fake data for aggregate VFs, aggregate interfaces and all NUMA data.
- Removed the "snap to base2 width" functionality of the Meter component. If we want the meter to have pixel perfect separators, that should now be handled by setting the width of the container (which is the case in the KVM list).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM details page.
- Check that the aggregate CPU core information is correct.
- Check that the CPU core and Virtual function meters match [the design](https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f33dc5944a05220896e857a) for both aggregate and NUMA node views.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2076
Fixes canonical-web-and-design/MAAS-squad#2077

## Screenshots
### Aggregate
![0 0 0 0_8400_MAAS_r_kvm_190 (17)](https://user-images.githubusercontent.com/25733845/90849256-3caee480-e3b2-11ea-85f3-c8d1bc3ef4d5.png)



### NUMA node
![0 0 0 0_8400_MAAS_r_kvm_190 (18)](https://user-images.githubusercontent.com/25733845/90849264-41739880-e3b2-11ea-91e5-d1f2f7e0cc23.png)



