### PR TITLE
fix(legacy): call delete_address_record when removing dns resources

### DIFF
--- a/legacy/src/app/factories/domains.js
+++ b/legacy/src/app/factories/domains.js
@@ -67,7 +67,10 @@ function DomainsManager(RegionConnection, Manager) {
   DomainsManager.prototype.deleteDNSRecord = function (record) {
     if (record.rrtype === "A" || record.rrtype === "AAAA") {
       record.ip_addresses = record.rrdata.split(/[ ,]+/);
-      return RegionConnection.callMethod("domain.delete_dnsresource", record);
+      return RegionConnection.callMethod(
+        "domain.delete_address_record",
+        record
+      );
     } else {
       return RegionConnection.callMethod("domain.delete_dnsdata", record);
     }

--- a/legacy/src/app/factories/tests/test_domains.js
+++ b/legacy/src/app/factories/tests/test_domains.js
@@ -145,7 +145,7 @@ describe("DomainsManager", function () {
   });
 
   describe("deleteDNSRecord", function () {
-    it("calls delete_dnsresource for A record", function () {
+    it("calls delete_address_record for A record", function () {
       spyOn(RegionConnection, "callMethod");
       var record = {
         rrtype: "A",
@@ -153,12 +153,12 @@ describe("DomainsManager", function () {
       };
       DomainsManager.deleteDNSRecord(record);
       expect(RegionConnection.callMethod).toHaveBeenCalledWith(
-        "domain.delete_dnsresource",
+        "domain.delete_address_record",
         record
       );
     });
 
-    it("calls delete_dnsresource for AAAA record", function () {
+    it("calls delete_address_record for AAAA record", function () {
       spyOn(RegionConnection, "callMethod");
       var record = {
         rrtype: "AAAA",
@@ -166,7 +166,7 @@ describe("DomainsManager", function () {
       };
       DomainsManager.deleteDNSRecord(record);
       expect(RegionConnection.callMethod).toHaveBeenCalledWith(
-        "domain.delete_dnsresource",
+        "domain.delete_address_record",
         record
       );
     });


### PR DESCRIPTION
## Done
* Call `domain.delete_address_record` rather than `domain.deleteresource` to ensure only that specific record is deleted.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a domain from /dns
- create a DNS record like "test" A "1.2.3.4"
- create a DNS record like "test" AAAA "2001::1"
- select one of those and select "remove record"
- ensure only the selected record is removed

## Fixes

Fixes: #1729

## Launchpad issue

[lp#1898218](https://bugs.launchpad.net/maas/+bug/1898218)

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
