### PR TITLE
feat(ui): Improve styling of KVM details RAM tables.

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -43,15 +43,15 @@ const generateDropdownContent = (
         <div className="u-align--right">Type</div>
         <ul className="p-inline-list u-default-text u-no-margin--bottom">
           <li className="p-inline-list__item">
-            <i className="p-icon--allocated is-inline"></i>
+            <i className="p-circle--link is-inline"></i>
             Allocated
           </li>
           <li className="p-inline-list__item">
-            <i className="p-icon--requested is-inline"></i>
+            <i className="p-circle--positive is-inline"></i>
             Requested
           </li>
           <li className="p-inline-list__item">
-            <i className="p-icon--free is-inline"></i>
+            <i className="p-circle--link-faded is-inline"></i>
             Free
           </li>
         </ul>
@@ -114,7 +114,7 @@ const generateDropdownContent = (
                   free >= 0 ? (
                     <ul className="p-inline-list u-no-margin--bottom">
                       <li className="p-inline-list__item" data-test="allocated">
-                        <i className="p-icon--allocated is-inline"></i>
+                        <i className="p-circle--link is-inline"></i>
                         {`${allocated}GB`}
                       </li>
                       {requested !== 0 && (
@@ -122,12 +122,12 @@ const generateDropdownContent = (
                           className="p-inline-list__item"
                           data-test="requested"
                         >
-                          <i className="p-icon--requested is-inline"></i>
+                          <i className="p-circle--positive is-inline"></i>
                           {`${requested}GB`}
                         </li>
                       )}
                       <li className="p-inline-list__item" data-test="free">
-                        <i className="p-icon--free is-inline"></i>
+                        <i className="p-circle--link-faded is-inline"></i>
                         {`${available - requested}GB`}
                       </li>
                     </ul>

--- a/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
+++ b/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
@@ -27,7 +27,7 @@ const KVMMeter = ({
         <p className="p-heading--small u-text--light">
           Allocated
           <span className="u-nudge-left--small">
-            <i className="p-icon--allocated"></i>
+            <i className="p-circle--link"></i>
           </span>
         </p>
         <div className="u-nudge-left">{`${allocated}${unit}`}</div>
@@ -36,7 +36,7 @@ const KVMMeter = ({
         <p className="p-heading--small u-text--light">
           Free
           <span className="u-nudge-left--small">
-            <i className="p-icon--free"></i>
+            <i className="p-circle--link-faded"></i>
           </span>
         </p>
         <div className="u-nudge-left">{`${free}${unit}`}</div>

--- a/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`KVMMeter renders 1`] = `
         className="u-nudge-left--small"
       >
         <i
-          className="p-icon--allocated"
+          className="p-circle--link"
         />
       </span>
     </p>
@@ -46,7 +46,7 @@ exports[`KVMMeter renders 1`] = `
         className="u-nudge-left--small"
       >
         <i
-          className="p-icon--free"
+          className="p-circle--link-faded"
         />
       </span>
     </p>

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -26,24 +26,54 @@ const KVMResourcesCard = ({ className, title }: Props): JSX.Element => {
       )}
       <div className="kvm-resources-card__section kvm-resources-card__ram">
         <h4 className="p-heading--small">RAM</h4>
-        <table className="u-no-margin--bottom">
+        <table className="kvm-resources-card__ram-table">
           <thead>
             <tr>
               <th></th>
-              <th>Allocated</th>
-              <th>Free</th>
+              <th className="u-align--right">
+                <span className="u-nudge-left">Allocated</span>
+              </th>
+              <th className="u-align--right">
+                <span className="u-nudge-left">Free</span>
+              </th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td>General</td>
-              <td>64GB</td>
-              <td>96GB</td>
+              <td className="u-align--right">
+                64GB
+                <span className="u-nudge-left--small">
+                  <i className="p-circle--link"></i>
+                </span>
+              </td>
+              <td className="u-align--right">
+                96GB
+                <span className="u-nudge-left--small">
+                  <i className="p-circle--link-faded"></i>
+                </span>
+              </td>
             </tr>
             <tr>
-              <td>Hugepage</td>
-              <td>32GB</td>
-              <td>64GB</td>
+              <td>
+                Hugepage
+                <br />
+                <strong className="p-text--x-small u-text--light">
+                  (Size: 2048KB)
+                </strong>
+              </td>
+              <td className="u-align--right">
+                32GB
+                <span className="u-nudge-left--small">
+                  <i className="p-circle--positive"></i>
+                </span>
+              </td>
+              <td className="u-align--right">
+                64GB
+                <span className="u-nudge-left--small">
+                  <i className="p-circle--positive-faded"></i>
+                </span>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
+++ b/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
@@ -1,4 +1,25 @@
 @mixin KVMResourcesCard {
+  .kvm-resources-card__ram-table {
+    margin-bottom: 0;
+
+    td {
+      padding-bottom: $spv-inner--small;
+      padding-top: calc(#{$spv-inner--small} - 1px);
+
+      &:first-of-type {
+        padding-left: 0;
+      }
+
+      &:last-of-type {
+        padding-right: 0;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      margin-top: -$spv-inner--small;
+    }
+  }
+
   // Base KVM resources card styling.
   .kvm-resources-card__section {
     @extend %base-grid;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.tsx
@@ -30,14 +30,14 @@ const CPUPopover = ({
               {allocated}
             </div>
             <div className="u-vertically-center">
-              <i className="p-icon--allocated"></i>
+              <i className="p-circle--link"></i>
             </div>
             <div>Allocated</div>
             <div className="u-align--right" data-test="free">
               {free}
             </div>
             <div className="u-vertically-center">
-              <i className="p-icon--free"></i>
+              <i className="p-circle--link-faded"></i>
             </div>
             <div>Free</div>
           </div>

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
@@ -41,14 +41,14 @@ const RAMPopover = ({
               {`${allocatedMemory.value} ${allocatedMemory.unit}`}
             </div>
             <div className="u-vertically-center">
-              <i className="p-icon--allocated"></i>
+              <i className="p-circle--link"></i>
             </div>
             <div>Allocated</div>
             <div className="u-align--right" data-test="free">
               {`${freeMemory.value} ${freeMemory.unit}`}
             </div>
             <div className="u-vertically-center">
-              <i className="p-icon--free"></i>
+              <i className="p-circle--link-faded"></i>
             </div>
             <div>Free</div>
           </div>

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
@@ -32,11 +32,11 @@ const StoragePopover = ({
             <div className="u-align--right">Type</div>
             <ul className="p-inline-list u-default-text u-no-margin--bottom">
               <li className="p-inline-list__item">
-                <i className="p-icon--allocated is-inline"></i>
+                <i className="p-circle--link is-inline"></i>
                 Allocated
               </li>
               <li className="p-inline-list__item">
-                <i className="p-icon--free is-inline"></i>
+                <i className="p-circle--link-faded is-inline"></i>
                 Free
               </li>
             </ul>
@@ -80,14 +80,14 @@ const StoragePopover = ({
                           className="p-inline-list__item"
                           data-test="pool-allocated"
                         >
-                          <i className="p-icon--allocated is-inline"></i>
+                          <i className="p-circle--link is-inline"></i>
                           {`${allocated.value}${allocated.unit}`}
                         </li>
                         <li
                           className="p-inline-list__item"
                           data-test="pool-free"
                         >
-                          <i className="p-icon--free is-inline"></i>
+                          <i className="p-circle--link-faded is-inline"></i>
                           {`${free.value}${free.unit}`}
                         </li>
                       </ul>

--- a/ui/src/scss/_patterns_icons.scss
+++ b/ui/src/scss/_patterns_icons.scss
@@ -38,21 +38,12 @@
 }
 
 @mixin maas-icons {
-  $color-allocated: $color-link;
-  $color-free: #d3e4ed;
-  $color-requested: $color-positive;
-
-  .p-icon--allocated {
-    @include maas-icon-circle($color-allocated);
-  }
+  $color-link--faded: #d3e4ed;
+  $color-positive--faded: #4dab4d;
 
   .p-icon--edit {
     @extend %icon;
     @include maas-icon-edit($color-mid-dark);
-  }
-
-  .p-icon--free {
-    @include maas-icon-circle($color-free);
   }
 
   .p-icon--locked {
@@ -85,10 +76,6 @@
     @include maas-icon-unknown($color-mid-dark);
   }
 
-  .p-icon--requested {
-    @include maas-icon-circle($color-requested);
-  }
-
   .p-icon--running {
     @extend %icon;
     background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg width='16px' height='16px' viewBox='0 0 16 16' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Erunning%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cdefs%3E%3C/defs%3E%3Cg id='Page-1' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3E%3Cg id='smoke-testing-status' transform='translate%28-62.000000, -159.000000%29'%3E%3Cg id='running' transform='translate%2850.000000, 144.000000%29'%3E%3Cg transform='translate%2812.000000, 15.000000%29'%3E%3Crect id='rect6425' x='9.99999997e-06' y='9.99999989e-06' width='16' height='16'%3E%3C/rect%3E%3Ccircle id='circle6427' stroke='%230E8420' stroke-width='1.5' fill='%230E8420' fill-rule='nonzero' cx='8.00001' cy='8.00001' r='7.2500086'%3E%3C/circle%3E%3Cpolygon id='path6429' fill='%23FFFFFF' fill-rule='nonzero' points='6.00002 12.00001 6.00002 4.00001 12.00002 8.00001'%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
@@ -104,6 +91,23 @@
     background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8' standalone='no'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' width='16px' version='1.1' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 16 16'%3E%3C!-- Generator: Sketch 42 %2836781%29 - http://www.bohemiancoding.com/sketch --%3E%3Ctitle%3Etimed out%3C/title%3E%3Cdesc%3ECreated with Sketch.%3C/desc%3E%3Cg id='Page-1' fill-rule='evenodd' fill='none'%3E%3Cg id='smoke-testing-status' transform='translate%28-62 -206%29'%3E%3Cg id='timed-out' transform='translate%2850 191%29'%3E%3Cg transform='translate%2812 15%29'%3E%3Crect id='rect4970' y='0.00002' x='0' height='16' width='16'/%3E%3Ccircle id='circle4972' stroke-width='1.5' cy='8' stroke='%23E95420' cx='8' r='7.25'/%3E%3Cpolyline id='path839' stroke='%23E95420' stroke-width='2' points='11.8 11.8 7.9999 8 7.9999 3'/%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/g%3E%3C/svg%3E%0A");
   }
 
+  .p-circle--link {
+    @include maas-icon-circle($color-link);
+  }
+
+  .p-circle--link-faded {
+    @include maas-icon-circle($color-link--faded);
+  }
+
+  .p-circle--positive {
+    @include maas-icon-circle($color-positive);
+  }
+
+  .p-circle--positive-faded {
+    @include maas-icon-circle($color-positive--faded);
+  }
+
+  [class*="p-circle--"].is-inline,
   [class*="p-icon--"].is-inline {
     margin-right: $sph-inner--small;
     top: 0;


### PR DESCRIPTION
## Done

- Updated KVM details RAM tables to match [design](https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f36a6fd1124de23d57b637b).
- Changed the icon class names for the little coloured circles (`p-icon--requested`, `p-icon--allocated` etc.) to just `p-circle--{colour}` because the meaning of the colour is no longer consistent. e.g. in the KVM compose form a green circle is "requested storage" but in the KVM details page a green circle is "allocated hugepage".

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go the a KVM details page.
- Check that the RAM table matches the [design](https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f36a6fd1124de23d57b637b) (minus the donut chart of course)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2075

## Screenshots
![2020-08-21_11-57](https://user-images.githubusercontent.com/25733845/90843689-8e9d3d80-e3a5-11ea-8c00-6c7f0ae9dfe0.png)
![2020-08-21_11-57_1](https://user-images.githubusercontent.com/25733845/90843692-90ff9780-e3a5-11ea-8a83-be072a981bdc.png)

