### PR TITLE
feat(ui): add the machine's power and locked status

### DIFF
--- a/ui/src/app/base/components/Section/_index.scss
+++ b/ui/src/app/base/components/Section/_index.scss
@@ -10,6 +10,10 @@
     background-color: #fff;
   }
 
+  .section__header-icon {
+    margin-right: $spv-outer--small;
+  }
+
   .section__header .p-icon--spinner {
     height: $spv-inner--large;
     width: $spv-inner--large;

--- a/ui/src/app/base/components/Section/_index.scss
+++ b/ui/src/app/base/components/Section/_index.scss
@@ -10,10 +10,6 @@
     background-color: #fff;
   }
 
-  .section__header-icon {
-    margin-right: $spv-outer--small;
-  }
-
   .section__header .p-icon--spinner {
     height: $spv-inner--large;
     width: $spv-inner--large;

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
@@ -23,6 +23,15 @@ describe("SectionHeader", () => {
     );
   });
 
+  it("can have multiple subtitle elements", () => {
+    const wrapper = shallow(
+      <SectionHeader title="Title" subtitle={["Subtitle1", "Subtitle2"]} />
+    );
+    expect(wrapper.find("[data-test='section-header-subtitle']").length).toBe(
+      2
+    );
+  });
+
   it("shows a spinner instead of subtitle if loading", () => {
     const wrapper = shallow(
       <SectionHeader title="Title" subtitle="Subtitle" loading />

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -1,6 +1,7 @@
 import { Col, Row, Spinner, Tabs } from "@canonical/react-components";
 import classNames from "classnames";
 import React from "react";
+import type { ReactNode } from "react";
 
 import type { TSFixMe } from "app/base/types";
 
@@ -8,9 +9,26 @@ type Props = {
   buttons?: JSX.Element[] | null;
   formWrapper?: JSX.Element | null;
   loading?: boolean;
-  subtitle?: TSFixMe;
+  subtitle?: ReactNode | ReactNode[];
   tabLinks?: TSFixMe[];
   title: string;
+};
+
+const generateSubtitle = (subtitle: Props["subtitle"]) => {
+  const items = (Array.isArray(subtitle) ? subtitle : [subtitle]).filter(
+    Boolean
+  );
+  return items.map((item, i) => (
+    <li
+      className={classNames("p-inline-list__item u-text--light", {
+        "last-item": i === items.length - 1,
+      })}
+      data-test="section-header-subtitle"
+      key={i}
+    >
+      {item}
+    </li>
+  ));
 };
 
 const SectionHeader = ({
@@ -31,19 +49,16 @@ const SectionHeader = ({
           >
             {title}
           </li>
-          {(loading || subtitle) && (
+          {loading ? (
             <li className="p-inline-list__item last-item u-text--light">
-              {subtitle && !loading && (
-                <span data-test="section-header-subtitle">{subtitle}</span>
-              )}
-              {loading && (
-                <Spinner
-                  className="u-no-padding u-no-margin"
-                  inline
-                  text="Loading..."
-                />
-              )}
+              <Spinner
+                className="u-no-padding u-no-margin"
+                inline
+                text="Loading..."
+              />
             </li>
+          ) : (
+            generateSubtitle(subtitle)
           )}
         </ul>
         {buttons?.length && (

--- a/ui/src/app/base/components/SectionHeader/__snapshots__/SectionHeader.test.tsx.snap
+++ b/ui/src/app/base/components/SectionHeader/__snapshots__/SectionHeader.test.tsx.snap
@@ -15,13 +15,11 @@ exports[`SectionHeader can render 1`] = `
         Title
       </li>
       <li
-        className="p-inline-list__item last-item u-text--light"
+        className="p-inline-list__item u-text--light last-item"
+        data-test="section-header-subtitle"
+        key="0"
       >
-        <span
-          data-test="section-header-subtitle"
-        >
-          Subtitle
-        </span>
+        Subtitle
       </li>
     </ul>
   </div>

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -5,10 +5,10 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import {
-  machine as machineFactory,
   machineDetails as machineDetailsFactory,
   machineDevice as machineDeviceFactory,
   machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 import MachineHeader from "./MachineHeader";
@@ -22,9 +22,117 @@ describe("MachineHeader", () => {
     state = rootStateFactory({
       machine: machineStateFactory({
         loaded: true,
-        items: [machineFactory({ system_id: "abc123" })],
+        items: [machineDetailsFactory({ system_id: "abc123" })],
       }),
     });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => (
+              <MachineHeader
+                selectedAction={null}
+                setSelectedAction={jest.fn()}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays an icon when locked", () => {
+    state.machine.items[0].locked = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => (
+              <MachineHeader
+                selectedAction={null}
+                setSelectedAction={jest.fn()}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .findWhere((n) => n.name() === "Icon" && n.prop("name") === "locked")
+        .exists()
+    ).toBe(true);
+  });
+
+  it("displays power status", () => {
+    state.machine.items[0].power_state = "on";
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => (
+              <MachineHeader
+                selectedAction={null}
+                setSelectedAction={jest.fn()}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".p-icon--power-on").exists()).toBe(true);
+    expect(wrapper.find("[data-test='machine-header-power']").text()).toBe(
+      "Power on"
+    );
+  });
+
+  it("displays power status when checking power", () => {
+    state.machine.statuses["abc123"] = machineStatusFactory({
+      checkingPower: true,
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => (
+              <MachineHeader
+                selectedAction={null}
+                setSelectedAction={jest.fn()}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".p-icon--power-checking").exists()).toBe(true);
+    expect(wrapper.find("[data-test='machine-header-power']").text()).toBe(
+      "Checking power"
+    );
   });
 
   it("includes a tab for instances if machine has any", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,17 +1,17 @@
+import { Icon, Tooltip } from "@canonical/react-components";
+import { Link, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import React, { useEffect } from "react";
-import { Link, useLocation } from "react-router-dom";
 
 import { SelectedAction, SetSelectedAction } from "../MachineSummary";
-import type { RouteParams } from "app/base/types";
-import type { MachineDetails } from "app/store/machine/types";
 import { machine as machineActions } from "app/base/actions";
-import machineSelectors from "app/store/machine/selectors";
 import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
+import machineSelectors from "app/store/machine/selectors";
 import SectionHeader from "app/base/components/SectionHeader";
 import TakeActionMenu from "app/machines/components/TakeActionMenu";
 import type { RootState } from "app/store/root/types";
+import type { RouteParams } from "app/base/types";
 
 type Props = {
   selectedAction: SelectedAction | null;
@@ -28,103 +28,131 @@ const MachineHeader = ({
   const loading = useSelector(machineSelectors.loading);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
-  ) as MachineDetails;
+  );
+  const statuses = useSelector((state: RootState) =>
+    machineSelectors.getStatuses(state, id)
+  );
+  const checkingPower = statuses?.checkingPower;
 
   useEffect(() => {
     dispatch(machineActions.get(id));
   }, [dispatch, id]);
 
-  if (!!machine) {
-    const { devices, fqdn, system_id } = machine;
-    const urlBase = `/machine/${system_id}`;
-
-    return (
-      <SectionHeader
-        buttons={
-          !selectedAction
-            ? [
-                <TakeActionMenu
-                  key="action-dropdown"
-                  setSelectedAction={setSelectedAction}
-                />,
-              ]
-            : null
-        }
-        formWrapper={
-          selectedAction ? (
-            <ActionFormWrapper
-              selectedAction={selectedAction}
-              setSelectedAction={setSelectedAction}
-            />
-          ) : null
-        }
-        loading={loading}
-        subtitle={machine.status}
-        tabLinks={[
-          {
-            active: pathname.startsWith(`${urlBase}/summary`),
-            component: Link,
-            label: "Summary",
-            to: `${urlBase}/summary`,
-          },
-          ...(devices?.length >= 1
-            ? [
-                {
-                  active: pathname.startsWith(`${urlBase}/instances`),
-                  component: Link,
-                  label: "Instances",
-                  to: `${urlBase}/instances`,
-                },
-              ]
-            : []),
-          {
-            active: pathname.startsWith(`${urlBase}/network`),
-            component: Link,
-            label: "Network",
-            to: `${urlBase}/network`,
-          },
-          {
-            active: pathname.startsWith(`${urlBase}/storage`),
-            component: Link,
-            label: "Storage",
-            to: `${urlBase}/storage`,
-          },
-          {
-            active: pathname.startsWith(`${urlBase}/commissioning`),
-            component: Link,
-            label: "Commissioning",
-            to: `${urlBase}/commissioning`,
-          },
-          {
-            active: pathname.startsWith(`${urlBase}/tests`),
-            component: Link,
-            label: "Tests",
-            to: `${urlBase}/tests`,
-          },
-          {
-            active: pathname.startsWith(`${urlBase}/logs`),
-            component: Link,
-            label: "Logs",
-            to: `${urlBase}/logs`,
-          },
-          {
-            active: pathname.startsWith(`${urlBase}/events`),
-            component: Link,
-            label: "Events",
-            to: `${urlBase}/events`,
-          },
-          {
-            active: pathname.startsWith(`${urlBase}/configuration`),
-            component: Link,
-            label: "Configuration",
-            to: `${urlBase}/configuration`,
-          },
-        ]}
-        title={fqdn}
-      />
-    );
+  if (!machine || !("devices" in machine)) {
+    return <SectionHeader loading title="" />;
   }
-  return <SectionHeader loading title="" />;
+
+  const { devices, fqdn, system_id } = machine;
+  const urlBase = `/machine/${system_id}`;
+
+  return (
+    <SectionHeader
+      buttons={
+        !selectedAction
+          ? [
+              <TakeActionMenu
+                key="action-dropdown"
+                setSelectedAction={setSelectedAction}
+              />,
+            ]
+          : null
+      }
+      formWrapper={
+        selectedAction ? (
+          <ActionFormWrapper
+            selectedAction={selectedAction}
+            setSelectedAction={setSelectedAction}
+          />
+        ) : null
+      }
+      loading={loading}
+      subtitle={[
+        <>
+          {machine.locked ? (
+            <Tooltip
+              className="section__header-icon"
+              message="This machine is locked. You have to unlock it to perform any actions."
+              position="btm-left"
+            >
+              <Icon name="locked" />
+            </Tooltip>
+          ) : null}
+          {machine.status}
+        </>,
+        <>
+          <span className="section__header-icon">
+            <Icon
+              name={`power-${checkingPower ? "checking" : machine.power_state}`}
+            />
+          </span>
+          <span data-test="machine-header-power">
+            {checkingPower ? "Checking power" : `Power ${machine.power_state}`}
+          </span>
+        </>,
+      ]}
+      tabLinks={[
+        {
+          active: pathname.startsWith(`${urlBase}/summary`),
+          component: Link,
+          label: "Summary",
+          to: `${urlBase}/summary`,
+        },
+        ...(devices?.length >= 1
+          ? [
+              {
+                active: pathname.startsWith(`${urlBase}/instances`),
+                component: Link,
+                label: "Instances",
+                to: `${urlBase}/instances`,
+              },
+            ]
+          : []),
+        {
+          active: pathname.startsWith(`${urlBase}/network`),
+          component: Link,
+          label: "Network",
+          to: `${urlBase}/network`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/storage`),
+          component: Link,
+          label: "Storage",
+          to: `${urlBase}/storage`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/commissioning`),
+          component: Link,
+          label: "Commissioning",
+          to: `${urlBase}/commissioning`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/tests`),
+          component: Link,
+          label: "Tests",
+          to: `${urlBase}/tests`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/logs`),
+          component: Link,
+          label: "Logs",
+          to: `${urlBase}/logs`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/events`),
+          component: Link,
+          label: "Events",
+          to: `${urlBase}/events`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/configuration`),
+          component: Link,
+          label: "Configuration",
+          to: `${urlBase}/configuration`,
+        },
+      ]}
+      title={fqdn}
+    />
+  );
 };
 
 export default MachineHeader;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -70,7 +70,7 @@ const MachineHeader = ({
         <>
           {machine.locked ? (
             <Tooltip
-              className="section__header-icon"
+              className="u-nudge-left--small"
               message="This machine is locked. You have to unlock it to perform any actions."
               position="btm-left"
             >
@@ -80,7 +80,7 @@ const MachineHeader = ({
           {machine.status}
         </>,
         <>
-          <span className="section__header-icon">
+          <span className="u-nudge-left--small">
             <Icon
               name={`power-${checkingPower ? "checking" : machine.power_state}`}
             />

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -109,6 +109,18 @@ describe("machine selectors", () => {
     expect(machine.statuses(state)).toStrictEqual(statuses);
   });
 
+  it("can get the statuses for a machine", () => {
+    const machineStatuses = machineStatusFactory();
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        statuses: machineStatusesFactory({
+          abc123: machineStatuses,
+        }),
+      }),
+    });
+    expect(machine.getStatuses(state, "abc123")).toStrictEqual(machineStatuses);
+  });
+
   it("can get machines that are processing", () => {
     const statuses = machineStatusesFactory({
       abc123: machineStatusFactory({ testing: true }),

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -91,6 +91,17 @@ ACTIONS.forEach(({ status }) => {
 });
 
 /**
+ * Get the statuses for a machine.
+ * @param state - The redux state.
+ * @param id - A machine's system id.
+ * @returns The machine's statuses
+ */
+const getStatuses = createSelector(
+  [statuses, (_state: RootState, id: Machine["system_id"]) => id],
+  (allStatuses, id) => allStatuses[id]
+);
+
+/**
  * Get machines that match terms.
  * @param {RootState} state - The redux state.
  * @param {String} terms - The terms to match against.
@@ -176,6 +187,7 @@ const selectors = {
   exitingRescueMode: statusSelectors["exitingRescueMode"],
   exitingRescueModeSelected: statusSelectors["exitingRescueModeSelected"],
   failedScriptResults,
+  getStatuses,
   locking: statusSelectors["locking"],
   lockingSelected: statusSelectors["lockingSelected"],
   markingBroken: statusSelectors["markingBroken"],


### PR DESCRIPTION
## Done

- Show the power and locked status to the machine details header.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine's details. The power state should be in the header.
- View a locked machine, there should be a lock icon in the header.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2103.