### PR TITLE
fix(legacy): truncate long fabric names in machine details

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -4629,7 +4629,7 @@
                 </td>
                 <td class="p-double-row">
                   <div class="p-double-row__rows-container">
-                    <div class="p-double-row__main-row" aria-label="Fabric">
+                    <div class="p-double-row__main-row u-truncate" aria-label="Fabric">
                       <span
                         data-ng-if="!isEditing(interface)"
                         title="{$ interface.fabric.name || 'Disconnected' $}"

--- a/legacy/src/scss/tables/_patterns_double-row.scss
+++ b/legacy/src/scss/tables/_patterns_double-row.scss
@@ -41,6 +41,11 @@
 
     .p-double-row__main-row {
       @extend %p-double-row__row;
+
+      &.u-truncate {
+        // Allow the content to be truncated.
+        display: block;
+      }
     }
 
     .p-double-row__muted-row {


### PR DESCRIPTION
## Done

- In the network table in machine details long fabric names have been truncated.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Edit a fabric name to be really long.
- Navigate to the machine details of a machine that uses that fabric.
- Click on the network tab and you should see the truncated fabric name.

<img width="279" alt="Screen Shot 2020-09-17 at 10 02 37 am" src="https://user-images.githubusercontent.com/361637/93404411-77cb0780-f8cd-11ea-8d43-7f85d4c71253.png">


## Fixes

Fixes: canonical-web-and-design/maas-ui#1572