### PR TITLE
fix(legacy): only fetch the current machine on machine details

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -1717,7 +1717,7 @@ function NodeDetailsController(
     $rootScope.page = "devices";
   } else {
     $scope.nodesManager = MachinesManager;
-    page_managers = [MachinesManager, PodsManager, ScriptsManager];
+    page_managers = [PodsManager, ScriptsManager];
     $scope.isController = false;
     $scope.isDevice = false;
     $scope.type_name = "machine";
@@ -1739,46 +1739,50 @@ function NodeDetailsController(
       FabricsManager,
       VLANsManager,
     ].concat(page_managers)
-  ).then(function () {
-    // Possibly redirected from another controller that already had
-    // this node set to active. Only call setActiveItem if not already
-    // the activeItem.
-    var activeNode = $scope.nodesManager.getActiveItem();
-    if (
-      angular.isObject(activeNode) &&
-      activeNode.system_id === $stateParams.system_id
-    ) {
-      nodeLoaded(activeNode);
+  ).then(() => {
+    // only fetch a single machine, rather than entire machine list
+    $scope.nodesManager.getItem($stateParams.system_id).then((node) => {
+      // Possibly redirected from another controller that already had
+      // this node set to active. Only call setActiveItem if not already
+      // the activeItem.
+      var activeNode = $scope.nodesManager.getActiveItem();
+      if (
+        angular.isObject(activeNode) &&
+        activeNode.system_id === node.system_id
+      ) {
+        nodeLoaded(activeNode);
 
-      // Set flag for RSD navigation item.
-      if (!$rootScope.showRSDLink) {
-        GeneralManager.getNavigationOptions().then(
-          (res) => ($rootScope.showRSDLink = res.rsd)
-        );
-      }
-    } else {
-      $scope.nodesManager.setActiveItem($stateParams.system_id).then(
-        function (node) {
-          nodeLoaded(node);
-          if (angular.isObject($scope.node.vlan)) {
-            if (
-              localStorage.getItem(
-                `hideHighAvailabilityNotification-${$scope.node.vlan.id}`
-              )
-            ) {
-              $scope.hideHighAvailabilityNotification = true;
-            }
-          }
-        },
-        function (error) {
-          ErrorService.raiseError(error);
+        // Set flag for RSD navigation item.
+        if (!$rootScope.showRSDLink) {
+          GeneralManager.getNavigationOptions().then(
+            (res) => ($rootScope.showRSDLink = res.rsd)
+          );
         }
-      );
-      activeNode = $scope.nodesManager.getActiveItem();
-    }
-    if ($scope.isDevice && activeNode) {
-      $scope.ip_assignment = activeNode.ip_assignment;
-    }
+      } else {
+        $scope.nodesManager.setActiveItem($stateParams.system_id).then(
+          function (node) {
+            nodeLoaded(node);
+            if (angular.isObject($scope.node.vlan)) {
+              if (
+                localStorage.getItem(
+                  `hideHighAvailabilityNotification-${$scope.node.vlan.id}`
+                )
+              ) {
+                $scope.hideHighAvailabilityNotification = true;
+              }
+            }
+          },
+          function (error) {
+            ErrorService.raiseError(error);
+          }
+        );
+        activeNode = $scope.nodesManager.getActiveItem();
+      }
+      if ($scope.isDevice && activeNode) {
+        $scope.ip_assignment = activeNode.ip_assignment;
+      }
+    });
+
     // Handle updating the area when the browser navigates back/forward.
     $scope.$on("$locationChangeStart", () => {
       $scope.section.area = angular.isString($location?.search()?.area)

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -340,7 +340,6 @@ describe("NodeDetailsController", function () {
       ResourcePoolsManager,
       FabricsManager,
       VLANsManager,
-      MachinesManager,
       PodsManager,
       ScriptsManager,
     ]);
@@ -383,11 +382,15 @@ describe("NodeDetailsController", function () {
   });
 
   it("doesnt call setActiveItem if node is loaded", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     spyOn(MachinesManager, "setActiveItem").and.returnValue($q.defer().promise);
     var defer = $q.defer();
     makeController(defer);
     MachinesManager._activeItem = node;
 
+    getItemDefer.resolve(node);
     defer.resolve();
     $rootScope.$digest();
 
@@ -397,10 +400,13 @@ describe("NodeDetailsController", function () {
   });
 
   it("calls setActiveItem if node is not active", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
     spyOn(MachinesManager, "setActiveItem").and.returnValue($q.defer().promise);
     var defer = $q.defer();
     makeController(defer);
 
+    getItemDefer.resolve(node);
     defer.resolve();
     $rootScope.$digest();
 
@@ -408,7 +414,12 @@ describe("NodeDetailsController", function () {
   });
 
   it("sets node and loaded once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     makeControllerResolveSetActiveItem();
+
     expect($scope.node).toBe(node);
     expect($scope.loaded).toBe(true);
   });
@@ -428,14 +439,18 @@ describe("NodeDetailsController", function () {
   });
 
   it("fetches pod details if node has a pod", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
     node.pod = { id: 1 };
     MachinesManager._activeItem = node;
     spyOn(PodsManager, "getItem").and.returnValue($q.defer().promise);
     var defer = $q.defer();
     makeController(defer);
 
+    getItemDefer.resolve(node);
     defer.resolve();
     $rootScope.$digest();
+
     expect(PodsManager.getItem).toHaveBeenCalledWith(node.pod.id);
   });
 
@@ -458,6 +473,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("updateServices sets $scope.services when node is loaded", function () {
+    const getItemDefer = $q.defer();
+    spyOn(ControllersManager, "getItem").and.returnValue(getItemDefer.promise);
+
     spyOn(ControllersManager, "getServices").and.returnValue([
       { status: "running", name: "rackd" },
     ]);
@@ -471,6 +489,7 @@ describe("NodeDetailsController", function () {
     ControllersManager._activeItem = node;
 
     defer.resolve();
+    getItemDefer.resolve(node);
     $rootScope.$digest();
 
     expect($scope.node).toBe(node);
@@ -483,6 +502,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("loads node actions", function () {
+    const getItemDefer = $q.defer();
+    spyOn(ControllersManager, "getItem").and.returnValue(getItemDefer.promise);
+
     spyOn(ControllersManager, "setActiveItem").and.returnValue(
       $q.defer().promise
     );
@@ -502,7 +524,9 @@ describe("NodeDetailsController", function () {
     ControllersManager._activeItem = myNode;
     loadManagersDefer.resolve();
     loadItemsDefer.resolve();
+    getItemDefer.resolve(myNode);
     $rootScope.$digest();
+
     expect(GeneralManager.isDataLoaded.calls.count()).toBe(2);
     expect(GeneralManager.isDataLoaded).toHaveBeenCalledWith(
       "rack_controller_actions"
@@ -513,11 +537,20 @@ describe("NodeDetailsController", function () {
   });
 
   it("title is updated once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     makeControllerResolveSetActiveItem();
+
     expect($rootScope.title).toBe(node.fqdn);
   });
 
   it("summary section placed in edit mode if architecture blank", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     node.architecture = "";
     node.permissions = ["edit"];
     GeneralManager._data.power_types.data = [{}];
@@ -545,7 +578,12 @@ describe("NodeDetailsController", function () {
   });
 
   it("summary section is updated once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     makeControllerResolveSetActiveItem();
+
     expect($scope.summary.zone.selected).toBe(
       ZonesManager.getItemFromList(node.zone.id)
     );
@@ -561,9 +599,14 @@ describe("NodeDetailsController", function () {
   });
 
   it("power section edit mode if power_type blank for a machine", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     GeneralManager._data.power_types.data = [{}];
     node.permissions = ["edit"];
     makeControllerResolveSetActiveItem();
+
     expect($scope.power.editing).toBe(true);
   });
 
@@ -581,6 +624,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("starts watching once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     var setActiveDefer = $q.defer();
     spyOn(MachinesManager, "setActiveItem").and.returnValue(
       setActiveDefer.promise
@@ -593,6 +639,7 @@ describe("NodeDetailsController", function () {
 
     defer.resolve();
     $rootScope.$digest();
+    getItemDefer.resolve(node);
     setActiveDefer.resolve(node);
     $rootScope.$digest();
 
@@ -633,6 +680,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("updates $scope.devices", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     var setActiveDefer = $q.defer();
     spyOn(MachinesManager, "setActiveItem").and.returnValue(
       setActiveDefer.promise
@@ -681,6 +731,7 @@ describe("NodeDetailsController", function () {
 
     defer.resolve();
     $rootScope.$digest();
+    getItemDefer.resolve(node);
     setActiveDefer.resolve(node);
     $rootScope.$digest();
 
@@ -721,10 +772,14 @@ describe("NodeDetailsController", function () {
   });
 
   it("updates $scope.actions", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     var setActiveDefer = $q.defer();
     spyOn(MachinesManager, "setActiveItem").and.returnValue(
       setActiveDefer.promise
     );
+
     var loadManagersDefer = $q.defer();
     var loadItemsDefer = $q.defer();
     makeController(loadManagersDefer, loadItemsDefer);
@@ -739,6 +794,7 @@ describe("NodeDetailsController", function () {
     ];
     loadManagersDefer.resolve();
     $rootScope.$digest();
+    getItemDefer.resolve(node);
     setActiveDefer.resolve(node);
     $rootScope.$digest();
     // loadItems normally sets loaded to true and sets data to the items

--- a/legacy/src/app/services/manager.js
+++ b/legacy/src/app/services/manager.js
@@ -396,7 +396,12 @@ function Manager($q, $rootScope, $timeout, RegionConnection) {
     var params = {};
     params[this._pk] = pk_value;
     return RegionConnection.callMethod(method, params).then(function (item) {
-      self._replaceItem(item);
+      self._loaded = true;
+      if (self._items.length === 0) {
+        self._items.push(item);
+      } else {
+        self._replaceItem(item);
+      }
       return item;
     });
   };


### PR DESCRIPTION
## Done

- Only fetch a single machine on machine details, rather than every machine.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure the machine details loads, and that all features continue to work as expected (network, storage, logs etc)

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
