### PR TITLE
fix(ui): remove routing hack

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -44,33 +44,6 @@ export const App = () => {
   const debug = process.env.NODE_ENV === "development";
 
   useEffect(() => {
-    // window.history.pushState events from *outside* of react
-    // are not observeable by react-router, which watches the history
-    // object for changes. To compensate for this, we manually push a route
-    // to history when SingleSPA mounts the react app, otherwise react just
-    // renders the last view when the app was unmounted.
-    if (history) {
-      window.addEventListener("popstate", (evt) => {
-        if (evt.singleSpa) {
-          const reactRoute =
-            window.location.pathname.split("/")[2] ===
-            process.env.REACT_APP_REACT_BASENAME.substr(1);
-          if (reactRoute) {
-            // Get path without basename, react basename
-            const newRoute = window.location.pathname.split("/").slice(3);
-            // get subPath e.g. 'settings' in '/MAAS/r/settings/configuration'
-            const newSubpath = newRoute[0];
-            const lastSubpath = history.location.pathname.split("/")[1];
-            if (newSubpath !== lastSubpath) {
-              history.replace(`/${newRoute}`);
-            }
-          }
-        }
-      });
-    }
-  }, [history]);
-
-  useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
   }, [dispatch]);
 


### PR DESCRIPTION
## Done

- Remove custom route handing in App on popState. This was required to work around a bug (see comment in diff), which no longer appears to be present, but also introduced the bug in question here. This has been removed.


## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Reproduce steps in bug (visit react route, visit angular route, visit user prefs). Ensure no , appears in the url, and that you are routed to preferences correctly.
- Ensure old routing bug no longer present (visit machine list, visit angular view, visit settings, ensure settings renders not the machine list).

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
