### PR TITLE
feat(ui): edit machine name from the details header

### DIFF
--- a/ui/src/app/base/components/FormikForm/FormikForm.test.js
+++ b/ui/src/app/base/components/FormikForm/FormikForm.test.js
@@ -165,4 +165,23 @@ describe("FormikForm", () => {
     wrapper.update();
     expect(wrapper.find("input[name='val1']").props().value).toBe("initial");
   });
+
+  it("can be inline", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <FormikForm
+            initialValues={{}}
+            onSubmit={jest.fn()}
+            validationSchema={{}}
+            inline
+          >
+            Content
+          </FormikForm>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikFormContent").prop("inline")).toBe(true);
+  });
 });

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -20,6 +20,7 @@ type Props = {
   children?: ReactNode;
   errors?: TSFixMe;
   initialValues: TSFixMe;
+  inline?: boolean;
   loading?: boolean;
   onCancel?: () => void;
   onSaveAnalytics?: {
@@ -52,6 +53,7 @@ const FormikForm = ({
   cleanup,
   children,
   errors,
+  inline,
   initialValues,
   loading,
   onCancel,
@@ -104,6 +106,7 @@ const FormikForm = ({
         buttonsHelpLink={buttonsHelpLink}
         buttons={buttons}
         errors={errors}
+        inline={inline}
         initialValues={initialValues}
         onCancel={onCancel}
         onValuesChanged={onValuesChanged}
@@ -134,6 +137,7 @@ FormikForm.propTypes = {
   children: PropTypes.node,
   errors: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   initialValues: PropTypes.object.isRequired,
+  inline: PropTypes.bool,
   onCancel: PropTypes.func,
   onSaveAnalytics: PropTypes.shape({
     category: PropTypes.string,

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
@@ -15,6 +15,7 @@ export const FormikFormButtons = ({
       {onCancel ? (
         <Button
           appearance="base"
+          className="u-no-margin--bottom"
           disabled={cancelDisabled}
           onClick={onCancel}
           type="button"

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.js
@@ -1,15 +1,27 @@
-import { ActionButton } from "@canonical/react-components";
+import { ActionButton, Button } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import React from "react";
 
 export const FormikFormButtons = ({
+  cancelDisabled,
   loading,
+  onCancel,
   submitDisabled,
   submitLabel,
   success,
 }) => {
   return (
     <div>
+      {onCancel ? (
+        <Button
+          appearance="base"
+          disabled={cancelDisabled}
+          onClick={onCancel}
+          type="button"
+        >
+          Cancel
+        </Button>
+      ) : null}
       <ActionButton
         appearance="positive"
         className="u-no-margin--bottom"
@@ -25,7 +37,9 @@ export const FormikFormButtons = ({
 };
 
 FormikFormButtons.propTypes = {
+  cancelDisabled: PropTypes.bool,
   loading: PropTypes.bool,
+  onCancel: PropTypes.func,
   submitDisabled: PropTypes.bool,
   submitLabel: PropTypes.string.isRequired,
   success: PropTypes.bool,

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.js
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.js
@@ -8,4 +8,13 @@ describe("FormikFormButtons ", () => {
     const wrapper = shallow(<FormikFormButtons submitLabel="Save user" />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("can display a cancel button", () => {
+    const wrapper = shallow(
+      <FormikFormButtons onCancel={jest.fn()} submitLabel="Save user" />
+    );
+    const button = wrapper.find("Button");
+    expect(button.exists()).toBe(true);
+    expect(button.children().text()).toBe("Cancel");
+  });
 });

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.js
@@ -15,6 +15,7 @@ const FormikFormContent = ({
   buttonsHelpLink,
   children,
   errors,
+  inline,
   initialValues,
   loading,
   onCancel,
@@ -53,15 +54,16 @@ const FormikFormContent = ({
   }
 
   return (
-    <Form onSubmit={handleSubmit}>
+    <Form inline={inline} onSubmit={handleSubmit}>
       {nonFieldError && (
         <Notification type="negative" status="Error:">
           {nonFieldError}
         </Notification>
       )}
-      <div>{children}</div>
+      {children}
       <Buttons
         bordered={buttonsBordered}
+        cancelDisabled={saving}
         helpLabel={buttonsHelpLabel}
         helpLink={buttonsHelpLink}
         loading={saving}
@@ -94,6 +96,7 @@ FormikFormContent.propTypes = {
   buttonsHelpLink: PropTypes.string,
   children: PropTypes.node,
   errors: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  inline: PropTypes.bool,
   initialValues: PropTypes.object,
   loading: PropTypes.bool,
   onCancel: PropTypes.func,

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.js
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.js
@@ -33,4 +33,13 @@ describe("FormikFormContent", () => {
     );
     expect(wrapper.find("Notification").text()).toEqual("Error:Uh oh!");
   });
+
+  it("can be inline", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}}>
+        <FormikFormContent inline>Content</FormikFormContent>
+      </Formik>
+    );
+    expect(wrapper.find("Form").prop("inline")).toBe(true);
+  });
 });

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -11,7 +11,7 @@ type Props = {
   loading?: boolean;
   subtitle?: ReactNode | ReactNode[];
   tabLinks?: TSFixMe[];
-  title: string;
+  title: ReactNode;
 };
 
 const generateSubtitle = (subtitle: Props["subtitle"]) => {

--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -2,7 +2,6 @@ import { Button } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import authSelectors from "app/store/auth/selectors";
@@ -56,6 +55,7 @@ export const UserForm = ({
   cleanup,
   includeCurrentPassword,
   includeUserType,
+  onCancel,
   onSave,
   onSaveAnalytics,
   onUpdateFields,
@@ -64,7 +64,6 @@ export const UserForm = ({
   user,
 }) => {
   const editing = !!user;
-  const history = useHistory();
   const [passwordVisible, showPassword] = useState(!editing);
   const saving = useSelector(userSelectors.saving);
   const saved = useSelector(userSelectors.saved);
@@ -101,7 +100,7 @@ export const UserForm = ({
       cleanup={cleanup}
       errors={errors}
       initialValues={initialValues}
-      onCancel={() => history.goBack()}
+      onCancel={onCancel}
       onSaveAnalytics={onSaveAnalytics}
       onSubmit={(values, { resetForm }) => {
         const params = {
@@ -215,6 +214,7 @@ UserForm.propTypes = {
   cleanup: PropTypes.func,
   includeCurrentPassword: PropTypes.bool,
   includeUserType: PropTypes.bool,
+  onCancel: PropTypes.func,
   onSave: PropTypes.func.isRequired,
   onSaveAnalytics: PropTypes.shape({
     category: PropTypes.string,

--- a/ui/src/app/base/reducers/machine/machine.js
+++ b/ui/src/app/base/reducers/machine/machine.js
@@ -160,11 +160,13 @@ const machine = createNextState(
         break;
       case "ADD_MACHINE_CHASSIS_START":
       case "CREATE_MACHINE_START":
+      case "UPDATE_MACHINE_START":
         draft.saved = false;
         draft.saving = true;
         break;
       case "ADD_MACHINE_CHASSIS_SUCCESS":
       case "CREATE_MACHINE_SUCCESS":
+      case "UPDATE_MACHINE_SUCCESS":
         draft.errors = {};
         draft.saved = true;
         draft.saving = false;
@@ -180,6 +182,7 @@ const machine = createNextState(
       case "FETCH_MACHINE_ERROR":
       case "GET_MACHINE_ERROR":
       case "CREATE_MACHINE_ERROR":
+      case "UPDATE_MACHINE_ERROR":
         draft.errors = action.error;
         draft.loading = false;
         draft.saving = false;

--- a/ui/src/app/base/reducers/machine/machine.test.js
+++ b/ui/src/app/base/reducers/machine/machine.test.js
@@ -463,4 +463,40 @@ describe("machine reducer", () => {
       );
     });
   });
+
+  it("should correctly reduce UPDATE_MACHINE_START", () => {
+    const initialState = machineStateFactory({ saved: true, saving: false });
+
+    expect(
+      machine(initialState, {
+        type: "UPDATE_MACHINE_START",
+      })
+    ).toEqual(
+      machineStateFactory({
+        saved: false,
+        saving: true,
+      })
+    );
+  });
+
+  it("should correctly reduce CREATE_MACHINE_ERROR", () => {
+    const initialState = machineStateFactory({
+      errors: {},
+      loading: true,
+      saving: true,
+    });
+
+    expect(
+      machine(initialState, {
+        error: "Uh oh",
+        type: "CREATE_MACHINE_ERROR",
+      })
+    ).toEqual(
+      machineStateFactory({
+        errors: "Uh oh",
+        loading: false,
+        saving: false,
+      })
+    );
+  });
 });

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.js.snap
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.js.snap
@@ -67,9 +67,9 @@ exports[`FieldlessForm renders 1`] = `
               className=""
               onSubmit={[Function]}
             >
-              <div />
               <FormCardButtons
                 bordered={false}
+                cancelDisabled={false}
                 loading={false}
                 loadingLabel="Releasing machine..."
                 onCancel={[Function]}

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -5,10 +5,13 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import {
+  generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
   machineDevice as machineDeviceFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 import MachineHeader from "./MachineHeader";
@@ -269,5 +272,46 @@ describe("MachineHeader", () => {
       </Provider>
     );
     expect(wrapper.find(".p-tabs__item").at(1).text()).toBe("Instances");
+  });
+
+  it("hides the subtitle when editing the name", () => {
+    state = rootStateFactory({
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+        }),
+      }),
+      machine: machineStateFactory({
+        loaded: true,
+        items: [
+          machineDetailsFactory({
+            locked: false,
+            permissions: ["edit"],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => (
+              <MachineHeader
+                selectedAction={null}
+                setSelectedAction={jest.fn()}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button.machine-name--editable").simulate("click");
+    expect(wrapper.find("SectionHeader").prop("subtitle")).toBe(null);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -2,12 +2,13 @@ import { Icon, Tooltip } from "@canonical/react-components";
 import { Link, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { SelectedAction, SetSelectedAction } from "../MachineSummary";
 import { machine as machineActions } from "app/base/actions";
 import { useMachineActions } from "app/base/hooks";
 import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
+import MachineName from "./MachineName";
 import machineSelectors from "app/store/machine/selectors";
 import SectionHeader from "app/base/components/SectionHeader";
 import TableMenu from "app/base/components/TableMenu";
@@ -24,6 +25,7 @@ const MachineHeader = ({
   selectedAction,
   setSelectedAction,
 }: Props): JSX.Element => {
+  const [editingName, setEditingName] = useState(false);
   const dispatch = useDispatch();
   const { pathname } = useLocation();
   const { id } = useParams<RouteParams>();
@@ -45,7 +47,7 @@ const MachineHeader = ({
     return <SectionHeader loading title="" />;
   }
 
-  const { devices, fqdn, system_id } = machine;
+  const { devices, system_id } = machine;
   const urlBase = `/machine/${system_id}`;
   const checkingPower = statuses?.checkingPower;
 
@@ -70,48 +72,54 @@ const MachineHeader = ({
         ) : null
       }
       loading={loading}
-      subtitle={[
-        <>
-          {machine.locked ? (
-            <Tooltip
-              className="u-nudge-left--small"
-              message="This machine is locked. You have to unlock it to perform any actions."
-              position="btm-left"
-            >
-              <Icon name="locked" />
-            </Tooltip>
-          ) : null}
-          {machine.status}
-        </>,
-        <>
-          <span className="u-nudge-left--small">
-            <i
-              className={
-                checkingPower
-                  ? "p-icon--spinner u-animation--spin"
-                  : `p-icon--power-${machine.power_state}`
-              }
-            />
-          </span>
-          <span data-test="machine-header-power" ref={powerMenuRef}>
-            {checkingPower ? "Checking power" : `Power ${machine.power_state}`}
-          </span>
-          <TableMenu
-            className="u-nudge-right--small"
-            links={[
-              ...powerMenuLinks,
-              {
-                children: "Check power",
-                onClick: () => {
-                  dispatch(machineActions.checkPower(system_id));
-                },
-              },
-            ]}
-            positionNode={powerMenuRef?.current}
-            title="Take action:"
-          />
-        </>,
-      ]}
+      subtitle={
+        editingName
+          ? null
+          : [
+              <>
+                {machine.locked ? (
+                  <Tooltip
+                    className="u-nudge-left--small"
+                    message="This machine is locked. You have to unlock it to perform any actions."
+                    position="btm-left"
+                  >
+                    <Icon name="locked" />
+                  </Tooltip>
+                ) : null}
+                {machine.status}
+              </>,
+              <>
+                <span className="u-nudge-left--small">
+                  <i
+                    className={
+                      checkingPower
+                        ? "p-icon--spinner u-animation--spin"
+                        : `p-icon--power-${machine.power_state}`
+                    }
+                  />
+                </span>
+                <span data-test="machine-header-power" ref={powerMenuRef}>
+                  {checkingPower
+                    ? "Checking power"
+                    : `Power ${machine.power_state}`}
+                </span>
+                <TableMenu
+                  className="u-nudge-right--small"
+                  links={[
+                    ...powerMenuLinks,
+                    {
+                      children: "Check power",
+                      onClick: () => {
+                        dispatch(machineActions.checkPower(system_id));
+                      },
+                    },
+                  ]}
+                  positionNode={powerMenuRef?.current}
+                  title="Take action:"
+                />
+              </>,
+            ]
+      }
       tabLinks={[
         {
           active: pathname.startsWith(`${urlBase}/summary`),
@@ -172,7 +180,13 @@ const MachineHeader = ({
           to: `${urlBase}/configuration`,
         },
       ]}
-      title={fqdn}
+      title={
+        <MachineName
+          editingName={editingName}
+          id={id}
+          setEditingName={setEditingName}
+        />
+      }
     />
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
@@ -6,6 +6,8 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
@@ -21,8 +23,12 @@ const mockStore = configureStore();
 
 describe("MachineName", () => {
   let state: RootState;
+  const domain = domainFactory({ id: 99 });
   beforeEach(() => {
     state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domain],
+      }),
       general: generalStateFactory({
         powerTypes: powerTypesStateFactory({
           data: [powerTypeFactory()],
@@ -32,6 +38,7 @@ describe("MachineName", () => {
         loaded: true,
         items: [
           machineDetailsFactory({
+            domain,
             locked: false,
             permissions: ["edit"],
             system_id: "abc123",

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
@@ -1,0 +1,163 @@
+import { act } from "react-dom/test-utils";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  generalState as generalStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { machine as machineActions } from "app/base/actions";
+import MachineName from "./MachineName";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("MachineName", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [powerTypeFactory()],
+        }),
+      }),
+      machine: machineStateFactory({
+        loaded: true,
+        items: [
+          machineDetailsFactory({
+            locked: false,
+            permissions: ["edit"],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineName
+            editingName={false}
+            id="abc123"
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays just the name when not editable", () => {
+    state.machine.items[0].locked = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineName
+            editingName={false}
+            id="abc123"
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".machine-name").exists()).toBe(true);
+  });
+
+  it("displays name in a button", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineName
+            editingName={false}
+            id="abc123"
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Button.machine-name--editable").exists()).toBe(true);
+  });
+
+  it("changes the form state when clicking the name", () => {
+    const setEditingName = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineName
+            editingName={false}
+            id="abc123"
+            setEditingName={setEditingName}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button.machine-name--editable").simulate("click");
+    expect(setEditingName).toHaveBeenCalled();
+  });
+
+  it("can display the form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineName
+            editingName={true}
+            id="abc123"
+            setEditingName={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikForm")).toMatchSnapshot();
+  });
+
+  it("closes the form when it saves", () => {
+    state.machine.saving = true;
+    const setEditingName = jest.fn();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineName
+            editingName={true}
+            id="abc123"
+            setEditingName={setEditingName}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    state.machine.saving = false;
+    state.machine.saved = true;
+    act(() => {
+      // Fire something so that the store gets updated.
+      store.dispatch(machineActions.update());
+    });
+    expect(setEditingName).toHaveBeenCalledWith(false);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
@@ -1,0 +1,115 @@
+import { Button, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { usePrevious } from "@canonical/react-components/dist/hooks";
+import React, { useEffect } from "react";
+import * as Yup from "yup";
+
+import { actions as domainActions } from "app/store/domain";
+import { machine as machineActions } from "app/base/actions";
+import { useCanEdit } from "app/store/machine/utils";
+import domainSelectors from "app/store/domain/selectors";
+import FormikForm from "app/base/components/FormikForm";
+import MachineNameFields from "../MachineNameFields";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  editingName: boolean;
+  id: Machine["system_id"];
+  setEditingName: (editingName: boolean) => void;
+};
+
+export type FormValues = {
+  hostname: string;
+  domain: string;
+};
+
+const hostnamePattern = /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])*$/;
+
+const Schema = Yup.object().shape({
+  hostname: Yup.string()
+    .max(63, "Hostname must be 63 characters or less.")
+    .matches(
+      hostnamePattern,
+      "Hostname must only contain letters, numbers and hyphens."
+    )
+    .required(),
+  domain: Yup.string(),
+});
+
+const MachineName = ({
+  editingName,
+  id,
+  setEditingName,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+  const saved = useSelector(machineSelectors.saved);
+  const saving = useSelector(machineSelectors.saving);
+  const domains = useSelector(domainSelectors.all);
+  const canEdit = useCanEdit(machine);
+  const previousSaving = usePrevious(saving);
+
+  useEffect(() => {
+    // The machine has transitioned from saving to saved so close the form.
+    if (saved && !saving && previousSaving) {
+      setEditingName(false);
+    }
+  }, [previousSaving, saved, saving, setEditingName]);
+
+  useEffect(() => {
+    dispatch(domainActions.fetch());
+  }, [dispatch]);
+
+  if (!machine) {
+    return <Spinner />;
+  }
+  if (!canEdit) {
+    return <span className="machine-name">{machine.fqdn}</span>;
+  }
+  if (!editingName) {
+    return (
+      <Button
+        appearance="base"
+        className="machine-name--editable"
+        onClick={() => setEditingName(true)}
+      >
+        {machine.fqdn}
+      </Button>
+    );
+  }
+  return (
+    <FormikForm
+      initialValues={{
+        domain: machine.domain.id,
+        hostname: machine.hostname,
+      }}
+      inline
+      onCancel={() => setEditingName(false)}
+      onSaveAnalytics={{
+        action: "Saved",
+        category: "Machine details header",
+        label: "name",
+      }}
+      onSubmit={({ hostname, domain }) => {
+        dispatch(
+          machineActions.update({
+            ...machine,
+            domain: domains.find(({ id }) => id === parseInt(domain, 10)),
+            hostname,
+          })
+        );
+      }}
+      saving={saving}
+      saved={saved}
+      validationSchema={Schema}
+    >
+      <MachineNameFields saving={saving} />
+    </FormikForm>
+  );
+};
+
+export default MachineName;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
@@ -1,0 +1,371 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineName can display the form 1`] = `
+<FormikForm
+  initialValues={
+    Object {
+      "domain": 106,
+      "hostname": "test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE",
+    }
+  }
+  inline={true}
+  onCancel={[Function]}
+  onSaveAnalytics={
+    Object {
+      "action": "Saved",
+      "category": "Machine details header",
+      "label": "name",
+    }
+  }
+  onSubmit={[Function]}
+  saved={false}
+  saving={false}
+  validationSchema={
+    ObjectSchema {
+      "_blacklist": RefSet {
+        "list": Set {},
+        "refs": Map {},
+      },
+      "_conditions": Array [],
+      "_defaultDefault": [Function],
+      "_deps": Array [],
+      "_excludedEdges": Array [],
+      "_exclusive": Object {},
+      "_mutate": undefined,
+      "_nodes": Array [
+        "domain",
+        "hostname",
+      ],
+      "_options": Object {
+        "abortEarly": true,
+        "recursive": true,
+      },
+      "_type": "object",
+      "_typeError": [Function],
+      "_whitelist": RefSet {
+        "list": Set {},
+        "refs": Map {},
+      },
+      "fields": Object {
+        "domain": StringSchema {
+          "_blacklist": RefSet {
+            "list": Set {},
+            "refs": Map {},
+          },
+          "_conditions": Array [],
+          "_deps": Array [],
+          "_exclusive": Object {},
+          "_mutate": undefined,
+          "_options": Object {
+            "abortEarly": true,
+            "recursive": true,
+          },
+          "_type": "string",
+          "_typeError": [Function],
+          "_whitelist": RefSet {
+            "list": Set {},
+            "refs": Map {},
+          },
+          "tests": Array [],
+          "transforms": Array [
+            [Function],
+          ],
+          "type": "string",
+        },
+        "hostname": StringSchema {
+          "_blacklist": RefSet {
+            "list": Set {},
+            "refs": Map {},
+          },
+          "_conditions": Array [],
+          "_deps": Array [],
+          "_exclusive": Object {
+            "matches": false,
+            "max": true,
+            "required": true,
+          },
+          "_mutate": undefined,
+          "_options": Object {
+            "abortEarly": true,
+            "recursive": true,
+          },
+          "_type": "string",
+          "_typeError": [Function],
+          "_whitelist": RefSet {
+            "list": Set {},
+            "refs": Map {},
+          },
+          "tests": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "transforms": Array [
+            [Function],
+          ],
+          "type": "string",
+        },
+      },
+      "tests": Array [],
+      "transforms": Array [
+        [Function],
+      ],
+      "type": "object",
+    }
+  }
+>
+  <Formik
+    initialValues={
+      Object {
+        "domain": 106,
+        "hostname": "test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE",
+      }
+    }
+    onSubmit={[Function]}
+    validationSchema={
+      ObjectSchema {
+        "_blacklist": RefSet {
+          "list": Set {},
+          "refs": Map {},
+        },
+        "_conditions": Array [],
+        "_defaultDefault": [Function],
+        "_deps": Array [],
+        "_excludedEdges": Array [],
+        "_exclusive": Object {},
+        "_mutate": undefined,
+        "_nodes": Array [
+          "domain",
+          "hostname",
+        ],
+        "_options": Object {
+          "abortEarly": true,
+          "recursive": true,
+        },
+        "_type": "object",
+        "_typeError": [Function],
+        "_whitelist": RefSet {
+          "list": Set {},
+          "refs": Map {},
+        },
+        "fields": Object {
+          "domain": StringSchema {
+            "_blacklist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "_conditions": Array [],
+            "_deps": Array [],
+            "_exclusive": Object {},
+            "_mutate": undefined,
+            "_options": Object {
+              "abortEarly": true,
+              "recursive": true,
+            },
+            "_type": "string",
+            "_typeError": [Function],
+            "_whitelist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "tests": Array [],
+            "transforms": Array [
+              [Function],
+            ],
+            "type": "string",
+          },
+          "hostname": StringSchema {
+            "_blacklist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "_conditions": Array [],
+            "_deps": Array [],
+            "_exclusive": Object {
+              "matches": false,
+              "max": true,
+              "required": true,
+            },
+            "_mutate": undefined,
+            "_options": Object {
+              "abortEarly": true,
+              "recursive": true,
+            },
+            "_type": "string",
+            "_typeError": [Function],
+            "_whitelist": RefSet {
+              "list": Set {},
+              "refs": Map {},
+            },
+            "tests": Array [
+              [Function],
+              [Function],
+              [Function],
+            ],
+            "transforms": Array [
+              [Function],
+            ],
+            "type": "string",
+          },
+        },
+        "tests": Array [],
+        "transforms": Array [
+          [Function],
+        ],
+        "type": "object",
+      }
+    }
+  >
+    <FormikFormContent
+      buttonsBordered={true}
+      initialValues={
+        Object {
+          "domain": 106,
+          "hostname": "test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE",
+        }
+      }
+      inline={true}
+      onCancel={[Function]}
+      saved={false}
+      saving={false}
+    >
+      <Form
+        inline={true}
+        onSubmit={[Function]}
+      >
+        <form
+          className="p-form p-form--inline"
+          onSubmit={[Function]}
+        >
+          <MachineNameFields
+            saving={false}
+          >
+            <FormikField
+              className="machine-name__hostname"
+              disabled={false}
+              name="hostname"
+              required={true}
+              style={
+                Object {
+                  "width": "69.7ch",
+                }
+              }
+              takeFocus={true}
+              type="text"
+              wrapperClassName="u-nudge-left--small"
+            >
+              <Input
+                className="machine-name__hostname"
+                disabled={false}
+                error={null}
+                id="Uakgb_J5m9g-0JDMbcJqLJ"
+                name="hostname"
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
+                style={
+                  Object {
+                    "width": "69.7ch",
+                  }
+                }
+                takeFocus={true}
+                type="text"
+                value="test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE"
+                wrapperClassName="u-nudge-left--small"
+              >
+                <Field
+                  className="u-nudge-left--small"
+                  error={null}
+                  forId="Uakgb_J5m9g-0JDMbcJqLJ"
+                  labelFirst={true}
+                  required={true}
+                >
+                  <div
+                    className="p-form__group p-form-validation u-nudge-left--small"
+                  >
+                    <div
+                      className="p-form__control u-clearfix"
+                    >
+                      <input
+                        className="p-form-validation__input machine-name__hostname"
+                        disabled={false}
+                        id="Uakgb_J5m9g-0JDMbcJqLJ"
+                        name="hostname"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        style={
+                          Object {
+                            "width": "69.7ch",
+                          }
+                        }
+                        type="text"
+                        value="test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE"
+                      />
+                    </div>
+                  </div>
+                </Field>
+              </Input>
+            </FormikField>
+            .
+            <Spinner
+              className="u-width--auto"
+              inline={true}
+            >
+              <span
+                className="u-width--auto p-spinner p-text--default p-spinner--inline"
+              >
+                <i
+                  className="p-icon--spinner u-animation--spin"
+                />
+              </span>
+            </Spinner>
+          </MachineNameFields>
+          <FormikFormButtons
+            bordered={true}
+            cancelDisabled={false}
+            loading={false}
+            onCancel={[Function]}
+            submitDisabled={true}
+            submitLabel="Save"
+            success={false}
+          >
+            <div>
+              <Button
+                appearance="base"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <button
+                  className="p-button--base"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Cancel
+                </button>
+              </Button>
+              <ActionButton
+                appearance="positive"
+                className="u-no-margin--bottom"
+                disabled={true}
+                loading={false}
+                success={false}
+                type="submit"
+              >
+                <button
+                  className="u-no-margin--bottom p-action-button p-button--positive is-disabled"
+                  disabled={true}
+                  type="submit"
+                >
+                  Save
+                </button>
+              </ActionButton>
+            </div>
+          </FormikFormButtons>
+        </form>
+      </Form>
+    </FormikFormContent>
+  </Formik>
+</FormikForm>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`MachineName can display the form 1`] = `
 <FormikForm
   initialValues={
     Object {
-      "domain": 106,
+      "domain": 99,
       "hostname": "test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE",
     }
   }
@@ -117,7 +117,7 @@ exports[`MachineName can display the form 1`] = `
   <Formik
     initialValues={
       Object {
-        "domain": 106,
+        "domain": 99,
         "hostname": "test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE",
       }
     }
@@ -220,7 +220,7 @@ exports[`MachineName can display the form 1`] = `
       buttonsBordered={true}
       initialValues={
         Object {
-          "domain": 106,
+          "domain": 99,
           "hostname": "test-machine-() => Math.floor(Math.random() * MAX_RANDOM_VALUE) + MIN_RANDOM_VALUE",
         }
       }
@@ -247,7 +247,7 @@ exports[`MachineName can display the form 1`] = `
               required={true}
               style={
                 Object {
-                  "width": "69.7ch",
+                  "width": "82ch",
                 }
               }
               takeFocus={true}
@@ -265,7 +265,7 @@ exports[`MachineName can display the form 1`] = `
                 required={true}
                 style={
                   Object {
-                    "width": "69.7ch",
+                    "width": "82ch",
                   }
                 }
                 takeFocus={true}
@@ -295,7 +295,7 @@ exports[`MachineName can display the form 1`] = `
                         onChange={[Function]}
                         style={
                           Object {
-                            "width": "69.7ch",
+                            "width": "82ch",
                           }
                         }
                         type="text"
@@ -306,7 +306,9 @@ exports[`MachineName can display the form 1`] = `
                 </Field>
               </Input>
             </FormikField>
-            .
+            <span>
+              .
+            </span>
             <Spinner
               className="u-width--auto"
               inline={true}
@@ -332,12 +334,13 @@ exports[`MachineName can display the form 1`] = `
             <div>
               <Button
                 appearance="base"
+                className="u-no-margin--bottom"
                 disabled={false}
                 onClick={[Function]}
                 type="button"
               >
                 <button
-                  className="p-button--base"
+                  className="p-button--base u-no-margin--bottom"
                   disabled={false}
                   onClick={[Function]}
                   type="button"

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/_index.scss
@@ -16,7 +16,10 @@
   [type="text"].machine-name__hostname {
     @extend %vf-heading-4;
     box-sizing: content-box;
+    margin-bottom: -1px;
     min-width: 3rem;
-    padding: calc(#{$sp-xx-small} - 1px) $spv-inner--large;
+    // Remove 2px to account for the top and bottom borders.
+    padding: calc(#{$sp-xx-small} - 2px) $spv-inner--large
+      calc(#{$sp-xx-small} + 1px);
   }
 }

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/_index.scss
@@ -1,0 +1,22 @@
+@mixin MachineName {
+  button.machine-name--editable {
+    @extend %vf-heading-4;
+    margin-bottom: 0;
+    padding: 0 $spv-inner--large;
+
+    &:active,
+    &:focus,
+    &:hover {
+      background-color: transparent;
+      cursor: text;
+      outline: 1px solid $color-mid-light;
+    }
+  }
+
+  [type="text"].machine-name__hostname {
+    @extend %vf-heading-4;
+    box-sizing: content-box;
+    min-width: 3rem;
+    padding: calc(#{$sp-xx-small} - 1px) $spv-inner--large;
+  }
+}

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineName";

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
@@ -1,0 +1,107 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import React from "react";
+
+import {
+  domainState as domainStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import FormikForm from "app/base/components/FormikForm";
+import MachineNameFields from "./MachineNameFields";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("MachineNameFields", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+      }),
+      machine: machineStateFactory({
+        loaded: true,
+        items: [
+          machineDetailsFactory({
+            locked: false,
+            permissions: ["edit"],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("displays a spinner when loading domains", () => {
+    state.domain.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <FormikForm
+            initialValues={{
+              domain: "",
+              hostname: "",
+            }}
+            onSubmit={jest.fn()}
+          >
+            <MachineNameFields />
+          </FormikForm>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays the fields", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <FormikForm
+            initialValues={{
+              domain: "",
+              hostname: "",
+            }}
+            onSubmit={jest.fn()}
+          >
+            <MachineNameFields />
+          </FormikForm>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("MachineNameFields")).toMatchSnapshot();
+  });
+
+  it("disables fields when saving", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <FormikForm
+            initialValues={{
+              domain: "",
+              hostname: "",
+            }}
+            onSubmit={jest.fn()}
+          >
+            <MachineNameFields saving />
+          </FormikForm>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("FormikField").everyWhere((n) => Boolean(n.prop("disabled")))
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
@@ -24,13 +24,14 @@ export const MachineNameFields = ({ saving }: Props): JSX.Element => {
         disabled={saving}
         name="hostname"
         required={true}
-        style={{ width: `${values.hostname.length * 0.85}ch` }}
+        style={{ width: `${values.hostname.length}ch` }}
         takeFocus
         wrapperClassName="u-nudge-left--small"
       />
-      .
+      <span>.</span>
       {domainsLoaded ? (
         <FormikField
+          className="u-no-margin--bottom"
           component={Select}
           disabled={saving}
           name="domain"

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
@@ -1,0 +1,51 @@
+import { Select, Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { useFormikContext } from "formik";
+import React from "react";
+
+import domainSelectors from "app/store/domain/selectors";
+import FormikField from "app/base/components/FormikField";
+import type { FormValues } from "../MachineName/MachineName";
+
+type Props = {
+  saving?: boolean;
+};
+
+export const MachineNameFields = ({ saving }: Props): JSX.Element => {
+  const domains = useSelector(domainSelectors.all);
+  const domainsLoaded = useSelector(domainSelectors.loaded);
+  const { values } = useFormikContext<FormValues>();
+
+  return (
+    <>
+      <FormikField
+        type="text"
+        className="machine-name__hostname"
+        disabled={saving}
+        name="hostname"
+        required={true}
+        style={{ width: `${values.hostname.length * 0.85}ch` }}
+        takeFocus
+        wrapperClassName="u-nudge-left--small"
+      />
+      .
+      {domainsLoaded ? (
+        <FormikField
+          component={Select}
+          disabled={saving}
+          name="domain"
+          options={domains.map((domain) => ({
+            label: domain.name,
+            value: domain.id,
+          }))}
+          required
+          wrapperClassName="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+        />
+      ) : (
+        <Spinner className="u-width--auto" inline />
+      )}
+    </>
+  );
+};
+
+export default MachineNameFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/__snapshots__/MachineNameFields.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/__snapshots__/MachineNameFields.test.tsx.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineNameFields displays the fields 1`] = `
+<MachineNameFields>
+  <FormikField
+    className="machine-name__hostname"
+    name="hostname"
+    required={true}
+    style={
+      Object {
+        "width": "0ch",
+      }
+    }
+    takeFocus={true}
+    type="text"
+    wrapperClassName="u-nudge-left--small"
+  >
+    <Input
+      className="machine-name__hostname"
+      error={null}
+      id="Uakgb_J5m9g-0JDMbcJqLJ"
+      name="hostname"
+      onBlur={[Function]}
+      onChange={[Function]}
+      required={true}
+      style={
+        Object {
+          "width": "0ch",
+        }
+      }
+      takeFocus={true}
+      type="text"
+      value=""
+      wrapperClassName="u-nudge-left--small"
+    >
+      <Field
+        className="u-nudge-left--small"
+        error={null}
+        forId="Uakgb_J5m9g-0JDMbcJqLJ"
+        labelFirst={true}
+        required={true}
+      >
+        <div
+          className="p-form__group p-form-validation u-nudge-left--small"
+        >
+          <div
+            className="p-form__control u-clearfix"
+          >
+            <input
+              className="p-form-validation__input machine-name__hostname"
+              id="Uakgb_J5m9g-0JDMbcJqLJ"
+              name="hostname"
+              onBlur={[Function]}
+              onChange={[Function]}
+              style={
+                Object {
+                  "width": "0ch",
+                }
+              }
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+      </Field>
+    </Input>
+  </FormikField>
+  .
+  <FormikField
+    component={[Function]}
+    name="domain"
+    options={Array []}
+    required={true}
+    wrapperClassName="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+  >
+    <Select
+      error={null}
+      id="Uakgb_J5m9g-0JDMbcJqLJ"
+      name="domain"
+      onBlur={[Function]}
+      onChange={[Function]}
+      options={Array []}
+      required={true}
+      value=""
+      wrapperClassName="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+    >
+      <Field
+        className="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+        error={null}
+        forId="Uakgb_J5m9g-0JDMbcJqLJ"
+        isSelect={true}
+        required={true}
+      >
+        <div
+          className="p-form__group p-form-validation u-no-margin--left u-nudge-right--small u-nudge-left--small"
+        >
+          <div
+            className="p-form__control u-clearfix"
+          >
+            <div
+              className="p-form-validation__select-wrapper"
+            >
+              <select
+                className="p-form-validation__input"
+                id="Uakgb_J5m9g-0JDMbcJqLJ"
+                name="domain"
+                onBlur={[Function]}
+                onChange={[Function]}
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+      </Field>
+    </Select>
+  </FormikField>
+</MachineNameFields>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/__snapshots__/MachineNameFields.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/__snapshots__/MachineNameFields.test.tsx.snap
@@ -65,8 +65,11 @@ exports[`MachineNameFields displays the fields 1`] = `
       </Field>
     </Input>
   </FormikField>
-  .
+  <span>
+    .
+  </span>
   <FormikField
+    className="u-no-margin--bottom"
     component={[Function]}
     name="domain"
     options={Array []}
@@ -74,6 +77,7 @@ exports[`MachineNameFields displays the fields 1`] = `
     wrapperClassName="u-no-margin--left u-nudge-right--small u-nudge-left--small"
   >
     <Select
+      className="u-no-margin--bottom"
       error={null}
       id="Uakgb_J5m9g-0JDMbcJqLJ"
       name="domain"
@@ -101,7 +105,7 @@ exports[`MachineNameFields displays the fields 1`] = `
               className="p-form-validation__select-wrapper"
             >
               <select
-                className="p-form-validation__input"
+                className="p-form-validation__input u-no-margin--bottom"
                 id="Uakgb_J5m9g-0JDMbcJqLJ"
                 name="domain"
                 onBlur={[Function]}

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineNameFields";

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
@@ -1,4 +1,5 @@
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import React, { useState } from "react";
 
 import { auth as authActions } from "app/base/actions";
@@ -22,6 +23,7 @@ type PropTypes = {
 };
 
 export const UserForm = ({ user }: PropTypes): JSX.Element => {
+  const history = useHistory();
   const dispatch = useDispatch();
   const saved = useSelector(userSelectors.saved);
   const [savingUser, setSaving] = useState();
@@ -45,6 +47,7 @@ export const UserForm = ({ user }: PropTypes): JSX.Element => {
         cleanup={userActions.cleanup}
         includeUserType
         submitLabel="Save user"
+        onCancel={() => history.goBack()}
         onSaveAnalytics={{
           action: "Saved",
           category: "Users settings",

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -86,4 +86,8 @@
   .u-upper-case--first:first-letter {
     text-transform: capitalize;
   }
+
+  .u-width--auto {
+    width: auto;
+  }
 }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -110,11 +110,13 @@
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
 @import "~app/machines/views/MachineList";
 @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
+@import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/OverviewCard";
 @include MachineList;
+@include MachineName;
 @include MachineSummary;
 @include MarkBrokenFormFields;
 @include NetworkCard;


### PR DESCRIPTION
## Done

- Add the form for editing the machine name from the machine details header.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View a locked machine and click on the machine name, nothing should happen.
- View a machine you can edit and click on the machine name, the form should appear.
- Edit the machine name or domain and click Save, it should save the details.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2102.