### PR TITLE
fix(ui): return to the correct login screen when logging out with external auth

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,6 +1,16 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
+    "src/app/App.test.tsx:4181464368": [
+      [30, 16, 24, "Type \'Factory<NavigationOptions>\' is not assignable to type \'NavigationOptions | ArrayFactory<never> | AttributeFunction<NavigationOptions | null> | Factory<NavigationOptions | null> | DerivedFunction<...> | null | undefined\'.\\n  Type \'Factory<NavigationOptions>\' is not assignable to type \'Factory<NavigationOptions | null>\'.\\n    Types of parameters \'override\' and \'override\' are incompatible.\\n      Type \'Partial<Config<NavigationOptions>> | null | undefined\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.\\n        Type \'null\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.", "3717115723"],
+      [149, 4, 36, "Object is possibly \'null\'.", "1039669632"],
+      [162, 4, 36, "Object is possibly \'null\'.", "1039669632"]
+    ],
+    "src/app/App.tsx:3872899616": [
+      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
+      [188, 17, 17, "Object is possibly \'null\'.", "2133029343"],
+      [193, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
+    ],
     "src/app/base/components/ActionForm/ActionForm.test.tsx:224588637": [
       [42, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [42, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
@@ -443,7 +453,7 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:2660496186": [
       [10, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:4101357281": [
+    "src/testing/factories/state.ts:1321822561": [
       [230, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
       [309, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2158674347"],
       [311, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2087809207"],
@@ -596,5 +606,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `446`
+  value: `444`
 };

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { Link, useHistory, useLocation } from "react-router-dom";
 import { Spinner, Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { usePrevious } from "@canonical/react-components/dist/hooks";
 import React, { useEffect } from "react";
 import * as Sentry from "@sentry/browser";
 
@@ -28,7 +29,18 @@ import Routes from "app/Routes";
 import Section from "app/base/components/Section";
 import status from "app/store/status/selectors";
 
-export const App = () => {
+declare global {
+  interface Window {
+    legacyWS: WebSocket;
+  }
+}
+
+type LinkType = {
+  label: string;
+  url: string;
+};
+
+export const App = (): JSX.Element => {
   const history = useHistory();
   const location = useLocation();
   const authUser = useSelector(authSelectors.get);
@@ -47,6 +59,7 @@ export const App = () => {
   const completedIntro = useSelector(configSelectors.completedIntro);
   const dispatch = useDispatch();
   const debug = process.env.NODE_ENV === "development";
+  const previousAuthenticated = usePrevious(authenticated, false);
   // the skipintro cookie is set by Cypress to make integration testing easier
   const skipIntro = getCookie("skipintro");
   const skipSetupIntro = getCookie("skipsetupintro");
@@ -54,6 +67,14 @@ export const App = () => {
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
   }, [dispatch]);
+
+  useEffect(() => {
+    // When a user logs out the redux store is reset so the authentication
+    // info needs to be fetched again to know if external auth is being used.
+    if (previousAuthenticated && !authenticated) {
+      dispatch(statusActions.checkAuthenticated());
+    }
+  }, [authenticated, dispatch, previousAuthenticated]);
 
   useEffect(() => {
     if (authenticated) {
@@ -85,7 +106,7 @@ export const App = () => {
     }
   }, [authUser, completedIntro, configLoaded, skipIntro, skipSetupIntro]);
 
-  let content;
+  let content: JSX.Element;
   if (authLoading || connecting || authenticating) {
     content = (
       <Section
@@ -133,7 +154,11 @@ export const App = () => {
         }
         debug={debug}
         enableAnalytics={analyticsEnabled}
-        generateLegacyLink={(link, linkClass, appendNewBase) => (
+        generateLegacyLink={(
+          link: LinkType,
+          linkClass: string,
+          _appendNewBase: boolean
+        ) => (
           <a
             className={linkClass}
             href={generateLegacyURL(link.url)}
@@ -144,7 +169,11 @@ export const App = () => {
             {link.label}
           </a>
         )}
-        generateNewLink={(link, linkClass, appendNewBase) => (
+        generateNewLink={(
+          link: LinkType,
+          linkClass: string,
+          _appendNewBase: boolean
+        ) => (
           <Link className={linkClass} to={link.url}>
             {link.label}
           </Link>

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -261,10 +261,10 @@ export const generalState = define<GeneralState>({
 export const statusState = define<StatusState>({
   authenticated: false,
   authenticating: false,
-  authenticationError: () => ({}),
+  authenticationError: null,
   connected: false,
   connecting: false,
-  error: () => ({}),
+  error: null,
   externalAuthURL: "http://example.com/auth",
   externalLoginURL: "http://example.com/login",
   noUsers: false,


### PR DESCRIPTION
## Done

- When using external auth return to the external auth login screen after logging out.
- Update App to typescript.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Setup your maas to use external auth (ask me).
- Log in and then log out, you should be returned to the external auth login screen.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1794.