### PR TITLE
Separate out selected KVM and RSD selectors

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -18,9 +18,11 @@ const DeleteForm = ({ setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams<RouteParams>();
   const errors = useSelector(podSelectors.errors);
-  const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const selectedKVMIDs = useSelector(podSelectors.selectedKVMs).map(
+    (kvm) => kvm.id
+  );
   const deletingSelected = useSelector(podSelectors.deletingSelected);
-  const podsToDelete = id ? [Number(id)] : selectedPodIDs;
+  const kvmsToDelete = id ? [Number(id)] : selectedKVMIDs;
   const cleanup = useCallback(() => podActions.cleanup(), []);
 
   return (
@@ -31,12 +33,12 @@ const DeleteForm = ({ setSelectedAction }: Props): JSX.Element => {
       errors={errors}
       modelName="KVM"
       onSubmit={() => {
-        podsToDelete.forEach((podID) => {
-          dispatch(podActions.delete(podID));
+        kvmsToDelete.forEach((kvmID) => {
+          dispatch(podActions.delete(kvmID));
         });
       }}
       processingCount={deletingSelected.length}
-      selectedCount={podsToDelete.length}
+      selectedCount={kvmsToDelete.length}
       submitAppearance="negative"
     />
   );

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -18,10 +18,12 @@ const RefreshForm = ({ setSelectedAction }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const { id } = useParams<RouteParams>();
   const errors = useSelector(podSelectors.errors);
-  const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const selectedKVMIDs = useSelector(podSelectors.selectedKVMs).map(
+    (kvm) => kvm.id
+  );
   const refreshing = useSelector(podSelectors.refreshing);
   const refreshingSelected = useSelector(podSelectors.refreshingSelected);
-  const podsToRefresh = id ? [Number(id)] : selectedPodIDs;
+  const kvmsToRefresh = id ? [Number(id)] : selectedKVMIDs;
   const cleanup = useCallback(() => podActions.cleanup(), []);
 
   return (
@@ -32,12 +34,12 @@ const RefreshForm = ({ setSelectedAction }: Props): JSX.Element | null => {
       errors={errors}
       modelName="KVM"
       onSubmit={() => {
-        podsToRefresh.forEach((podID) => {
+        kvmsToRefresh.forEach((podID) => {
           dispatch(podActions.refresh(podID));
         });
       }}
       processingCount={id ? refreshing.length : refreshingSelected.length}
-      selectedCount={podsToRefresh.length}
+      selectedCount={kvmsToRefresh.length}
     >
       <p>
         Refreshing KVMs will cause MAAS to recalculate usage metrics, update

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -6,28 +6,27 @@ import { Link, useLocation } from "react-router-dom";
 
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import type { Pod } from "app/store/pod/types";
 import KVMActionFormWrapper from "app/kvm/components/KVMActionFormWrapper";
 import KVMListActionMenu from "./KVMListActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
 
-const getPodCount = (pods: Pod[], selectedPodIDs: number[]) => {
-  const podCountString = pluralize("VM host", pods.length, true);
-  if (selectedPodIDs.length) {
-    if (pods.length === selectedPodIDs.length) {
+const getKVMCount = (kvmCount: number, selectedKVMCount: number) => {
+  const kvmCountString = pluralize("VM host", kvmCount, true);
+  if (selectedKVMCount > 0) {
+    if (kvmCount === selectedKVMCount) {
       return "All VM hosts selected";
     }
-    return `${selectedPodIDs.length} of ${podCountString} selected`;
+    return `${selectedKVMCount} of ${kvmCountString} selected`;
   }
-  return `${podCountString} available`;
+  return `${kvmCountString} available`;
 };
 
 const KVMListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
-  const pods = useSelector(podSelectors.kvm);
+  const kvms = useSelector(podSelectors.kvms);
   const podsLoaded = useSelector(podSelectors.loaded);
-  const selectedPodIDs = useSelector(podSelectors.selectedIDs);
+  const selectedKVMs = useSelector(podSelectors.selectedKVMs);
   const [selectedAction, setSelectedAction] = useState<string | null>(null);
 
   useEffect(() => {
@@ -36,10 +35,10 @@ const KVMListHeader = (): JSX.Element => {
 
   // If path is not exactly "/kvm" or no KVMs are selected, close the form.
   useEffect(() => {
-    if (location.pathname !== "/kvm" || selectedPodIDs.length === 0) {
+    if (location.pathname !== "/kvm" || selectedKVMs.length === 0) {
       setSelectedAction(null);
     }
-  }, [location.pathname, selectedPodIDs, setSelectedAction]);
+  }, [location.pathname, selectedKVMs, setSelectedAction]);
 
   return (
     <SectionHeader
@@ -49,7 +48,7 @@ const KVMListHeader = (): JSX.Element => {
           <Button
             appearance="neutral"
             data-test="add-kvm"
-            disabled={selectedPodIDs.length > 0}
+            disabled={selectedKVMs.length > 0}
             element={Link}
             key="add-kvm"
             to="/kvm/add"
@@ -71,7 +70,7 @@ const KVMListHeader = (): JSX.Element => {
         )
       }
       loading={!podsLoaded}
-      subtitle={getPodCount(pods, selectedPodIDs)}
+      subtitle={getKVMCount(kvms.length, selectedKVMs.length)}
       title="KVM"
     />
   );

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -32,7 +32,7 @@ describe("pod selectors", () => {
         items,
       }),
     });
-    expect(pod.kvm(state)).toStrictEqual([items[0], items[1]]);
+    expect(pod.kvms(state)).toStrictEqual([items[0], items[1]]);
   });
 
   it("can get all RSDs", () => {
@@ -47,7 +47,7 @@ describe("pod selectors", () => {
         items,
       }),
     });
-    expect(pod.rsd(state)).toStrictEqual([items[2], items[3]]);
+    expect(pod.rsds(state)).toStrictEqual([items[2], items[3]]);
   });
 
   it("can get the loading state", () => {
@@ -108,6 +108,36 @@ describe("pod selectors", () => {
       }),
     });
     expect(pod.selected(state)).toEqual([items[0], items[1]]);
+  });
+
+  it("can get the selected KVMs", () => {
+    const items = [
+      podFactory({ id: 1, type: "virsh" }),
+      podFactory({ id: 2, type: "rsd" }),
+      podFactory({ id: 3, type: "virsh" }),
+    ];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        selected: [1, 2],
+        items,
+      }),
+    });
+    expect(pod.selectedKVMs(state)).toEqual([items[0]]);
+  });
+
+  it("can get the selected RSDs", () => {
+    const items = [
+      podFactory({ id: 1, type: "rsd" }),
+      podFactory({ id: 2, type: "virsh" }),
+      podFactory({ id: 3, type: "rsd" }),
+    ];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        selected: [1, 2],
+        items,
+      }),
+    });
+    expect(pod.selectedRSDs(state)).toEqual([items[0]]);
   });
 
   it("can get the errors state", () => {

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -22,7 +22,7 @@ const defaultSelectors = generateBaseSelectors<PodState, Pod, "id">(
  * @param {RootState} state - The redux state.
  * @returns {Pod[]} A list of all KVMs.
  */
-const kvm = (state: RootState): Pod[] =>
+const kvms = (state: RootState): Pod[] =>
   state.pod.items.filter((pod) => pod.type !== "rsd");
 
 /**
@@ -30,7 +30,7 @@ const kvm = (state: RootState): Pod[] =>
  * @param {RootState} state - The redux state.
  * @returns {Pod[]} A list of all RSDs.
  */
-const rsd = (state: RootState): Pod[] =>
+const rsds = (state: RootState): Pod[] =>
   state.pod.items.filter((pod) => pod.type === "rsd");
 
 /**
@@ -48,7 +48,7 @@ const selectedIDs = (state: RootState): number[] => state.pod.selected;
 const statuses = (state: RootState): PodState["statuses"] => state.pod.statuses;
 
 /**
- * Returns selected pods.
+ * Returns all selected pods.
  * @param {RootState} state - The redux state.
  * @returns {Pod[]} Selected pods.
  */
@@ -56,6 +56,24 @@ const selected = createSelector(
   [defaultSelectors.all, selectedIDs],
   (pods, selectedIDs) =>
     selectedIDs.map((id) => pods.find((pod) => id === pod.id))
+);
+
+/**
+ * Returns all selected KVMs.
+ * @param {RootState} state - The redux state.
+ * @returns {Pod[]} Selected KVMs.
+ */
+const selectedKVMs = createSelector([kvms, selectedIDs], (kvms, selectedIDs) =>
+  kvms.filter((kvm) => selectedIDs.includes(kvm.id))
+);
+
+/**
+ * Returns all selected RSDs.
+ * @param {RootState} state - The redux state.
+ * @returns {Pod[]} Selected RSDs.
+ */
+const selectedRSDs = createSelector([rsds, selectedIDs], (rsds, selectedIDs) =>
+  rsds.filter((rsd) => selectedIDs.includes(rsd.id))
 );
 
 /**
@@ -179,12 +197,14 @@ const selectors = {
   deletingSelected,
   getAllHosts,
   getHost,
-  kvm,
+  kvms,
   refreshing,
   refreshingSelected,
-  rsd,
+  rsds,
   selected,
   selectedIDs,
+  selectedKVMs,
+  selectedRSDs,
   statuses,
 };
 


### PR DESCRIPTION
## Done

- Created separate selectors for selected KVMs and selected RSDs. Also renamed some variables ithe KVM components to be clearer in this regard.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the KVM list and details pages still load the data correctly.
- Check that you can select/unselect properly in the KVM list

## Fixes

Fixes #1633

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
