### PR TITLE
fix(ui): address SR-IOV/NUMA design feedback issues

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -34,7 +34,7 @@ exports[`stricter compilation`] = {
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -76,7 +76,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -195,9 +195,9 @@ exports[`stricter compilation`] = {
     "src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx:2780035521": [
       [80, 6, 68, "Object is possibly \'undefined\'.", "2960886801"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx:3681430920": [
-      [46, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"],
-      [74, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"]
+    "src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx:2087623559": [
+      [44, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"],
+      [78, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"]
     ],
     "src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx:2118393864": [
       [23, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],

--- a/ui/src/app/kvm/components/PodResourcesCard/_index.scss
+++ b/ui/src/app/kvm/components/PodResourcesCard/_index.scss
@@ -2,9 +2,10 @@
   $donut-size: 6.5rem;
   $donut-width: 14px;
 
-  .pod-machine-list-modal.p-contextual-menu__dropdown {
+  .pod-machine-list-modal {
     max-width: none;
     min-width: 0;
+    padding: $spv-inner--x-small $sph-inner--small;
     // Subtract small screen gutter width and card inner padding to center dropdown.
     width: calc(
       100vw - #{(map-get($grid-gutter-widths, small) + $sph-inner) * 2}
@@ -22,6 +23,11 @@
     .cores-col,
     .ram-col {
       width: 5rem;
+    }
+
+    // Overwrite overflow: hidden here where there's no checkbox and width is static.
+    td:first-child .p-double-row__primary-row-text {
+      overflow: inherit !important;
     }
 
     @media only screen and (min-width: $breakpoint-x-small) {
@@ -47,16 +53,16 @@
     td {
       &:nth-child(1) {
         padding-left: 0;
-        width: 30%;
+        width: 50%;
       }
 
       &:nth-child(2) {
-        width: 35%;
+        width: 6.25rem;
       }
 
       &:nth-child(3) {
         padding-right: 0;
-        width: 35%;
+        width: 50%;
       }
     }
 

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -50,9 +50,9 @@ const KVMSummary = (): JSX.Element => {
           </Code>
         </div>
         <hr className="u-sv1" />
-        <div className="u-flex--between">
+        <div className="u-flex--between u-flex--column-x-small">
           <h4 className="u-sv1">Resources</h4>
-          {pod.numa_pinning && (
+          {pod.numa_pinning && pod.numa_pinning.length >= 1 && (
             <Switch
               checked={viewByNuma}
               className="p-switch--inline-label"

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Col,
-  Input,
-  MainTable,
-  Row,
-  Strip,
-} from "@canonical/react-components";
+import { Button, Input, MainTable, Strip } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
 import classNames from "classnames";
@@ -753,40 +746,38 @@ export const MachineListTable = ({
   ];
 
   return (
-    <Row>
-      <Col size={12}>
-        <MainTable
-          className={classNames("p-table-expanding--light", "machine-list", {
-            "machine-list--grouped": grouping !== "none",
-          })}
-          headers={filterColumns(headers, hiddenColumns, showActions)}
-          paginate={paginateLimit}
-          rows={
-            grouping === "none"
-              ? generateRows({
-                  machines,
-                  selectedIDs,
-                  hiddenColumns,
-                  ...rowProps,
-                })
-              : generateGroupRows({
-                  groups,
-                  handleGroupCheckbox,
-                  hiddenGroups,
-                  selectedIDs,
-                  setHiddenGroups,
-                  hiddenColumns,
-                  ...rowProps,
-                })
-          }
-        />
-        {filter && machines.length === 0 ? (
-          <Strip rowClassName="u-align--center">
-            <span>No machines match the search criteria.</span>
-          </Strip>
-        ) : null}
-      </Col>
-    </Row>
+    <>
+      <MainTable
+        className={classNames("p-table-expanding--light", "machine-list", {
+          "machine-list--grouped": grouping !== "none",
+        })}
+        headers={filterColumns(headers, hiddenColumns, showActions)}
+        paginate={paginateLimit}
+        rows={
+          grouping === "none"
+            ? generateRows({
+                machines,
+                selectedIDs,
+                hiddenColumns,
+                ...rowProps,
+              })
+            : generateGroupRows({
+                groups,
+                handleGroupCheckbox,
+                hiddenGroups,
+                selectedIDs,
+                setHiddenGroups,
+                hiddenColumns,
+                ...rowProps,
+              })
+        }
+      />
+      {filter && machines.length === 0 ? (
+        <Strip rowClassName="u-align--center">
+          <span>No machines match the search criteria.</span>
+        </Strip>
+      ) : null}
+    </>
   );
 };
 

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -3,6 +3,10 @@
   $checkbox-offset: 0.1875rem; // Offset checkbox to prevent focus outline truncation
   $grouped-machines-indentation: $box-size + $sph-inner - $checkbox-offset; // Checkbox + label - offset
 
+  .machine-list {
+    margin-bottom: 0;
+  }
+
   .machine-list--grouped .machine-list__machine {
     border: 0;
     position: relative;

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -38,6 +38,12 @@
     flex-direction: column;
   }
 
+  .u-flex--column-x-small {
+    @media only screen and (max-width: $breakpoint-x-small) {
+      flex-direction: column;
+    }
+  }
+
   .u-flex--wrap {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Done

- Hide NUMA toggle if no numa data present
- Adjust VM dropdown padding
- Fix VM dropdown FQDN focus state
- Improve alignment of RAM table with the rest of the data
- Stack NUMA toggle on small screens

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM details page and open a VM dropdown
- Check that the padding is slightly tighter and the focus state on FQDN does not get cut off
- Resize to medium screen (768px-1036px) and check that the RAM table headers align with the meter headers (total, allocated, free).
- Resize to x-small screen (<460px) and check that the "View by NUMA node" toggle appears beneath the "Resources" title


Fixes canonical-web-and-design/MAAS-squad#2124

Note that not all issues are fixed in this PR - these are just the ones that should be fixed in the maas-ui repo. Bugs still to fix include:
NUMA values inconsistent: https://bugs.launchpad.net/maas/+bug/1897996
Code copyable orange focus state: https://github.com/canonical-web-and-design/vanilla-framework/issues/3328
Disabled base button border: https://github.com/canonical-web-and-design/vanilla-framework/issues/3327
Contextual menu auto-positioning: https://github.com/canonical-web-and-design/react-components/issues/299
