### PR TITLE
fix(legacy): use ng-if rather than dynamic maas-obj-form key

### DIFF
--- a/legacy/src/app/directives/maas_obj_form.js
+++ b/legacy/src/app/directives/maas_obj_form.js
@@ -157,17 +157,11 @@ export function maasObjForm(JSONService) {
 
   // Called by maas-obj-field to place field in edit mode.
   MAASFormController.prototype.startEditingField = function (key) {
-    if (!this.fields || !this.fields[key]) {
-      return;
-    }
     this.fields[key].editing = true;
   };
 
   // Called by maas-obj-field to end edit mode for the field.
   MAASFormController.prototype.stopEditingField = function (key, value) {
-    if (!this.fields || !this.fields[key]) {
-      return;
-    }
     var field = this.fields[key];
 
     // Do nothing if not save on blur.

--- a/legacy/src/app/partials/domain-details.html
+++ b/legacy/src/app/partials/domain-details.html
@@ -174,9 +174,20 @@
               input-width="4"
             ></maas-obj-field>
             <maas-obj-field
+              data-ng-if="newObject.$maasForm.getValue('rrtype') === 'A' || newObject.$maasForm.getValue('rrtype') === 'AAAA'"
               subtle="false"
               type="text"
-              key="{$ newObject.$maasForm.getValue('rrtype') === 'A' || newObject.$maasForm.getValue('rrtype') === 'AAAA' ? 'address_ttl' : 'ttl' $}"
+              key="address_ttl"
+              label="TTL"
+              placeholder="TTL in seconds (optional)"
+              label-width="2"
+              input-width="4"
+            ></maas-obj-field>
+            <maas-obj-field
+              data-ng-if="newObject.$maasForm.getValue('rrtype') !== 'A' && newObject.$maasForm.getValue('rrtype') !== 'AAAA'"
+              subtle="false"
+              type="text"
+              key="ttl"
               label="TTL"
               placeholder="TTL in seconds (optional)"
               label-width="2"


### PR DESCRIPTION
## Done
maas-obj-form apparently doesn't support dynamic keys. 

- use ng-if rather than dynamic maas-obj-form key

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- visit /domains
- ensure you can create an A record with a TTL without error
- ensure you can create a non-A record (e.g. TXT) with a TTL without error

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
