### PR TITLE
ui(feat): add machine summary details card

### DIFF
--- a/shared/src/utils.js
+++ b/shared/src/utils.js
@@ -45,9 +45,14 @@ export const navigateToNew = (route, evt) => {
  * @return {String} The formatted power type or the original power type key.
  */
 export const extractPowerType = (description, powerType) => {
+  if (!powerType) {
+    return null;
+  }
+
   if (!description) {
     return powerType;
   }
+
   const position = description.toLowerCase().indexOf(powerType.toLowerCase());
   return position === -1
     ? powerType

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -221,10 +221,6 @@ exports[`stricter compilation`] = {
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:2435825133": [
       [18, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx:2880885888": [
-      [16, 33, 15, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2973346775"],
-      [19, 33, 15, "Argument of type \'number | null\' is not assignable to parameter of type \'number\'.\\n  Type \'null\' is not assignable to type \'number\'.", "2973147829"]
-    ],
     "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:259372828": [
       [17, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
     ],
@@ -352,17 +348,20 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx:2985488462": [
+    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx:1301901847": [
+      [4, 33, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/Users/kit/src/canonical/local/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx:26357444": [
       [18, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
       [37, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [52, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [57, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [58, 10, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [74, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [75, 16, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [80, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [95, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [120, 14, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
+      [50, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [55, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [56, 10, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [70, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [71, 16, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [76, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [89, 15, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [112, 14, 7, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "1236122734"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:539216384": [
       [104, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
@@ -575,9 +574,9 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [11, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:193241885": [
+    "src/app/store/machine/types.ts:612274196": [
       [3, 13, 8, "RegExp match", "1152173309"],
-      [295, 9, 8, "RegExp match", "1152173309"]
+      [296, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/notification/types.ts:2586887406": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -186,7 +186,7 @@ describe("NetworkCard", () => {
       );
 
       expect(
-        wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+        wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
       ).toEqual("2");
     });
 
@@ -213,7 +213,7 @@ describe("NetworkCard", () => {
       );
 
       expect(
-        wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+        wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
       ).toEqual("3");
     });
 
@@ -238,7 +238,7 @@ describe("NetworkCard", () => {
       );
 
       expect(
-        wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+        wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
       ).toEqual("5");
     });
 
@@ -263,7 +263,7 @@ describe("NetworkCard", () => {
       );
 
       expect(
-        wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+        wrapper.find("[data-test='tests']").childAt(1).find("Link").text()
       ).toContain("View results");
     });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -84,7 +84,7 @@ describe("CpuCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("2");
   });
 
@@ -108,7 +108,7 @@ describe("CpuCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("3");
   });
 
@@ -131,7 +131,7 @@ describe("CpuCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("5");
   });
 
@@ -154,7 +154,7 @@ describe("CpuCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(1).find("Link").text()
     ).toContain("View results");
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -105,7 +105,7 @@ describe("DetailsCard", () => {
       id: 1,
       name: "pod-1",
       type: "lxd",
-      numa_pinning: null,
+      numa_pinning: [],
     });
 
     state.machine.items = [machine];

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -1,0 +1,274 @@
+import { mount } from "enzyme";
+import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DetailsCard from "./DetailsCard";
+import {
+  generalState as generalStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  pod as podFactory,
+  podNumaNode as podNumaNodeFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import type { RootState } from "app/store/root/types";
+
+const mockStore = configureStore();
+
+describe("DetailsCard", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+      general: generalStateFactory({
+        powerTypes: powerTypesStateFactory({
+          data: [],
+          loaded: true,
+        }),
+      }),
+    });
+  });
+
+  it("renders the owner", () => {
+    const machine = machineDetailsFactory({ owner: "admin" });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='owner']").text()).toEqual("admin");
+  });
+
+  it("renders the domain", () => {
+    const machine = machineDetailsFactory({ domain: { id: 1, name: "maas" } });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='domain']").text()).toEqual("maas");
+  });
+
+  it("renders host details for NUMA aligned machines", () => {
+    const machine = machineDetailsFactory({ pod: { id: 1, name: "pod-1" } });
+    const pod = podFactory({
+      id: 1,
+      name: "pod-1",
+      type: "lxd",
+      numa_pinning: [podNumaNodeFactory({ node_id: 10 })],
+    });
+
+    state.machine.items = [machine];
+    state.pod.items = [pod];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='host']").text()).toEqual(
+      "On NUMA node 10 of pod-1 ›"
+    );
+  });
+
+  it("renders host details for non-NUMA aligned machines", () => {
+    const machine = machineDetailsFactory({ pod: { id: 1, name: "pod-1" } });
+    const pod = podFactory({
+      id: 1,
+      name: "pod-1",
+      type: "lxd",
+      numa_pinning: null,
+    });
+
+    state.machine.items = [machine];
+    state.pod.items = [pod];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='host']").text()).toEqual(
+      "Not NUMA-aligned on pod-1 ›"
+    );
+  });
+
+  it("renders a link to zone configuration with edit permissions", () => {
+    const machine = machineDetailsFactory({
+      permissions: ["edit"],
+      zone: { id: 1, name: "danger" },
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='zone'] Link").text()).toEqual("Zone ›");
+    expect(wrapper.find("[data-test='zone'] span").text()).toEqual("danger");
+  });
+
+  it("renders a zone label without edit permissions", () => {
+    const machine = machineDetailsFactory({
+      permissions: [],
+      zone: { id: 1, name: "danger" },
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='zone'] Link").exists()).toBe(false);
+    expect(
+      wrapper.find("[data-test='zone']").childAt(1).find("span").text()
+    ).toEqual("danger");
+  });
+
+  it("renders a link to resource pool configuration with edit permissions", () => {
+    const machine = machineDetailsFactory({
+      permissions: ["edit"],
+      pool: { id: 1, name: "swimming" },
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='resource-pool'] Link").text()).toEqual(
+      "Resource pool ›"
+    );
+    expect(wrapper.find("[data-test='resource-pool'] span").text()).toEqual(
+      "swimming"
+    );
+  });
+
+  it("renders a resource pool label without edit permissions", () => {
+    const machine = machineDetailsFactory({
+      permissions: [],
+      pool: { id: 1, name: "swimming" },
+    });
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='resource-pool'] Link").exists()).toBe(
+      false
+    );
+    expect(
+      wrapper.find("[data-test='resource-pool']").childAt(1).find("span").text()
+    ).toEqual("swimming");
+  });
+
+  it("renders a formatted power type", () => {
+    const machine = machineDetailsFactory({
+      power_type: "lxd",
+    });
+    const powerType = powerTypeFactory({
+      name: "lxd",
+      description: "LXD (virtual systems)",
+    });
+    state.machine.items = [machine];
+    state.general.powerTypes.data = [powerType];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='power-type']").text()).toEqual("LXD");
+  });
+
+  it("renders a list of tags", () => {
+    const tags = ["virtual", "test", "lxd"];
+    const machine = machineDetailsFactory({ tags });
+
+    state.machine.items = [machine];
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DetailsCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='tags'] span").text()).toEqual(
+      tags.join(", ")
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import { extractPowerType } from "@maas-ui/maas-ui-shared";
+
+import { general as generalActions } from "app/base/actions";
+import { useSendAnalytics } from "app/base/hooks";
+import generalSelectors from "app/store/general/selectors";
+import type { MachineDetails } from "app/store/machine/types";
+import { getPodNumaID, useCanEdit } from "app/store/machine/utils";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  machine: MachineDetails;
+};
+
+const DetailsCard = ({ machine }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const sendAnalytics = useSendAnalytics();
+  const canEdit = useCanEdit(machine, true);
+
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, machine?.pod?.id)
+  );
+  const powerTypes = useSelector(generalSelectors.powerTypes.get);
+
+  const configTabUrl = `/machine/${machine.system_id}/configuration`;
+  const podNumaID = getPodNumaID(machine, pod);
+  const powerTypeDescription = powerTypes.find(
+    (powerType) => powerType.name === machine.power_type
+  )?.description;
+  const powerTypeDisplay = extractPowerType(
+    powerTypeDescription,
+    machine.power_type
+  );
+
+  useEffect(() => {
+    dispatch(generalActions.fetchPowerTypes());
+    dispatch(podActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <div className="overview-card__details">
+      <div>
+        <div className="u-text--muted">Owner</div>
+        <span title={machine.owner || "-"} data-test="owner">
+          {machine.owner || "-"}
+        </span>
+      </div>
+      <div>
+        <div className="u-text--muted">Domain</div>
+        <span title={machine.domain?.name} data-test="domain">
+          {machine.domain?.name}
+        </span>
+      </div>
+      {machine.pod ? (
+        <div>
+          <div className="u-text--muted">Host</div>
+          <span data-test="host">
+            {podNumaID !== null ? (
+              <>On NUMA node {podNumaID} of </>
+            ) : (
+              <>Not NUMA-aligned on </>
+            )}
+            <Link to={`/kvm/${machine.pod.id}`}>{machine.pod.name} ›</Link>
+          </span>
+        </div>
+      ) : null}
+
+      <div data-test="zone">
+        <div>
+          {canEdit ? (
+            <Link
+              to={configTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  "Zone configuration link",
+                  "Machine summary tab"
+                )
+              }
+            >
+              Zone ›
+            </Link>
+          ) : (
+            <span className="u-text--muted">Zone</span>
+          )}
+        </div>
+        <span title={machine.zone.name}>{machine.zone.name}</span>
+      </div>
+
+      <div data-test="resource-pool">
+        <div>
+          {canEdit ? (
+            <Link
+              to={configTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  "Resource pool configuration link",
+                  "Machine summary tab"
+                )
+              }
+            >
+              Resource pool ›
+            </Link>
+          ) : (
+            <span className="u-text--muted">Resource pool</span>
+          )}
+        </div>
+        <span title={machine.pool.name}>{machine.pool.name}</span>
+      </div>
+
+      <div>
+        <div>
+          {canEdit ? (
+            <Link
+              to={configTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  "Power type configuration link",
+                  "Machine summary tab"
+                )
+              }
+            >
+              Power type ›
+            </Link>
+          ) : (
+            <span className="u-text--muted">Power type</span>
+          )}
+        </div>
+        <span title={machine.power_type} data-test="power-type">
+          {powerTypeDisplay ? powerTypeDisplay : machine.power_type}
+        </span>
+      </div>
+      <div className="u-text-overflow">
+        <div>
+          {canEdit ? (
+            <Link
+              to={configTabUrl}
+              onClick={() =>
+                sendAnalytics(
+                  "Machine details",
+                  "Tags configuration link",
+                  "Machine summary tab"
+                )
+              }
+            >
+              Tags ›
+            </Link>
+          ) : (
+            <span className="u-text--muted">Tags</span>
+          )}
+        </div>
+        <span data-test="tags">
+          {machine.tags.length > 0 ? (
+            <span title={machine.tags.join(", ")}>
+              {machine.tags.join(", ")}
+            </span>
+          ) : (
+            <em>No tags</em>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default DetailsCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -28,7 +28,8 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
   const powerTypes = useSelector(generalSelectors.powerTypes.get);
 
   const configTabUrl = `/machine/${machine.system_id}/configuration`;
-  const podNumaID = getPodNumaID(machine, pod);
+  const podNumaID = pod ? getPodNumaID(machine, pod) : null;
+
   const powerTypeDescription = powerTypes.find(
     (powerType) => powerType.name === machine.power_type
   )?.description;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DetailsCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -44,7 +44,7 @@ describe("MemoryCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("2");
   });
 
@@ -68,7 +68,7 @@ describe("MemoryCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("3");
   });
 
@@ -91,7 +91,7 @@ describe("MemoryCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("5");
   });
 
@@ -114,7 +114,7 @@ describe("MemoryCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(1).find("Link").text()
     ).toContain("View results");
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import React from "react";
 
 import CpuCard from "./CpuCard";
+import DetailsCard from "./DetailsCard";
 import MemoryCard from "./MemoryCard";
 import StatusCard from "./StatusCard";
 import StorageCard from "./StorageCard";
@@ -35,6 +36,7 @@ const OverviewCard = ({ id, setSelectedAction }: Props): JSX.Element => {
         <CpuCard machine={machine} setSelectedAction={setSelectedAction} />
         <MemoryCard machine={machine} setSelectedAction={setSelectedAction} />
         <StorageCard machine={machine} setSelectedAction={setSelectedAction} />
+        <DetailsCard machine={machine} />
       </div>
     );
   }

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
@@ -42,7 +42,7 @@ describe("StorageCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("2");
   });
 
@@ -66,7 +66,7 @@ describe("StorageCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("3");
   });
 
@@ -89,7 +89,7 @@ describe("StorageCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("5");
   });
 
@@ -112,7 +112,7 @@ describe("StorageCard", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(1).find("Link").text()
     ).toContain("View results");
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -47,7 +47,7 @@ describe("TestResults", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("2");
   });
 
@@ -75,7 +75,7 @@ describe("TestResults", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("3");
   });
 
@@ -102,7 +102,7 @@ describe("TestResults", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(0).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(0).find("Link").text()
     ).toEqual("5");
   });
 
