### PR TITLE
fix(legacy): fix the back button for node details tabs

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -1759,6 +1759,12 @@ function NodeDetailsController(
     if ($scope.isDevice && activeNode) {
       $scope.ip_assignment = activeNode.ip_assignment;
     }
+    // Handle updating the area when the browser navigates back/forward.
+    $scope.$on("$locationChangeStart", () => {
+      $scope.section.area = angular.isString($location.search().area)
+        ? $location.search().area
+        : "summary";
+    });
   });
 }
 

--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -1761,7 +1761,7 @@ function NodeDetailsController(
     }
     // Handle updating the area when the browser navigates back/forward.
     $scope.$on("$locationChangeStart", () => {
-      $scope.section.area = angular.isString($location.search().area)
+      $scope.section.area = angular.isString($location?.search()?.area)
         ? $location.search().area
         : "summary";
     });


### PR DESCRIPTION
## Done

- Fix the routing when navigating back/forward between tabs for the node details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load a machine/controller or device details page.
- Click on a few tabs.
- Use your browser to navigate forward/back. The tabs and URL should change as you navigate.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1504