### PR TITLE
feat(legacy): enable OVS bridge interface type

### DIFF
--- a/legacy/src/app/controllers/node_details_networking.js
+++ b/legacy/src/app/controllers/node_details_networking.js
@@ -799,7 +799,7 @@ export function NodeNetworkingController(
     let text;
     let type = nic.type;
 
-    if (nic.params && nic.params.bridge_type === "ovs") {
+    if (nic?.params?.bridge_type === "ovs") {
       type = nic.params.bridge_type;
     }
 

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -1674,12 +1674,10 @@
                       >Bridge type</label
                     >
                     <div class="p-form__control col-4">
-                      <p>Standard</p>
-                      <!-- Hidden until OVS becomes available -->
-                      <!-- <select data-ng-model="newBridgeInterface.bridge_type">
-                                                <option value="standard">Standard</option>
-                                                <option value="ovs">Open vSwitch (ovs)</option>
-                                            </select> -->
+                      <select data-ng-model="newBridgeInterface.bridge_type">
+                        <option value="standard">Standard</option>
+                        <option value="ovs">Open vSwitch (ovs)</option>
+                      </select>
                     </div>
                   </div>
                   <div
@@ -6126,7 +6124,7 @@
                     blank?</strong
                   ><br />
                   Used disks will be returned to available, and any volume
-                  groups, raid sets,  caches, and filesystems removed.<br />
+                  groups, raid sets, caches, and filesystems removed.<br />
                   The storage layout will be applied to a node when it is
                   deployed.
                 </p>


### PR DESCRIPTION
## Done

Enable Open vSwitch support for bridge interfaces in Network Details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Add a new interface to a deployed machine.
- Create a bridge, and select Open vSwitch as the bridge type
- You should see a bridge created with the "Open vSwitch"

![image](https://user-images.githubusercontent.com/130286/92180256-b4910a80-ee9a-11ea-99e2-44e050eefd50.png)

## Fixes

Fixes: canonical-web-and-design/maas-squad#2090

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
