### PR TITLE
feat: add docs links

### DIFF
--- a/legacy/src/app/partials/intro.html
+++ b/legacy/src/app/partials/intro.html
@@ -2,10 +2,19 @@
     <div class="row">
         <div class="col-12">
             <div class="p-card--highlighted">
-                <h4 class="p-card__title">
-                    <i data-ng-class="{ 'p-icon--success': !welcomeInError(), 'p-icon--error': welcomeInError() }"></i>
-                    Welcome to MAAS
-                </h4>
+                <div class="row">
+                    <div class="col-6">
+                        <h4 class="p-card__title">
+                            <i data-ng-class="{ 'p-icon--success': !welcomeInError(), 'p-icon--error': welcomeInError() }"></i>
+                            Welcome to MAAS
+                        </h4>
+                    </div>
+                    <div class="col-6 u-align--right">
+                        <p class="u-no-margin--bottom">
+                            <a class="p-link--external" href="https://maas.io/docs/configuration-journey" target="_blank">Help with configuring MAAS</a>
+                        </p>
+                    </div>
+                </div>
                 <hr />
                 <div class="p-card__content">
                     <maas-obj-form obj="maasName" manager="configManager" class="p-form p-form--stacked">

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -667,22 +667,18 @@
         <div class="page-header__section col-12 ng-hide" data-ng-show="tabs.controllers.addController">
             <hr />
             <h4 class="page-header__dropdown-title">Add rack controller</h4>
-            <pre>
-                <code>
-                    # To add a new rack controller, SSH into the rack controller.
-                    # Install the maas-rack-controller package.
-                    # Confirm that the MAAS version is the same as the main rack controller.
-                    sudo apt install maas-rack-controller
-                    # Or if you use snap
-                    sudo snap install maas
+            <pre><code># To add a new rack controller, SSH into the rack controller.
+# Install the maas-rack-controller package.
+# Confirm that the MAAS version is the same as the main rack controller.
+sudo apt install maas-rack-controller
+# Or if you use snap
+sudo snap install maas
 
-                    # Register the rack controller with this MAAS. If the rack controller (and machines)
-                    # don't have access to the URL, use a different IP address to allow connection.
-                    sudo maas-rack register --url {$ tabs.controllers.registerUrl $} --secret {$ tabs.controllers.registerSecret $}
-                    # Or if you use snap
-                    sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ tabs.controllers.registerSecret $}
-                </code>
-            </pre>
+# Register the rack controller with this MAAS. If the rack controller (and machines)
+# don't have access to the URL, use a different IP address to allow connection.
+sudo maas-rack register --url {$ tabs.controllers.registerUrl $} --secret {$ tabs.controllers.registerSecret $}
+# Or if you use snap
+sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ tabs.controllers.registerSecret $}</code></pre>
         </div>
         <div class="row ng-hide" data-ng-show="tabs.controllers.addController">
             <div class="col-6">

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -684,9 +684,14 @@
                 </code>
             </pre>
         </div>
-        <div class="u-align--right ng-hide" data-ng-show="tabs.controllers.addController">
+        <div class="row ng-hide" data-ng-show="tabs.controllers.addController">
+            <div class="col-6">
+                <p class="u-no-margin--bottom"><a class="p-link--external" href="https://maas.io/docs/rack-controller" target="_blank">Help with adding a rack controller</a></p>
+            </div>
+            <div class="col-6 u-align--right">
                 <a href="" class="p-button--neutral"
                     data-ng-click="tabs.controllers.addController = false">Close</a>
+            </div>
         </div>
     </div>
     <nav class="p-tabs" data-ng-if="currentpage === 'machines' || currentpage === 'pools'">

--- a/legacy/src/app/partials/vlan-details.html
+++ b/legacy/src/app/partials/vlan-details.html
@@ -439,7 +439,10 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-12 u-align--right">
+                    <div class="col-4">
+                        <p class="u-no-margin--bottom"><a class="p-link--external" href="https://maas.io/docs/dhcp" target="_blank">About DHCP</a></p>
+                    </div>
+                    <div class="col-8 u-align--right">
                         <button class="p-button--base u-no-margin--bottom" data-ng-click="vlanDetails.closeDHCPPanel()">Cancel</button>
                         <button class="p-button--positive u-no-margin--bottom" data-ng-click="vlanDetails.enableDHCP()" data-ng-if="vlanDetails.provideDHCP && vlanDetails.MAASProvidesDHCP">
                             <span data-ng-if="vlanDetails.isProvidingDHCP">
@@ -563,6 +566,9 @@
                     </div>
                 </div>
             </div>
