### PR TITLE
fix(ui): clear kernel selection on OS/release change in deploy form

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -300,4 +300,35 @@ describe("DeployFormFields", () => {
     wrapper.update();
     expect(wrapper.find("FormikField[name='userData']").exists()).toBe(true);
   });
+
+  it("resets kernel selection on OS/release change", async () => {
+    const state = { ...initialState };
+    state.general.osInfo.data.default_release = "bionic";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DeployForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Default release is Ubuntu 18.04. Change kernel to non-default.
+    await act(async () => {
+      wrapper
+        .find("Select[name='kernel']")
+        .simulate("change", { target: { name: "kernel", value: "ga-18.04" } });
+    });
+    wrapper.update();
+    // Change release to Ubuntu 20.04.
+    await act(async () => {
+      wrapper.find("Select[name='release']").simulate("change", {
+        target: { name: "release", value: "ubuntu/focal" },
+      });
+    });
+    wrapper.update();
+    // Previous kernel selection should be cleared.
+    expect(wrapper.find("Select[name='kernel']").prop("value")).toBe("");
+  });
 });

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -54,6 +54,7 @@ export const DeployFormFields = (): JSX.Element => {
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 handleChange(e);
                 const value = e.target.value;
+                setFieldValue("kernel", "");
                 if (
                   allReleaseOptions[value] &&
                   allReleaseOptions[value].length
@@ -75,6 +76,7 @@ export const DeployFormFields = (): JSX.Element => {
               options={releaseOptions}
               onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
                 handleChange(e);
+                setFieldValue("kernel", "");
                 if (e.target.value !== "bionic") {
                   setFieldValue("installKVM", false);
                 }


### PR DESCRIPTION
## Done

- Explicitly clear kernel selection when changing the OS or release in the deploy form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the deploy form for a machine
- Change the OS/release to Ubuntu 18.04, then select a non-default kernel (e.g. "ga-18.04")
- Change the release to Ubuntu 20.04
- Check that the form submits successfully, i.e. there is no error about the previously selected kernel

## Fixes

Fixes #1724 

