### PR TITLE
fix(footer): prefix the offline docs with the provided basename

### DIFF
--- a/shared/src/components/Footer/Footer.js
+++ b/shared/src/components/Footer/Footer.js
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
 
+import { BASENAME } from "../../utils";
+
 export const Footer = ({ enableAnalytics, debug, maasName, version }) => {
   useEffect(() => {
     if (!debug && enableAnalytics && version) {
@@ -35,7 +37,7 @@ export const Footer = ({ enableAnalytics, debug, maasName, version }) => {
           <ul className="p-inline-list--middot">
             <li className="p-inline-list__item">
               <a
-                href={`/MAAS/docs/maas-documentation-25.html`}
+                href={`${BASENAME}/docs/maas-documentation-25.html`}
                 className="p-footer__link"
               >
                 Local documentation


### PR DESCRIPTION
## Done

- Remove the hardcoded offline docs prefix and use the basename from the env var.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load the ui and click on (or inspect) the offline docs link in the footer, it should start with "/MAAS".

## Fixes

Fixes: canonical-web-and-design/maas-ui#1762