### PR TITLE
2.8: correctly filter list of power types for use in Add Chassis form

### DIFF
--- a/ui/src/app/base/selectors/general/powerTypes.js
+++ b/ui/src/app/base/selectors/general/powerTypes.js
@@ -6,6 +6,19 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import { generateGeneralSelector } from "./utils";
 
+// List of power types that can be used with the add_chassis http method.
+// MAAS 2.9 handles this via the api but for 2.8 it has to be hardcoded.
+const ADD_CHASSIS_POWER_TYPES = [
+  "mscm",
+  "msftocs",
+  "powerkvm",
+  "recs_box",
+  "seamicro15k",
+  "ucsm",
+  "virsh",
+  "vmware",
+];
+
 const powerTypes = generateGeneralSelector("powerTypes");
 
 /**
@@ -13,8 +26,8 @@ const powerTypes = generateGeneralSelector("powerTypes");
  * @param {Object} state - The redux state.
  * @returns {Array} Chassis power types.
  */
-powerTypes.chassis = createSelector([powerTypes.get], (powerTypes) =>
-  powerTypes.filter((type) => type.chassis)
+powerTypes.canProbe = createSelector([powerTypes.get], (powerTypes) =>
+  powerTypes.filter((type) => ADD_CHASSIS_POWER_TYPES.includes(type.name))
 );
 
 export default powerTypes;

--- a/ui/src/app/base/selectors/general/powerTypes.test.js
+++ b/ui/src/app/base/selectors/general/powerTypes.test.js
@@ -106,24 +106,21 @@ describe("powerTypes selectors", () => {
     });
   });
 
-  describe("chassis", () => {
-    it("returns chassis powerTypes", () => {
-      const chassisPowerTypes = [
-        { name: "chassis-type-1", chassis: true },
-        { name: "chassis-type-2", chassis: true },
-      ];
-      const nonChassisPowerType = { name: "non-chassis-type", chassis: false };
+  describe("canProbe", () => {
+    it("returns powerTypes that can be used with the add_chassis http method", () => {
+      const probePowerTypes = [{ name: "mscm" }, { name: "virsh" }];
+      const nonProbePowerType = { name: "manual" };
       const state = {
         general: {
           powerTypes: {
-            data: [...chassisPowerTypes, nonChassisPowerType],
+            data: [...probePowerTypes, nonProbePowerType],
             errors: {},
             loaded: true,
             loading: false,
           },
         },
       };
-      expect(powerTypes.chassis(state)).toStrictEqual(chassisPowerTypes);
+      expect(powerTypes.canProbe(state)).toStrictEqual(probePowerTypes);
     });
   });
 });

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
@@ -35,7 +35,7 @@ const generateChassisSchema = (parametersSchema) =>
 export const AddChassisForm = () => {
   const dispatch = useDispatch();
 
-  const chassisPowerTypes = useSelector(generalSelectors.powerTypes.chassis);
+  const chassisPowerTypes = useSelector(generalSelectors.powerTypes.canProbe);
   const domains = useSelector(domainSelectors.all);
   const domainsLoaded = useSelector(domainSelectors.loaded);
   const machineErrors = useSelector(machineSelectors.errors);


### PR DESCRIPTION
## Done

- Add hardcoded list of power types that can be used with the `add_chassis` http method. The list was taken from [here](https://git.launchpad.net/maas/tree/src/maasserver/api/machines.py?h=2.8#n2520).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the Add Chassis form and try to add a chassis with each power type.
- You should not get any errors about invalid power types, though you will probably get an error about the name being unknown.