### PR TITLE
fix(legacy): fixed duplicate form ids

### DIFF
--- a/legacy/src/app/directives/maas_obj_form.js
+++ b/legacy/src/app/directives/maas_obj_form.js
@@ -523,6 +523,7 @@ export function maasObjFieldGroup() {
 
 /* @ngInject */
 export function maasObjField($compile) {
+  let uniqueId = 1;
   return {
     restrict: "E",
     require: ["^^maasObjForm", "?^^maasObjFieldGroup"],
@@ -533,6 +534,8 @@ export function maasObjField($compile) {
     transclude: true,
     template: "<div data-ng-transclude></div>",
     link: function (scope, element, attrs, controllers) {
+      const uniqueKey = `${attrs.key}-${uniqueId}`;
+      uniqueId++;
       // Select the controller based on which is available.
       var controller = controllers[1];
       if (!angular.isObject(controller)) {
@@ -579,7 +582,7 @@ export function maasObjField($compile) {
 
       if (attrs.disableLabel !== "true" && !(attrs.type === "hidden")) {
         var labelElement = angular.element("<label/>");
-        labelElement.attr("for", attrs.key);
+        labelElement.attr("for", uniqueKey);
         labelElement.text(label);
         labelElement.addClass("p-form__label");
         if (attrs.labelWidth) {
@@ -609,12 +612,12 @@ export function maasObjField($compile) {
           } else {
             infoIcon.addClass("p-icon--information");
           }
-          infoIcon.attr("aria-describedby", attrs.key + "-tooptip");
+          infoIcon.attr("aria-describedby", uniqueKey + "-tooltip");
 
           var infoTooltip = angular.element("<p></p>");
           infoTooltip.addClass("p-tooltip__message");
           infoTooltip.text(attrs.labelInfo);
-          infoTooltip.attr("id", attrs.key + "-tooptip");
+          infoTooltip.attr("id", uniqueKey + "-tooltip");
 
           infoWrapper.append(infoIcon);
           infoWrapper.append(infoTooltip);
@@ -653,7 +656,7 @@ export function maasObjField($compile) {
         if (attrs.type === "text") {
           inputElement = $compile(
             '<input type="text" id="' +
-              attrs.key +
+              uniqueKey +
               '" placeholder="' +
               placeholder +
               '"' +
@@ -662,7 +665,7 @@ export function maasObjField($compile) {
         } else if (attrs.type === "textarea") {
           inputElement = $compile(
             '<textarea id="' +
-              attrs.key +
+              uniqueKey +
               '" placeholder="' +
               placeholder +
               '"' +
@@ -672,7 +675,7 @@ export function maasObjField($compile) {
         } else if (attrs.type === "password") {
           inputElement = $compile(
             '<input type="password" id="' +
-              attrs.key +
+              uniqueKey +
               '" placeholder="' +
               placeholder +
               '"' +
@@ -768,7 +771,7 @@ export function maasObjField($compile) {
         // Construct the select.
         inputElement = $compile(
           '<select id="' +
-            attrs.key +
+            uniqueKey +
             '" ' +
             'data-ng-model="_selectValue" ' +
             'data-ng-options="' +
@@ -828,12 +831,12 @@ export function maasObjField($compile) {
             '<div class="p-form__group" ',
             'style="padding-top: .2rem;" ',
             'data-ng-repeat="val in ' + values + '">',
-            '<input id="' + attrs.key + "_" + "{$ val $}",
+            '<input id="' + uniqueKey + "_" + "{$ val $}",
             '" type="checkbox" value="{$ val $}" ',
             'class="checkbox" ',
             'data-ng-checked="_checked(val)" ',
             'data-ng-click="_toggleChecked(val)">',
-            '<label for="' + attrs.key + "_",
+            '<label for="' + uniqueKey + "_",
             "{$ val $}" + '" ',
             'class="checkbox-label">{$ val $}</label>',
             "</div>",
@@ -863,7 +866,7 @@ export function maasObjField($compile) {
             '<span data-ng-if="ngDisabled()" ',
             'data-ng-repeat="tag in _tags">',
             "{$ tag.text $} </span>",
-            '<tags-input id="' + attrs.key + '" ',
+            '<tags-input id="' + uniqueKey + '" ',
             'data-ng-model="_tags" ',
             'data-ng-if="!ngDisabled()" ',
             'placeholder="' + placeholder + '" ',
@@ -892,7 +895,7 @@ export function maasObjField($compile) {
         inputElement = angular.element(
           [
             '<input type="hidden" name="' + attrs.key + '" ',
-            'id="' + attrs.key + '" ',
+            'id="' + uniqueKey + '" ',
             'value="' + attrs.value + '">',
             "</input>",
           ].join("")
@@ -919,7 +922,7 @@ export function maasObjField($compile) {
             '<div class="maas-p-switch">',
             '<input type="checkbox" name="' + attrs.key + '" ',
             'class="maas-p-switch--input" ',
-            'id="' + attrs.key + '" ',
+            'id="' + uniqueKey + '" ',
             'data-ng-disabled="ngDisabled()" ',
             'data-ng-model="_toggle" ',
             'data-ng-change="_changed()">',
@@ -982,11 +985,11 @@ export function maasObjField($compile) {
             '<input class="p-slider" type="range"',
             'min="' + attrs.min + '" max="' + attrs.max + '" ',
             'value="1" step="' + attrs.step + '" ',
-            'id="' + attrs.key + '" ',
+            'id="' + uniqueKey + '" ',
             'data-ng-model="_slider" data-ng-disabled="',
             '_ngDisabled()">',
             '<input class="p-slider__input" type="text" ',
-            'maxlength="3" id="' + attrs.key + '-input" ',
+            'maxlength="3" id="' + uniqueKey + '-input" ',
             'data-ng-model="_slider" disabled="disabled" ',
             "></div>",
           ].join("")

--- a/legacy/src/app/directives/power_parameters.js
+++ b/legacy/src/app/directives/power_parameters.js
@@ -6,13 +6,13 @@
 import angular from "angular";
 
 const powerParametersTmpl = `<div class="p-form__group row">
-    <label for="power-type"
+    <label for="power-type-{{::uniqueId}}"
         class="p-form__label col-2 is-required"
         data-ng-class="{'is-disabled': !ngModel.editing }">
         Power type
     </label>
     <div class="p-form__control col-4">
-        <select name="power-type" id="power-type"
+        <select name="power-type" id="power-type-{{::uniqueId}}"
             data-ng-disabled="ngDisabled || ngModel.in_pod"
             data-ng-class="{ invalid: !ngModel.type }"
             data-ng-model="ngModel.type"
@@ -177,6 +177,7 @@ export function maasPowerInput($compile) {
 }
 
 export function maasPowerParameters() {
+  let uniqueId = 1;
   return {
     restrict: "A",
     require: "ngModel",
@@ -186,5 +187,9 @@ export function maasPowerParameters() {
       ngDisabled: "=",
     },
     template: powerParametersTmpl,
+    link: function (scope, elem, attrs) {
+      scope.uniqueId = uniqueId;
+      uniqueId++;
+    },
   };
 }

--- a/legacy/src/app/directives/tests/test_maas_obj_form.js
+++ b/legacy/src/app/directives/tests/test_maas_obj_form.js
@@ -85,13 +85,13 @@ describe("maasObjForm", function () {
     });
 
     it("creates input with type 'text'", function () {
-      var inputField = angular.element(directive.find("#key"));
+      var inputField = angular.element(directive.find("#key-1"));
       expect(inputField.prop("nodeName")).toBe("INPUT");
       expect(inputField.attr("type")).toBe("text");
     });
 
     it("sets placeholder", function () {
-      var inputField = angular.element(directive.find("#key"));
+      var inputField = angular.element(directive.find("#key-1"));
       expect(inputField.attr("placeholder")).toBe("Placeholder");
     });
 
@@ -108,7 +108,7 @@ describe("maasObjForm", function () {
     });
 
     it("reverts value on esc", function () {
-      var inputField = angular.element(directive.find("#key"));
+      var inputField = angular.element(directive.find("#key-1"));
       inputField.triggerHandler("focus");
       inputField.val(makeName("newValue"));
 
@@ -147,12 +147,12 @@ describe("maasObjForm", function () {
     });
 
     it("creates textarea", function () {
-      var textarea = angular.element(directive.find("#key"));
+      var textarea = angular.element(directive.find("#key-1"));
       expect(textarea.prop("nodeName")).toBe("TEXTAREA");
     });
 
     it("sets placeholder", function () {
-      var textarea = angular.element(directive.find("#key"));
+      var textarea = angular.element(directive.find("#key-1"));
       expect(textarea.attr("placeholder")).toBe("Placeholder");
     });
 
@@ -187,13 +187,13 @@ describe("maasObjForm", function () {
     });
 
     it("creates input with type 'password'", function () {
-      var inputField = angular.element(directive.find("#key"));
+      var inputField = angular.element(directive.find("#key-1"));
       expect(inputField.prop("nodeName")).toBe("INPUT");
       expect(inputField.attr("type")).toBe("password");
     });
 
     it("sets placeholder", function () {
-      var inputField = angular.element(directive.find("#key"));
+      var inputField = angular.element(directive.find("#key-1"));
       expect(inputField.attr("placeholder")).toBe("Placeholder");
     });
 
@@ -210,7 +210,7 @@ describe("maasObjForm", function () {
     });
 
     it("reverts value on esc", function () {
-      var inputField = angular.element(directive.find("#key"));
+      var inputField = angular.element(directive.find("#key-1"));
       inputField.triggerHandler("focus");
       inputField.val(makeName("newValue"));
 
@@ -257,13 +257,13 @@ describe("maasObjForm", function () {
     });
 
     it("creates select", function () {
-      var select = angular.element(directive.find("#key"));
+      var select = angular.element(directive.find("#key-1"));
       expect(select.prop("nodeName")).toBe("SELECT");
       expect(select.attr("data-ng-options")).toBe(options);
     });
 
     it("adds placeholder option", function () {
-      var select = angular.element(directive.find("#key"));
+      var select = angular.element(directive.find("#key-1"));
       var placeholder = angular.element(select.find('option[value=""]'));
       expect(placeholder.attr("disabled")).toBe("disabled");
       expect(placeholder.text()).toBe("Placeholder");
@@ -279,7 +279,7 @@ describe("maasObjForm", function () {
         "</maas-obj-form>",
       ].join("");
       directive = compileDirective(html);
-      var select = angular.element(directive.find("#key"));
+      var select = angular.element(directive.find("#key-1"));
       var placeholder = angular.element(select.find('option[value=""]'));
       expect(placeholder.attr("disabled")).toBeUndefined();
     });
@@ -364,14 +364,14 @@ describe("maasObjForm", function () {
         var div = angular.element(divs[idx]);
         var input = angular.element(div.find("input"));
         var label = angular.element(div.find("label"));
-        expect(input.attr("id")).toBe("key_" + value);
-        expect(label.attr("for")).toBe("key_" + value);
+        expect(input.attr("id")).toBe("key-1_" + value);
+        expect(label.attr("for")).toBe("key-1_" + value);
         expect(label.text()).toBe(value);
       });
     });
 
     it("adds label with width", function () {
-      var labelField = angular.element(directive.find('label[for="key"]'));
+      var labelField = angular.element(directive.find('label[for="key-1"]'));
       expect(labelField.text()).toBe("Key");
       expect(labelField.hasClass("col-2")).toBe(true);
     });
@@ -400,7 +400,7 @@ describe("maasObjForm", function () {
     });
 
     it("adds label with width", function () {
-      var labelField = angular.element(directive.find('label[for="key"]'));
+      var labelField = angular.element(directive.find('label[for="key-1"]'));
       expect(labelField.text()).toBe("Key");
       expect(labelField.hasClass("col-2")).toBe(true);
     });
@@ -429,7 +429,7 @@ describe("maasObjForm", function () {
     });
 
     it("adds label with width", function () {
-      var labelField = angular.element(directive.find('label[for="key"]'));
+      var labelField = angular.element(directive.find('label[for="key-1"]'));
       expect(labelField.text()).toBe("Key");
       expect(labelField.hasClass("col-2")).toBe(true);
     });
@@ -458,7 +458,7 @@ describe("maasObjForm", function () {
     });
 
     it("adds label with width", function () {
-      var labelField = angular.element(directive.find('label[for="key"]'));
+      var labelField = angular.element(directive.find('label[for="key-1"]'));
       expect(labelField.text()).toBe("Key");
       expect(labelField.hasClass("col-2")).toBe(true);
     });
@@ -510,12 +510,12 @@ describe("maasObjForm", function () {
     });
 
     it("sets input to value", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       expect(field.val()).toBe($scope.obj.key);
     });
 
     it("updates input to value when not in focus", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       expect(field.val()).toBe($scope.obj.key);
       $scope.obj.key = makeName("new_key");
       $scope.$digest();
@@ -523,7 +523,7 @@ describe("maasObjForm", function () {
     });
 
     it("doesn't update input to value when in focus", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       expect(field.val()).toBe($scope.obj.key);
       field.triggerHandler("focus");
       $scope.obj.key = makeName("new_key");
@@ -533,14 +533,14 @@ describe("maasObjForm", function () {
 
     it("sets 'saving' class on form when value changed", function () {
       var form = angular.element(directive.find("form"));
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var newKey = makeName("new_key");
       changeFieldValue(field, newKey);
       expect(form.hasClass("saving")).toBe(true);
     });
 
     it("calls updateItem on form when value changed", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var newKey = makeName("new_key");
       changeFieldValue(field, newKey);
       expect(updateItemMethod).toHaveBeenCalledWith({
@@ -549,14 +549,14 @@ describe("maasObjForm", function () {
     });
 
     it("doesnt call updateItem on form when no value change", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       changeFieldValue(field, $scope.obj.key);
       expect(updateItemMethod).not.toHaveBeenCalled();
     });
 
     it("removes 'saving' class on form when saved", function () {
       var form = angular.element(directive.find("form"));
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var newKey = makeName("new_key");
       changeFieldValue(field, newKey);
       expect(form.hasClass("saving")).toBe(true);
@@ -568,7 +568,7 @@ describe("maasObjForm", function () {
 
     it("updates the element to the value resolved", function () {
       var form = angular.element(directive.find("form"));
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       changeFieldValue(field, makeName("new_key"));
       expect(form.hasClass("saving")).toBe(true);
 
@@ -581,7 +581,7 @@ describe("maasObjForm", function () {
     });
 
     it("sets string error on field", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var control = angular.element(directive.find(".p-form__control"));
       changeFieldValue(field, makeName("new_key"));
 
@@ -594,7 +594,7 @@ describe("maasObjForm", function () {
     });
 
     it("sets field error on field", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var control = angular.element(directive.find(".p-form__control"));
       changeFieldValue(field, makeName("new_key"));
 
@@ -612,7 +612,7 @@ describe("maasObjForm", function () {
     });
 
     it("sets field error on another field", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var control = angular.element(directive.find(".p-form__control"));
       changeFieldValue(field, makeName("new_key"));
 
@@ -630,7 +630,7 @@ describe("maasObjForm", function () {
     });
 
     it("sets multiple errors on field", function () {
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var control = angular.element(directive.find(".p-form__control"));
       changeFieldValue(field, makeName("new_key"));
 
@@ -671,7 +671,7 @@ describe("maasObjForm", function () {
         "</maas-obj-form>",
       ].join("");
       var directive = compileDirective(html);
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var newKey = makeName("new_key");
       changeFieldValue(field, newKey);
       expect(preProcess).toHaveBeenCalled();
@@ -705,9 +705,9 @@ describe("maasObjForm", function () {
     });
 
     it("sets field error on both fields", function () {
-      var field1 = angular.element(directive.find("#key1"));
-      var selector1 = "label[for='key1'] + .p-form__control";
-      var selector2 = "label[for='key2'] + .p-form__control";
+      var field1 = angular.element(directive.find("#key1-1"));
+      var selector1 = "label[for='key1-1'] + .p-form__control";
+      var selector2 = "label[for='key2-2'] + .p-form__control";
       var control1 = angular.element(directive.find(selector1));
       var control2 = angular.element(directive.find(selector2));
       changeFieldValue(field1, makeName("new_key"));
@@ -756,8 +756,8 @@ describe("maasObjForm", function () {
     });
 
     it("doesnt try to save when switching between fields", function () {
-      var field1 = angular.element(directive.find("#key1"));
-      var field2 = angular.element(directive.find("#key2"));
+      var field1 = angular.element(directive.find("#key1-1"));
+      var field2 = angular.element(directive.find("#key2-2"));
       changeFieldValue(field1, makeName("new_key"));
       field2.triggerHandler("focus");
 
@@ -768,8 +768,8 @@ describe("maasObjForm", function () {
     });
 
     it("saves when both fields lose focus", function () {
-      var field1 = angular.element(directive.find("#key1"));
-      var field2 = angular.element(directive.find("#key2"));
+      var field1 = angular.element(directive.find("#key1-1"));
+      var field2 = angular.element(directive.find("#key2-2"));
       var newKey1 = makeName("new_key1");
       var newKey2 = makeName("new_key2");
       changeFieldValue(field1, newKey1);
@@ -796,8 +796,8 @@ describe("maasObjForm", function () {
     });
 
     it("doesn't change field value when one being edited", function () {
-      var field1 = angular.element(directive.find("#key1"));
-      var field2 = angular.element(directive.find("#key2"));
+      var field1 = angular.element(directive.find("#key1-1"));
+      var field2 = angular.element(directive.find("#key2-2"));
 
       // Grab the focus of the first field.
       field1.triggerHandler("focus");
@@ -844,8 +844,8 @@ describe("maasObjForm", function () {
     });
 
     it("both input and select can be disabled", function () {
-      var input = angular.element(directive.find("#key"));
-      var select = angular.element(directive.find("#key2"));
+      var input = angular.element(directive.find("#key-1"));
+      var select = angular.element(directive.find("#key2-2"));
 
       expect(input.prop("disabled")).toBe(false);
       expect(select.prop("disabled")).toBe(false);
@@ -880,7 +880,7 @@ describe("maasObjForm", function () {
         "</maas-obj-form>",
       ].join("");
       var directive = compileDirective(html);
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
 
       var newKey = makeName("new_key");
       changeFieldValue(field, newKey);
@@ -908,7 +908,7 @@ describe("maasObjForm", function () {
       ].join("");
       var directive = compileDirective(html);
       var group = angular.element(directive.find('maas-obj-field[key="key"]'));
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       expect(group.hasClass("p-form__group")).toBe(true);
       expect(field.parent("div").hasClass("p-form__control")).toBe(true);
     });
@@ -934,7 +934,7 @@ describe("maasObjForm", function () {
         "</maas-obj-form>",
       ].join("");
       var directive = compileDirective(html);
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
 
       var newKey = makeName("new_key");
       changeFieldValue(field, newKey);
@@ -962,7 +962,7 @@ describe("maasObjForm", function () {
         "</maas-obj-form>",
       ].join("");
       var directive = compileDirective(html);
-      var field = angular.element(directive.find("#key"));
+      var field = angular.element(directive.find("#key-1"));
       var button = angular.element(directive.find("button"));
 
       var newKey = makeName("new_key");

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -533,11 +533,11 @@
                         </td>
                         <td class="p-table__cell" aria-label="IP address">
                             <div class="p-form-validation u-no-margin--top" data-ng-class="{ 'is-error': ipHasError(interface) }">
-                                <input type="text" id="ip-address" placeholder="000.000.000.000"
+                                <input type="text" placeholder="000.000.000.000"
                                     class="p-form-validation__input"
                                     data-ng-model="interface.ipAddress"
                                     data-ng-show="interface.ipAssignment.name === 'external'">
-                                <input type="text" id="ip-address"
+                                <input type="text"
                                     class="p-form-validation__input"
                                     data-ng-model="interface.ipAddress"
                                     data-ng-show="interface.ipAssignment.name === 'static'">


### PR DESCRIPTION
## Done

- Updated forms to use unique ids so that there aren't duplicate ids on the page.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

There should be no duplicate console warnings for any of the following:
- Visit devices. 
  - Add device and supply an IP address (need to change ip assignment for the field to appear).
- Visit controllers.
  - View a controller and open the Configuration tab. Click edit for 'Power configuration'. Click on the power type label, it should focus on the select box.
- View subnets.
  - Use the take action menu to open one of the forms. Clicking on the name label should focus on the input.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1560