### PR TITLE
test(cypress): improve the cypress machine add test

### DIFF
--- a/integration/cypress/integration/machines/add.spec.ts
+++ b/integration/cypress/integration/machines/add.spec.ts
@@ -19,10 +19,8 @@ context("Machine add", () => {
     const hostname = `cypress-${nanoid()}`;
     cy.get("input[name='hostname']").type(hostname);
     cy.get("input[name='pxe_mac']").type(generateMac());
-    cy.get("select[name='power_type']").select("Manual").blur();
+    cy.get("select[name='power_type']").select("manual").blur();
     cy.get("button[type='submit']").click();
-    cy.get("p.p-notification__response").contains(
-      `${hostname} added successfully.`
-    );
-  }).skip();
+    cy.get(`[data-test='message']:contains(${hostname} added successfully.)`);
+  });
 });


### PR DESCRIPTION
## Done

- Use a more reliable method for getting the success message when adding a machine in the cypress
test.

## QA

No QA.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1342.