### PR TITLE
fix(ui): remove mimetype checks for file uploads

### DIFF
--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.js
@@ -29,7 +29,7 @@ const ScriptsUpload = ({ type }) => {
 
   useEffect(() => {
     if (hasErrors) {
-      Object.keys(errors).forEach(key => {
+      Object.keys(errors).forEach((key) => {
         dispatch(
           messages.add(
             `Error uploading ${savedScript}: ${errors[key]}`,
@@ -79,13 +79,11 @@ const ScriptsUpload = ({ type }) => {
     getInputProps,
     isDragActive,
     isDragAccept,
-    isDragReject
+    isDragReject,
   } = useDropzone({
     onDrop,
-    accept:
-      "text/*, application/x-csh, application/x-sh, application/x-shellscript",
     maxSize: MAX_SIZE_BYTES,
-    multiple: false
+    multiple: false,
   });
 
   useEffect(() => {
@@ -111,7 +109,7 @@ const ScriptsUpload = ({ type }) => {
           className={classNames("scripts-upload", {
             "scripts-upload--active": isDragActive,
             "scripts-upload--accept": isDragAccept,
-            "scripts-upload--reject": isDragReject
+            "scripts-upload--reject": isDragReject,
           })}
         >
           <input {...getInputProps()} />
@@ -127,7 +125,7 @@ const ScriptsUpload = ({ type }) => {
       </Row>
       <Row>
         <Form
-          onSubmit={e => {
+          onSubmit={(e) => {
             e.preventDefault();
             dispatch(scriptActions.cleanup());
             if (script) {
@@ -160,7 +158,7 @@ const ScriptsUpload = ({ type }) => {
 };
 
 ScriptsUpload.propTypes = {
-  type: PropTypes.oneOf(["commissioning", "testing"]).isRequired
+  type: PropTypes.oneOf(["commissioning", "testing"]).isRequired,
 };
 
 export default ScriptsUpload;

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload.test.js
@@ -17,7 +17,7 @@ const createFile = (name, size, type, contents = "") => {
   Reflect.defineProperty(file, "size", {
     get() {
       return size;
-    }
+    },
   });
   return file;
 };
@@ -27,21 +27,21 @@ describe("ScriptsUpload", () => {
   beforeEach(() => {
     initialState = {
       config: {
-        items: []
+        items: [],
       },
       scripts: {
         loading: false,
         loaded: true,
         errors: {},
-        items: []
-      }
+        items: [],
+      },
     };
   });
 
-  it("accepts files of text mimetype", async () => {
+  it("accepts files of any mimetype", async () => {
     const store = mockStore(initialState);
 
-    const files = [createFile("foo.sh", 2000, "text/script")];
+    const files = [createFile("foo.sh", 2000, "")];
 
     const wrapper = mount(
       <Provider store={store}>
@@ -55,7 +55,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -79,36 +79,11 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
     expect(wrapper.text()).toContain("foo.sh (2000 bytes) ready for upload");
-  });
-
-  it("displays an error if a file with a non text mimetype is uploaded", async () => {
-    const store = mockStore(initialState);
-    const files = [createFile("foo.jpg", 200, "image/jpg")];
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsUpload type="testing" />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    await act(async () => {
-      wrapper.find("input").simulate("change", {
-        target: { files },
-        preventDefault: () => {},
-        persist: () => {}
-      });
-    });
-
-    expect(store.getActions()[0]["payload"]["message"]).toEqual(
-      "Invalid filetype, please try again."
-    );
   });
 
   it("displays an error if a file larger than 2MB is uploaded", async () => {
@@ -127,7 +102,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -140,7 +115,7 @@ describe("ScriptsUpload", () => {
     const store = mockStore(initialState);
     const files = [
       createFile("foo.sh", 1000, "text/script"),
-      createFile("bar.sh", 1000, "text/script")
+      createFile("bar.sh", 1000, "text/script"),
     ];
 
     const wrapper = mount(
@@ -155,7 +130,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -171,7 +146,7 @@ describe("ScriptsUpload", () => {
       callback({
         name: "foo",
         script: contents,
-        hasMetadata: true
+        hasMetadata: true,
       });
     });
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
@@ -188,7 +163,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -200,8 +175,8 @@ describe("ScriptsUpload", () => {
       { type: "CLEANUP_SCRIPTS" },
       {
         payload: { contents, type: "testing" },
-        type: "UPLOAD_SCRIPT"
-      }
+        type: "UPLOAD_SCRIPT",
+      },
     ]);
   });
 
@@ -212,7 +187,7 @@ describe("ScriptsUpload", () => {
       callback({
         name: "foo",
         script: contents,
-        hasMetadata: false
+        hasMetadata: false,
       });
     });
     const files = [createFile("foo.sh", 1000, "text/script", contents)];
@@ -229,7 +204,7 @@ describe("ScriptsUpload", () => {
       wrapper.find("input").simulate("change", {
         target: { files },
         preventDefault: () => {},
-        persist: () => {}
+        persist: () => {},
       });
     });
 
@@ -241,8 +216,8 @@ describe("ScriptsUpload", () => {
       { type: "CLEANUP_SCRIPTS" },
       {
         payload: { contents, type: "testing", name: "foo" },
-        type: "UPLOAD_SCRIPT"
-      }
+        type: "UPLOAD_SCRIPT",
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Done
Removes mimetype checks for file uploads.

See https://github.com/canonical-web-and-design/maas-ui/pull/1731

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure uploading a script from Settings, and deploying a machine with user data works as expeced.

## Fixes

Fixes: lp#1896179
Backport: https://github.com/canonical-web-and-design/maas-ui/pull/1731

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
