### PR TITLE
Refactor useSendAnalytics 

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,19 +1,19 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
-    "src/app/base/components/ActionForm/ActionForm.test.tsx:1113426617": [
-      [35, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [35, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
-      [49, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
-      [63, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [63, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
-      [74, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
-      [88, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [88, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
-      [99, 21, 6, "Binding element \'errors\' implicitly has an \'any\' type.", "1168132398"],
-      [99, 29, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
-      [114, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [114, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
+    "src/app/base/components/ActionForm/ActionForm.test.tsx:224588637": [
+      [42, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [42, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [56, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [70, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [70, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [81, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [95, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [95, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [106, 21, 6, "Binding element \'errors\' implicitly has an \'any\' type.", "1168132398"],
+      [106, 29, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [121, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [121, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
     "src/app/base/components/ActionForm/ActionForm.tsx:1368649959": [
       [15, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
@@ -30,11 +30,11 @@ exports[`stricter compilation`] = {
       [93, 8, 10, "Type \'(() => void) | null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.\\n  Type \'null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.", "4228750763"],
       [131, 8, 7, "Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
-    "src/app/base/components/FormikForm/FormikForm.tsx:3762663666": [
+    "src/app/base/components/FormikForm/FormikForm.tsx:181765042": [
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -76,7 +76,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -188,16 +188,20 @@ exports[`stricter compilation`] = {
       [37, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
       [80, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
+    "src/app/kvm/components/PodStorage/PodStorage.test.tsx:1980022262": [
+      [106, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    ],
     "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:9765032": [
       [16, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
       [36, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx:2780035521": [
-      [80, 6, 68, "Object is possibly \'undefined\'.", "2960886801"]
+    "src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx:4283049524": [
+      [76, 6, 68, "Object is possibly \'undefined\'.", "2960886801"],
+      [102, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx:2087623559": [
-      [44, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"],
-      [78, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"]
+    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx:1194877294": [
+      [40, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"],
+      [76, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:2118393864": [
       [23, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -264,18 +268,17 @@ exports[`stricter compilation`] = {
       [134, 14, 7, "Object is possibly \'undefined\'.", "1060875104"],
       [153, 42, 25, "Argument of type \'(Scripts | undefined)[]\' is not assignable to parameter of type \'Scripts[]\'.\\n  Type \'Scripts | undefined\' is not assignable to type \'Scripts\'.\\n    Type \'undefined\' is not assignable to type \'Scripts\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "4025185665"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.test.tsx:1717182927": [
-      [99, 23, 9, "Property \'mockClear\' does not exist on type \'(eventCategory: any, eventAction: any, eventLabel: any) => void\'.", "2526230614"],
-      [117, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [118, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
-      [182, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [183, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
-      [231, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [232, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"],
-      [279, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [280, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"]
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.test.tsx:1810823825": [
+      [109, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [110, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
+      [174, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [175, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
+      [223, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [224, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"],
+      [272, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [273, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:1271179547": [
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx:2364344527": [
       [92, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
       [110, 34, 6, "Property \'deploy\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1121484462"],
       [110, 41, 7, "Object is possibly \'undefined\'.", "1060875104"]
@@ -607,5 +610,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `449`
+  value: `448`
 };

--- a/ui/src/analytics.js
+++ b/ui/src/analytics.js
@@ -1,5 +1,0 @@
-export const sendAnalyticsEvent = (eventCategory, eventAction, eventLabel) => {
-  if (window.ga && eventCategory && eventAction && eventLabel) {
-    window.ga("send", "event", eventCategory, eventAction, eventLabel);
-  }
-};

--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -5,12 +5,19 @@ import React from "react";
 import { Provider } from "react-redux";
 
 import ActionForm from "./ActionForm";
+import { rootState as rootStateFactory } from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
+let state: RootState;
 const mockStore = configureStore();
 
 describe("ActionForm", () => {
+  beforeEach(() => {
+    state = rootStateFactory();
+  });
+
   it("can show the correct submit label", () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <ActionForm modelName="machine" onSubmit={jest.fn()} />
@@ -21,7 +28,7 @@ describe("ActionForm", () => {
   });
 
   it("can show the correct saving state", () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <ActionForm
@@ -45,7 +52,7 @@ describe("ActionForm", () => {
   });
 
   it("runs clearSelectedAction function when processing complete", () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const clearSelectedAction = jest.fn();
     const Proxy = ({ processingCount }) => (
       <Provider store={store}>
@@ -70,7 +77,7 @@ describe("ActionForm", () => {
   });
 
   it("runs onSuccess function if processing is successful", () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const onSuccess = jest.fn();
     const Proxy = ({ processingCount }) => (
       <Provider store={store}>
@@ -95,7 +102,7 @@ describe("ActionForm", () => {
   });
 
   it("does not run clearSelectedAction function if errors occur while processing", () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const clearSelectedAction = jest.fn();
     const Proxy = ({ errors, processingCount }) => (
       <Provider store={store}>

--- a/ui/src/app/base/components/FormikForm/FormikForm.test.js
+++ b/ui/src/app/base/components/FormikForm/FormikForm.test.js
@@ -7,19 +7,28 @@ import React from "react";
 import { Provider } from "react-redux";
 import * as Yup from "yup";
 
-import { useSendAnalytics } from "app/base/hooks";
 import FormikForm from "./FormikForm";
+import * as hooks from "app/base/hooks";
+import {
+  config as configFactory,
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
-jest.mock("app/base/hooks");
 
 describe("FormikForm", () => {
-  afterEach(() => {
-    jest.resetAllMocks();
+  let state;
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [configFactory({ name: "analytics_enabled", value: false })],
+      }),
+    });
   });
 
   it("can render", () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
@@ -37,7 +46,7 @@ describe("FormikForm", () => {
   });
 
   it("can redirect when saved", () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
@@ -60,7 +69,7 @@ describe("FormikForm", () => {
     const cleanup = jest.fn(() => ({
       type: "CLEANUP",
     }));
-    const store = mockStore({});
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
@@ -85,7 +94,8 @@ describe("FormikForm", () => {
       category: "Settings",
       label: "Form",
     };
-    const store = mockStore({});
+    const useSendMock = jest.spyOn(hooks, "useSendAnalyticsWhen");
+    const store = mockStore(state);
     mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
@@ -102,17 +112,18 @@ describe("FormikForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(useSendAnalytics).toHaveBeenCalled();
-    expect(useSendAnalytics.mock.calls[0]).toEqual([
+    expect(useSendMock).toHaveBeenCalled();
+    expect(useSendMock.mock.calls[0]).toEqual([
       true,
       eventData.category,
       eventData.action,
       eventData.label,
     ]);
+    useSendMock.mockRestore();
   });
 
   it("can reset form on save if resetOnSave is true", async () => {
-    const store = mockStore({});
+    const store = mockStore(state);
     const initialValues = {
       val1: "initial",
     };

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import type { ReactNode } from "react";
 import React, { useEffect } from "react";
 
-import { useSendAnalytics } from "app/base/hooks";
+import { useSendAnalyticsWhen } from "app/base/hooks";
 import type { TSFixMe } from "app/base/types";
 import FormikFormContent from "app/base/components/FormikFormContent";
 
@@ -72,7 +72,7 @@ const FormikForm = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
 
-  useSendAnalytics(
+  useSendAnalyticsWhen(
     saved,
     onSaveAnalytics.category,
     onSaveAnalytics.action,

--- a/ui/src/app/base/components/UserForm/UserForm.test.js
+++ b/ui/src/app/base/components/UserForm/UserForm.test.js
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import { UserForm } from "./UserForm";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -22,8 +23,7 @@ describe("UserForm", () => {
       password2: "test1234",
       username: "admin",
     };
-    state = {
-      status: {},
+    state = rootStateFactory({
       user: {
         auth: {},
         errors: {},
@@ -33,7 +33,7 @@ describe("UserForm", () => {
         saved: false,
         saving: false,
       },
-    };
+    });
   });
 
   it("can render", () => {

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
@@ -3,13 +3,12 @@ import pluralize from "pluralize";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
-import { sendAnalyticsEvent } from "analytics";
+import { useSendAnalytics } from "app/base/hooks";
+import PodMeter from "app/kvm/components/PodMeter";
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
-import configSelectors from "app/store/config/selectors";
 import podSelectors from "app/store/pod/selectors";
 import { formatBytes } from "app/utils";
-import PodMeter from "app/kvm/components/PodMeter";
 
 export const TRUNCATION_POINT = 3;
 
@@ -19,8 +18,8 @@ const PodStorage = ({ id }: Props): JSX.Element | null => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
-  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const [expanded, setExpanded] = useState(false);
+  const sendAnalytics = useSendAnalytics();
 
   if (!!pod) {
     const sortedPools = [...pod.storage_pools].sort((a, b) => {
@@ -89,15 +88,13 @@ const PodStorage = ({ id }: Props): JSX.Element | null => {
               hasIcon
               onClick={() => {
                 setExpanded(!expanded);
-                if (analyticsEnabled) {
-                  sendAnalyticsEvent(
-                    `${pod.type === "rsd" ? "RSD" : "KVM"} details`,
-                    "Toggle expanded storage pools",
-                    expanded
-                      ? "Show less storage pools"
-                      : "Show more storage pools"
-                  );
-                }
+                sendAnalytics(
+                  `${pod.type === "rsd" ? "RSD" : "KVM"} details`,
+                  "Toggle expanded storage pools",
+                  expanded
+                    ? "Show less storage pools"
+                    : "Show more storage pools"
+                );
               }}
             >
               {expanded ? (

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -8,10 +8,9 @@ import type { Machine } from "app/store/machine/types";
 import type { Pod, PodNumaNode } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import type { PodResourcesCardProps } from "app/kvm/components/PodResourcesCard";
-import { sendAnalyticsEvent } from "analytics";
 import { machine as machineActions } from "app/base/actions";
+import { useSendAnalytics } from "app/base/hooks";
 import { actions as podActions } from "app/store/pod";
-import configSelectors from "app/store/config/selectors";
 import podSelectors from "app/store/pod/selectors";
 import PodResourcesCard from "app/kvm/components/PodResourcesCard";
 
@@ -73,8 +72,9 @@ const KVMNumaResources = ({ id }: Props): JSX.Element => {
   const podVMs = useSelector((state: RootState) =>
     podSelectors.getVMs(state, pod)
   );
-  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const [expanded, setExpanded] = useState(false);
+
+  const sendAnalytics = useSendAnalytics();
 
   useEffect(() => {
     dispatch(machineActions.fetch());
@@ -118,13 +118,11 @@ const KVMNumaResources = ({ id }: Props): JSX.Element => {
               hasIcon
               onClick={() => {
                 setExpanded(!expanded);
-                if (analyticsEnabled) {
-                  sendAnalyticsEvent(
-                    "KVM details",
-                    "Toggle expanded NUMA nodes",
-                    expanded ? "Show less NUMA nodes" : "Show more NUMA nodes"
-                  );
-                }
+                sendAnalytics(
+                  "KVM details",
+                  "Toggle expanded NUMA nodes",
+                  expanded ? "Show less NUMA nodes" : "Show more NUMA nodes"
+                );
               }}
             >
               {expanded ? (

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import { sendAnalyticsEvent } from "analytics";
+import * as hooks from "app/base/hooks";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -15,10 +15,6 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import KVMSummary from "./KVMSummary";
-
-jest.mock("analytics", () => ({
-  sendAnalyticsEvent: jest.fn(),
-}));
 
 const mockStore = configureStore();
 
@@ -66,6 +62,8 @@ describe("KVMSummary", () => {
         items: [podFactory({ id: 1 })],
       }),
     });
+
+    const useSendMock = jest.spyOn(hooks, "useSendAnalytics");
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -82,7 +80,8 @@ describe("KVMSummary", () => {
     });
     wrapper.update();
 
-    expect(sendAnalyticsEvent).toHaveBeenCalled();
+    expect(useSendMock).toHaveBeenCalled();
+    useSendMock.mockRestore();
   });
 
   it("can display the power address", () => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -4,16 +4,14 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { useStorageState } from "react-storage-hooks";
 
-import { sendAnalyticsEvent } from "analytics";
-import type { RootState } from "app/store/root/types";
-import { actions as podActions } from "app/store/pod";
-import configSelectors from "app/store/config/selectors";
-import podSelectors from "app/store/pod/selectors";
-import { useWindowTitle } from "app/base/hooks";
-import PodAggregateResources from "app/kvm/components/PodAggregateResources";
 import KVMNumaResources from "./KVMNumaResources";
-import PodStorage from "app/kvm/components/PodStorage";
 import Switch from "app/base/components/Switch";
+import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
+import PodAggregateResources from "app/kvm/components/PodAggregateResources";
+import PodStorage from "app/kvm/components/PodStorage";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import type { RootState } from "app/store/root/types";
 
 type RouteParams = {
   id: string;
@@ -25,12 +23,13 @@ const KVMSummary = (): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
-  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const [viewByNuma, setViewByNuma] = useStorageState(
     localStorage,
     `viewPod${id}ByNuma`,
     false
   );
+
+  const sendAnalytics = useSendAnalytics();
 
   useWindowTitle(`KVM ${`${pod?.name} ` || ""} details`);
 
@@ -61,13 +60,11 @@ const KVMSummary = (): JSX.Element => {
               onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
                 const checked = evt.target.checked;
                 setViewByNuma(checked);
-                if (analyticsEnabled) {
-                  sendAnalyticsEvent(
-                    "KVM details",
-                    "Toggle NUMA view",
-                    checked ? "View by NUMA node" : "View aggregate"
-                  );
-                }
+                sendAnalytics(
+                  "KVM details",
+                  "Toggle NUMA view",
+                  checked ? "View by NUMA node" : "View aggregate"
+                );
               }}
             />
           )}

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import { sendAnalyticsEvent } from "analytics";
+import * as hooks from "app/base/hooks";
 import DeployForm from "./DeployForm";
 import type { RootState } from "app/store/root/types";
 import {
@@ -18,10 +18,6 @@ import {
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
 } from "testing/factories";
-
-jest.mock("analytics", () => ({
-  sendAnalyticsEvent: jest.fn(),
-}));
 
 const mockStore = configureStore();
 
@@ -94,10 +90,6 @@ describe("DeployForm", () => {
         },
       }),
     });
-  });
-
-  afterEach(() => {
-    sendAnalyticsEvent.mockClear();
   });
 
   it("correctly dispatches actions to deploy selected machines", () => {
@@ -266,6 +258,7 @@ describe("DeployForm", () => {
   it("sends an event if cloud-init is set", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123"];
+    const useSendMock = jest.spyOn(hooks, "useSendAnalytics");
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -286,6 +279,6 @@ describe("DeployForm", () => {
         userData: "test script",
       })
     );
-    expect(sendAnalyticsEvent).toHaveBeenCalled();
+    expect(useSendMock).toHaveBeenCalled();
   });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -7,9 +7,8 @@ import {
   general as generalActions,
   machine as machineActions,
 } from "app/base/actions";
-import { sendAnalyticsEvent } from "analytics";
+import { useSendAnalytics } from "app/base/hooks";
 import ActionForm from "app/base/components/ActionForm";
-import configSelectors from "app/store/config/selectors";
 import DeployFormFields from "./DeployFormFields";
 import generalSelectors from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
@@ -50,7 +49,6 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
     generalSelectors.osInfo.get
   );
   const deployingSelected = useSelector(machineSelectors.deployingSelected);
-  const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
 
   useEffect(() => {
     dispatch(generalActions.fetchDefaultMinHweKernel());
@@ -74,6 +72,8 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
   ) {
     initialRelease = default_release;
   }
+
+  const sendAnalytics = useSendAnalytics();
 
   return (
     <ActionForm
@@ -100,8 +100,8 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
           hwe_kernel: values.kernel,
           ...(hasUserData && { user_data: values.userData }),
         };
-        if (analyticsEnabled && hasUserData) {
-          sendAnalyticsEvent(
+        if (hasUserData) {
+          sendAnalytics(
             "Machine list deploy form",
             "Has cloud-init config",
             "Cloud-init user data"

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
@@ -6,13 +6,14 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import SetPoolForm from "./SetPoolForm";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("SetPoolForm", () => {
   let state;
   beforeEach(() => {
-    state = {
+    state = rootStateFactory({
       general: {
         machineActions: {
           data: [{ name: "set-pool", sentence: "change those pools" }],
@@ -43,7 +44,7 @@ describe("SetPoolForm", () => {
           { id: 1, name: "pool-1" },
         ],
       },
-    };
+    });
   });
 
   it("correctly dispatches actions to set pools of selected machines", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.js
@@ -6,13 +6,14 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import SetPoolForm from "../SetPoolForm";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("SetPoolFormFields", () => {
   let state;
   beforeEach(() => {
-    state = {
+    state = rootStateFactory({
       machine: {
         errors: {},
         loading: false,
@@ -38,7 +39,7 @@ describe("SetPoolFormFields", () => {
           { id: 1, name: "pool-1" },
         ],
       },
-    };
+    });
   });
 
   it("shows a select if select pool radio chosen", async () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
@@ -6,13 +6,14 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import SetZoneForm from "./SetZoneForm";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("SetZoneForm", () => {
   let state;
   beforeEach(() => {
-    state = {
+    state = rootStateFactory({
       general: {
         machineActions: {
           data: [{ name: "set-zone", sentence: "set-zone" }],
@@ -42,7 +43,7 @@ describe("SetZoneForm", () => {
           { id: 1, name: "zone-1" },
         ],
       },
-    };
+    });
   });
 
   it("correctly dispatches actions to set zones of selected machines", () => {

--- a/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.test.tsx
@@ -11,10 +11,6 @@ import {
 } from "testing/factories";
 import RSDSummary from "./RSDSummary";
 
-jest.mock("analytics", () => ({
-  sendAnalyticsEvent: jest.fn(),
-}));
-
 const mockStore = configureStore();
 
 describe("RSDSummary", () => {

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -5,8 +5,7 @@ import * as Yup from "yup";
 
 import { config as configActions } from "app/settings/actions";
 import configSelectors from "app/store/config/selectors";
-import { sendAnalyticsEvent } from "analytics";
-import { usePrevious } from "app/base/hooks";
+import { usePrevious, useSendAnalytics } from "app/base/hooks";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 
@@ -44,6 +43,8 @@ const GeneralForm = (): JSX.Element => {
     }
   }, [analyticsEnabled, previousEnableAnalytics]);
 
+  const sendAnalytics = useSendAnalytics();
+
   return (
     <FormikForm
       initialValues={{
@@ -59,7 +60,7 @@ const GeneralForm = (): JSX.Element => {
       onSubmit={(values, { resetForm }) => {
         if (values.enable_analytics !== previousEnableAnalytics) {
           // Only send the analytics event if the value changes.
-          sendAnalyticsEvent(
+          sendAnalytics(
             "General configuration settings",
             values.enable_analytics ? "Turned on" : "Turned off",
             "Enable Google Analytics"


### PR DESCRIPTION
## Done

Refactors the useSendAnalytics hook into three hooks, which removes the need to check for analyticsEnabled in calling code:

sendAnalytics - sends a google analytics event if window.ga defined.
useSendAnalytics - wraps sendAnalytics and sends an event if the analyticsEnabled setting is true. Now returns a function, allowing this to be used for callbacks (e.g. in an onClick handler)
useSendAnalyticsWhen - wraps useSendAnalytics and provides an additional sendCondition param.

Additionally, fixes some remaining tests that weren't setting update state with `rootStateFactory`.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Probably the best way to QA this is just to drop a `console.log` in `hooks.sendAnalytics`, and submit some forms.

## Fixes

Fixes: #1581 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
