### PR TITLE
feat(ui): add mini machine list to kvm node contextual menus.

### DIFF
--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 import ContextualMenu from "app/base/components/ContextualMenu";
 import KVMMeter from "app/kvm/components/KVMMeter";
+import { MachineListTable } from "app/machines/views/MachineList/MachineListTable/MachineListTable";
 
 type ChartValues = {
   allocated: number;
@@ -42,12 +43,28 @@ const KVMResourcesCard = ({
           <h5 className="p-text--paragraph u-flex--between u-no-max-width">
             <span data-test="kvm-resources-card-title">{title}</span>
             <ContextualMenu
-              dropdownContent={<></>}
+              dropdownClassName="kvm-machine-list-modal"
+              dropdownContent={
+                <MachineListTable
+                  hiddenColumns={[
+                    "power",
+                    "owner",
+                    "pool",
+                    "zone",
+                    "fabric",
+                    "disks",
+                    "storage",
+                  ]}
+                  showActions={false}
+                  paginateLimit={5}
+                ></MachineListTable>
+              }
               hasToggleIcon
               toggleAppearance="base"
               toggleClassName="kvm-resources-card__vms-button is-dense"
               toggleDisabled={vms.length === 0}
               toggleLabel={pluralize("machine", vms.length, true)}
+              position="left"
             />
           </h5>
           <hr />
@@ -165,11 +182,27 @@ const KVMResourcesCard = ({
         >
           <h4 className="p-heading--small">Total VMs</h4>
           <ContextualMenu
-            dropdownContent={<></>}
+            dropdownClassName="kvm-machine-list-modal"
+            dropdownContent={
+              <MachineListTable
+                hiddenColumns={[
+                  "power",
+                  "owner",
+                  "pool",
+                  "zone",
+                  "fabric",
+                  "disks",
+                  "storage",
+                ]}
+                showActions={false}
+                paginateLimit={5}
+              ></MachineListTable>
+            }
             hasToggleIcon
             toggleAppearance="base"
             toggleClassName="kvm-resources-card__vms-button is-dense"
             toggleLabel={`${vms.length}`}
+            position="right"
           />
         </div>
       )}

--- a/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
@@ -13,8 +13,26 @@ exports[`KVMResourcesCard renders 1`] = `
       Title
     </span>
     <ContextualMenu
-      dropdownContent={<React.Fragment />}
+      dropdownClassName="kvm-machine-list-modal"
+      dropdownContent={
+        <MachineListTable
+          hiddenColumns={
+            Array [
+              "power",
+              "owner",
+              "pool",
+              "zone",
+              "fabric",
+              "disks",
+              "storage",
+            ]
+          }
+          paginateLimit={5}
+          showActions={false}
+        />
+      }
       hasToggleIcon={true}
+      position="left"
       toggleAppearance="base"
       toggleClassName="kvm-resources-card__vms-button is-dense"
       toggleDisabled={false}

--- a/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
+++ b/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
@@ -2,6 +2,16 @@
   $donut-size: 6.5rem;
   $donut-width: 14px;
 
+  .kvm-machine-list-modal {
+    max-width: none;
+    min-width: 0;
+    width: 35rem;
+
+    @media only screen and (max-width: $breakpoint-small) {
+      width: auto;
+    }
+  }
+
   .kvm-resources-card__ram-chart {
     align-items: center;
     border-radius: 50%;

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -463,6 +463,7 @@ export const MachineListTable = ({
   setSearchFilter,
   showActions = true,
   hiddenColumns = [],
+  paginateLimit = 50,
 }) => {
   const dispatch = useDispatch();
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
@@ -747,7 +748,7 @@ export const MachineListTable = ({
             "machine-list--grouped": grouping !== "none",
           })}
           headers={filterColumns(headers, hiddenColumns, showActions)}
-          paginate={50}
+          paginate={paginateLimit}
           rows={
             grouping === "none"
               ? generateRows({
@@ -785,6 +786,7 @@ MachineListTable.propTypes = {
   setSearchFilter: PropTypes.func,
   showActions: PropTypes.bool,
   hiddenColumns: PropTypes.arrayOf(PropTypes.string),
+  paginateLimit: PropTypes.number,
 };
 
 export default React.memo(MachineListTable);


### PR DESCRIPTION
## Done

- Add machine list modal to kvm node contextual menu dropdown.
- Add `paginateLimit` prop to MachineListTable.

Note: this list is not filtered by numa node, as we're using fake data currently.

![image](https://user-images.githubusercontent.com/130286/91518619-cd526b00-e944-11ea-9993-fb4ceeaa30f4.png)

@amylily1011 I've left this with pagination enabled, and I think it actually feels reasonable, let me know your thoughts. An open question for the core team is how many machines can be associated with any given NUMA node? Is there a realistic range, and a theoretical maximum? 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit KVM details.
- Click the VM and machine chevrons on both NUMA and aggregate view - a mini machine list should render.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2078

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
