### PR TITLE
feat(ui): Build RSD list in React

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -39,7 +39,7 @@ exports[`stricter compilation`] = {
       [71, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Cannot find module \'@maas-ui/maas-ui-shared\' or its corresponding type declarations.", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:2156486800": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -81,7 +81,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -241,9 +241,9 @@ exports[`stricter compilation`] = {
       [92, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [108, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:3847277689": [
-      [44, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
-      [63, 6, 11, "Type \'\\"\\" | Element | null\' is not assignable to type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3453098368"]
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:4064608059": [
+      [33, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
+      [52, 6, 11, "Type \'\\"\\" | Element | null\' is not assignable to type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3453098368"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx:2252990650": [
       [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -394,6 +394,18 @@ exports[`stricter compilation`] = {
       [75, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
       [119, 6, 7, "Type \'Element[] | null\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'null\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
       [129, 42, 16, "Argument of type \'(Machine | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
+    ],
+    "src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx:4288871559": [
+      [40, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [40, 14, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [91, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [91, 14, 41, "Expected 1 arguments, but got 0.", "1767895374"]
+    ],
+    "src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.test.tsx:2757849859": [
+      [40, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [40, 14, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [91, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [91, 14, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
     "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:42858656": [
       [87, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],

--- a/ui/src/app/Routes.js
+++ b/ui/src/app/Routes.js
@@ -6,6 +6,7 @@ import KVM from "app/kvm/views/KVM";
 import Machines from "app/machines/views/Machines";
 import NotFound from "app/base/views/NotFound";
 import Preferences from "app/preferences/views/Preferences";
+import RSD from "app/rsd/views/RSD";
 import Settings from "app/settings/views/Settings";
 
 const Routes = () => (
@@ -42,6 +43,14 @@ const Routes = () => (
       render={() => (
         <ErrorBoundary>
           <Machines />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path="/rsd"
+      render={() => (
+        <ErrorBoundary>
+          <RSD />
         </ErrorBoundary>
       )}
     />

--- a/ui/src/app/kvm/utils.ts
+++ b/ui/src/app/kvm/utils.ts
@@ -8,3 +8,17 @@ export const formatHostType = (type: string): string => {
       return type;
   }
 };
+
+export const getVMHostCount = (
+  kvmCount: number,
+  selectedKVMCount: number
+): string => {
+  const kvmCountString = `${kvmCount} VM host${kvmCount === 1 ? "" : "s"}`;
+  if (selectedKVMCount > 0) {
+    if (kvmCount === selectedKVMCount) {
+      return "All VM hosts selected";
+    }
+    return `${selectedKVMCount} of ${kvmCountString} selected`;
+  }
+  return `${kvmCountString} available`;
+};

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -1,25 +1,14 @@
 import { Button } from "@canonical/react-components";
-import pluralize from "pluralize";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
+import { getVMHostCount } from "app/kvm/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import KVMActionFormWrapper from "app/kvm/components/KVMActionFormWrapper";
 import KVMListActionMenu from "./KVMListActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
-
-const getKVMCount = (kvmCount: number, selectedKVMCount: number) => {
-  const kvmCountString = pluralize("VM host", kvmCount, true);
-  if (selectedKVMCount > 0) {
-    if (kvmCount === selectedKVMCount) {
-      return "All VM hosts selected";
-    }
-    return `${selectedKVMCount} of ${kvmCountString} selected`;
-  }
-  return `${kvmCountString} available`;
-};
 
 const KVMListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -70,7 +59,7 @@ const KVMListHeader = (): JSX.Element => {
         )
       }
       loading={!podsLoaded}
-      subtitle={getKVMCount(kvms.length, selectedKVMs.length)}
+      subtitle={getVMHostCount(kvms.length, selectedKVMs.length)}
       title="KVM"
     />
   );

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/_index.scss
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/_index.scss
@@ -47,9 +47,5 @@
         @include breakpoint-widths(0, 8rem, 11rem, 11rem, 11rem);
       }
     }
-
-    .u-align-header-checkbox {
-      top: -.175rem;
-    }
   }
 }

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx
@@ -1,0 +1,99 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  podStatus as podStatusFactory,
+  podStatuses as podStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import DeleteForm from "./DeleteForm";
+
+const mockStore = configureStore();
+
+describe("DeleteForm", () => {
+  it("correctly dispatches actions to delete selected RSDs", () => {
+    const rsds = [podFactory({ type: "rsd" }), podFactory({ type: "rsd" })];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: rsds,
+        selected: [rsds[0].id, rsds[1].id],
+        statuses: podStatusesFactory({
+          [rsds[0].id]: podStatusFactory(),
+          [rsds[1].id]: podStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <DeleteForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => wrapper.find("Formik").prop("onSubmit")());
+    expect(
+      store.getActions().filter((action) => action.type === "pod/delete")
+    ).toStrictEqual([
+      {
+        type: "pod/delete",
+        meta: {
+          model: "pod",
+          method: "delete",
+        },
+        payload: {
+          params: {
+            id: rsds[0].id,
+          },
+        },
+      },
+      {
+        type: "pod/delete",
+        meta: {
+          model: "pod",
+          method: "delete",
+        },
+        payload: {
+          params: {
+            id: rsds[1].id,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("can show the processing status when deleting RSDs", () => {
+    const rsds = [podFactory({ type: "rsd" }), podFactory({ type: "rsd" })];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: rsds,
+        selected: [rsds[0].id, rsds[1].id],
+        statuses: podStatusesFactory({
+          [rsds[0].id]: podStatusFactory({ deleting: true }),
+          [rsds[1].id]: podStatusFactory({ deleting: false }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <DeleteForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => wrapper.find("Formik").prop("onSubmit")());
+    wrapper.update();
+    expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Deleting 1 of 2 RSDs..."
+    );
+  });
+});

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import ActionForm from "app/base/components/ActionForm";
+
+type Props = {
+  setSelectedAction: (action: string | null) => void;
+};
+
+type RouteParams = {
+  id: string;
+};
+
+const DeleteForm = ({ setSelectedAction }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const { id } = useParams<RouteParams>();
+  const errors = useSelector(podSelectors.errors);
+  const selectedRSDIDs = useSelector(podSelectors.selectedRSDs).map(
+    (rsd) => rsd.id
+  );
+  const deletingSelected = useSelector(podSelectors.deletingSelected);
+  const rsdsToDelete = id ? [Number(id)] : selectedRSDIDs;
+  const cleanup = useCallback(() => podActions.cleanup(), []);
+
+  return (
+    <ActionForm
+      actionName="delete"
+      cleanup={cleanup}
+      clearSelectedAction={() => setSelectedAction(null)}
+      errors={errors}
+      modelName="RSD"
+      onSubmit={() => {
+        rsdsToDelete.forEach((kvmID) => {
+          dispatch(podActions.delete(kvmID));
+        });
+      }}
+      processingCount={deletingSelected.length}
+      selectedCount={rsdsToDelete.length}
+      submitAppearance="negative"
+    />
+  );
+};
+
+export default DeleteForm;

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/index.ts
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteForm";

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.test.tsx
@@ -1,0 +1,66 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  podStatus as podStatusFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import RSDActionFormWrapper from "./RSDActionFormWrapper";
+
+const mockStore = configureStore();
+
+describe("RSDActionFormWrapper", () => {
+  let initialState = rootStateFactory();
+
+  beforeEach(() => {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({ id: 1, name: "pod-1", type: "rsd" }),
+          podFactory({ id: 2, name: "pod-2", type: "rsd" }),
+        ],
+        statuses: {
+          1: podStatusFactory(),
+          2: podStatusFactory(),
+        },
+      }),
+    });
+  });
+
+  it("renders DeleteForm if delete action selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDActionFormWrapper
+            selectedAction="delete"
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("DeleteForm").exists()).toBe(true);
+  });
+
+  it("renders RefreshForm if refresh action selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDActionFormWrapper
+            selectedAction="refresh"
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("RefreshForm").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import DeleteForm from "./DeleteForm";
+import RefreshForm from "./RefreshForm";
+
+type Props = {
+  selectedAction: string;
+  setSelectedAction: (action: string | null) => void;
+};
+
+const RSDActionFormWrapper = ({
+  selectedAction,
+  setSelectedAction,
+}: Props): JSX.Element | null => {
+  if (!selectedAction) {
+    return null;
+  }
+  return (
+    <>
+      {selectedAction === "delete" && (
+        <DeleteForm setSelectedAction={setSelectedAction} />
+      )}
+      {selectedAction === "refresh" && (
+        <RefreshForm setSelectedAction={setSelectedAction} />
+      )}
+    </>
+  );
+};
+
+export default RSDActionFormWrapper;

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.test.tsx
@@ -1,0 +1,99 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  podStatus as podStatusFactory,
+  podStatuses as podStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import RefreshForm from "./RefreshForm";
+
+const mockStore = configureStore();
+
+describe("RefreshForm", () => {
+  it("correctly dispatches actions to refresh selected RSDs", () => {
+    const rsds = [podFactory({ type: "rsd" }), podFactory({ type: "rsd" })];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: rsds,
+        selected: [rsds[0].id, rsds[1].id],
+        statuses: podStatusesFactory({
+          [rsds[0].id]: podStatusFactory(),
+          [rsds[1].id]: podStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RefreshForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => wrapper.find("Formik").prop("onSubmit")());
+    expect(
+      store.getActions().filter((action) => action.type === "pod/refresh")
+    ).toStrictEqual([
+      {
+        type: "pod/refresh",
+        meta: {
+          model: "pod",
+          method: "refresh",
+        },
+        payload: {
+          params: {
+            id: rsds[0].id,
+          },
+        },
+      },
+      {
+        type: "pod/refresh",
+        meta: {
+          model: "pod",
+          method: "refresh",
+        },
+        payload: {
+          params: {
+            id: rsds[1].id,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("can show the processing status when refreshing RSDs", () => {
+    const rsds = [podFactory({ type: "rsd" }), podFactory({ type: "rsd" })];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: rsds,
+        selected: [rsds[0].id, rsds[1].id],
+        statuses: podStatusesFactory({
+          [rsds[0].id]: podStatusFactory({ refreshing: true }),
+          [rsds[1].id]: podStatusFactory({ refreshing: false }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RefreshForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => wrapper.find("Formik").prop("onSubmit")());
+    wrapper.update();
+    expect(wrapper.find("FormikForm").prop("saving")).toBe(true);
+    expect(wrapper.find('[data-test="loading-label"]').text()).toBe(
+      "Refreshing 1 of 2 RSDs..."
+    );
+  });
+});

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import ActionForm from "app/base/components/ActionForm";
+
+type Props = {
+  setSelectedAction: (action: string | null) => void;
+};
+
+type RouteParams = {
+  id: string;
+};
+
+const RefreshForm = ({ setSelectedAction }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const { id } = useParams<RouteParams>();
+  const errors = useSelector(podSelectors.errors);
+  const selectedRSDIDs = useSelector(podSelectors.selectedRSDs).map(
+    (rsd) => rsd.id
+  );
+  const refreshing = useSelector(podSelectors.refreshing);
+  const refreshingSelected = useSelector(podSelectors.refreshingSelected);
+  const rsdsToRefresh = id ? [Number(id)] : selectedRSDIDs;
+  const cleanup = useCallback(() => podActions.cleanup(), []);
+
+  return (
+    <ActionForm
+      actionName="refresh"
+      cleanup={cleanup}
+      clearSelectedAction={() => setSelectedAction(null)}
+      errors={errors}
+      modelName="RSD"
+      onSubmit={() => {
+        rsdsToRefresh.forEach((podID) => {
+          dispatch(podActions.refresh(podID));
+        });
+      }}
+      processingCount={id ? refreshing.length : refreshingSelected.length}
+      selectedCount={rsdsToRefresh.length}
+    >
+      <p>
+        Refreshing RSDs will cause MAAS to recalculate usage metrics, update
+        information about storage pools, and commission any machines present in
+        the RSDs that are not yet known to MAAS.
+      </p>
+    </ActionForm>
+  );
+};
+
+export default RefreshForm;

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/index.ts
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RefreshForm";

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/index.ts
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RSDActionFormWrapper";

--- a/ui/src/app/rsd/views/RSD.tsx
+++ b/ui/src/app/rsd/views/RSD.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+
+import RSDList from "./RSDList";
+import NotFound from "app/base/views/NotFound";
+
+const RSD = (): JSX.Element => {
+  return (
+    <Switch>
+      <Route exact path={["/rsd", "/rsd/add"]}>
+        <RSDList />
+      </Route>
+      <Route path="*">
+        <NotFound />
+      </Route>
+    </Switch>
+  );
+};
+
+export default RSD;

--- a/ui/src/app/rsd/views/RSDList/RSDList.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDList.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Redirect, Route, Switch } from "react-router-dom";
+
+import { useWindowTitle } from "app/base/hooks";
+import RSDListHeader from "./RSDListHeader";
+import RSDListTable from "./RSDListTable";
+import Section from "app/base/components/Section";
+
+const RSDList = (): JSX.Element => {
+  useWindowTitle("RSD");
+
+  return (
+    <Section header={<RSDListHeader />} headerClassName="u-no-padding--bottom">
+      <Switch>
+        <Route exact path="/rsd">
+          <RSDListTable />
+        </Route>
+        <Route exact path="/rsd/add">
+          <Redirect to="/machines/rsd/add" />
+        </Route>
+      </Switch>
+    </Section>
+  );
+};
+
+export default RSDList;

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.test.tsx
@@ -1,0 +1,53 @@
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import RSDListActionMenu from "./RSDListActionMenu";
+
+const mockStore = configureStore();
+
+describe("RSDListActionMenu", () => {
+  it("is disabled with tooltip if no RSDs are selected", () => {
+    const state = rootStateFactory({ pod: podStateFactory({ selected: [] }) });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListActionMenu setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="action-dropdown"] button').prop("disabled")
+    ).toBe(true);
+    expect(wrapper.find("Tooltip").prop("message")).toBe(
+      "Select RSDs below to perform an action."
+    );
+  });
+
+  it("is enabled if at least one RSD is selected", () => {
+    const rsds = [podFactory({ type: "rsd" }), podFactory({ type: "rsd" })];
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: rsds, selected: [rsds[0].id] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListActionMenu setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="action-dropdown"] button').props().disabled
+    ).toBe(false);
+    expect(wrapper.find("Tooltip").prop("message")).toBe(undefined);
+  });
+});

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.tsx
@@ -7,15 +7,15 @@ import ContextualMenu from "app/base/components/ContextualMenu";
 
 type Props = { setSelectedAction: (action: string) => void };
 
-const KVMListActionMenu = ({ setSelectedAction }: Props): JSX.Element => {
-  const selectedKVMs = useSelector(podSelectors.selectedKVMs);
-  const actionMenuDisabled = selectedKVMs.length === 0;
+const RSDListActionMenu = ({ setSelectedAction }: Props): JSX.Element => {
+  const selectedRSDs = useSelector(podSelectors.selectedRSDs);
+  const actionMenuDisabled = selectedRSDs.length === 0;
 
   return (
     <Tooltip
       message={
         actionMenuDisabled
-          ? "Select KVMs below to perform an action."
+          ? "Select RSDs below to perform an action."
           : undefined
       }
       position="left"
@@ -42,4 +42,4 @@ const KVMListActionMenu = ({ setSelectedAction }: Props): JSX.Element => {
   );
 };
 
-export default KVMListActionMenu;
+export default RSDListActionMenu;

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/index.ts
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RSDListActionMenu";

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.test.tsx
@@ -1,0 +1,96 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import * as React from "react";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import RSDListHeader from "./RSDListHeader";
+
+const mockStore = configureStore();
+
+describe("RSDListHeader", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("displays a loader if pods have not loaded", () => {
+    const state = rootStateFactory({ pod: podStateFactory({ loaded: false }) });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays an rsd count if pods have loaded", () => {
+    const pods = [
+      podFactory({ type: "rsd" }),
+      podFactory({ type: "rsd" }),
+      podFactory({ type: "virsh" }),
+    ];
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: pods, loaded: true }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="section-header-subtitle"]').text()).toBe(
+      "2 VM hosts available"
+    );
+  });
+
+  it("disables 'Add RSD' button if at least one RSD is selected", () => {
+    const rsds = [podFactory({ type: "rsd" }), podFactory({ type: "rsd" })];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: rsds,
+        loaded: true,
+        selected: [rsds[0].id],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('Button[data-test="add-rsd"]').prop("disabled")).toBe(
+      true
+    );
+  });
+
+  it("clears action form if no RSDs are selected", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: [podFactory()], loaded: true }),
+    });
+    const store = mockStore(state);
+    const setSelectedAction = jest.fn();
+    jest
+      .spyOn(React, "useState")
+      .mockImplementation(() => ["", setSelectedAction]);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(setSelectedAction).toHaveBeenCalledWith(null);
+  });
+});

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@canonical/react-components";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useLocation } from "react-router-dom";
+
+import { getVMHostCount } from "app/kvm/utils";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import RSDActionFormWrapper from "app/rsd/components/RSDActionFormWrapper";
+import RSDListActionMenu from "./RSDListActionMenu";
+import SectionHeader from "app/base/components/SectionHeader";
+
+const RSDListHeader = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const location = useLocation();
+  const rsds = useSelector(podSelectors.rsds);
+  const podsLoaded = useSelector(podSelectors.loaded);
+  const selectedRSDs = useSelector(podSelectors.selectedRSDs);
+  const [selectedAction, setSelectedAction] = useState<string | null>(null);
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
+  }, [dispatch]);
+
+  // If path is not exactly "/rsd" or no RSDs are selected, close the form.
+  useEffect(() => {
+    if (location.pathname !== "/rsd" || selectedRSDs.length === 0) {
+      setSelectedAction(null);
+    }
+  }, [location.pathname, selectedRSDs, setSelectedAction]);
+
+  return (
+    <SectionHeader
+      buttons={
+        location.pathname === "/rsd" && !selectedAction
+          ? [
+              <Button
+                appearance="neutral"
+                data-test="add-rsd"
+                disabled={selectedRSDs.length > 0}
+                element={Link}
+                key="add-rsd"
+                to="/rsd/add"
+              >
+                Add RSD
+              </Button>,
+              <RSDListActionMenu
+                key="action-dropdown"
+                setSelectedAction={setSelectedAction}
+              />,
+            ]
+          : undefined
+      }
+      formWrapper={
+        selectedAction ? (
+          <RSDActionFormWrapper
+            selectedAction={selectedAction}
+            setSelectedAction={setSelectedAction}
+          />
+        ) : undefined
+      }
+      loading={!podsLoaded}
+      subtitle={getVMHostCount(rsds.length, selectedRSDs.length)}
+      title="RSD"
+    />
+  );
+};
+
+export default RSDListHeader;

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/index.ts
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RSDListHeader";

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
@@ -1,0 +1,275 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import type { RootState } from "app/store/root/types";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import RSDListTable from "./RSDListTable";
+
+const mockStore = configureStore();
+
+describe("RSDListTable", () => {
+  let initialState: RootState;
+  beforeEach(() => {
+    const pods = [
+      podFactory({ pool: 1, type: "rsd", zone: 1 }),
+      podFactory({ pool: 2, type: "rsd", zone: 2 }),
+    ];
+    initialState = rootStateFactory({
+      pod: podStateFactory({ items: pods, loaded: true }),
+      resourcepool: resourcePoolStateFactory({
+        loaded: true,
+        items: [
+          resourcePoolFactory({ id: pods[0].pool }),
+          resourcePoolFactory({ id: pods[1].pool }),
+        ],
+      }),
+      zone: zoneStateFactory({
+        loaded: true,
+        items: [
+          zoneFactory({ id: pods[0].zone }),
+          zoneFactory({ id: pods[1].zone }),
+        ],
+      }),
+    });
+  });
+
+  it("correctly fetches the necessary data", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+    const expectedActions = ["pod/fetch", "resourcepool/fetch", "zone/fetch"];
+    const actualActions = store.getActions();
+    expect(
+      actualActions.every((action) => expectedActions.includes(action.type))
+    ).toBe(true);
+  });
+
+  it("shows RSDs sorted by descending FQDN by default", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="fqdn-header"] i').exists()).toBe(true);
+    expect(
+      wrapper
+        .find('[data-test="fqdn-header"] i')
+        .props()
+        .className?.includes("u-mirror--y")
+    ).toBe(false);
+  });
+
+  it("can sort by parameters of the RSDs themselves", () => {
+    const state = { ...initialState };
+    state.pod.items[0].composed_machines_count = 1;
+    state.pod.items[1].composed_machines_count = 2;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+    const [firstPod, secondPod] = [state.pod.items[0], state.pod.items[1]];
+
+    // Pods are initially sorted by descending FQDN
+    expect(
+      wrapper.find('[data-test="vms-header"]').prop("currentSort")
+    ).toStrictEqual({
+      key: "name",
+      direction: "descending",
+    });
+
+    // Click the VMs table header to order by descending VMs count
+    wrapper.find('[data-test="vms-header"]').find("button").simulate("click");
+    expect(
+      wrapper.find('[data-test="vms-header"]').prop("currentSort")
+    ).toStrictEqual({
+      key: "composed_machines_count",
+      direction: "descending",
+    });
+    expect(wrapper.find("TableCell").at(0).text()).toBe(firstPod.name);
+
+    // Click the VMs table header again to order by ascending VMs count
+    wrapper.find('[data-test="vms-header"]').find("button").simulate("click");
+    expect(
+      wrapper.find('[data-test="vms-header"]').prop("currentSort")
+    ).toStrictEqual({
+      key: "composed_machines_count",
+      direction: "ascending",
+    });
+    expect(wrapper.find("TableCell").at(0).text()).toBe(secondPod.name);
+
+    // Click the VMs table header again to remove sort
+    wrapper.find('[data-test="vms-header"]').find("button").simulate("click");
+    expect(
+      wrapper.find('[data-test="vms-header"]').prop("currentSort")
+    ).toStrictEqual({
+      key: "",
+      direction: "none",
+    });
+  });
+
+  it("can sort by pod resource pool", () => {
+    const pools = [
+      resourcePoolFactory({
+        id: 1,
+        name: "first-pool",
+      }),
+      resourcePoolFactory({
+        id: 2,
+        name: "second-pool",
+      }),
+    ];
+    const state = { ...initialState };
+    state.resourcepool.items = pools;
+    const [firstPod, secondPod] = [state.pod.items[0], state.pod.items[1]];
+    firstPod.pool = pools[0].id;
+    secondPod.pool = pools[1].id;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Sort pods by descending pool.
+    wrapper.find('[data-test="pool-header"]').find("button").simulate("click");
+    expect(
+      wrapper.find('[data-test="pool-header"]').prop("currentSort")
+    ).toStrictEqual({
+      key: "pool",
+      direction: "descending",
+    });
+    expect(wrapper.find("TableCell").at(0).text()).toBe(firstPod.name);
+
+    // Reverse sort order
+    wrapper.find('[data-test="pool-header"]').find("button").simulate("click");
+    expect(
+      wrapper.find('[data-test="pool-header"]').prop("currentSort")
+    ).toStrictEqual({
+      key: "pool",
+      direction: "ascending",
+    });
+    expect(wrapper.find("TableCell").at(0).text()).toBe(secondPod.name);
+  });
+
+  it("shows a checked checkbox in header row if all RSDs are selected", () => {
+    const state = { ...initialState };
+    state.pod.selected = [state.pod.items[0].id, state.pod.items[1].id];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='all-rsds-checkbox'] input[checked=true]").length
+    ).toBe(1);
+    expect(
+      wrapper
+        .find("[data-test='all-rsds-checkbox'] input")
+        .props()
+        ?.className?.includes("p-checkbox--mixed")
+    ).toBe(false);
+  });
+
+  it("shows a mixed checkbox in header row if only some RSDs are selected", () => {
+    const state = { ...initialState };
+    state.pod.selected = [state.pod.items[0].id];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='all-rsds-checkbox'] input[checked=true]").length
+    ).toBe(1);
+    expect(
+      wrapper
+        .find("[data-test='all-rsds-checkbox'] input")
+        .props()
+        ?.className?.includes("p-checkbox--mixed")
+    ).toBe(true);
+  });
+
+  it("correctly dispatches action when unchecked RSD checkbox clicked", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("[data-test='pod-checkbox'] input")
+      .at(0)
+      .simulate("change", {
+        target: { name: state.pod.items[0].id },
+      });
+
+    expect(
+      store.getActions().find((action) => action.type === "pod/setSelected")
+    ).toStrictEqual({
+      type: "pod/setSelected",
+      payload: [state.pod.items[0].id],
+    });
+  });
+
+  it("correctly dispatches action when checked RSD checkbox clicked", () => {
+    const state = { ...initialState };
+    state.pod.selected = [state.pod.items[0].id];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/rsd", key: "testKey" }]}>
+          <RSDListTable />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("[data-test='pod-checkbox'] input")
+      .at(0)
+      .simulate("change", {
+        target: { name: state.pod.items[0].id },
+      });
+
+    expect(
+      store.getActions().find((action) => action.type === "pod/setSelected")
+    ).toStrictEqual({
+      type: "pod/setSelected",
+      payload: [],
+    });
+  });
+});

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
@@ -1,0 +1,203 @@
+import { Col, Input, MainTable, Row } from "@canonical/react-components";
+import classNames from "classnames";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import CPUColumn from "app/kvm/views/KVMList/KVMListTable/CPUColumn";
+import NameColumn from "app/kvm/views/KVMList/KVMListTable/NameColumn";
+import PoolColumn from "app/kvm/views/KVMList/KVMListTable/PoolColumn";
+import RAMColumn from "app/kvm/views/KVMList/KVMListTable/RAMColumn";
+import StorageColumn from "app/kvm/views/KVMList/KVMListTable/StorageColumn";
+import VMsColumn from "app/kvm/views/KVMList/KVMListTable/VMsColumn";
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import { actions as podActions } from "app/store/pod";
+import { actions as poolActions } from "app/store/resourcepool";
+import poolSelectors from "app/store/resourcepool/selectors";
+import type { ResourcePool } from "app/store/resourcepool/types";
+import { actions as zoneActions } from "app/store/zone";
+import { generateCheckboxHandlers, someInArray, someNotAll } from "app/utils";
+
+const getSortValue = (
+  sortKey: keyof Pod | "cpu" | "pool" | "ram" | "storage",
+  rsd: Pod,
+  pools: ResourcePool[]
+) => {
+  const rsdPool = pools.find((pool) => rsd.pool === pool.id);
+
+  switch (sortKey) {
+    case "cpu":
+      return rsd.used.cores;
+    case "pool":
+      return rsdPool?.name || "unknown";
+    case "ram":
+      return rsd.used.memory;
+    case "storage":
+      return rsd.used.local_storage;
+    default:
+      return rsd[sortKey];
+  }
+};
+
+const generateRows = (
+  rsds: Pod[],
+  selectedRSDIDs: Pod["id"][],
+  handleRowCheckbox: (rsdID: Pod["id"], selectedRSDIDs: Pod["id"][]) => void
+) =>
+  rsds.map((rsd) => ({
+    key: rsd.id,
+    columns: [
+      {
+        content: (
+          <NameColumn
+            handleCheckbox={() => handleRowCheckbox(rsd.id, selectedRSDIDs)}
+            id={rsd.id}
+            selected={someInArray(rsd.id, selectedRSDIDs)}
+          />
+        ),
+      },
+      { className: "u-align--right", content: <VMsColumn id={rsd.id} /> },
+      { content: <PoolColumn id={rsd.id} /> },
+      { content: <CPUColumn id={rsd.id} /> },
+      { content: <RAMColumn id={rsd.id} /> },
+      { content: <StorageColumn id={rsd.id} /> },
+    ],
+  }));
+
+const RSDListTable = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const rsds = useSelector(podSelectors.rsds);
+  const selectedRSDIDs = useSelector(podSelectors.selectedRSDs).map(
+    (rsd) => rsd.id
+  );
+  const pools = useSelector(poolSelectors.all);
+  const rsdIDs = rsds.map((rsd) => rsd.id);
+
+  const { currentSort, sortRows, updateSort } = useTableSort(getSortValue, {
+    key: "name",
+    direction: "descending",
+  });
+  const { handleGroupCheckbox, handleRowCheckbox } = generateCheckboxHandlers<
+    Pod["id"]
+  >((ids) => dispatch(podActions.setSelected(ids)));
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
+    dispatch(poolActions.fetch());
+    dispatch(zoneActions.fetch());
+  }, [dispatch]);
+
+  const sortedRSDs = sortRows(rsds, pools);
+
+  return (
+    <Row>
+      <Col size={12}>
+        <MainTable
+          className="rsd-list-table"
+          headers={[
+            {
+              content: (
+                <div className="u-flex">
+                  <Input
+                    checked={someInArray(rsdIDs, selectedRSDIDs)}
+                    className={classNames("has-inline-label", {
+                      "p-checkbox--mixed": someNotAll(rsdIDs, selectedRSDIDs),
+                    })}
+                    data-test="all-rsds-checkbox"
+                    disabled={rsds.length === 0}
+                    id="all-rsds-checkbox"
+                    label={" "}
+                    onChange={() => handleGroupCheckbox(rsdIDs, selectedRSDIDs)}
+                    type="checkbox"
+                    wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
+                  />
+                  <TableHeader
+                    currentSort={currentSort}
+                    data-test="fqdn-header"
+                    onClick={() => updateSort("name")}
+                    sortKey="name"
+                  >
+                    FQDN
+                  </TableHeader>
+                </div>
+              ),
+            },
+            {
+              className: "u-align--right",
+              content: (
+                <>
+                  <TableHeader
+                    currentSort={currentSort}
+                    data-test="vms-header"
+                    onClick={() => updateSort("composed_machines_count")}
+                    sortKey="composed_machines_count"
+                  >
+                    VM<span className="u-no-text-transform">s</span>
+                  </TableHeader>
+                  <TableHeader>Owners</TableHeader>
+                </>
+              ),
+            },
+            {
+              content: (
+                <>
+                  <TableHeader
+                    currentSort={currentSort}
+                    data-test="pool-header"
+                    onClick={() => updateSort("pool")}
+                    sortKey="pool"
+                  >
+                    Resource pool
+                  </TableHeader>
+                  <TableHeader>Az</TableHeader>
+                </>
+              ),
+            },
+            {
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="cpu-header"
+                  onClick={() => updateSort("cpu")}
+                  sortKey="cpu"
+                >
+                  CPU cores
+                </TableHeader>
+              ),
+            },
+            {
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="ram-header"
+                  onClick={() => updateSort("ram")}
+                  sortKey="ram"
+                >
+                  RAM
+                </TableHeader>
+              ),
+            },
+            {
+              content: (
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="storage-header"
+                  onClick={() => updateSort("storage")}
+                  sortKey="storage"
+                >
+                  Storage
+                </TableHeader>
+              ),
+            },
+          ]}
+          paginate={50}
+          rows={generateRows(sortedRSDs, selectedRSDIDs, handleRowCheckbox)}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default RSDListTable;

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/_index.scss
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/_index.scss
@@ -1,0 +1,36 @@
+@mixin RSDListTable {
+  .rsd-list-table {
+    td,
+    th {
+      // FQDN
+      &:nth-child(1) {
+        @include breakpoint-widths(50%, 50%, 60%);
+      }
+
+      // VMs / Owners
+      &:nth-child(2) {
+        @include breakpoint-widths(5rem);
+      }
+
+      // Resource pool / AZ
+      &:nth-child(3) {
+        @include breakpoint-widths(50%, 50%, 40%);
+      }
+
+      // CPU
+      &:nth-child(4) {
+        @include breakpoint-widths(0, 0, 9rem, 13rem);
+      }
+
+      // RAM
+      &:nth-child(5) {
+        @include breakpoint-widths(0, 0, 9rem, 13rem);
+      }
+
+      // Storage
+      &:nth-child(6) {
+        @include breakpoint-widths(0, 0, 9rem, 13rem);
+      }
+    }
+  }
+}

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/index.ts
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RSDListTable";

--- a/ui/src/app/rsd/views/RSDList/index.ts
+++ b/ui/src/app/rsd/views/RSDList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RSDList";

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -1,4 +1,9 @@
 @mixin maas-utilities {
+  // Vertically align checkboxes in double row table headers
+  .u-align-header-checkbox {
+    top: -$form-tick-box-nudge;
+  }
+
   .u-default-text {
     color: $color-dark !important;
     font-size: 1rem !important;

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -120,6 +120,10 @@
 @include AddSSLKey;
 @include SSLKeyList;
 
+// rsd
+@import "~app/rsd/views/RSDList/RSDListTable";
+@include RSDListTable;
+
 // settings
 @import "~app/settings/components/SettingsTable";
 @import "~app/settings/views/Dhcp/DhcpList";


### PR DESCRIPTION
## Done

- The RSD components have mostly been copied over from the KVM components, with minor changes where necessary. I originally tried to just have a single component `Pod` that could be given a prop `type="rsd"` or `type="kvm"` but the amount of inline conditionals in the component got pretty out of hand. So I think this is a cleaner option that can be refactored after the fact if necessary.
- For now the "Add RSD" button takes you to the form on the machine list but I'll create a component for that next.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Get a MAAS running with RSDs. Using `make sampledata` creates 3 KVMs and 3 RSDs.
- Check that RSD shows up in the main navigation.
- Go to /r/rsd manually (I'll update the nav link once it's all complete) and check that the RSDs show up correctly.
- Select some and check that the checkboxes and the header text respond accordingly
- Check that deleting works
- Check that refreshing sends the correct websocket response, but times out because it's not actually real.

## Fixes

Fixes #1638 

## Screenshot

![0 0 0 0_8400_MAAS_r_rsd (2)](https://user-images.githubusercontent.com/25733845/93729503-17f39a00-fc08-11ea-8e3f-a3dc1e4d271c.png)

