### PR TITLE
fix(legacy): add undefined object guards to KVM poolOverCapacity function

### DIFF
--- a/legacy/src/app/directives/pod-details/kvm_storage_dropdown.js
+++ b/legacy/src/app/directives/pod-details/kvm_storage_dropdown.js
@@ -50,12 +50,12 @@ function KVMStorageDropdownController($scope, $filter) {
   $scope.poolOverCapacity = storage => {
     const { compose, pod } = $scope;
 
-    if (compose && compose.obj && pod && pod.storage_pools) {
+    if (compose?.obj?.requests && pod?.storage_pools && storage?.pool) {
       const storagePool = pod.storage_pools.find(
-        pool => pool.id === storage.pool.id
+        (pool) => pool.id === storage.pool.id
       );
       const request = compose.obj.requests.find(
-        req => storagePool.id === req.poolId
+        (req) => storagePool.id === req.poolId
       );
       const requestSize = request ? request.size : 0;
 


### PR DESCRIPTION
## Done

- Added some undefined object guards to KVM `poolOverCapacity` function

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes #1705 
