### PR TITLE
feat(ui): allow Ubuntu 20.04 LTS to be deployed as a KVM host

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -928,13 +928,7 @@ function NodeDetailsController(
       ) {
         extra.hwe_kernel = $scope.osSelection.hwe_kernel;
       }
-      let installKVM = $scope.deployOptions.installKVM;
-      // KVM pod deployment required bionic.
-      if (installKVM) {
-        extra.osystem = "ubuntu";
-        extra.distro_series = "bionic";
-      }
-      extra.install_kvm = installKVM;
+      extra.install_kvm = $scope.deployOptions.installKVM;
 
       // cloud-config
       const userData = $scope.deployOptions.userData;

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -1221,8 +1221,8 @@ describe("NodeDetailsController", function () {
       $scope.action.option = {
         name: "deploy",
       };
-      $scope.osSelection.osystem = "debian";
-      $scope.osSelection.release = "etch";
+      $scope.osSelection.osystem = "ubuntu";
+      $scope.osSelection.release = "focal";
       $scope.deployOptions.installKVM = true;
       $scope.actionGo();
       // When deploying KVM, coerce the distro to ubuntu/bionic.
@@ -1231,7 +1231,7 @@ describe("NodeDetailsController", function () {
         "deploy",
         {
           osystem: "ubuntu",
-          distro_series: "bionic",
+          distro_series: "focal",
           install_kvm: true,
         }
       );

--- a/legacy/src/app/partials/nodedetails/deploy-options.html
+++ b/legacy/src/app/partials/nodedetails/deploy-options.html
@@ -17,15 +17,24 @@
           class="u-float--left"
           style="width: auto; margin-right: 1rem"
         >
-          Register as MAAS KVM host (Ubuntu 18.04 LTS required).&nbsp;
-          <a
-            class="p-link--external"
-            href="https://maas.io/docs/kvm-introduction"
-            target="_blank"
-          >
-            Read more
-          </a>
+          <ul class="p-inline-list u-no-margin--bottom">
+            <li class="p-inline-list__item">
+              Register as MAAS KVM host.&nbsp;
+            </li>
+            <li class="p-inline-list__item">
+              <a
+                class="p-link--external"
+                href="https://maas.io/docs/kvm-introduction"
+                target="_blank"
+              >
+                Read more
+              </a>
+            </li>
+          </ul>
         </label>
+        <p class="p-form-help-text u-no-margin--top" style="padding-left: 2rem">
+          Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially supported.
+        </p>
       </div>
     </div>
     <div class="p-form-group p-form-validation u-sv2">
@@ -40,14 +49,20 @@
           class="u-float--left"
           style="width: auto; margin-right: 1rem"
         >
-          Cloud-init user-data&hellip;&nbsp;
-          <a
-            class="p-link--external"
-            href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
-            target="_blank"
-          >
-            Read more
-          </a>
+          <ul class="p-inline-list u-no-margin--bottom">
+            <li class="p-inline-list__item">
+              Cloud-init user-data&hellip;
+            </li>
+            <li class="p-inline-list__item">
+              <a
+                class="p-link--external"
+                href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+                target="_blank"
+              >
+                Read more
+              </a>
+            </li>
+          </ul>
         </label>
       </div>
     </div>

--- a/legacy/src/app/services/osblacklist.js
+++ b/legacy/src/app/services/osblacklist.js
@@ -15,7 +15,7 @@ function KVMDeployOSBlacklist() {
     "ubuntu/cosmic",
     "ubuntu/disco",
     "ubuntu/eoan",
-    "ubuntu/focal",
+    "ubuntu/groovy",
   ];
 }
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -57,6 +57,7 @@ describe("DeployFormFields", () => {
             releases: [
               ["centos/centos66", "CentOS 6"],
               ["centos/centos70", "CentOS 7"],
+              ["ubuntu/xenial", 'Ubuntu 16.04 LTS "Xenial Xerus"'],
               ["ubuntu/bionic", 'Ubuntu 18.04 LTS "Bionic Beaver"'],
               ["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"'],
             ],
@@ -76,6 +77,10 @@ describe("DeployFormFields", () => {
                 focal: [
                   ["ga-20.04", "focal (ga-20.04)"],
                   ["ga-20.04-lowlatency", "focal (ga-20.04-lowlatency)"],
+                ],
+                xenial: [
+                  ["ga-16.04", "xenial (ga-16.04)"],
+                  ["ga-16.04-lowlatency", "xenial (ga-16.04-lowlatency)"],
                 ],
               },
             },
@@ -171,8 +176,9 @@ describe("DeployFormFields", () => {
     );
   });
 
-  it("disables KVM checkbox with warning if not Ubuntu 18.04", async () => {
+  it("disables KVM checkbox if not Ubuntu 18.04 or 20.04", async () => {
     const state = { ...initialState };
+    state.general.osInfo.data.default_release = "xenial";
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -190,6 +196,15 @@ describe("DeployFormFields", () => {
       wrapper
         .find("select[name='release']")
         .simulate("change", { target: { name: "release", value: "bionic" } });
+    });
+    wrapper.update();
+    expect(wrapper.find("Input[name='installKVM']").props().disabled).toBe(
+      false
+    );
+    await act(async () => {
+      wrapper
+        .find("select[name='release']")
+        .simulate("change", { target: { name: "release", value: "focal" } });
     });
     wrapper.update();
     expect(wrapper.find("Input[name='installKVM']").props().disabled).toBe(

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -30,7 +30,7 @@ export const DeployFormFields = (): JSX.Element => {
     generalSelectors.osInfo.getUbuntuKernelOptions(state, values.release)
   );
   const canBeKVMHost =
-    values.oSystem === "ubuntu" && values.release === "bionic";
+    values.oSystem === "ubuntu" && ["bionic", "focal"].includes(values.release);
   const noImages = osystems.length === 0 || releases.length === 0;
 
   return (
@@ -77,7 +77,7 @@ export const DeployFormFields = (): JSX.Element => {
               onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
                 handleChange(e);
                 setFieldValue("kernel", "");
-                if (e.target.value !== "bionic") {
+                if (!["bionic", "focal"].includes(e.target.value)) {
                   setFieldValue("installKVM", false);
                 }
               }}
@@ -105,31 +105,43 @@ export const DeployFormFields = (): JSX.Element => {
             <FormikField
               disabled={!canBeKVMHost || noImages}
               label={
-                <>
-                  Register as MAAS KVM host (Ubuntu 18.04 LTS required).{" "}
-                  <a
-                    className="p-link--external"
-                    href="https://maas.io/docs/kvm-introduction"
-                  >
-                    Read more
-                  </a>
-                </>
+                <ul className="p-inline-list u-no-margin--bottom">
+                  <li className="p-inline-list__item">
+                    Register as MAAS KVM host.
+                  </li>
+                  <li className="p-inline-list__item">
+                    <a
+                      className="p-link--external"
+                      href="https://maas.io/docs/kvm-introduction"
+                    >
+                      Read more
+                    </a>
+                  </li>
+                </ul>
               }
               name="installKVM"
               type="checkbox"
             />
+            <p className="p-form-help-text" style={{ paddingLeft: "2rem" }}>
+              Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially
+              supported.
+            </p>
             <FormikField
               disabled={noImages}
               label={
-                <>
-                  Cloud-init user-data&hellip;{" "}
-                  <a
-                    className="p-link--external"
-                    href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
-                  >
-                    Read more
-                  </a>
-                </>
+                <ul className="p-inline-list u-no-margin--bottom">
+                  <li className="p-inline-list__item">
+                    Cloud-init user-data&hellip;
+                  </li>
+                  <li className="p-inline-list__item">
+                    <a
+                      className="p-link--external"
+                      href="https://maas.io/docs/custom-node-setup-preseed#heading--cloud-init"
+                    >
+                      Read more
+                    </a>
+                  </li>
+                </ul>
               }
               name="includeUserData"
               type="checkbox"


### PR DESCRIPTION
## Done

- Updated deploy forms (legacy details + react list) to allow choosing Ubuntu 20.04 LTS when registering as a KVM host.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and choose "Deploy" from the action menu
- Check that choosing Ubuntu 18.04 or 20.04 enables the KVM checkbox
- Check that choosing anything else disables the checkbox and unchecks it if it was checked
- Do the same in the legacy details page

## Fixes

Fixes #1856 

## Screenshot
![Screenshot_2020-11-11 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/98754220-f21d9100-2411-11eb-87c2-5042200bb036.png)

