### PR TITLE
fix(cypress): remove header RSD test

### DIFF
--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -46,12 +46,6 @@ context("Header", () => {
     cy.get(".p-navigation__link.is-selected a").contains("KVM");
   });
 
-  it("navigates to rsd", () => {
-    cy.get(".p-navigation__link a:contains(RSD)").click();
-    cy.location("pathname").should("eq", generateNewURL("/rsd"));
-    cy.get(".p-navigation__link.is-selected a").contains("RSD");
-  });
-
   it("navigates to images", () => {
     cy.get(".p-navigation__link a:contains(Images)").click();
     cy.location("pathname").should("eq", generateLegacyURL("/images"));


### PR DESCRIPTION
##  Done

- We don't currently have a method for adding RSDs in our Cypress CI setup (fake or real), so the test has been removed as it will otherwise always fail.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- No QA
