### PR TITLE
refactor(ui): use hooks from react-components

### DIFF
--- a/ui/src/app/base/components/Meter/Meter.tsx
+++ b/ui/src/app/base/components/Meter/Meter.tsx
@@ -1,8 +1,8 @@
+import { useListener } from "@canonical/react-components/dist/hooks";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
-import { useOnWindowResize } from "app/base/hooks";
 import { COLOURS } from "app/base/constants";
 
 export const DEFAULT_FILLED_COLORS = [
@@ -72,11 +72,11 @@ const Meter = ({
     }
   }, [maximum, segmented]);
 
-  useOnWindowResize(() => {
-    if (segmented) {
-      updateWidths(el, maximum, setSegmentWidth);
-    }
-  });
+  const onResize = useCallback(() => {
+    updateWidths(el, maximum, setSegmentWidth);
+  }, [el, maximum, setSegmentWidth]);
+
+  useListener(window, onResize, "resize", true, segmented);
 
   return (
     <div

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -2,6 +2,7 @@ import { notificationTypes } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFormikContext } from "formik";
+import { usePrevious } from "@canonical/react-components/dist/hooks";
 import * as Yup from "yup";
 
 import { machine as machineActions } from "app/base/actions";
@@ -12,19 +13,6 @@ import machineSelectors from "app/store/machine/selectors";
 import generalSelectors from "app/store/general/selectors";
 import { kebabToCamelCase } from "app/utils";
 import { useCallback } from "react";
-
-/**
- * Returns previous value of a variable.
- * @param {*} value - Current value.
- * @returns {*} Previous value.
- */
-export const usePrevious = (value) => {
-  const ref = useRef(value);
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
-  return ref.current;
-};
 
 /**
  * Combines formik validation errors and errors returned from server
@@ -305,44 +293,6 @@ export const useAllPowerParameters = (powerTypes) =>
       }, {}),
     [powerTypes]
   );
-
-export const THROTTLE_DELAY = 100;
-
-/**
- * Handle window resize events.
- * @param {Function} callback - The function to call when the window resizes.
- */
-export const useOnWindowResize = (callback) => {
-  const storedCallback = useRef(callback);
-  const timeout = useRef();
-  const lastCall = useRef(Date.now());
-  useEffect(() => {
-    // Clean up the previous listener:
-    window.removeEventListener("resize", storedCallback.current);
-    // Store the callback for the cleanup method.
-    storedCallback.current = () => {
-      if (Date.now() - lastCall.current >= THROTTLE_DELAY) {
-        // This is after the throttle delay so call the callback and reset
-        // the timer.
-        clearTimeout(timeout.current);
-        callback();
-        lastCall.current = Date.now();
-        timeout.current = null;
-      } else if (!timeout.current) {
-        // Set a timeout to call the callback if the window is not resized
-        // after the delay time.
-        timeout.current = setTimeout(() => {
-          callback();
-        }, THROTTLE_DELAY);
-      }
-    };
-    window.addEventListener("resize", storedCallback.current);
-    return () => {
-      clearTimeout(timeout.current);
-      window.removeEventListener("resize", storedCallback.current);
-    };
-  }, [callback]);
-};
 
 /**
  * Handle checking when a value has cycled from false to true.

--- a/ui/src/app/machines/views/Machines.js
+++ b/ui/src/app/machines/views/Machines.js
@@ -1,7 +1,7 @@
+import { usePrevious } from "@canonical/react-components/dist/hooks";
 import React, { useEffect, useState } from "react";
 import { Route, Switch, useHistory, useLocation } from "react-router-dom";
 
-import { usePrevious } from "app/base/hooks";
 import {
   filtersToQueryString,
   filtersToString,

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -1,11 +1,12 @@
 import { Link } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { usePrevious } from "@canonical/react-components/dist/hooks";
 import React, { useEffect, useRef } from "react";
 import * as Yup from "yup";
 
 import { config as configActions } from "app/settings/actions";
 import configSelectors from "app/store/config/selectors";
-import { usePrevious, useSendAnalytics } from "app/base/hooks";
+import { useSendAnalytics } from "app/base/hooks";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 


### PR DESCRIPTION
## Done

- Replace hooks with those migrated to react-components.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the kvm page. Resizing the window should update the segment widths.
- Visit the machine list and set some filters. Clicking on the pools tab should clear the filters in the URL.
- Go to the general settings. Enabling/disabling analytics should refresh the page.

## Fixes

Fixes: canonical-web-and-design/maas-ui/issues/1687