### PR TITLE
fix(root): handle network errors from single-spa

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -84,10 +84,6 @@ function MasterController(
   };
 
   const displayTemplate = () => {
-    const loadingNode = document.querySelector(".root-loading");
-    if (!loadingNode.classList.contains("u-hide")) {
-      loadingNode.classList.add("u-hide");
-    }
     $rootScope.site = window.CONFIG.maas_name;
     renderHeader();
     renderFooter();

--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -16,7 +16,7 @@
     <title>MAAS</title>
   </head>
   <body>
-    <div class="root-loading">
+    <div class="root">
       <nav class="p-navigation is-dark">
         <div class="p-navigation__row row">
           <div class="p-navigation__banner">
@@ -48,13 +48,24 @@
           </div>
         </div>
       </nav>
-      <header class="p-strip is-shallow root-loading__header">
+      <header class="p-strip is-shallow root-loading">
         <div class="row">
           <div class="col-12">
             <p class="u-no-margin--bottom">
               <i class="p-icon--spinner u-animation--spin"></i>
               <span style="margin-left: .25rem;">Loading...</span>
             </p>
+          </div>
+        </div>
+      </header>
+      <header class="p-strip is-shallow root-error u-hide">
+        <div class="row">
+          <div class="col-12">
+            <div class="p-notification--negative">
+              <p class="p-notification__response">
+                <span class="p-notification__status">Error:</span> There was an issue loading MAAS. Try checking your network connection and <a href="" class="p-notification__action" onclick="window.location.reload();">refresh</a> this page.
+              </p>
+            </div>
           </div>
         </div>
       </header>

--- a/root/src/scss/base.scss
+++ b/root/src/scss/base.scss
@@ -4,12 +4,12 @@
 // Import and include base Vanilla
 @import "~vanilla-framework/scss/build";
 
-.root-loading {
+.root {
   background-color: $color-light;
   height: 100vh;
 }
 
-.root-loading__header {
+.root-loading {
   @extend %vf-has-box-shadow;
   background-color: $color-x-light;
 }

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,5 +1,5 @@
 import { Provider } from "react-redux";
-import React, { useEffect } from "react";
+import React from "react";
 import ReactDOM from "react-dom";
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
 import { ConnectedRouter, routerMiddleware } from "connected-react-router";
@@ -41,16 +41,6 @@ let websocketClient = new WebSocketClient();
 sagaMiddleware.run(rootSaga, websocketClient);
 
 const Root = () => {
-  useEffect(() => {
-    const loadingNode = document.querySelector(".root-loading");
-    if (!loadingNode) {
-      return;
-    }
-    if (!loadingNode.classList.contains("u-hide")) {
-      loadingNode.classList.add("u-hide");
-    }
-  }, []);
-
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>


### PR DESCRIPTION
## Done

- Handle errors when loading single-spa apps.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load maas-ui at a legacy url e.g. /MAAS/l/images (without having first visited a React url).
- Stop your proxy/single-spa server.
- Click on a React URL in the header.
- You should see a nice error message on the page.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1618