### PR TITLE
feat(ui): add memory card to machine details overview

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -355,6 +355,10 @@ exports[`stricter compilation`] = {
       [17, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
       [146, 18, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
+    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx:3019693856": [
+      [16, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [120, 18, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
+    ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:539216384": [
       [104, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
       [125, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.", "167402512"],

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -1,0 +1,141 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  testStatus as testStatusFactory,
+} from "testing/factories";
+import MemoryCard from "./MemoryCard";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("MemoryCard", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+  });
+
+  it("renders a link with a count of passed tests", () => {
+    const machine = machineDetailsFactory();
+    machine.memory_test_status = testStatusFactory({
+      passed: 2,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toEqual("2");
+  });
+
+  it("renders a link with a count of pending and running tests", () => {
+    const machine = machineDetailsFactory();
+    machine.memory_test_status = testStatusFactory({
+      running: 1,
+      pending: 2,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toEqual("3");
+  });
+
+  it("renders a link with a count of failed tests", () => {
+    const machine = machineDetailsFactory();
+    machine.memory_test_status = testStatusFactory({
+      failed: 5,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toEqual("5");
+  });
+
+  it("renders a results link", () => {
+    const machine = machineDetailsFactory();
+    machine.memory_test_status = testStatusFactory({
+      failed: 5,
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+    ).toContain("View results");
+  });
+
+  it("renders a test cpu link if no tests run", () => {
+    const machine = machineDetailsFactory();
+    machine.memory_test_status = testStatusFactory();
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MemoryCard machine={machine} setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+    ).toContain("Test memory");
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
@@ -116,37 +116,35 @@ const MemoryCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
             </li>
           ) : (
             <li className="p-inline-list__item">
-              <span className="p-tooltip--top-left">
-                <Tooltip
-                  message={
-                    !machine.actions.includes("test")
-                      ? "Machine cannot run tests at this time."
-                      : null
-                  }
-                  position={"top-left"}
+              <Tooltip
+                message={
+                  !machine.actions.includes("test")
+                    ? "Machine cannot run tests at this time."
+                    : null
+                }
+                position={"top-left"}
+              >
+                <Button
+                  className="p-button--link"
+                  disabled={!machine.actions.includes("test")}
+                  onClick={() => {
+                    setSelectedAction(
+                      {
+                        name: "test",
+                        formProps: { hardwareType: HardwareType.Memory },
+                      },
+                      false
+                    );
+                    sendAnalytics(
+                      "Machine details",
+                      "Test memory",
+                      "Machine summary tab"
+                    );
+                  }}
                 >
-                  <Button
-                    className="p-button--link"
-                    disabled={!machine.actions.includes("test")}
-                    onClick={() => {
-                      setSelectedAction(
-                        {
-                          name: "test",
-                          formProps: { hardwareType: HardwareType.Memory },
-                        },
-                        false
-                      );
-                      sendAnalytics(
-                        "Machine details",
-                        "Test memory",
-                        "Machine summary tab"
-                      );
-                    }}
-                  >
-                    Test memory...
-                  </Button>
-                </Tooltip>
-              </span>
+                  Test memory...
+                </Button>
+              </Tooltip>
             </li>
           )}
         </ul>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
+
+import type { SetSelectedAction } from "../../MachineSummary";
+import { useSendAnalytics } from "app/base/hooks";
+import type { MachineDetails } from "app/store/machine/types";
+import { HardwareType } from "app/base/enum";
+
+type Props = {
+  machine: MachineDetails;
+  setSelectedAction: SetSelectedAction;
+};
+
+const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
+  const testObj = machine[`${scriptType}_test_status`];
+  return (
+    testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
+  );
+};
+
+const MemoryCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
+  const sendAnalytics = useSendAnalytics();
+
+  const testsTabUrl = `/machine/${machine.system_id}/tests`;
+
+  return (
+    <>
+      <div className="overview-card__memory">
+        <strong className="p-muted-heading">Memory</strong>
+        <h4>{machine.memory ? machine.memory + " GiB" : "Unknown"}</h4>
+      </div>
+
+      <div className="overview-card__memory-tests u-flex--vertically">
+        <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
+          {machine.memory_test_status.passed > 0 ? (
+            <li className="p-inline-list__item">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "Memory tests passed link",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                <Icon name={ICONS.success} />
+                {machine.memory_test_status.passed}
+              </Button>
+            </li>
+          ) : null}
+
+          {machine.memory_test_status.pending +
+            machine.memory_test_status.running >
+          0 ? (
+            <li className="p-inline-list__item">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "Memory tests running link",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                <Icon name={"pending"} />
+                {machine.memory_test_status.pending +
+                  machine.memory_test_status.running}
+              </Button>
+            </li>
+          ) : null}
+
+          {machine.memory_test_status.failed > 0 ? (
+            <li className="p-inline-list__item">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "Memory tests failed",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                <Icon name={ICONS.error} />
+                {machine.memory_test_status.failed}
+              </Button>
+            </li>
+          ) : null}
+
+          {hasTestsRun(machine, "memory") ? (
+            <li className="p-inline-list__item">
+              <Button
+                className="p-button--link"
+                element={Link}
+                to={testsTabUrl}
+                onClick={() =>
+                  sendAnalytics(
+                    "Machine details",
+                    "View memory tests results",
+                    "Machine summary tab"
+                  )
+                }
+              >
+                View results&nbsp;&rsaquo;
+              </Button>
+            </li>
+          ) : (
+            <li className="p-inline-list__item">
+              <span className="p-tooltip--top-left">
+                <Tooltip
+                  message={
+                    !machine.actions.includes("test")
+                      ? "Machine cannot run tests at this time."
+                      : null
+                  }
+                  position={"top-left"}
+                >
+                  <Button
+                    className="p-button--link"
+                    disabled={!machine.actions.includes("test")}
+                    onClick={() => {
+                      setSelectedAction(
+                        {
+                          name: "test",
+                          formProps: { hardwareType: HardwareType.Memory },
+                        },
+                        false
+                      );
+                      sendAnalytics(
+                        "Machine details",
+                        "Test memory",
+                        "Machine summary tab"
+                      );
+                    }}
+                  >
+                    Test memory...
+                  </Button>
+                </Tooltip>
+              </span>
+            </li>
+          )}
+        </ul>
+      </div>
+    </>
+  );
+};
+
+export default MemoryCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MemoryCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import React from "react";
 
 import CpuCard from "./CpuCard";
+import MemoryCard from "./MemoryCard";
 import StatusCard from "./StatusCard";
 import type { SetSelectedAction } from "../MachineSummary";
 import machineSelectors from "app/store/machine/selectors";
@@ -31,6 +32,7 @@ const OverviewCard = ({ id, setSelectedAction }: Props): JSX.Element => {
       <div className="overview-card">
         <StatusCard machine={machine} />
         <CpuCard machine={machine} setSelectedAction={setSelectedAction} />
+        <MemoryCard machine={machine} setSelectedAction={setSelectedAction} />
       </div>
     );
   }


### PR DESCRIPTION
## Done

-add memory card to machine details overview

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

* Ensure the memory card renders as expected.
* Ensure links in the results list take you to the testing tab.
* With a machine with no memory tests run, ensure the "Test memory..." link opens the testing take action button with the appropriate memory tests selected.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
