### PR TITLE
fix(ui): add validation for ipmi username config

### DIFF
--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
@@ -10,9 +10,13 @@ import FormikForm from "app/base/components/FormikForm";
 const CommissioningSchema = Yup.object().shape({
   commissioning_distro_series: Yup.string(),
   default_min_hwe_kernel: Yup.string(),
-  maas_auto_ipmi_user: Yup.string().required(
-    'The username cannot be left blank. The username is "maas" by default.'
-  ),
+  maas_auto_ipmi_user: Yup.string()
+    .required(
+      'The username cannot be left blank. The username is "maas" by default.'
+    )
+    .min(3, "The username must be 3 characters or more")
+    .max(16, "The username must be 16 characters or less.")
+    .matches(/^\S*$/, "The username may not contain spaces"),
   maas_auto_ipmi_k_g_bmc_key: Yup.string(),
   maas_auto_ipmi_user_privilege_level: Yup.string().matches(
     /(ADMIN|OPERATOR|USER)/

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -88,7 +88,7 @@ const CommissioningFormFields = (): JSX.Element => {
         name="maas_auto_ipmi_k_g_bmc_key"
         type="password"
       />
-      <h6 className="u-sv1">MAAS generated IPMI user privilege level</h6>
+      <p className="u-sv1">MAAS generated IPMI user privilege level</p>
       <FormikField
         name="maas_auto_ipmi_user_privilege_level"
         value="ADMIN"


### PR DESCRIPTION
## Done
- Add validation for IPMI username configuration (3-16 characters, no spaces)
- Use paragraph styling for "MAAS generated IPMI user privilege level" to ensure it doesn't render in italics

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit settings | configuration | commissioning
- Ensure only IPMI usernames with no spaces and between 3-16 characters can be saved

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2123

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
