### PR TITLE
fix(ci): ensure betterer returns exit code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: CYPRESS_INSTALL_BINARY=0 yarn install
-      - run: yarn betterer |& tee results.txt
+      - name: Pipe betterer results to results.txt
+        run: |
+          set -o pipefail
+          yarn betterer |& tee results.txt
+          set +o pipefail
         env:
           CI: true
       - name: Upload betterer results


### PR DESCRIPTION
## Done
Previously, the betterer ci job would always pass as we returned the exit code of tee, rather than the exit code of the betterer command piped to tee. Setting `pipefail` ensures we return the correct exit code.

> The exit status of a pipeline is the exit status of the last command in the pipeline, unless the pipefail option is enabled (see The Set Builtin). If pipefail is enabled, the pipeline’s return status is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands exit successfully. If the reserved word ‘!’ precedes the pipeline, the exit status is the logical negation of the exit status as described above. The shell waits for all commands in the pipeline to terminate before returning a value.

https://www.gnu.org/software/bash/manual/html_node/Pipelines.html

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
Tricky for someone else to QA, as getting CI to pass here requires me to update betterer. Prior to updating betterer, I confirmed that CI was indeed failing without a betterer update:

![image](https://user-images.githubusercontent.com/130286/92345422-59bb1580-f11d-11ea-860a-43af3d3a61c7.png)

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
