### PR TITLE
feat(ui): Build AddRSDForm component for RSD list

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -407,9 +407,9 @@ exports[`stricter compilation`] = {
       [91, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [91, 14, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx:3537248278": [
+    "src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx:2475074294": [
       [70, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [71, 8, 24, "Argument of type \'{ name: string; pool: string; power_address: string; power_pass: string; power_user: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "244873512"]
+      [71, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; power_pass: string; power_user: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "244873512"]
     ],
     "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:42858656": [
       [87, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
@@ -651,5 +651,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `476`
+  value: `475`
 };

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -407,6 +407,10 @@ exports[`stricter compilation`] = {
       [91, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [91, 14, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
+    "src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx:3537248278": [
+      [70, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [71, 8, 24, "Argument of type \'{ name: string; pool: string; power_address: string; power_pass: string; power_user: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "244873512"]
+    ],
     "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:42858656": [
       [87, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [92, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
@@ -70,11 +70,11 @@ describe("AddRSDForm", () => {
     act(() =>
       wrapper.find("Formik").invoke("onSubmit")({
         name: "my-favourite-rsd",
-        pool: "pool-1",
+        pool: 0,
         power_address: "192.68.1.1",
         power_pass: "password",
         power_user: "admin",
-        zone: "zone-1",
+        zone: 1,
       })
     );
 
@@ -89,12 +89,12 @@ describe("AddRSDForm", () => {
       payload: {
         params: {
           name: "my-favourite-rsd",
-          pool: "pool-1",
+          pool: 0,
           power_address: "192.68.1.1",
           power_pass: "password",
           power_user: "admin",
           type: "rsd",
-          zone: "zone-1",
+          zone: 1,
         },
       },
     });

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
@@ -1,0 +1,102 @@
+import { act } from "react-dom/test-utils";
+import { MemoryRouter } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import AddRSDForm from "./AddRSDForm";
+
+const mockStore = configureStore();
+
+describe("AddRSDForm", () => {
+  it("fetches the necessary data on load", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/rsd/add", key: "testKey" }]}
+        >
+          <AddRSDForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    const expectedActions = ["resourcepool/fetch", "zone/fetch"];
+    const actions = store.getActions();
+    expectedActions.forEach((expectedAction) => {
+      expect(actions.some((action) => action.type === expectedAction));
+    });
+  });
+
+  it("displays a spinner if data has not loaded", () => {
+    const state = rootStateFactory({
+      resourcepool: resourcePoolStateFactory({ loaded: false }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/rsd/add", key: "testKey" }]}
+        >
+          <AddRSDForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").length).toBe(1);
+  });
+
+  it("can handle saving an RSD", () => {
+    const state = rootStateFactory({
+      resourcepool: resourcePoolStateFactory({ loaded: true }),
+      zone: zoneStateFactory({ loaded: true }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/rsd/add", key: "testKey" }]}
+        >
+          <AddRSDForm />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper.find("Formik").invoke("onSubmit")({
+        name: "my-favourite-rsd",
+        pool: "pool-1",
+        power_address: "192.68.1.1",
+        power_pass: "password",
+        power_user: "admin",
+        zone: "zone-1",
+      })
+    );
+
+    expect(
+      store.getActions().find((action) => action.type === "pod/create")
+    ).toStrictEqual({
+      type: "pod/create",
+      meta: {
+        method: "create",
+        model: "pod",
+      },
+      payload: {
+        params: {
+          name: "my-favourite-rsd",
+          pool: "pool-1",
+          power_address: "192.68.1.1",
+          power_pass: "password",
+          power_user: "admin",
+          type: "rsd",
+          zone: "zone-1",
+        },
+      },
+    });
+  });
+});

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
@@ -20,20 +20,20 @@ import { formatErrors } from "app/utils";
 
 const AddRSDFormSchema = Yup.object().shape({
   name: Yup.string(),
-  pool: Yup.string(),
+  pool: Yup.number(),
   power_address: Yup.string().required("Address required"),
   power_pass: Yup.string().required("Password required"),
   power_user: Yup.string().required("User required"),
-  zone: Yup.string(),
+  zone: Yup.number(),
 });
 
 export type AddRSDFormValues = {
   name: string;
-  pool: string;
+  pool: number;
   power_address: string;
   power_pass: string;
   power_user: string;
-  zone: string;
+  zone: number;
 };
 
 export const AddRSDForm = (): JSX.Element => {
@@ -84,11 +84,11 @@ export const AddRSDForm = (): JSX.Element => {
             errors={errors}
             initialValues={{
               name: "",
-              pool: (resourcePools.length && resourcePools[0].name) || "",
+              pool: (resourcePools.length && resourcePools[0].id) || 0,
               power_address: "",
               power_pass: "",
               power_user: "",
-              zone: (zones.length && zones[0].name) || "",
+              zone: (zones.length && zones[0].id) || 0,
             }}
             onCancel={() => history.push({ pathname: "/rsd" })}
             onSaveAnalytics={{
@@ -99,12 +99,12 @@ export const AddRSDForm = (): JSX.Element => {
             onSubmit={(values: AddRSDFormValues) => {
               const params = {
                 name: values.name,
-                pool: values.pool,
+                pool: Number(values.pool),
                 power_address: values.power_address,
                 power_pass: values.power_pass,
                 power_user: values.power_user,
                 type: "rsd",
-                zone: values.zone,
+                zone: Number(values.zone),
               };
               dispatch(podActions.create(params));
               setSavingRSD(values.name || "RSD");

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
@@ -1,0 +1,126 @@
+import { Spinner } from "@canonical/react-components";
+import React, { useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import * as Yup from "yup";
+
+import AddRSDFormFields from "./AddRSDFormFields";
+import { general as generalActions } from "app/base/actions";
+import FormCard from "app/base/components/FormCard";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { useAddMessage, useWindowTitle } from "app/base/hooks";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import { actions as resourcePoolActions } from "app/store/resourcepool";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import { actions as zoneActions } from "app/store/zone";
+import zoneSelectors from "app/store/zone/selectors";
+import { formatErrors } from "app/utils";
+
+const AddRSDFormSchema = Yup.object().shape({
+  name: Yup.string(),
+  pool: Yup.string(),
+  power_address: Yup.string().required("Address required"),
+  power_pass: Yup.string().required("Password required"),
+  power_user: Yup.string().required("User required"),
+  zone: Yup.string(),
+});
+
+export type AddRSDFormValues = {
+  name: string;
+  pool: string;
+  power_address: string;
+  power_pass: string;
+  power_user: string;
+  zone: string;
+};
+
+export const AddRSDForm = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const podSaved = useSelector(podSelectors.saved);
+  const podSaving = useSelector(podSelectors.saving);
+  const podErrors = useSelector(podSelectors.errors);
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
+  const zones = useSelector(zoneSelectors.all);
+  const zonesLoaded = useSelector(zoneSelectors.loaded);
+
+  const [savingRSD, setSavingRSD] = useState("");
+
+  const allLoaded = resourcePoolsLoaded && zonesLoaded;
+
+  const cleanup = useCallback(() => podActions.cleanup(), []);
+
+  // Fetch all data required for the form.
+  useEffect(() => {
+    dispatch(generalActions.fetchPowerTypes());
+    dispatch(resourcePoolActions.fetch());
+    dispatch(zoneActions.fetch());
+  }, [dispatch]);
+
+  useWindowTitle("Add RSD");
+
+  useAddMessage(
+    podSaved,
+    cleanup,
+    `${savingRSD} added successfully.`,
+    setSavingRSD
+  );
+
+  const errors = formatErrors(podErrors);
+
+  return (
+    <>
+      {!allLoaded ? (
+        <Spinner className="u-no-margin u-no-padding" text="Loading" />
+      ) : (
+        <FormCard sidebar={false} title="Add RSD">
+          <FormikForm
+            buttons={FormCardButtons}
+            cleanup={cleanup}
+            errors={errors}
+            initialValues={{
+              name: "",
+              pool: (resourcePools.length && resourcePools[0].name) || "",
+              power_address: "",
+              power_pass: "",
+              power_user: "",
+              zone: (zones.length && zones[0].name) || "",
+            }}
+            onCancel={() => history.push({ pathname: "/rsd" })}
+            onSaveAnalytics={{
+              action: "Save",
+              category: "RSD",
+              label: "Add RSD form",
+            }}
+            onSubmit={(values: AddRSDFormValues) => {
+              const params = {
+                name: values.name,
+                pool: values.pool,
+                power_address: values.power_address,
+                power_pass: values.power_pass,
+                power_user: values.power_user,
+                type: "rsd",
+                zone: values.zone,
+              };
+              dispatch(podActions.create(params));
+              setSavingRSD(values.name || "RSD");
+            }}
+            saving={podSaving}
+            saved={podSaved}
+            savedRedirect="/rsd"
+            submitLabel="Save RSD"
+            validationSchema={AddRSDFormSchema}
+          >
+            <AddRSDFormFields />
+          </FormikForm>
+        </FormCard>
+      )}
+    </>
+  );
+};
+
+export default AddRSDForm;

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/AddRSDFormFields.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/AddRSDFormFields.tsx
@@ -1,0 +1,68 @@
+import { Col, Row, Select } from "@canonical/react-components";
+import React from "react";
+import { useSelector } from "react-redux";
+
+import FormikField from "app/base/components/FormikField";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import zoneSelectors from "app/store/zone/selectors";
+
+export const AddRSDFormFields = (): JSX.Element => {
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const zones = useSelector(zoneSelectors.all);
+
+  return (
+    <Row>
+      <Col size="5">
+        <FormikField
+          label="Name"
+          name="name"
+          placeholder="Name (optional)"
+          type="text"
+        />
+        <FormikField
+          component={Select}
+          label="Zone"
+          name="zone"
+          options={[
+            { label: "Select your zone", value: "", disabled: true },
+            ...zones.map((zone) => ({
+              key: `zone-${zone.id}`,
+              label: zone.name,
+              value: zone.name,
+            })),
+          ]}
+        />
+        <FormikField
+          component={Select}
+          label="Resource pool"
+          name="pool"
+          options={[
+            { label: "Select your resource pool", value: "", disabled: true },
+            ...resourcePools.map((pool) => ({
+              key: `pool-${pool.id}`,
+              label: pool.name,
+              value: pool.name,
+            })),
+          ]}
+        />
+      </Col>
+      <Col size="5">
+        <FormikField
+          label="Address"
+          name="power_address"
+          type="text"
+          required
+        />
+        <FormikField label="User" name="power_user" type="text" required />
+        <FormikField
+          label="Password"
+          name="power_pass"
+          type="password"
+          required
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default AddRSDFormFields;

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/AddRSDFormFields.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/AddRSDFormFields.tsx
@@ -28,7 +28,7 @@ export const AddRSDFormFields = (): JSX.Element => {
             ...zones.map((zone) => ({
               key: `zone-${zone.id}`,
               label: zone.name,
-              value: zone.name,
+              value: zone.id,
             })),
           ]}
         />
@@ -41,7 +41,7 @@ export const AddRSDFormFields = (): JSX.Element => {
             ...resourcePools.map((pool) => ({
               key: `pool-${pool.id}`,
               label: pool.name,
-              value: pool.name,
+              value: pool.id,
             })),
           ]}
         />

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/index.ts
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddRSDFormFields";

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/index.ts
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddRSDForm";

--- a/ui/src/app/rsd/views/RSDList/RSDList.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDList.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { Redirect, Route, Switch } from "react-router-dom";
+import { Route, Switch } from "react-router-dom";
 
 import { useWindowTitle } from "app/base/hooks";
+import AddRSDForm from "./AddRSDForm";
 import RSDListHeader from "./RSDListHeader";
 import RSDListTable from "./RSDListTable";
 import Section from "app/base/components/Section";
@@ -16,7 +17,7 @@ const RSDList = (): JSX.Element => {
           <RSDListTable />
         </Route>
         <Route exact path="/rsd/add">
-          <Redirect to="/machines/rsd/add" />
+          <AddRSDForm />
         </Route>
       </Switch>
     </Section>


### PR DESCRIPTION
## Done

- Built AddRSDForm component, which is essentially the AddKVMForm component with the `rsd` type preselected.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/rsd and click the "Add RSD" button
- Check that you are redirected to /r/rsd/add and the Add RSD form shows
- Fill in the fields and click Save
- Check that the websocket request matches [the api](https://git.launchpad.net/maas/tree/src/maasserver/api/pods.py#n461) and the fields shown in the `rsd` power type in `general.powerTypes`

## Fixes

Fixes #1640 

## Screenshot

![0 0 0 0_8400_MAAS_r_rsd (3)](https://user-images.githubusercontent.com/25733845/93741999-b5fb5a80-fc30-11ea-9259-ae1a698455bd.png)

