### PR TITLE
fix(legacy, ui): fix nav links to have full paths

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -49,7 +49,7 @@ function MasterController(
         generateNewLink={(link, linkClass, appendNewBase) => (
           <a
             className={linkClass}
-            href={link.url}
+            href={generateNewURL(link.url)}
             target="_self"
             onClick={(evt) => {
               navigateToNew(link.url, evt);

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -13,7 +13,12 @@ import {
 import { getCookie } from "app/utils";
 import { config as configActions } from "app/settings/actions";
 import configSelectors from "app/store/config/selectors";
-import { Footer, Header, navigateToLegacy } from "@maas-ui/maas-ui-shared";
+import {
+  Footer,
+  generateLegacyURL,
+  Header,
+  navigateToLegacy,
+} from "@maas-ui/maas-ui-shared";
 import { status as statusActions } from "app/base/actions";
 import { websocket } from "./base/actions";
 import authSelectors from "app/store/auth/selectors";
@@ -124,7 +129,7 @@ export const App = () => {
         generateLegacyLink={(link, linkClass, appendNewBase) => (
           <a
             className={linkClass}
-            href={link.url}
+            href={generateLegacyURL(link.url)}
             onClick={(evt) => {
               navigateToLegacy(link.url, evt);
             }}


### PR DESCRIPTION
## Done

- Generate full paths for the header nav links.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit a react URL and hover a link to a legacy page, it should show the correct path.
- Visit an angular URL and hover a link to a react page, it should show the correct path.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1737