### PR TITLE
feat(ui): add the machine details notifications

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -7,7 +7,7 @@ exports[`stricter compilation`] = {
       [162, 4, 36, "Object is possibly \'null\'.", "1039669632"]
     ],
     "src/app/App.tsx:3872899616": [
-      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
+      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
       [188, 17, 17, "Object is possibly \'null\'.", "2133029343"],
       [193, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
@@ -44,7 +44,7 @@ exports[`stricter compilation`] = {
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -86,7 +86,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -328,10 +328,10 @@ exports[`stricter compilation`] = {
       [45, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [49, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineDetails.tsx:1423715566": [
-      [27, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
-      [29, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
-      [33, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
+    "src/app/machines/views/MachineDetails/MachineDetails.tsx:3349853769": [
+      [28, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
+      [30, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
+      [34, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
     ],
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:7094616": [
       [33, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]

--- a/ui/package.json
+++ b/ui/package.json
@@ -88,7 +88,7 @@
     "@betterer/regexp": "3.1.0",
     "@betterer/reporter": "3.1.0",
     "@betterer/typescript": "3.1.0",
-    "@testing-library/react-hooks": "^3.4.2",
+    "@testing-library/react-hooks": "3.4.2",
     "@typescript-eslint/eslint-plugin": "4.6.0",
     "@typescript-eslint/parser": "4.6.0",
     "babel-eslint": "10.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -88,6 +88,7 @@
     "@betterer/regexp": "3.1.0",
     "@betterer/reporter": "3.1.0",
     "@betterer/typescript": "3.1.0",
+    "@testing-library/react-hooks": "^3.4.2",
     "@typescript-eslint/eslint-plugin": "4.6.0",
     "@typescript-eslint/parser": "4.6.0",
     "babel-eslint": "10.1.0",

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from "react";
 import type { RouteParams } from "app/base/types";
 import { machine as machineActions } from "app/base/actions";
 import MachineHeader from "./MachineHeader";
+import MachineNotifications from "./MachineNotifications";
 import machineSelectors from "app/store/machine/selectors";
 import MachineSummary from "./MachineSummary";
 import Section from "app/base/components/Section";
@@ -50,6 +51,7 @@ const MachineDetails = (): JSX.Element => {
       }
       headerClassName="u-no-padding--bottom"
     >
+      <MachineNotifications />
       {machine && (
         <Switch>
           <Route exact path="/machine/:id/summary">

--- a/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
@@ -62,7 +62,18 @@ describe("MachineNotifications", () => {
   });
 
   it("can display a power error", () => {
-    state.machine.items[0].power_state = "error";
+    state.machine.items = [
+      machineFactory({
+        architecture: "amd64",
+        events: [
+          machineEventFactory({
+            description: "machine timed out",
+          }),
+        ],
+        power_state: "error",
+        system_id: "abc123",
+      }),
+    ];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -82,9 +93,7 @@ describe("MachineNotifications", () => {
         .findWhere(
           (n) =>
             n.name() === "Notification" &&
-            n
-              .text()
-              .includes("Script - smartctl-validate on name-VZJoCN timed out")
+            n.text().includes("Script - machine timed out")
         )
         .exists()
     ).toBe(true);

--- a/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
@@ -1,0 +1,204 @@
+import { MemoryRouter, Route } from "react-router-dom";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  architecturesState as architecturesStateFactory,
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineEvent as machineEventFactory,
+  machineState as machineStateFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import MachineNotifications from "./MachineNotifications";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("MachineNotifications", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      general: generalStateFactory({
+        architectures: architecturesStateFactory({
+          data: ["amd64"],
+        }),
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+        }),
+      }),
+      machine: machineStateFactory({
+        items: [
+          machineFactory({
+            architecture: "amd64",
+            events: [machineEventFactory()],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("handles no notifications", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <MachineNotifications />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(false);
+  });
+
+  it("can display a power error", () => {
+    state.machine.items[0].power_state = "error";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <MachineNotifications />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.name() === "Notification" &&
+            n
+              .text()
+              .includes("Script - smartctl-validate on name-VZJoCN timed out")
+        )
+        .exists()
+    ).toBe(true);
+  });
+
+  it("can display a rack connection error", () => {
+    state.general.powerTypes.data = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <MachineNotifications />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.name() === "Notification" &&
+            n.text().includes("no rack controller is currently connected")
+        )
+        .exists()
+    ).toBe(true);
+  });
+
+  it("can display an architecture error", () => {
+    state.machine.items[0].architecture = "";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <MachineNotifications />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.name() === "Notification" &&
+            n
+              .text()
+              .includes("This machine currently has an invalid architecture")
+        )
+        .exists()
+    ).toBe(true);
+  });
+
+  it("can display a boot images error", () => {
+    state.general.architectures = architecturesStateFactory({
+      data: [],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <MachineNotifications />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.name() === "Notification" &&
+            n.text().includes("No boot images have been imported")
+        )
+        .exists()
+    ).toBe(true);
+  });
+
+  it("can display a hardware error", () => {
+    state.machine.items[0].cpu_count = 0;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <MachineNotifications />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.name() === "Notification" &&
+            n.text().includes("Commission this machine to get CPU")
+        )
+        .exists()
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.tsx
@@ -1,0 +1,132 @@
+import { Link } from "react-router-dom";
+import { Notification, Spinner } from "@canonical/react-components";
+import { useParams } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
+import React, { useEffect } from "react";
+
+import { general as generalActions } from "app/base/actions";
+import {
+  useCanEdit,
+  useHasInvalidArchitecture,
+  useIsRackControllerConnected,
+} from "app/store/machine/utils";
+import generalSelectors from "app/store/general/selectors";
+import LegacyLink from "app/base/components/LegacyLink";
+import machineSelectors from "app/store/machine/selectors";
+import type { RootState } from "app/store/root/types";
+import type { Event } from "app/store/machine/types";
+
+type RouteParams = {
+  id: string;
+};
+
+const formatEventText = (event: Event) => {
+  if (!event) {
+    return "";
+  }
+  const text = [];
+  if (event.type?.description) {
+    text.push(event.type.description);
+  }
+  if (event.description) {
+    text.push(event.description);
+  }
+  return text.join(" - ");
+};
+
+const MachineNotifications = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const params = useParams<RouteParams>();
+  const { id } = params;
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+  const architectures = useSelector(generalSelectors.architectures.get);
+  const hasUsableArchitectures = architectures.length > 0;
+  const canEdit = useCanEdit(machine, true);
+  const isRackControllerConnected = useIsRackControllerConnected();
+  const hasInvalidArchitecture = useHasInvalidArchitecture(machine);
+
+  useEffect(() => {
+    dispatch(generalActions.fetchArchitectures());
+  }, [dispatch]);
+
+  // Confirm that the full machine details have been fetched. This also allows
+  // TypeScript know we're using the right union type (otherwise it will
+  // complain that events don't exist on the base machine type).
+  if (!machine || !("events" in machine)) {
+    return <Spinner />;
+  }
+  const notifications = [
+    {
+      active: machine.power_state === "error" && machine.events?.length > 0,
+      content: (
+        <>
+          {formatEventText(machine.events[0])}.{" "}
+          <Link
+            to={`/machine/${machine.system_id}/logs`}
+            className="p-notification__action"
+          >
+            See logs
+          </Link>
+        </>
+      ),
+      status: "Error:",
+      type: "negative",
+    },
+    {
+      active: canEdit && !isRackControllerConnected,
+      content:
+        "Editing is currently disabled because no rack controller is currently connected to the region.",
+      status: "Error:",
+      type: "negative",
+    },
+    {
+      active:
+        canEdit &&
+        hasInvalidArchitecture &&
+        isRackControllerConnected &&
+        hasUsableArchitectures,
+      content:
+        "This machine currently has an invalid architecture. Update the architecture of this machine to make it deployable.",
+      status: "Error:",
+      type: "negative",
+    },
+    {
+      active:
+        canEdit &&
+        hasInvalidArchitecture &&
+        isRackControllerConnected &&
+        !hasUsableArchitectures,
+      content: (
+        <>
+          No boot images have been imported for a valid architecture to be
+          selected. Visit the{" "}
+          <LegacyLink route="/images">images page</LegacyLink> to start the
+          import process.
+        </>
+      ),
+      status: "Error:",
+      type: "negative",
+    },
+    {
+      active: machine.cpu_count === 0,
+      content:
+        "Commission this machine to get CPU, Memory and Storage information.",
+    },
+  ].filter(({ active }) => active);
+
+  return (
+    <section className="p-strip u-no-padding--top u-no-padding--bottom">
+      <div className="row">
+        {notifications.map(({ content, status, type }, i) => (
+          <Notification key={i} status={status} type={type}>
+            {content}
+          </Notification>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default MachineNotifications;

--- a/ui/src/app/machines/views/MachineDetails/MachineNotifications/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNotifications/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineNotifications";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/_index.scss
@@ -5,6 +5,8 @@
       [row1-start] "overview-card overview-card overview-card overview-card" min-content [row1-end]
       [row2-start] "system-card numa-card network-card network-card" min-content [row2-end]
       / 1fr 1fr 1fr 1fr;
+    padding-left: 0;
+    padding-right: 0;
 
     @media only screen and (max-width: $breakpoint-x-large) {
       grid:

--- a/ui/src/app/store/machine/utils.test.tsx
+++ b/ui/src/app/store/machine/utils.test.tsx
@@ -89,6 +89,9 @@ describe("machine utils", () => {
 
   describe("useIsRackControllerConnected", () => {
     it("handles a connected state", () => {
+      state.general.powerTypes = powerTypesStateFactory({
+        data: [powerTypeFactory()],
+      });
       const store = mockStore(state);
       const { result } = renderHook(() => useIsRackControllerConnected(), {
         wrapper: generateWrapper(store),

--- a/ui/src/app/store/machine/utils.test.tsx
+++ b/ui/src/app/store/machine/utils.test.tsx
@@ -1,0 +1,154 @@
+import { Provider } from "react-redux";
+import { renderHook } from "@testing-library/react-hooks";
+import configureStore from "redux-mock-store";
+import React from "react";
+import type { MockStoreEnhanced } from "redux-mock-store";
+import type { ReactNode } from "react";
+
+import {
+  architecturesState as architecturesStateFactory,
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineEvent as machineEventFactory,
+  machineState as machineStateFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+import {
+  useCanEdit,
+  useHasInvalidArchitecture,
+  useIsRackControllerConnected,
+} from "./utils";
+
+const mockStore = configureStore();
+
+const generateWrapper = (store: MockStoreEnhanced<unknown>) => ({
+  children,
+}: {
+  children: ReactNode;
+}) => <Provider store={store}>{children}</Provider>;
+
+describe("machine utils", () => {
+  let state: RootState;
+  let machine: Machine | null;
+
+  beforeEach(() => {
+    machine = machineFactory({
+      architecture: "amd64",
+      events: [machineEventFactory()],
+      locked: false,
+      permissions: ["edit"],
+      system_id: "abc123",
+    });
+    state = rootStateFactory({
+      general: generalStateFactory({
+        architectures: architecturesStateFactory({
+          data: ["amd64"],
+        }),
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+        }),
+      }),
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+    });
+  });
+
+  describe("useHasInvalidArchitecture", () => {
+    it("can return a valid result", () => {
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasInvalidArchitecture(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("handles a machine that has no architecture", () => {
+      state.machine.items[0].architecture = "";
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasInvalidArchitecture(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("handles an architecture with no match", () => {
+      state.machine.items[0].architecture = "unknown";
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasInvalidArchitecture(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("useIsRackControllerConnected", () => {
+    it("handles a connected state", () => {
+      const store = mockStore(state);
+      const { result } = renderHook(() => useIsRackControllerConnected(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("handles a disconnected state", () => {
+      state.general.powerTypes.data = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useIsRackControllerConnected(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("useCanEdit", () => {
+    it("handles an editable machine", () => {
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("handles incorrect permissions", () => {
+      state.machine.items[0].permissions = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("handles a locked machine", () => {
+      state.machine.items[0].locked = true;
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("handles a disconnected rack controller", () => {
+      state.general.powerTypes.data = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("can ignore the rack controller state", () => {
+      state.general.powerTypes.data = [];
+      const store = mockStore(state);
+      const { result } = renderHook(() => useCanEdit(machine, true), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { general as generalActions } from "app/base/actions";
+import generalSelectors from "app/store/general/selectors";
+import type { Machine } from "app/store/machine/types";
+
+/**
+ * Check if a machine has an invalid architecture.
+ * @param machine - A machine object.
+ * @returns Whether the machine has an invalid architecture.
+ */
+export const useHasInvalidArchitecture = (
+  machine?: Machine | null
+): boolean => {
+  const dispatch = useDispatch();
+  const architectures = useSelector(generalSelectors.architectures.get);
+
+  useEffect(() => {
+    dispatch(generalActions.fetchArchitectures());
+  }, [dispatch]);
+
+  if (!machine) {
+    return false;
+  }
+
+  return (
+    machine.architecture === "" || !architectures.includes(machine.architecture)
+  );
+};
+
+/**
+ * Check if the rack controller is connected.
+ * @returns Whether the rack controller is connected.
+ */
+export const useIsRackControllerConnected = (): boolean => {
+  const dispatch = useDispatch();
+  const powerTypes = useSelector(generalSelectors.powerTypes.get);
+
+  useEffect(() => {
+    dispatch(generalActions.fetchPowerTypes());
+  }, [dispatch]);
+
+  // If power types exist then a rack controller is connected.
+  return powerTypes.length > 0;
+};
+
+/**
+ * Check if a machine can be edited.
+ * @param machine - A machine object.
+ * @param ignoreRackControllerConnection - Whether the editable check should
+ *                                         include whether the rack controller
+ *                                          is connected.
+ * @returns Whether the machine can be edited.
+ */
+export const useCanEdit = (
+  machine?: Machine | null,
+  ignoreRackControllerConnection = false
+): boolean => {
+  const isRackControllerConnected = useIsRackControllerConnected();
+  if (!machine) {
+    return false;
+  }
+  return (
+    machine.permissions.includes("edit") &&
+    !machine.locked &&
+    (ignoreRackControllerConnection || isRackControllerConnected)
+  );
+};

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -53,6 +53,8 @@ export {
   machine,
   machineDetails,
   machineDevice,
+  machineEvent,
+  machineEventType,
   machineNumaNode,
   controller,
   pod,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -3,6 +3,8 @@ import { define, extend, random, sequence } from "cooky-cutter";
 import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
 import type {
+  Event,
+  EventType,
   Machine,
   MachineDetails,
   MachineDevice,
@@ -130,6 +132,18 @@ export const machineNumaNode = define<MachineNumaNode>({
   hugepages_set: () => [],
   index: sequence,
   memory: 256,
+});
+
+export const machineEventType = extend<Model, EventType>(model, {
+  description: "Script",
+  level: "info",
+  name: "SCRIPT_DID_NOT_COMPLETE",
+});
+
+export const machineEvent = extend<Model, Event>(model, {
+  created: "Mon, 19 Oct. 2020 07:04:37",
+  description: "smartctl-validate on name-VZJoCN timed out",
+  type: machineEventType,
 });
 
 export const machineDetails = extend<Machine, MachineDetails>(machine, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,7 +3053,7 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@testing-library/react-hooks@^3.4.2":
+"@testing-library/react-hooks@3.4.2":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz#8deb94f7684e0d896edd84a4c90e5b79a0810bc2"
   integrity sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,7 +1987,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.5.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
   integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
@@ -3053,6 +3053,14 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@testing-library/react-hooks@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz#8deb94f7684e0d896edd84a4c90e5b79a0810bc2"
+  integrity sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.4.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -3348,6 +3356,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
+  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.0.tgz#882839db465df1320e4753e6e9f70ca7e9b4d46d"
@@ -3414,6 +3429,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/testing-library__react-hooks@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
+  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/uglify-js@*":
   version "3.9.2"


### PR DESCRIPTION
## Done

- Add notifications and warnings to the machine details.
- Add hooks for different machine states.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- There are a number of different states to make these notifications appear, I recommend using sampledata which shows most of these notifications or modify `MachineNotifications` to make all the notifications active.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2113.