### PR TITLE
fix(ui): remove mimetype checks for file uploads

### DIFF
--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.js
@@ -78,8 +78,6 @@ const ScriptsUpload = ({ type }) => {
     isDragReject,
   } = useDropzone({
     onDrop,
-    accept:
-      "text/*, application/x-csh, application/x-sh, application/x-shellscript",
     maxSize: MAX_SIZE_BYTES,
     multiple: false,
   });

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.js
@@ -38,10 +38,10 @@ describe("ScriptsUpload", () => {
     };
   });
 
-  it("accepts files of text mimetype", async () => {
+  it("accepts files of any mimetype", async () => {
     const store = mockStore(initialState);
 
-    const files = [createFile("foo.sh", 2000, "text/script")];
+    const files = [createFile("foo.sh", 2000, "")];
 
     const wrapper = mount(
       <Provider store={store}>
@@ -60,31 +60,6 @@ describe("ScriptsUpload", () => {
     });
 
     expect(wrapper.text()).toContain("foo.sh (2000 bytes) ready for upload");
-  });
-
-  it("displays an error if a file with a non text mimetype is uploaded", async () => {
-    const store = mockStore(initialState);
-    const files = [createFile("foo.jpg", 200, "image/jpg")];
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-          <ScriptsUpload type="testing" />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    await act(async () => {
-      wrapper.find("input").simulate("change", {
-        target: { files },
-        preventDefault: () => {},
-        persist: () => {},
-      });
-    });
-
-    expect(store.getActions()[0]["payload"]["message"]).toEqual(
-      "foo.jpg: File type must be text/*, application/x-csh, application/x-sh, application/x-shellscript"
-    );
   });
 
   it("displays an error if a file larger than 2MB is uploaded", async () => {


### PR DESCRIPTION
## Done

Removes mimetype checks for file uploads.

See #1731

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

* Ensure uploading a script from Settings, and deploying a machine with user data works as expeced.

## Fixes

Backport https://github.com/canonical-web-and-design/maas-ui/pull/1731
Fix lp#1896179

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
