### PR TITLE
feat(ui): Update NUMA view to 4-col design + handle cases of absent data.

### DIFF
--- a/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
+++ b/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
@@ -26,7 +26,7 @@ const KVMMeter = ({
       <div className="u-align--right">
         <p className="p-heading--small u-text--light">
           Allocated
-          <span className="u-nudge-left--small">
+          <span className="u-nudge-right--small">
             <i className="p-circle--link u-no-margin--top"></i>
           </span>
         </p>
@@ -38,7 +38,7 @@ const KVMMeter = ({
       <div className="u-align--right">
         <p className="p-heading--small u-text--light">
           Free
-          <span className="u-nudge-left--small">
+          <span className="u-nudge-right--small">
             <i className="p-circle--link-faded u-no-margin--top"></i>
           </span>
         </p>

--- a/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMMeter/__snapshots__/KVMMeter.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`KVMMeter renders 1`] = `
     >
       Allocated
       <span
-        className="u-nudge-left--small"
+        className="u-nudge-right--small"
       >
         <i
           className="p-circle--link u-no-margin--top"
@@ -46,7 +46,7 @@ exports[`KVMMeter renders 1`] = `
     >
       Free
       <span
-        className="u-nudge-left--small"
+        className="u-nudge-right--small"
       >
         <i
           className="p-circle--link-faded u-no-margin--top"

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -10,7 +10,7 @@ describe("KVMResourcesCard", () => {
         cores={{ allocated: 1, free: 2, total: 3 }}
         nics={[]}
         ram={{ general: { allocated: 2, free: 3, total: 5 } }}
-        vfs={{ allocated: 100, free: 156, total: 256 }}
+        vms={["abc123"]}
         title="Title"
       />
     );
@@ -24,13 +24,61 @@ describe("KVMResourcesCard", () => {
         cores={{ allocated: 1, free: 2, total: 3 }}
         nics={[]}
         ram={{ general: { allocated: 2, free: 3, total: 5 } }}
-        vfs={{ allocated: 100, free: 156, total: 256 }}
+        vms={["abc123"]}
         title="Title"
       />
     );
 
     expect(wrapper.find("[data-test='kvm-resources-card-title']").text()).toBe(
       "Title"
+    );
+  });
+
+  it("shows hugepage RAM details if provided", () => {
+    const wrapper = shallow(
+      <KVMResourcesCard
+        cores={{ allocated: 1, free: 2, total: 3 }}
+        nics={[]}
+        ram={{
+          general: { allocated: 2, free: 3, total: 5 },
+          hugepage: { allocated: 1, free: 1, total: 2, pagesize: 1024 },
+        }}
+        vfs={{ allocated: 100, free: 156, total: 256 }}
+        vms={["abc123"]}
+      />
+    );
+
+    expect(wrapper.find("[data-test='hugepage-ram']").exists()).toBe(true);
+  });
+
+  it("shows virtual function details if provided", () => {
+    const wrapper = shallow(
+      <KVMResourcesCard
+        cores={{ allocated: 1, free: 2, total: 3 }}
+        nics={[]}
+        ram={{
+          general: { allocated: 2, free: 3, total: 5 },
+        }}
+        vfs={{ allocated: 100, free: 156, total: 256 }}
+        vms={["abc123"]}
+      />
+    );
+
+    expect(wrapper.find("[data-test='vfs-meter']").exists()).toBe(true);
+  });
+
+  it("shows VMs button at bottom of container if no title provided", () => {
+    const wrapper = shallow(
+      <KVMResourcesCard
+        cores={{ allocated: 1, free: 2, total: 3 }}
+        nics={[]}
+        ram={{ general: { allocated: 2, free: 3, total: 5 } }}
+        vms={["abc123"]}
+      />
+    );
+
+    expect(wrapper.find("[data-test='vms-button-no-title']").exists()).toBe(
+      true
     );
   });
 });

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -1,5 +1,6 @@
 import { Card } from "@canonical/react-components";
 import classNames from "classnames";
+import pluralize from "pluralize";
 import React from "react";
 
 import ContextualMenu from "app/base/components/ContextualMenu";
@@ -21,7 +22,8 @@ type Props = {
     hugepage?: ChartValues & { pagesize: number };
   };
   title?: string;
-  vfs: ChartValues;
+  vfs?: ChartValues;
+  vms: string[];
 };
 
 const KVMResourcesCard = ({
@@ -31,22 +33,34 @@ const KVMResourcesCard = ({
   ram,
   title,
   vfs,
+  vms,
 }: Props): JSX.Element => {
   return (
     <Card className={classNames("kvm-resources-card", className)}>
       {title && (
         <>
-          <h5
-            className="p-text--paragraph"
-            data-test="kvm-resources-card-title"
-          >
-            {title}
+          <h5 className="p-text--paragraph u-flex--between u-no-max-width">
+            <span data-test="kvm-resources-card-title">{title}</span>
+            <ContextualMenu
+              dropdownContent={<></>}
+              hasToggleIcon
+              toggleAppearance="base"
+              toggleClassName="kvm-resources-card__vms-button is-dense"
+              toggleDisabled={vms.length === 0}
+              toggleLabel={pluralize("machine", vms.length, true)}
+            />
           </h5>
           <hr />
         </>
       )}
       <div className="kvm-resources-card__section kvm-resources-card__ram">
-        <h4 className="p-heading--small">RAM</h4>
+        <div>
+          <h4 className="p-heading--small">RAM</h4>
+          <div className="kvm-resources-card__ram-chart">
+            {ram.general.total}
+            {ram.general.unit}
+          </div>
+        </div>
         <table className="kvm-resources-card__ram-table">
           <thead>
             <tr>
@@ -67,7 +81,7 @@ const KVMResourcesCard = ({
                   {ram.general.allocated}
                   {ram.general.unit}
                 </span>
-                <span className="u-nudge-left--small">
+                <span className="u-nudge-right--small">
                   <i className="p-circle--link"></i>
                 </span>
               </td>
@@ -76,13 +90,13 @@ const KVMResourcesCard = ({
                   {ram.general.free}
                   {ram.general.unit}
                 </span>
-                <span className="u-nudge-left--small">
+                <span className="u-nudge-right--small">
                   <i className="p-circle--link-faded"></i>
                 </span>
               </td>
             </tr>
             {ram.hugepage && (
-              <tr>
+              <tr data-test="hugepage-ram">
                 <td>
                   Hugepage
                   <br />
@@ -93,14 +107,14 @@ const KVMResourcesCard = ({
                 <td className="u-align--right">
                   {ram.hugepage.allocated}
                   {ram.hugepage.unit}
-                  <span className="u-nudge-left--small">
+                  <span className="u-nudge-right--small">
                     <i className="p-circle--positive"></i>
                   </span>
                 </td>
                 <td className="u-align--right">
                   {ram.hugepage.free}
                   {ram.hugepage.unit}
-                  <span className="u-nudge-left--small">
+                  <span className="u-nudge-right--small">
                     <i className="p-circle--positive-faded"></i>
                   </span>
                 </td>
@@ -120,31 +134,45 @@ const KVMResourcesCard = ({
         />
       </div>
       <div className="kvm-resources-card__section kvm-resources-card__vfs">
-        <h4 className="p-heading--small u-sv1">Virtual functions</h4>
-        <div>
-          <KVMMeter
-            allocated={vfs.allocated}
-            data-test="vfs-meter"
-            free={vfs.free}
-            total={vfs.total}
+        {vfs ? (
+          <>
+            <h4 className="p-heading--small u-sv1">Virtual functions</h4>
+            <div>
+              <KVMMeter
+                allocated={vfs.allocated}
+                data-test="vfs-meter"
+                free={vfs.free}
+                total={vfs.total}
+              />
+              <hr />
+              <div className="p-heading--small u-text--light">
+                Network interfaces
+              </div>
+              <span>{nics.length >= 1 ? nics.join(", ") : <em>None</em>}</span>
+            </div>
+          </>
+        ) : (
+          <>
+            <h4 className="p-heading--small u-sv1">Network interfaces</h4>
+            <span>{nics.length >= 1 ? nics.join(", ") : <em>None</em>}</span>
+          </>
+        )}
+      </div>
+      {!title && (
+        <div
+          className="kvm-resources-card__section kvm-resources-card__vms"
+          data-test="vms-button-no-title"
+        >
+          <h4 className="p-heading--small">Total VMs</h4>
+          <ContextualMenu
+            dropdownContent={<></>}
+            hasToggleIcon
+            toggleAppearance="base"
+            toggleClassName="kvm-resources-card__vms-button is-dense"
+            toggleLabel={`${vms.length}`}
           />
-          <hr />
-          <div className="p-heading--small u-text--light">
-            Network interfaces
-          </div>
-          <span>{nics.join(", ")}</span>
         </div>
-      </div>
-      <div className="kvm-resources-card__section kvm-resources-card__vms">
-        <h4 className="p-heading--small">Total VMs</h4>
-        <ContextualMenu
-          dropdownContent={<></>}
-          hasToggleIcon
-          toggleAppearance="base"
-          toggleClassName="is-dense is-thin"
-          toggleLabel="4"
-        />
-      </div>
+      )}
     </Card>
   );
 };

--- a/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
@@ -5,20 +5,38 @@ exports[`KVMResourcesCard renders 1`] = `
   className="kvm-resources-card"
 >
   <h5
-    className="p-text--paragraph"
-    data-test="kvm-resources-card-title"
+    className="p-text--paragraph u-flex--between u-no-max-width"
   >
-    Title
+    <span
+      data-test="kvm-resources-card-title"
+    >
+      Title
+    </span>
+    <ContextualMenu
+      dropdownContent={<React.Fragment />}
+      hasToggleIcon={true}
+      toggleAppearance="base"
+      toggleClassName="kvm-resources-card__vms-button is-dense"
+      toggleDisabled={false}
+      toggleLabel="1 machine"
+    />
   </h5>
   <hr />
   <div
     className="kvm-resources-card__section kvm-resources-card__ram"
   >
-    <h4
-      className="p-heading--small"
-    >
-      RAM
-    </h4>
+    <div>
+      <h4
+        className="p-heading--small"
+      >
+        RAM
+      </h4>
+      <div
+        className="kvm-resources-card__ram-chart"
+      >
+        5
+      </div>
+    </div>
     <table
       className="kvm-resources-card__ram-table"
     >
@@ -59,7 +77,7 @@ exports[`KVMResourcesCard renders 1`] = `
               2
             </span>
             <span
-              className="u-nudge-left--small"
+              className="u-nudge-right--small"
             >
               <i
                 className="p-circle--link"
@@ -75,7 +93,7 @@ exports[`KVMResourcesCard renders 1`] = `
               3
             </span>
             <span
-              className="u-nudge-left--small"
+              className="u-nudge-right--small"
             >
               <i
                 className="p-circle--link-faded"
@@ -108,39 +126,13 @@ exports[`KVMResourcesCard renders 1`] = `
     <h4
       className="p-heading--small u-sv1"
     >
-      Virtual functions
+      Network interfaces
     </h4>
-    <div>
-      <KVMMeter
-        allocated={100}
-        data-test="vfs-meter"
-        free={156}
-        total={256}
-      />
-      <hr />
-      <div
-        className="p-heading--small u-text--light"
-      >
-        Network interfaces
-      </div>
-      <span />
-    </div>
-  </div>
-  <div
-    className="kvm-resources-card__section kvm-resources-card__vms"
-  >
-    <h4
-      className="p-heading--small"
-    >
-      Total VMs
-    </h4>
-    <ContextualMenu
-      dropdownContent={<React.Fragment />}
-      hasToggleIcon={true}
-      toggleAppearance="base"
-      toggleClassName="is-dense is-thin"
-      toggleLabel="4"
-    />
+    <span>
+      <em>
+        None
+      </em>
+    </span>
   </div>
 </Card>
 `;

--- a/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
+++ b/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
@@ -1,23 +1,53 @@
 @mixin KVMResourcesCard {
+  $donut-size: 6.5rem;
+  $donut-width: 14px;
+
+  .kvm-resources-card__ram-chart {
+    align-items: center;
+    border-radius: 50%;
+    border: $donut-width solid $color-mid-x-light;
+    display: flex;
+    height: $donut-size;
+    justify-content: center;
+    margin: $spv-outer--small auto $spv-outer--medium auto;
+    width: $donut-size;
+  }
+
   .kvm-resources-card__ram-table {
     margin-bottom: 0;
+
+    th,
+    td {
+      &:nth-child(1) {
+        padding-left: 0;
+        width: 30%;
+      }
+
+      &:nth-child(2) {
+        width: 35%;
+      }
+
+      &:nth-child(3) {
+        padding-right: 0;
+        width: 35%;
+      }
+    }
 
     td {
       padding-bottom: $spv-inner--small;
       padding-top: calc(#{$spv-inner--small} - 1px);
-
-      &:first-of-type {
-        padding-left: 0;
-      }
-
-      &:last-of-type {
-        padding-right: 0;
-      }
     }
 
     @media only screen and (min-width: $breakpoint-medium) {
       margin-top: -$spv-inner--small;
     }
+  }
+
+  .kvm-resources-card__vms-button {
+    line-height: 1;
+    margin: 0;
+    padding-left: $sph-inner--small * 0.5;
+    padding-right: $sph-inner--small;
   }
 
   // Base KVM resources card styling.
@@ -53,9 +83,17 @@
     }
 
     @media only screen and (min-width: $breakpoint-medium) {
+      .kvm-resources-card--wide & {
+        grid:
+          [row1-start] "header content content content" min-content [row1-end]
+          / minmax($donut-size, 1fr) 1fr 1fr 1fr;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-medium) and (max-width: $breakpoint-x-large - 1px) {
       grid:
         [row1-start] "header content content content" min-content [row1-end]
-        / 1fr 1fr 1fr 1fr;
+        / minmax($donut-size, 1fr) 1fr 1fr 1fr;
     }
   }
 
@@ -88,8 +126,9 @@
 
         .kvm-resources-card__ram {
           grid-area: ram;
-          grid-template-areas: "header content content content content";
-          grid-template-columns: repeat(5, minmax(0, 1fr));
+          grid-column-gap: $sph-inner;
+          grid-template-areas: "header content";
+          grid-template-columns: minmax($donut-size, 1fr) 3fr;
         }
 
         .kvm-resources-card__cpu {
@@ -120,11 +159,6 @@
 
       @media only screen and (min-width: $breakpoint-x-large) {
         grid-template-areas: "ram ram ram ram cpu cpu cpu vfs vfs vfs vms vms";
-
-        .kvm-resources-card__ram {
-          grid-template-areas: "header content content content";
-          grid-template-columns: repeat(4, minmax(0, 1fr));
-        }
 
         .kvm-resources-card__vms {
           grid-template-areas: "header content";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
@@ -21,6 +21,7 @@ const fakeVFs = {
   free: 224,
   total: 256,
 };
+const fakeVMs = ["machine1", "machine2", "machine3", "machine4"];
 
 type Props = { id: number };
 
@@ -68,6 +69,7 @@ const KVMAggregateResources = ({ id }: Props): JSX.Element => {
           hugepage: fakeHugepageRAM,
         }}
         vfs={fakeVFs}
+        vms={fakeVMs}
       />
     );
   }

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
@@ -25,4 +25,18 @@ describe("KVMNumaResources", () => {
     ).toBe("Show less NUMA nodes");
     expect(wrapper.find("KVMResourcesCard").length).toBe(numaNodes.length);
   });
+
+  it("shows wide cards if the pod has less than or equal to 2 NUMA nodes", () => {
+    const numaNodes = [fakeNumas[0]];
+    const wrapper = shallow(<KVMNumaResources numaNodes={numaNodes} />);
+
+    expect(wrapper.find(".numa-resources-grid.is-wide").exists()).toBe(true);
+    expect(wrapper.find("KVMResourcesCard").length).toBe(1);
+    expect(
+      wrapper
+        .find("KVMResourcesCard")
+        .prop("className")
+        .includes("kvm-resources-card--wide")
+    ).toBe(true);
+  });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@canonical/react-components";
+import classNames from "classnames";
 import pluralize from "pluralize";
 import React, { useState } from "react";
 
 import type { TSFixMe } from "app/base/types";
 import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
 
-export const TRUNCATION_POINT = 3;
+export const TRUNCATION_POINT = 4;
 
 type Props = { numaNodes: TSFixMe[] };
 
@@ -16,18 +17,25 @@ const KVMNumaResources = ({ numaNodes }: Props): JSX.Element => {
     canBeTruncated && !expanded
       ? numaNodes.slice(0, TRUNCATION_POINT)
       : numaNodes;
+  const showWideCards = numaNodes.length <= 2;
 
   return (
     <>
-      <div className="numa-resources-grid">
+      <div
+        className={classNames("numa-resources-grid", {
+          "is-wide": showWideCards,
+        })}
+      >
         {shownNumaNodes.map((numa) => (
           <KVMResourcesCard
+            className={showWideCards ? "kvm-resources-card--wide" : undefined}
             cores={numa.cores}
             key={numa.index}
             nics={numa.nics}
             ram={numa.ram}
             title={`NUMA node ${numa.index}`}
             vfs={numa.vfs}
+            vms={numa.vms}
           />
         ))}
       </div>

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/_index.scss
@@ -8,7 +8,9 @@
     }
 
     @media only screen and (min-width: $breakpoint-x-large) {
-      grid-template-columns: 1fr 1fr 1fr;
+      &:not(.is-wide) {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+      }
     }
   }
 }

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -37,6 +37,7 @@ export const fakeNumas = [
       },
     },
     vfs: { allocated: 13, free: 1, total: 14 },
+    vms: ["machine1", "machine2", "machine3"],
   },
   {
     cores: { allocated: 200, free: 100, total: 300 },
@@ -57,7 +58,21 @@ export const fakeNumas = [
         unit: "GiB",
       },
     },
-    vfs: { allocated: 18, free: 226, total: 242 },
+    vms: ["machine4"],
+  },
+  {
+    cores: { allocated: 5, free: 5, total: 10 },
+    index: 2,
+    nics: [],
+    ram: {
+      general: {
+        allocated: 5,
+        free: 2,
+        total: 7,
+        unit: "GiB",
+      },
+    },
+    vms: [],
   },
 ];
 

--- a/ui/src/scss/_patterns_buttons.scss
+++ b/ui/src/scss/_patterns_buttons.scss
@@ -65,13 +65,4 @@
   .p-button--link:not(:last-of-type):not(:only-of-type) {
     margin-right: 0;
   }
-
-  button.is-thin {
-    padding-left: $sph-inner--small;
-    padding-right: $sph-inner--small;
-
-    &.has-icon {
-      padding-left: $sph-inner--small * 0.5;
-    }
-  }
 }

--- a/ui/src/scss/_settings.scss
+++ b/ui/src/scss/_settings.scss
@@ -4,7 +4,7 @@ $grid-max-width: 1440 / 16 * 1rem; // express in rems for easier calculations
 $color-navigation-background: #666;
 $color-navigation-background--hover: darken($color-navigation-background, 3%);
 
-$breakpoint-x-large: 1300px;
+$breakpoint-x-large: 1440px;
 $breakpoint-navigation-threshold: 870px;
 $increase-font-size-on-larger-screens: false;
 

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -51,23 +51,15 @@
   }
 
   .u-nudge-left--small {
-    padding-left: $sph-inner--small !important;
+    padding-right: $sph-inner--small !important;
   }
 
   .u-nudge-right {
     padding-left: $sph-inner !important;
   }
 
-  .u-nudge-left {
-    padding-right: $sph-inner !important;
-  }
-
   .u-nudge-right--small {
     padding-left: $sph-inner--small !important;
-  }
-
-  .u-nudge-left--small {
-    padding-right: $sph-inner--small !important;
   }
 
   .u-text--light {


### PR DESCRIPTION
##  Done

- Updated NUMA view to use latest [4-col design](https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f3d3e51af976f14aa6cff34). If the pod has >2 NUMA nodes it will show the 4-col design, otherwise it will show a wider version to fill up the empty space.
- Added a placeholder RAM chart to get an idea of the spacing.
- Updated the fake NUMA data to include instances where VFs, hugepage or VMs are missing, which should be possible with real data.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM details page and check that there is a placeholder RAM chart in the aggregate view.
- Check that this view is fully responsive.
- Go to the NUMA view and check that it now follows the [4-col design](https://app.zeplin.io/project/5f1a24be5ee8af8723f4e7fa/screen/5f3d3e51af976f14aa6cff34)
- Check that this view is fully responsive.
- Remove one or two of the fake NUMA nodes from `KVMSummary.tsx` so there are less than or equal to 2.
- Go to the NUMA view and check that the cards are wide, and that the view is still fully responsive.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2085

## Screenshots
### Aggregate
![0 0 0 0_8400_MAAS_r_kvm_190 (20)](https://user-images.githubusercontent.com/25733845/91245922-fed70500-e791-11ea-8565-e74ab78096b2.png)


### >2 NUMAs
![0 0 0 0_8400_MAAS_r_kvm_190 (21)](https://user-images.githubusercontent.com/25733845/91245926-026a8c00-e792-11ea-9501-ae7af4dfa5ab.png)


### 2 NUMAs
![0 0 0 0_8400_MAAS_r_kvm_190 (22)](https://user-images.githubusercontent.com/25733845/91245929-05657c80-e792-11ea-8f6c-adda09e33071.png)

