### PR TITLE
Show the correct login page when logging out with external auth.

### DIFF
--- a/ui/src/app/App.js
+++ b/ui/src/app/App.js
@@ -17,7 +17,7 @@ import { config as configSelectors } from "app/settings/selectors";
 import { Footer, Header } from "@maas-ui/maas-ui-shared";
 import { status } from "app/base/selectors";
 import { status as statusActions } from "app/base/actions";
-import { useLocation, useRouter } from "app/base/hooks";
+import { useLocation, usePrevious, useRouter } from "app/base/hooks";
 import { websocket } from "./base/actions";
 import Login from "app/base/components/Login";
 import Routes from "app/Routes";
@@ -42,10 +42,19 @@ export const App = () => {
   const dispatch = useDispatch();
   const basename = process.env.REACT_APP_BASENAME;
   const debug = process.env.NODE_ENV === "development";
+  const previousAuthenticated = usePrevious(authenticated, false);
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
   }, [dispatch]);
+
+  useEffect(() => {
+    // When a user logs out the redux store is reset so the authentication
+    // info needs to be fetched again to know if external auth is being used.
+    if (previousAuthenticated && !authenticated) {
+      dispatch(statusActions.checkAuthenticated());
+    }
+  }, [authenticated, dispatch, previousAuthenticated]);
 
   useEffect(() => {
     if (authenticated) {

--- a/ui/src/app/App.test.js
+++ b/ui/src/app/App.test.js
@@ -1,3 +1,4 @@
+import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
@@ -5,6 +6,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import { App } from "./App";
+import { status as statusActions } from "app/base/actions";
 
 const mockStore = configureStore();
 
@@ -251,5 +253,31 @@ describe("App", () => {
       </Provider>
     );
     expect(wrapper.find("Header").prop("showRSD")).toBe(false);
+  });
+
+  it("fetches the auth details again when logging out", () => {
+    state.status.authenticated = true;
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
+          <App />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "CHECK_AUTHENTICATED").length
+    ).toBe(1);
+    state.status.authenticated = false;
+    act(() => {
+      store.dispatch(statusActions.logout());
+    });
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "CHECK_AUTHENTICATED").length
+    ).toBe(2);
   });
 });

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -42,8 +42,8 @@ export const useLocation = () => {
  * @param {*} value - Current value.
  * @returns {*} Previous value.
  */
-export const usePrevious = (value) => {
-  const ref = useRef(value);
+export const usePrevious = (value, setInitial = true) => {
+  const ref = useRef(setInitial ? value : undefined);
   useEffect(() => {
     ref.current = value;
   }, [value]);


### PR DESCRIPTION
## Done

- Backport the fix for showing the correct loging page when logging out with external auth (from https://github.com/canonical-web-and-design/maas-ui/pull/1796).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Connect your ui to a maas using external auth.
- Login in and then log out, you should see the external auth login page.
- Connect your ui to a maas that is NOT using external auth.
- Login in and then log out, you should see the normal login page.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/1844.