### PR TITLE
test(legacy,ui): add simple integration smoke tests for all pages in the navigation

### DIFF
--- a/integration/cypress/integration/kvm/list.spec.ts
+++ b/integration/cypress/integration/kvm/list.spec.ts
@@ -2,11 +2,11 @@ import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("KVM listing", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateNewURL("/kvm"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get("[data-test='section-header-title']").contains("KVM");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateNewURL("/kvm")
     );
   });
 });

--- a/integration/cypress/integration/legacy/azs.spec.ts
+++ b/integration/cypress/integration/legacy/azs.spec.ts
@@ -1,12 +1,12 @@
-import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("AZs", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateLegacyURL("/zones"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get(".page-header__title").contains("Availability zones");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateLegacyURL("/zones")
     );
   });
 });

--- a/integration/cypress/integration/legacy/controllers.spec.ts
+++ b/integration/cypress/integration/legacy/controllers.spec.ts
@@ -1,12 +1,12 @@
-import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("Controller listing", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateLegacyURL("/controllers"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get("[data-test='section-header-title']").contains("Controllers");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateLegacyURL("/controllers")
     );
   });
 });

--- a/integration/cypress/integration/legacy/devices.spec.ts
+++ b/integration/cypress/integration/legacy/devices.spec.ts
@@ -1,12 +1,12 @@
-import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("Device listing", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateLegacyURL("/devices"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get("[data-test='section-header-title']").contains("Devices");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateLegacyURL("/devices")
     );
   });
 });

--- a/integration/cypress/integration/legacy/dns.spec.ts
+++ b/integration/cypress/integration/legacy/dns.spec.ts
@@ -1,12 +1,12 @@
-import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("DNS", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateLegacyURL("/domains"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get(".page-header__title").contains("DNS");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateLegacyURL("/domains")
     );
   });
 });

--- a/integration/cypress/integration/legacy/images.spec.ts
+++ b/integration/cypress/integration/legacy/images.spec.ts
@@ -1,12 +1,12 @@
-import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("Images", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateLegacyURL("/images"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get("[data-test='section-header-title']").contains("Images");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateLegacyURL("/images")
     );
   });
 });

--- a/integration/cypress/integration/legacy/subnets.spec.ts
+++ b/integration/cypress/integration/legacy/subnets.spec.ts
@@ -1,12 +1,12 @@
-import { generateNewURL } from "@maas-ui/maas-ui-shared";
+import { generateLegacyURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("Subnets", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateLegacyURL("/networks?by=fabric"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get(".page-header__title").contains("Subnets");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateLegacyURL("/networks?by=fabric")
     );
   });
 });

--- a/integration/cypress/integration/preferences/base.spec.ts
+++ b/integration/cypress/integration/preferences/base.spec.ts
@@ -2,11 +2,11 @@ import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("User preferences", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateNewURL("/account/prefs"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get("h1.p-heading--four").contains("My preferences");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateNewURL("/account/prefs")
     );
   });
 });

--- a/integration/cypress/integration/settings/base.spec.ts
+++ b/integration/cypress/integration/settings/base.spec.ts
@@ -2,11 +2,11 @@ import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../utils";
 
-context("Machine listing", () => {
+context("Settings", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");
-    cy.visit(generateNewURL("/machines"));
+    cy.visit(generateNewURL("/settings"));
   });
 
   afterEach(() => {
@@ -14,14 +14,14 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-test='section-header-title']").contains("Machines");
+    cy.get("h1.p-heading--four").contains("Settings");
   });
 
   it("highlights the correct navigation link", () => {
     cy.get(".p-navigation__link.is-selected a").should(
       "have.attr",
       "href",
-      generateNewURL("/machines")
+      generateNewURL("/settings")
     );
   });
 });

--- a/integration/cypress/integration/settings/users/add.spec.ts
+++ b/integration/cypress/integration/settings/users/add.spec.ts
@@ -5,7 +5,7 @@ import { generateEmail, login } from "../../utils";
 
 const nanoid = customAlphabet("1234567890abcdefghi", 10);
 
-context("User add", () => {
+context("Settings - User add", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");

--- a/integration/cypress/integration/settings/users/list.spec.ts
+++ b/integration/cypress/integration/settings/users/list.spec.ts
@@ -2,7 +2,7 @@ import { generateNewURL } from "@maas-ui/maas-ui-shared";
 
 import { login } from "../../utils";
 
-context("User list", () => {
+context("Settings - User list", () => {
   beforeEach(() => {
     login();
     cy.setCookie("skipintro", "true");

--- a/legacy/src/app/partials/images.html
+++ b/legacy/src/app/partials/images.html
@@ -6,7 +6,7 @@
 
                 <!-- Title -->
                 <ul class="p-inline-list">
-                    <li class="p-inline-list__item p-heading--four">
+                    <li class="p-inline-list__item p-heading--four" data-test="section-header-title">
                         Images
                     </li>
                     <li class="p-inline-list__item" ng-if="loading">

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -6,7 +6,7 @@
 
                 <!-- Title + node count -->
                 <ul class="p-inline-list">
-                    <li class="p-inline-list__item p-heading--four">
+                    <li class="p-inline-list__item p-heading--four" data-test="section-header-title">
                         {$ title $}
                     </li>
                     <li class="p-inline-list__item" ng-if="loading">


### PR DESCRIPTION
## Done

- Added integration tests that check that the heading and navigation highlight is correct for Devices,
Controllers, KVM, Images, DNS, AZs, Subnets and user preferences.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using a test MAAS, run a local UI server with `yarn start` (make sure username/pw is admin/test, otherwise edit the cypress login util)
- In a separate terminal run `yarn cypress-run` and check that all tests pass

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2227
