### PR TITLE
build(legacy, ui): minimise legacy and remove profile from ui

### DIFF
--- a/legacy/webpack.prod.js
+++ b/legacy/webpack.prod.js
@@ -2,6 +2,7 @@ const { merge } = require("webpack-merge");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 
 const common = require("./webpack.common.js");
 
@@ -9,7 +10,14 @@ module.exports = merge(common, {
   mode: "production",
   devtool: "source-map",
   optimization: {
-    minimizer: [new OptimizeCSSAssetsPlugin({})],
+    minimizer: [
+      new OptimizeCSSAssetsPlugin({}),
+      new TerserPlugin({
+        cache: true,
+        parallel: true,
+        sourceMap: true,
+      }),
+    ],
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/ui/package.json
+++ b/ui/package.json
@@ -60,7 +60,7 @@
     "standalone": "REACT_APP_STANDALONE=true react-scripts start",
     "start": "REACT_APP_STANDALONE=false react-app-rewired start",
     "serve": "yarn run start",
-    "build": "REACT_APP_STANDALONE=false react-app-rewired build --profile && rm -rf dist && mv build dist",
+    "build": "REACT_APP_STANDALONE=false react-app-rewired build && rm -rf dist && mv build dist",
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
## Done

- Minimise the legacy js.
- Remove the profiler from ui.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

None, CI should build the files.