### PR TITLE
fix(root): don't show slow mount warnings for 30 seconds

### DIFF
--- a/root/src/root-application.js
+++ b/root/src/root-application.js
@@ -3,6 +3,8 @@ import {
   addErrorHandler,
   getAppStatus,
   registerApplication,
+  setBootstrapMaxTime,
+  setMountMaxTime,
   start,
 } from "single-spa";
 import { name as appName, version as appVersion } from "../../ui/package.json";
@@ -61,6 +63,11 @@ window.addEventListener("single-spa:app-change", (evt) => {
     showError(false);
   }
 });
+
+// Don't display an error or warning about slow bootstrap/mount unless it takes
+// more than 30 seconds.
+setBootstrapMaxTime(30000, false, 30000);
+setMountMaxTime(30000, false, 30000);
 
 addErrorHandler((err) => {
   showError(true);


### PR DESCRIPTION
## Done

- Don't show a warning if the mount is slow unless it takes longer than 30 seconds.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load a legacy page (refresh if you've navigated from a react view).
- You shouldn't see a warning in the console from single-spa.