### PR TITLE
feat(ui): Replace fake NUMA data with API data.

### DIFF
--- a/ui/src/app/kvm/components/KVMMeter/KVMMeter.test.tsx
+++ b/ui/src/app/kvm/components/KVMMeter/KVMMeter.test.tsx
@@ -5,9 +5,7 @@ import KVMMeter from "./KVMMeter";
 
 describe("KVMMeter", () => {
   it("renders", () => {
-    const wrapper = shallow(
-      <KVMMeter allocated={2} free={1} total={3} unit="GB" />
-    );
+    const wrapper = shallow(<KVMMeter allocated={2} free={1} unit="GB" />);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
+++ b/ui/src/app/kvm/components/KVMMeter/KVMMeter.tsx
@@ -6,7 +6,6 @@ type Props = {
   allocated: number;
   free: number;
   segmented?: boolean;
-  total: number;
   unit?: string;
 };
 
@@ -14,9 +13,10 @@ const KVMMeter = ({
   allocated,
   free,
   segmented = false,
-  total,
   unit = "",
 }: Props): JSX.Element | null => {
+  const total = allocated + free;
+
   return (
     <div className="kvm-meter">
       <div>

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -7,9 +7,8 @@ describe("KVMResourcesCard", () => {
   it("renders", () => {
     const wrapper = shallow(
       <KVMResourcesCard
-        cores={{ allocated: 1, free: 2, total: 3 }}
-        nics={[]}
-        ram={{ general: { allocated: 2, free: 3, total: 5, unit: "MB" } }}
+        cores={{ allocated: 1, free: 2 }}
+        ram={{ general: { allocated: 2048, free: 3072 } }}
         vms={["abc123"]}
         title="Title"
       />
@@ -21,9 +20,8 @@ describe("KVMResourcesCard", () => {
   it("can be given a title", () => {
     const wrapper = shallow(
       <KVMResourcesCard
-        cores={{ allocated: 1, free: 2, total: 3 }}
-        nics={[]}
-        ram={{ general: { allocated: 2, free: 3, total: 5 } }}
+        cores={{ allocated: 1, free: 2 }}
+        ram={{ general: { allocated: 2, free: 3 } }}
         vms={["abc123"]}
         title="Title"
       />
@@ -37,13 +35,11 @@ describe("KVMResourcesCard", () => {
   it("shows hugepage RAM details if provided", () => {
     const wrapper = shallow(
       <KVMResourcesCard
-        cores={{ allocated: 1, free: 2, total: 3 }}
-        nics={[]}
+        cores={{ allocated: 1, free: 2 }}
         ram={{
-          general: { allocated: 2, free: 3, total: 5 },
-          hugepage: { allocated: 1, free: 1, total: 2, pagesize: 1024 },
+          general: { allocated: 2, free: 3 },
+          hugepages: [{ allocated: 1, free: 1, pageSize: 1024 }],
         }}
-        vfs={{ allocated: 100, free: 156, total: 256 }}
         vms={["abc123"]}
       />
     );
@@ -51,15 +47,16 @@ describe("KVMResourcesCard", () => {
     expect(wrapper.find("[data-test='hugepage-ram']").exists()).toBe(true);
   });
 
-  it("shows virtual function details if provided", () => {
+  it("shows virtual function details if any provided interfaces use virtual functions", () => {
     const wrapper = shallow(
       <KVMResourcesCard
-        cores={{ allocated: 1, free: 2, total: 3 }}
-        nics={[]}
+        cores={{ allocated: 1, free: 2 }}
+        interfaces={[
+          { name: "eth0", virtualFunctions: { allocated: 100, free: 20 } },
+        ]}
         ram={{
-          general: { allocated: 2, free: 3, total: 5 },
+          general: { allocated: 2, free: 3 },
         }}
-        vfs={{ allocated: 100, free: 156, total: 256 }}
         vms={["abc123"]}
       />
     );
@@ -70,9 +67,8 @@ describe("KVMResourcesCard", () => {
   it("shows VMs button at bottom of container if no title provided", () => {
     const wrapper = shallow(
       <KVMResourcesCard
-        cores={{ allocated: 1, free: 2, total: 3 }}
-        nics={[]}
-        ram={{ general: { allocated: 2, free: 3, total: 5 } }}
+        cores={{ allocated: 1, free: 2 }}
+        ram={{ general: { allocated: 2, free: 3 } }}
         vms={["abc123"]}
       />
     );

--- a/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
@@ -50,20 +50,20 @@ exports[`KVMResourcesCard renders 1`] = `
       </h4>
       <DoughnutChart
         className="kvm-resources-card__ram-chart"
-        label="5MB"
+        label="5KiB"
         segmentHoverWidth={18}
         segmentWidth={15}
         segments={
           Array [
             Object {
               "color": "#0066CC",
-              "tooltip": "General allocated 2MB",
-              "value": 2,
+              "tooltip": "General allocated 2KiB",
+              "value": 2048,
             },
             Object {
               "color": "#D3E4ED",
-              "tooltip": "General free 3MB",
-              "value": 3,
+              "tooltip": "General free 3KiB",
+              "value": 3072,
             },
           ]
         }
@@ -107,8 +107,7 @@ exports[`KVMResourcesCard renders 1`] = `
             <span
               data-test="ram-general-allocated"
             >
-              2
-              MB
+              2KiB
             </span>
             <span
               className="u-nudge-right--small"
@@ -124,8 +123,7 @@ exports[`KVMResourcesCard renders 1`] = `
             <span
               data-test="ram-general-free"
             >
-              3
-              MB
+              3KiB
             </span>
             <span
               className="u-nudge-right--small"
@@ -152,7 +150,6 @@ exports[`KVMResourcesCard renders 1`] = `
       data-test="cpu-meter"
       free={2}
       segmented={true}
-      total={3}
     />
   </div>
   <div

--- a/ui/src/app/kvm/components/KVMResourcesCard/index.ts
+++ b/ui/src/app/kvm/components/KVMResourcesCard/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./KVMResourcesCard";
+export type { Props as KVMResourcesCardProps } from "./KVMResourcesCard";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMAggregateResources/KVMAggregateResources.tsx
@@ -8,21 +8,6 @@ import podSelectors from "app/store/pod/selectors";
 import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
 import { formatBytes } from "app/utils";
 
-const fakeHugepageRAM = {
-  allocated: 10,
-  free: 2,
-  total: 12,
-  pagesize: 2048,
-  unit: "GiB",
-};
-const fakeNICs = ["eth0", "eth1", "eth2", "eth3"];
-const fakeVFs = {
-  allocated: 32,
-  free: 224,
-  total: 256,
-};
-const fakeVMs = ["machine1", "machine2", "machine3", "machine4"];
-
 type Props = { id: number };
 
 const KVMAggregateResources = ({ id }: Props): JSX.Element => {
@@ -37,11 +22,6 @@ const KVMAggregateResources = ({ id }: Props): JSX.Element => {
 
   if (!!pod) {
     const totalCores = pod.total.cores * pod.cpu_over_commit_ratio;
-    const totalGeneralRAM = formatBytes(
-      pod.total.memory * pod.memory_over_commit_ratio,
-      "MiB",
-      { binary: true }
-    );
 
     return (
       <KVMResourcesCard
@@ -49,27 +29,21 @@ const KVMAggregateResources = ({ id }: Props): JSX.Element => {
         cores={{
           allocated: pod.used.cores,
           free: totalCores - pod.used.cores,
-          total: totalCores,
         }}
-        nics={fakeNICs}
         ram={{
           general: {
             allocated: formatBytes(pod.used.memory, "MiB", {
               binary: true,
-              convertTo: totalGeneralRAM.unit,
+              convertTo: "B",
             }).value,
             free: formatBytes(
               pod.total.memory * pod.memory_over_commit_ratio - pod.used.memory,
               "MiB",
-              { binary: true, convertTo: totalGeneralRAM.unit }
+              { binary: true, convertTo: "B" }
             ).value,
-            total: totalGeneralRAM.value,
-            unit: totalGeneralRAM.unit,
           },
-          hugepage: fakeHugepageRAM,
         }}
-        vfs={fakeVFs}
-        vms={fakeVMs}
+        vms={[]}
       />
     );
   }

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -1,88 +1,152 @@
-import { Button } from "@canonical/react-components";
+import { Button, Spinner } from "@canonical/react-components";
 import classNames from "classnames";
 import pluralize from "pluralize";
-import React, { useState } from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
-import type { TSFixMe } from "app/base/types";
+import type { Pod, PodNumaNode } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import type { KVMResourcesCardProps } from "app/kvm/components/KVMResourcesCard";
 import { sendAnalyticsEvent } from "analytics";
+import { formatBytes } from "app/utils";
+import { actions as podActions } from "app/store/pod";
 import configSelectors from "app/store/config/selectors";
+import podSelectors from "app/store/pod/selectors";
 import KVMResourcesCard from "app/kvm/components/KVMResourcesCard";
 
 export const TRUNCATION_POINT = 4;
 
-type Props = { numaNodes: TSFixMe[] };
+type Props = { id: Pod["id"] };
 
-const KVMNumaResources = ({ numaNodes }: Props): JSX.Element => {
+/**
+ * Normalise numa_pinning data from API for use in KVMResourcesCard component.
+ *
+ * @param numaNode - the NUMA node to normalise
+ * @returns {KVMResourcesCardProps}
+ */
+const normaliseNuma = (numaNode: PodNumaNode): KVMResourcesCardProps => {
+  const { cores, interfaces, memory, node_id, vms } = numaNode;
+  const { general, hugepages } = memory;
+
+  const normalisedInterfaces =
+    interfaces?.map((iface) => ({
+      name: iface.name,
+      virtualFunctions: iface.virtual_functions,
+    })) || [];
+  const normalisedHugepages =
+    hugepages?.map((hugepage) => ({
+      allocated: hugepage.allocated,
+      free: hugepage.free,
+      pageSize: hugepage.page_size,
+    })) || [];
+  const normalisedVMs = vms?.map((vm) => vm.system_id) || [];
+
+  return {
+    cores: {
+      allocated: cores.allocated.length,
+      free: cores.free.length,
+    },
+    interfaces: normalisedInterfaces,
+    ram: {
+      general: {
+        // Convert to B for easier calculcations with hugepages
+        allocated: formatBytes(general.allocated, "MiB", {
+          binary: true,
+          convertTo: "B",
+        }).value,
+        free: formatBytes(general.free, "MiB", { binary: true, convertTo: "B" })
+          .value,
+      },
+      hugepages: normalisedHugepages,
+    },
+    title: `NUMA node ${node_id}`,
+    vms: normalisedVMs,
+  };
+};
+
+const KVMNumaResources = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  );
   const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const [expanded, setExpanded] = useState(false);
-  const canBeTruncated = numaNodes.length > TRUNCATION_POINT;
-  const shownNumaNodes =
-    canBeTruncated && !expanded
-      ? numaNodes.slice(0, TRUNCATION_POINT)
-      : numaNodes;
-  const showWideCards = numaNodes.length <= 2;
 
-  return (
-    <>
-      <div
-        className={classNames("numa-resources-grid", {
-          "is-wide": showWideCards,
-        })}
-      >
-        {shownNumaNodes.map((numa) => (
-          <KVMResourcesCard
-            className={showWideCards ? "kvm-resources-card--wide" : undefined}
-            cores={numa.cores}
-            key={numa.index}
-            nics={numa.nics}
-            ram={numa.ram}
-            title={`NUMA node ${numa.index}`}
-            vfs={numa.vfs}
-            vms={numa.vms}
-          />
-        ))}
-      </div>
-      {canBeTruncated && (
-        <div className="u-align--center">
-          <Button
-            appearance="base"
-            data-test="show-more-numas"
-            hasIcon
-            onClick={() => {
-              setExpanded(!expanded);
-              if (analyticsEnabled) {
-                sendAnalyticsEvent(
-                  "KVM details",
-                  "Toggle expanded NUMA nodes",
-                  expanded ? "Show less NUMA nodes" : "Show more NUMA nodes"
-                );
-              }
-            }}
-          >
-            {expanded ? (
-              <>
-                <span>Show less NUMA nodes</span>
-                <i className="p-icon--contextual-menu u-mirror--y"></i>
-              </>
-            ) : (
-              <>
-                <span>
-                  {pluralize(
-                    "more NUMA node",
-                    numaNodes.length - TRUNCATION_POINT,
-                    true
-                  )}
-                </span>
-                <i className="p-icon--contextual-menu"></i>
-              </>
-            )}
-          </Button>
-          <hr />
+  useEffect(() => {
+    dispatch(podActions.fetch());
+  }, [dispatch]);
+
+  if (!!pod) {
+    const numaNodes = pod.numa_pinning || [];
+    const canBeTruncated = numaNodes.length > TRUNCATION_POINT;
+    const shownNumaNodes =
+      canBeTruncated && !expanded
+        ? numaNodes.slice(0, TRUNCATION_POINT)
+        : numaNodes;
+    const showWideCards = numaNodes.length <= 2;
+
+    return (
+      <>
+        <div
+          className={classNames("numa-resources-grid", {
+            "is-wide": showWideCards,
+          })}
+        >
+          {shownNumaNodes.map((numa) => {
+            const kvmResourcesCardProps = normaliseNuma(numa);
+            return (
+              <KVMResourcesCard
+                className={
+                  showWideCards ? "kvm-resources-card--wide" : undefined
+                }
+                key={numa.node_id}
+                {...kvmResourcesCardProps}
+              />
+            );
+          })}
         </div>
-      )}
-    </>
-  );
+        {canBeTruncated && (
+          <div className="u-align--center">
+            <Button
+              appearance="base"
+              data-test="show-more-numas"
+              hasIcon
+              onClick={() => {
+                setExpanded(!expanded);
+                if (analyticsEnabled) {
+                  sendAnalyticsEvent(
+                    "KVM details",
+                    "Toggle expanded NUMA nodes",
+                    expanded ? "Show less NUMA nodes" : "Show more NUMA nodes"
+                  );
+                }
+              }}
+            >
+              {expanded ? (
+                <>
+                  <span>Show less NUMA nodes</span>
+                  <i className="p-icon--contextual-menu u-mirror--y"></i>
+                </>
+              ) : (
+                <>
+                  <span>
+                    {pluralize(
+                      "more NUMA node",
+                      numaNodes.length - TRUNCATION_POINT,
+                      true
+                    )}
+                  </span>
+                  <i className="p-icon--contextual-menu"></i>
+                </>
+              )}
+            </Button>
+            <hr />
+          </div>
+        )}
+      </>
+    );
+  }
+  return <Spinner text="Loading" />;
 };
 
 export default KVMNumaResources;

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMStorage/KVMStorage.tsx
@@ -74,7 +74,6 @@ const KVMStorage = ({ id }: Props): JSX.Element | null => {
                   <KVMMeter
                     allocated={allocated.value}
                     free={free.value}
-                    total={total.value}
                     unit={total.unit}
                   />
                 </div>

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -19,66 +19,6 @@ type RouteParams = {
   id: string;
 };
 
-export const fakeNumas = [
-  {
-    cores: { allocated: 1, free: 2, total: 3 },
-    index: 0,
-    nics: ["eth0", "eth2"],
-    ram: {
-      general: {
-        allocated: 12,
-        free: 12,
-        total: 24,
-        unit: "GiB",
-      },
-      hugepage: {
-        allocated: 540,
-        free: 420,
-        pagesize: 4068,
-        total: 960,
-        unit: "MiB",
-      },
-    },
-    vfs: { allocated: 13, free: 1, total: 14 },
-    vms: ["machine1", "machine2", "machine3"],
-  },
-  {
-    cores: { allocated: 200, free: 100, total: 300 },
-    index: 1,
-    nics: ["eth1", "eth3"],
-    ram: {
-      general: {
-        allocated: 3,
-        free: 1,
-        total: 4,
-        unit: "GiB",
-      },
-      hugepage: {
-        allocated: 1,
-        free: 1,
-        pagesize: 2048,
-        total: 2,
-        unit: "GiB",
-      },
-    },
-    vms: ["machine4"],
-  },
-  {
-    cores: { allocated: 5, free: 5, total: 10 },
-    index: 2,
-    nics: [],
-    ram: {
-      general: {
-        allocated: 5,
-        free: 2,
-        total: 7,
-        unit: "GiB",
-      },
-    },
-    vms: [],
-  },
-];
-
 const KVMSummary = (): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams<RouteParams>();
@@ -112,26 +52,28 @@ const KVMSummary = (): JSX.Element => {
         <hr className="u-sv1" />
         <div className="u-flex--between">
           <h4 className="u-sv1">Resources</h4>
-          <Switch
-            checked={viewByNuma}
-            className="p-switch--inline-label"
-            data-test="numa-switch"
-            label="View by NUMA node"
-            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-              const checked = evt.target.checked;
-              setViewByNuma(checked);
-              if (analyticsEnabled) {
-                sendAnalyticsEvent(
-                  "KVM details",
-                  "Toggle NUMA view",
-                  checked ? "View by NUMA node" : "View aggregate"
-                );
-              }
-            }}
-          />
+          {pod.numa_pinning && (
+            <Switch
+              checked={viewByNuma}
+              className="p-switch--inline-label"
+              data-test="numa-switch"
+              label="View by NUMA node"
+              onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                const checked = evt.target.checked;
+                setViewByNuma(checked);
+                if (analyticsEnabled) {
+                  sendAnalyticsEvent(
+                    "KVM details",
+                    "Toggle NUMA view",
+                    checked ? "View by NUMA node" : "View aggregate"
+                  );
+                }
+              }}
+            />
+          )}
         </div>
         {viewByNuma ? (
-          <KVMNumaResources numaNodes={fakeNumas} />
+          <KVMNumaResources id={pod.id} />
         ) : (
           <KVMAggregateResources id={pod.id} />
         )}

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -27,6 +27,37 @@ export type PodStoragePool = {
   used: number;
 };
 
+export type NumaResource<T> = {
+  allocated: T;
+  free: T;
+};
+
+export type NumaInterface = {
+  id: number;
+  name: string;
+  virtual_functions?: NumaResource<number>;
+};
+
+export type NumaVM = {
+  networks: {
+    guest_nic_id: number;
+    host_nic_id: number;
+  };
+  pinned_cores: number[];
+  system_id: string;
+};
+
+export type PodNumaNode = {
+  cores: NumaResource<number[]>;
+  interfaces: NumaInterface[];
+  memory: {
+    hugepages: (NumaResource<number> & { page_size: number })[];
+    general: NumaResource<number>;
+  };
+  node_id: number;
+  vms: NumaVM[];
+};
+
 // BasePod is returned from the server when using "pod.list", and is used in the
 // pod list pages. This type is missing some properties due to an optimisation
 // on the backend to reduce the amount of database queries on list pages.
@@ -45,6 +76,7 @@ export type BasePod = Model & {
   ip_address: number | string;
   memory_over_commit_ratio: number;
   name: string;
+  numa_pinning?: PodNumaNode[];
   password?: string;
   permissions: string[];
   pool: number;

--- a/ui/src/app/utils/formatBytes.test.ts
+++ b/ui/src/app/utils/formatBytes.test.ts
@@ -12,6 +12,10 @@ describe("formatBytes", () => {
   });
 
   it("returns the value to the correct precision", () => {
+    expect(formatBytes(1234, "B", { precision: 1 })).toStrictEqual({
+      value: 1,
+      unit: "KB",
+    });
     expect(formatBytes(1234, "B", { precision: 2 })).toStrictEqual({
       value: 1.2,
       unit: "KB",
@@ -21,7 +25,11 @@ describe("formatBytes", () => {
       unit: "KB",
     });
     expect(formatBytes(123, "B", { precision: 1 })).toStrictEqual({
-      value: 100,
+      value: 123,
+      unit: "B",
+    });
+    expect(formatBytes(0.123, "KB", { precision: 1 })).toStrictEqual({
+      value: 123,
       unit: "B",
     });
   });

--- a/ui/src/app/utils/formatBytes.ts
+++ b/ui/src/app/utils/formatBytes.ts
@@ -41,9 +41,12 @@ export const formatBytes = (
   const j = convertTo
     ? sizes.findIndex((size) => size === convertTo)
     : Math.floor(Math.log(valueInBytes) / Math.log(k));
-  const valueInUnit = parseFloat(
-    (valueInBytes / Math.pow(k, j)).toPrecision(precision)
-  );
+  let valueInUnit = valueInBytes / Math.pow(k, j);
+
+  // Only truncate value if converting to a higher unit, e.g. "KB" => "MB"
+  if (j > i) {
+    valueInUnit = parseFloat(valueInUnit.toPrecision(precision));
+  }
 
   return {
     value: negative ? -valueInUnit : valueInUnit,

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -55,6 +55,7 @@ export {
   pod,
   podDetails,
   podHint,
+  podNumaNode,
   podStoragePool,
 } from "./nodes";
 export { dhcpSnippet } from "./dhcpsnippet";

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -8,6 +8,7 @@ import type {
   PodDetails,
   PodHint,
   PodHintExtras,
+  PodNumaNode,
   PodStoragePool,
 } from "app/store/pod/types";
 import type { Model } from "app/store/types/model";
@@ -156,6 +157,23 @@ export const podStoragePool = define<PodStoragePool>({
   used: 300000000000,
 });
 
+export const podNumaNode = define<PodNumaNode>({
+  cores: () => ({
+    allocated: [0, 2, 4, 6],
+    free: [1, 3],
+  }),
+  interfaces: () => [],
+  memory: () => ({
+    general: {
+      allocated: 10240,
+      free: 4068,
+    },
+    hugepages: [],
+  }),
+  node_id: () => random(),
+  vms: () => [],
+});
+
 export const pod = extend<Model, Pod>(model, {
   architectures,
   available: podHint,
@@ -171,6 +189,7 @@ export const pod = extend<Model, Pod>(model, {
   ip_address: (i: number) => `192.168.1.${i}`,
   memory_over_commit_ratio: 8,
   name: (i: number) => `pod${i}`,
+  numa_pinning: () => [podNumaNode()],
   permissions,
   pool: 1,
   power_address: "qemu+ssh://ubuntu@127.0.0.1/system",


### PR DESCRIPTION
## Done

- Removed all fake data from NUMA view and aggregate view.
- Populated NUMA view with API data. Next will be to populate the aggregate view using the same data.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the values listed on the NUMA view match what's given by the API. Note that master websocket API is currently sending fake NUMA data that has absurdly small hugepage values, so it doesn't appear on the donut chart.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2084
