### PR TITLE
refactor(ui): add device slice

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -634,5 +634,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `548`
+  value: `542`
 };

--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -19,7 +19,7 @@ Object {
     "saving": false,
   },
   "device": Object {
-    "errors": Object {},
+    "errors": null,
     "items": Array [],
     "loaded": false,
     "loading": false,

--- a/ui/src/app/base/actions/device/device.js
+++ b/ui/src/app/base/actions/device/device.js
@@ -1,5 +1,0 @@
-import { createStandardActions } from "app/utils/redux";
-
-const device = createStandardActions("device");
-
-export default device;

--- a/ui/src/app/base/actions/device/index.js
+++ b/ui/src/app/base/actions/device/index.js
@@ -1,1 +1,0 @@
-export { default } from "./device";

--- a/ui/src/app/base/actions/index.ts
+++ b/ui/src/app/base/actions/index.ts
@@ -1,6 +1,5 @@
 export { default as auth } from "./auth";
 export { default as controller } from "./controller";
-export { default as device } from "./device";
 export { default as dhcpsnippet } from "./dhcpsnippet";
 export { default as fabric } from "./fabric";
 export { default as general } from "./general";

--- a/ui/src/app/base/reducers/device/device.js
+++ b/ui/src/app/base/reducers/device/device.js
@@ -1,7 +1,0 @@
-import { createStandardReducer } from "app/utils/redux";
-
-import { device as deviceActions } from "app/base/actions";
-
-const device = createStandardReducer(deviceActions);
-
-export default device;

--- a/ui/src/app/base/reducers/device/index.js
+++ b/ui/src/app/base/reducers/device/index.js
@@ -1,1 +1,0 @@
-export { default } from "./device";

--- a/ui/src/app/base/reducers/index.ts
+++ b/ui/src/app/base/reducers/index.ts
@@ -1,6 +1,5 @@
 export { default as auth } from "./auth";
 export { default as controller } from "./controller";
-export { default as device } from "./device";
 export { default as dhcpsnippet } from "./dhcpsnippet";
 export { default as fabric } from "./fabric";
 export { default as general } from "./general";

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.js
@@ -6,7 +6,6 @@ import * as Yup from "yup";
 
 import {
   controller as controllerActions,
-  device as deviceActions,
   dhcpsnippet as dhcpsnippetActions,
   machine as machineActions,
   subnet as subnetActions,
@@ -20,6 +19,7 @@ import DhcpFormFields from "../DhcpFormFields";
 import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
+import { actions as deviceActions } from "app/store/device";
 
 const DhcpSchema = Yup.object().shape({
   description: Yup.string(),

--- a/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.js
@@ -184,7 +184,7 @@ describe("DhcpForm", () => {
     expect(actions.some((action) => action.type === "FETCH_MACHINE")).toBe(
       true
     );
-    expect(actions.some((action) => action.type === "FETCH_DEVICE")).toBe(true);
+    expect(actions.some((action) => action.type === "device/fetch")).toBe(true);
     expect(actions.some((action) => action.type === "FETCH_SUBNET")).toBe(true);
     expect(actions.some((action) => action.type === "FETCH_CONTROLLER")).toBe(
       true

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
@@ -6,12 +6,12 @@ import React, { useEffect, useState } from "react";
 
 import {
   controller as controllerActions,
-  device as deviceActions,
   dhcpsnippet as dhcpsnippetActions,
   machine as machineActions,
   subnet as subnetActions,
 } from "app/base/actions";
 import controllerSelectors from "app/store/controller/selectors";
+import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import subnetSelectors from "app/store/subnet/selectors";

--- a/ui/src/app/store/device/actions.test.ts
+++ b/ui/src/app/store/device/actions.test.ts
@@ -1,13 +1,14 @@
-import device from "./device";
+import { actions } from "./";
 
 describe("device actions", () => {
   it("should handle fetching devices", () => {
-    expect(device.fetch()).toEqual({
-      type: "FETCH_DEVICE",
+    expect(actions.fetch()).toEqual({
+      type: "device/fetch",
       meta: {
         model: "device",
         method: "list",
       },
+      payload: null,
     });
   });
 });

--- a/ui/src/app/store/device/index.ts
+++ b/ui/src/app/store/device/index.ts
@@ -1,0 +1,1 @@
+export { default, actions } from "./slice";

--- a/ui/src/app/store/device/reducers.test.ts
+++ b/ui/src/app/store/device/reducers.test.ts
@@ -1,9 +1,10 @@
-import device from "./device";
+import { device as deviceFactory } from "testing/factories";
+import reducers, { actions } from "./";
 
 describe("device reducer", () => {
   it("should return the initial state", () => {
-    expect(device(undefined, {})).toEqual({
-      errors: {},
+    expect(reducers(undefined, { type: "" })).toEqual({
+      errors: null,
       items: [],
       loaded: false,
       loading: false,
@@ -12,13 +13,9 @@ describe("device reducer", () => {
     });
   });
 
-  it("should correctly reduce FETCH_DEVICE_START", () => {
-    expect(
-      device(undefined, {
-        type: "FETCH_DEVICE_START",
-      })
-    ).toEqual({
-      errors: {},
+  it("reduces fetchStart", () => {
+    expect(reducers(undefined, actions.fetchStart())).toEqual({
+      errors: null,
       items: [],
       loaded: false,
       loading: true,
@@ -27,9 +24,10 @@ describe("device reducer", () => {
     });
   });
 
-  it("should correctly reduce FETCH_DEVICE_SUCCESS", () => {
+  it("reduces fetchSuccess", () => {
+    const devices = [deviceFactory(), deviceFactory()];
     expect(
-      device(
+      reducers(
         {
           errors: {},
           items: [],
@@ -38,22 +36,13 @@ describe("device reducer", () => {
           saved: false,
           saving: false,
         },
-        {
-          type: "FETCH_DEVICE_SUCCESS",
-          payload: [
-            { id: 1, hostname: "test1" },
-            { id: 2, hostname: "test2" },
-          ],
-        }
+        actions.fetchSuccess(devices)
       )
     ).toEqual({
       errors: {},
       loading: false,
       loaded: true,
-      items: [
-        { id: 1, hostname: "test1" },
-        { id: 2, hostname: "test2" },
-      ],
+      items: devices,
       saved: false,
       saving: false,
     });

--- a/ui/src/app/store/device/slice.ts
+++ b/ui/src/app/store/device/slice.ts
@@ -1,0 +1,18 @@
+import { SliceCaseReducers } from "@reduxjs/toolkit";
+
+import { generateSlice, GenericSlice } from "../utils";
+import { Device, DeviceState } from "./types";
+
+type DeviceReducers = SliceCaseReducers<DeviceState>;
+
+export type DeviceSlice = GenericSlice<DeviceState, Device, DeviceReducers>;
+
+const DeviceSlice = generateSlice<
+  Device,
+  DeviceState["errors"],
+  DeviceReducers
+>({ name: "device" }) as DeviceSlice;
+
+export const { actions } = DeviceSlice;
+
+export default DeviceSlice.reducer;

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -5,7 +5,6 @@ import { connectRouter } from "connected-react-router";
 import {
   auth,
   controller,
-  device,
   dhcpsnippet,
   fabric,
   general,
@@ -26,6 +25,7 @@ import {
 } from "./app/base/reducers";
 import { config } from "./app/settings/reducers";
 import { initialState as userInitialState } from "./app/base/reducers/user/user";
+import device from "app/store/device";
 import domain from "app/store/domain";
 import pod from "app/store/pod";
 import resourcepool from "app/store/resourcepool";


### PR DESCRIPTION
## Done
Migrate `device` to slice.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- visit dhcp form, ensure devices are still fetched.

## Fixes

Fixes: canonical-web-and-design/MAAS-design#921

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
