### PR TITLE
fix(ui): fix expanding table header misalignment

### DIFF
--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -69,3 +69,12 @@ input[type="radio"] {
     margin: 0;
   }
 }
+
+// 20-10-2020 Caleb: ModularTable.scss in react-components v0.13.0 includes
+// styling that overrides .u-hide behaviour in tables. This overrides that
+// override so that expanding tables still get the normal .u-hide behaviour.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3337
+.p-table-expanding th.u-hide,
+.p-table-expanding td.u-hide {
+  display: none !important;
+}


### PR DESCRIPTION
## Done

- Add hotfix for react-components bug that was causing `.u-hide` not to work on expanding tables. We can remove it once the issue is fixed upstream.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to a settings table, /MAAS/r/settings/dhcp
- Check that the table headers are properly aligned with the cell contents

## Fixes

Fixes #1767 
