### PR TITLE
feat(ui): add power actions to machine details header

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -7,7 +7,7 @@ exports[`stricter compilation`] = {
       [162, 4, 36, "Object is possibly \'null\'.", "1039669632"]
     ],
     "src/app/App.tsx:3872899616": [
-      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
+      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
       [188, 17, 17, "Object is possibly \'null\'.", "2133029343"],
       [193, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
@@ -44,7 +44,7 @@ exports[`stricter compilation`] = {
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -86,7 +86,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -342,8 +342,9 @@ exports[`stricter compilation`] = {
       [29, 28, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"],
       [33, 30, 9, "Property \'setActive\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "1891567915"]
     ],
-    "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:2666992142": [
-      [37, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
+    "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:914617473": [
+      [40, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
+      [105, 42, 10, "Property \'checkPower\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "953482588"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:564355202": [
       [42, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -184,7 +184,12 @@ export const useSendAnalyticsWhen = (
  * @param {String} noneMessage - The message to display if there are no items.
  * @param {Function} onClick - A function to call when the item is clicked.
  */
-export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
+export const useMachineActions = (
+  systemId,
+  actions,
+  noneMessage = null,
+  onClick = null
+) => {
   const dispatch = useDispatch();
   const generalMachineActions = useSelector(
     generalSelectors.machineActions.get
@@ -193,32 +198,34 @@ export const useMachineActions = (systemId, actions, noneMessage, onClick) => {
     machineSelectors.getById(state, systemId)
   );
   let actionLinks = [];
-  actions.forEach((action) => {
-    if (machine.actions.includes(action)) {
-      let actionLabel = action;
-      generalMachineActions.forEach((machineAction) => {
-        if (machineAction.name === action) {
-          actionLabel = machineAction.title;
-        }
-      });
+  if (machine) {
+    actions.forEach((action) => {
+      if (machine.actions.includes(action)) {
+        let actionLabel = action;
+        generalMachineActions.forEach((machineAction) => {
+          if (machineAction.name === action) {
+            actionLabel = machineAction.title;
+          }
+        });
 
-      actionLinks.push({
-        children: actionLabel,
-        onClick: () => {
-          const actionMethod = kebabToCamelCase(action);
-          dispatch(machineActions[actionMethod](systemId));
-          onClick && onClick();
+        actionLinks.push({
+          children: actionLabel,
+          onClick: () => {
+            const actionMethod = kebabToCamelCase(action);
+            dispatch(machineActions[actionMethod](systemId));
+            onClick && onClick();
+          },
+        });
+      }
+    });
+    if (actionLinks.length === 0 && noneMessage) {
+      return [
+        {
+          children: noneMessage,
+          disabled: true,
         },
-      });
+      ];
     }
-  });
-  if (actionLinks.length === 0 && noneMessage) {
-    return [
-      {
-        children: noneMessage,
-        disabled: true,
-      },
-    ];
   }
   return actionLinks;
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -129,10 +129,119 @@ describe("MachineHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find(".p-icon--power-checking").exists()).toBe(true);
+    expect(wrapper.find(".p-icon--spinner").exists()).toBe(true);
     expect(wrapper.find("[data-test='machine-header-power']").text()).toBe(
       "Checking power"
     );
+  });
+
+  describe("power menu", () => {
+    it("can dispatch the power on action", () => {
+      state.machine.items[0].actions = ["on"];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <Route
+              exact
+              path="/machine/:id"
+              component={() => (
+                <MachineHeader
+                  selectedAction={null}
+                  setSelectedAction={jest.fn()}
+                />
+              )}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      // Open the power menu dropdown
+      wrapper.find("TableMenu Button").simulate("click");
+      // Click the "Power on" link
+      wrapper
+        .find("TableMenu .p-contextual-menu__link")
+        .at(0)
+        .simulate("click");
+
+      expect(
+        store.getActions().some((action) => action.type === "TURN_MACHINE_ON")
+      ).toBe(true);
+    });
+
+    it("can dispatch the power off action", () => {
+      state.machine.items[0].actions = ["off"];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <Route
+              exact
+              path="/machine/:id"
+              component={() => (
+                <MachineHeader
+                  selectedAction={null}
+                  setSelectedAction={jest.fn()}
+                />
+              )}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      // Open the power menu dropdown
+      wrapper.find("TableMenu Button").simulate("click");
+      // Click the "Power off" link
+      wrapper
+        .find("TableMenu .p-contextual-menu__link")
+        .at(0)
+        .simulate("click");
+
+      expect(
+        store.getActions().some((action) => action.type === "TURN_MACHINE_OFF")
+      ).toBe(true);
+    });
+
+    it("can dispatch the check power action", () => {
+      state.machine.items[0].actions = [];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <Route
+              exact
+              path="/machine/:id"
+              component={() => (
+                <MachineHeader
+                  selectedAction={null}
+                  setSelectedAction={jest.fn()}
+                />
+              )}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      // Open the power menu dropdown
+      wrapper.find("TableMenu Button").simulate("click");
+      // Click the "Check power" link
+      wrapper
+        .find("TableMenu .p-contextual-menu__link")
+        .at(0)
+        .simulate("click");
+
+      expect(
+        store
+          .getActions()
+          .some((action) => action.type === "CHECK_MACHINE_POWER")
+      ).toBe(true);
+    });
   });
 
   it("includes a tab for instances if machine has any", () => {


### PR DESCRIPTION
## Done

- Added a power actions dropdown next to the power status of the machine. Originally I was going to add "Check power" to the take action menu, but it was a bit awkward because the rest of the actions lived in `general.machineActions` and required a particular shape. Besides, this was considered the ideal solution in https://github.com/canonical-web-and-design/MAAS-squad/issues/2104#issuecomment-686404038

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine details page and check that you can power on, power off and check power from the header strip.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2104

## Screenshot
![2020-11-04_20-34](https://user-images.githubusercontent.com/25733845/98102269-2e676380-1edf-11eb-8a7c-8925a7afb825.png)

