### PR TITLE
fix(legacy): show the full power type name

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -5,7 +5,11 @@
  */
 import angular from "angular";
 
-import { generateLegacyURL, generateNewURL } from "@maas-ui/maas-ui-shared";
+import {
+  extractPowerType,
+  generateLegacyURL,
+  generateNewURL,
+} from "@maas-ui/maas-ui-shared";
 import { HardwareType, NodeTypes } from "../enum";
 
 // Convert MiB to GiB value if over 1024 and round to 4 significant figures.
@@ -430,9 +434,14 @@ function NodeDetailsController(
     }
 
     $scope.power.type = null;
+    $scope.power.typeDisplay = null;
     for (let i = 0; i < $scope.power_types.length; i++) {
       if ($scope.node.power_type === $scope.power_types[i].name) {
         $scope.power.type = $scope.power_types[i];
+        $scope.power.typeDisplay = extractPowerType(
+          $scope.power.type.description,
+          $scope.node.power_type
+        );
         break;
       }
     }

--- a/legacy/src/app/partials/cards/controller.html
+++ b/legacy/src/app/partials/cards/controller.html
@@ -16,7 +16,7 @@
     <li class="p-list__item" data-ng-if="node.show_os_info"><span class="muted-label">OS:</span> <span data-maas-release-name="node.osystem + '/' + node.distro_series"></span></li>
     <li class="p-list__item"><span class="muted-label">Domain:</span> {$ header.domain.selected.name $}</li>
     <li class="p-list__item"><span class="muted-label">Zone:</span> {$ summary.zone.selected.name $}</li>
-    <li class="p-list__item" data-ng-if="node.power_type"><span class="muted-label">Power type:</span> {$ node.power_type $}</li>
+    <li class="p-list__item" data-ng-if="node.power_type"><span class="muted-label">Power type:</span> {$ power.type.description || node.power_type $}</li>
   </ul>
 </div>
 <footer>

--- a/legacy/src/app/partials/cards/controller.html
+++ b/legacy/src/app/partials/cards/controller.html
@@ -16,7 +16,7 @@
     <li class="p-list__item" data-ng-if="node.show_os_info"><span class="muted-label">OS:</span> <span data-maas-release-name="node.osystem + '/' + node.distro_series"></span></li>
     <li class="p-list__item"><span class="muted-label">Domain:</span> {$ header.domain.selected.name $}</li>
     <li class="p-list__item"><span class="muted-label">Zone:</span> {$ summary.zone.selected.name $}</li>
-    <li class="p-list__item" data-ng-if="node.power_type"><span class="muted-label">Power type:</span> {$ power.type.description || node.power_type $}</li>
+    <li class="p-list__item" data-ng-if="node.power_type"><span class="muted-label">Power type:</span> {$ power.typeDisplay || node.power_type $}</li>
   </ul>
 </div>
 <footer>

--- a/legacy/src/app/partials/cards/machine-overview.html
+++ b/legacy/src/app/partials/cards/machine-overview.html
@@ -193,7 +193,7 @@
         <a ng-click="openEditConfig()" ng-if="canEdit()">Power type&nbsp;&rsaquo;</a>
         <span class="p-text--muted" ng-if="!canEdit()">Power type</span>
       </div>
-      <span title="{$ node.power_type $}">{$ node.power_type $}</span>
+      <span title="{$ node.power_type $}">{$ power.type.description || node.power_type $}</span>
     </div>
     <div class="u-text-overflow">
       <div>

--- a/legacy/src/app/partials/cards/machine-overview.html
+++ b/legacy/src/app/partials/cards/machine-overview.html
@@ -193,7 +193,7 @@
         <a ng-click="openEditConfig()" ng-if="canEdit()">Power type&nbsp;&rsaquo;</a>
         <span class="p-text--muted" ng-if="!canEdit()">Power type</span>
       </div>
-      <span title="{$ node.power_type $}">{$ power.type.description || node.power_type $}</span>
+      <span title="{$ node.power_type $}">{$ power.typeDisplay|| node.power_type $}</span>
     </div>
     <div class="u-text-overflow">
       <div>

--- a/shared/src/index.js
+++ b/shared/src/index.js
@@ -2,6 +2,7 @@ export { default as Header } from "./components/Header";
 export { default as Footer } from "./components/Footer";
 export {
   BASENAME,
+  extractPowerType,
   generateBaseURL,
   generateLegacyURL,
   generateNewURL,

--- a/shared/src/utils.js
+++ b/shared/src/utils.js
@@ -37,3 +37,19 @@ export const navigateToLegacy = (route, evt) => {
 export const navigateToNew = (route, evt) => {
   navigate(generateNewURL(route), evt);
 };
+
+/**
+ * Get the formatted power type from a power type description.
+ * @param {String} description - A power type description.
+ * @param {String} powerType - A power type.
+ * @return {String} The formatted power type or the original power type key.
+ */
+export const extractPowerType = (description, powerType) => {
+  if (!description) {
+    return powerType;
+  }
+  const position = description.toLowerCase().indexOf(powerType.toLowerCase());
+  return position === -1
+    ? powerType
+    : description.substring(position, position + powerType.length);
+};

--- a/shared/src/utils.test.js
+++ b/shared/src/utils.test.js
@@ -1,4 +1,5 @@
 import {
+  extractPowerType,
   generateBaseURL,
   generateLegacyURL,
   generateNewURL,
@@ -88,6 +89,24 @@ describe("utils", () => {
       navigateToNew("/machines", { button: 0, metaKey: true, preventDefault });
       expect(pushState).not.toHaveBeenCalled();
       expect(preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("extractPowerType", () => {
+    it("can extract a power type from a description", () => {
+      expect(extractPowerType("The OpenBMC Power Driver", "openbmc")).toBe(
+        "OpenBMC"
+      );
+    });
+
+    it("handles no matching power type", () => {
+      expect(extractPowerType("Open BMC Power Driver", "openbmc")).toBe(
+        "openbmc"
+      );
+    });
+
+    it("handles no description", () => {
+      expect(extractPowerType(null, "openbmc")).toBe("openbmc");
     });
   });
 });


### PR DESCRIPTION
## Done

- Show the full power type name on controller and machine details

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit a machine and controller summary. Both should display the full power type name (specifically IPMI should be capitalised).

## Fixes

Fixes: canonical-web-and-design/maas-ui#987