### PR TITLE
docs(shared): update the docs lnks in the footer to the offline docs

### DIFF
--- a/shared/src/components/Footer/Footer.js
+++ b/shared/src/components/Footer/Footer.js
@@ -35,15 +35,10 @@ export const Footer = ({ enableAnalytics, debug, maasName, version }) => {
           <ul className="p-inline-list--middot">
             <li className="p-inline-list__item">
               <a
-                href={`https://maas.io/docs/release-notes`}
+                href={`/MAAS/docs/maas-documentation-25.html`}
                 className="p-footer__link"
               >
-                View release notes
-              </a>
-            </li>
-            <li className="p-inline-list__item">
-              <a href={`https://maas.io/docs/`} className="p-footer__link">
-                View documentation
+                Local documentation
               </a>
             </li>
             <li className="p-inline-list__item">

--- a/shared/src/components/Footer/__snapshots__/Footer.test.js.snap
+++ b/shared/src/components/Footer/__snapshots__/Footer.test.js.snap
@@ -39,19 +39,9 @@ exports[`Footer renders 1`] = `
         >
           <a
             className="p-footer__link"
-            href="https://maas.io/docs/release-notes"
+            href="/MAAS/docs/maas-documentation-25.html"
           >
-            View release notes
-          </a>
-        </li>
-        <li
-          className="p-inline-list__item"
-        >
-          <a
-            className="p-footer__link"
-            href="https://maas.io/docs/"
-          >
-            View documentation
+            Local documentation
           </a>
         </li>
         <li


### PR DESCRIPTION
The offline docs are not provided by the MAAS itself. This change links to the offline docs from the
footer links. This change does not include all docs links across the UI.

Fixes https://github.com/canonical-web-and-design/MAAS-squad/issues/2125

## Done

- Itemised list of what was changed by this PR.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
**Two ways**
- Build a new maas containing the offline docs and run this UI, scroll to the footer and click the two links to docs
- Run locally and click the docs links. Once they load switch the base URL to bolla.internal. For example: http://bolla.internal:5240/MAAS/docs/maas-documentation-25.html

## Backports
N/A