### PR TITLE
feat(ui): add action/selector/reducer for setting active machines.

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -248,11 +248,11 @@ exports[`stricter compilation`] = {
       [122, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"],
       [136, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
     ],
-    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2776231238": [
+    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2858846500": [
       [106, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [110, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
-      [200, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [204, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
+      [201, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [205, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
     "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx:1528444456": [
       [106, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
@@ -260,17 +260,17 @@ exports[`stricter compilation`] = {
       [135, 27, 10, "Property \'commission\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "2592181864"],
       [155, 42, 25, "Argument of type \'(Scripts | undefined)[]\' is not assignable to parameter of type \'Scripts[]\'.\\n  Type \'Scripts | undefined\' is not assignable to type \'Scripts\'.\\n    Type \'undefined\' is not assignable to type \'Scripts\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "4025185665"]
     ],
-    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx:162397730": [
+    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx:1194028480": [
       [139, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [140, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
-      [209, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [210, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
-      [256, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [257, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
-      [305, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [306, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"],
-      [354, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [355, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"]
+      [210, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [211, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
+      [257, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [258, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
+      [306, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [307, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"],
+      [355, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [356, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"]
     ],
     "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx:2382076300": [
       [97, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"],
@@ -289,13 +289,13 @@ exports[`stricter compilation`] = {
       [67, 4, 14, "Type \'([file]: [any]) => void\' is not assignable to type \'<T extends File>(files: T[], event: DropEvent) => void\'.\\n  Types of parameters \'__0\' and \'files\' are incompatible.\\n    Type \'T[]\' is not assignable to type \'[any]\'.\\n      Target requires 1 element(s) but source may have fewer.", "3837758380"],
       [100, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
     ],
-    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx:626866004": [
+    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx:2328625110": [
       [63, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [64, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"],
       [118, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [119, 8, 11, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "942845580"],
-      [162, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [163, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"]
+      [163, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [164, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"]
     ],
     "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:4230109469": [
       [50, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
@@ -322,14 +322,16 @@ exports[`stricter compilation`] = {
       [85, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"],
       [96, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
-    "src/app/machines/hooks.tsx:3237848671": [
-      [51, 4, 65, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 51 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 51 more ...; saving: (state: RootState) => boolean; }\'.", "2485430307"],
-      [51, 26, 6, "Object is possibly \'undefined\'.", "1314712411"],
-      [51, 45, 6, "Object is possibly \'undefined\'.", "1314712411"],
-      [55, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[] | (BaseMachine | MachineDetails | null)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n    Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n      Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
+    "src/app/machines/hooks.tsx:3635236711": [
+      [45, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
+      [45, 37, 6, "Object is possibly \'undefined\'.", "1314712411"],
+      [45, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
+      [49, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineDetails.tsx:2503184678": [
-      [27, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    "src/app/machines/views/MachineDetails/MachineDetails.tsx:1423715566": [
+      [27, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
+      [29, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
+      [33, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
     ],
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:7094616": [
       [33, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
@@ -409,7 +411,7 @@ exports[`stricter compilation`] = {
     "src/app/store/pod/reducers.test.ts:25266970": [
       [77, 38, 10, "Expected 1 arguments, but got 0.", "2565503122"]
     ],
-    "src/app/store/pod/slice.ts:1686133448": [
+    "src/app/store/pod/slice.ts:995813338": [
       [55, 56, 11, "Type \'PodReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Pod, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'{ errors: any; items: ({ id: number; architectures: string[]; available: { cores: number; local_storage: number; local_storage_gb: string; memory: number; memory_gb: string; }; capabilities: string[]; ... 24 more ...; zone: number; } | { ...; })[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is missing the following properties from type \'{ active: number | null; selected: number[]; statuses: { [x: number]: { composing: boolean; deleting: boolean; refreshing: boolean; }; }; errors: any; items: ({ id: number; architectures: string[]; available: { ...; }; ... 25 more ...; zone: number; } | { ...; })[]; loaded: boolean; loading: boolean; saved: boolean;...\': active, selected, statuses", "1022550047"],
       [56, 16, 71, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'PodState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ active: null; selected: never[]; statuses: {}; }\' is missing the following properties from type \'GenericState<Pod, any>\': errors, items, loaded, loading, and 2 more.", "3283281399"]
     ],
@@ -486,11 +488,11 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:2660496186": [
       [10, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:1428613834": [
-      [231, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
-      [310, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2158674347"],
-      [312, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2087809207"],
-      [317, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<PoorMansUnknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:3687536065": [
+      [232, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
+      [311, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2158674347"],
+      [313, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2087809207"],
+      [318, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<PoorMansUnknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -550,9 +552,9 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [11, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:1236906617": [
+    "src/app/store/machine/types.ts:1368476588": [
       [3, 13, 8, "RegExp match", "1152173309"],
-      [294, 9, 8, "RegExp match", "1152173309"]
+      [295, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/notification/types.ts:2586887406": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -125,6 +125,7 @@ Object {
     "loading": false,
   },
   "machine": Object {
+    "active": null,
     "errors": Object {},
     "items": Array [],
     "loaded": false,

--- a/ui/src/app/base/actions/machine/machine.js
+++ b/ui/src/app/base/actions/machine/machine.js
@@ -29,6 +29,20 @@ machine.get = (system_id) => {
   };
 };
 
+machine.setActive = (system_id) => {
+  return {
+    type: "SET_ACTIVE_MACHINE",
+    meta: {
+      model: "machine",
+      method: "set_active",
+    },
+    payload: {
+      // Server unsets active item if primary key (system_id) is not sent.
+      params: system_id ? { system_id } : null,
+    },
+  };
+};
+
 machine.create = (params) => {
   return {
     type: "CREATE_MACHINE",

--- a/ui/src/app/base/actions/machine/machine.test.js
+++ b/ui/src/app/base/actions/machine/machine.test.js
@@ -28,6 +28,19 @@ describe("machine actions", () => {
     });
   });
 
+  it("can set an active machine", () => {
+    expect(machine.setActive("abc123")).toEqual({
+      type: "SET_ACTIVE_MACHINE",
+      meta: {
+        model: "machine",
+        method: "set_active",
+      },
+      payload: {
+        params: { system_id: "abc123" },
+      },
+    });
+  });
+
   it("can handle creating machines", () => {
     expect(
       machine.create({ name: "machine1", description: "a machine" })

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -169,6 +169,13 @@ const machine = createNextState(
         draft.saved = true;
         draft.saving = false;
         break;
+      case "SET_ACTIVE_MACHINE_SUCCESS":
+        draft.active = action.payload?.system_id || null;
+        break;
+      case "SET_ACTIVE_MACHINE_ERROR":
+        draft.errors = action.error;
+        draft.active = null;
+        break;
       case "ADD_MACHINE_CHASSIS_ERROR":
       case "FETCH_MACHINE_ERROR":
       case "GET_MACHINE_ERROR":
@@ -237,6 +244,7 @@ const machine = createNextState(
     }
   },
   {
+    active: null,
     errors: {},
     items: [],
     loaded: false,

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -181,6 +181,7 @@ describe("CommissionForm", () => {
 
   it("correctly dispatches action to commission machine from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -190,6 +190,7 @@ describe("DeployForm", () => {
 
   it("correctly dispatches action to deploy machine from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
@@ -70,7 +70,7 @@ describe("FieldlessForm", () => {
     expect(wrapper.find("FieldlessForm")).toMatchSnapshot();
   });
 
-  it("can unset the selected action on selected machines", () => {
+  it("can unset the selected action", () => {
     const state = { ...initialState };
     state.machine.items = [{ system_id: "a", actions: ["release"] }];
     state.machine.selected = ["a"];
@@ -156,6 +156,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch abort action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -239,6 +240,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch acquire action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -323,6 +325,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch delete action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -411,6 +414,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch exit rescue mode action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -497,6 +501,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch lock action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -581,6 +586,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch mark fixed action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -665,6 +671,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch power off action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -749,6 +756,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch power on action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -833,6 +841,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch release action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -917,6 +926,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch unlock action from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -143,6 +143,7 @@ describe("MarkBrokenForm", () => {
 
   it("correctly dispatches action to mark machine broken from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -246,6 +246,7 @@ describe("OverrideTestForm", () => {
   it(`correctly dispatches action to override failed testing of machine from
     details view`, () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -293,6 +294,7 @@ describe("OverrideTestForm", () => {
   it(`correctly dispatches action to suppress test results of machine from
     details view`, () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
@@ -131,6 +131,7 @@ describe("SetPoolForm", () => {
   });
 
   it("correctly dispatches action to set machine pool from details view", () => {
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
@@ -111,6 +111,7 @@ describe("SetZoneForm", () => {
   });
 
   it("correctly dispatches action to set machine zone from details view", () => {
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.js
@@ -123,6 +123,7 @@ describe("TagForm", () => {
 
   it("correctly dispatches action to tag machine from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.js
@@ -145,6 +145,7 @@ describe("TestForm", () => {
 
   it("correctly dispatches action to test machine from details view", () => {
     const state = { ...initialState };
+    state.machine.active = "abc123";
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/hooks.tsx
+++ b/ui/src/app/machines/hooks.tsx
@@ -1,13 +1,10 @@
 import { useCallback } from "react";
 import { useSelector } from "react-redux";
-import { useParams } from "react-router";
 
 import { ACTIONS } from "app/base/reducers/machine/machine";
-import type { RouteParams } from "app/base/types";
 import type { MachineActionName } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 
 /**
  * Create a callback for toggling the menu
@@ -26,10 +23,10 @@ export const useToggleMenu = (
 };
 
 /**
- * Determine the machines to perform an action on. If "id" is present in the
- * route params, this means the app is in the machine details view so the action
- * need only be performed on that machine. Otherwise, perform the action on the
- * machines selected in state.
+ * Determine the machines to perform an action on. If a machine is "active",
+ * this means the app is in the machine details view so the action need only be
+ * performed on that machine. Otherwise, perform the action on the machines
+ * selected in state.
  * @param actionName - The name of the machine action e.g. "commission".
  * @returns object with machines to perform action on and count of currently
  * processing machines.
@@ -40,18 +37,15 @@ export const useMachineActionForm = (
   machinesToAction: Machine[];
   processingCount: number;
 } => {
-  const { id } = useParams<RouteParams>();
-  const machineFromID = useSelector((state: RootState) =>
-    machineSelectors.getById(state, id)
-  );
+  const activeMachine = useSelector(machineSelectors.active);
   const selectedMachines = useSelector(machineSelectors.selected);
   const action = ACTIONS.find((action) => action.name === actionName);
   // If in the machine details view, the machine is not in selected state so
   // instead we use the regular selector.
   const processingMachines = useSelector(
-    machineSelectors[id ? action.status : `${action.status}Selected`]
+    machineSelectors[activeMachine ? action.status : `${action.status}Selected`]
   ) as Machine[];
-  const machinesToAction = id ? [machineFromID] : selectedMachines;
+  const machinesToAction = activeMachine ? [activeMachine] : selectedMachines;
 
   return { machinesToAction, processingCount: processingMachines.length };
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import React from "react";
 
@@ -22,6 +22,38 @@ describe("MachineDetails", () => {
         items: [machineFactory({ system_id: "abc123" })],
         loaded: true,
       }),
+    });
+  });
+
+  it("dispatches an action to set the machine as active", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <MachineDetails />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().find((action) => action.type === "SET_ACTIVE_MACHINE")
+    ).toEqual({
+      meta: {
+        method: "set_active",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          system_id: "abc123",
+        },
+      },
+      type: "SET_ACTIVE_MACHINE",
     });
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -26,6 +26,13 @@ const MachineDetails = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(machineActions.get(id));
+    // Set machine as active to ensure all machine data is sent from the server.
+    dispatch(machineActions.setActive(id));
+
+    // Unset active machine on cleanup.
+    return () => {
+      dispatch(machineActions.setActive(null));
+    };
   }, [dispatch, id]);
 
   // If machine has been deleted, redirect to machine list.

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -57,6 +57,26 @@ describe("machine selectors", () => {
     expect(machine.saved(state)).toEqual(true);
   });
 
+  it("can get the active machine's system ID", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        active: "abc123",
+      }),
+    });
+    expect(machine.activeID(state)).toEqual("abc123");
+  });
+
+  it("can get the active machine", () => {
+    const activeMachine = machineFactory();
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        active: activeMachine.system_id,
+        items: [activeMachine],
+      }),
+    });
+    expect(machine.active(state)).toEqual(activeMachine);
+  });
+
   it("can get the errors state", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
@@ -77,17 +97,6 @@ describe("machine selectors", () => {
       }),
     });
     expect(machine.getById(state, "909")).toStrictEqual(items[1]);
-  });
-
-  it("can get the error state", () => {
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        errors: "Uh oh!",
-        items: [],
-        loaded: true,
-      }),
-    });
-    expect(machine.errors(state)).toEqual("Uh oh!");
   });
 
   it("can get the machine statuses", () => {

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -20,6 +20,14 @@ const defaultSelectors = generateBaseSelectors<
 >("machine", "system_id");
 
 /**
+ * Returns currently active machine's system_id.
+ * @param {RootState} state - The redux state.
+ * @returns {Machine["system_id"]} Active machine system_id.
+ */
+const activeID = (state: RootState): Machine["system_id"] | null =>
+  state.machine.active;
+
+/**
  * Returns selected machine system_ids.
  * @param {RootState} state - The redux state.
  * @returns {Machine["system_id"][]} Selected machine system_ids.
@@ -105,6 +113,17 @@ const search = createSelector(
 );
 
 /**
+ * Returns currently active machine.
+ * @param {RootState} state - The redux state.
+ * @returns {Machine} Active machine.
+ */
+const active = createSelector(
+  [defaultSelectors.all, activeID],
+  (machines: Machine[], activeID: Machine["system_id"] | null) =>
+    machines.find((machine) => activeID === machine.system_id)
+);
+
+/**
  * Returns selected machines.
  * @param {RootState} state - The redux state.
  * @returns {Machine[]} Selected machines.
@@ -142,6 +161,8 @@ const selectors = {
   abortingSelected: statusSelectors["abortingSelected"],
   acquiring: statusSelectors["acquiring"],
   acquiringSelected: statusSelectors["acquiringSelected"],
+  active,
+  activeID,
   checkingPower: statusSelectors["checkingPower"],
   checkingPowerSelected: statusSelectors["checkingPowerSelected"],
   commissioning: statusSelectors["commissioning"],

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -292,6 +292,7 @@ export type MachineStatuses = {
 };
 
 export type MachineState = {
+  active: string | null;
   errors: TSFixMe;
   items: Machine[];
   loaded: boolean;

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -129,6 +129,7 @@ export const machineStatuses = define<MachineStatuses>({
 
 export const machineState = define<MachineState>({
   ...defaultState,
+  active: null,
   selected: () => [],
   statuses: () => ({}),
 });


### PR DESCRIPTION
## Done

- Added action/selectors/reducers for setting active machines. Setting a machine as active lets the server know to send all the data of that machine whenever it is updated, otherwise it only sends the data required for the machine list.
- Updated machine reducer tests to use the test factories

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to a machine details page and check that `machine.active` is set to the machine's system_id.
- Perform an action on the machine (any should do) and check that the machine is updated with all of the details data intact.
- Navigate back to the machine list and check that `machine.active` is set back to `null`.

## Fixes

Fixes #1820 