### PR TITLE
fix(ui): fix the truncation in the machine table

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/canonical-web-and-design/maas-ui/issues",
   "dependencies": {
     "@canonical/macaroon-bakery": "0.3.0",
-    "@canonical/react-components": "0.13.0",
+    "@canonical/react-components": "0.14.0",
     "@maas-ui/maas-ui-shared": "1.3.1",
     "@reduxjs/toolkit": "1.4.0",
     "@sentry/browser": "5.27.1",

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
@@ -27,7 +27,11 @@ const ScriptStatus = ({
     case scriptStatus.FAILED_APPLYING_NETCONF:
     case scriptStatus.FAILED_INSTALLING: {
       return (
-        <Tooltip message="Machine has failed tests." position={tooltipPosition}>
+        <Tooltip
+          message="Machine has failed tests."
+          position={tooltipPosition}
+          positionElementClassName="p-double-row__tooltip-inner"
+        >
           <i className="p-icon--error is-inline" />
           {children}
         </Tooltip>
@@ -39,6 +43,7 @@ const ScriptStatus = ({
         <Tooltip
           message="Machine has tests that have timed out."
           position={tooltipPosition}
+          positionElementClassName="p-double-row__tooltip-inner"
         >
           <i className="p-icon--timed-out is-inline" />
           {children}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -66,6 +66,7 @@ const generateIPAddresses = (machine) => {
             </ul>
           </>
         }
+        positionElementClassName="p-double-row__tooltip-inner"
       >
         {ipAddressesLine}
       </Tooltip>

--- a/ui/src/scss/_patterns_double-row.scss
+++ b/ui/src/scss/_patterns_double-row.scss
@@ -41,4 +41,8 @@
   [class*="p-double-row"] .p-table-menu {
     margin-left: $sph-inner--small / 2;
   }
+
+  .p-double-row__tooltip-inner {
+    display: inline !important;
+  }
 }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -69,12 +69,3 @@ input[type="radio"] {
     margin: 0;
   }
 }
-
-// 20-10-2020 Caleb: ModularTable.scss in react-components v0.13.0 includes
-// styling that overrides .u-hide behaviour in tables. This overrides that
-// override so that expanding tables still get the normal .u-hide behaviour.
-// https://github.com/canonical-web-and-design/vanilla-framework/issues/3337
-.p-table-expanding th.u-hide,
-.p-table-expanding td.u-hide {
-  display: none !important;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,23 +2209,23 @@
   dependencies:
     macaroon "^3.0.4"
 
-"@canonical/react-components@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.13.0.tgz#52e45616798f994658b35159ff8ab144a7901dc4"
-  integrity sha512-IKfhfJzsTKdikZMnxy0CAzbpFJ90e9uV+Fk6O6fPkWtxJbkV5xgpn4VK72j+NM4dWumRs29pJoaVDy+LPfCmsw==
+"@canonical/react-components@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.14.0.tgz#7ec4fc3de31909fefc363bf3eec584237904fd40"
+  integrity sha512-tPgGYzcIfmy27PwMped/VxavPh7xDiJW93UD3QqcEvSHxoc22E5GKmUaVOMtVFcPdgIJ6WhcU/JLG4YdSzHg9g==
   dependencies:
     "@types/jest" "26.0.14"
-    "@types/node" "14.11.4"
-    "@types/react" "16.9.51"
+    "@types/node" "14.11.10"
+    "@types/react" "16.9.53"
     "@types/react-dom" "16.9.8"
-    "@types/react-table" "7.0.23"
+    "@types/react-table" "7.0.24"
     "@types/react-transition-group" "4.4.0"
     classnames "2.2.6"
     prop-types "15.7.2"
-    react-table "7.5.2"
+    react-table "7.6.0"
     react-transition-group "4.4.1"
     react-useportal "1.0.13"
-    vanilla-framework "2.19.1"
+    vanilla-framework "2.19.2"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -3259,10 +3259,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
   integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
 
-"@types/node@14.11.4":
-  version "14.11.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.4.tgz#bf6ea3d5f7b1504232b11acbc40e1ac4c750d3b9"
-  integrity sha512-KmoLCUeW2cWKkEOQ0gQcECuqOc0g7B7zcmRPQNMT4ntNm0luKv3BTLcqIyWpTxkhLDzLTdMus11j/6DROaZdPw==
+"@types/node@14.11.10":
+  version "14.11.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.10.tgz#8c102aba13bf5253f35146affbf8b26275069bef"
+  integrity sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==
 
 "@types/node@14.14.5":
   version "14.14.5"
@@ -3341,10 +3341,10 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-table@7.0.23":
-  version "7.0.23"
-  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.0.23.tgz#77d10ac36be759f6598f2b185865905425b47833"
-  integrity sha512-1L2wFQVm6QcrSUbAdTUpk2PTYX5Wqx11Kh+wuN/kYYRWNI4OGpj3sIn3QAQ1jOwXKpyLMTL6lpEcUfKw2ZEieQ==
+"@types/react-table@7.0.24":
+  version "7.0.24"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.0.24.tgz#ef27334f8da55d7890dc8dbec63a3f873f8d97fe"
+  integrity sha512-71JT+7R+Av1mF249SUAyAvH0Y8ZiI/8Rbbei3ka3ofPtD2yHUhm6XC68WHPoHSwQ71wkscKZfI3EcuxepWC7Mw==
   dependencies:
     "@types/react" "*"
 
@@ -3362,14 +3362,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
-
-"@types/react@16.9.51":
-  version "16.9.51"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.51.tgz#f8aa51ffa9996f1387f63686696d9b59713d2b60"
-  integrity sha512-lQa12IyO+DMlnSZ3+AGHRUiUcpK47aakMMoBG8f7HGxJT8Yfe+WE128HIXaHOHVPReAW0oDS3KAI0JI2DDe1PQ==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
 
 "@types/react@16.9.53":
   version "16.9.53"
@@ -14157,10 +14149,10 @@ react-storage-hooks@4.0.1:
   resolved "https://registry.yarnpkg.com/react-storage-hooks/-/react-storage-hooks-4.0.1.tgz#e30ed5cda48c77c431ecc02ec3824bd615f5b7fb"
   integrity sha512-fetDkT5RDHGruc2NrdD1iqqoLuXgbx6AUpQSQLLkrCiJf8i97EtwJNXNTy3+GRfsATLG8TZgNc9lGRZOaU5yQA==
 
-react-table@7.5.2:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.5.2.tgz#d82ceee3d4d40b119159bce1708f084a95d3435c"
-  integrity sha512-qiceR/gQUOBsO/q1z1wZ3RbRvkRt39Gbzo631HiPuWmo+eTmTgaXDqLGzCmU+bOr81PB6kDxXhoWQR8hiWaUJA==
+react-table@7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.6.0.tgz#83d765b96505b5332d108a2e0c27ab653f5a78c3"
+  integrity sha512-16kRTypBWz9ZwLnPWA8hc3eIC64POzO9GaMBiKaCcVM+0QOQzt0G7ebzGUM8SW0CYUpVM+glv1kMXrWj9tr3Sw==
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"
@@ -16666,11 +16658,6 @@ value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
-
-vanilla-framework@2.19.1:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.19.1.tgz#f071deed5504a5fe2104d6d9b087ce654e190881"
-  integrity sha512-y79SKAwertvgHVAf1PbGxiq6QvVxNI78txilSgESx80HUWBrooT1nXCDUuHC/ySGEq+JUpmVIv0PrmXXilYWdg==
 
 vanilla-framework@2.19.2:
   version "2.19.2"


### PR DESCRIPTION
## Done

- Fix the trunction of some content in the machine list.
- Upgrade react-components. 
- Remove a Vanilla override.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the machine list.
- Reduce your window width until the fabric names are being cut off. They should truncate with ellipsis.
- Reduce your window width again until the ip addresses are being cut off. They should truncate with ellipsis.
- View a table in settings, the headers should line up with the columns.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1784