### PR TITLE
fix(ui): correctly determine when to display machine list non-actionable warning

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { machine as machineActions } from "app/base/actions";
@@ -60,13 +60,7 @@ export const ActionFormWrapper = ({
       }, [])
     : [];
   const selectedProcessing = useSelector(machineSelectors.selectedProcessing);
-
-  // The action should be disabled if not all the selected machines can perform
-  // The selected action. When machines are processing the available actions
-  // can change, so the action should not be disabled while processing.
-  const actionDisabled =
-    !selectedProcessing.length &&
-    actionableMachineIDs.length !== selectedMachines.length;
+  const [actionDisabled, setActionDisabled] = useState(false);
 
   useEffect(() => {
     if (selectedMachines.length === 0) {
@@ -74,6 +68,20 @@ export const ActionFormWrapper = ({
       setSelectedAction(null);
     }
   }, [selectedMachines, setSelectedAction]);
+
+  useEffect(() => {
+    // The action should be disabled if not all the selected machines can perform
+    // the selected action. When machines are processing the available actions
+    // can change, so the action should not be disabled while processing.
+    const newActionDisabled =
+      !selectedProcessing.length &&
+      actionableMachineIDs.length !== selectedMachines.length;
+    setActionDisabled(newActionDisabled);
+  }, [
+    selectedProcessing.length,
+    actionableMachineIDs.length,
+    selectedMachines.length,
+  ]);
 
   const getFormComponent = () => {
     if (selectedAction && selectedAction.name) {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -25,6 +25,9 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
 
   const selectedMachines = useSelector(machineSelectors.selected);
+  const markingBrokenSelected = useSelector(
+    machineSelectors.markingBrokenSelected
+  );
   const machineErrors = useSelector(machineSelectors.errors);
   const errors = Object.keys(machineErrors).length > 0 ? machineErrors : null;
 
@@ -38,6 +41,7 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
   return (
     <ActionForm
       actionName="mark-broken"
+      allowAllEmpty
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}
       errors={errors}
@@ -52,9 +56,9 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
           );
         });
       }}
+      processingCount={markingBrokenSelected.length}
       selectedCount={selectedMachines.length}
       validationSchema={MarkBrokenSchema}
-      allowAllEmpty
     >
       <MarkBrokenFormFields selectedCount={selectedMachines.length} />
     </ActionForm>


### PR DESCRIPTION
## Done

- Adding missing `markingBrokenSelected` selector to the mark broken form, which determines when to close the form on success.
- Wrapped `ActionFormWrapper`'s `actionDisabled` logic in a `useEffect` so that it only updates when the relevant bits of state change.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a few machines and choose "Mark broken" from the action dropdown.
- Check that the action completes successfully and there is no warning about "X selected machines cannot be marked broken".
- Do the same but with the "Deploy" action.
- Select a bunch of machines then select an action that not all machines can perform.
- Check that the warning displays correctly.

## Fixes

Fixes #1690 
