### PR TITLE
feat(ui): add status and cpu cards to machine details summary overview

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -240,11 +240,11 @@ exports[`stricter compilation`] = {
       [62, 23, 4, "Object is possibly \'undefined\'.", "2088098233"],
       [66, 48, 4, "Object is possibly \'undefined\'.", "2088098233"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:159415340": [
-      [63, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [98, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'MachineAction | null\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction | null\'.", "167402512"],
-      [128, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"],
-      [142, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
+    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:3165983158": [
+      [66, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
+      [101, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"],
+      [131, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"],
+      [145, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
     ],
     "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2858846500": [
       [106, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -298,7 +298,7 @@ exports[`stricter compilation`] = {
       [50, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
       [53, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"]
     ],
-    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:4245401623": [
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:2108746829": [
       [93, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [97, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
       [214, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -323,13 +323,13 @@ exports[`stricter compilation`] = {
       [320, 11, 5, "Object is of type \'unknown\'.", "173192470"],
       [321, 11, 5, "Object is of type \'unknown\'.", "173192470"]
     ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:1813490482": [
-      [42, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
-      [43, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
-      [58, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
-      [59, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
-      [90, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"],
-      [101, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
+    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:3204147639": [
+      [38, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
+      [39, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
+      [54, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
+      [55, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
+      [86, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"],
+      [97, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
     "src/app/machines/hooks.tsx:3635236711": [
       [45, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
@@ -337,27 +337,27 @@ exports[`stricter compilation`] = {
       [45, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [49, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineDetails.tsx:2042650453": [
-      [27, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
-      [29, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
-      [33, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
+    "src/app/machines/views/MachineDetails/MachineDetails.tsx:1265256178": [
+      [28, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
+      [30, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
+      [34, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
     ],
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:7094616": [
       [33, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:578846724": [
-      [34, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:1487253938": [
+      [40, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx:3496905299": [
-      [20, 20, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx:461133352": [
+      [17, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
       [146, 18, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:539216384": [
-      [104, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
-      [125, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [104, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [125, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.", "167402512"],
       [130, 42, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
     "src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx:4288871559": [

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -7,7 +7,7 @@ exports[`stricter compilation`] = {
       [162, 4, 36, "Object is possibly \'null\'.", "1039669632"]
     ],
     "src/app/App.tsx:3872899616": [
-      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
+      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
       [188, 17, 17, "Object is possibly \'null\'.", "2133029343"],
       [193, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
@@ -44,7 +44,7 @@ exports[`stricter compilation`] = {
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/multipass/code/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -86,7 +86,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -240,13 +240,11 @@ exports[`stricter compilation`] = {
       [62, 23, 4, "Object is possibly \'undefined\'.", "2088098233"],
       [66, 48, 4, "Object is possibly \'undefined\'.", "2088098233"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:1100062891": [
-      [62, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [71, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
-      [97, 29, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'MachineAction\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction\'.", "167402512"],
-      [99, 33, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'(action: MachineAction | null, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
-      [122, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"],
-      [136, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
+    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:159415340": [
+      [63, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
+      [98, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'MachineAction | null\'.\\n      Type \'undefined\' is not assignable to type \'MachineAction | null\'.", "167402512"],
+      [128, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"],
+      [142, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
     ],
     "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2858846500": [
       [106, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -254,8 +252,7 @@ exports[`stricter compilation`] = {
       [201, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [205, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
-    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx:1528444456": [
-      [106, 51, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
+    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx:1892825711": [
       [121, 6, 8, "Type \'(values: CommissionFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'CommissionFormValues\'.", "1301647696"],
       [135, 27, 10, "Property \'commission\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "2592181864"],
       [155, 42, 25, "Argument of type \'(Scripts | undefined)[]\' is not assignable to parameter of type \'Scripts[]\'.\\n  Type \'Scripts | undefined\' is not assignable to type \'Scripts\'.\\n    Type \'undefined\' is not assignable to type \'Scripts\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "4025185665"]
@@ -301,6 +298,18 @@ exports[`stricter compilation`] = {
       [50, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
       [53, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"]
     ],
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:4245401623": [
+      [93, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [97, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
+      [214, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [218, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
+    ],
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:739278699": [
+      [76, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"],
+      [99, 6, 8, "Type \'(values: FormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'FormValues\'.", "1301647696"],
+      [103, 27, 4, "Property \'test\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "2087956275"],
+      [116, 22, 11, "Type \'({ displayName: string; id: number; apply_configured_networking: boolean; default: boolean; description: string; destructive: boolean; for_hardware: string[]; hardware_type_name: \\"Node\\" | \\"CPU\\" | \\"Memory\\" | \\"Storage\\" | \\"Network\\"; ... 15 more ...; type: number; } | undefined)[]\' is not assignable to type \'ScriptsDisplay[]\'.\\n  Type \'{ displayName: string; id: number; apply_configured_networking: boolean; default: boolean; description: string; destructive: boolean; for_hardware: string[]; hardware_type_name: \\"Node\\" | \\"CPU\\" | \\"Memory\\" | \\"Storage\\" | \\"Network\\"; ... 15 more ...; type: number; } | undefined\' is not assignable to type \'ScriptsDisplay\'.\\n    Type \'undefined\' is not assignable to type \'ScriptsDisplay\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"]
+    ],
     "src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx:2594365837": [
       [77, 8, 4, "Type \'\\"lifecycle1\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
       [82, 8, 4, "Type \'\\"lifecycle2\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
@@ -314,13 +323,13 @@ exports[`stricter compilation`] = {
       [320, 11, 5, "Object is of type \'unknown\'.", "173192470"],
       [321, 11, 5, "Object is of type \'unknown\'.", "173192470"]
     ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:3297157433": [
-      [37, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
-      [38, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
-      [53, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
-      [54, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
-      [85, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"],
-      [96, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
+    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:1813490482": [
+      [42, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
+      [43, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
+      [58, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
+      [59, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
+      [90, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | undefined\'.\\n  Type \'false\' is not assignable to type \'string | undefined\'.", "1236122734"],
+      [101, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
     "src/app/machines/hooks.tsx:3635236711": [
       [45, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
@@ -328,23 +337,28 @@ exports[`stricter compilation`] = {
       [45, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [49, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineDetails.tsx:3349853769": [
-      [28, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
-      [30, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
-      [34, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
+    "src/app/machines/views/MachineDetails/MachineDetails.tsx:2042650453": [
+      [27, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
+      [29, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
+      [33, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
     ],
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:7094616": [
       [33, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:3827082703": [
-      [23, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:578846724": [
+      [34, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:4130863562": [
-      [75, 24, 4, "Argument of type \'null\' is not assignable to parameter of type \'MachineAction\'.", "2087897566"],
-      [129, 42, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
+    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx:3496905299": [
+      [20, 20, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [146, 18, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
+    ],
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:539216384": [
+      [104, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [125, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [130, 42, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
     "src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx:4288871559": [
       [40, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -534,19 +548,19 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [5, 31, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/general/types.ts:1563597444": [
+    "src/app/store/general/types.ts:978842410": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [5, 9, 8, "RegExp match", "1152173309"],
       [14, 9, 8, "RegExp match", "1152173309"],
       [23, 9, 8, "RegExp match", "1152173309"],
       [32, 9, 8, "RegExp match", "1152173309"],
       [47, 9, 8, "RegExp match", "1152173309"],
-      [83, 9, 8, "RegExp match", "1152173309"],
-      [94, 9, 8, "RegExp match", "1152173309"],
-      [122, 9, 8, "RegExp match", "1152173309"],
-      [131, 9, 8, "RegExp match", "1152173309"],
-      [166, 9, 8, "RegExp match", "1152173309"],
-      [175, 9, 8, "RegExp match", "1152173309"]
+      [84, 9, 8, "RegExp match", "1152173309"],
+      [95, 9, 8, "RegExp match", "1152173309"],
+      [123, 9, 8, "RegExp match", "1152173309"],
+      [132, 9, 8, "RegExp match", "1152173309"],
+      [167, 9, 8, "RegExp match", "1152173309"],
+      [176, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/licensekeys/types.ts:2257386395": [
       [1, 13, 8, "RegExp match", "1152173309"],
@@ -641,5 +655,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `439`
+  value: `434`
 };

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -240,11 +240,11 @@ exports[`stricter compilation`] = {
       [62, 23, 4, "Object is possibly \'undefined\'.", "2088098233"],
       [66, 48, 4, "Object is possibly \'undefined\'.", "2088098233"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:3165983158": [
-      [66, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [101, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"],
-      [131, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"],
-      [145, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
+    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:2244145737": [
+      [65, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
+      [100, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"],
+      [130, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"],
+      [144, 36, 11, "Property \'setSelected\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1023496814"]
     ],
     "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2858846500": [
       [106, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -298,11 +298,11 @@ exports[`stricter compilation`] = {
       [50, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
       [53, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"]
     ],
-    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:2108746829": [
-      [93, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [97, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
-      [214, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [218, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:3198696153": [
+      [95, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [99, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
+      [216, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [220, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
     "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:739278699": [
       [76, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"],
@@ -337,16 +337,16 @@ exports[`stricter compilation`] = {
       [45, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [49, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineDetails.tsx:1265256178": [
-      [28, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
-      [30, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
-      [34, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
+    "src/app/machines/views/MachineDetails/MachineDetails.tsx:3514974960": [
+      [27, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
+      [29, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
+      [33, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
     ],
-    "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:7094616": [
+    "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:2073227660": [
       [33, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:1487253938": [
-      [40, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:1620177595": [
+      [41, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
@@ -548,7 +548,7 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [5, 31, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/general/types.ts:810237147": [
+    "src/app/store/general/types.ts:1563597444": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [5, 9, 8, "RegExp match", "1152173309"],
       [14, 9, 8, "RegExp match", "1152173309"],

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -548,19 +548,19 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [5, 31, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/general/types.ts:978842410": [
+    "src/app/store/general/types.ts:810237147": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [5, 9, 8, "RegExp match", "1152173309"],
       [14, 9, 8, "RegExp match", "1152173309"],
       [23, 9, 8, "RegExp match", "1152173309"],
       [32, 9, 8, "RegExp match", "1152173309"],
       [47, 9, 8, "RegExp match", "1152173309"],
-      [84, 9, 8, "RegExp match", "1152173309"],
-      [95, 9, 8, "RegExp match", "1152173309"],
-      [123, 9, 8, "RegExp match", "1152173309"],
-      [132, 9, 8, "RegExp match", "1152173309"],
-      [167, 9, 8, "RegExp match", "1152173309"],
-      [176, 9, 8, "RegExp match", "1152173309"]
+      [83, 9, 8, "RegExp match", "1152173309"],
+      [94, 9, 8, "RegExp match", "1152173309"],
+      [122, 9, 8, "RegExp match", "1152173309"],
+      [131, 9, 8, "RegExp match", "1152173309"],
+      [166, 9, 8, "RegExp match", "1152173309"],
+      [175, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/licensekeys/types.ts:2257386395": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/base/enum.ts
+++ b/ui/src/app/base/enum.ts
@@ -65,3 +65,11 @@ export const scriptStatus = {
   APPLYING_NETCONF: 10,
   FAILED_APPLYING_NETCONF: 11,
 };
+
+export enum HardwareType {
+  Node = 0,
+  Cpu = 1,
+  Memory = 2,
+  Storage = 3,
+  Network = 4,
+}

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -31,7 +31,6 @@ describe("ActionFormWrapper", () => {
           data: [
             machineActionFactory({
               name: "commission",
-              sentence: "commission",
             }),
           ],
         }),
@@ -93,9 +92,6 @@ describe("ActionFormWrapper", () => {
           <ActionFormWrapper
             selectedAction={{
               name: "commission",
-              sentence: "commissioned",
-              title: "Commission...",
-              type: "lifecycle",
             }}
             setSelectedAction={jest.fn()}
           />
@@ -132,9 +128,6 @@ describe("ActionFormWrapper", () => {
           <ActionFormWrapper
             selectedAction={{
               name: "commission",
-              sentence: "commissioned",
-              title: "Commission...",
-              type: "lifecycle",
             }}
             setSelectedAction={jest.fn()}
           />
@@ -166,9 +159,6 @@ describe("ActionFormWrapper", () => {
           <ActionFormWrapper
             selectedAction={{
               name: "commission",
-              sentence: "commissioned",
-              title: "Commission...",
-              type: "lifecycle",
             }}
             setSelectedAction={jest.fn()}
           />

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useParams } from "react-router";
 
+import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
 import { machine as machineActions } from "app/base/actions";
 import type { RouteParams } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
@@ -44,7 +45,7 @@ const getErrorSentence = (action: MachineAction, count: number) => {
 
 type Props = {
   selectedAction: MachineAction;
-  setSelectedAction: (action: MachineAction, deselect?: boolean) => void;
+  setSelectedAction: SetSelectedAction;
 };
 
 export const ActionFormWrapper = ({

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -107,7 +107,12 @@ export const ActionFormWrapper = ({
         case "tag":
           return <TagForm setSelectedAction={setSelectedAction} />;
         case "test":
-          return <TestForm setSelectedAction={setSelectedAction} />;
+          return (
+            <TestForm
+              hardwareType={selectedAction.hardwareType}
+              setSelectedAction={setSelectedAction}
+            />
+          );
         default:
           return (
             <FieldlessForm

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -5,7 +5,10 @@ import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useParams } from "react-router";
 
-import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
+import type {
+  SelectedAction,
+  SetSelectedAction,
+} from "app/machines/views/MachineDetails/MachineSummary";
 import { machine as machineActions } from "app/base/actions";
 import type { RouteParams } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
@@ -44,7 +47,7 @@ const getErrorSentence = (action: MachineAction, count: number) => {
 };
 
 type Props = {
-  selectedAction: MachineAction;
+  selectedAction: SelectedAction;
   setSelectedAction: SetSelectedAction;
 };
 
@@ -110,8 +113,8 @@ export const ActionFormWrapper = ({
         case "test":
           return (
             <TestForm
-              hardwareType={selectedAction.hardwareType}
               setSelectedAction={setSelectedAction}
+              {...selectedAction.formProps}
             />
           );
         default:

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -12,7 +12,6 @@ import type {
 import { machine as machineActions } from "app/base/actions";
 import type { RouteParams } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
-import type { MachineAction } from "app/store/general/types";
 import CommissionForm from "./CommissionForm";
 import DeployForm from "./DeployForm";
 import FieldlessForm from "./FieldlessForm";
@@ -23,7 +22,7 @@ import SetZoneForm from "./SetZoneForm";
 import TagForm from "./TagForm";
 import TestForm from "./TestForm";
 
-const getErrorSentence = (action: MachineAction, count: number) => {
+const getErrorSentence = (action: SelectedAction, count: number) => {
   const machineString = pluralize("machine", count, true);
 
   switch (action.name) {

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -57,7 +57,7 @@ export type CommissionFormValues = {
 };
 
 type Props = {
-  setSelectedAction: (action: MachineAction, deselect?: boolean) => void;
+  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
 };
 
 export const CommissionForm = ({ setSelectedAction }: Props): JSX.Element => {

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -19,11 +19,12 @@ import {
 } from "testing/factories";
 import { ScriptType } from "testing/factories/scripts";
 import { Scripts } from "app/store/scripts/types";
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("TestForm", () => {
-  let initialState;
+  let initialState: RootState;
 
   beforeEach(() => {
     initialState = rootStateFactory({

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -6,13 +6,19 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import TestForm from "./TestForm";
+import { HardwareType } from "app/base/enum";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
+  scripts as scriptsFactory,
+  machineActionsState as machineActionsStateFactory,
   machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
   scriptsState as scriptsStateFactory,
 } from "testing/factories";
+import { ScriptType } from "testing/factories/scripts";
+import { Scripts } from "app/store/scripts/types";
 
 const mockStore = configureStore();
 
@@ -22,9 +28,9 @@ describe("TestForm", () => {
   beforeEach(() => {
     initialState = rootStateFactory({
       general: generalStateFactory({
-        machineActions: {
+        machineActions: machineActionsStateFactory({
           data: [{ name: "test", sentence: "test" }],
-        },
+        }),
       }),
       machine: machineStateFactory({
         loaded: true,
@@ -33,14 +39,14 @@ describe("TestForm", () => {
           machineFactory({ system_id: "def456" }),
         ],
         statuses: {
-          abc123: {},
-          def456: {},
+          abc123: machineStatusFactory(),
+          def456: machineStatusFactory(),
         },
       }),
       scripts: scriptsStateFactory({
         loaded: true,
         items: [
-          {
+          scriptsFactory({
             name: "smartctl-validate",
             tags: ["commissioning", "storage"],
             parameters: {
@@ -50,8 +56,8 @@ describe("TestForm", () => {
               },
             },
             type: 2,
-          },
-          {
+          }),
+          scriptsFactory({
             name: "internet-connectivity",
             tags: ["internet", "network-validation", "network"],
             parameters: {
@@ -63,13 +69,13 @@ describe("TestForm", () => {
               },
             },
             type: 2,
-          },
+          }),
         ],
       }),
     });
   });
 
-  it("correctly dispatches actions to test selected machines", () => {
+  it("dispatches actions to test selected machines", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
     const store = mockStore(state);
@@ -143,7 +149,49 @@ describe("TestForm", () => {
     ]);
   });
 
-  it("correctly dispatches action to test machine from details view", () => {
+  it.only("prepopulates scripts of a given hardwareType", () => {
+    const state = { ...initialState };
+    const networkScript = scriptsFactory({
+      hardware_type: HardwareType.Network,
+      type: ScriptType.Testing,
+    });
+
+    state.scripts.items = [
+      networkScript,
+      scriptsFactory({
+        hardware_type: HardwareType.Cpu,
+        type: ScriptType.Testing,
+      }),
+      scriptsFactory({
+        hardware_type: HardwareType.Memory,
+        type: ScriptType.Testing,
+      }),
+    ];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TestForm
+            setSelectedAction={jest.fn()}
+            hardwareType={HardwareType.Network}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // An equality assertion can't be made here as preselected scripts have
+    // a 'displayName' added
+    const preselected: Scripts[] = wrapper
+      .find("TestFormFields")
+      .prop("preselected");
+    expect(preselected[0].id).toEqual(networkScript.id);
+    expect(preselected.length).toEqual(1);
+  });
+
+  it("dispatches an action to test machine from details view", () => {
     const state = { ...initialState };
     state.machine.active = "abc123";
     state.machine.selected = [];

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -150,7 +150,7 @@ describe("TestForm", () => {
     ]);
   });
 
-  it.only("prepopulates scripts of a given hardwareType", () => {
+  it("prepopulates scripts of a given hardwareType", () => {
     const state = { ...initialState };
     const networkScript = scriptsFactory({
       hardware_type: HardwareType.Network,

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -30,7 +30,9 @@ describe("TestForm", () => {
     initialState = rootStateFactory({
       general: generalStateFactory({
         machineActions: machineActionsStateFactory({
-          data: [{ name: "test", sentence: "test" }],
+          data: [
+            { name: "test", sentence: "test", type: "test", title: "test" },
+          ],
         }),
       }),
       machine: machineStateFactory({

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -40,7 +40,7 @@ export type FormValues = {
 };
 
 type Props = {
-  setSelectedAction: (action: MachineAction, deselect?: boolean) => void;
+  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
   hardwareType?: HardwareType;
 };
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -9,6 +9,7 @@ import TestForm from "../TestForm";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
   scriptsState as scriptsStateFactory,
   scripts as scriptsFactory,
@@ -28,8 +29,8 @@ describe("TestForm", () => {
           machineFactory({ system_id: "def456" }),
         ],
         statuses: {
-          abc123: {},
-          def456: {},
+          abc123: machineStatusFactory(),
+          def456: machineStatusFactory(),
         },
       }),
       scripts: scriptsStateFactory({
@@ -72,7 +73,7 @@ describe("TestForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
         >
-          <TestForm setProcessing={jest.fn()} setSelectedAction={jest.fn()} />
+          <TestForm setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -14,11 +14,12 @@ import {
   scriptsState as scriptsStateFactory,
   scripts as scriptsFactory,
 } from "testing/factories";
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 
 describe("TestForm", () => {
-  let initialState;
+  let initialState: RootState;
 
   beforeEach(() => {
     initialState = rootStateFactory({

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
@@ -2,11 +2,23 @@ import { Col, Row } from "@canonical/react-components";
 import React from "react";
 import { useFormikContext } from "formik";
 
+import type { FormValues } from "../TestForm";
 import FormikField from "app/base/components/FormikField";
 import TagSelector from "app/base/components/TagSelector";
+import { Scripts } from "app/store/scripts/types";
 
-export const TestFormFields = ({ preselected, scripts }) => {
-  const { handleChange, setFieldValue, values } = useFormikContext();
+type ScriptsDisplay = Scripts & { displayName: string };
+type Props = {
+  preselected: ScriptsDisplay[];
+  scripts: Scripts[];
+};
+export const TestFormFields = ({
+  preselected,
+  scripts,
+}: Props): JSX.Element => {
+  const { handleChange, setFieldValue, values } = useFormikContext<
+    FormValues
+  >();
   const urlScriptsSelected = values.scripts.filter((script) =>
     Object.keys(script.parameters).some((key) => key === "url")
   );

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
@@ -37,7 +37,7 @@ export const TestFormFields = ({
           initialSelected={preselected}
           label="Tests"
           name="tests"
-          onTagsUpdate={(selectedScripts) =>
+          onTagsUpdate={(selectedScripts: Scripts[]) =>
             setFieldValue("scripts", selectedScripts)
           }
           placeholder="Select scripts"
@@ -55,7 +55,7 @@ export const TestFormFields = ({
               </span>
             }
             name={`scriptInputs[${script.name}].url`}
-            onChange={(e) => {
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               handleChange(e);
               setFieldValue(`scriptInputs[${script.name}].url`, e.target.value);
             }}

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -6,16 +6,12 @@ import { useParams } from "react-router";
 
 import type { RouteParams } from "app/base/types";
 import { general as generalActions } from "app/base/actions";
+import { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
 import generalSelectors from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { MachineAction } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
-
-type SetSelectedAction = (
-  action: MachineAction | null,
-  deselect?: boolean
-) => void;
 
 const getTakeActionLinks = (
   actionOptions: MachineAction[],

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -12,10 +12,15 @@ import type { Machine } from "app/store/machine/types";
 import type { MachineAction } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
 
+type SetSelectedAction = (
+  action: MachineAction | null,
+  deselect?: boolean
+) => void;
+
 const getTakeActionLinks = (
   actionOptions: MachineAction[],
   machines: Machine[],
-  setSelectedAction: (action: MachineAction, deselect?: boolean) => void
+  setSelectedAction: SetSelectedAction
 ) => {
   const initGroups = [
     { type: "lifecycle", items: [] },
@@ -62,7 +67,7 @@ const getTakeActionLinks = (
 };
 
 type Props = {
-  setSelectedAction: (action: MachineAction, deselect?: boolean) => void;
+  setSelectedAction: SetSelectedAction;
 };
 
 export const TakeActionMenu = ({ setSelectedAction }: Props): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -8,9 +8,8 @@ import { machine as machineActions } from "app/base/actions";
 import MachineHeader from "./MachineHeader";
 import MachineNotifications from "./MachineNotifications";
 import machineSelectors from "app/store/machine/selectors";
-import MachineSummary from "./MachineSummary";
+import MachineSummary, { SelectedAction } from "./MachineSummary";
 import Section from "app/base/components/Section";
-import type { MachineAction } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
 
 const MachineDetails = (): JSX.Element => {
@@ -21,7 +20,7 @@ const MachineDetails = (): JSX.Element => {
     machineSelectors.getById(state, id)
   );
   const machinesLoaded = useSelector(machineSelectors.loaded);
-  const [selectedAction, setSelectedAction] = useState<MachineAction | null>(
+  const [selectedAction, setSelectedAction] = useState<SelectedAction | null>(
     null
   );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -55,7 +55,7 @@ const MachineDetails = (): JSX.Element => {
       {machine && (
         <Switch>
           <Route exact path="/machine/:id/summary">
-            <MachineSummary />
+            <MachineSummary setSelectedAction={setSelectedAction} />
           </Route>
           <Route exact path="/machine/:id">
             <Redirect to={`/machine/${id}/summary`} />

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router";
 import React, { useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 
+import { SelectedAction, SetSelectedAction } from "../MachineSummary";
 import type { RouteParams } from "app/base/types";
 import type { MachineDetails } from "app/store/machine/types";
 import { machine as machineActions } from "app/base/actions";
@@ -10,12 +11,11 @@ import machineSelectors from "app/store/machine/selectors";
 import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
 import SectionHeader from "app/base/components/SectionHeader";
 import TakeActionMenu from "app/machines/components/TakeActionMenu";
-import type { MachineAction } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
-  selectedAction: MachineAction | null;
-  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+  selectedAction: SelectedAction | null;
+  setSelectedAction: SetSelectedAction;
 };
 
 const MachineHeader = ({

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -32,7 +32,7 @@ describe("MachineSummary", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineSummary />
+          <MachineSummary setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );
@@ -46,7 +46,7 @@ describe("MachineSummary", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineSummary />
+          <MachineSummary setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -12,9 +12,13 @@ import type { RouteParams } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
+import { HardwareType } from "app/base/enum";
 
 export type SetSelectedAction = (
-  action: MachineAction | null,
+  action:
+    | MachineAction
+    | (MachineAction & { hardwareType: HardwareType })
+    | null,
   deselect?: boolean
 ) => void;
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -14,11 +14,13 @@ import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 import { HardwareType } from "app/base/enum";
 
+export type SelectedAction = {
+  name: MachineAction["name"];
+  formProps?: { hardwareType: HardwareType };
+};
+
 export type SetSelectedAction = (
-  action:
-    | MachineAction
-    | (MachineAction & { hardwareType: HardwareType })
-    | null,
+  action: SelectedAction | null,
   deselect?: boolean
 ) => void;
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -7,12 +7,12 @@ import NumaCard from "./NumaCard";
 import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
 import { machine as machineActions } from "app/base/actions";
+import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
-import { HardwareType } from "app/base/enum";
 
 export type SelectedAction = {
   name: MachineAction["name"];

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -3,15 +3,21 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import React, { useEffect } from "react";
 
-import type { RouteParams } from "app/base/types";
+import NumaCard from "./NumaCard";
+import OverviewCard from "./OverviewCard";
+import SystemCard from "./SystemCard";
 import { machine as machineActions } from "app/base/actions";
 import { useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
+import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
-import NumaCard from "./NumaCard";
-import SystemCard from "./SystemCard";
 import type { RootState } from "app/store/root/types";
 
-const MachineSummary = (): JSX.Element => {
+type Props = {
+  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+};
+
+const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const { id } = useParams<RouteParams>();
   const machine = useSelector((state: RootState) =>
@@ -30,7 +36,7 @@ const MachineSummary = (): JSX.Element => {
 
   return (
     <div className="machine-summary__cards">
-      <Card className="machine-summary__overview-card">Overview</Card>
+      <OverviewCard id={id} setSelectedAction={setSelectedAction} />
       <SystemCard id={id} />
       <NumaCard id={id} />
       <Card className="machine-summary__network-card">Network</Card>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -16,6 +16,7 @@ import type { RootState } from "app/store/root/types";
 
 export type SelectedAction = {
   name: MachineAction["name"];
+  sentence?: MachineAction["sentence"];
   formProps?: { hardwareType: HardwareType };
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -13,8 +13,13 @@ import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 
+export type SetSelectedAction = (
+  action: MachineAction | null,
+  deselect?: boolean
+) => void;
+
 type Props = {
-  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+  setSelectedAction: SetSelectedAction;
 };
 
 const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -26,8 +26,7 @@ describe("CpuCard", () => {
   });
 
   it("renders the cpu subtext", () => {
-    const machine = machineDetailsFactory();
-    machine.cpu_speed = 2000;
+    const machine = machineDetailsFactory({ cpu_speed: 2000 });
     state.machine.items = [machine];
 
     const store = mockStore(state);
@@ -47,8 +46,7 @@ describe("CpuCard", () => {
   });
 
   it("renders the cpu subtext for slow machines", () => {
-    const machine = machineDetailsFactory();
-    machine.cpu_speed = 200;
+    const machine = machineDetailsFactory({ cpu_speed: 200 });
     state.machine.items = [machine];
 
     const store = mockStore(state);

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -1,0 +1,184 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  testStatus as testStatusFactory,
+} from "testing/factories";
+import CpuCard from "./CpuCard";
+import type { RootState } from "app/store/root/types";
+import { scriptStatus } from "app/base/enum";
+
+const mockStore = configureStore();
+
+describe("CpuCard", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+  });
+
+  it("renders the cpu subtext", () => {
+    const machine = machineDetailsFactory();
+    machine.cpu_speed = 2000;
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='cpu-subtext']").text()).toEqual(
+      `${machine.cpu_count} core, 2 GHz`
+    );
+  });
+
+  it("renders the cpu subtext for slow machines", () => {
+    const machine = machineDetailsFactory();
+    machine.cpu_speed = 200;
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='cpu-subtext']").text()).toEqual(
+      `${machine.cpu_count} core, 200 MHz`
+    );
+  });
+
+  it("renders a link with a count of passed tests", () => {
+    const machine = machineDetailsFactory();
+    machine.cpu_test_status = testStatusFactory({
+      passed: 2,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toEqual("2");
+  });
+
+  it("renders a link with a count of pending and running tests", () => {
+    const machine = machineDetailsFactory();
+    machine.cpu_test_status = testStatusFactory({
+      running: 1,
+      pending: 2,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toEqual("3");
+  });
+
+  it("renders a link with a count of failed tests", () => {
+    const machine = machineDetailsFactory();
+    machine.cpu_test_status = testStatusFactory({
+      failed: 5,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toEqual("5");
+  });
+
+  it("renders a results link", () => {
+    const machine = machineDetailsFactory();
+    machine.cpu_test_status = testStatusFactory({
+      failed: 5,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+    ).toContain("View results");
+  });
+
+  it("renders a test cpu link if no tests run", () => {
+    const machine = machineDetailsFactory();
+    machine.cpu_test_status = testStatusFactory();
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toContain("Test CPU");
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -12,7 +12,6 @@ import {
 } from "testing/factories";
 import CpuCard from "./CpuCard";
 import type { RootState } from "app/store/root/types";
-import { scriptStatus } from "app/base/enum";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -1,0 +1,184 @@
+import pluralize from "pluralize";
+import React from "react";
+import { Link } from "react-router-dom";
+
+import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
+
+import { useSendAnalytics } from "app/base/hooks";
+import type { MachineAction } from "app/store/general/types";
+import type { MachineDetails } from "app/store/machine/types";
+import { HardwareType } from "app/base/enum";
+
+type Props = {
+  machine: MachineDetails;
+  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+};
+
+const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
+  const sendAnalytics = useSendAnalytics();
+
+  const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
+    const testObj = machine[`${scriptType}_test_status`];
+    return (
+      testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
+    );
+  };
+
+  // Get the subtext for the CPU card. Only nodes commissioned after
+  // MAAS 2.4 will have the CPU speed.
+  const getCPUSubtext = (machine: MachineDetails) => {
+    let text = "Unknown";
+
+    if (machine.cpu_count) {
+      text = pluralize("core", machine.cpu_count, true);
+    }
+    if (machine.cpu_speed) {
+      const speedText =
+        machine.cpu_speed > 1000
+          ? `${machine.cpu_speed / 1000} GHz`
+          : `${machine.cpu_speed} MHz`;
+      text += `, ${speedText}`;
+    }
+    return text;
+  };
+
+  const testsTabUrl = `/machine/${machine.system_id}/tests`;
+
+  return (
+    <>
+      <div className="overview-card__cpu">
+        <div className="u-flex--between">
+          <strong className="p-muted-heading">CPU</strong>
+          <span>{machine.architecture}</span>
+        </div>
+        <h4 className="u-no-margin--bottom" data-test="cpu-subtext">
+          {getCPUSubtext(machine)}
+        </h4>
+        <p className="p-text--muted">
+          {machine.metadata.cpu_model || "Unknown model"}
+        </p>
+      </div>
+
+      <div className="overview-card__cpu-tests u-flex--vertically">
+        <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
+          {machine.cpu_test_status.passed ? (
+            <li className="p-inline-list__item--compact">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "CPU tests passed link",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                <Icon name={ICONS.success} />
+                {machine.cpu_test_status.passed}
+              </Button>
+            </li>
+          ) : null}
+
+          {machine.cpu_test_status.pending + machine.cpu_test_status.running >
+          0 ? (
+            <li className="p-inline-list__item--compact">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "CPU tests running link",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                <Icon name={"pending"} />
+                {machine.cpu_test_status.pending +
+                  machine.cpu_test_status.running}
+              </Button>
+            </li>
+          ) : null}
+
+          {machine.cpu_test_status.failed > 0 ? (
+            <li className="p-inline-list__item--compact">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "CPU tests failed",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                <Icon name={ICONS.error} />
+                {machine.cpu_test_status.failed}
+              </Button>
+            </li>
+          ) : null}
+
+          {hasTestsRun(machine, "cpu") ? (
+            <li className="p-inline-list__item--compact">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "View CPU tests results",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                View results&nbsp;&rsaquo;
+              </Button>
+            </li>
+          ) : (
+            <li className="p-inline-list__item--compact">
+              <span className="p-tooltip--top-left">
+                <Tooltip
+                  message={
+                    !machine.actions.includes("test")
+                      ? "Machine cannot run tests at this time."
+                      : null
+                  }
+                  position={"top-left"}
+                >
+                  <Button
+                    className="p-button--link"
+                    disabled={!machine.actions.includes("test")}
+                    onClick={() => {
+                      setSelectedAction(
+                        {
+                          name: "test",
+                          hardwareType: HardwareType.Cpu,
+                        },
+                        false
+                      );
+                      sendAnalytics(
+                        "Machine details",
+                        "Test CPU",
+                        "Machine summary tab"
+                      );
+                    }}
+                  >
+                    Test CPU...
+                  </Button>
+                </Tooltip>
+              </span>
+            </li>
+          )}
+        </ul>
+      </div>
+    </>
+  );
+};
+
+export default CpuCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 
-import { SetSelectedAction } from "../../MachineSummary";
+import type { SetSelectedAction } from "../../MachineSummary";
 import { useSendAnalytics } from "app/base/hooks";
 import type { MachineDetails } from "app/store/machine/types";
 import { HardwareType } from "app/base/enum";
@@ -14,33 +14,33 @@ type Props = {
   setSelectedAction: SetSelectedAction;
 };
 
+const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
+  const testObj = machine[`${scriptType}_test_status`];
+  return (
+    testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
+  );
+};
+
+// Get the subtext for the CPU card. Only nodes commissioned after
+// MAAS 2.4 will have the CPU speed.
+const getCPUSubtext = (machine: MachineDetails) => {
+  let text = "Unknown";
+
+  if (machine.cpu_count) {
+    text = pluralize("core", machine.cpu_count, true);
+  }
+  if (machine.cpu_speed) {
+    const speedText =
+      machine.cpu_speed > 1000
+        ? `${machine.cpu_speed / 1000} GHz`
+        : `${machine.cpu_speed} MHz`;
+    text += `, ${speedText}`;
+  }
+  return text;
+};
+
 const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
   const sendAnalytics = useSendAnalytics();
-
-  const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
-    const testObj = machine[`${scriptType}_test_status`];
-    return (
-      testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
-    );
-  };
-
-  // Get the subtext for the CPU card. Only nodes commissioned after
-  // MAAS 2.4 will have the CPU speed.
-  const getCPUSubtext = (machine: MachineDetails) => {
-    let text = "Unknown";
-
-    if (machine.cpu_count) {
-      text = pluralize("core", machine.cpu_count, true);
-    }
-    if (machine.cpu_speed) {
-      const speedText =
-        machine.cpu_speed > 1000
-          ? `${machine.cpu_speed / 1000} GHz`
-          : `${machine.cpu_speed} MHz`;
-      text += `, ${speedText}`;
-    }
-    return text;
-  };
 
   const testsTabUrl = `/machine/${machine.system_id}/tests`;
 
@@ -62,7 +62,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
       <div className="overview-card__cpu-tests u-flex--vertically">
         <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
           {machine.cpu_test_status.passed ? (
-            <li className="p-inline-list__item--compact">
+            <li className="p-inline-list__item">
               <Button
                 className="p-button--link"
                 element={Link}
@@ -83,7 +83,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
 
           {machine.cpu_test_status.pending + machine.cpu_test_status.running >
           0 ? (
-            <li className="p-inline-list__item--compact">
+            <li className="p-inline-list__item">
               <Button
                 className="p-button--link"
                 element={Link}
@@ -104,7 +104,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
           ) : null}
 
           {machine.cpu_test_status.failed > 0 ? (
-            <li className="p-inline-list__item--compact">
+            <li className="p-inline-list__item">
               <Button
                 className="p-button--link"
                 element={Link}
@@ -124,7 +124,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
           ) : null}
 
           {hasTestsRun(machine, "cpu") ? (
-            <li className="p-inline-list__item--compact">
+            <li className="p-inline-list__item">
               <Button
                 className="p-button--link"
                 element={Link}
@@ -141,7 +141,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
               </Button>
             </li>
           ) : (
-            <li className="p-inline-list__item--compact">
+            <li className="p-inline-list__item">
               <span className="p-tooltip--top-left">
                 <Tooltip
                   message={

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -158,7 +158,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
                       setSelectedAction(
                         {
                           name: "test",
-                          hardwareType: HardwareType.Cpu,
+                          formProps: { hardwareType: HardwareType.Cpu },
                         },
                         false
                       );

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -4,14 +4,14 @@ import { Link } from "react-router-dom";
 
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 
+import { SetSelectedAction } from "../../MachineSummary";
 import { useSendAnalytics } from "app/base/hooks";
-import type { MachineAction } from "app/store/general/types";
 import type { MachineDetails } from "app/store/machine/types";
 import { HardwareType } from "app/base/enum";
 
 type Props = {
   machine: MachineDetails;
-  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+  setSelectedAction: SetSelectedAction;
 };
 
 const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CpuCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -4,14 +4,14 @@ import React from "react";
 
 import CpuCard from "./CpuCard";
 import StatusCard from "./StatusCard";
-import type { MachineAction } from "app/store/general/types";
+import type { SetSelectedAction } from "../MachineSummary";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
   id: Machine["system_id"];
-  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+  setSelectedAction: SetSelectedAction;
 };
 
 const OverviewCard = ({ id, setSelectedAction }: Props): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -1,0 +1,41 @@
+import { Card, Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import React from "react";
+
+import CpuCard from "./CpuCard";
+import StatusCard from "./StatusCard";
+import type { MachineAction } from "app/store/general/types";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  id: Machine["system_id"];
+  setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
+};
+
+const OverviewCard = ({ id, setSelectedAction }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+
+  let content: JSX.Element;
+
+  // Confirm that the full machine details have been fetched. This also allows
+  // TypeScript know we're using the right union type (otherwise it will
+  // complain that metadata doesn't exist on the base machine type).
+  if (!machine || !("metadata" in machine)) {
+    content = <Spinner />;
+  } else {
+    content = (
+      <div className="overview-card">
+        <StatusCard machine={machine} />
+        <CpuCard machine={machine} setSelectedAction={setSelectedAction} />
+      </div>
+    );
+  }
+
+  return <Card className="machine-summary__overview-card">{content}</Card>;
+};
+
+export default OverviewCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -1,0 +1,90 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import StatusCard from "./StatusCard";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("StatusCard", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+  });
+
+  it("renders a locked machine and status", () => {
+    const machine = machineDetailsFactory();
+    machine.status = "Testing";
+    machine.locked = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <StatusCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='locked']").text()).toEqual(
+      "Locked: Testing"
+    );
+  });
+
+  it("renders os info", () => {
+    const machine = machineDetailsFactory();
+    machine.osystem = "ubuntu";
+    machine.distro_series = "focal";
+    machine.show_os_info = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <StatusCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='os-info']").text()).toEqual(
+      "ubuntu/focal"
+    );
+  });
+
+  it("renders a failed test warning", () => {
+    const machine = machineDetailsFactory();
+    machine.testing_status.status = -1;
+
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <StatusCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='failed-test-warning']").text()).toEqual(
+      "Warning: Some tests failed, use with caution."
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -69,7 +69,7 @@ describe("StatusCard", () => {
 
   it("renders a failed test warning", () => {
     const machine = machineDetailsFactory();
-    machine.testing_status.status = -1;
+    machine.testing_status.status = 3;
 
     const store = mockStore(state);
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -7,27 +7,34 @@ type Props = {
   machine: MachineDetails;
 };
 
+const isVM = (machine: MachineDetails) => {
+  if (machine.tags?.includes("virtual")) {
+    return true;
+  }
+  const vmPowerTypes = ["lxd", "virsh", "vmware"];
+  return vmPowerTypes.includes(machine.power_type);
+};
+
+const showFailedTestsWarning = (machine: MachineDetails) => {
+  switch (machine.status_code) {
+    case nodeStatus.COMMISSIONING:
+    case nodeStatus.TESTING:
+      return false;
+  }
+
+  return (
+    machine.testing_status.status === scriptStatus.FAILED ||
+    machine.testing_status.status === scriptStatus.FAILED_INSTALLING ||
+    machine.testing_status.status === scriptStatus.DEGRADED ||
+    machine.testing_status.status === scriptStatus.TIMEDOUT
+  );
+};
+
 const StatusCard = ({ machine }: Props): JSX.Element => {
-  const isVM = machine.tags?.includes("virtual");
-  const showFailedTestsWarning = () => {
-    switch (machine.status_code) {
-      case nodeStatus.COMMISSIONING:
-      case nodeStatus.TESTING:
-        return false;
-    }
-
-    return (
-      machine.testing_status.status === scriptStatus.FAILED ||
-      scriptStatus.FAILED_INSTALLING ||
-      scriptStatus.DEGRADED ||
-      scriptStatus.TIMEDOUT
-    );
-  };
-
   return (
     <div className="overview-card__status">
       <strong className="p-muted-heading">
-        {isVM ? "Virtual Machine Status" : "Machine Status"}
+        {isVM(machine) ? "Virtual Machine Status" : "Machine Status"}
       </strong>
 
       <h4 className="u-no-margin--bottom" data-test="locked">
@@ -45,7 +52,7 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
         </p>
       ) : null}
 
-      {showFailedTestsWarning() ? (
+      {showFailedTestsWarning(machine) ? (
         <div
           className="overview-card__test-warning u-flex-bottom"
           data-test="failed-test-warning"

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import type { MachineDetails } from "app/store/machine/types";
+import { nodeStatus, scriptStatus } from "app/base/enum";
+
+type Props = {
+  machine: MachineDetails;
+};
+
+const StatusCard = ({ machine }: Props): JSX.Element => {
+  const isVM = machine.tags?.includes("virtual");
+  const showFailedTestsWarning = () => {
+    switch (machine.status_code) {
+      case nodeStatus.COMMISSIONING:
+      case nodeStatus.TESTING:
+        return false;
+    }
+
+    return (
+      machine.testing_status.status === scriptStatus.FAILED ||
+      scriptStatus.FAILED_INSTALLING ||
+      scriptStatus.DEGRADED ||
+      scriptStatus.TIMEDOUT
+    );
+  };
+
+  return (
+    <div className="overview-card__status">
+      <strong className="p-muted-heading">
+        {isVM ? "Virtual Machine Status" : "Machine Status"}
+      </strong>
+
+      <h4 className="u-no-margin--bottom" data-test="locked">
+        {machine.locked ? (
+          <i className="p-icon--locked" ng-if="node.locked">
+            Locked:{" "}
+          </i>
+        ) : null}
+        {machine.status}
+      </h4>
+
+      {machine.show_os_info ? (
+        <p className="p-text--muted" data-test="os-info">
+          {`${machine.osystem}/${machine.distro_series}`}
+        </p>
+      ) : null}
+
+      {showFailedTestsWarning() ? (
+        <div
+          className="overview-card__test-warning u-flex-bottom"
+          data-test="failed-test-warning"
+        >
+          <i className="p-icon--warning">Warning:</i> Some tests failed, use
+          with caution.
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default StatusCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StatusCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/_index.scss
@@ -1,0 +1,256 @@
+@mixin pseudo-border($pos) {
+  position: relative;
+
+  &::after,
+  &::before {
+    background-color: $color-mid-light;
+    content: "";
+    position: absolute;
+  }
+
+  @if $pos == top {
+    &::before {
+      height: 1px;
+      left: 0;
+      right: 0;
+      top: 0;
+    }
+  } @else if $pos == left {
+    &::after {
+      bottom: 0;
+      left: -#{map-get($grid-gutter-widths, large) / 2};
+      top: 0;
+      width: 1px;
+    }
+  }
+}
+
+@mixin OverviewCard {
+  .overview-card {
+    @extend %base-grid;
+    grid:
+      [row1-start] "status cpu memory storage" min-content [row1-end]
+      [row2-start] "test-warning cpu-tests memory-tests storage-tests" min-content [row2-end]
+      [row3-start] "details details details details" min-content [row2-end]
+      / 1fr 1fr 1fr 1fr;
+
+    .overview-card__status {
+      grid-area: status;
+      padding: $spv-inner--large 0 0 $sph-inner;
+    }
+
+    .overview-card__cpu {
+      @include pseudo-border(left);
+      grid-area: cpu;
+      padding: $spv-inner--large 0 0 0;
+      &::after {
+        top: $spv-inner--large;
+      }
+    }
+
+    .overview-card__memory {
+      @include pseudo-border(left);
+      grid-area: memory;
+      padding: $spv-inner--large 0 0 0;
+      &::after {
+        top: $spv-inner--large;
+      }
+    }
+
+    .overview-card__storage {
+      @include pseudo-border(left);
+      grid-area: storage;
+      padding: $spv-inner--large $sph-inner 0 0;
+      &::after {
+        top: $spv-inner--large;
+      }
+    }
+
+    .overview-card__test-warning {
+      grid-area: test-warning;
+      padding: $spv-inner--large 0 $spv-inner--large $sph-inner;
+    }
+
+    .overview-card__cpu-tests {
+      @include pseudo-border(left);
+      grid-area: cpu-tests;
+      padding: $spv-inner--large 0;
+      &::after {
+        bottom: $spv-inner--large;
+      }
+    }
+
+    .overview-card__memory-tests {
+      @include pseudo-border(left);
+      grid-area: memory-tests;
+      padding: $spv-inner--large 0;
+      &::after {
+        bottom: $spv-inner--large;
+      }
+    }
+
+    .overview-card__storage-tests {
+      @include pseudo-border(left);
+      grid-area: storage-tests;
+      padding: $spv-inner--large $sph-inner $spv-inner--large 0;
+      &::after {
+        bottom: $spv-inner--large;
+      }
+    }
+
+    .overview-card__details {
+      @include pseudo-border(top);
+      display: flex;
+      grid-area: details;
+      padding: $spv-inner--large $sph-inner;
+
+      > * {
+        flex: 1 auto;
+        padding-right: $sph-inner;
+
+        &:last-child {
+          padding-right: 0;
+        }
+      }
+    }
+
+    @media only screen and (max-width: $breakpoint-x-large) {
+      grid:
+        [row1-start] "cpu cpu cpu memory memory memory storage storage storage" min-content [row1-end]
+        [row2-start] "cpu-tests cpu-tests cpu-tests memory-tests memory-tests memory-tests storage-tests storage-tests storage-tests" min-content [row2-end]
+        [row3-start] "status status details details details details details details details" min-content [row3-end]
+        [row4-start] "status test-warning test-warning test-warning test-warning test-warning test-warning test-warning" min-content [row4-end]
+        / 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+
+      .overview-card__cpu {
+        padding: $spv-inner--large 0 $spv-inner--large $sph-inner;
+      }
+
+      .overview-card__cpu-tests {
+        padding: $spv-inner--large 0 $spv-inner--large $sph-inner;
+        &::after {
+          content: none;
+        }
+      }
+
+      .overview-card__overview {
+        @include pseudo-border(top);
+        padding: $spv-inner--large 0 $spv-inner--large $sph-inner;
+        &::before {
+          right: -#{map-get($grid-gutter-widths, large)};
+        }
+      }
+
+      .overview-card__test-warning {
+        @include pseudo-border(top);
+        padding: $spv-inner--large $sph-inner $spv-inner--large 0;
+      }
+    }
+
+    @media only screen and (max-width: $breakpoint-large) {
+      grid:
+        [row1-start] "status cpu" min-content [row1-end]
+        [row2-start] "test-warning cpu-tests" min-content [row2-end]
+        [row3-start] "memory storage" min-content [row3-end]
+        [row4-start] "memory-tests storage-tests" min-content [row4-end]
+        [row5-start] "details details" min-content [row5-end]
+        / 1fr 1fr;
+
+      .overview-card__status,
+      .overview-card__memory {
+        padding: $spv-inner--large 0 0 $sph-inner;
+        &::before {
+          content: none;
+        }
+      }
+
+      .overview-card__test-warning,
+      .overview-card__memory-tests {
+        padding: $spv-inner--large 0 $spv-inner--large $sph-inner;
+        &::before {
+          content: none;
+        }
+      }
+
+      .overview-card__cpu,
+      .overview-card__storage {
+        @include pseudo-border(left);
+        padding: $spv-inner--large $sph-inner 0 0;
+        &::after {
+          top: $spv-inner--large;
+        }
+      }
+
+      .overview-card__cpu-tests,
+      .overview-card__storage-tests {
+        @include pseudo-border(left);
+        padding: $spv-inner--large $sph-inner $spv-inner--large 0;
+        &::after {
+          bottom: $spv-inner--large;
+        }
+      }
+
+      .overview-card__memory {
+        @include pseudo-border(top);
+        &::before {
+          right: -#{map-get($grid-gutter-widths, large)};
+        }
+      }
+
+      .overview-card__storage {
+        @include pseudo-border(top);
+      }
+    }
+
+    @media only screen and (max-width: $breakpoint-medium) {
+      grid:
+        [row1-start] "status" min-content [row1-end]
+        [row2-start] "test-warning" min-content [row2-end]
+        [row3-start] "cpu" min-content [row3-end]
+        [row4-start] "cpu-tests" min-content [row4-end]
+        [row5-start] "memory" min-content [row5-end]
+        [row6-start] "memory-tests" min-content [row6-end]
+        [row7-start] "storage" min-content [row7-end]
+        [row8-start] "storage-tests" min-content [row8-end]
+        [row9-start] "details" min-content [row9-end]
+        / 1fr;
+
+      .overview-card__status {
+        padding: $spv-inner--large $sph-inner 0 $sph-inner;
+      }
+
+      .overview-card__cpu,
+      .overview-card__memory,
+      .overview-card__storage {
+        @include pseudo-border(top);
+        padding: $spv-inner--large $sph-inner 0 $sph-inner;
+        &::before {
+          left: 0;
+          right: 0;
+        }
+      }
+
+      .overview-card__test-warning,
+      .overview-card__cpu-tests,
+      .overview-card__memory-tests,
+      .overview-card__storage-tests,
+      .overview-card__details {
+        padding: $spv-inner--large $sph-inner;
+      }
+
+      .overview-card__details {
+        flex-wrap: wrap;
+
+        > * {
+          flex: 1 50%;
+          padding-bottom: $spv-inner--small;
+
+          &:last-child,
+          &:nth-last-child(2) {
+            padding-bottom: 0;
+          }
+        }
+      }
+    }
+  }
+}

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./OverviewCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/__snapshots__/MachineSummary.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/__snapshots__/MachineSummary.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MachineSummary renders 1`] = `
-<MachineSummary>
+<MachineSummary
+  setSelectedAction={[MockFunction]}
+>
   <Spinner
     text="Loading"
   >

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./MachineSummary";
-export type { SetSelectedAction } from "./MachineSummary";
+export type { SelectedAction, SetSelectedAction } from "./MachineSummary";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./MachineSummary";
+export type { SetSelectedAction } from "./MachineSummary";

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -10,6 +10,7 @@ import {
   getCurrentFilters,
   toggleFilter,
 } from "app/machines/search";
+import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
 import { machine as machineActions } from "app/base/actions";
 import machineSelectors from "app/store/machine/selectors";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
@@ -50,7 +51,7 @@ type Props = {
   searchFilter?: string;
   selectedAction?: MachineAction;
   setSearchFilter: (filter: string) => void;
-  setSelectedAction: (action: MachineAction) => void;
+  setSelectedAction: SetSelectedAction;
 };
 
 export const MachineListHeader = ({

--- a/ui/src/app/store/general/types.ts
+++ b/ui/src/app/store/general/types.ts
@@ -78,7 +78,6 @@ export type MachineAction = {
   sentence?: string;
   title?: string;
   type?: string;
-  hardwareType?: number;
 };
 
 export type MachineActionsState = {

--- a/ui/src/app/store/general/types.ts
+++ b/ui/src/app/store/general/types.ts
@@ -75,9 +75,10 @@ export type MachineActionName =
 
 export type MachineAction = {
   name: MachineActionName;
-  sentence: string;
-  title: string;
-  type: string;
+  sentence?: string;
+  title?: string;
+  type?: string;
+  hardwareType?: number;
 };
 
 export type MachineActionsState = {

--- a/ui/src/app/store/general/types.ts
+++ b/ui/src/app/store/general/types.ts
@@ -75,9 +75,9 @@ export type MachineActionName =
 
 export type MachineAction = {
   name: MachineActionName;
-  sentence?: string;
-  title?: string;
-  type?: string;
+  sentence: string;
+  title: string;
+  type: string;
 };
 
 export type MachineActionsState = {

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -1,13 +1,13 @@
 import type { Model, ModelRef } from "app/store/types/model";
 
-type TestResult = -1 | 0 | 1;
+type TestResult = -1 | 0 | 1 | 2 | 3;
 
 export type TestStatus = {
   status: TestResult;
-  pending: TestResult;
-  running: TestResult;
-  passed: TestResult;
-  failed: TestResult;
+  pending: number;
+  running: number;
+  passed: number;
+  failed: number;
 };
 
 /**

--- a/ui/src/scss/_patterns_lists.scss
+++ b/ui/src/scss/_patterns_lists.scss
@@ -9,7 +9,7 @@
   .p-grid-list__label {
     color: $color-mid-dark;
     text-align: right;
-    
+
     &:not(:nth-last-child(2)) {
       margin-bottom: $spv-outer--small-scaleable;
     }
@@ -21,5 +21,10 @@
     &:not(:last-child) {
       margin-bottom: $spv-outer--small-scaleable;
     }
+  }
+
+  .p-inline-list__item--compact {
+    @include vf-inline-list-item;
+    margin-right: $sph-inner--small;
   }
 }

--- a/ui/src/scss/_patterns_lists.scss
+++ b/ui/src/scss/_patterns_lists.scss
@@ -22,9 +22,4 @@
       margin-bottom: $spv-outer--small-scaleable;
     }
   }
-
-  .p-inline-list__item--compact {
-    @include vf-inline-list-item;
-    margin-right: $sph-inner--small;
-  }
 }

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -32,6 +32,12 @@
     justify-content: space-between;
   }
 
+  .u-flex--vertically {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
   .u-flex--column-align-end {
     align-items: flex-end;
     display: flex;

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -112,10 +112,12 @@
 @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
+@import "~app/machines/views/MachineDetails/MachineSummary/OverviewCard";
 @include MachineList;
 @include MachineSummary;
 @include MarkBrokenFormFields;
 @include NumaCard;
+@include OverviewCard;
 @include FilterAccordion;
 
 // preferences

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -62,6 +62,7 @@ export {
   podHint,
   podNumaNode,
   podStoragePool,
+  testStatus,
 } from "./nodes";
 export { dhcpSnippet } from "./dhcpsnippet";
 export { fabric } from "./fabric";

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -22,7 +22,7 @@ import type { Model } from "app/store/types/model";
 import { BaseNode, SimpleNode, TestStatus } from "app/store/types/node";
 import { model, modelRef } from "./model";
 
-const testStatus = define<TestStatus>({
+export const testStatus = define<TestStatus>({
   status: 0,
   pending: 0,
   running: 0,


### PR DESCRIPTION
## Done

- add status and cpu cards to machine details summary overview

This branch was getting quite large, so `Memory` and `Storage` cards will be in follow-up branches.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure the status and cpu cards render as expected.
- Ensure links in the results list take you to the testing tab.
- With a machine with no tests run, ensure the "Test CPU..." link opens the testing take action button with the appropriate CPU tests selected.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
