### PR TITLE
fix(ui): only show hugepage RAM in table if it exists

### DIFF
--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -21,7 +21,7 @@ describe("KVMResourcesCard", () => {
   });
 
   it("shows hugepage RAM details if provided", () => {
-    const wrapper = shallow(
+    const withHugepage = shallow(
       <KVMResourcesCard
         cores={{ allocated: 1, free: 2 }}
         ram={{
@@ -31,8 +31,21 @@ describe("KVMResourcesCard", () => {
         vms={[machineFactory({ system_id: "abc123" })]}
       />
     );
+    const withoutHugepage = shallow(
+      <KVMResourcesCard
+        cores={{ allocated: 1, free: 2 }}
+        ram={{
+          general: { allocated: 2, free: 3 },
+          hugepages: [],
+        }}
+        vms={[machineFactory({ system_id: "abc123" })]}
+      />
+    );
 
-    expect(wrapper.find("[data-test='hugepage-ram']").exists()).toBe(true);
+    expect(withHugepage.find("[data-test='hugepage-ram']").exists()).toBe(true);
+    expect(withoutHugepage.find("[data-test='hugepage-ram']").exists()).toBe(
+      false
+    );
   });
 
   it("shows virtual function details if any provided interfaces use virtual functions", () => {

--- a/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/ui/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -177,36 +177,37 @@ const KVMResourcesCard = ({
                 </span>
               </td>
             </tr>
-            {ram.hugepages?.map((hugepage, i) => (
-              <tr data-test="hugepage-ram" key={i}>
-                <td>
-                  Hugepage
-                  <br />
-                  <strong
-                    className="p-text--x-small u-text--light"
-                    data-test="hugepage-size"
-                  >
-                    {`(Size: ${memoryWithUnit(hugepage.pageSize)})`}
-                  </strong>
-                </td>
-                <td className="u-align--right">
-                  <span data-test="hugepage-allocated">
-                    {memoryWithUnit(hugepage.allocated)}
-                  </span>
-                  <span className="u-nudge-right--small">
-                    <i className="p-circle--positive"></i>
-                  </span>
-                </td>
-                <td className="u-align--right">
-                  <span data-test="hugepage-free">
-                    {memoryWithUnit(hugepage.free)}
-                  </span>
-                  <span className="u-nudge-right--small">
-                    <i className="p-circle--positive-faded"></i>
-                  </span>
-                </td>
-              </tr>
-            ))}
+            {hugepageTotal > 0 &&
+              ram.hugepages?.map((hugepage, i) => (
+                <tr data-test="hugepage-ram" key={i}>
+                  <td>
+                    Hugepage
+                    <br />
+                    <strong
+                      className="p-text--x-small u-text--light"
+                      data-test="hugepage-size"
+                    >
+                      {`(Size: ${memoryWithUnit(hugepage.pageSize)})`}
+                    </strong>
+                  </td>
+                  <td className="u-align--right">
+                    <span data-test="hugepage-allocated">
+                      {memoryWithUnit(hugepage.allocated)}
+                    </span>
+                    <span className="u-nudge-right--small">
+                      <i className="p-circle--positive"></i>
+                    </span>
+                  </td>
+                  <td className="u-align--right">
+                    <span data-test="hugepage-free">
+                      {memoryWithUnit(hugepage.free)}
+                    </span>
+                    <span className="u-nudge-right--small">
+                      <i className="p-circle--positive-faded"></i>
+                    </span>
+                  </td>
+                </tr>
+              ))}
           </tbody>
         </table>
       </div>

--- a/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
+++ b/ui/src/app/kvm/components/KVMResourcesCard/_index.scss
@@ -40,6 +40,7 @@
   }
 
   .kvm-resources-card__ram-table {
+    align-self: start;
     margin-bottom: 0;
 
     th,


### PR DESCRIPTION
## Done

- Don't display hugepage RAM row(s) if it doesn't actually exist.
- Fixed a FF alignment bug.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM details page of bolla using Firefox
- Check that there is no row for hugepages
- Check that the table headers don't take up half the height of the cell

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2120

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
