### PR TITLE
feat(ui): added the machine details route

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -39,7 +39,7 @@ exports[`stricter compilation`] = {
       [71, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:2156486800": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -81,7 +81,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -359,6 +359,15 @@ exports[`stricter compilation`] = {
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [27, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
+    "src/app/machines/views/MachineDetails/MachineDetails.tsx:1571476111": [
+      [25, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:373422406": [
+      [22, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:176262547": [
+      [24, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx:3272981959": [
       [12, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [62, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
@@ -634,5 +643,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `542`
+  value: `537`
 };

--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -4,6 +4,7 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import ErrorBoundary from "app/base/components/ErrorBoundary";
 import KVM from "app/kvm/views/KVM";
 import Machines from "app/machines/views/Machines";
+import MachineDetails from "app/machines/views/MachineDetails";
 import NotFound from "app/base/views/NotFound";
 import Preferences from "app/preferences/views/Preferences";
 import Settings from "app/settings/views/Settings";
@@ -34,6 +35,15 @@ const Routes = () => (
       render={() => (
         <ErrorBoundary>
           <Machines />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      exact
+      path={["/machine/:id"]}
+      render={() => (
+        <ErrorBoundary>
+          <MachineDetails />
         </ErrorBoundary>
       )}
     />

--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -15,6 +15,19 @@ machine.fetch = () => {
   };
 };
 
+machine.get = (system_id) => {
+  return {
+    type: "GET_MACHINE",
+    meta: {
+      model: "machine",
+      method: "get",
+    },
+    payload: {
+      params: { system_id },
+    },
+  };
+};
+
 machine.create = (params) => {
   return {
     type: "CREATE_MACHINE",

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -14,6 +14,19 @@ describe("machine actions", () => {
     });
   });
 
+  it("can get machines", () => {
+    expect(machine.get("abc123")).toEqual({
+      type: "GET_MACHINE",
+      meta: {
+        model: "machine",
+        method: "get",
+      },
+      payload: {
+        params: { system_id: "abc123" },
+      },
+    });
+  });
+
   it("can handle creating machines", () => {
     expect(
       machine.create({ name: "machine1", description: "a machine" })

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -115,6 +115,7 @@ const machine = createNextState(
     });
     switch (action.type) {
       case "FETCH_MACHINE_START":
+      case "GET_MACHINE_START":
         draft.loading = true;
         break;
       case "FETCH_MACHINE_COMPLETE":
@@ -150,8 +151,10 @@ const machine = createNextState(
         break;
       case "ADD_MACHINE_CHASSIS_ERROR":
       case "FETCH_MACHINE_ERROR":
+      case "GET_MACHINE_ERROR":
       case "CREATE_MACHINE_ERROR":
         draft.errors = action.error;
+        draft.loading = false;
         draft.saving = false;
         break;
       case "CREATE_MACHINE_NOTIFY":
@@ -184,6 +187,22 @@ const machine = createNextState(
             break;
           }
         }
+        break;
+      case "GET_MACHINE_SUCCESS":
+        const machine = action.payload;
+        // If the item already exists, update it, otherwise
+        // add it to the store.
+        const i = draft.items.findIndex(
+          (draftItem) => draftItem.system_id === machine.system_id
+        );
+        if (i !== -1) {
+          draft.items[i] = machine;
+        } else {
+          draft.items.push(machine);
+          // Set up the statuses for this machine.
+          draft.statuses[machine.system_id] = DEFAULT_STATUSES;
+        }
+        draft.loading = false;
         break;
       case "SET_SELECTED_MACHINES":
         draft.selected = action.payload;

--- a/ui/src/app/base/reducers/machine/machine.test.js
+++ b/ui/src/app/base/reducers/machine/machine.test.js
@@ -150,6 +150,128 @@ describe("machine reducer", () => {
     });
   });
 
+  it("should correctly reduce GET_MACHINE_START", () => {
+    expect(
+      machine(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: true,
+          saving: false,
+          selected: [],
+        },
+        {
+          type: "GET_MACHINE_START",
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [],
+      loaded: false,
+      loading: true,
+      saved: true,
+      saving: false,
+      selected: [],
+    });
+  });
+
+  it("should correctly reduce GET_MACHINE_ERROR", () => {
+    expect(
+      machine(
+        {
+          errors: {},
+          items: [],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: true,
+          selected: [],
+        },
+        {
+          error: { system_id: "id was not supplied" },
+          type: "GET_MACHINE_ERROR",
+        }
+      )
+    ).toEqual({
+      errors: { system_id: "id was not supplied" },
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+      selected: [],
+    });
+  });
+
+  it("should update if machine exists on GET_MACHINE_SUCCESS", () => {
+    expect(
+      machine(
+        {
+          errors: {},
+          items: [{ id: 1, name: "machine1", system_id: "abc" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false,
+          selected: [],
+          statuses: { abc: STATUSES },
+        },
+        {
+          payload: { id: 1, name: "machine1-newname", system_id: "abc" },
+          type: "GET_MACHINE_SUCCESS",
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [{ id: 1, name: "machine1-newname", system_id: "abc" }],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+      selected: [],
+      statuses: {
+        abc: STATUSES,
+      },
+    });
+  });
+
+  it("should correctly reduce GET_MACHINE_SUCCESS", () => {
+    expect(
+      machine(
+        {
+          errors: {},
+          items: [{ id: 1, name: "machine1" }],
+          loaded: false,
+          loading: false,
+          saved: false,
+          saving: false,
+          selected: [],
+          statuses: {},
+        },
+        {
+          payload: { id: 2, name: "machine2", system_id: "abc" },
+          type: "GET_MACHINE_SUCCESS",
+        }
+      )
+    ).toEqual({
+      errors: {},
+      items: [
+        { id: 1, name: "machine1" },
+        { id: 2, name: "machine2", system_id: "abc" },
+      ],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+      selected: [],
+      statuses: {
+        abc: STATUSES,
+      },
+    });
+  });
+
   it("should correctly reduce CREATE_MACHINE_START", () => {
     expect(
       machine(
@@ -236,6 +358,7 @@ describe("machine reducer", () => {
       },
     });
   });
+
   it("should correctly reduce CREATE_MACHINE_NOTIFY", () => {
     expect(
       machine(

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -1,0 +1,40 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import MachineDetails from "./MachineDetails";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("MachineDetails", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineFactory({ system_id: "abc123" })],
+      }),
+    });
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineDetails />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachineDetails")).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -1,0 +1,42 @@
+import { Route, Switch } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import React, { useEffect } from "react";
+
+import { machine as machineActions } from "app/base/actions";
+import MachineHeader from "./MachineHeader";
+import machineSelectors from "app/store/machine/selectors";
+import MachineSummary from "./MachineSummary";
+import Section from "app/base/components/Section";
+import type { RootState } from "app/store/root/types";
+
+type RouteParams = {
+  id: string;
+};
+
+const MachineDetails = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const params = useParams<RouteParams>();
+  const { id } = params;
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+
+  useEffect(() => {
+    dispatch(machineActions.get(id));
+  }, [dispatch, id]);
+
+  return (
+    <Section header={<MachineHeader />} headerClassName="u-no-padding--bottom">
+      {machine && (
+        <Switch>
+          <Route exact path="/machine/:id">
+            <MachineSummary />
+          </Route>
+        </Switch>
+      )}
+    </Section>
+  );
+};
+
+export default MachineDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -1,0 +1,40 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import MachineHeader from "./MachineHeader";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("MachineHeader", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineFactory({ system_id: "abc123" })],
+      }),
+    });
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachineHeader")).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,0 +1,31 @@
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import React, { useEffect } from "react";
+
+import { machine as machineActions } from "app/base/actions";
+import machineSelectors from "app/store/machine/selectors";
+import SectionHeader from "app/base/components/SectionHeader";
+import type { RootState } from "app/store/root/types";
+
+type RouteParams = {
+  id: string;
+};
+
+const MachineHeader = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const { id } = useParams<RouteParams>();
+  const loading = useSelector(machineSelectors.loading);
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+
+  useEffect(() => {
+    dispatch(machineActions.get(id));
+  }, [dispatch, id]);
+
+  return (
+    <SectionHeader loading={loading || !machine} title={machine?.fqdn || ""} />
+  );
+};
+
+export default MachineHeader;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/__snapshots__/MachineHeader.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/__snapshots__/MachineHeader.test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineHeader renders 1`] = `
+<MachineHeader>
+  <SectionHeader
+    loading={true}
+    title=""
+  >
+    <div
+      className="u-flex--between u-flex--wrap"
+    >
+      <ul
+        className="p-inline-list"
+      >
+        <li
+          className="p-inline-list__item p-heading--four"
+          data-test="section-header-title"
+        />
+        <li
+          className="p-inline-list__item last-item u-text--light"
+        >
+          <Spinner
+            className="u-no-padding u-no-margin"
+            inline={true}
+            text="Loading..."
+          >
+            <span
+              className="u-no-padding u-no-margin p-spinner p-text--default p-spinner--inline"
+            >
+              <i
+                className="p-icon--spinner u-animation--spin"
+              />
+              <span
+                className="p-icon__text"
+              >
+                Loading...
+              </span>
+            </span>
+          </Spinner>
+        </li>
+      </ul>
+    </div>
+  </SectionHeader>
+</MachineHeader>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineHeader";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -1,0 +1,55 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import MachineSummary from "./MachineSummary";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("MachineSummary", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineFactory({ system_id: "abc123" })],
+      }),
+    });
+  });
+
+  it("displays a spinner if pods are loading", () => {
+    state.machine.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineSummary />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineSummary />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachineSummary")).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -1,0 +1,35 @@
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import React, { useEffect } from "react";
+
+import { machine as machineActions } from "app/base/actions";
+import { useWindowTitle } from "app/base/hooks";
+import machineSelectors from "app/store/machine/selectors";
+import type { RootState } from "app/store/root/types";
+
+type RouteParams = {
+  id: string;
+};
+
+const MachineSummary = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const { id } = useParams<RouteParams>();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+
+  useWindowTitle(`machine ${`${machine?.fqdn} ` || ""} details`);
+
+  useEffect(() => {
+    dispatch(machineActions.get(id));
+  }, [dispatch, id]);
+
+  if (!machine) {
+    return <Spinner text="Loading" />;
+  }
+
+  return <>{machine.fqdn}</>;
+};
+
+export default MachineSummary;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/__snapshots__/MachineSummary.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/__snapshots__/MachineSummary.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineSummary renders 1`] = `
+<MachineSummary>
+  <Spinner
+    text="Loading"
+  >
+    <span
+      className="p-spinner p-text--default"
+    >
+      <i
+        className="p-icon--spinner u-animation--spin"
+      />
+      <span
+        className="p-icon__text"
+      >
+        Loading
+      </span>
+    </span>
+  </Spinner>
+</MachineSummary>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineSummary";

--- a/ui/src/app/machines/views/MachineDetails/__snapshots__/MachineDetails.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/__snapshots__/MachineDetails.test.tsx.snap
@@ -1,0 +1,410 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineDetails renders 1`] = `
+<MachineDetails>
+  <Section
+    header={<MachineHeader />}
+    headerClassName="u-no-padding--bottom"
+  >
+    <div
+      className="section"
+    >
+      <Strip
+        className="section__header u-no-padding--bottom"
+        element="header"
+        shallow={true}
+      >
+        <header
+          className="section__header u-no-padding--bottom p-strip is-shallow"
+        >
+          <Row>
+            <div
+              className="row"
+            >
+              <Col
+                size="12"
+              >
+                <div
+                  className="col-12"
+                >
+                  <MachineHeader>
+                    <SectionHeader
+                      loading={true}
+                      title=""
+                    >
+                      <div
+                        className="u-flex--between u-flex--wrap"
+                      >
+                        <ul
+                          className="p-inline-list"
+                        >
+                          <li
+                            className="p-inline-list__item p-heading--four"
+                            data-test="section-header-title"
+                          />
+                          <li
+                            className="p-inline-list__item last-item u-text--light"
+                          >
+                            <Spinner
+                              className="u-no-padding u-no-margin"
+                              inline={true}
+                              text="Loading..."
+                            >
+                              <span
+                                className="u-no-padding u-no-margin p-spinner p-text--default p-spinner--inline"
+                              >
+                                <i
+                                  className="p-icon--spinner u-animation--spin"
+                                />
+                                <span
+                                  className="p-icon__text"
+                                >
+                                  Loading...
+                                </span>
+                              </span>
+                            </Spinner>
+                          </li>
+                        </ul>
+                      </div>
+                    </SectionHeader>
+                  </MachineHeader>
+                </div>
+              </Col>
+            </div>
+          </Row>
+        </header>
+      </Strip>
+      <Strip
+        element="main"
+        includeCol={false}
+        rowClassName="section__content-wrapper"
+        shallow={true}
+      >
+        <main
+          className="p-strip is-shallow"
+        >
+          <Row
+            className="section__content-wrapper"
+          >
+            <div
+              className="section__content-wrapper row"
+            >
+              <Col
+                className="section__content"
+                size={12}
+              >
+                <div
+                  className="section__content col-12"
+                >
+                  <NotificationList>
+                    <NotificationGroup
+                      key="caution"
+                      notifications={
+                        Array [
+                          Object {
+                            "admins": true,
+                            "category": "warning",
+                            "created": "Wed, 08 Jul. 2020 05:35:4",
+                            "dismissable": true,
+                            "id": 11,
+                            "ident": null,
+                            "message": "Testing notification",
+                            "updated": "Wed, 08 Jul. 2020 05:35:4",
+                            "user": Object {
+                              "completed_intro": true,
+                              "email": "email1@example.com",
+                              "global_permissions": Array [
+                                "machine_create",
+                              ],
+                              "id": 12,
+                              "is_superuser": true,
+                              "last_name": "Full Name jr.",
+                              "sshkeys_count": 3,
+                              "username": "user1",
+                            },
+                            "users": true,
+                          },
+                          Object {
+                            "admins": true,
+                            "category": "warning",
+                            "created": "Wed, 08 Jul. 2020 05:35:4",
+                            "dismissable": true,
+                            "id": 13,
+                            "ident": null,
+                            "message": "Testing notification",
+                            "updated": "Wed, 08 Jul. 2020 05:35:4",
+                            "user": Object {
+                              "completed_intro": true,
+                              "email": "email2@example.com",
+                              "global_permissions": Array [
+                                "machine_create",
+                              ],
+                              "id": 14,
+                              "is_superuser": true,
+                              "last_name": "Full Name jr.",
+                              "sshkeys_count": 3,
+                              "username": "user2",
+                            },
+                            "users": true,
+                          },
+                          Object {
+                            "admins": true,
+                            "category": "warning",
+                            "created": "Wed, 08 Jul. 2020 05:35:4",
+                            "dismissable": true,
+                            "id": 15,
+                            "ident": null,
+                            "message": "Testing notification",
+                            "updated": "Wed, 08 Jul. 2020 05:35:4",
+                            "user": Object {
+                              "completed_intro": true,
+                              "email": "email3@example.com",
+                              "global_permissions": Array [
+                                "machine_create",
+                              ],
+                              "id": 16,
+                              "is_superuser": true,
+                              "last_name": "Full Name jr.",
+                              "sshkeys_count": 3,
+                              "username": "user3",
+                            },
+                            "users": true,
+                          },
+                          Object {
+                            "admins": true,
+                            "category": "warning",
+                            "created": "Wed, 08 Jul. 2020 05:35:4",
+                            "dismissable": true,
+                            "id": 17,
+                            "ident": null,
+                            "message": "Testing notification",
+                            "updated": "Wed, 08 Jul. 2020 05:35:4",
+                            "user": Object {
+                              "completed_intro": true,
+                              "email": "email4@example.com",
+                              "global_permissions": Array [
+                                "machine_create",
+                              ],
+                              "id": 18,
+                              "is_superuser": true,
+                              "last_name": "Full Name jr.",
+                              "sshkeys_count": 3,
+                              "username": "user4",
+                            },
+                            "users": true,
+                          },
+                          Object {
+                            "admins": true,
+                            "category": "warning",
+                            "created": "Wed, 08 Jul. 2020 05:35:4",
+                            "dismissable": true,
+                            "id": 19,
+                            "ident": null,
+                            "message": "Testing notification",
+                            "updated": "Wed, 08 Jul. 2020 05:35:4",
+                            "user": Object {
+                              "completed_intro": true,
+                              "email": "email5@example.com",
+                              "global_permissions": Array [
+                                "machine_create",
+                              ],
+                              "id": 20,
+                              "is_superuser": true,
+                              "last_name": "Full Name jr.",
+                              "sshkeys_count": 3,
+                              "username": "user5",
+                            },
+                            "users": true,
+                          },
+                        ]
+                      }
+                      type="caution"
+                    >
+                      <div
+                        className="p-notification--group"
+                      >
+                        <Notification
+                          type="caution"
+                        >
+                          <div
+                            className="p-notification--caution"
+                          >
+                            <p
+                              className="p-notification__response"
+                            >
+                              <Button
+                                appearance="link"
+                                aria-label="5 caution, click to open messages."
+                                onClick={[Function]}
+                              >
+                                <button
+                                  aria-label="5 caution, click to open messages."
+                                  className="p-button--link"
+                                  onClick={[Function]}
+                                >
+                                  <span
+                                    className="p-notification__status"
+                                    data-test="notification-count"
+                                  >
+                                    5 Warnings
+                                  </span>
+                                  <small>
+                                    <i
+                                      className="p-icon--expand"
+                                    />
+                                  </small>
+                                </button>
+                              </Button>
+                              <Button
+                                appearance="link"
+                                className="p-notification__action u-nudge-right"
+                                onClick={[Function]}
+                              >
+                                <button
+                                  className="p-button--link p-notification__action u-nudge-right"
+                                  onClick={[Function]}
+                                >
+                                  Dismiss all
+                                </button>
+                              </Button>
+                            </p>
+                          </div>
+                        </Notification>
+                      </div>
+                    </NotificationGroup>
+                    <Notification
+                      close={[Function]}
+                      data-test="message"
+                      key="6"
+                      timeout={5000}
+                      type="caution"
+                    >
+                      <div
+                        className="p-notification--caution"
+                        data-test="message"
+                      >
+                        <p
+                          className="p-notification__response"
+                        >
+                          Test message
+                        </p>
+                        <button
+                          aria-label="Close notification"
+                          className="p-icon--close"
+                          onClick={[Function]}
+                        >
+                          Close
+                        </button>
+                      </div>
+                    </Notification>
+                    <Notification
+                      close={[Function]}
+                      data-test="message"
+                      key="7"
+                      timeout={5000}
+                      type="caution"
+                    >
+                      <div
+                        className="p-notification--caution"
+                        data-test="message"
+                      >
+                        <p
+                          className="p-notification__response"
+                        >
+                          Test message
+                        </p>
+                        <button
+                          aria-label="Close notification"
+                          className="p-icon--close"
+                          onClick={[Function]}
+                        >
+                          Close
+                        </button>
+                      </div>
+                    </Notification>
+                    <Notification
+                      close={[Function]}
+                      data-test="message"
+                      key="8"
+                      timeout={5000}
+                      type="caution"
+                    >
+                      <div
+                        className="p-notification--caution"
+                        data-test="message"
+                      >
+                        <p
+                          className="p-notification__response"
+                        >
+                          Test message
+                        </p>
+                        <button
+                          aria-label="Close notification"
+                          className="p-icon--close"
+                          onClick={[Function]}
+                        >
+                          Close
+                        </button>
+                      </div>
+                    </Notification>
+                    <Notification
+                      close={[Function]}
+                      data-test="message"
+                      key="9"
+                      timeout={5000}
+                      type="caution"
+                    >
+                      <div
+                        className="p-notification--caution"
+                        data-test="message"
+                      >
+                        <p
+                          className="p-notification__response"
+                        >
+                          Test message
+                        </p>
+                        <button
+                          aria-label="Close notification"
+                          className="p-icon--close"
+                          onClick={[Function]}
+                        >
+                          Close
+                        </button>
+                      </div>
+                    </Notification>
+                    <Notification
+                      close={[Function]}
+                      data-test="message"
+                      key="10"
+                      timeout={5000}
+                      type="caution"
+                    >
+                      <div
+                        className="p-notification--caution"
+                        data-test="message"
+                      >
+                        <p
+                          className="p-notification__response"
+                        >
+                          Test message
+                        </p>
+                        <button
+                          aria-label="Close notification"
+                          className="p-icon--close"
+                          onClick={[Function]}
+                        >
+                          Close
+                        </button>
+                      </div>
+                    </Notification>
+                  </NotificationList>
+                </div>
+              </Col>
+            </div>
+          </Row>
+        </main>
+      </Strip>
+    </div>
+  </Section>
+</MachineDetails>
+`;

--- a/ui/src/app/machines/views/MachineDetails/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineDetails";

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -1,4 +1,5 @@
 import { Col, Row, Spinner } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
@@ -10,7 +11,6 @@ import machineSelectors from "app/store/machine/selectors";
 import scriptresultsSelectors from "app/store/scriptresults/selectors";
 import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
-import LegacyLink from "app/base/components/LegacyLink";
 
 const generateFailedTestsMessage = (numFailedTests, selectedMachines) => {
   const singleMachine = selectedMachines.length === 1 && selectedMachines[0];
@@ -23,9 +23,9 @@ const generateFailedTestsMessage = (numFailedTests, selectedMachines) => {
       return (
         <span>
           Machine <strong>{singleMachine.hostname}</strong> has{" "}
-          <LegacyLink route={`/machine/${singleMachine.system_id}`}>
+          <Link to={`/machine/${singleMachine.system_id}`}>
             {numFailedTestsString}
-          </LegacyLink>
+          </Link>
         </span>
       );
     }
@@ -134,11 +134,9 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
                       remain visible in
                       <br />
                       {selectedMachines.length === 1 ? (
-                        <LegacyLink
-                          route={`/machine/${selectedMachines[0].system_id}`}
-                        >
+                        <Link to={`/machine/${selectedMachines[0].system_id}`}>
                           Machine &gt; Hardware tests
-                        </LegacyLink>
+                        </Link>
                       ) : (
                         "Machine > Hardware tests"
                       )}

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -122,7 +122,7 @@ describe("OverrideTestForm", () => {
     );
     expect(
       wrapper.find('[data-test-id="failed-results-message"] a').props().href
-    ).toBe(generateLegacyURL(`/machine/abc123`));
+    ).toBe("/machine/abc123");
   });
 
   it("displays message for multiple machines with failed tests", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -5,7 +5,6 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 import OverrideTestForm from "./OverrideTestForm";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -1,16 +1,16 @@
 import { Tooltip } from "@canonical/react-components";
 import { Input } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import React from "react";
 import { useSelector } from "react-redux";
 
 import machineSelectors from "app/store/machine/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
-import LegacyLink from "app/base/components/LegacyLink";
 
 const generateFQDN = (machine, machineURL) => {
   return (
-    <LegacyLink route={machineURL} title={machine.fqdn}>
+    <Link to={machineURL} title={machine.fqdn}>
       <strong data-test="hostname">
         {machine.locked ? (
           <span title="This machine is locked. You have to unlock it to perform any actions.">
@@ -20,7 +20,7 @@ const generateFQDN = (machine, machineURL) => {
         {machine.hostname}
       </strong>
       <small>.{machine.domain.name}</small>
-    </LegacyLink>
+    </Link>
   );
 };
 
@@ -77,14 +77,11 @@ const generateIPAddresses = (machine) => {
 const generateMAC = (machine, machineURL) => {
   return (
     <>
-      <LegacyLink route={machineURL} title={machine.pxe_mac_vendor}>
+      <Link to={machineURL} title={machine.pxe_mac_vendor}>
         {machine.pxe_mac}
-      </LegacyLink>
+      </Link>
       {machine.extra_macs && machine.extra_macs.length > 0 ? (
-        <LegacyLink route={machineURL}>
-          {" "}
-          (+{machine.extra_macs.length})
-        </LegacyLink>
+        <Link to={machineURL}> (+{machine.extra_macs.length})</Link>
       ) : null}
     </>
   );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -12,8 +12,8 @@ exports[`NameColumn renders 1`] = `
         className="has-inline-label keep-label-opacity"
         id="abc123"
         label={
-          <LegacyLink
-            route="/undefined/abc123"
+          <ForwardRef
+            to="/undefined/abc123"
           >
             <strong
               data-test="hostname"
@@ -24,7 +24,7 @@ exports[`NameColumn renders 1`] = `
               .
               example
             </small>
-          </LegacyLink>
+          </ForwardRef>
         }
         onChange={[MockFunction]}
         type="checkbox"
@@ -51,8 +51,8 @@ exports[`NameColumn renders 1`] = `
               className="has-inline-label keep-label-opacity"
               id="abc123"
               label={
-                <LegacyLink
-                  route="/undefined/abc123"
+                <ForwardRef
+                  to="/undefined/abc123"
                 >
                   <strong
                     data-test="hostname"
@@ -63,7 +63,7 @@ exports[`NameColumn renders 1`] = `
                     .
                     example
                   </small>
-                </LegacyLink>
+                </ForwardRef>
               }
               onChange={[MockFunction]}
               type="checkbox"
@@ -73,8 +73,8 @@ exports[`NameColumn renders 1`] = `
                 className="u-no-margin--bottom machine-list--inline-input"
                 forId="abc123"
                 label={
-                  <LegacyLink
-                    route="/undefined/abc123"
+                  <ForwardRef
+                    to="/undefined/abc123"
                   >
                     <strong
                       data-test="hostname"
@@ -85,7 +85,7 @@ exports[`NameColumn renders 1`] = `
                       .
                       example
                     </small>
-                  </LegacyLink>
+                  </ForwardRef>
                 }
                 labelFirst={false}
               >
@@ -108,16 +108,15 @@ exports[`NameColumn renders 1`] = `
                         className="p-form__label"
                         htmlFor="abc123"
                       >
-                        <LegacyLink
-                          route="/undefined/abc123"
+                        <Link
+                          to="/undefined/abc123"
                         >
-                          <Link
-                            href="/MAAS/l/undefined/abc123"
-                            onClick={[Function]}
+                          <LinkAnchor
+                            href="/undefined/abc123"
+                            navigate={[Function]}
                           >
                             <a
-                              className=""
-                              href="/MAAS/l/undefined/abc123"
+                              href="/undefined/abc123"
                               onClick={[Function]}
                             >
                               <strong
@@ -130,8 +129,8 @@ exports[`NameColumn renders 1`] = `
                                 example
                               </small>
                             </a>
-                          </Link>
-                        </LegacyLink>
+                          </LinkAnchor>
+                        </Link>
                       </label>
                     </Label>
                   </div>

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
@@ -1,4 +1,5 @@
 import { Spinner } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -20,6 +21,9 @@ const DhcpTarget = ({ nodeId, subnetId }) => {
       <small>.{target.domain.name}</small>
     </>
   );
+  if (type === "machine") {
+    return <Link to={`/${type}/${nodeId || subnetId}`}>{name}</Link>;
+  }
   return (
     <LegacyLink route={`/${type}/${nodeId || subnetId}`}>{name}</LegacyLink>
   );

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.js
@@ -91,7 +91,7 @@ describe("DhcpTarget", () => {
       </Provider>
     );
     const link = wrapper.find("Link");
-    expect(link.prop("href").includes("/machine/xyz")).toBe(true);
+    expect(link.prop("to")).toBe("/machine/xyz");
     expect(link).toMatchSnapshot();
   });
 });

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.js.snap
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.js.snap
@@ -2,19 +2,22 @@
 
 exports[`DhcpTarget can display a node link 1`] = `
 <Link
-  href="/MAAS/l/machine/xyz"
-  onClick={[Function]}
+  to="/machine/xyz"
 >
-  <a
-    className=""
-    href="/MAAS/l/machine/xyz"
-    onClick={[Function]}
+  <LinkAnchor
+    href="/machine/xyz"
+    navigate={[Function]}
   >
-    machine1
-    <small>
-      .
-      test
-    </small>
-  </a>
+    <a
+      href="/machine/xyz"
+      onClick={[Function]}
+    >
+      machine1
+      <small>
+        .
+        test
+      </small>
+    </a>
+  </LinkAnchor>
 </Link>
 `;


### PR DESCRIPTION
## Done

- Added routing for the machine details and added basic page structure.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and click on a machine.
- You should navigate to the machine details route and see the fqdn.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2101