### PR TITLE
feat(ui): right align release notification settings link

### DIFF
--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -27,6 +27,7 @@ const NotificationGroupNotification = ({ id, type }: Props): JSX.Element => {
     isReleaseNotification(notification) && authUser?.is_superuser;
   return (
     <Notification
+      className={showSettings ? "p-notification--has-action" : null}
       close={
         notification.dismissable
           ? () => dispatch(notificationActions.delete(id))
@@ -35,13 +36,19 @@ const NotificationGroupNotification = ({ id, type }: Props): JSX.Element => {
       type={type}
     >
       <span
+        className="p-notification__message"
         data-test="notification-message"
         dangerouslySetInnerHTML={{ __html: notification.message }}
       ></span>
       {showSettings ? (
         <>
           {" "}
-          <Link to="/settings/configuration/general">See settings</Link>
+          <Link
+            to="/settings/configuration/general"
+            className="p-notification__action"
+          >
+            See settings
+          </Link>
         </>
       ) : null}
     </Notification>

--- a/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`NotificationGroupNotification renders 1`] = `
   type="negative"
 >
   <Notification
+    className={null}
     close={[Function]}
     type="negative"
   >
@@ -16,6 +17,7 @@ exports[`NotificationGroupNotification renders 1`] = `
         className="p-notification__response"
       >
         <span
+          className="p-notification__message"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Testing notification",

--- a/ui/src/app/base/components/NotificationList/__snapshots__/NotificationList.test.tsx.snap
+++ b/ui/src/app/base/components/NotificationList/__snapshots__/NotificationList.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`NotificationList renders a list of messages 1`] = `
         type="negative"
       >
         <Notification
+          className={null}
           close={[Function]}
           type="negative"
         >
@@ -52,6 +53,7 @@ exports[`NotificationList renders a list of messages 1`] = `
               className="p-notification__response"
             >
               <span
+                className="p-notification__message"
                 dangerouslySetInnerHTML={
                   Object {
                     "__html": "an error",

--- a/ui/src/scss/_patterns_notifications.scss
+++ b/ui/src/scss/_patterns_notifications.scss
@@ -5,15 +5,15 @@
     @extend %vf-card;
     padding: 0;
 
-    [class^="p-notification"] {
+    [class^="p-notification--"] {
       box-shadow: none;
     }
 
-    [class^="p-notification"]:first-child {
+    [class^="p-notification--"]:first-child {
       margin-bottom: 0;
     }
 
-    [class^="p-notification"] + [class^="p-notification"] {
+    [class^="p-notification--"] + [class^="p-notification--"] {
       border-top-left-radius: 0;
       border-top-right-radius: 0;
       border-top: $border;
@@ -31,6 +31,23 @@
       .p-icon--close {
         margin-top: $spv-inner--small;
       }
+    }
+  }
+
+  .p-notification--has-action {
+    .p-notification__response {
+      display: flex;
+      flex: 1;
+    }
+
+    .p-notification__message {
+      flex: 1;
+    }
+
+    .p-notification__action {
+      flex: 0;
+      white-space: nowrap;
+      margin-left: $spv-outer--small;
     }
   }
 }


### PR DESCRIPTION
## Done

- Update the new release notification to show the settings link on the right.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a new release notification (instructions are here: https://github.com/canonical-web-and-design/MAAS-squad/issues/2065#issue-669660220).
- Check that the "See settings" link is aligned right (next to the X).

<img width="1072" alt="Screen Shot 2020-08-26 at 10 18 30 am" src="https://user-images.githubusercontent.com/361637/91240489-823e2980-e785-11ea-9c64-6833e9bf1972.png">
