### PR TITLE
feat(ui): build available disks and partitions list

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -7,7 +7,6 @@ exports[`stricter compilation`] = {
       [162, 4, 36, "Object is possibly \'null\'.", "1039669632"]
     ],
     "src/app/App.tsx:2048624384": [
-      [21, 7, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"],
       [188, 17, 17, "Object is possibly \'null\'.", "2133029343"],
       [193, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
@@ -41,9 +40,6 @@ exports[`stricter compilation`] = {
     ],
     "src/app/base/components/FormikForm/FormikForm.tsx:1590075926": [
       [77, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
-    ],
-    "src/app/base/components/LegacyLink/LegacyLink.tsx:2706551295": [
-      [4, 52, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/base/components/NotificationGroup/Notification/Notification.tsx:122297593": [
       [26, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
@@ -341,7 +337,7 @@ exports[`stricter compilation`] = {
       [42, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
       [112, 48, 10, "Property \'checkPower\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "953482588"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx:1521910028": [
+    "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx:1626600482": [
       [64, 27, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
       [73, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
     ],
@@ -350,9 +346,6 @@ exports[`stricter compilation`] = {
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
-    ],
-    "src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx:2883346391": [
-      [4, 33, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx:3588892375": [
       [18, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
@@ -389,9 +382,6 @@ exports[`stricter compilation`] = {
     "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:42858656": [
       [87, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [92, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
-    ],
-    "src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx:227377903": [
-      [5, 34, 25, "Could not find a declaration file for module \'@maas-ui/maas-ui-shared\'. \'/home/caleb/Projects/maas-ui/shared/dist/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/maas-ui__maas-ui-shared\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@maas-ui/maas-ui-shared\';\`", "1778274862"]
     ],
     "src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx:3551628603": [
       [25, 10, 4, "Type \'{ osystems: [string, string][]; releases: [string, string][]; }\' is missing the following properties from type \'OSInfo\': kernels, default_osystem, default_release", "2087377941"]
@@ -519,7 +509,7 @@ exports[`stricter compilation`] = {
       [233, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
       [312, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2158674347"],
       [314, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2087809207"],
-      [319, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<PoorMansUnknown>, Action>\'.", "1314712411"]
+      [319, 2, 6, "Type \'null\' is not assignable to type \'\\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | ArrayFactory<never> | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<PoorMansUnknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -579,9 +569,9 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [11, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:1016460159": [
+    "src/app/store/machine/types.ts:1575244389": [
       [3, 13, 8, "RegExp match", "1152173309"],
-      [293, 9, 8, "RegExp match", "1152173309"]
+      [300, 9, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/notification/types.ts:2586887406": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,0 +1,174 @@
+import { mount } from "enzyme";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import {
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+  machinePartition as partitionFactory,
+} from "testing/factories";
+import { MIN_PARTITION_SIZE } from "../MachineStorage";
+import AvailableStorageTable from "./AvailableStorageTable";
+
+describe("AvailableStorageTable", () => {
+  it("can show an empty message", () => {
+    const wrapper = mount(<AvailableStorageTable disks={[]} />);
+
+    expect(wrapper.find("[data-test='no-available']").text()).toBe(
+      "No available disks or partitions."
+    );
+  });
+
+  it("correctly filters available disks", () => {
+    const [availableDisk, unavailableDisk] = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        name: "available-disk",
+      }),
+      diskFactory({ available_size: 0, name: "unavailable-disk" }),
+    ];
+    const wrapper = mount(
+      <AvailableStorageTable disks={[availableDisk, unavailableDisk]} />
+    );
+
+    expect(wrapper.find("tbody TableRow").length).toBe(1);
+    expect(wrapper.find("tbody TableRow DoubleRow").at(0).prop("primary")).toBe(
+      "available-disk"
+    );
+  });
+
+  it("correctly filters available partitions", () => {
+    const [availablePartition, unavailablePartition] = [
+      partitionFactory({
+        filesystem: fsFactory({ mount_point: "" }),
+        name: "available-partition",
+      }),
+      partitionFactory({
+        filesystem: fsFactory({ mount_point: "/path" }),
+        name: "unavailable-partition",
+      }),
+    ];
+    const disk = diskFactory({
+      available_size: 0,
+      partitions: [availablePartition, unavailablePartition],
+    });
+    const wrapper = mount(<AvailableStorageTable disks={[disk]} />);
+
+    expect(wrapper.find("tbody TableRow").length).toBe(1);
+    expect(wrapper.find("[data-test='name']").at(0).prop("primary")).toBe(
+      "available-partition"
+    );
+  });
+
+  it("shows boot status for physical disks", () => {
+    const disks = [diskFactory({ is_boot: true, type: "physical" })];
+    const wrapper = mount(<AvailableStorageTable disks={disks} />);
+
+    expect(wrapper.find("[data-test='boot'] .p-icon--tick").exists()).toBe(
+      true
+    );
+  });
+
+  it("correctly shows type of physical disks", () => {
+    const disks = [diskFactory({ type: "physical" })];
+    const wrapper = mount(<AvailableStorageTable disks={disks} />);
+
+    expect(wrapper.find("[data-test='type']").at(0).prop("primary")).toBe(
+      "Physical"
+    );
+  });
+
+  it("correctly shows type of partitions", () => {
+    const disk = diskFactory({
+      available_size: 0,
+      partitions: [
+        partitionFactory({
+          filesystem: fsFactory({ mount_point: "" }),
+          type: "partition",
+        }),
+      ],
+    });
+    const wrapper = mount(<AvailableStorageTable disks={[disk]} />);
+
+    expect(wrapper.find("[data-test='type']").at(0).prop("primary")).toBe(
+      "Partition"
+    );
+  });
+
+  it("correctly shows type of volume groups", () => {
+    const disks = [
+      diskFactory({ available_size: MIN_PARTITION_SIZE + 1, type: "lvm-vg" }),
+    ];
+    const wrapper = mount(<AvailableStorageTable disks={disks} />);
+
+    expect(wrapper.find("[data-test='type']").at(0).prop("primary")).toBe(
+      "Volume group"
+    );
+  });
+
+  it("correctly shows type of logical volumes", () => {
+    const [parent, child] = [
+      diskFactory({ available_size: 0, id: 1, type: "lvm-vg" }),
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        parent: { id: 1, type: "lvm-vg", uuid: "abc" },
+        type: "virtual",
+      }),
+    ];
+    const wrapper = mount(<AvailableStorageTable disks={[parent, child]} />);
+
+    expect(wrapper.find("[data-test='type']").at(0).prop("primary")).toBe(
+      "Logical volume"
+    );
+  });
+
+  it("correctly shows type of RAIDs", () => {
+    const [parent, child] = [
+      diskFactory({ available_size: 0, id: 1, type: "raid-0" }),
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        parent: { id: 1, type: "raid-0", uuid: "abc" },
+        type: "virtual",
+      }),
+    ];
+    const wrapper = mount(<AvailableStorageTable disks={[parent, child]} />);
+
+    expect(wrapper.find("[data-test='type']").at(0).prop("primary")).toBe(
+      "RAID 0"
+    );
+  });
+
+  it("shows a warning if volume is spread over multiple NUMA nodes", () => {
+    const disks = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        numa_node: undefined,
+        numa_nodes: [0, 1],
+        type: "lvm-vg",
+      }),
+    ];
+    const wrapper = mount(<AvailableStorageTable disks={disks} />);
+
+    expect(wrapper.find("[data-test='numa-warning']").prop("message")).toBe(
+      "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
+    );
+  });
+
+  it("can show links to filter machine list by storage tag", () => {
+    const disks = [
+      diskFactory({ available_size: MIN_PARTITION_SIZE + 1, tags: ["tag-1"] }),
+    ];
+    const wrapper = mount(
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+      >
+        <AvailableStorageTable disks={disks} />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find("[data-test='health'] Link").exists()).toBe(true);
+    expect(wrapper.find("[data-test='health'] Link").prop("to")).toBe(
+      "/machines?storage_tags=%3Dtag-1"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,0 +1,382 @@
+import { MainTable, Tooltip } from "@canonical/react-components";
+import React from "react";
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import TableHeader from "app/base/components/TableHeader";
+import { scriptStatus } from "app/base/enum";
+import { useTableSort } from "app/base/hooks";
+import { filtersToQueryString } from "app/machines/search";
+import type { Disk } from "app/store/machine/types";
+import { formatBytes } from "app/utils";
+import { storageDeviceInUse } from "../MachineStorage";
+
+type StorageDevice = {
+  boot: boolean | null;
+  firmware: string | null;
+  id: number;
+  model: string | null;
+  name: string;
+  numaNodes: number[];
+  parentType: string | null;
+  serial: string | null;
+  size: number;
+  tags: string[];
+  testStatus: number | null;
+  type: string;
+};
+
+const formatTestStatus = (testStatus: StorageDevice["testStatus"]) => {
+  switch (testStatus) {
+    case scriptStatus.PENDING:
+      return <i className="p-icon--pending"></i>;
+    case scriptStatus.RUNNING:
+    case scriptStatus.APPLYING_NETCONF:
+    case scriptStatus.INSTALLING:
+      return <i className="p-icon--running"></i>;
+    case scriptStatus.PASSED:
+      return (
+        <>
+          <i className="p-icon--success is-inline"></i>
+          <span>OK</span>
+        </>
+      );
+    case scriptStatus.FAILED:
+    case scriptStatus.ABORTED:
+    case scriptStatus.DEGRADED:
+    case scriptStatus.FAILED_APPLYING_NETCONF:
+    case scriptStatus.FAILED_INSTALLING:
+      return (
+        <>
+          <i className="p-icon--error is-inline"></i>
+          <span>Error</span>
+        </>
+      );
+    case scriptStatus.TIMEDOUT:
+      return (
+        <>
+          <i className="p-icon--timed-out is-inline"></i>
+          <span>Timed out</span>
+        </>
+      );
+    case scriptStatus.SKIPPED:
+      return (
+        <>
+          <i className="p-icon--warning is-inline"></i>
+          <span>Skipped</span>
+        </>
+      );
+    default:
+      return (
+        <>
+          <i className="p-icon--power-unknown is-inline"></i>
+          <span>Unknown</span>
+        </>
+      );
+  }
+};
+
+const formatTags = (tags: StorageDevice["tags"]) =>
+  tags.map((tag, i) => {
+    const filter = filtersToQueryString({ storage_tags: `=${tag}` });
+    return (
+      <span key={tag}>
+        <Link to={`/machines${filter}`}>{tag}</Link>
+        {i !== tags.length - 1 && ", "}
+      </span>
+    );
+  });
+
+const formatType = (
+  type: StorageDevice["type"],
+  parentType?: StorageDevice["parentType"]
+) => {
+  let typeToFormat = type;
+  if (type === "virtual" && !!parentType) {
+    if (parentType === "lvm-vg") {
+      return "Logical volume";
+    } else if (parentType.includes("raid-")) {
+      return `RAID ${parentType.split("-")[1]}`;
+    }
+    typeToFormat = parentType;
+  }
+
+  switch (typeToFormat) {
+    case "iscsi":
+      return "ISCSI";
+    case "lvm-vg":
+      return "Volume group";
+    case "partition":
+      return "Partition";
+    case "physical":
+      return "Physical";
+    case "virtual":
+      return "Virtual";
+    default:
+      return type;
+  }
+};
+
+const getAvailableStorageDevices = (disks: Disk[]): StorageDevice[] =>
+  disks.reduce((available: StorageDevice[], disk: Disk) => {
+    if (!storageDeviceInUse(disk)) {
+      let numaNodes: StorageDevice["numaNodes"] = [];
+      if (disk.numa_nodes) {
+        numaNodes = disk.numa_nodes;
+      } else if (disk.numa_node) {
+        numaNodes = [disk.numa_node];
+      }
+
+      available.push({
+        boot: disk.is_boot,
+        firmware: disk.firmware_version,
+        id: disk.id,
+        model: disk.model,
+        name: disk.name,
+        numaNodes,
+        parentType: disk.parent?.type || null,
+        serial: disk.serial,
+        size: disk.size,
+        tags: disk.tags,
+        testStatus: disk.test_status,
+        type: disk.type,
+      });
+    }
+
+    if (disk.partitions) {
+      disk.partitions.forEach((partition) => {
+        if (!storageDeviceInUse(partition)) {
+          available.push({
+            boot: null,
+            firmware: null,
+            id: partition.id,
+            model: null,
+            name: partition.name,
+            numaNodes: [],
+            parentType: null,
+            serial: null,
+            size: partition.size,
+            tags: partition.tags,
+            testStatus: null,
+            type: partition.type,
+          });
+        }
+      });
+    }
+
+    return available;
+  }, []);
+
+const getSortValue = (
+  sortKey: keyof StorageDevice,
+  storageDevice: StorageDevice
+) => storageDevice[sortKey];
+
+type Props = { disks: Disk[] };
+
+const AvailableDisksTable = ({ disks }: Props): JSX.Element => {
+  const { currentSort, sortRows, updateSort } = useTableSort(getSortValue, {
+    key: "name",
+    direction: "descending",
+  });
+  const availableStorageDevices = getAvailableStorageDevices(disks);
+  // TODO: update useTableSort to TS with generics
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1869
+  const sortedStorageDevices = sortRows(
+    availableStorageDevices
+  ) as StorageDevice[];
+
+  return (
+    <>
+      <MainTable
+        defaultSort="name"
+        defaultSortDirection="ascending"
+        headers={[
+          {
+            content: (
+              <>
+                <TableHeader
+                  currentSort={currentSort}
+                  onClick={() => updateSort("name")}
+                  sortKey="name"
+                >
+                  Name
+                </TableHeader>
+                <TableHeader>Serial</TableHeader>
+              </>
+            ),
+          },
+          {
+            content: (
+              <>
+                <TableHeader
+                  currentSort={currentSort}
+                  onClick={() => updateSort("model")}
+                  sortKey="model"
+                >
+                  Model
+                </TableHeader>
+                <TableHeader>Firmware</TableHeader>
+              </>
+            ),
+          },
+          {
+            className: "u-align--center",
+            content: (
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("boot")}
+                sortKey="boot"
+              >
+                Boot
+              </TableHeader>
+            ),
+          },
+          {
+            content: (
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("size")}
+                sortKey="size"
+              >
+                Size
+              </TableHeader>
+            ),
+          },
+          {
+            content: (
+              <>
+                <TableHeader
+                  currentSort={currentSort}
+                  onClick={() => updateSort("type")}
+                  sortKey="type"
+                >
+                  Type
+                </TableHeader>
+                <TableHeader>NUMA node</TableHeader>
+              </>
+            ),
+          },
+          {
+            content: (
+              <>
+                <TableHeader
+                  currentSort={currentSort}
+                  onClick={() => updateSort("testStatus")}
+                  sortKey="testStatus"
+                >
+                  Health
+                </TableHeader>
+                <TableHeader>Tags</TableHeader>
+              </>
+            ),
+          },
+          {
+            content: <TableHeader>Actions</TableHeader>,
+            className: "u-align--right",
+          },
+        ]}
+        rows={sortedStorageDevices.map((storageDevice) => {
+          const size = formatBytes(storageDevice.size, "B");
+          let boot: ReactNode = "—";
+          if (storageDevice.type === "physical") {
+            boot = storageDevice.boot ? (
+              <i className="p-icon--tick"></i>
+            ) : (
+              <i className="p-icon--close"></i>
+            );
+          }
+
+          return {
+            columns: [
+              {
+                content: (
+                  <DoubleRow
+                    data-test="name"
+                    primary={storageDevice.name}
+                    secondary={storageDevice.serial}
+                  />
+                ),
+              },
+              {
+                content: (
+                  <DoubleRow
+                    data-test="model"
+                    primary={storageDevice.model || "—"}
+                    secondary={storageDevice.firmware}
+                  />
+                ),
+              },
+              {
+                content: (
+                  <DoubleRow
+                    data-test="boot"
+                    primary={boot}
+                    primaryClassName="u-align--center"
+                  />
+                ),
+              },
+              {
+                content: (
+                  <DoubleRow
+                    data-test="size"
+                    primary={`${size.value} ${size.unit}`}
+                  />
+                ),
+              },
+              {
+                content: (
+                  <DoubleRow
+                    data-test="type"
+                    primary={formatType(
+                      storageDevice.type,
+                      storageDevice.parentType
+                    )}
+                    secondary={
+                      <>
+                        {storageDevice.numaNodes.length > 1 && (
+                          <Tooltip
+                            data-test="numa-warning"
+                            message={
+                              "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
+                            }
+                          >
+                            <i className="p-icon--warning is-inline"></i>
+                          </Tooltip>
+                        )}
+                        <span>{storageDevice.numaNodes.join(", ")}</span>
+                      </>
+                    }
+                  />
+                ),
+              },
+              {
+                content: (
+                  <DoubleRow
+                    data-test="health"
+                    primary={
+                      storageDevice.type === "physical"
+                        ? formatTestStatus(storageDevice.testStatus)
+                        : "—"
+                    }
+                    secondary={formatTags(storageDevice.tags)}
+                  />
+                ),
+              },
+              { content: "" },
+            ],
+            key: storageDevice.id,
+          };
+        })}
+      />
+      {sortedStorageDevices.length === 0 && (
+        <div className="u-nudge-right--small" data-test="no-available">
+          No available disks or partitions.
+        </div>
+      )}
+    </>
+  );
+};
+
+export default AvailableDisksTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AvailableStorageTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -14,7 +14,7 @@ describe("FilesystemsTable", () => {
       <FilesystemsTable disks={[]} specialFilesystems={[]} />
     );
 
-    expect(wrapper.find("TableRow TableCell").at(0).text()).toBe(
+    expect(wrapper.find("[data-test='no-filesystems']").text()).toBe(
       "No filesystems defined."
     );
   });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -99,65 +99,68 @@ const FilesystemsTable = ({
   const filesystems = getFilesystems(disks, specialFilesystems);
 
   return (
-    <MainTable
-      defaultSort="name"
-      defaultSortDirection="ascending"
-      headers={[
-        {
-          content: "Name",
-          sortKey: "name",
-        },
-        {
-          content: "Size",
-          sortKey: "size",
-        },
-        {
-          content: "Filesystem",
-          sortKey: "fstype",
-        },
-        {
-          content: "Mount point",
-          sortKey: "mountPoint",
-        },
-        {
-          content: "Mount options",
-        },
-        {
-          content: "Actions",
-          className: "u-align--right",
-        },
-      ]}
-      rows={
-        filesystems.length > 0
-          ? filesystems.map((fs) => {
-              const size = formatBytes(fs.size, "B");
-              return {
-                columns: [
-                  { content: fs.name },
-                  {
-                    content: fs.size === 0 ? "—" : `${size.value} ${size.unit}`,
-                  },
-                  { content: fs.fstype },
-                  { content: fs.mountPoint },
-                  { content: fs.mountOptions },
-                  {
-                    content: "",
-                    className: "u-align--right",
-                  },
-                ],
-                key: fs.id,
-                sortData: {
-                  mountPoint: fs.mountPoint,
-                  name: fs.name,
-                  size: fs.size,
-                  fstype: fs.fstype,
-                },
-              };
-            })
-          : [{ columns: [{ content: "No filesystems defined." }] }]
-      }
-      sortable
-    />
+    <>
+      <MainTable
+        defaultSort="name"
+        defaultSortDirection="ascending"
+        headers={[
+          {
+            content: "Name",
+            sortKey: "name",
+          },
+          {
+            content: "Size",
+            sortKey: "size",
+          },
+          {
+            content: "Filesystem",
+            sortKey: "fstype",
+          },
+          {
+            content: "Mount point",
+            sortKey: "mountPoint",
+          },
+          {
+            content: "Mount options",
+          },
+          {
+            content: "Actions",
+            className: "u-align--right",
+          },
+        ]}
+        rows={filesystems.map((fs) => {
+          const size = formatBytes(fs.size, "B");
+          return {
+            columns: [
+              { content: fs.name },
+              {
+                content: fs.size === 0 ? "—" : `${size.value} ${size.unit}`,
+              },
+              { content: fs.fstype },
+              { content: fs.mountPoint },
+              { content: fs.mountOptions },
+              {
+                content: "",
+                className: "u-align--right",
+              },
+            ],
+            key: fs.id,
+            sortData: {
+              mountPoint: fs.mountPoint,
+              name: fs.name,
+              size: fs.size,
+              fstype: fs.fstype,
+            },
+          };
+        })}
+        sortable
+      />
+      {filesystems.length === 0 && (
+        <div className="u-nudge-right--small" data-test="no-filesystems">
+          No filesystems defined.
+        </div>
+      )}
+    </>
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@canonical/react-components";
+import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 import React from "react";
@@ -6,8 +6,31 @@ import React from "react";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
+import type { Disk, Partition } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import AvailableStorageTable from "./AvailableStorageTable";
 import FilesystemsTable from "./FilesystemsTable";
+
+// From models/partition.py. This should ideally be available over the websocket.
+// https://github.com/canonical-web-and-design/maas-ui/issues/1866
+export const MIN_PARTITION_SIZE = 4 * 1024 * 1024;
+
+export const storageDeviceInUse = (
+  storageDevice: Disk | Partition
+): boolean => {
+  const { filesystem, type } = storageDevice;
+
+  if (type === "cache-set") {
+    return true;
+  }
+  if (!!filesystem) {
+    return (
+      (!!filesystem.is_format_fstype && !!filesystem.mount_point) ||
+      !filesystem.is_format_fstype
+    );
+  }
+  return (storageDevice as Disk).available_size < MIN_PARTITION_SIZE;
+};
 
 const MachineStorage = (): JSX.Element => {
   const params = useParams<RouteParams>();
@@ -21,11 +44,17 @@ const MachineStorage = (): JSX.Element => {
   if (machine && "disks" in machine && "special_filesystems" in machine) {
     return (
       <>
-        <h4>Filesystems</h4>
-        <FilesystemsTable
-          disks={machine.disks}
-          specialFilesystems={machine.special_filesystems}
-        />
+        <Strip shallow>
+          <h4>Filesystems</h4>
+          <FilesystemsTable
+            disks={machine.disks}
+            specialFilesystems={machine.special_filesystems}
+          />
+        </Strip>
+        <Strip shallow>
+          <h4>Available disks and partitions</h4>
+          <AvailableStorageTable disks={machine.disks} />
+        </Strip>
       </>
     );
   }

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -49,6 +49,7 @@ export type NetworkInterface = Model & {
 
 export type Filesystem = Model & {
   fstype: string;
+  is_format_fstype: boolean;
   label: string;
   mount_options: string | null;
   mount_point: string;
@@ -75,7 +76,13 @@ export type Disk = Model & {
   is_boot: boolean;
   model: string;
   name: string;
-  numa_node: number;
+  numa_node?: number;
+  numa_nodes?: number[];
+  parent?: {
+    id: number;
+    uuid: string;
+    type: string;
+  };
   partition_table_type: string;
   partitions: Partition[] | null;
   path: string;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -152,6 +152,7 @@ export const machineEvent = extend<Model, Event>(model, {
 
 export const machineFilesystem = extend<Model, Filesystem>(model, {
   fstype: "fat32",
+  is_format_fstype: true,
   label: "efi",
   mount_options: "abc",
   mount_point: "/boot/efi",


### PR DESCRIPTION
## Done

- built available disks and partitions list in machine storage tab. It's almost the same as the angular version, only the Boot column is now an icon instead of a radio button, and instead of having empty cells if the column isn't relevant I've made them dashes (e.g `—`)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the react available disks and partitions list shows the same data as the angular version. You might need a `make sampledata`'d MAAS to see things like volume groups and RAIDs.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2157

## Screenshot
![Screenshot_2020-11-12 able-boar maas storage focal-maas MAAS](https://user-images.githubusercontent.com/25733845/98890536-f4521f00-24e7-11eb-8ec1-3e42bf9da40b.png)

