### PR TITLE
feat(ui): add description field for marking machine broken

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -15,14 +15,14 @@ exports[`stricter compilation`] = {
       [114, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [114, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/base/components/ActionForm/ActionForm.tsx:1504028928": [
+    "src/app/base/components/ActionForm/ActionForm.tsx:1368649959": [
       [15, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [19, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [22, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [22, 22, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [24, 13, 13, "Object is possibly \'undefined\'.", "3155939599"],
-      [125, 39, 6, "Argument of type \'{ [x: string]: any; } | undefined\' is not assignable to parameter of type \'string | object | string[]\'.\\n  Type \'undefined\' is not assignable to type \'string | object | string[]\'.", "1168132398"],
-      [128, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
+      [127, 39, 6, "Argument of type \'{ [x: string]: any; } | undefined\' is not assignable to parameter of type \'string | object | string[]\'.\\n  Type \'undefined\' is not assignable to type \'string | object | string[]\'.", "1168132398"],
+      [130, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
     "src/app/base/components/DoughnutChart/DoughnutChart.tsx:2227983544": [
       [98, 8, 11, "Type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.\\n  Type \'null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.", "2109816907"],
@@ -39,11 +39,7 @@ exports[`stricter compilation`] = {
       [71, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-<<<<<<< HEAD
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
-=======
       [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
->>>>>>> 0fd1d14f... feat(ui): add description field for marking machine broken
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -85,11 +81,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-<<<<<<< HEAD
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
-=======
       [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
->>>>>>> 0fd1d14f... feat(ui): add description field for marking machine broken
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -375,14 +367,16 @@ exports[`stricter compilation`] = {
       [69, 4, 14, "Type \'([file]: [any]) => void\' is not assignable to type \'<T extends File>(files: T[], event: DropEvent) => void\'.\\n  Types of parameters \'__0\' and \'files\' are incompatible.\\n    Type \'T[]\' is not assignable to type \'[any]\'.\\n      Target requires 1 element(s) but source may have fewer.", "3837758380"],
       [102, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx:4023639892": [
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx:2835343033": [
       [63, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [64, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"]
+      [64, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"],
+      [118, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [119, 8, 11, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "942845580"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:1113274649": [
-      [44, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
-      [47, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"],
-      [47, 38, 7, "Object is possibly \'undefined\'.", "1060875104"]
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:368427658": [
+      [47, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
+      [50, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"],
+      [50, 38, 7, "Object is possibly \'undefined\'.", "1060875104"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx:3260645888": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -669,9 +663,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-<<<<<<< HEAD
-  value: `470`
-=======
-  value: `585`
->>>>>>> 0fd1d14f... feat(ui): add description field for marking machine broken
+  value: `608`
 };

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -39,7 +39,11 @@ exports[`stricter compilation`] = {
       [71, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
+<<<<<<< HEAD
       [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+=======
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+>>>>>>> 0fd1d14f... feat(ui): add description field for marking machine broken
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -81,7 +85,11 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
+<<<<<<< HEAD
       [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+=======
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+>>>>>>> 0fd1d14f... feat(ui): add description field for marking machine broken
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -328,14 +336,15 @@ exports[`stricter compilation`] = {
       [93, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [135, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:558999798": [
-      [54, 12, 7, "Object is possibly \'undefined\'.", "1060875104"],
-      [55, 26, 7, "Object is possibly \'undefined\'.", "1060875104"],
-      [55, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [72, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
-      [82, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
-      [105, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
-      [119, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:1127825407": [
+      [55, 12, 7, "Object is possibly \'undefined\'.", "1060875104"],
+      [56, 26, 7, "Object is possibly \'undefined\'.", "1060875104"],
+      [56, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
+      [73, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+      [83, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [85, 33, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action: MachineAction | null, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [108, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
+      [122, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.test.tsx:1717182927": [
       [99, 23, 9, "Property \'mockClear\' does not exist on type \'(eventCategory: any, eventAction: any, eventLabel: any) => void\'.", "2526230614"],
@@ -365,6 +374,15 @@ exports[`stricter compilation`] = {
       [53, 18, 6, "Argument of type \'string\' is not assignable to parameter of type \'SetStateAction<null>\'.", "1168132398"],
       [69, 4, 14, "Type \'([file]: [any]) => void\' is not assignable to type \'<T extends File>(files: T[], event: DropEvent) => void\'.\\n  Types of parameters \'__0\' and \'files\' are incompatible.\\n    Type \'T[]\' is not assignable to type \'[any]\'.\\n      Target requires 1 element(s) but source may have fewer.", "3837758380"],
       [102, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx:4023639892": [
+      [63, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [64, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:1113274649": [
+      [44, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
+      [47, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"],
+      [47, 38, 7, "Object is possibly \'undefined\'.", "1060875104"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx:3260645888": [
       [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -651,5 +669,9 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
+<<<<<<< HEAD
   value: `470`
+=======
+  value: `585`
+>>>>>>> 0fd1d14f... feat(ui): add description field for marking machine broken
 };

--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -183,8 +183,10 @@ machine.exitRescueMode = (systemId) =>
     systemId
   );
 
-machine.markBroken = (systemId) =>
-  generateMachineAction("MARK_MACHINE_BROKEN", "mark-broken", systemId);
+machine.markBroken = (systemId, message) =>
+  generateMachineAction("MARK_MACHINE_BROKEN", "mark-broken", systemId, {
+    message,
+  });
 
 machine.markFixed = (systemId) =>
   generateMachineAction("MARK_MACHINE_FIXED", "mark-fixed", systemId);

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -343,7 +343,7 @@ describe("machine actions", () => {
   });
 
   it("can handle marking a machine as broken", () => {
-    expect(machine.markBroken("abc123")).toEqual({
+    expect(machine.markBroken("abc123", "machine is on fire")).toEqual({
       type: "MARK_MACHINE_BROKEN",
       meta: {
         model: "machine",
@@ -352,7 +352,9 @@ describe("machine actions", () => {
       payload: {
         params: {
           action: "mark-broken",
-          extra: {},
+          extra: {
+            message: "machine is on fire",
+          },
           system_id: "abc123",
         },
       },

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -88,6 +88,7 @@ const getLabel = (
 type Props = {
   actionName?: string;
   allowUnchanged?: boolean;
+  allowAllEmpty?: boolean;
   children?: ReactNode;
   cleanup?: () => void;
   clearSelectedAction?: (...args: unknown[]) => void;
@@ -107,6 +108,7 @@ type Props = {
 const ActionForm = ({
   actionName,
   allowUnchanged = false,
+  allowAllEmpty = false,
   children,
   cleanup,
   clearSelectedAction,
@@ -139,6 +141,7 @@ const ActionForm = ({
   return (
     <FormikForm
       allowUnchanged={allowUnchanged}
+      allowAllEmpty={allowAllEmpty}
       buttons={FormCardButtons}
       buttonsBordered={false}
       cleanup={cleanup}

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -67,15 +67,18 @@ export const useFormikFormDisabled = ({
   allowUnchanged = false,
 }) => {
   const { initialValues, errors, values } = useFormikContext();
+  // As we delete keys from values below, we don't want to
+  // mutate the actual form values
+  const newValues = { ...values };
   let hasErrors = false;
   if (errors) {
     hasErrors = Object.keys(errors).length > 0;
   }
   if (allowAllEmpty) {
     // If all fields are allowed to be empty then remove the from the values.
-    Object.keys(values).forEach((key) => {
-      if (!values[key]) {
-        delete values[key];
+    Object.keys(newValues).forEach((key) => {
+      if (!newValues[key]) {
+        delete newValues[key];
       }
     });
   }
@@ -85,8 +88,8 @@ export const useFormikFormDisabled = ({
   let matchesInitial = false;
   // Now that fields have been removed then make sure there are some fields left
   // to compare.
-  if (Object.keys(values).length) {
-    matchesInitial = simpleObjectEquality(initialValues, values);
+  if (Object.keys(newValues).length) {
+    matchesInitial = simpleObjectEquality(initialValues, newValues);
   }
   return matchesInitial || hasErrors;
 };

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx
@@ -10,6 +10,7 @@ import type { MachineAction } from "app/store/general/types";
 import CommissionForm from "./CommissionForm";
 import DeployForm from "./DeployForm";
 import FieldlessForm from "./FieldlessForm";
+import MarkBrokenForm from "./MarkBrokenForm";
 import OverrideTestForm from "./OverrideTestForm";
 import SetPoolForm from "./SetPoolForm";
 import SetZoneForm from "./SetZoneForm";
@@ -81,6 +82,8 @@ export const ActionFormWrapper = ({
           return <CommissionForm setSelectedAction={setSelectedAction} />;
         case "deploy":
           return <DeployForm setSelectedAction={setSelectedAction} />;
+        case "mark-broken":
+          return <MarkBrokenForm setSelectedAction={setSelectedAction} />;
         case "override-failed-testing":
           return <OverrideTestForm setSelectedAction={setSelectedAction} />;
         case "set-pool":

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/FieldlessForm.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/FieldlessForm.js
@@ -43,9 +43,6 @@ const useSelectedProcessing = (actionName) => {
     case "lock":
       selector = machineSelectors.lockingSelected;
       break;
-    case "mark-broken":
-      selector = machineSelectors.markingBrokenSelected;
-      break;
     case "mark-fixed":
       selector = machineSelectors.markingFixedSelected;
       break;

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
@@ -35,7 +35,6 @@ describe("FieldlessForm", () => {
             { name: "delete", sentence: "delete" },
             { name: "exit-rescue-mode", sentence: "exit-rescue-mode" },
             { name: "lock", sentence: "lock" },
-            { name: "mark-broken", sentence: "mark-broken" },
             { name: "mark-fixed", sentence: "mark-fixed" },
             { name: "off", sentence: "off" },
             { name: "on", sentence: "on" },
@@ -302,45 +301,6 @@ describe("FieldlessForm", () => {
         payload: {
           params: {
             action: "lock",
-            extra: {},
-            system_id: "abc123",
-          },
-        },
-      },
-    ]);
-  });
-
-  it("can dispatch mark broken action", () => {
-    const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["mark-broken"] }];
-    state.machine.selected = ["abc123"];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <FieldlessForm
-            selectedAction={{ name: "mark-broken" }}
-            setSelectedAction={jest.fn()}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    act(() => wrapper.find("Formik").props().onSubmit());
-    expect(
-      store.getActions().filter(({ type }) => type === "MARK_MACHINE_BROKEN")
-    ).toStrictEqual([
-      {
-        type: "MARK_MACHINE_BROKEN",
-        meta: {
-          model: "machine",
-          method: "action",
-        },
-        payload: {
-          params: {
-            action: "mark-broken",
             extra: {},
             system_id: "abc123",
           },

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.js.snap
@@ -22,6 +22,7 @@ exports[`FieldlessForm renders 1`] = `
     submitAppearance="positive"
   >
     <FormikForm
+      allowAllEmpty={false}
       allowUnchanged={true}
       buttons={[Function]}
       buttonsBordered={false}
@@ -47,6 +48,7 @@ exports[`FieldlessForm renders 1`] = `
         onSubmit={[Function]}
       >
         <FormikFormContent
+          allowAllEmpty={false}
           allowUnchanged={true}
           buttons={[Function]}
           buttonsBordered={false}

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -101,4 +101,43 @@ describe("MarkBrokenForm", () => {
       },
     ]);
   });
+
+  it("dispatches actions to mark selected machines broken without a message", () => {
+    const store = mockStore(initialState);
+    initialState.machine.selected = ["abc123"];
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MarkBrokenForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper.find("Formik").props().onSubmit({
+        comment: "",
+      })
+    );
+
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "MARK_MACHINE_BROKEN",
+        meta: {
+          model: "machine",
+          method: "action",
+        },
+        payload: {
+          params: {
+            action: "mark-broken",
+            extra: {
+              message: "",
+            },
+            system_id: "abc123",
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -1,0 +1,104 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import MarkBrokenForm from "./MarkBrokenForm";
+import { RootState } from "app/store/root/types";
+import {
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+  machine as machineFactory,
+  machineActionsState as machineActionsStateFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MarkBrokenForm", () => {
+  let initialState: RootState;
+  beforeEach(() => {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
+        machineActions: machineActionsStateFactory({
+          data: [
+            {
+              name: "mark-broken",
+              title: "Mark broken",
+              sentence: "marked broken",
+              type: "testing",
+            },
+          ],
+        }),
+      }),
+      machine: machineStateFactory({
+        items: [
+          machineFactory({ system_id: "abc123" }),
+          machineFactory({ system_id: "def456" }),
+        ],
+        statuses: {
+          abc123: machineStatusFactory({ markingBroken: false }),
+          def456: machineStatusFactory({ markingBroken: false }),
+        },
+      }),
+    });
+  });
+
+  it("dispatches actions to mark selected machines broken", () => {
+    const store = mockStore(initialState);
+    initialState.machine.selected = ["abc123", "def456"];
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <MarkBrokenForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper.find("Formik").props().onSubmit({
+        comment: "machine is on fire",
+      })
+    );
+
+    expect(store.getActions()).toStrictEqual([
+      {
+        type: "MARK_MACHINE_BROKEN",
+        meta: {
+          model: "machine",
+          method: "action",
+        },
+        payload: {
+          params: {
+            action: "mark-broken",
+            extra: {
+              message: "machine is on fire",
+            },
+            system_id: "abc123",
+          },
+        },
+      },
+      {
+        type: "MARK_MACHINE_BROKEN",
+        meta: {
+          model: "machine",
+          method: "action",
+        },
+        payload: {
+          params: {
+            action: "mark-broken",
+            extra: {
+              message: "machine is on fire",
+            },
+            system_id: "def456",
+          },
+        },
+      },
+    ]);
+  });
+});

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -41,6 +41,9 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}
       errors={errors}
+      initialValues={{
+        comment: "",
+      }}
       modelName="machine"
       onSubmit={(values: MarkBrokenFormValues) => {
         selectedMachines.forEach((machine) => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -1,0 +1,64 @@
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+import PropTypes from "prop-types";
+import React, { useEffect } from "react";
+
+import MarkBrokenFormFields from "./MarkBrokenFormFields";
+import { machine as machineActions } from "app/base/actions";
+import ActionForm from "app/base/components/ActionForm";
+import type { MachineAction } from "app/store/general/types";
+import machineSelectors from "app/store/machine/selectors";
+
+const MarkBrokenSchema = Yup.object().shape({
+  comment: Yup.string(),
+});
+
+type MarkBrokenFormValues = {
+  comment: string;
+};
+
+type Props = {
+  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+};
+
+export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+
+  const selectedMachines = useSelector(machineSelectors.selected);
+  const machineErrors = useSelector(machineSelectors.errors);
+  const errors = Object.keys(machineErrors).length > 0 ? machineErrors : null;
+
+  useEffect(
+    () => () => {
+      dispatch(machineActions.cleanup());
+    },
+    [dispatch]
+  );
+
+  return (
+    <ActionForm
+      actionName="mark-broken"
+      cleanup={machineActions.cleanup}
+      clearSelectedAction={() => setSelectedAction(null, true)}
+      errors={errors}
+      modelName="machine"
+      onSubmit={(values: MarkBrokenFormValues) => {
+        selectedMachines.forEach((machine) => {
+          dispatch(
+            machineActions.markBroken(machine.system_id, values.comment)
+          );
+        });
+      }}
+      selectedCount={selectedMachines.length}
+      validationSchema={MarkBrokenSchema}
+    >
+      <MarkBrokenFormFields selectedCount={selectedMachines.length} />
+    </ActionForm>
+  );
+};
+
+MarkBrokenForm.propTypes = {
+  setSelectedAction: PropTypes.func.isRequired,
+};
+
+export default MarkBrokenForm;

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -54,6 +54,7 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
       }}
       selectedCount={selectedMachines.length}
       validationSchema={MarkBrokenSchema}
+      allowAllEmpty
     >
       <MarkBrokenFormFields selectedCount={selectedMachines.length} />
     </ActionForm>

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/MarkBrokenFormFields.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/MarkBrokenFormFields.tsx
@@ -1,0 +1,33 @@
+import pluralize from "pluralize";
+import { Col, Row } from "@canonical/react-components";
+import React from "react";
+
+import FormikField from "app/base/components/FormikField";
+
+type Props = {
+  selectedCount: number;
+};
+
+export const MarkBrokenFormFields = ({ selectedCount }: Props): JSX.Element => (
+  <Row>
+    <Col size="4">
+      <FormikField
+        label={`Add error description to ${selectedCount} ${pluralize(
+          "machine",
+          selectedCount
+        )}`}
+        type="text"
+        name="comment"
+      />
+    </Col>
+    <Col size="5">
+      <p className="p-form__help">
+        The error description will be visible under the status of each machine
+        in the machine listing. It will be removed when the machine is marked as
+        fixed.
+      </p>
+    </Col>
+  </Row>
+);
+
+export default MarkBrokenFormFields;

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/_index.scss
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/_index.scss
@@ -1,0 +1,8 @@
+@mixin MarkBrokenFormFields {
+  // Vertically align inline form help text
+  .p-form__help {
+    @extend %small-text;
+    color: $color-mid-dark;
+    margin-top: $sp-large;
+  }
+}

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/index.ts
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MarkBrokenFormFields";

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/index.ts
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MarkBrokenForm";

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.js
@@ -136,9 +136,17 @@ export const StatusColumn = ({ onToggleMenu, systemId }) => {
         </span>
       }
       secondary={
-        <span data-test="progress-text" title={getProgressText(machine)}>
-          {getProgressText(machine)}
-        </span>
+        <>
+          <span data-test="progress-text" title={getProgressText(machine)}>
+            {getProgressText(machine)}
+          </span>
+          <span data-test="error-text">
+            {machine.error_description &&
+            machine.status_code === nodeStatus.BROKEN
+              ? machine.error_description
+              : ""}
+          </span>
+        </>
       }
     />
   );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.js
@@ -148,6 +148,27 @@ describe("StatusColumn", () => {
         "Deploying Ubuntu 18.04 LTS"
       );
     });
+
+    it("displays an error message for broken machines", () => {
+      state.machine.items[0].error_description = "machine is on fire";
+      state.machine.items[0].status = "Broken";
+      state.machine.items[0].status_code = nodeStatus.BROKEN;
+      const store = mockStore(state);
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+          >
+            <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='error-text']").text()).toBe(
+        "machine is on fire"
+      );
+    });
   });
 
   describe("progress text", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.js.snap
@@ -250,12 +250,19 @@ exports[`StatusColumn renders 1`] = `
       </span>
     }
     secondary={
-      <span
-        data-test="progress-text"
-        title=""
-      >
-        
-      </span>
+      <React.Fragment>
+        <span
+          data-test="progress-text"
+          title=""
+        >
+          
+        </span>
+        <span
+          data-test="error-text"
+        >
+          
+        </span>
+      </React.Fragment>
     }
   >
     <div
@@ -437,6 +444,9 @@ exports[`StatusColumn renders 1`] = `
           <span
             data-test="progress-text"
             title=""
+          />
+          <span
+            data-test="error-text"
           />
         </div>
       </div>

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -32,7 +32,7 @@
   .p-checkbox--mixed:checked {
     + label::after {
       border-left: 0;
-      top: .3125rem;
+      top: 0.3125rem;
       transform: none;
     }
   }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -106,8 +106,10 @@
 
 // machines
 @import "~app/machines/views/MachineList";
+@import "~app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
 @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
 @include MachineList;
+@include MarkBrokenFormFields;
 @include FilterAccordion;
 
 // preferences


### PR DESCRIPTION
## Done
A description can now be provided when marking a machine broken,
which now displays the text under status on the machine listing.

designs:
https://app.zeplin.io/project/5e6a623cde850113ba28d75b/screen/5e7d035047a0278e20c0aa72

![image](https://user-images.githubusercontent.com/130286/93556174-3d945f80-f9cc-11ea-9a4d-212b242e73ae.png)

![image](https://user-images.githubusercontent.com/130286/93556230-6288d280-f9cc-11ea-9fc3-6be61476cb09.png)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a few allocated machines, and select the mark broken action.
- Add a description and mark broken.
- You should see the mark broken description in the machine listing in the status column.

## Fixes
Fixes: canonical-web-and-design/MAAS-design#924

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
