### PR TITLE
feat(root): display a message when JavaScript is disabled

### DIFF
--- a/root/src/index.ejs
+++ b/root/src/index.ejs
@@ -69,6 +69,19 @@
           </div>
         </div>
       </header>
+      <noscript>
+        <div class="p-strip">
+          <div class="row">
+            <div class="col-12">
+              <div class="p-notification--negative">
+                <p class="p-notification__response">
+                  <span class="p-notification__status">Error:</span> JavaScript must be enabled in your browser to use MAAS.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </noscript>
     </div>
     <% htmlWebpackPlugin.files.js.forEach(function(file){ %>
       <script src="<%= file %>"></script>


### PR DESCRIPTION
## Done

- Add a message to the root template to warn users if JavaScript is disabled.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Disable JavaScript in your browser (might be in your devtools settings).
- Load the ui. You should see a warning.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1522
