### PR TITLE
fix(legacy): preselect default commissioning release when using custom image source

### DIFF
--- a/legacy/src/app/directives/boot_images.js
+++ b/legacy/src/app/directives/boot_images.js
@@ -61,7 +61,7 @@ export function maasBootImages(
 
   /* @ngInject */
   function BootImagesController($scope) {
-    const DEFAULT_RELEASE = "bionic";
+    const DEFAULT_RELEASE_NAME = "bionic";
     const DEFAULT_ARCH = "amd64";
 
     $scope.loading = true;
@@ -254,10 +254,13 @@ export function maasBootImages(
     };
 
     // Select the default images that should be selected. Current
-    // defaults are '18.04 LTS' and 'amd64'.
+    // defaults are '20.04 LTS' and 'amd64'.
     $scope.selectDefaults = () => {
+      const defaultReleaseName =
+        $scope.bootResources?.ubuntu?.commissioning_series ||
+        DEFAULT_RELEASE_NAME;
       const defaultRelease = $scope.source.releases.find(
-        (release) => release.name === DEFAULT_RELEASE
+        (release) => release.name === defaultReleaseName
       );
       const defaultArch = $scope.source.arches.find(
         (arch) => arch.name === DEFAULT_ARCH

--- a/legacy/src/app/directives/tests/test_boot_images.js
+++ b/legacy/src/app/directives/tests/test_boot_images.js
@@ -540,21 +540,31 @@ describe("maasBootImages", function () {
   });
 
   describe("selectDefaults", function () {
-    it("selects bionic and amd64", function () {
-      var directive = compileDirective();
-      var scope = directive.isolateScope();
-      var bionic = {
-        name: "bionic",
-      };
-      var amd64 = {
-        name: "amd64",
-      };
-      scope.source.releases = [bionic];
-      scope.source.arches = [amd64];
+    it("selects amd64 and bionic if default commissioning series unset", () => {
+      const directive = compileDirective();
+      const scope = directive.isolateScope();
+      scope.source.releases = [{ name: "bionic" }, { name: "focal" }];
+      scope.source.arches = [{ name: "amd64" }, { name: "arm64" }];
       scope.selectDefaults();
 
-      expect(scope.source.selections.releases).toEqual([bionic]);
-      expect(scope.source.selections.arches).toEqual([amd64]);
+      expect(scope.source.selections.releases).toEqual([{ name: "bionic" }]);
+      expect(scope.source.selections.arches).toEqual([{ name: "amd64" }]);
+    });
+
+    it("selects amd64 and default commissioning series if set", () => {
+      const directive = compileDirective();
+      const scope = directive.isolateScope();
+      scope.source.releases = [{ name: "bionic" }, { name: "focal" }];
+      scope.source.arches = [{ name: "amd64" }, { name: "arm64" }];
+      scope.bootResources = {
+        ubuntu: {
+          commissioning_series: "focal",
+        },
+      };
+      scope.selectDefaults();
+
+      expect(scope.source.selections.releases).toEqual([{ name: "focal" }]);
+      expect(scope.source.selections.arches).toEqual([{ name: "amd64" }]);
     });
   });
 


### PR DESCRIPTION
## Done

- Preselect default commissioning release when using custom image source, as opposed to only selecting bionic amd64 (which is still used as a fallback if commissioning release is unset).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/settings/configuration/commissioning and change the default Ubuntu release
- Go to /MAAS/l/images and choose "Custom".
- Use the default daily source (https://images.maas.io/ephemeral-v3/daily/) and check that the preselected release is the previously defined default commissioning release with amd64 architecture

## Fixes

Fixes #1500 
