### PR TITLE
fix(ci): betterer js counts only src dir

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -607,5 +607,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `487`
+  value: `449`
 };

--- a/ui/.betterer.ts
+++ b/ui/.betterer.ts
@@ -4,12 +4,13 @@ import { smaller } from "@betterer/constraints";
 
 const { execSync } = require("child_process");
 
-const jsFileCount = parseInt(execSync(
-  'find . -type f -name "*.js" -not -path "./node_modules/*" | wc -l',
-  { encoding: "utf8" }
-)
-  .replace("\n", "")
-  .trim());
+const jsFileCount = parseInt(
+  execSync('find . -type f -name "*.js" -path "./src/*" | wc -l', {
+    encoding: "utf8",
+  })
+    .replace("\n", "")
+    .trim()
+);
 
 export default {
   "stricter compilation": typescriptBetterer("./tsconfig.json", {


### PR DESCRIPTION
## Done
Betterer's "migrate js files to ts" test was counting all files, including dist etc. which lead to inconsistent counts. We really only care about the files in src.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run `yarn betterer` before and after a build to confirm the count is consistent. Confirm your count doesn't deviate from this PR's count (449).

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
