### PR TITLE
fix(legacy): don't use text--small

### DIFF
--- a/legacy/src/app/partials/dashboard.html
+++ b/legacy/src/app/partials/dashboard.html
@@ -70,7 +70,7 @@
                                     <br>
                                     If active subnet mapping is enabled on the configured subnets, MAAS will actively scan them and ensure discovery information is accurate and complete.
                                 </p>
-                                <p class="u-remove-max-width u-no-margin--bottom">Learn more about <a class="p-link--external p-text--small" href="https://maas.io/docs/network-discovery">network discovery</a>.</p>
+                                <p class="u-remove-max-width u-no-margin--bottom">Learn more about <a class="p-link--external" href="https://maas.io/docs/network-discovery">network discovery</a>.</p>
                             </div>
                             <div data-ng-if="networkDiscovery.value === 'disabled'">
                                 <p class="u-remove-max-width u-no-padding--top">Clearing all discoveries will remove all items from the list.</p>


### PR DESCRIPTION
## Done

- Removed `p-text--small` class

## QA

Fixes issue from #1599 

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- On a MAAS with discoveries, go to the dashboard, click on 'Clear all discoveries' and observe the text
