### PR TITLE
fix(notifications): fix dismiss all link appearing when none can be dismissed

### DIFF
--- a/legacy/src/app/directives/notifications.js
+++ b/legacy/src/app/directives/notifications.js
@@ -57,6 +57,9 @@ export function maasNotifications(
         });
       };
 
+      scope.dismissable = (notifications) =>
+        notifications.some(({ dismissable }) => !!dismissable);
+
       scope.navigateToSettings = () => {
         $rootScope.navigateToNew("/settings");
       };

--- a/legacy/src/app/directives/tests/test_notifications.js
+++ b/legacy/src/app/directives/tests/test_notifications.js
@@ -138,6 +138,15 @@ describe("maasNotifications", function () {
       expect(dismiss).not.toHaveBeenCalledWith(notifications[3]);
     });
 
+    it("does not display a dismiss all link if none can be dismissed", () => {
+      theNotificationsManager._items = [
+        exampleAdditionalNotification,
+        { ...exampleAdditionalNotification, id: 5 },
+      ];
+      const directive = compileDirective();
+      expect(directive.find('[data-test="dismiss-all"]').length).toBe(0);
+    });
+
     it("adjusts class according to category", function () {
       theNotificationsManager._items = exampleNotifications;
       var directive = compileDirective();

--- a/legacy/src/app/partials/nodelist/notifications.html
+++ b/legacy/src/app/partials/nodelist/notifications.html
@@ -61,7 +61,10 @@
               ></i>
             </small> </a
           >&nbsp;&nbsp;
-          <a data-test="dismiss-all" ng-click="dismissCategory(category)"
+          <a
+            data-test="dismiss-all"
+            ng-click="dismissCategory(category)"
+            ng-if="dismissable(notifications)"
             >Dismiss all</a
           >
         </p>

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
@@ -92,6 +92,30 @@ describe("NotificationGroup", () => {
     );
   });
 
+  it("does not display a dismiss all link if none can be dismissed", () => {
+    const notifications = [
+      notificationFactory({ dismissable: false }),
+      notificationFactory({ dismissable: false }),
+    ];
+    const state = rootStateFactory({
+      notification: notificationStateFactory({
+        items: notifications,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NotificationGroup notifications={notifications} type="negative" />
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .findWhere((n) => n.name() === "Button" && n.text() === "Dismiss all")
+        .exists()
+    ).toBe(false);
+  });
+
   it("can dismiss multiple notifications", () => {
     const notifications = [
       notificationFactory({ dismissable: true }),

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
@@ -38,6 +38,8 @@ const NotificationGroup = ({ notifications, type }: Props): JSX.Element => {
           notifications.length
         )}`;
 
+  const dismissable = notifications.some(({ dismissable }) => !!dismissable);
+
   return (
     <div className="p-notification--group">
       {notifications.length > 1 ? (
@@ -62,13 +64,15 @@ const NotificationGroup = ({ notifications, type }: Props): JSX.Element => {
               ></i>
             </small>
           </Button>
-          <Button
-            appearance="link"
-            className="p-notification__action u-nudge-right"
-            onClick={() => dismissAll(notifications, dispatch)}
-          >
-            Dismiss all
-          </Button>
+          {dismissable ? (
+            <Button
+              appearance="link"
+              className="p-notification__action u-nudge-right"
+              onClick={() => dismissAll(notifications, dispatch)}
+            >
+              Dismiss all
+            </Button>
+          ) : null}
         </Notification>
       ) : null}
       {((groupOpen && notifications.length > 1) ||


### PR DESCRIPTION
## Done

- Don't display the dismiss all link if no notifications in the group can be dismissed.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create some notifications that can and can't be dismissed.
- On both a react and angular page check that the dismiss all link is hidden for any groups that have no dismissible notifications.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1287