### PR TITLE
fix(legacy): correctly set ttl for address records

### DIFF
--- a/legacy/src/app/partials/domain-details.html
+++ b/legacy/src/app/partials/domain-details.html
@@ -176,7 +176,7 @@
             <maas-obj-field
               subtle="false"
               type="text"
-              key="ttl"
+              key="address_ttl"
               label="TTL"
               placeholder="TTL in seconds (optional)"
               label-width="2"
@@ -507,8 +507,9 @@
                   <maas-obj-field
                     label="TTL"
                     type="text"
-                    key="ttl"
+                    key="address_ttl"
                     placeholder="TTL (default: 30)"
+                    value="{$ row.ttl $}"
                   ></maas-obj-field>
                 </div>
               </div>


### PR DESCRIPTION
## Done

- Use correct key for address record TTL

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Edit the TTL for an address record.
- Ensure it is saved correctly.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
