### PR TITLE
fix(cypress): fix cypress tests rendering incorrect navigation on new MAAS installs

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           config: baseUrl=${{env.MAAS_URL}},pageLoadTimeout=100000
           install: false
-          spec: cypress/integration/no-users/login.spec.ts
+          spec: "**/no-users/*.spec.ts"
           wait-on: "${{env.MAAS_URL}}/MAAS/r/machines"
           working-directory: integration
       - name: Create MAAS admin
@@ -44,9 +44,4 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: cypress/screenshots
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: cypress-videos
-          path: cypress/videos
+          path: integration/cypress/screenshots

--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -1,6 +1,9 @@
 {
   "baseUrl": "http://localhost:8400",
-  "ignoreTestFiles": "**/no-users/*",
-  "video": false,
-  "projectId": "gp2cox"
+  "env": {
+    "username": "admin",
+    "password": "test"
+  },
+  "projectId": "gp2cox",
+  "video": false
 }

--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -87,11 +87,15 @@ context("Header", () => {
   });
 
   it("navigates to preferences", () => {
-    cy.get(".p-navigation__link a:contains(admin)").click();
+    cy.get(
+      `.p-navigation__link a:contains(${Cypress.env("username")})`
+    ).click();
     cy.location("pathname").should(
       "eq",
       generateNewURL("/account/prefs/details")
     );
-    cy.get(".p-navigation__link.is-selected a").contains("admin");
+    cy.get(".p-navigation__link.is-selected a").contains(
+      Cypress.env("username")
+    );
   });
 });

--- a/integration/cypress/integration/login/login.spec.ts
+++ b/integration/cypress/integration/login/login.spec.ts
@@ -41,8 +41,8 @@ context("Login page", () => {
   });
 
   it("logs in and redirects to the intro", () => {
-    cy.get("input[name='username']").type("admin");
-    cy.get("input[name='password']").type("test");
+    cy.get("input[name='username']").type(Cypress.env("username"));
+    cy.get("input[name='password']").type(Cypress.env("password"));
     cy.get("button[type='submit']").click();
     cy.location("pathname").should("eq", generateLegacyURL("/intro"));
   });
@@ -50,8 +50,8 @@ context("Login page", () => {
   it("logs in and redirects to the user intro", () => {
     // Skip the first intro.
     cy.setCookie("skipsetupintro", "true");
-    cy.get("input[name='username']").type("admin");
-    cy.get("input[name='password']").type("test");
+    cy.get("input[name='username']").type(Cypress.env("username"));
+    cy.get("input[name='password']").type(Cypress.env("password"));
     cy.get("button[type='submit']").click();
     cy.location("pathname").should("eq", generateLegacyURL("/intro/user"));
   });
@@ -59,8 +59,8 @@ context("Login page", () => {
   it("logs in and redirects to the machine list", () => {
     cy.setCookie("skipintro", "true");
     cy.get("button").should("have.attr", "disabled", "disabled");
-    cy.get("input[name='username']").type("admin");
-    cy.get("input[name='password']").type("test");
+    cy.get("input[name='username']").type(Cypress.env("username"));
+    cy.get("input[name='password']").type(Cypress.env("password"));
     cy.get("button[type='submit']").click();
     cy.location("pathname").should("eq", generateNewURL("/machines"));
   });

--- a/integration/cypress/integration/utils.ts
+++ b/integration/cypress/integration/utils.ts
@@ -9,8 +9,8 @@ export const login = () => {
     url: `${BASENAME}/accounts/login/`,
     form: true,
     body: {
-      username: "admin",
-      password: "test",
+      username: Cypress.env("username"),
+      password: Cypress.env("password"),
     },
   });
 };

--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -17,6 +17,7 @@ function MasterController(
   $transitions,
   $window,
   $http,
+  $cookies,
   ErrorService
 ) {
   const debug = process.env.NODE_ENV === "development";
@@ -25,6 +26,8 @@ function MasterController(
   $rootScope.newURLBase = generateNewURL();
   $rootScope.navigateToLegacy = navigateToLegacy;
   $rootScope.navigateToNew = navigateToNew;
+  // the skipintro cookie is set by Cypress to make integration testing easier
+  const skipIntro = $cookies.get("skipintro");
 
   const renderHeader = () => {
     const headerNode = document.querySelector("#header");
@@ -42,7 +45,8 @@ function MasterController(
       <Header
         authUser={current_user}
         completedIntro={
-          completed_intro && current_user && current_user.completed_intro
+          (completed_intro && current_user && current_user.completed_intro) ||
+          !!skipIntro
         }
         debug={debug}
         enableAnalytics={window.CONFIG.enable_analytics}

--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -47,6 +47,9 @@ export const App = () => {
   const completedIntro = useSelector(configSelectors.completedIntro);
   const dispatch = useDispatch();
   const debug = process.env.NODE_ENV === "development";
+  // the skipintro cookie is set by Cypress to make integration testing easier
+  const skipIntro = getCookie("skipintro");
+  const skipSetupIntro = getCookie("skipsetupintro");
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
@@ -71,9 +74,6 @@ export const App = () => {
   }, [dispatch, connected]);
 
   useEffect(() => {
-    // the skipintro cookie is set by Cypress to make integration testing easier
-    const skipIntro = getCookie("skipintro");
-    const skipSetupIntro = getCookie("skipsetupintro");
     if (!skipIntro && configLoaded) {
       // Explicitly check that completedIntro is false so that it doesn't redirect
       // if the config isn't defined yet.
@@ -83,7 +83,7 @@ export const App = () => {
         navigateToLegacy("/intro/user");
       }
     }
-  }, [authUser, completedIntro, configLoaded]);
+  }, [authUser, completedIntro, configLoaded, skipIntro, skipSetupIntro]);
 
   let content;
   if (authLoading || connecting || authenticating) {
@@ -127,7 +127,10 @@ export const App = () => {
       <Header
         appendNewBase={false}
         authUser={authUser}
-        completedIntro={completedIntro && authUser && authUser.completed_intro}
+        completedIntro={
+          (completedIntro && authUser && authUser.completed_intro) ||
+          !!skipIntro
+        }
         debug={debug}
         enableAnalytics={analyticsEnabled}
         generateLegacyLink={(link, linkClass, appendNewBase) => (


### PR DESCRIPTION
## Done

- In the Cypress tests, the intro is skipped by setting a cookie. This allowed access to the rest of the app but did not update the navigation. This was only apparent on fresh MAAS installs that had not yet completed the setup or user intros.
- Fixed screenshot upload and removed video upload

## QA

### QA steps

- Checkout master, run the UI (`yarn start`) and run Cypress in separate terminals (`yarn cypress-open`).
- Click "Run all specs" in the Cypress interactive runner and confirm that the tests regarding navigation all fail, except for user preferences.
- Checkout this branch
- Create a new user and update the `integration/cypress.json` env variables with their credentials.
- Run all Cypress specs and check that all of the tests regarding navigation pass. There will be some failed tests due to MAAS having gone through the setup intro already and the UI running in development. A full, "proper" QA would involve building a new MAAS snap and running Cypress on that, but I think checking that the navigation tests pass should be enough.

## Fixes

Fixes #1795 
