### PR TITLE
feat(ui): improve responsiveness of KVM VM dropdowns

### DIFF
--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.js
@@ -8,6 +8,18 @@ import usePortal from "react-useportal";
 import ContextualMenuDropdown from "./ContextualMenuDropdown";
 import { usePrevious } from "app/base/hooks";
 
+export const getDropdownPosition = (wrapper) => {
+  if (!wrapper?.current?.getBoundingClientRect) {
+    return "right";
+  }
+  const { left, width } = wrapper.current.getBoundingClientRect();
+
+  if (left + width / 2 < window.innerWidth / 2) {
+    return "left";
+  }
+  return "right";
+};
+
 const ContextualMenu = ({
   className,
   constrainPanelWidth,
@@ -32,9 +44,14 @@ const ContextualMenu = ({
   });
   const previousIsOpen = usePrevious(isOpen);
   const labelNode = toggleLabel ? <span>{toggleLabel}</span> : null;
+  const dropdownPosition =
+    position === "auto" ? getDropdownPosition(wrapper) : position;
   const wrapperClass = classNames(
     className,
-    ["p-contextual-menu", position === "right" ? null : position]
+    [
+      "p-contextual-menu",
+      dropdownPosition === "right" ? null : dropdownPosition,
+    ]
       .filter(Boolean)
       .join("--")
   );
@@ -96,7 +113,7 @@ const ContextualMenu = ({
             id={id.current}
             isOpen={isOpen}
             links={links}
-            position={position}
+            position={dropdownPosition}
             positionNode={positionNode ? positionNode.current : null}
             wrapper={wrapper.current}
             wrapperClass={wrapperClass}
@@ -122,7 +139,7 @@ ContextualMenu.propTypes = {
   ),
   onToggleMenu: PropTypes.func,
   positionNode: PropTypes.object,
-  position: PropTypes.oneOf(["left", "center", "right"]),
+  position: PropTypes.oneOf(["auto", "left", "center", "right"]),
   toggleAppearance: PropTypes.string,
   toggleClassName: PropTypes.string,
   toggleDisabled: PropTypes.bool,

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenu.test.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenu.test.js
@@ -1,9 +1,13 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import ContextualMenu from "./ContextualMenu";
+import ContextualMenu, { getDropdownPosition } from "./ContextualMenu";
 
 describe("ContextualMenu ", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("renders", () => {
     const wrapper = mount(<ContextualMenu links={[]} />);
     expect(wrapper.find("ContextualMenu")).toMatchSnapshot();
@@ -186,5 +190,28 @@ describe("ContextualMenu ", () => {
     expect(
       wrapper.find("button.p-contextual-menu__toggle").prop("aria-expanded")
     ).toBe("false");
+  });
+
+  it("can dynamically calculate position, defaulting to right", () => {
+    expect(getDropdownPosition()).toBe("right");
+
+    global.innerWidth = 1000;
+    const leftWrapper = {
+      current: {
+        // Middle of toggle is to the left of the viewport center
+        // 300 + 200 / 2 = 400, less than 500
+        getBoundingClientRect: () => ({ left: 300, width: 200 }),
+      },
+    };
+    expect(getDropdownPosition(leftWrapper)).toBe("left");
+
+    const rightWrapper = {
+      current: {
+        // Middle of toggle is to the right of the viewport center
+        // 200 + 800 / 2 = 600, more than 500
+        getBoundingClientRect: () => ({ left: 200, width: 800 }),
+      },
+    };
+    expect(getDropdownPosition(rightWrapper)).toBe("right");
   });
 });

--- a/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.js
+++ b/ui/src/app/base/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.js
@@ -152,7 +152,7 @@ ContextualMenuDropdown.propTypes = {
       PropTypes.arrayOf(PropTypes.shape(Button.propTypes)),
     ])
   ),
-  position: PropTypes.oneOf(["left", "center", "right"]),
+  position: PropTypes.oneOf(["auto", "left", "center", "right"]),
   positionNode: PropTypes.object,
   wrapper: PropTypes.object,
   wrapperClass: PropTypes.string,

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -49,7 +49,6 @@ const KVMResourcesCard = ({
               dropdownContent={
                 <MachineListTable
                   hiddenColumns={[
-                    "power",
                     "owner",
                     "pool",
                     "zone",
@@ -66,7 +65,7 @@ const KVMResourcesCard = ({
               toggleClassName="kvm-resources-card__vms-button is-dense"
               toggleDisabled={vms.length === 0}
               toggleLabel={pluralize("machine", vms.length, true)}
-              position="left"
+              position="auto"
             />
           </h5>
           <hr />
@@ -219,7 +218,6 @@ const KVMResourcesCard = ({
             dropdownContent={
               <MachineListTable
                 hiddenColumns={[
-                  "power",
                   "owner",
                   "pool",
                   "zone",
@@ -235,7 +233,7 @@ const KVMResourcesCard = ({
             toggleAppearance="base"
             toggleClassName="kvm-resources-card__vms-button is-dense"
             toggleLabel={`${vms.length}`}
-            position="right"
+            position="auto"
           />
         </div>
       )}

--- a/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`KVMResourcesCard renders 1`] = `
         <MachineListTable
           hiddenColumns={
             Array [
-              "power",
               "owner",
               "pool",
               "zone",
@@ -32,7 +31,7 @@ exports[`KVMResourcesCard renders 1`] = `
         />
       }
       hasToggleIcon={true}
-      position="left"
+      position="auto"
       toggleAppearance="base"
       toggleClassName="kvm-resources-card__vms-button is-dense"
       toggleDisabled={false}

--- a/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
+++ b/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
@@ -5,10 +5,35 @@
   .kvm-machine-list-modal {
     max-width: none;
     min-width: 0;
-    width: 35rem;
+    // Subtract small screen gutter width and card inner padding to center dropdown.
+    width: calc(100vw - #{(map-get($grid-gutter-widths, small) + $sph-inner) * 2});
 
-    @media only screen and (max-width: $breakpoint-small) {
-      width: auto;
+    .fqdn-col,
+    .status-col {
+      width: 50%;
+    }
+
+    .power-col {
+      width: 0;
+    }
+
+    .cores-col,
+    .ram-col {
+      width: 5rem;
+    }
+
+    @media only screen and (min-width: $breakpoint-x-small) {
+      .power-col {
+        width: 7rem;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-small) {
+      width: 35rem;
+    }
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      width: 40rem;
     }
   }
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -122,6 +122,7 @@ const generateRows = ({
     const columns = [
       {
         key: "fqdn",
+        className: "fqdn-col",
         content: (
           <NameColumn
             data-test="fqdn-column"
@@ -138,6 +139,7 @@ const generateRows = ({
       },
       {
         key: "power",
+        className: "power-col",
         content: (
           <PowerColumn
             data-test="power-column"
@@ -148,6 +150,7 @@ const generateRows = ({
       },
       {
         key: "status",
+        className: "status-col",
         content: (
           <StatusColumn
             data-test="status-column"
@@ -158,6 +161,7 @@ const generateRows = ({
       },
       {
         key: "owner",
+        className: "owner-col",
         content: (
           <OwnerColumn
             data-test="owner-column"
@@ -168,6 +172,7 @@ const generateRows = ({
       },
       {
         key: "pool",
+        className: "pool-col",
         content: (
           <PoolColumn
             data-test="pool-column"
@@ -178,6 +183,7 @@ const generateRows = ({
       },
       {
         key: "zone",
+        className: "zone-col",
         content: (
           <ZoneColumn
             data-test="zone-column"
@@ -188,30 +194,35 @@ const generateRows = ({
       },
       {
         key: "fabric",
+        className: "fabric-col",
         content: (
           <FabricColumn data-test="fabric-column" systemId={row.system_id} />
         ),
       },
       {
         key: "cpu",
+        className: "cores-col",
         content: (
           <CoresColumn data-test="cpu-column" systemId={row.system_id} />
         ),
       },
       {
         key: "memory",
+        className: "ram-col",
         content: (
           <RamColumn data-test="memory-column" systemId={row.system_id} />
         ),
       },
       {
         key: "disks",
+        className: "disks-col",
         content: (
           <DisksColumn data-test="disks-column" systemId={row.system_id} />
         ),
       },
       {
         key: "storage",
+        className: "storage-col",
         content: (
           <StorageColumn data-test="storage-column" systemId={row.system_id} />
         ),
@@ -537,6 +548,7 @@ export const MachineListTable = ({
   const headers = [
     {
       key: "fqdn",
+      className: "fqdn-col",
       content: (
         <div
           className={classNames("u-flex", {
@@ -589,6 +601,7 @@ export const MachineListTable = ({
     },
     {
       key: "power",
+      className: "power-col",
       content: (
         <TableHeader
           className="p-double-row__header-spacer"
@@ -603,6 +616,7 @@ export const MachineListTable = ({
     },
     {
       key: "status",
+      className: "status-col",
       content: (
         <TableHeader
           className="p-double-row__header-spacer"
@@ -617,6 +631,7 @@ export const MachineListTable = ({
     },
     {
       key: "owner",
+      className: "owner-col",
       content: (
         <>
           <TableHeader
@@ -633,6 +648,7 @@ export const MachineListTable = ({
     },
     {
       key: "pool",
+      className: "pool-col",
       content: (
         <>
           <TableHeader
@@ -649,6 +665,7 @@ export const MachineListTable = ({
     },
     {
       key: "zone",
+      className: "zone-col",
       content: (
         <>
           <TableHeader
@@ -665,6 +682,7 @@ export const MachineListTable = ({
     },
     {
       key: "fabric",
+      className: "fabric-col",
       content: (
         <>
           <TableHeader
@@ -681,6 +699,7 @@ export const MachineListTable = ({
     },
     {
       key: "cpu",
+      className: "cores-col u-align--right",
       content: (
         <>
           <TableHeader
@@ -694,10 +713,10 @@ export const MachineListTable = ({
           <TableHeader>Arch</TableHeader>
         </>
       ),
-      className: "u-align--right",
     },
     {
       key: "memory",
+      className: "ram-col u-align--right",
       content: (
         <TableHeader
           currentSort={currentSort}
@@ -708,10 +727,10 @@ export const MachineListTable = ({
           RAM
         </TableHeader>
       ),
-      className: "u-align--right",
     },
     {
       key: "disks",
+      className: "disks-col u-align--right",
       content: (
         <TableHeader
           currentSort={currentSort}
@@ -722,10 +741,10 @@ export const MachineListTable = ({
           Disks
         </TableHeader>
       ),
-      className: "u-align--right",
     },
     {
       key: "storage",
+      className: "storage-col u-align--right",
       content: (
         <TableHeader
           currentSort={currentSort}
@@ -736,7 +755,6 @@ export const MachineListTable = ({
           Storage
         </TableHeader>
       ),
-      className: "u-align--right",
     },
   ];
 

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -59,52 +59,48 @@
     justify-content: flex-end;
   }
 
-  .machine-list td,
-  .machine-list th {
-    // FQDN/MAC
-    &:nth-child(1) {
-      @include breakpoint-widths(45%, 35%, 26%, 24%, 20%);
-    }
-    // Power
-    &:nth-child(2) {
-      @include breakpoint-widths(25%, 17%, 14%, 12%, 10%);
-    }
-    // Status
-    &:nth-child(3) {
-      @include breakpoint-widths(30%, 28%, 18%, 18%, 15%);
-    }
-    // Owner
-    &:nth-child(4) {
-      @include breakpoint-widths(0, 20%, 8%, 9%, 9%);
-    }
-    // Pool
-    &:nth-child(5) {
-      @include breakpoint-widths(0, 0, 0, 0, 7%);
-    }
-    // Zone
-    &:nth-child(6) {
-      @include breakpoint-widths(0, 0, 0, 9%, 7%);
-    }
-    // Fabric
-    &:nth-child(7) {
-      @include breakpoint-widths(0, 0, 0, 0, 7%);
-    }
-    // Cores
-    &:nth-child(8) {
-      @include breakpoint-widths(0, 0, 8%, 6%, 6%);
-    }
-    // RAM
-    &:nth-child(9) {
-      @include breakpoint-widths(0, 0, 9%, 8%, 7%);
-    }
-    // Disks
-    &:nth-child(10) {
-      @include breakpoint-widths(0, 0, 8%, 6%, 6%);
-    }
-    // Storage
-    &:nth-child(11) {
-      @include breakpoint-widths(0, 0, 9%, 8%, 6%);
-    }
+  .fqdn-col {
+    @include breakpoint-widths(45%, 35%, 26%, 24%, 20%);
+  }
+
+  .power-col {
+    @include breakpoint-widths(25%, 17%, 14%, 12%, 10%);
+  }
+
+  .status-col {
+    @include breakpoint-widths(30%, 28%, 18%, 18%, 15%);
+  }
+
+  .owner-col {
+    @include breakpoint-widths(0, 20%, 8%, 9%, 9%);
+  }
+
+  .pool-col {
+    @include breakpoint-widths(0, 0, 0, 0, 7%);
+  }
+
+  .zone-col {
+    @include breakpoint-widths(0, 0, 0, 9%, 7%);
+  }
+
+  .fabric-col {
+    @include breakpoint-widths(0, 0, 0, 0, 7%);
+  }
+
+  .cores-col {
+    @include breakpoint-widths(0, 0, 8%, 6%, 6%);
+  }
+
+  .ram-col {
+    @include breakpoint-widths(0, 0, 9%, 8%, 7%);
+  }
+
+  .disks-col {
+    @include breakpoint-widths(0, 0, 8%, 6%, 6%);
+  }
+
+  .storage-col {
+    @include breakpoint-widths(0, 0, 9%, 8%, 6%);
   }
 
   .u-nudge--checkbox {


### PR DESCRIPTION
## Done

- Added "auto" position prop to ContextualMenu.
- Gave class names to MachineList cells.
- Added Power col to VMs dropdown.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to KVM details and check that the VMs dropdown shows to the left or right of the toggle depending on where it sits in the viewport.

## Fixes

Fixes #1590 
