### PR TITLE
refactor(test): ensure state in tests is setup using rootStateFactory

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -34,7 +34,7 @@ exports[`stricter compilation`] = {
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -76,7 +76,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -177,33 +177,20 @@ exports[`stricter compilation`] = {
       [137, 24, 10, "Type \'(poolName: string) => void\' is not assignable to type \'SelectPool\'.\\n  Types of parameters \'poolName\' and \'poolName\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1972538641"],
       [191, 10, 7, "Type \'false | \\"For the Beta version of LXD VM hosts each VM can only be assigned a single block device.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
-    "src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx:3808680172": [
-      [17, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [67, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [83, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [100, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [104, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"],
-      [139, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [156, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [160, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
+    "src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx:512155228": [
+      [99, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [103, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"],
+      [155, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [159, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
     ],
-    "src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx:3226799621": [
-      [15, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [40, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [83, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx:2368988330": [
+      [19, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [37, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [80, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:2892838463": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [39, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx:1760423572": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [30, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [44, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [60, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [81, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [94, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/kvm/views/KVMDetails/KVMDetails.test.tsx:9765032": [
+      [16, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [36, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx:2780035521": [
       [80, 6, 68, "Object is possibly \'undefined\'.", "2960886801"]
@@ -212,84 +199,37 @@ exports[`stricter compilation`] = {
       [46, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"],
       [74, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"]
     ],
-    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:475451368": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [129, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:2118393864": [
+      [23, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [132, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
-    "src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx:2184902936": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [22, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx:2739913947": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [28, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [42, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [58, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [75, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [92, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [108, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx:1158651717": [
+      [16, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
+      [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [46, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [62, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [79, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [96, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
+      [112, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx:4064608059": [
       [33, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | undefined\'.", "2807267104"],
       [52, 6, 11, "Type \'\\"\\" | Element | null\' is not assignable to type \'Element | undefined\'.\\n  Type \'null\' is not assignable to type \'Element | undefined\'.", "3453098368"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx:2252990650": [
-      [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [46, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:108173061": [
-      [27, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [61, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [85, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [96, 6, 88, "Object is possibly \'undefined\'.", "465871270"],
-      [104, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [166, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [219, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [279, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [315, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [329, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
-      [337, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [351, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
-      [359, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [384, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx:2529226174": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [27, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [41, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx:2366141448": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [55, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [68, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [90, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:3371023757": [
+      [98, 6, 88, "Object is possibly \'undefined\'.", "465871270"],
+      [331, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
+      [353, 6, 98, "Object is possibly \'undefined\'.", "1041189900"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:2435825133": [
       [18, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx:2138170176": [
-      [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [43, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx:2880885888": [
       [16, 33, 15, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2973346775"],
       [19, 33, 15, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2973147829"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx:1989368010": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [39, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [53, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [71, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
     "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:259372828": [
       [17, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx:2824893159": [
-      [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [32, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [46, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx:984922973": [
       [44, 34, 4, "Object is possibly \'undefined\'.", "2088098233"],
@@ -303,29 +243,15 @@ exports[`stricter compilation`] = {
       [62, 23, 4, "Object is possibly \'undefined\'.", "2088098233"],
       [66, 48, 4, "Object is possibly \'undefined\'.", "2088098233"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx:3510081411": [
-      [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [26, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx:1476552216": [
-      [10, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [27, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx:3272981959": [
-      [12, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [62, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [93, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [135, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
-    ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:1127825407": [
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.tsx:3720550160": [
       [55, 12, 7, "Object is possibly \'undefined\'.", "1060875104"],
       [56, 26, 7, "Object is possibly \'undefined\'.", "1060875104"],
       [56, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [73, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
-      [83, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
-      [85, 33, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action: MachineAction | null, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
-      [108, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
-      [122, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
+      [67, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+      [91, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [93, 33, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action: MachineAction | null, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [116, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "1699375473"],
+      [130, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:554268234": [
       [88, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -373,26 +299,17 @@ exports[`stricter compilation`] = {
       [118, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [119, 8, 11, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "942845580"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:368427658": [
-      [47, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
-      [50, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"],
-      [50, 38, 7, "Object is possibly \'undefined\'.", "1060875104"]
+    "src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:4172246097": [
+      [51, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
+      [54, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"],
+      [54, 38, 7, "Object is possibly \'undefined\'.", "1060875104"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx:3260645888": [
-      [11, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
-      [30, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [48, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [70, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [112, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [146, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [180, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [208, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"],
-      [248, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [249, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [250, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [251, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [252, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [256, 23, 12, "Variable \'initialState\' implicitly has an \'any\' type.", "2722999692"]
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx:3798393233": [
+      [317, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [318, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [319, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [320, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [321, 11, 5, "Object is of type \'unknown\'.", "173192470"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.tsx:2025862623": [
       [34, 6, 5, "Object is possibly \'undefined\'.", "172404922"],

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.test.js
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.test.js
@@ -6,20 +6,24 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import DeleteForm from "./DeleteForm";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("DeleteForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          { id: 1, name: "pod-1", type: "lxd" },
-          { id: 2, name: "pod-2", type: "virsh" },
+          podFactory({ id: 1, name: "pod-1", type: "lxd" }),
+          podFactory({ id: 2, name: "pod-2", type: "virsh" }),
         ],
-        selected: [],
-        errors: {},
         statuses: {
           1: {
             deleting: false,
@@ -30,8 +34,8 @@ describe("DeleteForm", () => {
             refreshing: false,
           },
         },
-      },
-    };
+      }),
+    });
   });
 
   it("correctly dispatches actions to delete selected KVMs", () => {

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.test.js
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.test.js
@@ -6,20 +6,24 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import RefreshForm from "./RefreshForm";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("RefreshForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          { id: 1, name: "pod-1", type: "lxd" },
-          { id: 2, name: "pod-2", type: "virsh" },
+          podFactory({ id: 1, name: "pod-1", type: "lxd" }),
+          podFactory({ id: 2, name: "pod-2", type: "virsh" }),
         ],
-        selected: [],
-        errors: {},
         statuses: {
           1: {
             deleting: false,
@@ -30,8 +34,8 @@ describe("RefreshForm", () => {
             refreshing: false,
           },
         },
-      },
-    };
+      }),
+    });
   });
 
   it("correctly dispatches actions to refresh selected KVMs", () => {

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
@@ -5,39 +5,38 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
+import PodConfiguration from "./PodConfiguration";
+import { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  tagState as tagStateFactory,
+  zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import PodConfiguration from "./PodConfiguration";
 
 const mockStore = configureStore();
 
 describe("PodConfiguration", () => {
-  let initialState;
+  let initialState: RootState;
 
   beforeEach(() => {
-    const pods = [podFactory({ id: 1, name: "pod1" })];
-    const podState = podStateFactory({ items: pods, loaded: true });
-    initialState = {
-      config: {
-        items: [],
-      },
-      pod: podState,
-      resourcepool: {
-        items: [],
+    initialState = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ id: 1, name: "pod1" })],
         loaded: true,
-      },
-      tag: {
-        items: [],
+      }),
+      resourcepool: resourcePoolStateFactory({
         loaded: true,
-      },
-      zone: {
-        items: [],
+      }),
+      tag: tagStateFactory({
         loaded: true,
-      },
-    };
+      }),
+      zone: zoneStateFactory({
+        loaded: true,
+      }),
+    });
   });
 
   it("fetches the necessary data on load", () => {

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
@@ -4,11 +4,15 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
+import PodConfiguration from "../PodConfiguration";
 import {
   pod as podFactory,
   podState as podStateFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  tagState as tagStateFactory,
+  zoneState as zoneStateFactory,
 } from "testing/factories";
-import PodConfiguration from "../PodConfiguration";
 
 const mockStore = configureStore();
 
@@ -16,25 +20,18 @@ describe("PodConfigurationFields", () => {
   let initialState;
 
   beforeEach(() => {
-    const podState = podStateFactory({ items: [], loaded: true });
-    initialState = {
-      config: {
-        items: [],
-      },
-      pod: podState,
-      resourcepool: {
-        items: [],
+    initialState = rootStateFactory({
+      pod: podStateFactory({ items: [], loaded: true }),
+      resourcepool: resourcePoolStateFactory({
         loaded: true,
-      },
-      tag: {
-        items: [],
+      }),
+      tag: tagStateFactory({
         loaded: true,
-      },
-      zone: {
-        items: [],
+      }),
+      zone: zoneStateFactory({
         loaded: true,
-      },
-    };
+      }),
+    });
   });
 
   it("correctly sets initial values for virsh pods", () => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
@@ -5,35 +5,32 @@ import { MemoryRouter } from "react-router-dom";
 import { Provider } from "react-redux";
 
 import KVMDetails from "./KVMDetails";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("KVMDetails", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      messages: {
-        items: [],
-      },
-      notification: {
-        items: [],
-      },
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         errors: {},
         loading: false,
         loaded: true,
         items: [
-          {
+          podFactory({
             id: 1,
             name: "pod-1",
             composed_machines_count: 10,
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("redirects to KVM list if pods have loaded but pod is not in state", () => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -5,26 +5,33 @@ import { MemoryRouter, Route } from "react-router-dom";
 import { Provider } from "react-redux";
 
 import KVMDetailsHeader from "./KVMDetailsHeader";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("KVMDetailsHeader", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         errors: {},
         loading: false,
         loaded: true,
         items: [
-          {
+          podFactory({
             id: 1,
             name: "pod-1",
             composed_machines_count: 10,
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if pods are loading", () => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -50,7 +50,7 @@ describe("KVMDetailsHeader", () => {
 
   it("displays pod name in header strip when loaded", () => {
     const state = { ...initialState };
-    state.pod.items = [{ id: 1, name: "pod-name" }];
+    state.pod.items = [podFactory({ id: 1, name: "pod-name" })];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -66,7 +66,7 @@ describe("KVMDetailsHeader", () => {
 
   it("can display composed machines count", () => {
     const state = { ...initialState };
-    state.pod.items = [{ id: 1, composed_machines_count: 5 }];
+    state.pod.items = [podFactory({ id: 1, composed_machines_count: 5 })];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.test.js
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.test.js
@@ -6,17 +6,28 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import AddKVMForm from "./AddKVMForm";
+import {
+  configState as configStateFactory,
+  generalState as generalStateFactory,
+  podState as podStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("AddKVMForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [{ name: "maas_name", value: "MAAS" }],
-      },
-      general: {
+      }),
+      general: generalStateFactory({
         powerTypes: {
           data: [
             {
@@ -98,33 +109,19 @@ describe("AddKVMForm", () => {
           ],
           loaded: true,
         },
-      },
-      pod: {
-        items: [],
+      }),
+      pod: podStateFactory({
         loaded: true,
-        loading: false,
-        saved: false,
-        saving: false,
-      },
-      resourcepool: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory()],
         loaded: true,
-      },
-      zone: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
+      }),
+      zone: zoneStateFactory({
+        items: [zoneFactory()],
         loaded: true,
-      },
-    };
+      }),
+    });
   });
 
   it("fetches the necessary data on load", () => {

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx
@@ -5,20 +5,33 @@ import React from "react";
 import { Provider } from "react-redux";
 
 import AddKVMForm from "../AddKVMForm";
+import {
+  configState as configStateFactory,
+  generalState as generalStateFactory,
+  podState as podStateFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("AddKVMFormFields", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [{ name: "maas_name", value: "MAAS" }],
-      },
-      general: {
-        powerTypes: {
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
           data: [
-            {
+            powerTypeFactory({
               driver_type: "pod",
               name: "lxd",
               description: "LXD (virtual systems)",
@@ -59,8 +72,8 @@ describe("AddKVMFormFields", () => {
                 memory: 2048,
                 storage: 8,
               },
-            },
-            {
+            }),
+            powerTypeFactory({
               name: "virsh",
               description: "Virsh (virtual systems)",
               fields: [
@@ -93,37 +106,27 @@ describe("AddKVMFormFields", () => {
                 },
               ],
               chassis: true,
-            },
+            }),
           ],
           loaded: true,
-        },
-      },
-      pod: {
+        }),
+      }),
+      pod: podStateFactory({
         items: [],
         loaded: true,
         loading: false,
         saved: false,
         saving: false,
-      },
-      resourcepool: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory()],
         loaded: true,
-      },
-      zone: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
+      }),
+      zone: zoneStateFactory({
+        items: [zoneFactory()],
         loaded: true,
-      },
-    };
+      }),
+    });
   });
 
   it("does not show power type fields that are scoped to nodes", async () => {

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
@@ -6,7 +6,10 @@ import React from "react";
 
 import KVMListActionMenu from "./KVMListActionMenu";
 import { RootState } from "app/store/root/types";
-import { rootState as rootStateFactory } from "testing/factories";
+import {
+  pod as podFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -41,8 +44,8 @@ describe("KVMListActionMenu", () => {
   it("is enabled if at least one KVM is selected", () => {
     const state = { ...initialState };
     state.pod.items = [
-      { id: 1, name: "pod-1", type: "lxd" },
-      { id: 2, name: "pod-2", type: "virsh" },
+      podFactory({ id: 1, name: "pod-1", type: "lxd" }),
+      podFactory({ id: 2, name: "pod-2", type: "virsh" }),
     ];
     state.pod.selected = [1];
     const store = mockStore(state);

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
@@ -5,18 +5,16 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import KVMListActionMenu from "./KVMListActionMenu";
+import { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("KVMListActionMenu", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
-        items: [],
-        selected: [],
-      },
-    };
+    initialState = rootStateFactory();
   });
 
   it("is disabled with tooltip if no KVMs are selected", () => {

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -5,20 +5,24 @@ import configureStore from "redux-mock-store";
 import * as React from "react";
 
 import KVMListHeader from "./KVMListHeader";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("KVMListHeader", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         loaded: true,
-        loading: false,
-        items: [{ id: 1 }, { id: 2 }],
-        selected: [],
-      },
-    };
+        items: [podFactory({ id: 1 }), podFactory({ id: 2 })],
+      }),
+    });
   });
 
   afterEach(() => {

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import CPUColumn from "./CPUColumn";
 import {
   pod as podFactory,
+  podHint as podHintFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -24,12 +25,12 @@ describe("CPUColumn", () => {
             cpu_over_commit_ratio: 1,
             id: 1,
             name: "pod-1",
-            total: {
+            total: podHintFactory({
               cores: 8,
-            },
-            used: {
+            }),
+            used: podHintFactory({
               cores: 4,
-            },
+            }),
           }),
         ],
       }),

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
@@ -4,16 +4,23 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import CPUColumn from "./CPUColumn";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("CPUColumn", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          {
+          podFactory({
             cpu_over_commit_ratio: 1,
             id: 1,
             name: "pod-1",
@@ -23,10 +30,10 @@ describe("CPUColumn", () => {
             used: {
               cores: 4,
             },
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("can display correct cpu core information without overcommit", () => {

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
@@ -4,6 +4,8 @@ import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import React from "react";
 
+import KVMListTable from "./KVMListTable";
+import { nodeStatus } from "app/base/enum";
 import {
   controllerState as controllerStateFactory,
   generalState as generalStateFactory,
@@ -19,13 +21,13 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { nodeStatus } from "app/base/enum";
-import KVMListTable from "./KVMListTable";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("KVMListTable", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
     const pods = [
       podFactory({ pool: 1, zone: 1 }),

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
@@ -5,28 +5,26 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import NameColumn from "./NameColumn";
+import {
+  pod as podFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("NameColumn", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
-        items: [
-          {
-            id: 1,
-            name: "pod-1",
-          },
-        ],
-        selected: [],
-      },
-    };
+    initialState = rootStateFactory();
   });
 
   it("can display a link to details page", () => {
     const state = { ...initialState };
+    state.pod.items = [podFactory({ id: 1, name: "pod-1" })];
     const store = mockStore(state);
+
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
@@ -34,14 +32,17 @@ describe("NameColumn", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(wrapper.find("Link").text()).toBe("pod-1");
     expect(wrapper.find("Link").props().to).toBe("/kvm/1");
   });
 
   it("sets checkbox to checked if pod is selected", () => {
     const state = { ...initialState };
+    state.pod.items = [podFactory({ id: 1, name: "pod-1" })];
     state.pod.selected = [1];
     const store = mockStore(state);
+
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
@@ -51,6 +52,7 @@ describe("NameColumn", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(wrapper.find("Input").prop("checked")).toBe(true);
   });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
@@ -3,25 +3,33 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import { nodeStatus } from "app/base/enum";
 import OSColumn from "./OSColumn";
+import { nodeStatus } from "app/base/enum";
+import {
+  controllerState as controllerStateFactory,
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  osInfo as osInfoFactory,
+  osInfoState as osInfoStateFactory,
+  pod as podFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("OSColumn", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      controller: {
+    initialState = rootStateFactory({
+      controller: controllerStateFactory({
         loaded: true,
-        loading: false,
-        items: [],
-      },
-      general: {
-        osInfo: {
+      }),
+      general: generalStateFactory({
+        osInfo: osInfoStateFactory({
           loaded: true,
-          loading: false,
-          data: {
+          data: osInfoFactory({
             osystems: [
               ["centos", "CentOS"],
               ["ubuntu", "Ubuntu"],
@@ -32,56 +40,47 @@ describe("OSColumn", () => {
               ["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"'],
               ["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"'],
             ],
-          },
-        },
-      },
-      machine: {
-        loaded: true,
-        loading: false,
-        items: [],
-      },
-      pod: {
-        items: [
-          {
-            id: 1,
-            name: "pod-1",
-          },
-        ],
-      },
-    };
+          }),
+        }),
+      }),
+    });
   });
 
   it(`shows a spinner if machines/controllers are loading and pod's host is not
     yet in state`, () => {
     const state = { ...initialState };
     state.machine.loading = true;
-    state.pod.items[0].host = "abc123";
+    state.pod.items = [podFactory({ host: "abc123", id: 1, name: "pod-1" })];
     const store = mockStore(state);
+
     const wrapper = mount(
       <Provider store={store}>
         <OSColumn id={1} />
       </Provider>
     );
+
     expect(wrapper.find(".p-icon--spinner").exists()).toBe(true);
   });
 
   it("can display the pod's host OS information", () => {
     const state = { ...initialState };
     state.machine.items = [
-      {
+      machineFactory({
         distro_series: "focal",
         osystem: "ubuntu",
         status_code: nodeStatus.DEPLOYED,
         system_id: "abc123",
-      },
+      }),
     ];
-    state.pod.items = [{ host: "abc123", id: 1, name: "pod-1" }];
+    state.pod.items = [podFactory({ host: "abc123", id: 1, name: "pod-1" })];
     const store = mockStore(state);
+
     const wrapper = mount(
       <Provider store={store}>
         <OSColumn id={1} />
       </Provider>
     );
+
     expect(wrapper.find("[data-test='pod-os']").text()).toBe(
       "Ubuntu 20.04 LTS"
     );
@@ -90,20 +89,22 @@ describe("OSColumn", () => {
   it("displays 'Unknown' if pod's host cannot be found", () => {
     const state = { ...initialState };
     state.machine.items = [
-      {
+      machineFactory({
         distro_series: "focal",
         osystem: "ubuntu",
         status_code: nodeStatus.DEPLOYED,
         system_id: "abc123",
-      },
+      }),
     ];
-    state.pod.items = [{ host: "def456", id: 1, name: "pod-1" }];
+    state.pod.items = [podFactory({ host: "def456", id: 1, name: "pod-1" })];
     const store = mockStore(state);
+
     const wrapper = mount(
       <Provider store={store}>
         <OSColumn id={1} />
       </Provider>
     );
+
     expect(wrapper.find("[data-test='pod-os']").text()).toBe("Unknown");
   });
 });

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
@@ -4,40 +4,50 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import PoolColumn from "./PoolColumn";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("PoolColumn", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          {
-            id: 1,
+          podFactory({
             name: "pod-1",
             pool: 1,
             zone: 1,
-          },
+          }),
         ],
-      },
-      resourcepool: {
+      }),
+      resourcepool: resourcePoolStateFactory({
         items: [
-          {
+          resourcePoolFactory({
             id: 1,
             name: "swimming-pool",
-          },
+          }),
         ],
-      },
-      zone: {
+      }),
+      zone: zoneStateFactory({
         items: [
-          {
+          zoneFactory({
             id: 1,
             name: "alone-zone",
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("can display the pod's resource pool and zone", () => {

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
@@ -3,36 +3,30 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import { machine as machineFactory } from "testing/factories";
 import PowerColumn from "./PowerColumn";
+import {
+  machine as machineFactory,
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("PowerColumn", () => {
-  let initialState;
-  const machine = machineFactory();
+  let initialState: RootState;
 
   beforeEach(() => {
-    initialState = {
-      controller: {
-        loaded: true,
-        loading: false,
-        items: [],
-      },
-      machine: {
-        loaded: true,
-        loading: false,
-        items: [],
-      },
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          {
-            id: 1,
+          podFactory({
             name: "pod-1",
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it(`shows a spinner if machines/controllers are loading and pod's host is not
@@ -52,6 +46,7 @@ describe("PowerColumn", () => {
 
   it("can display the pod's host power information", () => {
     const state = { ...initialState };
+    const machine = machineFactory();
     machine.power_state = "on";
     machine.system_id = "abc123";
     state.machine.items = [machine];
@@ -70,6 +65,7 @@ describe("PowerColumn", () => {
 
   it("displays 'Unknown' if pod's host cannot be found", () => {
     const state = { ...initialState };
+    const machine = machineFactory();
     machine.power_state = "on";
     machine.system_id = "abc123";
     state.machine.items = [machine];

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
@@ -7,7 +7,6 @@ import PowerColumn from "./PowerColumn";
 import {
   machine as machineFactory,
   pod as podFactory,
-  podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 import type { RootState } from "app/store/root/types";
@@ -18,22 +17,14 @@ describe("PowerColumn", () => {
   let initialState: RootState;
 
   beforeEach(() => {
-    initialState = rootStateFactory({
-      pod: podStateFactory({
-        items: [
-          podFactory({
-            name: "pod-1",
-          }),
-        ],
-      }),
-    });
+    initialState = rootStateFactory();
   });
 
   it(`shows a spinner if machines/controllers are loading and pod's host is not
     yet in state`, () => {
     const state = { ...initialState };
     state.machine.loading = true;
-    state.pod.items[0].host = "abc123";
+    state.pod.items = [podFactory({ host: "abc123", id: 1, name: "pod-1" })];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -50,7 +41,7 @@ describe("PowerColumn", () => {
     machine.power_state = "on";
     machine.system_id = "abc123";
     state.machine.items = [machine];
-    state.pod.items = [{ host: "abc123", id: 1, name: "pod-1" }];
+    state.pod.items = [podFactory({ host: "abc123", id: 1, name: "pod-1" })];
     const store = mockStore(state);
 
     const wrapper = mount(
@@ -69,7 +60,7 @@ describe("PowerColumn", () => {
     machine.power_state = "on";
     machine.system_id = "abc123";
     state.machine.items = [machine];
-    state.pod.items = [{ host: "def456", id: 1, name: "pod-1" }];
+    state.pod.items = [podFactory({ host: "def456", id: 1, name: "pod-1" })];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import RAMColumn from "./RAMColumn";
 import {
   pod as podFactory,
+  podHint as podHintFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -24,12 +25,12 @@ describe("RAMColumn", () => {
             id: 1,
             memory_over_commit_ratio: 1,
             name: "pod-1",
-            total: {
+            total: podHintFactory({
               memory: 8192,
-            },
-            used: {
+            }),
+            used: podHintFactory({
               memory: 2048,
-            },
+            }),
           }),
         ],
       }),

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
@@ -4,16 +4,23 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import RAMColumn from "./RAMColumn";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("RAMColumn", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          {
+          podFactory({
             id: 1,
             memory_over_commit_ratio: 1,
             name: "pod-1",
@@ -23,10 +30,10 @@ describe("RAMColumn", () => {
             used: {
               memory: 2048,
             },
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("can display correct RAM information without overcommit", () => {

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
@@ -4,23 +4,28 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import TypeColumn from "./TypeColumn";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("TypeColumn", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          {
-            id: 1,
-            name: "pod-1",
+          podFactory({
             type: "virsh",
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays the formatted pod type", () => {

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
@@ -4,24 +4,29 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import VMsColumn from "./VMsColumn";
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("VMsColumn", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      pod: {
+    initialState = rootStateFactory({
+      pod: podStateFactory({
         items: [
-          {
+          podFactory({
             composed_machines_count: 10,
-            id: 1,
-            name: "pod-1",
             owners_count: 5,
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays the pod's machine and owner counts", () => {

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.test.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.test.js
@@ -6,27 +6,31 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import AddChassisForm from "./AddChassisForm";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  generalState as generalStateFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("AddChassisForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [{ name: "maas_name", value: "MAAS" }],
-      },
-      domain: {
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
         items: [
-          {
-            id: 0,
+          domainFactory({
             name: "maas",
-          },
+          }),
         ],
         loaded: true,
-      },
-      general: {
-        powerTypes: {
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
           data: [
             {
               name: "manual",
@@ -125,14 +129,9 @@ describe("AddChassisForm", () => {
             },
           ],
           loaded: true,
-        },
-      },
-      machine: {
-        errors: {},
-        saved: false,
-        saving: false,
-      },
-    };
+        }),
+      }),
+    });
   });
 
   it("fetches the necessary data on load if not already loaded", () => {

--- a/ui/src/app/machines/views/AddChassis/AddChassisFormFields/AddChassisFormFields.test.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisFormFields/AddChassisFormFields.test.js
@@ -6,44 +6,31 @@ import React from "react";
 import { Provider } from "react-redux";
 
 import AddChassisForm from "../AddChassisForm";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  generalState as generalStateFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("AddChassisFormFields", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [{ name: "maas_name", value: "MAAS" }],
-      },
-      domain: {
-        items: [
-          {
-            id: 0,
-            name: "maas",
-          },
-        ],
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ name: "maas" })],
         loaded: true,
-      },
-      general: {
-        powerTypes: {
-          data: [
-            {
-              name: "manual",
-              description: "Manual",
-              fields: [],
-              can_probe: false,
-            },
-          ],
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
           loaded: true,
-        },
-      },
-      machine: {
-        errors: {},
-        saved: false,
-        saving: false,
-      },
-    };
+        }),
+      }),
+    });
   });
 
   it("can render", () => {

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.test.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.test.js
@@ -6,26 +6,29 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import AddMachineForm from "./AddMachineForm";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  generalState as generalStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("AddMachine", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [{ name: "maas_name", value: "MAAS" }],
-      },
-      domain: {
-        items: [
-          {
-            id: 0,
-            name: "maas",
-          },
-        ],
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ name: "maas" })],
         loaded: true,
-      },
-      general: {
+      }),
+      general: generalStateFactory({
         architectures: {
           data: ["amd64/generic"],
           loaded: true,
@@ -66,31 +69,20 @@ describe("AddMachine", () => {
           ],
           loaded: true,
         },
-      },
-      machine: {
-        errors: {},
-        saved: false,
-        saving: false,
-      },
-      resourcepool: {
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory({ name: "default" })],
+        loaded: true,
+      }),
+      zone: zoneStateFactory({
         items: [
-          {
-            id: 0,
+          zoneFactory({
             name: "default",
-          },
+          }),
         ],
         loaded: true,
-      },
-      zone: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
-        loaded: true,
-      },
-    };
+      }),
+    });
   });
 
   it("fetches the necessary data on load if not already loaded", () => {

--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.test.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.test.js
@@ -6,26 +6,29 @@ import React from "react";
 import { Provider } from "react-redux";
 
 import AddMachineForm from "../AddMachineForm";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  generalState as generalStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("AddMachineFormFields", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [{ name: "maas_name", value: "MAAS" }],
-      },
-      domain: {
-        items: [
-          {
-            id: 0,
-            name: "maas",
-          },
-        ],
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory()],
         loaded: true,
-      },
-      general: {
+      }),
+      general: generalStateFactory({
         architectures: {
           data: ["amd64/generic"],
           loaded: true,
@@ -51,30 +54,16 @@ describe("AddMachineFormFields", () => {
           ],
           loaded: true,
         },
-      },
-      machine: {
-        saved: false,
-        saving: false,
-      },
-      resourcepool: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory()],
         loaded: true,
-      },
-      zone: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
+      }),
+      zone: zoneStateFactory({
+        items: [zoneFactory()],
         loaded: true,
-      },
-    };
+      }),
+    });
   });
 
   it("correctly sets minimum kernel to default", () => {

--- a/ui/src/app/machines/views/AddRSD/AddRSDForm/AddRSDForm.test.js
+++ b/ui/src/app/machines/views/AddRSD/AddRSDForm/AddRSDForm.test.js
@@ -6,42 +6,30 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import AddRSDForm from "./AddRSDForm";
+import {
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("AddRSDForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [{ name: "maas_name", value: "MAAS" }],
-      },
-      pod: {
-        items: [],
+    initialState = rootStateFactory({
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory()],
         loaded: true,
-        loading: false,
-        saved: false,
-        saving: false,
-      },
-      resourcepool: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
+      }),
+      zone: zoneStateFactory({
+        items: [zoneFactory()],
         loaded: true,
-      },
-      zone: {
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-        ],
-        loaded: true,
-      },
-    };
+      }),
+    });
   });
 
   it("fetches the necessary data on load", () => {

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -6,6 +6,11 @@ import React from "react";
 
 import MachineList from "./MachineList";
 import { nodeStatus, scriptStatus } from "app/base/enum";
+import {
+  generalState as generalStateFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -13,12 +18,10 @@ jest.useFakeTimers();
 
 describe("MachineList", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         machineActions: {
           data: [],
           loaded: false,
@@ -29,14 +32,10 @@ describe("MachineList", () => {
             osystems: [["ubuntu", "Ubuntu"]],
             releases: [["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"']],
           },
-          errors: {},
           loaded: true,
-          loading: false,
         },
-      },
-      machine: {
-        errors: null,
-        loading: false,
+      }),
+      machine: machineStateFactory({
         loaded: true,
         items: [
           {
@@ -166,35 +165,8 @@ describe("MachineList", () => {
             zone: {},
           },
         ],
-        selected: [],
-      },
-      resourcepool: {
-        loaded: true,
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-          {
-            id: 1,
-            name: "Backup",
-          },
-        ],
-      },
-      zone: {
-        loaded: true,
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-          {
-            id: 1,
-            name: "Backup",
-          },
-        ],
-      },
-    };
+      }),
+    });
   });
 
   afterEach(() => {

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.js
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import MachineListControls, { DEBOUNCE_INTERVAL } from "./MachineListControls";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -13,16 +14,9 @@ jest.useFakeTimers();
 
 describe("MachineListControls", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      machine: {
-        errors: null,
-        loading: false,
-        loaded: true,
-        items: [],
-        selected: [],
-      },
-    };
+    initialState = rootStateFactory();
   });
 
   afterEach(() => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -6,30 +6,39 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import ActionFormWrapper from "./ActionFormWrapper";
+import { RootState } from "app/store/root/types";
+import {
+  generalState as generalStateFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  scriptsState as scriptsStateFactory,
+  scripts as scriptsFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("ActionFormWrapper", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         machineActions: {
           data: [{ name: "commission", sentence: "commission" }],
         },
-      },
-      machine: {
+      }),
+      machine: machineStateFactory({
         errors: {},
         items: [],
         selected: [],
         statuses: { a: {}, b: {} },
-      },
-      scripts: {
+      }),
+      scripts: scriptsStateFactory({
         errors: {},
         loading: false,
         loaded: true,
         items: [
-          {
+          scriptsFactory({
             name: "smartctl-validate",
             tags: ["commissioning", "storage"],
             parameters: {
@@ -39,8 +48,8 @@ describe("ActionFormWrapper", () => {
               },
             },
             type: 2,
-          },
-          {
+          }),
+          scriptsFactory({
             name: "internet-connectivity",
             tags: ["internet", "network-validation", "network"],
             parameters: {
@@ -52,10 +61,10 @@ describe("ActionFormWrapper", () => {
               },
             },
             type: 2,
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it(`displays a warning if not all selected machines can perform selected

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -9,7 +9,11 @@ import ActionFormWrapper from "./ActionFormWrapper";
 import { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
+  machine as machineFactory,
   machineState as machineStateFactory,
+  machineAction as machineActionFactory,
+  machineActionsState as machineActionsStateFactory,
+  machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
   scriptsState as scriptsStateFactory,
   scripts as scriptsFactory,
@@ -23,15 +27,20 @@ describe("ActionFormWrapper", () => {
   beforeEach(() => {
     initialState = rootStateFactory({
       general: generalStateFactory({
-        machineActions: {
-          data: [{ name: "commission", sentence: "commission" }],
-        },
+        machineActions: machineActionsStateFactory({
+          data: [
+            machineActionFactory({
+              name: "commission",
+              sentence: "commission",
+            }),
+          ],
+        }),
       }),
       machine: machineStateFactory({
         errors: {},
         items: [],
         selected: [],
-        statuses: { a: {}, b: {} },
+        statuses: { a: machineStatusFactory(), b: machineStatusFactory() },
       }),
       scripts: scriptsStateFactory({
         errors: {},
@@ -71,8 +80,8 @@ describe("ActionFormWrapper", () => {
   action`, () => {
     const state = { ...initialState };
     state.machine.items = [
-      { system_id: "a", actions: ["commission"] },
-      { system_id: "b", actions: [] },
+      machineFactory({ system_id: "a", actions: ["commission"] }),
+      machineFactory({ system_id: "b", actions: [] }),
     ];
     state.machine.selected = ["a", "b"];
     const store = mockStore(state);
@@ -102,17 +111,17 @@ describe("ActionFormWrapper", () => {
     can perform selected action`, async () => {
     const state = { ...initialState };
     state.machine.items = [
-      { system_id: "a", actions: ["commission"] },
-      { system_id: "b", actions: [] },
+      machineFactory({ system_id: "a", actions: ["commission"] }),
+      machineFactory({ system_id: "b", actions: [] }),
     ];
     state.machine.selected = ["a", "b"];
     state.machine.statuses = {
-      a: {
+      a: machineStatusFactory({
         commissioning: true,
-      },
-      b: {
+      }),
+      b: machineStatusFactory({
         commissioning: true,
-      },
+      }),
     };
     const store = mockStore(state);
     const wrapper = mount(
@@ -144,8 +153,8 @@ describe("ActionFormWrapper", () => {
   it("can set selected machines to those that can perform action", () => {
     const state = { ...initialState };
     state.machine.items = [
-      { system_id: "a", actions: ["commission"] },
-      { system_id: "b", actions: [] },
+      machineFactory({ system_id: "a", actions: ["commission"] }),
+      machineFactory({ system_id: "b", actions: [] }),
     ];
     state.machine.selected = ["a", "b"];
     const store = mockStore(state);

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.js
@@ -6,30 +6,36 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import CommissionForm from "../CommissionForm";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  scriptsState as scriptsStateFactory,
+  scripts as scriptsFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("CommissionForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      machine: {
-        errors: {},
-        loading: false,
+    initialState = rootStateFactory({
+      machine: machineStateFactory({
         loaded: true,
-        items: [{ system_id: "abc123" }, { system_id: "def456" }],
-        selected: [],
+        items: [
+          machineFactory({ system_id: "abc123" }),
+          machineFactory({ system_id: "def456" }),
+        ],
         statuses: {
           abc123: {},
           def456: {},
         },
-      },
-      scripts: {
-        errors: {},
-        loading: false,
+      }),
+      scripts: scriptsStateFactory({
         loaded: true,
         items: [
-          {
+          scriptsFactory({
             name: "smartctl-validate",
             tags: ["commissioning", "storage"],
             parameters: {
@@ -39,8 +45,8 @@ describe("CommissionForm", () => {
               },
             },
             type: 2,
-          },
-          {
+          }),
+          scriptsFactory({
             name: "internet-connectivity",
             tags: ["internet", "network-validation", "network"],
             parameters: {
@@ -52,10 +58,10 @@ describe("CommissionForm", () => {
               },
             },
             type: 2,
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a field for URL if a selected script has url parameter", async () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -6,15 +6,27 @@ import React from "react";
 import { Provider } from "react-redux";
 
 import DeployForm from "../DeployForm";
-import type { TSFixMe } from "app/base/types";
+import { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  configState as configStateFactory,
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("DeployFormFields", () => {
-  let initialState: TSFixMe;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [
           {
             name: "default_osystem",
@@ -28,8 +40,8 @@ describe("DeployFormFields", () => {
         errors: {},
         loaded: true,
         loading: false,
-      },
-      general: {
+      }),
+      general: generalStateFactory({
         defaultMinHweKernel: {
           data: "",
           errors: {},
@@ -74,29 +86,27 @@ describe("DeployFormFields", () => {
           loaded: true,
           loading: false,
         },
-      },
-      machine: {
-        errors: {},
-        loading: false,
+      }),
+      machine: machineStateFactory({
         loaded: true,
         items: [
-          {
+          machineFactory({
             system_id: "abc123",
-          },
-          {
+          }),
+          machineFactory({
             system_id: "def456",
-          },
+          }),
         ],
         selected: [],
         statuses: {
-          abc123: {},
-          def456: {},
+          abc123: machineStatusFactory(),
+          def456: machineStatusFactory(),
         },
-      },
-      user: {
-        auth: {
+      }),
+      user: userStateFactory({
+        auth: authStateFactory({
           saved: false,
-          user: {
+          user: userFactory({
             email: "test@example.com",
             global_permissions: ["machine_create"],
             id: 1,
@@ -104,16 +114,11 @@ describe("DeployFormFields", () => {
             last_name: "",
             sshkeys_count: 1,
             username: "admin",
-          },
-        },
-        errors: {},
-        items: [],
+          }),
+        }),
         loaded: true,
-        loading: false,
-        saved: false,
-        saving: false,
-      },
-    };
+      }),
+    });
   });
 
   it("correctly sets operating system to default", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
@@ -6,28 +6,33 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import FieldlessForm from "./FieldlessForm";
+import {
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("FieldlessForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      machine: {
-        errors: {},
-        loading: false,
+    initialState = rootStateFactory({
+      machine: machineStateFactory({
         loaded: true,
         items: [
-          {
+          machineFactory({
             system_id: "abc123",
-          },
+          }),
         ],
         selected: [],
         statuses: {
           abc123: {},
         },
-      },
-      general: {
+      }),
+      general: generalStateFactory({
         machineActions: {
           data: [
             { name: "abort", sentence: "abort" },
@@ -43,8 +48,8 @@ describe("FieldlessForm", () => {
             { name: "unlock", sentence: "unlock" },
           ],
         },
-      },
-    };
+      }),
+    });
   });
 
   it("renders", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -7,37 +7,40 @@ import React from "react";
 
 import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 import OverrideTestForm from "./OverrideTestForm";
+import {
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  scriptResultsState as scriptResultsStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("OverrideTestForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         machineActions: {
           data: [
             { name: "override-failed-testing", sentence: "change those pools" },
           ],
         },
-      },
-      machine: {
-        errors: {},
-        loading: false,
+      }),
+      machine: machineStateFactory({
         loaded: true,
         items: [
-          { hostname: "host1", system_id: "abc123" },
-          { hostname: "host2", system_id: "def456" },
+          machineFactory({ hostname: "host1", system_id: "abc123" }),
+          machineFactory({ hostname: "host2", system_id: "def456" }),
         ],
-        selected: [],
         statuses: {
           abc123: { settingPool: false },
           def456: { settingPool: false },
         },
-      },
-      scriptresults: {
-        errors: {},
-        loading: false,
+      }),
+      scriptresults: scriptResultsStateFactory({
         loaded: true,
         items: {
           abc123: [
@@ -51,8 +54,8 @@ describe("OverrideTestForm", () => {
             },
           ],
         },
-      },
-    };
+      }),
+    });
   });
 
   it(`displays failed tests warning without suppress tests checkbox for a single

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TagForm/TagForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TagForm/TagForm.test.js
@@ -6,36 +6,37 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import TagForm from "./TagForm";
+import {
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("TagForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         machineActions: {
           data: [{ name: "tag", sentence: "tag" }],
         },
-      },
-      machine: {
-        errors: {},
-        loading: false,
+      }),
+      machine: machineStateFactory({
         loaded: true,
-        items: [{ system_id: "abc123" }, { system_id: "def456" }],
-        selected: [],
+        items: [
+          machineFactory({ system_id: "abc123" }),
+          machineFactory({ system_id: "def456" }),
+        ],
         statuses: {
           abc123: {},
           def456: {},
         },
-      },
-      tag: {
-        errors: {},
-        loading: false,
-        loaded: true,
-        items: [],
-      },
-    };
+      }),
+    });
   });
 
   it("correctly dispatches actions to tag selected machines", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.js
@@ -5,31 +5,34 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import TagForm from "../TagForm";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("TagFormFields", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      machine: {
+    initialState = rootStateFactory({
+      machine: machineStateFactory({
         errors: {},
         loading: false,
         loaded: true,
-        items: [{ system_id: "abc123" }, { system_id: "def456" }],
+        items: [
+          machineFactory({ system_id: "abc123" }),
+          machineFactory({ system_id: "def456" }),
+        ],
         selected: [],
         statuses: {
           abc123: {},
           def456: {},
         },
-      },
-      tag: {
-        errors: {},
-        loading: false,
-        loaded: true,
-        items: [],
-      },
-    };
+      }),
+    });
   });
 
   it("fetches tags on mount", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TestForm/TestForm.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TestForm/TestForm.test.js
@@ -6,32 +6,38 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import TestForm from "./TestForm";
+import {
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  scriptsState as scriptsStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("TestForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         machineActions: {
           data: [{ name: "test", sentence: "test" }],
         },
-      },
-      machine: {
-        errors: {},
-        loading: false,
+      }),
+      machine: machineStateFactory({
         loaded: true,
-        items: [{ system_id: "abc123" }, { system_id: "def456" }],
-        selected: [],
+        items: [
+          machineFactory({ system_id: "abc123" }),
+          machineFactory({ system_id: "def456" }),
+        ],
         statuses: {
           abc123: {},
           def456: {},
         },
-      },
-      scripts: {
-        errors: {},
-        loading: false,
+      }),
+      scripts: scriptsStateFactory({
         loaded: true,
         items: [
           {
@@ -59,8 +65,8 @@ describe("TestForm", () => {
             type: 2,
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("correctly dispatches actions to test selected machines", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.js
@@ -6,30 +6,36 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import TestForm from "../TestForm";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  scriptsState as scriptsStateFactory,
+  scripts as scriptsFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("TestForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      machine: {
-        errors: {},
-        loading: false,
+    initialState = rootStateFactory({
+      machine: machineStateFactory({
         loaded: true,
-        items: [{ system_id: "abc123" }, { system_id: "def456" }],
-        selected: [],
+        items: [
+          machineFactory({ system_id: "abc123" }),
+          machineFactory({ system_id: "def456" }),
+        ],
         statuses: {
           abc123: {},
           def456: {},
         },
-      },
-      scripts: {
-        errors: {},
-        loading: false,
+      }),
+      scripts: scriptsStateFactory({
         loaded: true,
         items: [
-          {
+          scriptsFactory({
             name: "smartctl-validate",
             tags: ["commissioning", "storage"],
             parameters: {
@@ -39,8 +45,8 @@ describe("TestForm", () => {
               },
             },
             type: 2,
-          },
-          {
+          }),
+          scriptsFactory({
             name: "internet-connectivity",
             tags: ["internet", "network-validation", "network"],
             parameters: {
@@ -52,10 +58,10 @@ describe("TestForm", () => {
               },
             },
             type: 2,
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a field for URL if a selected script has url parameter", async () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx
@@ -5,26 +5,28 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import MachineListActionMenu from "./MachineListActionMenu";
+import { RootState } from "app/store/root/types";
+import {
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("MachineListActionMenu", () => {
-  let initialState;
+  let initialState: RootState;
+
   beforeEach(() => {
-    initialState = {
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         machineActions: {
           data: [],
           errors: {},
           loaded: true,
           loading: false,
         },
-      },
-      machine: {
-        items: [],
-        selected: [],
-      },
-    };
+      }),
+    });
   });
 
   it("is disabled if no are machines selected", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListActionMenu/MachineListActionMenu.test.tsx
@@ -8,6 +8,8 @@ import MachineListActionMenu from "./MachineListActionMenu";
 import { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
+  machine as machineFactory,
+  machineAction as machineActionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -50,7 +52,7 @@ describe("MachineListActionMenu", () => {
   it("is enabled if at least one machine selected", () => {
     const state = { ...initialState };
     state.machine.items = [
-      { system_id: "a", actions: ["lifecycle1", "lifecycle2"] },
+      machineFactory({ system_id: "a", actions: ["lifecycle1", "lifecycle2"] }),
     ];
     state.machine.selected = ["a"];
     const store = mockStore(state);
@@ -72,15 +74,27 @@ describe("MachineListActionMenu", () => {
     those in which selected machines cannot perform`, () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
-      { name: "lifecycle1", title: "Lifecycle 1", type: "lifecycle" },
-      { name: "lifecycle2", title: "Lifecycle 2", type: "lifecycle" },
-      { name: "lifecycle3", title: "Lifecycle 3", type: "lifecycle" },
+      machineActionFactory({
+        name: "lifecycle1",
+        title: "Lifecycle 1",
+        type: "lifecycle",
+      }),
+      machineActionFactory({
+        name: "lifecycle2",
+        title: "Lifecycle 2",
+        type: "lifecycle",
+      }),
+      machineActionFactory({
+        name: "lifecycle3",
+        title: "Lifecycle 3",
+        type: "lifecycle",
+      }),
     ];
     // No machine can perform "lifecycle3" action
     state.machine.items = [
-      { system_id: "a", actions: ["lifecycle1", "lifecycle2"] },
-      { system_id: "b", actions: ["lifecycle1"] },
-      { system_id: "c", actions: ["other"] },
+      machineFactory({ system_id: "a", actions: ["lifecycle1", "lifecycle2"] }),
+      machineFactory({ system_id: "b", actions: ["lifecycle1"] }),
+      machineFactory({ system_id: "c", actions: ["other"] }),
     ];
     state.machine.selected = ["a", "b", "c"];
     const store = mockStore(state);
@@ -114,15 +128,23 @@ describe("MachineListActionMenu", () => {
     perform the action`, () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
-      { name: "on", title: "Power on...", type: "power" },
-      { name: "off", title: "Power off...", type: "power" },
-      { name: "house", title: "Power house...", type: "power" },
+      machineActionFactory({ name: "on", title: "Power on...", type: "power" }),
+      machineActionFactory({
+        name: "off",
+        title: "Power off...",
+        type: "power",
+      }),
+      machineActionFactory({
+        name: "house",
+        title: "Power house...",
+        type: "power",
+      }),
     ];
     // No machine can perform "house" action
     state.machine.items = [
-      { system_id: "a", actions: ["on", "off"] },
-      { system_id: "b", actions: ["on"] },
-      { system_id: "c", actions: ["off"] },
+      machineFactory({ system_id: "a", actions: ["on", "off"] }),
+      machineFactory({ system_id: "b", actions: ["on"] }),
+      machineFactory({ system_id: "c", actions: ["off"] }),
     ];
     state.machine.selected = ["a", "b", "c"];
     const store = mockStore(state);
@@ -148,15 +170,30 @@ describe("MachineListActionMenu", () => {
   it("correctly calculates number of machines that can perform each action", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
-      { name: "commission", title: "Commission...", type: "lifecycle" },
-      { name: "release", title: "Release...", type: "lifecycle" },
-      { name: "deploy", title: "Deploy...", type: "lifecycle" },
+      machineActionFactory({
+        name: "commission",
+        title: "Commission...",
+        type: "lifecycle",
+      }),
+      machineActionFactory({
+        name: "release",
+        title: "Release...",
+        type: "lifecycle",
+      }),
+      machineActionFactory({
+        name: "deploy",
+        title: "Deploy...",
+        type: "lifecycle",
+      }),
     ];
     // 3 commission, 2 release, 1 deploy
     state.machine.items = [
-      { system_id: "a", actions: ["commission", "release", "deploy"] },
-      { system_id: "b", actions: ["commission", "release"] },
-      { system_id: "c", actions: ["commission"] },
+      machineFactory({
+        system_id: "a",
+        actions: ["commission", "release", "deploy"],
+      }),
+      machineFactory({ system_id: "b", actions: ["commission", "release"] }),
+      machineFactory({ system_id: "c", actions: ["commission"] }),
     ];
     state.machine.selected = ["a", "b", "c"];
     const store = mockStore(state);
@@ -182,11 +219,21 @@ describe("MachineListActionMenu", () => {
   machine is selected`, () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
-      { name: "action1", title: "Action 1", type: "power" },
-      { name: "action2", title: "Action 2", type: "power" },
+      machineActionFactory({
+        name: "action1",
+        title: "Action 1",
+        type: "power",
+      }),
+      machineActionFactory({
+        name: "action2",
+        title: "Action 2",
+        type: "power",
+      }),
     ];
     // No machine can perform "lifecycle3" action
-    state.machine.items = [{ system_id: "a", actions: ["action1"] }];
+    state.machine.items = [
+      machineFactory({ system_id: "a", actions: ["action1"] }),
+    ];
     state.machine.selected = ["a"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -210,17 +257,37 @@ describe("MachineListActionMenu", () => {
   it("groups actions by type", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
-      { name: "commission", title: "Commission...", type: "lifecycle" },
-      { name: "on", title: "Power on...", type: "power" },
-      { name: "off", title: "Power on...", type: "power" },
-      { name: "test", title: "Test...", type: "testing" },
-      { name: "lock", title: "Lock...", type: "lock" },
-      { name: "set-pool", title: "Set pool...", type: "misc" },
-      { name: "set-zone", title: "Set zone...", type: "misc" },
-      { name: "delete", title: "Delete...", type: "misc" },
+      machineActionFactory({
+        name: "commission",
+        title: "Commission...",
+        type: "lifecycle",
+      }),
+      machineActionFactory({ name: "on", title: "Power on...", type: "power" }),
+      machineActionFactory({
+        name: "off",
+        title: "Power on...",
+        type: "power",
+      }),
+      machineActionFactory({ name: "test", title: "Test...", type: "testing" }),
+      machineActionFactory({ name: "lock", title: "Lock...", type: "lock" }),
+      machineActionFactory({
+        name: "set-pool",
+        title: "Set pool...",
+        type: "misc",
+      }),
+      machineActionFactory({
+        name: "set-zone",
+        title: "Set zone...",
+        type: "misc",
+      }),
+      machineActionFactory({
+        name: "delete",
+        title: "Delete...",
+        type: "misc",
+      }),
     ];
     state.machine.items = [
-      {
+      machineFactory({
         system_id: "a",
         actions: [
           "commission",
@@ -232,7 +299,7 @@ describe("MachineListActionMenu", () => {
           "set-zone",
           "delete",
         ],
-      },
+      }),
     ];
     state.machine.selected = ["a"];
     const store = mockStore(state);
@@ -258,9 +325,15 @@ describe("MachineListActionMenu", () => {
   it("fires setSelectedAction function on action button click", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
-      { name: "commission", title: "Commission...", type: "lifecycle" },
+      machineActionFactory({
+        name: "commission",
+        title: "Commission...",
+        type: "lifecycle",
+      }),
     ];
-    state.machine.items = [{ system_id: "a", actions: ["commission"] }];
+    state.machine.items = [
+      machineFactory({ system_id: "a", actions: ["commission"] }),
+    ];
     state.machine.selected = ["a"];
     const setSelectedAction = jest.fn();
     const store = mockStore(state);

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.js
@@ -6,17 +6,25 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import MachineListHeader from "./MachineListHeader";
+import {
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("MachineListHeader", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         osInfo: {
           data: {
             osystems: [["ubuntu", "Ubuntu"]],
@@ -28,7 +36,6 @@ describe("MachineListHeader", () => {
         },
         machineActions: {
           data: [],
-          errors: {},
           loaded: true,
           loading: false,
         },
@@ -37,42 +44,31 @@ describe("MachineListHeader", () => {
             rsd: false,
           },
         },
-      },
-      messages: {
-        items: [],
-      },
-      machine: {
-        errors: {},
+      }),
+      machine: machineStateFactory({
         loaded: true,
-        items: [{ system_id: "abc123" }, { system_id: "def456" }],
-        selected: [],
+        items: [
+          machineFactory({ system_id: "abc123" }),
+          machineFactory({ system_id: "def456" }),
+        ],
         statuses: {
           abc123: {},
           def456: {},
         },
-      },
-      resourcepool: {
+      }),
+      resourcepool: resourcePoolStateFactory({
         errors: {},
         loaded: false,
         items: [
-          { id: 0, name: "default" },
-          { id: 1, name: "other" },
+          resourcePoolFactory({ id: 0, name: "default" }),
+          resourcePoolFactory({ id: 1, name: "other" }),
         ],
-      },
-      zone: {
+      }),
+      zone: zoneStateFactory({
         loaded: true,
-        items: [
-          {
-            id: 0,
-            name: "default",
-          },
-          {
-            id: 1,
-            name: "Backup",
-          },
-        ],
-      },
-    };
+        items: [zoneFactory()],
+      }),
+    });
   });
 
   it("displays a loader if machines have not loaded", () => {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
@@ -5,8 +5,10 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import {
+  generalState as generalStateFactory,
   machine as machineFactory,
   machineState as machineStateFactory,
+  rootState as rootStateFactory,
 } from "testing/factories";
 import { MachineListTable } from "./MachineListTable";
 import { nodeStatus, scriptStatus } from "app/base/enum";
@@ -146,8 +148,8 @@ describe("MachineListTable", () => {
         zone: {},
       }),
     ];
-    initialState = {
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         machineActions: {
           data: [],
           loaded: false,
@@ -162,7 +164,7 @@ describe("MachineListTable", () => {
           loaded: true,
           loading: false,
         },
-      },
+      }),
       machine: machineStateFactory({
         loaded: true,
         items: machines,
@@ -193,7 +195,7 @@ describe("MachineListTable", () => {
           },
         ],
       },
-    };
+    });
   });
 
   afterEach(() => {

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -5,48 +5,24 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import React from "react";
 
-import { nodeStatus, scriptStatus } from "app/base/enum";
-import { routerState as routerStateFactory } from "testing/factories";
 import Machines from "./Machines";
+import { nodeStatus, scriptStatus } from "app/base/enum";
+import {
+  generalState as generalStateFactory,
+  machineState as machineStateFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  routerState as routerStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("Machines", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      domain: {
-        items: [],
-      },
-      general: {
-        architectures: {
-          data: [],
-          loaded: false,
-          loading: false,
-        },
-        defaultMinHweKernel: {
-          data: "",
-          loaded: false,
-          loading: false,
-        },
-        hweKernels: {
-          data: [],
-          loaded: false,
-          loading: false,
-        },
-        machineActions: {
-          data: [],
-          loaded: false,
-          loading: false,
-        },
-        navigationOptions: {
-          data: {},
-          loaded: false,
-          loading: false,
-        },
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         osInfo: {
           data: {
             osystems: [["ubuntu", "Ubuntu"]],
@@ -56,23 +32,13 @@ describe("Machines", () => {
           loaded: true,
           loading: false,
         },
-        powerTypes: {
-          data: [],
-          loaded: false,
-          loading: false,
-        },
         version: {
           data: "2.8.0",
           loaded: true,
           loading: false,
         },
-      },
-      messages: {
-        items: [],
-      },
-      machine: {
-        errors: {},
-        loading: false,
+      }),
+      machine: machineStateFactory({
         loaded: true,
         items: [
           {
@@ -111,6 +77,7 @@ describe("Machines", () => {
             storage_test_status: {
               status: scriptStatus.PASSED,
             },
+
             testing_status: {
               status: scriptStatus.PASSED,
             },
@@ -160,17 +127,12 @@ describe("Machines", () => {
             zone: {},
           },
         ],
-        selected: [],
         statuses: {
           abc123: {},
           def456: {},
         },
-      },
-      notification: {
-        items: [],
-      },
-      resourcepool: {
-        errors: {},
+      }),
+      resourcepool: resourcePoolStateFactory({
         loaded: true,
         items: [
           {
@@ -188,12 +150,9 @@ describe("Machines", () => {
             permissions: [],
           },
         ],
-      },
+      }),
       router: routerStateFactory(),
-      zone: {
-        items: [],
-      },
-    };
+    });
   });
 
   it("correctly routes to machine list", () => {

--- a/ui/src/app/pools/views/Pools.test.js
+++ b/ui/src/app/pools/views/Pools.test.js
@@ -5,49 +5,31 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import Pools from "./Pools";
+import {
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("Pools", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      machine: {
-        errors: {},
-        loading: false,
+    initialState = rootStateFactory({
+      resourcepool: resourcePoolStateFactory({
         loaded: true,
-        items: [],
-      },
-      resourcepool: {
-        errors: {},
-        loaded: true,
-        items: [
-          {
-            id: 0,
-            name: "default",
-            description: "default",
-            is_default: true,
-            permissions: [],
-          },
-          {
-            id: 1,
-            name: "Backup",
-            description: "A backup pool",
-            is_default: false,
-            permissions: [],
-          },
-        ],
-      },
-    };
+        items: [resourcePoolFactory({ name: "default" })],
+      }),
+    });
   });
 
   it("displays a loading component if pools are loading", () => {
     const state = { ...initialState };
     state.resourcepool.loading = true;
     const store = mockStore(state);
+
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
@@ -55,21 +37,15 @@ describe("Pools", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
   it("disables the edit button without permissions", () => {
     const state = { ...initialState };
+    state.resourcepool.items = [resourcePoolFactory({ permissions: [] })];
     const store = mockStore(state);
-    state.resourcepool.items = [
-      {
-        id: 0,
-        name: "default",
-        description: "default",
-        is_default: true,
-        permissions: [],
-      },
-    ];
+
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
@@ -77,21 +53,15 @@ describe("Pools", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(wrapper.find("Button").first().props().disabled).toBe(true);
   });
 
   it("enables the edit button with correct permissions", () => {
     const state = { ...initialState };
+    state.resourcepool.items = [resourcePoolFactory({ permissions: ["edit"] })];
     const store = mockStore(state);
-    state.resourcepool.items = [
-      {
-        id: 0,
-        name: "default",
-        description: "default",
-        is_default: true,
-        permissions: ["edit"],
-      },
-    ];
+
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
@@ -99,6 +69,7 @@ describe("Pools", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(wrapper.find("Button").first().props().disabled).toBe(false);
   });
 
@@ -122,6 +93,7 @@ describe("Pools", () => {
         </MemoryRouter>
       </Provider>
     );
+
     let row = wrapper.find("MainTable").prop("rows")[0];
     expect(row.expanded).toBe(false);
     // Click on the delete button:

--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
@@ -4,16 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import Commissioning from "./Commissioning";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("Commissioning", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [
           {
             name: "commissioning_distro_series",
@@ -26,7 +29,7 @@ describe("Commissioning", () => {
             choices: [],
           },
         ],
-      },
+      }),
       general: {
         osInfo: {
           loading: false,
@@ -34,7 +37,7 @@ describe("Commissioning", () => {
           data: {},
         },
       },
-    };
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
+++ b/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
@@ -4,20 +4,15 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import Deploy from "./Deploy";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("Deploy", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      general: {
-        osInfo: {},
-      },
-    };
+    initialState = rootStateFactory();
   });
 
   it("loads", () => {

--- a/ui/src/app/settings/views/Configuration/General/General.test.js
+++ b/ui/src/app/settings/views/Configuration/General/General.test.js
@@ -4,16 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import General from "./General";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("General", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [
           {
             name: "maas_name",
@@ -24,8 +27,8 @@ describe("General", () => {
             value: true,
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.js
+++ b/ui/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.js
@@ -4,24 +4,27 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import KernelParameters from "./KernelParameters";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("KernelParameters", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [
           {
             name: "kernel_opts",
             value: "foo",
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.js
+++ b/ui/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.js
@@ -4,24 +4,27 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import KernelParametersForm from "./KernelParametersForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("KernelParametersForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [
           {
             name: "kernel_opts",
             value: "foo",
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("sets kernel_opts value", () => {

--- a/ui/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.js
+++ b/ui/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.js
@@ -4,20 +4,15 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import ThirdPartyDrivers from "./ThirdPartyDrivers";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("ThirdPartyDrivers", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
-        items: [],
-      },
-      general: {},
-    };
+    initialState = rootStateFactory();
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.js
+++ b/ui/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.js
@@ -4,24 +4,27 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import ThirdPartyDriversForm from "./ThirdPartyDriversForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("ThirdPartyDriversForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [
           {
             name: "enable_third_party_drivers",
             value: true,
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("can render", () => {

--- a/ui/src/app/settings/views/Images/VMWare/VMWare.test.js
+++ b/ui/src/app/settings/views/Images/VMWare/VMWare.test.js
@@ -4,20 +4,15 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import VMWare from "./VMWare";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("VMWare", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
-        items: [],
-      },
-      general: {},
-    };
+    initialState = rootStateFactory();
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Images/VMWareForm/VMWareForm.test.js
+++ b/ui/src/app/settings/views/Images/VMWareForm/VMWareForm.test.js
@@ -4,16 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import VMWareForm from "./VMWareForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("VMWareForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         items: [
           {
             name: "vcenter_server",
@@ -32,8 +35,8 @@ describe("VMWareForm", () => {
             value: "my datacenter",
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("can render", () => {

--- a/ui/src/app/settings/views/Images/Windows/Windows.test.js
+++ b/ui/src/app/settings/views/Images/Windows/Windows.test.js
@@ -4,20 +4,15 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import Windows from "./Windows";
+import { rootState as rootStateFactory } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("Windows", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
-        loaded: true,
-        items: [],
-      },
-      general: {},
-    };
+    initialState = rootStateFactory();
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Images/WindowsForm/WindowsForm.test.js
+++ b/ui/src/app/settings/views/Images/WindowsForm/WindowsForm.test.js
@@ -4,14 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import WindowsForm from "./WindowsForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("WindowsForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loading: false,
         loaded: true,
         items: [
@@ -20,8 +25,8 @@ describe("WindowsForm", () => {
             value: "127.0.0.1",
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("can render", () => {

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.js
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.js
@@ -5,20 +5,23 @@ import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LicenseKeyList from ".";
+import {
+  generalState as generalStateFactory,
+  licenseKeys as licenseKeysFactory,
+  licenseKeysState as licenseKeysStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("LicenseKeyList", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      general: {
+    initialState = rootStateFactory({
+      general: generalStateFactory({
         osInfo: {
           loaded: true,
-          loading: false,
           data: {
             osystems: [
               ["ubuntu", "Ubuntu"],
@@ -30,25 +33,12 @@ describe("LicenseKeyList", () => {
             ],
           },
         },
-      },
-      licensekeys: {
-        loading: false,
+      }),
+      licensekeys: licenseKeysStateFactory({
         loaded: true,
-        errors: {},
-        items: [
-          {
-            osystem: "windows",
-            distro_series: "win2012",
-            license_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX",
-          },
-          {
-            osystem: "windows",
-            distro_series: "win2019",
-            license_key: "XXXXX-XXXXX-XXXXX-XXXXX-AAABBB",
-          },
-        ],
-      },
-    };
+        items: [licenseKeysFactory()],
+      }),
+    });
   });
 
   it("dispatches action to fetch license keys on load", () => {

--- a/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
+++ b/ui/src/app/settings/views/Network/DnsForm/DnsForm.test.js
@@ -4,15 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import DnsForm from "./DnsForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("DnsForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loaded: true,
         items: [
           {
@@ -30,8 +34,8 @@ describe("DnsForm", () => {
           { name: "dns_trusted_acl", value: "" },
           { name: "upstream_dns", value: "" },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.js
@@ -4,15 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import NetworkDiscoveryForm from "./NetworkDiscoveryForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("NetworkDiscoveryForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loaded: true,
         items: [
           {
@@ -39,8 +43,8 @@ describe("NetworkDiscoveryForm", () => {
             ],
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
+++ b/ui/src/app/settings/views/Network/NtpForm/NtpForm.test.js
@@ -4,15 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import NtpForm from "./NtpForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("NtpForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loaded: true,
         items: [
           {
@@ -21,8 +25,8 @@ describe("NtpForm", () => {
           },
           { name: "ntp_servers", value: "" },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.test.js
+++ b/ui/src/app/settings/views/Network/ProxyForm/ProxyForm.test.js
@@ -4,17 +4,21 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { MemoryRouter } from "react-router-dom";
 
-import { reduceInitialState } from "testing/utils";
 import ProxyForm from "./ProxyForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { reduceInitialState } from "testing/utils";
 
 const mockStore = configureStore();
 
 describe("ProxyForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loaded: true,
         items: [
           {
@@ -30,8 +34,8 @@ describe("ProxyForm", () => {
             value: false,
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
+++ b/ui/src/app/settings/views/Network/SyslogForm/SyslogForm.test.js
@@ -4,15 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import SyslogForm from "./SyslogForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("SyslogForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loaded: true,
         items: [
           {
@@ -20,8 +24,8 @@ describe("SyslogForm", () => {
             value: "",
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a spinner if config is loading", () => {

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
@@ -6,51 +6,53 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import RepositoriesList from "./RepositoriesList";
+import {
+  packageRepository as packageRepositoryFactory,
+  packageRepositoryState as packageRepositoryStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("RepositoriesList", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      packagerepository: {
-        loading: false,
+    initialState = rootStateFactory({
+      packagerepository: packageRepositoryStateFactory({
         loaded: true,
         items: [
-          {
+          packageRepositoryFactory({
             id: 1,
             name: "main_archive",
             url: "http://archive.ubuntu.com/ubuntu",
             default: true,
             enabled: true,
-          },
-          {
+          }),
+          packageRepositoryFactory({
             id: 2,
             name: "ports_archive",
             url: "http://ports.ubuntu.com/ubuntu-ports",
             default: true,
             enabled: true,
-          },
-          {
+          }),
+          packageRepositoryFactory({
             id: 3,
             name: "extra_archive",
             url: "http://maas.io",
             default: false,
             enabled: true,
-          },
-          {
+          }),
+          packageRepositoryFactory({
             id: 4,
             name: "secret_archive",
             url: "http://www.website.com",
             default: false,
             enabled: false,
-          },
+          }),
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a loading component if loading", () => {

--- a/ui/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.js
@@ -5,27 +5,22 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import RepositoryAdd from "./RepositoryAdd";
+import {
+  packageRepositoryState as packageRepositoryStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("RepositoryAdd", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      packagerepository: {
-        loading: false,
+    initialState = rootStateFactory({
+      packagerepository: packageRepositoryStateFactory({
         loaded: true,
-        items: [],
-      },
-      general: {
-        componentsToDisable: {},
-        knownArchitectures: {},
-        pocketsToDisable: {},
-      },
-    };
+      }),
+    });
   });
 
   it("can display a repository add form with type ppa", () => {

--- a/ui/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.js
@@ -5,60 +5,30 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import RepositoryEdit from "./RepositoryEdit";
+import {
+  packageRepository as packageRepositoryFactory,
+  packageRepositoryState as packageRepositoryStateFactory,
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("RepositoryEdit", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      packagerepository: {
-        loading: false,
+    initialState = rootStateFactory({
+      general: generalStateFactory(),
+      packagerepository: packageRepositoryStateFactory({
         loaded: true,
         items: [
-          {
+          packageRepositoryFactory({
             id: 1,
-            created: "Fri, 23 Aug. 2019 09:17:44",
-            updated: "Fri, 23 Aug. 2019 09:17:44",
-            name: "main_archive",
-            url: "http://archive.ubuntu.com/ubuntu",
-            distributions: [],
-            disabled_pockets: ["security"],
-            disabled_components: ["universe", "restricted"],
-            disable_sources: true,
-            components: [],
-            arches: ["amd64", "i386"],
-            key: "",
-            default: true,
-            enabled: true,
-          },
-          {
-            id: 2,
-            created: "Fri, 23 Aug. 2019 09:17:44",
-            updated: "Fri, 23 Aug. 2019 09:17:44",
-            name: "ports_archive",
-            url: "http://ports.ubuntu.com/ubuntu-ports",
-            distributions: [],
-            disabled_pockets: [],
-            disabled_components: [],
-            disable_sources: true,
-            components: [],
-            arches: ["armhf", "arm64", "ppc64el", "s390x"],
-            key: "",
-            default: true,
-            enabled: true,
-          },
+          }),
         ],
-      },
-      general: {
-        componentsToDisable: {},
-        knownArchitectures: {},
-        pocketsToDisable: {},
-      },
-    };
+      }),
+    });
   });
 
   it("displays a loading component if loading", () => {

--- a/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.js
@@ -6,59 +6,39 @@ import configureStore from "redux-mock-store";
 import { MemoryRouter } from "react-router-dom";
 
 import RepositoryForm from "./RepositoryForm";
+import {
+  componentsToDisableState as componentsToDisableStateFactory,
+  knownArchitecturesState as knownArchitecturesStateFactory,
+  packageRepository as packageRepositoryFactory,
+  packageRepositoryState as packageRepositoryStateFactory,
+  pocketsToDisableState as pocketsToDisableStateFactory,
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("RepositoryForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      general: {
-        componentsToDisable: {
-          data: [],
+    initialState = rootStateFactory({
+      general: generalStateFactory({
+        componentsToDisable: componentsToDisableStateFactory({
           loaded: true,
-          loading: false,
-        },
-        knownArchitectures: {
-          data: [],
+        }),
+        knownArchitectures: knownArchitecturesStateFactory({
           loaded: true,
-          loading: false,
-        },
-        pocketsToDisable: {
-          data: [],
+        }),
+        pocketsToDisable: pocketsToDisableStateFactory({
           loaded: true,
-          loading: false,
-        },
-      },
-      packagerepository: {
-        errors: null,
-        loading: false,
+        }),
+      }),
+      packagerepository: packageRepositoryStateFactory({
         loaded: true,
-        saving: false,
-        saved: false,
-        items: [
-          {
-            id: 1,
-            created: "Fri, 23 Aug. 2019 09:17:44",
-            updated: "Fri, 23 Aug. 2019 09:17:44",
-            name: "main_archive",
-            url: "http://archive.ubuntu.com/ubuntu",
-            distributions: [],
-            disabled_pockets: ["security"],
-            disabled_components: ["universe", "restricted"],
-            disable_sources: true,
-            components: [],
-            arches: ["amd64", "i386"],
-            key: "",
-            default: true,
-            enabled: true,
-          },
-        ],
-      },
-    };
+        items: [packageRepositoryFactory()],
+      }),
+    });
   });
 
   it(`dispatches actions to fetch repos, components to disable,

--- a/ui/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.js
@@ -5,6 +5,15 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import RepositoryForm from "../RepositoryForm";
+import {
+  componentsToDisableState as componentsToDisableStateFactory,
+  knownArchitecturesState as knownArchitecturesStateFactory,
+  packageRepository as packageRepositoryFactory,
+  packageRepositoryState as packageRepositoryStateFactory,
+  pocketsToDisableState as pocketsToDisableStateFactory,
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -12,69 +21,23 @@ describe("RepositoryFormFields", () => {
   let initialState;
 
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      general: {
-        componentsToDisable: {
-          data: [],
+    initialState = rootStateFactory({
+      general: generalStateFactory({
+        componentsToDisable: componentsToDisableStateFactory({
           loaded: true,
-          loading: false,
-        },
-        knownArchitectures: {
-          data: [],
+        }),
+        knownArchitectures: knownArchitecturesStateFactory({
           loaded: true,
-          loading: false,
-        },
-        pocketsToDisable: {
-          data: [],
+        }),
+        pocketsToDisable: pocketsToDisableStateFactory({
           loaded: true,
-          loading: false,
-        },
-      },
-      packagerepository: {
-        errors: {},
-        loading: false,
+        }),
+      }),
+      packagerepository: packageRepositoryStateFactory({
         loaded: true,
-        saved: false,
-        saving: false,
-        items: [
-          {
-            id: 1,
-            created: "Fri, 23 Aug. 2019 09:17:44",
-            updated: "Fri, 23 Aug. 2019 09:17:44",
-            name: "main_archive",
-            url: "http://archive.ubuntu.com/ubuntu",
-            distributions: [],
-            disabled_pockets: ["security"],
-            disabled_components: ["universe", "restricted"],
-            disable_sources: true,
-            components: [],
-            arches: ["amd64", "i386"],
-            key: "",
-            default: true,
-            enabled: true,
-          },
-          {
-            id: 2,
-            created: "Fri, 23 Aug. 2019 09:17:44",
-            updated: "Fri, 23 Aug. 2019 09:17:44",
-            name: "ports_archive",
-            url: "http://ports.ubuntu.com/ubuntu-ports",
-            distributions: [],
-            disabled_pockets: [],
-            disabled_components: [],
-            disable_sources: true,
-            components: [],
-            arches: ["armhf", "arm64", "ppc64el", "s390x"],
-            key: "",
-            default: false,
-            enabled: true,
-          },
-        ],
-      },
-    };
+        items: [packageRepositoryFactory()],
+      }),
+    });
   });
 
   it("displays disitribution and component inputs if type is repository", () => {

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.js
@@ -7,6 +7,10 @@ import configureStore from "redux-mock-store";
 
 import ScriptsUpload from "./ScriptsUpload";
 import readScript from "./readScript";
+import {
+  scriptsState as scriptsStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -24,18 +28,13 @@ const createFile = (name, size, type, contents = "") => {
 
 describe("ScriptsUpload", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        items: [],
-      },
-      scripts: {
-        loading: false,
+    initialState = rootStateFactory({
+      scripts: scriptsStateFactory({
         loaded: true,
-        errors: {},
-        items: [],
-      },
-    };
+      }),
+    });
   });
 
   it("accepts files of text mimetype", async () => {

--- a/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
+++ b/ui/src/app/settings/views/Storage/StorageForm/StorageForm.test.js
@@ -4,15 +4,19 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import StorageForm from "./StorageForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("StorageForm", () => {
   let initialState;
+
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loaded: true,
         items: [
           {
@@ -39,8 +43,8 @@ describe("StorageForm", () => {
             value: false,
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("dispatches an action to update config on save button click", () => {

--- a/ui/src/app/settings/views/Storage/StorageFormFields/StorageFormFields.test.js
+++ b/ui/src/app/settings/views/Storage/StorageFormFields/StorageFormFields.test.js
@@ -5,6 +5,10 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import StorageForm from "../StorageForm";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
@@ -12,9 +16,8 @@ describe("StorageFormFields", () => {
   let initialState;
 
   beforeEach(() => {
-    initialState = {
-      config: {
-        loading: false,
+    initialState = rootStateFactory({
+      config: configStateFactory({
         loaded: true,
         items: [
           {
@@ -29,8 +32,8 @@ describe("StorageFormFields", () => {
             ],
           },
         ],
-      },
-    };
+      }),
+    });
   });
 
   it("displays a warning if blank storage layout chosen", async () => {


### PR DESCRIPTION
## Done
- Ensure no partial state in tests with consistent use of rootStateFactory
- Additionally, use factories for setting up child state where appropriate 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- none, tests should pass

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