@@ -129,7 +129,7 @@ describe("TestResults", () => {
     );
 
     expect(
-      wrapper.find("[data-test='tests']").childAt(1).find("Button").text()
+      wrapper.find("[data-test='tests']").childAt(1).find("Link").text()
     ).toContain("View results");
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -37,9 +37,7 @@ const TestResults = ({
       <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
         {machine[`${scriptType}_test_status`].passed ? (
           <li className="p-inline-list__item">
-            <Button
-              className="p-button--link"
-              element={Link}
+            <Link
               to={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
@@ -51,7 +49,7 @@ const TestResults = ({
             >
               <Icon name={ICONS.success} />
               {machine[`${scriptType}_test_status`].passed}
-            </Button>
+            </Link>
           </li>
         ) : null}
 
@@ -59,9 +57,7 @@ const TestResults = ({
           machine[`${scriptType}_test_status`].running >
         0 ? (
           <li className="p-inline-list__item">
-            <Button
-              className="p-button--link"
-              element={Link}
+            <Link
               to={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
@@ -74,15 +70,13 @@ const TestResults = ({
               <Icon name={"pending"} />
               {machine[`${scriptType}_test_status`].pending +
                 machine[`${scriptType}_test_status`].running}
-            </Button>
+            </Link>
           </li>
         ) : null}
 
         {machine[`${scriptType}_test_status`].failed > 0 ? (
           <li className="p-inline-list__item">
-            <Button
-              className="p-button--link"
-              element={Link}
+            <Link
               to={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
@@ -94,15 +88,13 @@ const TestResults = ({
             >
               <Icon name={ICONS.error} />
               {machine[`${scriptType}_test_status`].failed}
-            </Button>
+            </Link>
           </li>
         ) : null}
 
         {hasTestsRun(machine, scriptType) ? (
           <li className="p-inline-list__item">
-            <Button
-              className="p-button--link"
-              element={Link}
+            <Link
               to={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
@@ -113,7 +105,7 @@ const TestResults = ({
               }
             >
               View results&nbsp;&rsaquo;
-            </Button>
+            </Link>
           </li>
         ) : (
           <li className="p-inline-list__item">

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -194,6 +194,7 @@ export type BaseMachine = BaseNode & {
   owner: string;
   physical_disk_count: number;
   pod?: ModelRef;
+  pool: ModelRef;
   power_state: PowerState;
   power_type: string;
   pxe_mac_vendor: string;

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { general as generalActions } from "app/base/actions";
 import generalSelectors from "app/store/general/selectors";
 import type { Machine } from "app/store/machine/types";
+import { Pod } from "../pod/types";
 
 /**
  * Check if a machine has an invalid architecture.
@@ -66,4 +67,21 @@ export const useCanEdit = (
     !machine.locked &&
     (ignoreRackControllerConnection || isRackControllerConnected)
   );
+};
+
+export const getPodNumaID = (machine: Machine, pod: Pod): number => {
+  if (pod?.numa_pinning) {
+    // If there is only one NUMA node on the VM host, then the VM must be
+    // aligned on that node even if it isn't specifically pinned.
+    if (pod.numa_pinning.length === 1) {
+      return pod.numa_pinning[0].node_id;
+    }
+    const podNuma = pod.numa_pinning.find((numa) =>
+      numa.vms.some((vm) => vm.system_id === machine.system_id)
+    );
+    if (podNuma) {
+      return podNuma.node_id;
+    }
+  }
+  return null;
 };

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -69,7 +69,7 @@ export const useCanEdit = (
   );
 };
 
-export const getPodNumaID = (machine: Machine, pod: Pod): number => {
+export const getPodNumaID = (machine: Machine, pod: Pod): number | null => {
   if (pod?.numa_pinning) {
     // If there is only one NUMA node on the VM host, then the VM must be
     // aligned on that node even if it isn't specifically pinned.

--- a/ui/src/app/store/utils/selectors.ts
+++ b/ui/src/app/store/utils/selectors.ts
@@ -41,7 +41,7 @@ type BaseSelectors<
     // The provided state.
     RootState,
     // The provided parameter (id).
-    I[K],
+    I[K] | undefined | null,
     // The result (an item or null).
     I | null,
     // The computation function to select an item.
@@ -102,8 +102,11 @@ export const generateBaseSelectors = <
       (items as Array<I>).filter((item) => searchFunction(item, term))
   );
   const getById = createSelector(
-    [all, (_state: RootState, id: I[K]) => id],
+    [all, (_state: RootState, id: I[K] | null | undefined = null) => id],
     (items, id) => {
+      if (!id) {
+        return null;
+      }
       return (items as Array<I>).find((item) => item[indexKey] === id) || null;
     }
   );


### PR DESCRIPTION
## Done

- add machine summary details card

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure the details card renders as expected
- Ensure links to the configuration tab render with edit permissions (admin)

## Fixes

Fixes:  canonical-web-and-design/MAAS-squad#2108

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
