### PR TITLE
fix(legacy): show VM as NUMA-aligned if its host has only one NUMA node

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -46,6 +46,11 @@ export const getRanges = (array) => {
 
 export const getPodNumaID = (node, pod) => {
   if (pod.numa_pinning) {
+    // If there is only one NUMA node on the VM host, then the VM must be
+    // aligned on that node even if it isn't specifically pinned.
+    if (pod.numa_pinning.length === 1) {
+      return pod.numa_pinning[0].node_id;
+    }
     const podNuma = pod.numa_pinning.find((numa) =>
       numa.vms.some((vm) => vm.system_id === node.system_id)
     );

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -3115,4 +3115,17 @@ describe("NodeDetailsController", function () {
       expect(getPodNumaID(node3, pod)).toEqual(null);
     });
   });
+
+  it(`returns the id of the only NUMA node of a pod, even if it has not
+    specifically pinned the VM`, () => {
+    const node = { pod: { id: 1, name: "pod1" }, system_id: "abc123" };
+    const pod = {
+      id: 1,
+      name: "pod1",
+      numa_pinning: [
+        { node_id: 1, vms: [] }, // VM is not pinned here
+      ],
+    };
+    expect(getPodNumaID(node, pod)).toEqual(1);
+  });
 });

--- a/legacy/src/app/partials/cards/machine-overview.html
+++ b/legacy/src/app/partials/cards/machine-overview.html
@@ -169,8 +169,8 @@
     <div ng-if="node.pod">
       <div class="p-text--muted">Host</div>
       <span>
-        <span ng-if="podNumaID">On NUMA node {$ podNumaID $} of</span>
-        <span ng-if="!podNumaID">Not NUMA-aligned on</span>
+        <span ng-if="podNumaID !== null">On NUMA node {$ podNumaID $} of</span>
+        <span ng-if="podNumaID === null">Not NUMA-aligned on</span>
         <a href="{$ newUrlBase $}/kvm/{$ node.pod.id $}">{$ node.pod.name $}&nbsp;&rsaquo;</a>
       </span>
     </div>


### PR DESCRIPTION
## Done

- Show a VM as "NUMA-aligned on X" if its host has only one NUMA node, even if that VM has not specifically been pinned to a node (because it's already implied).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using bolla (which has only one NUMA node), go to the Machine details page of one of its VMs.
- Check that the summary says it's `NUMA aligned on node 0 of bolla`

## Fixes

Fixes #1761 
