### PR TITLE
fix(header): highlight nav for sub urls

### DIFF
--- a/shared/src/components/Header/Header.test.js
+++ b/shared/src/components/Header/Header.test.js
@@ -138,4 +138,23 @@ describe("Header", () => {
     expect(selected.exists()).toBe(true);
     expect(selected.text()).toEqual("Subnets");
   });
+
+  it("highlights sub-urls", () => {
+    const wrapper = shallow(
+      <Header
+        authUser={{
+          is_superuser: true,
+          username: "koala",
+        }}
+        completedIntro={true}
+        location={{
+          pathname: "/MAAS/l/machine/abc123",
+        }}
+        logout={jest.fn()}
+      />
+    );
+    const selected = wrapper.find(".p-navigation__link.is-selected");
+    expect(selected.exists()).toBe(true);
+    expect(selected.text()).toEqual("Machines");
+  });
 });


### PR DESCRIPTION
## Done

- Match sub-urls to the header section so that the nav is highlighted correctly.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click on each nav item in the header and then click on a details page.
- Each page should be highlighted in the header with the correct section.

## Fixes

Fixes: canonical-web-and-design/maas-ui#873