+        </div>
+        <div class="row">
+            <p class="u-no-margin--bottom"><a class="p-link--external" href="https://maas.io/docs/dhcp" target="_blank">About DHCP</a></p>
         </div>
     </section>
     <section class="p-strip" data-ng-if="!vlanDetails.showDHCPPanel">

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -30,8 +30,8 @@ exports[`stricter compilation`] = {
       [93, 8, 10, "Type \'(() => void) | null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.\\n  Type \'null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.", "4228750763"],
       [131, 8, 7, "Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
-    "src/app/base/components/FormikForm/FormikForm.tsx:344624276": [
-      [71, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
+    "src/app/base/components/FormikForm/FormikForm.tsx:3762663666": [
+      [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
       [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
@@ -113,15 +113,15 @@ exports[`stricter compilation`] = {
       [189, 13, 12, "Argument of type \'FabricState\' is not assignable to parameter of type \'{ errors: {}; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\'.", "2722999692"],
       [200, 13, 12, "Argument of type \'FabricState\' is not assignable to parameter of type \'{ errors: {}; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\'.", "2722999692"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:2517085915": [
-      [136, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [136, 27, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [136, 41, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [136, 59, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [202, 8, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4165046927"],
-      [252, 34, 27, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4259134870"],
-      [261, 19, 5, "Variable \'error\' is used before being assigned.", "165548477"],
-      [303, 8, 8, "Type \'(values: ComposeFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ComposeFormValues\'.", "1301647696"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:2883988514": [
+      [137, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [137, 27, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [137, 41, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [137, 59, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [218, 8, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4165046927"],
+      [266, 34, 27, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4259134870"],
+      [275, 19, 5, "Variable \'error\' is used before being assigned.", "165548477"],
+      [317, 8, 8, "Type \'(values: ComposeFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ComposeFormValues\'.", "1301647696"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx:3478481718": [
       [94, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.\\n    The types returned by \'getState()\' are incompatible between these types.\\n      Type \'unknown\' is not assignable to type \'{}\'.", "195037722"],
@@ -167,21 +167,15 @@ exports[`stricter compilation`] = {
       [164, 6, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"],
       [166, 6, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx:3611294755": [
-      [92, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [108, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [120, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [154, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx:1348646753": [
       [158, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
-      [184, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
       [188, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
-      [213, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
       [223, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
       [234, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "2561676462"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx:3287585099": [
-      [119, 22, 10, "Type \'(poolName: string) => void\' is not assignable to type \'SelectPool\'.\\n  Types of parameters \'poolName\' and \'poolName\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1972538641"],
-      [172, 10, 7, "Type \'false | \\"For the Beta version of LXD VM hosts each VM can only be assigned a single block device.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx:4197161610": [
+      [138, 24, 10, "Type \'(poolName: string) => void\' is not assignable to type \'SelectPool\'.\\n  Types of parameters \'poolName\' and \'poolName\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1972538641"],
+      [192, 10, 7, "Type \'false | \\"For the Beta version of LXD VM hosts each VM can only be assigned a single block device.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
     "src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx:3808680172": [
       [17, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -333,10 +327,9 @@ exports[`stricter compilation`] = {
       [108, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
       [122, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:215157653": [
-      [6, 0, 39, "\'FormEvent\' is declared but its value is never read.", "4214660592"],
-      [89, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [93, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:554268234": [
+      [88, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [92, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.tsx:184858439": [
       [105, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
@@ -697,5 +690,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `486`
+  value: `493`
 };

--- a/ui/src/app/base/components/FormCard/_index.scss
+++ b/ui/src/app/base/components/FormCard/_index.scss
@@ -12,6 +12,10 @@
     }
   }
 
+  .form-card__buttons-help {
+    flex: 1;
+  }
+
   .form-card__help {
     @extend %small-text;
     color: $color-mid-dark;

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.js
@@ -1,10 +1,12 @@
-import { ActionButton, Button } from "@canonical/react-components";
+import { ActionButton, Button, Link } from "@canonical/react-components";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
 export const FormCardButtons = ({
   bordered = true,
+  helpLabel,
+  helpLink,
   loading,
   loadingLabel,
   onCancel,
@@ -23,6 +25,18 @@ export const FormCardButtons = ({
           "is-bordered": bordered,
         })}
       >
+        {helpLink && helpLabel ? (
+          <p className="u-no-margin--bottom form-card__buttons-help">
+            <Link
+              external
+              href={helpLink}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {helpLabel}
+            </Link>
+          </p>
+        ) : null}
         {onCancel && (
           <Button
             appearance="base"
@@ -71,6 +85,8 @@ export const FormCardButtons = ({
 
 FormCardButtons.propTypes = {
   bordered: PropTypes.bool,
+  helpLabel: PropTypes.string,
+  helpLink: PropTypes.string,
   loading: PropTypes.bool,
   loadingLabel: PropTypes.string,
   onCancel: PropTypes.func,

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -14,6 +14,8 @@ type Props = {
   allowUnchanged?: boolean;
   Buttons?: JSX.Element;
   buttonsBordered?: boolean;
+  buttonsHelpLabel?: string;
+  buttonsHelpLink?: string;
   cleanup?: () => void;
   children?: ReactNode;
   errors?: TSFixMe;
@@ -45,6 +47,8 @@ const FormikForm = ({
   allowUnchanged,
   buttons,
   buttonsBordered = true,
+  buttonsHelpLabel,
+  buttonsHelpLink,
   cleanup,
   children,
   errors,
@@ -96,6 +100,8 @@ const FormikForm = ({
         allowAllEmpty={allowAllEmpty}
         allowUnchanged={allowUnchanged}
         buttonsBordered={buttonsBordered}
+        buttonsHelpLabel={buttonsHelpLabel}
+        buttonsHelpLink={buttonsHelpLink}
         buttons={buttons}
         errors={errors}
         initialValues={initialValues}
@@ -121,6 +127,8 @@ FormikForm.propTypes = {
   allowAllEmpty: PropTypes.bool,
   allowUnchanged: PropTypes.bool,
   buttons: PropTypes.func,
+  buttonsHelpLabel: PropTypes.string,
+  buttonsHelpLink: PropTypes.string,
   buttonsBordered: PropTypes.bool,
   cleanup: PropTypes.func,
   children: PropTypes.node,

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
@@ -11,6 +11,8 @@ const FormikFormContent = ({
   allowUnchanged,
   buttons: Buttons = FormikFormButtons,
   buttonsBordered,
+  buttonsHelpLabel,
+  buttonsHelpLink,
   children,
   errors,
   initialValues,
@@ -60,6 +62,8 @@ const FormikFormContent = ({
       <div>{children}</div>
       <Buttons
         bordered={buttonsBordered}
+        helpLabel={buttonsHelpLabel}
+        helpLink={buttonsHelpLink}
         loading={saving}
         onCancel={onCancel}
         loadingLabel={savingLabel}
@@ -86,6 +90,8 @@ FormikFormContent.propTypes = {
   allowUnchanged: PropTypes.bool,
   buttons: PropTypes.func,
   buttonsBordered: PropTypes.bool,
+  buttonsHelpLabel: PropTypes.string,
+  buttonsHelpLink: PropTypes.string,
   children: PropTypes.node,
   errors: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   initialValues: PropTypes.object,

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
@@ -92,6 +92,8 @@ export const AddChassisForm = () => {
         <FormCard sidebar={false} title="Add chassis">
           <FormikForm
             buttons={FormCardButtons}
+            buttonsHelpLabel="Help with adding chassis"
+            buttonsHelpLink="https://maas.io/docs/add-machines#heading--add-nodes-via-a-chassis"
             cleanup={machineActions.cleanup}
             errors={errors}
             initialValues={{

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -142,6 +142,8 @@ export const AddMachineForm = () => {
         <FormCard sidebar={false} title="Add machine">
           <FormikForm
             buttons={FormCardButtons}
+            buttonsHelpLabel="Help with adding machines"
+            buttonsHelpLink="https://maas.io/docs/add-machines"
             cleanup={machineActions.cleanup}
             errors={errors}
             initialValues={{

--- a/ui/src/app/settings/components/SettingsTable/SettingsTable.js
+++ b/ui/src/app/settings/components/SettingsTable/SettingsTable.js
@@ -1,4 +1,4 @@
-import { Tooltip } from "@canonical/react-components";
+import { Link as VanillaLink, Tooltip } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 import classNames from "classnames";
 import PropTypes from "prop-types";
@@ -15,6 +15,8 @@ export const SettingsTable = ({
   buttons,
   defaultSort,
   headers,
+  helpLabel,
+  helpLink,
   loaded,
   loading,
   rows,
@@ -67,6 +69,18 @@ export const SettingsTable = ({
         sortable
       />
       {loading && !loaded && <div className="settings-table__lines"></div>}
+      {helpLink && helpLabel ? (
+        <p className="u-no-margin--bottom settings-table__help">
+          <VanillaLink
+            external
+            href={helpLink}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {helpLabel}
+          </VanillaLink>
+        </p>
+      ) : null}
     </div>
   );
 };
@@ -82,6 +96,8 @@ SettingsTable.propTypes = {
   ).isRequired,
   defaultSort: PropTypes.string,
   headers: PropTypes.array,
+  helpLabel: PropTypes.string,
+  helpLink: PropTypes.string,
   loaded: PropTypes.bool,
   loading: PropTypes.bool,
   rows: PropTypes.array,

--- a/ui/src/app/settings/components/SettingsTable/_index.scss
+++ b/ui/src/app/settings/components/SettingsTable/_index.scss
@@ -33,4 +33,9 @@
       background-size: 100% $sp-x-large;
     }
   }
+
+  .settings-table__help {
+    align-items: flex-end;
+    display: flex;
+  }
 }

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.js
@@ -228,6 +228,8 @@ const DhcpList = () => {
           className: "u-align--right",
         },
       ]}
+      helpLabel="About DHCP"
+      helpLink="https://maas.io/docs/dhcp"
       loaded={dhcpsnippetLoaded}
       loading={dhcpsnippetLoading}
       rows={generateRows(


### PR DESCRIPTION
## Done

- Add a number of help links to forms and lists.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit each of the pages from https://github.com/canonical-web-and-design/maas-ui/issues/861 and check that the help links appear as per the screenshot.

## Fixes

Fixes: canonical-web-and-design/maas-ui#861