### PR TITLE
feat(ui): Build expanding dropdowns for KVM NUMA and storage cards.

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
@@ -1,0 +1,28 @@
+import { shallow } from "enzyme";
+import React from "react";
+import { act } from "react-dom/test-utils";
+
+import KVMNumaResources, { TRUNCATION_POINT } from "./KVMNumaResources";
+import { fakeNumas } from "../KVMSummary";
+
+describe("KVMNumaResources", () => {
+  it("can expand truncated NUMA nodes if above truncation point", () => {
+    const numaNodes = [...fakeNumas, ...fakeNumas];
+    const wrapper = shallow(<KVMNumaResources numaNodes={numaNodes} />);
+
+    expect(wrapper.find("Button[data-test='show-more-numas']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("KVMResourcesCard").length).toBe(TRUNCATION_POINT);
+
+    act(() => {
+      wrapper.find("Button[data-test='show-more-numas']").simulate("click");
+    });
+    wrapper.update();
+
+    expect(
+      wrapper.find("Button[data-test='show-more-numas'] span").text()
+    ).toBe("Show less NUMA nodes");
+    expect(wrapper.find("KVMResourcesCard").length).toBe(numaNodes.length);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -1,66 +1,66 @@
-import React from "react";
+import { Button } from "@canonical/react-components";
+import pluralize from "pluralize";
+import React, { useState } from "react";
 
+import type { TSFixMe } from "app/base/types";
 import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
 
-const fakeNumas = [
-  {
-    cores: { allocated: 1, free: 2, total: 3 },
-    index: 0,
-    nics: ["eth0", "eth2"],
-    ram: {
-      general: {
-        allocated: 12,
-        free: 12,
-        total: 24,
-        unit: "GiB",
-      },
-      hugepage: {
-        allocated: 540,
-        free: 420,
-        pagesize: 4068,
-        total: 960,
-        unit: "MiB",
-      },
-    },
-    vfs: { allocated: 13, free: 1, total: 14 },
-  },
-  {
-    cores: { allocated: 200, free: 100, total: 300 },
-    index: 1,
-    nics: ["eth1", "eth3"],
-    ram: {
-      general: {
-        allocated: 3,
-        free: 1,
-        total: 4,
-        unit: "GiB",
-      },
-      hugepage: {
-        allocated: 1,
-        free: 1,
-        pagesize: 2048,
-        total: 2,
-        unit: "GiB",
-      },
-    },
-    vfs: { allocated: 18, free: 226, total: 242 },
-  },
-];
+export const TRUNCATION_POINT = 3;
 
-const KVMNumaResources = (): JSX.Element => {
+type Props = { numaNodes: TSFixMe[] };
+
+const KVMNumaResources = ({ numaNodes }: Props): JSX.Element => {
+  const [expanded, setExpanded] = useState(false);
+  const canBeTruncated = numaNodes.length > TRUNCATION_POINT;
+  const shownNumaNodes =
+    canBeTruncated && !expanded
+      ? numaNodes.slice(0, TRUNCATION_POINT)
+      : numaNodes;
+
   return (
-    <div className="numa-resources-grid">
-      {fakeNumas.map((numa) => (
-        <KVMResourcesCard
-          cores={numa.cores}
-          key={numa.index}
-          nics={numa.nics}
-          ram={numa.ram}
-          title={`NUMA node ${numa.index}`}
-          vfs={numa.vfs}
-        />
-      ))}
-    </div>
+    <>
+      <div className="numa-resources-grid">
+        {shownNumaNodes.map((numa) => (
+          <KVMResourcesCard
+            cores={numa.cores}
+            key={numa.index}
+            nics={numa.nics}
+            ram={numa.ram}
+            title={`NUMA node ${numa.index}`}
+            vfs={numa.vfs}
+          />
+        ))}
+      </div>
+      {canBeTruncated && (
+        <div className="u-align--center">
+          <Button
+            appearance="base"
+            data-test="show-more-numas"
+            hasIcon
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? (
+              <>
+                <span>Show less NUMA nodes</span>
+                <i className="p-icon--contextual-menu u-mirror--y"></i>
+              </>
+            ) : (
+              <>
+                <span>
+                  {pluralize(
+                    "more NUMA node",
+                    numaNodes.length - TRUNCATION_POINT,
+                    true
+                  )}
+                </span>
+                <i className="p-icon--contextual-menu"></i>
+              </>
+            )}
+          </Button>
+          <hr />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -16,6 +16,51 @@ type RouteParams = {
   id: string;
 };
 
+export const fakeNumas = [
+  {
+    cores: { allocated: 1, free: 2, total: 3 },
+    index: 0,
+    nics: ["eth0", "eth2"],
+    ram: {
+      general: {
+        allocated: 12,
+        free: 12,
+        total: 24,
+        unit: "GiB",
+      },
+      hugepage: {
+        allocated: 540,
+        free: 420,
+        pagesize: 4068,
+        total: 960,
+        unit: "MiB",
+      },
+    },
+    vfs: { allocated: 13, free: 1, total: 14 },
+  },
+  {
+    cores: { allocated: 200, free: 100, total: 300 },
+    index: 1,
+    nics: ["eth1", "eth3"],
+    ram: {
+      general: {
+        allocated: 3,
+        free: 1,
+        total: 4,
+        unit: "GiB",
+      },
+      hugepage: {
+        allocated: 1,
+        free: 1,
+        pagesize: 2048,
+        total: 2,
+        unit: "GiB",
+      },
+    },
+    vfs: { allocated: 18, free: 226, total: 242 },
+  },
+];
+
 const KVMSummary = (): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams<RouteParams>();
@@ -46,7 +91,7 @@ const KVMSummary = (): JSX.Element => {
           />
         </div>
         {viewByNuma ? (
-          <KVMNumaResources />
+          <KVMNumaResources numaNodes={fakeNumas} />
         ) : (
           <KVMAggregateResources id={pod.id} />
         )}


### PR DESCRIPTION
## Done

- Built expanding dropdowns for KVM NUMA and storage cards.
- Truncation is set at 3 for both, regardless of screen size. We can look into making that number a bit more dynamic as a follow up if it's considered important.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open `KVMSummary.tsx` and change the variable `fakeNumas` to include more than 3 "nodes".
- Open `KVMStorage.tsx` and replace `pod.storage_pools` with some fake pools. It's probably easiest to just use the testing factories:
``` js
import { podStoragePool } from "testing/factories";

const fakePools = [podStoragePool(), podStoragePool(), podStoragePool(), podStoragePool()];
```
- Go to the KVM details page and check that the NUMAs and pools are truncated to 3.
- Click on the "X more Y" buttons and check that the lists are no longer truncated.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2082

## Screenshot
![0 0 0 0_8400_MAAS_r_kvm_190 (19)](https://user-images.githubusercontent.com/25733845/90862426-c1106000-e3d0-11ea-8f6e-9d8c18aaf87d.png)

