### PR TITLE
fix(legacy): fix the legacy navigation css

### DIFF
--- a/legacy/src/scss/_patterns_navigation.scss
+++ b/legacy/src/scss/_patterns_navigation.scss
@@ -1,0 +1,27 @@
+@mixin maas-navigation {
+  $breakpoint-hardware-menu: 1200px;
+
+  .hardware-menu {
+    display: none;
+
+    @media (min-width: $breakpoint-navigation-threshold) and (max-width: $breakpoint-hardware-menu) {
+      display: inherit;
+    }
+  }
+
+  .u-hide--hardware-menu-threshold {
+    @media (min-width: $breakpoint-navigation-threshold) and (max-width: $breakpoint-hardware-menu) {
+      display: none;
+    }
+  }
+
+  // This is fixed in Vanilla > 2.4.0, but is hardcoded here because we aren't
+  // committing to a full upgrade.
+  @media (max-width: $breakpoint-navigation-threshold) {
+    .p-navigation.is-dark .p-navigation__link > a::before {
+      background: hsl(0, 0%, 27%);
+      left: map-get($grid-gutter-widths, small);
+      right: map-get($grid-gutter-widths, small);
+    }
+  }
+}

--- a/legacy/src/scss/build.scss
+++ b/legacy/src/scss/build.scss
@@ -28,6 +28,7 @@
 @import "patterns_cta";
 @import "patterns_code";
 @import "patterns_icons";
+@import "patterns_navigation";
 @import "patterns_numa";
 @import "patterns_page-header";
 @import "patterns_tabs";
@@ -52,6 +53,7 @@
 @include maas-b-links;
 @include maas-action-button;
 @include maas-icons;
+@include maas-navigation;
 @include maas-numa-card;
 @include maas-page-header;
 @include maas-tabs;


### PR DESCRIPTION
## Done

- Restore the legacy navigation css so that it looks correct when the hardware menu is shown.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to a legacy page.
- Resize your window until the hardware menu is shown.
- Check that the items in the menu don't also appear in the main nav.

Fixes https://github.com/canonical-web-and-design/maas-ui/issues/1799