### PR TITLE
fix(legacy): correctly truncate network summary DHCP column

### DIFF
--- a/legacy/src/app/partials/cards/network.html
+++ b/legacy/src/app/partials/cards/network.html
@@ -59,8 +59,11 @@
           <td class="p-table__cell--fabric" title="{$ getFabricName(iface) $}">
             {$ getFabricName(iface) $}
           </td>
-          <td class="p-table__cell--dhcp" style="overflow: visible;" title="{$ getDHCPStatus(iface) $}">
-            {$ getDHCPStatus(iface) $}
+          <td
+            class="p-table__cell--dhcp"
+            ng-style="{ 'overflow': isRelayed(iface) ? 'visible' : 'hidden' }"
+          >
+            <span title="{$ getDHCPStatus(iface) $}">{$ getDHCPStatus(iface) $}</span>
             <span class="p-tooltip--btm-right" ng-if="isRelayed(iface)" style="margin-left: .25rem;">
                 <i class="p-icon--information" style="width: .875rem;">{$ getDHCPStatus(iface, true) $}</i>
                 <span class="p-tooltip__message">{$ getDHCPStatus(iface, true) $}</span>


### PR DESCRIPTION
## Done

- On the machine network summary, only apply `overflow: visible` to interfaces that are relayed because those are the only ones that need an `[i]` tooltip. 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine details summary of a machine that has a relayed VLAN (e.g. `fun-mammal` on bolla).
- Check that the tooltip in the DHCP column still works, next to "Relayed".
- On a non-relayed interface, check that the cell contents are correctly truncated if the text gets too long (you can just add text via the inspector)

## Fixes

Fixes #1768 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
