### PR TITLE
fix(ui): fix inconsistent table header colours

### DIFF
--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -139,10 +139,10 @@ const KVMResourcesCard = ({
           <thead>
             <tr>
               <th></th>
-              <th className="u-align--right">
+              <th className="u-align--right u-text--light">
                 <span className="u-nudge-left">Allocated</span>
               </th>
-              <th className="u-align--right">
+              <th className="u-align--right u-text--light">
                 <span className="u-nudge-left">Free</span>
               </th>
             </tr>

--- a/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
+++ b/ui/src/app/kvm/components/KVMResourcesCard/__snapshots__/KVMResourcesCard.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`KVMResourcesCard renders 1`] = `
         <tr>
           <th />
           <th
-            className="u-align--right"
+            className="u-align--right u-text--light"
           >
             <span
               className="u-nudge-left"
@@ -86,7 +86,7 @@ exports[`KVMResourcesCard renders 1`] = `
             </span>
           </th>
           <th
-            className="u-align--right"
+            className="u-align--right u-text--light"
           >
             <span
               className="u-nudge-left"

--- a/ui/src/scss/_patterns_buttons.scss
+++ b/ui/src/scss/_patterns_buttons.scss
@@ -27,6 +27,7 @@
 
     &:hover {
       background-color: inherit;
+      color: $color-link;
       text-decoration: underline;
     }
 
@@ -46,7 +47,7 @@
 
     // Table header sort buttons
     th & {
-      color: $color-mid-dark;
+      color: $color-dark;
       font-weight: 400;
 
       .p-icon--contextual-menu {


### PR DESCRIPTION
## Done

- Fixed bug where bespoke double row/sortable headers had different colours. Now `#111` is the default, and `#666` is the exception (as in the case of the KVM RAM tables)
- Updated hover colour to match Vanilla's sortable table headers

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/kvm and check that both rows of the table header are `#111`

## Fixes

Fixes #1625 

