### PR TITLE
refactor(ui): move overview test results to TestResults component

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -7,7 +7,7 @@ exports[`stricter compilation`] = {
       [162, 4, 36, "Object is possibly \'null\'.", "1039669632"]
     ],
     "src/app/App.tsx:3872899616": [
-      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
+      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
       [188, 17, 17, "Object is possibly \'null\'.", "2133029343"],
       [193, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
@@ -44,7 +44,7 @@ exports[`stricter compilation`] = {
       [75, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
     "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -86,7 +86,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -298,7 +298,7 @@ exports[`stricter compilation`] = {
       [50, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"],
       [53, 27, 10, "Property \'markBroken\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "3004692879"]
     ],
-    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:3198696153": [
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:3774525721": [
       [95, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [99, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
       [216, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -346,23 +346,23 @@ exports[`stricter compilation`] = {
       [40, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
       [105, 42, 10, "Property \'checkPower\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "953482588"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:564355202": [
+    "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:2439231865": [
       [42, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx:461133352": [
-      [17, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [146, 18, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
-    ],
-    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx:2120332270": [
-      [16, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [119, 16, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
-    ],
-    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx:3582856219": [
-      [17, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [127, 16, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
+    "src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx:4182062532": [
+      [18, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [37, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [52, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [57, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [58, 10, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [74, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [75, 16, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [80, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [95, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [120, 14, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:539216384": [
       [104, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],

--- a/ui/src/app/base/enum.ts
+++ b/ui/src/app/base/enum.ts
@@ -68,7 +68,7 @@ export const scriptStatus = {
 
 export enum HardwareType {
   Node = 0,
-  Cpu = 1,
+  CPU = 1,
   Memory = 2,
   Storage = 3,
   Network = 4,

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -162,7 +162,7 @@ describe("TestForm", () => {
     state.scripts.items = [
       networkScript,
       scriptsFactory({
-        hardware_type: HardwareType.Cpu,
+        hardware_type: HardwareType.CPU,
         type: ScriptType.Testing,
       }),
       scriptsFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -52,7 +52,7 @@ const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
       <OverviewCard id={id} setSelectedAction={setSelectedAction} />
       <SystemCard id={id} />
       <NumaCard id={id} />
-      <NetworkCard id={id} />
+      <NetworkCard id={id} setSelectedAction={setSelectedAction} />
     </div>
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -287,7 +287,7 @@ describe("NetworkCard", () => {
 
       expect(
         wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
-      ).toContain("Test Network");
+      ).toContain("Test network");
     });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -11,6 +11,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
   vlanState as vlanStateFactory,
+  testStatus as testStatusFactory,
 } from "testing/factories";
 import NetworkCard from "./NetworkCard";
 import type { RootState } from "app/store/root/types";
@@ -39,7 +40,9 @@ describe("NetworkCard", () => {
           <Route
             exact
             path="/machine/abc123/summary"
-            component={() => <NetworkCard id="abc123" />}
+            component={() => (
+              <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            )}
           />
         </MemoryRouter>
       </Provider>
@@ -79,7 +82,9 @@ describe("NetworkCard", () => {
           <Route
             exact
             path="/machine/abc123/summary"
-            component={() => <NetworkCard id="abc123" />}
+            component={() => (
+              <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            )}
           />
         </MemoryRouter>
       </Provider>
@@ -144,7 +149,9 @@ describe("NetworkCard", () => {
           <Route
             exact
             path="/machine/abc123/summary"
-            component={() => <NetworkCard id="abc123" />}
+            component={() => (
+              <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+            )}
           />
         </MemoryRouter>
       </Provider>
@@ -154,5 +161,133 @@ describe("NetworkCard", () => {
     expect(wrapper.find("Table").at(1).find("tbody TableRow").length).toBe(3);
     expect(wrapper.find("Table").at(2).find("tbody TableRow").length).toBe(2);
     expect(wrapper.find("Table").at(3).find("tbody TableRow").length).toBe(1);
+  });
+
+  describe("test results", () => {
+    it("renders a link with a count of passed tests", () => {
+      const machine = machineDetailsFactory({
+        system_id: "abc123",
+      });
+
+      machine.network_test_status = testStatusFactory({
+        passed: 2,
+      });
+      state.machine.items = [machine];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(
+        wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      ).toEqual("2");
+    });
+
+    it("renders a link with a count of pending and running tests", () => {
+      const machine = machineDetailsFactory({
+        system_id: "abc123",
+      });
+
+      machine.network_test_status = testStatusFactory({
+        running: 1,
+        pending: 2,
+      });
+      state.machine.items = [machine];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(
+        wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      ).toEqual("3");
+    });
+
+    it("renders a link with a count of failed tests", () => {
+      const machine = machineDetailsFactory({
+        system_id: "abc123",
+      });
+      machine.network_test_status = testStatusFactory({
+        failed: 5,
+      });
+      state.machine.items = [machine];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(
+        wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      ).toEqual("5");
+    });
+
+    it("renders a results link", () => {
+      const machine = machineDetailsFactory({
+        system_id: "abc123",
+      });
+      machine.network_test_status = testStatusFactory({
+        failed: 5,
+      });
+      state.machine.items = [machine];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(
+        wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+      ).toContain("View results");
+    });
+
+    it("renders a test storage link if no tests run", () => {
+      const machine = machineDetailsFactory({
+        system_id: "abc123",
+      });
+      machine.network_test_status = testStatusFactory();
+      state.machine.items = [machine];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <MemoryRouter
+            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          >
+            <NetworkCard id="abc123" setSelectedAction={jest.fn()} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(
+        wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      ).toContain("Test Network");
+    });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -3,14 +3,17 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import React, { Fragment, useEffect } from "react";
 
+import NetworkCardTable from "./NetworkCardTable";
+import { SetSelectedAction } from "../MachineSummary";
+import TestResults from "../TestResults";
+import { HardwareType } from "app/base/enum";
 import { actions as fabricActions } from "app/store/fabric";
-import { actions as vlanActions } from "app/store/vlan";
 import fabricSelectors from "app/store/fabric/selectors";
 import machineSelectors from "app/store/machine/selectors";
-import vlanSelectors from "app/store/vlan/selectors";
 import type { Machine, NetworkInterface } from "app/store/machine/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
 import type { RootState } from "app/store/root/types";
-import NetworkCardTable from "./NetworkCardTable";
 
 type InterfaceGroup = {
   firmwareVersion: string;
@@ -21,6 +24,7 @@ type InterfaceGroup = {
 
 type Props = {
   id: Machine["system_id"];
+  setSelectedAction: SetSelectedAction;
 };
 
 /**
@@ -92,7 +96,7 @@ const groupInterfaces = (interfaces: NetworkInterface[]): InterfaceGroup[] => {
   return sortedGroups;
 };
 
-const NetworkCard = ({ id }: Props): JSX.Element => {
+const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
@@ -144,6 +148,12 @@ const NetworkCard = ({ id }: Props): JSX.Element => {
           Information about tagged traffic can be seen in the{" "}
           <Link to={`/machine/${id}/network`}>Network tab</Link>.
         </span>
+
+        <TestResults
+          machine={machine}
+          hardwareType={HardwareType.Network}
+          setSelectedAction={setSelectedAction}
+        />
       </>
     );
   } else {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -176,6 +176,6 @@ describe("CpuCard", () => {
 
     expect(
       wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
-    ).toContain("Test cpu");
+    ).toContain("Test CPU");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -1,24 +1,14 @@
 import pluralize from "pluralize";
 import React from "react";
-import { Link } from "react-router-dom";
-
-import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 
 import type { SetSelectedAction } from "../../MachineSummary";
-import { useSendAnalytics } from "app/base/hooks";
 import type { MachineDetails } from "app/store/machine/types";
 import { HardwareType } from "app/base/enum";
+import TestResults from "../../TestResults";
 
 type Props = {
   machine: MachineDetails;
   setSelectedAction: SetSelectedAction;
-};
-
-const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
-  const testObj = machine[`${scriptType}_test_status`];
-  return (
-    testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
-  );
 };
 
 // Get the subtext for the CPU card. Only nodes commissioned after
@@ -39,146 +29,27 @@ const getCPUSubtext = (machine: MachineDetails) => {
   return text;
 };
 
-const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
-  const sendAnalytics = useSendAnalytics();
-
-  const testsTabUrl = `/machine/${machine.system_id}/tests`;
-
-  return (
-    <>
-      <div className="overview-card__cpu">
-        <div className="u-flex--between">
-          <strong className="p-muted-heading">CPU</strong>
-          <span>{machine.architecture}</span>
-        </div>
-        <h4 className="u-no-margin--bottom" data-test="cpu-subtext">
-          {getCPUSubtext(machine)}
-        </h4>
-        <p className="p-text--muted">
-          {machine.metadata.cpu_model || "Unknown model"}
-        </p>
+const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
+  <>
+    <div className="overview-card__cpu">
+      <div className="u-flex--between">
+        <strong className="p-muted-heading">CPU</strong>
+        <span>{machine.architecture}</span>
       </div>
+      <h4 className="u-no-margin--bottom" data-test="cpu-subtext">
+        {getCPUSubtext(machine)}
+      </h4>
+      <p className="p-text--muted">
+        {machine.metadata.cpu_model || "Unknown model"}
+      </p>
+    </div>
 
-      <div className="overview-card__cpu-tests u-flex--vertically">
-        <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
-          {machine.cpu_test_status.passed ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "CPU tests passed link",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={ICONS.success} />
-                {machine.cpu_test_status.passed}
-              </Button>
-            </li>
-          ) : null}
-
-          {machine.cpu_test_status.pending + machine.cpu_test_status.running >
-          0 ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "CPU tests running link",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={"pending"} />
-                {machine.cpu_test_status.pending +
-                  machine.cpu_test_status.running}
-              </Button>
-            </li>
-          ) : null}
-
-          {machine.cpu_test_status.failed > 0 ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "CPU tests failed",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={ICONS.error} />
-                {machine.cpu_test_status.failed}
-              </Button>
-            </li>
-          ) : null}
-
-          {hasTestsRun(machine, "cpu") ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "View CPU tests results",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                View results&nbsp;&rsaquo;
-              </Button>
-            </li>
-          ) : (
-            <li className="p-inline-list__item">
-              <span className="p-tooltip--top-left">
-                <Tooltip
-                  message={
-                    !machine.actions.includes("test")
-                      ? "Machine cannot run tests at this time."
-                      : null
-                  }
-                  position={"top-left"}
-                >
-                  <Button
-                    className="p-button--link"
-                    disabled={!machine.actions.includes("test")}
-                    onClick={() => {
-                      setSelectedAction(
-                        {
-                          name: "test",
-                          formProps: { hardwareType: HardwareType.Cpu },
-                        },
-                        false
-                      );
-                      sendAnalytics(
-                        "Machine details",
-                        "Test CPU",
-                        "Machine summary tab"
-                      );
-                    }}
-                  >
-                    Test CPU...
-                  </Button>
-                </Tooltip>
-              </span>
-            </li>
-          )}
-        </ul>
-      </div>
-    </>
-  );
-};
+    <TestResults
+      machine={machine}
+      hardwareType={HardwareType.Cpu}
+      setSelectedAction={setSelectedAction}
+    />
+  </>
+);
 
 export default CpuCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -46,7 +46,7 @@ const CpuCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
 
     <TestResults
       machine={machine}
-      hardwareType={HardwareType.Cpu}
+      hardwareType={HardwareType.CPU}
       setSelectedAction={setSelectedAction}
     />
   </>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
@@ -1,156 +1,28 @@
 import React from "react";
-import { Link } from "react-router-dom";
-
-import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 
 import type { SetSelectedAction } from "../../MachineSummary";
-import { useSendAnalytics } from "app/base/hooks";
-import type { MachineDetails } from "app/store/machine/types";
+import TestResults from "../../TestResults";
 import { HardwareType } from "app/base/enum";
+import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;
   setSelectedAction: SetSelectedAction;
 };
 
-const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
-  const testObj = machine[`${scriptType}_test_status`];
-  return (
-    testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
-  );
-};
+const MemoryCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
+  <>
+    <div className="overview-card__memory">
+      <strong className="p-muted-heading">Memory</strong>
+      <h4>{machine.memory ? machine.memory + " GiB" : "Unknown"}</h4>
+    </div>
 
-const MemoryCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
-  const sendAnalytics = useSendAnalytics();
-
-  const testsTabUrl = `/machine/${machine.system_id}/tests`;
-
-  return (
-    <>
-      <div className="overview-card__memory">
-        <strong className="p-muted-heading">Memory</strong>
-        <h4>{machine.memory ? machine.memory + " GiB" : "Unknown"}</h4>
-      </div>
-
-      <div className="overview-card__memory-tests u-flex--vertically">
-        <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
-          {machine.memory_test_status.passed > 0 ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "Memory tests passed link",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={ICONS.success} />
-                {machine.memory_test_status.passed}
-              </Button>
-            </li>
-          ) : null}
-
-          {machine.memory_test_status.pending +
-            machine.memory_test_status.running >
-          0 ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "Memory tests running link",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={"pending"} />
-                {machine.memory_test_status.pending +
-                  machine.memory_test_status.running}
-              </Button>
-            </li>
-          ) : null}
-
-          {machine.memory_test_status.failed > 0 ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "Memory tests failed",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={ICONS.error} />
-                {machine.memory_test_status.failed}
-              </Button>
-            </li>
-          ) : null}
-
-          {hasTestsRun(machine, "memory") ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "View memory tests results",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                View results&nbsp;&rsaquo;
-              </Button>
-            </li>
-          ) : (
-            <li className="p-inline-list__item">
-              <Tooltip
-                message={
-                  !machine.actions.includes("test")
-                    ? "Machine cannot run tests at this time."
-                    : null
-                }
-                position={"top-left"}
-              >
-                <Button
-                  className="p-button--link"
-                  disabled={!machine.actions.includes("test")}
-                  onClick={() => {
-                    setSelectedAction(
-                      {
-                        name: "test",
-                        formProps: { hardwareType: HardwareType.Memory },
-                      },
-                      false
-                    );
-                    sendAnalytics(
-                      "Machine details",
-                      "Test memory",
-                      "Machine summary tab"
-                    );
-                  }}
-                >
-                  Test memory...
-                </Button>
-              </Tooltip>
-            </li>
-          )}
-        </ul>
-      </div>
-    </>
-  );
-};
+    <TestResults
+      machine={machine}
+      hardwareType={HardwareType.Memory}
+      setSelectedAction={setSelectedAction}
+    />
+  </>
+);
 
 export default MemoryCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
@@ -1,164 +1,36 @@
 import pluralize from "pluralize";
 import React from "react";
-import { Link } from "react-router-dom";
-
-import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 
 import type { SetSelectedAction } from "../../MachineSummary";
-import { useSendAnalytics } from "app/base/hooks";
-import type { MachineDetails } from "app/store/machine/types";
+import TestResults from "../../TestResults";
 import { HardwareType } from "app/base/enum";
+import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;
   setSelectedAction: SetSelectedAction;
 };
 
-const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
-  const testObj = machine[`${scriptType}_test_status`];
-  return (
-    testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
-  );
-};
+const StorageCard = ({ machine, setSelectedAction }: Props): JSX.Element => (
+  <>
+    <div className="overview-card__storage">
+      <strong className="p-muted-heading">Storage</strong>
+      <h4>
+        <span>{machine.storage ? `${machine.storage}GB` : "Unknown"}</span>
+        {machine.storage && machine.physical_disk_count ? (
+          <span className="p-muted-text">
+            &nbsp;over {pluralize("disk", machine.physical_disk_count, true)}
+          </span>
+        ) : null}
+      </h4>
+    </div>
 
-const StorageCard = ({ machine, setSelectedAction }: Props): JSX.Element => {
-  const sendAnalytics = useSendAnalytics();
-
-  const testsTabUrl = `/machine/${machine.system_id}/tests`;
-
-  return (
-    <>
-      <div className="overview-card__storage">
-        <strong className="p-muted-heading">Storage</strong>
-        <h4>
-          <span>{machine.storage ? `${machine.storage}GB` : "Unknown"}</span>
-          {machine.storage && machine.physical_disk_count ? (
-            <span className="p-muted-text">
-              &nbsp;over {pluralize("disk", machine.physical_disk_count, true)}
-            </span>
-          ) : null}
-        </h4>
-      </div>
-
-      <div className="overview-card__storage-tests u-flex--vertically">
-        <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
-          {machine.storage_test_status.passed ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "Storage tests passed link",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={ICONS.success} />
-                {machine.storage_test_status.passed}
-              </Button>
-            </li>
-          ) : null}
-
-          {machine.storage_test_status.pending +
-            machine.storage_test_status.running >
-          0 ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "Storage tests running link",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={"pending"} />
-                {machine.storage_test_status.pending +
-                  machine.storage_test_status.running}
-              </Button>
-            </li>
-          ) : null}
-
-          {machine.storage_test_status.failed > 0 ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "Storage tests failed",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                <Icon name={ICONS.error} />
-                {machine.storage_test_status.failed}
-              </Button>
-            </li>
-          ) : null}
-
-          {hasTestsRun(machine, "storage") ? (
-            <li className="p-inline-list__item">
-              <Button
-                className="p-button--link"
-                element={Link}
-                to={testsTabUrl}
-                onClick={() =>
-                  sendAnalytics(
-                    "Machine details",
-                    "View storagte tests results",
-                    "Machine summary tab"
-                  )
-                }
-              >
-                View results&nbsp;&rsaquo;
-              </Button>
-            </li>
-          ) : (
-            <li className="p-inline-list__item">
-              <Tooltip
-                message={
-                  !machine.actions.includes("test")
-                    ? "Machine cannot run tests at this time."
-                    : null
-                }
-                position={"top-left"}
-              >
-                <Button
-                  className="p-button--link"
-                  disabled={!machine.actions.includes("test")}
-                  onClick={() => {
-                    setSelectedAction(
-                      {
-                        name: "test",
-                        formProps: { hardwareType: HardwareType.Storage },
-                      },
-                      false
-                    );
-                    sendAnalytics(
-                      "Machine details",
-                      "Test storage",
-                      "Machine summary tab"
-                    );
-                  }}
-                >
-                  Test storage...
-                </Button>
-              </Tooltip>
-            </li>
-          )}
-        </ul>
-      </div>
-    </>
-  );
-};
+    <TestResults
+      machine={machine}
+      hardwareType={HardwareType.Storage}
+      setSelectedAction={setSelectedAction}
+    />
+  </>
+);
 
 export default StorageCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -39,7 +39,7 @@ describe("TestResults", () => {
         >
           <TestResults
             machine={machine}
-            hardwareType={HardwareType.Cpu}
+            hardwareType={HardwareType.CPU}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -121,7 +121,7 @@ describe("TestResults", () => {
         >
           <TestResults
             machine={machine}
-            hardwareType={HardwareType.Cpu}
+            hardwareType={HardwareType.CPU}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -10,62 +10,21 @@ import {
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-import CpuCard from "./CpuCard";
+import TestResults from "./TestResults";
 import type { RootState } from "app/store/root/types";
+import { HardwareType } from "app/base/enum";
 
 const mockStore = configureStore();
 
-describe("CpuCard", () => {
+describe("TestResults", () => {
   let state: RootState;
   beforeEach(() => {
     state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [],
-      }),
+      machine: machineStateFactory(),
     });
   });
 
-  it("renders the cpu subtext", () => {
-    const machine = machineDetailsFactory({ cpu_speed: 2000 });
-    state.machine.items = [machine];
-
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='cpu-subtext']").text()).toEqual(
-      `${machine.cpu_count} core, 2 GHz`
-    );
-  });
-
-  it("renders the cpu subtext for slow machines", () => {
-    const machine = machineDetailsFactory({ cpu_speed: 200 });
-    state.machine.items = [machine];
-
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='cpu-subtext']").text()).toEqual(
-      `${machine.cpu_count} core, 200 MHz`
-    );
-  });
-
-  it("renders a link with a count of passed tests", () => {
+  it("renders a link with a count of passed cpu tests", () => {
     const machine = machineDetailsFactory();
     machine.cpu_test_status = testStatusFactory({
       passed: 2,
@@ -78,7 +37,11 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <TestResults
+            machine={machine}
+            hardwareType={HardwareType.Cpu}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -88,9 +51,9 @@ describe("CpuCard", () => {
     ).toEqual("2");
   });
 
-  it("renders a link with a count of pending and running tests", () => {
+  it("renders a link with a count of pending and running memory tests", () => {
     const machine = machineDetailsFactory();
-    machine.cpu_test_status = testStatusFactory({
+    machine.memory_test_status = testStatusFactory({
       running: 1,
       pending: 2,
     });
@@ -102,7 +65,11 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <TestResults
+            machine={machine}
+            hardwareType={HardwareType.Memory}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -112,9 +79,9 @@ describe("CpuCard", () => {
     ).toEqual("3");
   });
 
-  it("renders a link with a count of failed tests", () => {
+  it("renders a link with a count of failed storage tests", () => {
     const machine = machineDetailsFactory();
-    machine.cpu_test_status = testStatusFactory({
+    machine.storage_test_status = testStatusFactory({
       failed: 5,
     });
     state.machine.items = [machine];
@@ -125,7 +92,11 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <TestResults
+            machine={machine}
+            hardwareType={HardwareType.Storage}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -148,7 +119,11 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <TestResults
+            machine={machine}
+            hardwareType={HardwareType.Cpu}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -158,9 +133,9 @@ describe("CpuCard", () => {
     ).toContain("View results");
   });
 
-  it("renders a test cpu link if no tests run", () => {
+  it("renders a test network link if no tests run", () => {
     const machine = machineDetailsFactory();
-    machine.cpu_test_status = testStatusFactory();
+    machine.network_test_status = testStatusFactory();
     state.machine.items = [machine];
 
     const store = mockStore(state);
@@ -169,13 +144,17 @@ describe("CpuCard", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <CpuCard machine={machine} setSelectedAction={jest.fn()} />
+          <TestResults
+            machine={machine}
+            hardwareType={HardwareType.Network}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
 
     expect(
       wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
-    ).toContain("Test cpu");
+    ).toContain("Test network");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
+
+import type { SetSelectedAction } from "..";
+import { capitaliseFirst } from "app/utils";
+import { useSendAnalytics } from "app/base/hooks";
+import type { MachineDetails } from "app/store/machine/types";
+import { HardwareType } from "app/base/enum";
+
+type Props = {
+  machine: MachineDetails;
+  hardwareType: HardwareType;
+  setSelectedAction: SetSelectedAction;
+};
+
+const getScriptType = (hardwareType: HardwareType) =>
+  HardwareType[hardwareType].toLowerCase();
+
+const hasTestsRun = (machine: MachineDetails, hardwareType: HardwareType) => {
+  const scriptType = getScriptType(hardwareType);
+  const testObj = machine[`${scriptType}_test_status`];
+  return (
+    testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
+  );
+};
+
+const TestResults = ({
+  machine,
+  hardwareType,
+  setSelectedAction,
+}: Props): JSX.Element => {
+  const sendAnalytics = useSendAnalytics();
+
+  const testsTabUrl = `/machine/${machine.system_id}/tests`;
+  const scriptType = getScriptType(hardwareType);
+
+  return (
+    <div className={`overview-card__${scriptType}-tests u-flex--vertically`}>
+      <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
+        {machine[`${scriptType}_test_status`].passed ? (
+          <li className="p-inline-list__item">
+            <Button
+              className="p-button--link"
+              element={Link}
+              to={testsTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  "Storage tests passed link",
+                  "Machine summary tab"
+                )
+              }
+            >
+              <Icon name={ICONS.success} />
+              {machine[`${scriptType}_test_status`].passed}
+            </Button>
+          </li>
+        ) : null}
+
+        {machine[`${scriptType}_test_status`].pending +
+          machine[`${scriptType}_test_status`].running >
+        0 ? (
+          <li className="p-inline-list__item">
+            <Button
+              className="p-button--link"
+              element={Link}
+              to={testsTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  `${capitaliseFirst(scriptType)} tests running link`,
+                  "Machine summary tab"
+                )
+              }
+            >
+              <Icon name={"pending"} />
+              {machine[`${scriptType}_test_status`].pending +
+                machine[`${scriptType}_test_status`].running}
+            </Button>
+          </li>
+        ) : null}
+
+        {machine[`${scriptType}_test_status`].failed > 0 ? (
+          <li className="p-inline-list__item">
+            <Button
+              className="p-button--link"
+              element={Link}
+              to={testsTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  `${capitaliseFirst(scriptType)} tests failed`,
+                  "Machine summary tab"
+                )
+              }
+            >
+              <Icon name={ICONS.error} />
+              {machine[`${scriptType}_test_status`].failed}
+            </Button>
+          </li>
+        ) : null}
+
+        {hasTestsRun(machine, hardwareType) ? (
+          <li className="p-inline-list__item">
+            <Button
+              className="p-button--link"
+              element={Link}
+              to={testsTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  `View ${scriptType} tests results`,
+                  "Machine summary tab"
+                )
+              }
+            >
+              View results&nbsp;&rsaquo;
+            </Button>
+          </li>
+        ) : (
+          <li className="p-inline-list__item">
+            <Tooltip
+              message={
+                !machine.actions.includes("test")
+                  ? "Machine cannot run tests at this time."
+                  : null
+              }
+              position={"top-left"}
+            >
+              <Button
+                className="p-button--link"
+                disabled={!machine.actions.includes("test")}
+                onClick={() => {
+                  setSelectedAction(
+                    {
+                      name: "test",
+                      formProps: { hardwareType: hardwareType },
+                    },
+                    false
+                  );
+                  sendAnalytics(
+                    "Machine details",
+                    `Test ${scriptType}`,
+                    "Machine summary tab"
+                  );
+                }}
+              >
+                {`Test ${scriptType}…`}
+              </Button>
+            </Tooltip>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default TestResults;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -30,7 +30,7 @@ const TestResults = ({
   const sendAnalytics = useSendAnalytics();
 
   const testsTabUrl = `/machine/${machine.system_id}/tests`;
-  const scriptType = HardwareType[hardwareType].toLowerCase();
+  const scriptType = HardwareType[hardwareType]?.toLowerCase();
 
   return (
     <div className={`overview-card__${scriptType}-tests u-flex--vertically`}>
@@ -143,7 +143,9 @@ const TestResults = ({
                   );
                 }}
               >
-                {`Test ${HardwareType[hardwareType]}…`}
+                {hardwareType === HardwareType.CPU
+                  ? "Test CPU…"
+                  : `Test ${scriptType}…`}
               </Button>
             </Tooltip>
           </li>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -15,11 +15,7 @@ type Props = {
   setSelectedAction: SetSelectedAction;
 };
 
-const getScriptType = (hardwareType: HardwareType) =>
-  HardwareType[hardwareType].toLowerCase();
-
-const hasTestsRun = (machine: MachineDetails, hardwareType: HardwareType) => {
-  const scriptType = getScriptType(hardwareType);
+const hasTestsRun = (machine: MachineDetails, scriptType: string) => {
   const testObj = machine[`${scriptType}_test_status`];
   return (
     testObj.passed + testObj.pending + testObj.running + testObj.failed > 0
@@ -34,7 +30,7 @@ const TestResults = ({
   const sendAnalytics = useSendAnalytics();
 
   const testsTabUrl = `/machine/${machine.system_id}/tests`;
-  const scriptType = getScriptType(hardwareType);
+  const scriptType = HardwareType[hardwareType].toLowerCase();
 
   return (
     <div className={`overview-card__${scriptType}-tests u-flex--vertically`}>
@@ -102,7 +98,7 @@ const TestResults = ({
           </li>
         ) : null}
 
-        {hasTestsRun(machine, hardwareType) ? (
+        {hasTestsRun(machine, scriptType) ? (
           <li className="p-inline-list__item">
             <Button
               className="p-button--link"
@@ -147,7 +143,7 @@ const TestResults = ({
                   );
                 }}
               >
-                {`Test ${scriptType}…`}
+                {`Test ${HardwareType[hardwareType]}…`}
               </Button>
             </Tooltip>
           </li>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TestResults";


### PR DESCRIPTION
## Done

- move overview test results to TestResults component

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure overview cards still render correctly, open appropriate testing modals and link to testing tab.

## Fixes

Fixes: #1837 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
