### PR TITLE
feat(ui): build the machine details network card

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -7,7 +7,7 @@ exports[`stricter compilation`] = {
       [162, 4, 36, "Object is possibly \'null\'.", "1039669632"]
     ],
     "src/app/App.tsx:3872899616": [
-      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
+      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
       [188, 17, 17, "Object is possibly \'null\'.", "2133029343"],
       [193, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
@@ -44,7 +44,7 @@ exports[`stricter compilation`] = {
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -86,7 +86,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -345,8 +345,8 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:2073227660": [
       [33, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:1620177595": [
-      [41, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:564355202": [
+      [42, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
@@ -566,7 +566,7 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [11, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:1368476588": [
+    "src/app/store/machine/types.ts:193241885": [
       [3, 13, 8, "RegExp match", "1152173309"],
       [295, 9, 8, "RegExp match", "1152173309"]
     ],

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -1,8 +1,9 @@
-import { Card, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import React, { useEffect } from "react";
 
+import NetworkCard from "./NetworkCard";
 import NumaCard from "./NumaCard";
 import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
@@ -51,7 +52,7 @@ const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
       <OverviewCard id={id} setSelectedAction={setSelectedAction} />
       <SystemCard id={id} />
       <NumaCard id={id} />
-      <Card className="machine-summary__network-card">Network</Card>
+      <NetworkCard id={id} />
     </div>
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -1,0 +1,158 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  fabricState as fabricStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+import NetworkCard from "./NetworkCard";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("NetworkCard", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      fabric: fabricStateFactory({ loaded: true }),
+      machine: machineStateFactory(),
+      vlan: vlanStateFactory({ loaded: true }),
+    });
+  });
+
+  it("fetches the necessary data on load", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/abc123/summary"
+            component={() => <NetworkCard id="abc123" />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const actions = store.getActions();
+
+    expect(actions.some((action) => action.type === "fabric/fetch"));
+    expect(actions.some((action) => action.type === "vlan/fetch"));
+  });
+
+  it("displays product, vendor and firmware information, if they exist", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            firmware_version: "1.0.0",
+            product: "Product 1",
+            vendor: "Vendor 1",
+          }),
+          machineInterfaceFactory({
+            firmware_version: null,
+            product: null,
+            vendor: null,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/abc123/summary"
+            component={() => <NetworkCard id="abc123" />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("ul [data-test='nic-vendor']").at(0).text()).toBe(
+      "Vendor 1"
+    );
+    expect(wrapper.find("ul [data-test='nic-product']").at(0).text()).toBe(
+      "Product 1"
+    );
+    expect(
+      wrapper.find("ul [data-test='nic-firmware-version']").at(0).text()
+    ).toBe("1.0.0");
+    expect(wrapper.find("ul [data-test='nic-vendor']").at(1).text()).toBe(
+      "Unknown network card"
+    );
+  });
+
+  it("groups interfaces by vendor, product and firmware version", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          ...Array.from(Array(4)).map(() =>
+            machineInterfaceFactory({
+              firmware_version: "1.0.0",
+              product: "Product 1",
+              vendor: "Vendor 1",
+            })
+          ),
+          ...Array.from(Array(3)).map(() =>
+            machineInterfaceFactory({
+              firmware_version: "2.0.0",
+              product: "Product 1",
+              vendor: "Vendor 1",
+            })
+          ),
+          ...Array.from(Array(2)).map(() =>
+            machineInterfaceFactory({
+              firmware_version: "2.0.0",
+              product: "Product 2",
+              vendor: "Vendor 1",
+            })
+          ),
+          machineInterfaceFactory({
+            firmware_version: "2.0.0",
+            product: "Product 2",
+            vendor: "Vendor 2",
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/abc123/summary"
+            component={() => <NetworkCard id="abc123" />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Table").at(0).find("tbody TableRow").length).toBe(4);
+    expect(wrapper.find("Table").at(1).find("tbody TableRow").length).toBe(3);
+    expect(wrapper.find("Table").at(2).find("tbody TableRow").length).toBe(2);
+    expect(wrapper.find("Table").at(3).find("tbody TableRow").length).toBe(1);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -1,0 +1,165 @@
+import { Card, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+import React, { Fragment, useEffect } from "react";
+
+import { actions as fabricActions } from "app/store/fabric";
+import { actions as vlanActions } from "app/store/vlan";
+import fabricSelectors from "app/store/fabric/selectors";
+import machineSelectors from "app/store/machine/selectors";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { Machine, NetworkInterface } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import NetworkCardTable from "./NetworkCardTable";
+
+type InterfaceGroup = {
+  firmwareVersion: string;
+  interfaces: NetworkInterface[];
+  product: string;
+  vendor: string;
+};
+
+type Props = {
+  id: Machine["system_id"];
+};
+
+/**
+ * Group physical interfaces by vendor, product and firmware version.
+ * @param interfaces - the interfaces to group
+ * @returns interfaces grouped by vendor, product and firmware version
+ */
+const groupInterfaces = (interfaces: NetworkInterface[]): InterfaceGroup[] => {
+  const physicalInterfaces = interfaces.filter(
+    (iface) => iface.type === "physical"
+  );
+
+  // Group interfaces by vendor, product and firmware version
+  const interfaceGroups = physicalInterfaces.reduce(
+    (groups: InterfaceGroup[], iface: NetworkInterface) => {
+      const vendor = iface.vendor || "Unknown network card";
+      const product = iface.product || "";
+      const firmwareVersion = iface.firmware_version || "";
+      const existingGroup = groups.find(
+        (group) =>
+          group.vendor === vendor &&
+          group.product === product &&
+          group.firmwareVersion === firmwareVersion
+      );
+
+      if (existingGroup) {
+        existingGroup.interfaces.push(iface);
+      } else {
+        groups.push({
+          interfaces: [iface],
+          vendor,
+          product,
+          firmwareVersion,
+        });
+      }
+      return groups;
+    },
+    []
+  );
+
+  // Sort groups by vendor, then product, then firmware version. Unknown vendors
+  // should appear last.
+  const sortedGroups = interfaceGroups.sort((a, b) => {
+    const vendorA = a.vendor;
+    const vendorB = b.vendor;
+    const productA = a.product;
+    const productB = b.product;
+    const versionA = a.firmwareVersion;
+    const versionB = b.firmwareVersion;
+
+    if (vendorA === "Unknown network card") {
+      return 1;
+    }
+    if (vendorB === "Unknown network card") {
+      return -1;
+    }
+    if (vendorA === vendorB) {
+      if (productA === productB) {
+        if (versionA === versionB) {
+          return 0;
+        }
+        return versionA > versionB ? 1 : -1;
+      }
+      return productA > productB ? 1 : -1;
+    }
+    return vendorA > vendorB ? 1 : -1;
+  });
+
+  return sortedGroups;
+};
+
+const NetworkCard = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+  const fabricsLoaded = useSelector(fabricSelectors.loaded);
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  let content: JSX.Element;
+
+  // Confirm that the full machine details have been fetched. This also allows
+  // TypeScript know we're using the right union type (otherwise it will
+  // complain that interfaces doesn't exist on the base machine type).
+  if (machine && "interfaces" in machine && fabricsLoaded && vlansLoaded) {
+    const groupedInterfaces = groupInterfaces(machine.interfaces);
+    content = (
+      <>
+        {groupedInterfaces.map((group, i) => (
+          <Fragment key={i}>
+            <ul className="p-inline-list u-no-margin--bottom">
+              <li className="p-inline-list__item" data-test="nic-vendor">
+                {group.vendor}
+              </li>
+              {group.product && (
+                <li
+                  className="p-inline-list__item u-text--muted"
+                  data-test="nic-product"
+                >
+                  {group.product}
+                </li>
+              )}
+              {group.firmwareVersion && (
+                <li
+                  className="p-inline-list__item u-text--muted"
+                  data-test="nic-firmware-version"
+                >
+                  {group.firmwareVersion}
+                </li>
+              )}
+            </ul>
+            <NetworkCardTable interfaces={group.interfaces} />
+          </Fragment>
+        ))}
+        <span>
+          Information about tagged traffic can be seen in the{" "}
+          <Link to={`/machine/${id}/network`}>Network tab</Link>.
+        </span>
+      </>
+    );
+  } else {
+    content = <Spinner />;
+  }
+
+  return (
+    <div className="machine-summary__network-card">
+      <Card>
+        <h4 className="p-muted-heading u-sv1">
+          <Link to={`/machine/${id}/network`}>Network&nbsp;&rsaquo;</Link>
+        </h4>
+        {content}
+      </Card>
+    </div>
+  );
+};
+
+export default NetworkCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
@@ -1,0 +1,165 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  fabric as fabricFactory,
+  machineInterface as machineInterfaceFactory,
+  rootState as rootStateFactory,
+  vlan as vlanFactory,
+} from "testing/factories";
+import NetworkCardTable from "./NetworkCardTable";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("NetworkCardInterface", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory();
+  });
+
+  it("can render the interface's fabric name", () => {
+    state.fabric.items = [fabricFactory({ id: 1, name: "fabric-name" })];
+    state.vlan.items = [vlanFactory({ fabric: 1, id: 2 })];
+    const store = mockStore(state);
+    const iface = machineInterfaceFactory({ vlan_id: 2 });
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <NetworkCardTable interfaces={[iface]} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableCell.fabric").text()).toBe("fabric-name");
+  });
+
+  it("formats link speed in Gbps if above 1000 Mbps", () => {
+    const store = mockStore(state);
+    const iface = machineInterfaceFactory({ link_speed: 10000 });
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <NetworkCardTable interfaces={[iface]} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableCell.speed").text()).toBe("10 Gbps");
+  });
+
+  describe("DHCP status", () => {
+    it("can show external DHCP", () => {
+      state.vlan.items = [vlanFactory({ external_dhcp: "192.168.1.1", id: 1 })];
+      const store = mockStore(state);
+      const iface = machineInterfaceFactory({ vlan_id: 1 });
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[
+              { pathname: "/machine/abc123/summary", key: "testKey" },
+            ]}
+          >
+            <NetworkCardTable interfaces={[iface]} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("TableCell.dhcp").text()).toBe(
+        "External (192.168.1.1)"
+      );
+    });
+
+    it("can show MAAS-provided DHCP", () => {
+      state.vlan.items = [vlanFactory({ dhcp_on: true, id: 1 })];
+      const store = mockStore(state);
+      const iface = machineInterfaceFactory({ vlan_id: 1 });
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[
+              { pathname: "/machine/abc123/summary", key: "testKey" },
+            ]}
+          >
+            <NetworkCardTable interfaces={[iface]} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("TableCell.dhcp").text()).toBe("MAAS-provided");
+    });
+
+    it("can show DHCP relay information with a tooltip", () => {
+      state.fabric.items = [fabricFactory({ id: 1, name: "fabrice" })];
+      state.vlan.items = [
+        vlanFactory({ fabric: 1, id: 2, name: "flan-vlan", relay_vlan: 3 }),
+      ];
+      const store = mockStore(state);
+      const iface = machineInterfaceFactory({ vlan_id: 2 });
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[
+              { pathname: "/machine/abc123/summary", key: "testKey" },
+            ]}
+          >
+            <NetworkCardTable interfaces={[iface]} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("TableCell.dhcp").text()).toBe("Relayed");
+      expect(wrapper.find("TableCell.dhcp Tooltip").prop("message")).toBe(
+        "Relayed via fabrice.flan-vlan"
+      );
+    });
+
+    it("can show if interface has no DHCP", () => {
+      state.vlan.items = [vlanFactory({ id: 1 })];
+      const store = mockStore(state);
+      const iface = machineInterfaceFactory({ vlan_id: 1 });
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[
+              { pathname: "/machine/abc123/summary", key: "testKey" },
+            ]}
+          >
+            <NetworkCardTable interfaces={[iface]} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(wrapper.find("TableCell.dhcp").text()).toBe("No DHCP");
+    });
+  });
+
+  it("can show if the interface is SR-IOV enabled", () => {
+    const store = mockStore(state);
+    const iface = machineInterfaceFactory({ sriov_max_vf: 256 });
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <NetworkCardTable interfaces={[iface]} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("TableCell.sriov").text()).toBe("Yes");
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
@@ -1,0 +1,145 @@
+import {
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  Tooltip,
+} from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import React from "react";
+
+import type { NetworkInterface } from "app/store/machine/types";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { Fabric } from "app/store/fabric/types";
+import vlanSelectors from "app/store/vlan/selectors";
+import type { VLAN } from "app/store/vlan/types";
+import { formatSpeedUnits } from "app/utils";
+
+/**
+ * Returns the name of an interface's fabric.
+ * @param iface - the interface from which to get the fabric name.
+ * @param fabrics - list of fabrics to search.
+ * @param vlans - list of VLANs to search.
+ * @returns the interface's fabric name.
+ */
+const getInterfaceFabricName = (
+  iface: NetworkInterface,
+  fabrics: Fabric[],
+  vlans: VLAN[]
+): string => {
+  const vlan = vlans.find((vlan) => vlan.id === iface.vlan_id);
+  if (vlan) {
+    const fabric = fabrics.find((fabric) => fabric.id === vlan.fabric);
+    if (fabric) {
+      return fabric.name;
+    }
+  }
+  return "Unknown";
+};
+
+/**
+ * Returns the DHCP status of an interface.
+ * @param iface - the interface from which to get the DHCP status.
+ * @param fabrics - list of fabrics to search.
+ * @param vlans - list of VLANs to search.
+ * @param verbose - whether to return additional relay information, if applicable
+ * @returns interface's DHCP status.
+ */
+const getInterfaceDHCPStatus = (
+  iface: NetworkInterface,
+  fabrics: Fabric[],
+  vlans: VLAN[],
+  verbose = false
+): string => {
+  const vlan = vlans.find((vlan) => vlan.id === iface.vlan_id);
+  if (vlan) {
+    if (vlan.external_dhcp) {
+      return `External (${vlan.external_dhcp})`;
+    }
+
+    if (vlan.dhcp_on) {
+      return "MAAS-provided";
+    }
+
+    if (vlan.relay_vlan) {
+      const fabric = fabrics.find((fabric) => fabric.id === vlan.fabric);
+      if (fabric && verbose) {
+        return `Relayed via ${getInterfaceFabricName(iface, fabrics, vlans)}.${
+          vlan.name
+        }`;
+      }
+      return "Relayed";
+    }
+  }
+  return "No DHCP";
+};
+
+type Props = { interfaces: NetworkInterface[] };
+
+const NetworkCardInterface = ({ interfaces }: Props): JSX.Element => {
+  const fabrics = useSelector(fabricSelectors.all);
+  const vlans = useSelector(vlanSelectors.all);
+
+  return (
+    <Table className="network-card-table">
+      <thead>
+        <TableRow>
+          <TableHeader className="name">Name</TableHeader>
+          <TableHeader className="mac">MAC</TableHeader>
+          <TableHeader className="speed">Link speed</TableHeader>
+          <TableHeader className="fabric">
+            Fabric
+            <Tooltip message="Untagged traffic only" position="top-right">
+              <div className="u-nudge-right--small">
+                <i className="p-icon--information"></i>
+              </div>
+            </Tooltip>
+          </TableHeader>
+          <TableHeader className="dhcp">DHCP</TableHeader>
+          <TableHeader className="sriov">SR-IOV</TableHeader>
+        </TableRow>
+      </thead>
+      <tbody>
+        {interfaces.map((iface) => {
+          const dhcpStatus = getInterfaceDHCPStatus(iface, fabrics, vlans);
+
+          return (
+            <TableRow key={iface.id}>
+              <TableCell className="name">{iface.name}</TableCell>
+              <TableCell className="mac">{iface.mac_address}</TableCell>
+              <TableCell className="speed">
+                {formatSpeedUnits(iface.link_speed)}
+              </TableCell>
+              <TableCell className="fabric">
+                {getInterfaceFabricName(iface, fabrics, vlans)}
+              </TableCell>
+              <TableCell className="dhcp">
+                {dhcpStatus}
+                {dhcpStatus === "Relayed" && (
+                  <Tooltip
+                    message={getInterfaceDHCPStatus(
+                      iface,
+                      fabrics,
+                      vlans,
+                      true
+                    )}
+                    position="btm-right"
+                  >
+                    <div className="u-nudge-right--small">
+                      <i className="p-icon--information"></i>
+                    </div>
+                  </Tooltip>
+                )}
+              </TableCell>
+              <TableCell className="sriov">
+                {iface.sriov_max_vf > 0 ? "Yes" : "No"}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+};
+
+export default NetworkCardInterface;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NetworkCardTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/_index.scss
@@ -1,0 +1,47 @@
+@mixin NetworkCard {
+  .network-card-table {
+    margin-bottom: $sp-large;
+
+    th:first-of-type,
+    td:first-of-type {
+      padding-left: 0;
+    }
+
+    th:last-of-type,
+    td:last-of-type {
+      padding-right: 0;
+    }
+
+    .name {
+      width: 40%;
+    }
+
+    .mac {
+      width: 9.5rem;
+    }
+
+    .speed {
+      width: 7rem;
+    }
+
+    .fabric {
+      width: 7rem;
+    }
+
+    .dhcp {
+      width: 60%;
+    }
+
+    .sriov {
+      width: 3rem;
+    }
+
+    @media only screen and (max-width: $breakpoint-medium) {
+      .speed,
+      .fabric,
+      .sriov {
+        display: none;
+      }
+    }
+  }
+}

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NetworkCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/_index.scss
@@ -1,6 +1,6 @@
 @mixin MachineSummary {
   .machine-summary__cards {
-    @extend %full-span-grid;
+    @extend %base-grid;
     grid:
       [row1-start] "overview-card overview-card overview-card overview-card" min-content [row1-end]
       [row2-start] "system-card numa-card network-card network-card" min-content [row2-end]

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -28,22 +28,22 @@ export type NetworkInterface = Model & {
   children: string[];
   discovered?: DiscoveredIP[]; // Only shown when machine is in ephemeral state.
   enabled: boolean;
-  firmware_version: string;
+  firmware_version: string | null;
   interface_speed: number;
   is_boot: boolean;
   link_connected: boolean;
   link_speed: number;
   links: NetworkLink[];
   mac_address: string;
-  name: number;
+  name: string;
   numa_node: number;
   params: string;
   parents: string[];
-  product: string;
+  product: string | null;
   sriov_max_vf: number;
   tags: string[];
   type: string;
-  vendor: string;
+  vendor: string | null;
   vlan_id: number;
 };
 

--- a/ui/src/app/utils/formatSpeedUnits.js
+++ b/ui/src/app/utils/formatSpeedUnits.js
@@ -6,6 +6,9 @@ import { formatBytes } from "./formatBytes";
  * @returns {String} Formatted value and unit.
  */
 export const formatSpeedUnits = (speedInMbytes) => {
-  const adjusted = formatBytes(speedInMbytes, "MB");
+  const adjusted =
+    speedInMbytes > 1
+      ? formatBytes(speedInMbytes, "MB")
+      : { unit: "MB", value: speedInMbytes };
   return `${Math.floor(adjusted.value)} ${adjusted.unit[0]}bps`;
 };

--- a/ui/src/scss/_patterns_grids.scss
+++ b/ui/src/scss/_patterns_grids.scss
@@ -11,20 +11,4 @@
       grid-column-gap: map-get($grid-gutter-widths, small);
     }
   }
-
-  %full-span-grid {
-    @extend %base-grid;
-    padding-left: map-get($grid-margin-widths, large);
-    padding-right: map-get($grid-margin-widths, large);
-
-    @media only screen and (max-width: $breakpoint-medium) {
-      padding-left: map-get($grid-margin-widths, medium);
-      padding-right: map-get($grid-margin-widths, medium);
-    }
-
-    @media only screen and (max-width: $breakpoint-small) {
-      padding-left: map-get($grid-margin-widths, small);
-      padding-right: map-get($grid-margin-widths, small);
-    }
-  }
 }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -111,11 +111,13 @@
 @import "~app/machines/views/MachineList";
 @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
 @import "~app/machines/views/MachineDetails/MachineSummary";
+@import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/OverviewCard";
 @include MachineList;
 @include MachineSummary;
 @include MarkBrokenFormFields;
+@include NetworkCard;
 @include NumaCard;
 @include OverviewCard;
 @include FilterAccordion;

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -55,6 +55,7 @@ export {
   machineDevice,
   machineEvent,
   machineEventType,
+  machineInterface,
   machineNumaNode,
   controller,
   pod,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -9,6 +9,7 @@ import type {
   MachineDetails,
   MachineDevice,
   MachineNumaNode,
+  NetworkInterface,
 } from "app/store/machine/types";
 import type {
   Pod,
@@ -146,6 +147,34 @@ export const machineEvent = extend<Model, Event>(model, {
   type: machineEventType,
 });
 
+export const machineInterface = extend<Model, NetworkInterface>(model, {
+  children: () => [],
+  discovered: () => [],
+  enabled: true,
+  firmware_version: "1.0.0",
+  interface_speed: 10000,
+  is_boot: true,
+  link_connected: true,
+  link_speed: 10000,
+  links: () => [],
+  mac_address: "00.00.00.00.00.00",
+  name: (i: number) => `eth${i}`,
+  numa_node: 0,
+  params: "",
+  parents: () => [],
+  product: "Product",
+  sriov_max_vf: 0,
+  tags: () => [],
+  type: "physical",
+  vendor: "Vendor",
+  vlan_id: 5001,
+});
+
+export const machineDevice = define<MachineDevice>({
+  fqdn: "device.maas",
+  interfaces: () => [],
+});
+
 export const machineDetails = extend<Machine, MachineDetails>(machine, {
   bios_boot_method: "uefi",
   bmc: 190,
@@ -198,11 +227,6 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   supported_filesystems: () => [],
   swap_size: null,
   updated: "Fri, 23 Oct. 2020 05:24:41",
-});
-
-export const machineDevice = define<MachineDevice>({
-  fqdn: "device.maas",
-  interfaces: () => [],
 });
 
 export const controller = extend<BaseNode, Controller>(node, {


### PR DESCRIPTION
## Done

- Rebuilt Network card in React. Currently missing the test bit.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine details page and check that the network card matches the old angular design and looks good on all screen sizes.
- Check that the interfaces group correctly (by vendor, then product, then version).
- Check that the DHCP relay tooltip works as expected (legal-finch on bolla has an example).

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2111

## Screenshot
![2020-11-03_16-52](https://user-images.githubusercontent.com/25733845/97956826-6a25fe80-1df5-11eb-8717-aa209e637878.png)

