### PR TITLE
refactor(ui): add eslint-plugin-import and sort imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint-ui": "cd ui && yarn run lint",
     "lint-shared": "cd shared && yarn run lint",
     "lint-root": "cd root && yarn run lint",
-    "lint": "yarn lint-legacy && yarn lint-ui && yarn lint-shared && yarn lint-root",
+    "lint": "yarn build-shared && yarn lint-legacy && yarn lint-ui && yarn lint-shared && yarn lint-root",
     "test-cypress": "yarn --cwd integration run cypress-test",
     "test-legacy": "cd legacy && yarn run test",
     "test-ui": "cd ui && yarn run test --watchAll=false",

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -60,6 +60,11 @@ module.exports = {
           {
             pathGroups: [
               {
+                pattern: "react",
+                group: "external",
+                position: "before",
+              },
+              {
                 pattern: "**/types",
                 group: "internal",
                 position: "after",
@@ -69,6 +74,7 @@ module.exports = {
                 group: "internal",
               },
             ],
+            "pathGroupsExcludedImportTypes": ["react"],
             "newlines-between": "always",
             alphabetize: {
               order: "asc",

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   parser: "babel-eslint",
-  plugins: ["react", "@typescript-eslint", "prettier"],
+  plugins: ["react", "@typescript-eslint", "prettier", "eslint-plugin-import"],
   extends: [
     "react-app", // Use the recommended rules from CRA.
     "plugin:prettier/recommended", // Ensure this is last in the list.
@@ -32,6 +32,9 @@ module.exports = {
         "react-app", // Uses the recommended rules from CRA.
         "plugin:@typescript-eslint/recommended", // Uses the recommended rules from @typescript-eslint/eslint-plugin
         "prettier/@typescript-eslint", // Use eslint-config-prettier to disable rules from @typescript-eslint/eslint-plugin that conflict with prettier.
+        "plugin:import/errors",
+        "plugin:import/warnings",
+        "plugin:import/typescript",
         "plugin:prettier/recommended", // Ensure this is last in the list.
       ],
       parserOptions: {
@@ -50,8 +53,36 @@ module.exports = {
             ignoreRestSiblings: true,
           },
         ],
+        "import/namespace": "off",
+        "import/no-named-as-default": 0,
+        "import/order": [
+          "error",
+          {
+            pathGroups: [
+              {
+                pattern: "**/types",
+                group: "internal",
+                position: "after",
+              },
+              {
+                pattern: "~/app",
+                group: "internal",
+              },
+            ],
+            "newlines-between": "always",
+            alphabetize: {
+              order: "asc",
+            },
+          },
+        ],
       },
       settings: {
+        "import/resolver": {
+          node: {
+            paths: ["src"],
+            extensions: [".js", ".jsx", ".ts", ".tsx"],
+          },
+        },
         react: {
           version: "detect",
         },

--- a/ui/src/app/App.test.tsx
+++ b/ui/src/app/App.test.tsx
@@ -1,12 +1,13 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
-import type { RootState } from "app/store/root/types";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import { App } from "./App";
+
+import { status as statusActions } from "app/base/actions";
 import {
   configState as configStateFactory,
   generalState as generalStateFactory,
@@ -14,7 +15,8 @@ import {
   navigationOptionsState as navigationOptionsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { status as statusActions } from "app/base/actions";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/App.test.tsx
+++ b/ui/src/app/App.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,33 +1,33 @@
-import { Link, useHistory, useLocation } from "react-router-dom";
 import { Spinner, Notification } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import React, { useEffect } from "react";
-import * as Sentry from "@sentry/browser";
-
-import "../scss/index.scss";
-
-import {
-  auth as authActions,
-  general as generalActions,
-} from "app/base/actions";
-import { getCookie } from "app/utils";
-import { config as configActions } from "app/settings/actions";
-import configSelectors from "app/store/config/selectors";
 import {
   Footer,
   generateLegacyURL,
   Header,
   navigateToLegacy,
 } from "@maas-ui/maas-ui-shared";
-import { status as statusActions } from "app/base/actions";
+import * as Sentry from "@sentry/browser";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useHistory, useLocation } from "react-router-dom";
+
+import "../scss/index.scss";
 import { websocket } from "./base/actions";
-import authSelectors from "app/store/auth/selectors";
-import generalSelectors from "app/store/general/selectors";
-import Login from "app/base/components/Login";
+
 import Routes from "app/Routes";
+import {
+  auth as authActions,
+  general as generalActions,
+  status as statusActions,
+} from "app/base/actions";
+import Login from "app/base/components/Login";
 import Section from "app/base/components/Section";
+import { config as configActions } from "app/settings/actions";
+import authSelectors from "app/store/auth/selectors";
+import configSelectors from "app/store/config/selectors";
+import generalSelectors from "app/store/general/selectors";
 import status from "app/store/status/selectors";
+import { getCookie } from "app/utils";
 
 declare global {
   interface Window {

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -1,3 +1,5 @@
+import React, { useEffect } from "react";
+
 import { Spinner, Notification } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import {
@@ -7,7 +9,6 @@ import {
   navigateToLegacy,
 } from "@maas-ui/maas-ui-shared";
 import * as Sentry from "@sentry/browser";
-import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useHistory, useLocation } from "react-router-dom";
 

--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Redirect, Route, Switch } from "react-router-dom";
 
 import ErrorBoundary from "app/base/components/ErrorBoundary";

--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
 
 import ErrorBoundary from "app/base/components/ErrorBoundary";
-import KVM from "app/kvm/views/KVM";
-import Machines from "app/machines/views/Machines";
-import MachineDetails from "app/machines/views/MachineDetails";
 import NotFound from "app/base/views/NotFound";
+import KVM from "app/kvm/views/KVM";
+import MachineDetails from "app/machines/views/MachineDetails";
+import Machines from "app/machines/views/Machines";
 import Preferences from "app/preferences/views/Preferences";
 import RSD from "app/rsd/views/RSD";
 import Settings from "app/settings/views/Settings";

--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -1,11 +1,13 @@
-import { act } from "react-dom/test-utils";
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
 import React from "react";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
 import ActionForm from "./ActionForm";
+
 import { rootState as rootStateFactory } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 let state: RootState;

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -2,11 +2,12 @@ import { Spinner, Strip } from "@canonical/react-components";
 import type { ReactNode } from "react";
 import React, { useEffect, useState } from "react";
 
-import type { AnalyticsEvent, TSFixMe } from "app/base/types";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
 import { useProcessing } from "app/base/hooks";
 import { formatErrors } from "app/utils";
-import FormikForm from "app/base/components/FormikForm";
-import FormCardButtons from "app/base/components/FormCardButtons";
+
+import type { AnalyticsEvent, TSFixMe } from "app/base/types";
 
 const getLabel = (
   modelName: string,

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -1,6 +1,7 @@
-import { Spinner, Strip } from "@canonical/react-components";
 import type { ReactNode } from "react";
 import React, { useEffect, useState } from "react";
+
+import { Spinner, Strip } from "@canonical/react-components";
 
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";

--- a/ui/src/app/base/components/DoughnutChart/DoughnutChart.test.tsx
+++ b/ui/src/app/base/components/DoughnutChart/DoughnutChart.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import DoughnutChart from "./DoughnutChart";
 

--- a/ui/src/app/base/components/DoughnutChart/DoughnutChart.tsx
+++ b/ui/src/app/base/components/DoughnutChart/DoughnutChart.tsx
@@ -1,7 +1,8 @@
+import React, { useRef, useState } from "react";
+
 import { Tooltip } from "@canonical/react-components";
 import { nanoid } from "@reduxjs/toolkit";
 import classNames from "classnames";
-import React, { useRef, useState } from "react";
 
 type Segment = {
   /**

--- a/ui/src/app/base/components/DoughnutChart/DoughnutChart.tsx
+++ b/ui/src/app/base/components/DoughnutChart/DoughnutChart.tsx
@@ -1,5 +1,5 @@
-import { nanoid } from "@reduxjs/toolkit";
 import { Tooltip } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
 import classNames from "classnames";
 import React, { useRef, useState } from "react";
 

--- a/ui/src/app/base/components/FormCard/FormCard.test.tsx
+++ b/ui/src/app/base/components/FormCard/FormCard.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import FormCard from "./FormCard";
 

--- a/ui/src/app/base/components/FormCard/FormCard.test.tsx
+++ b/ui/src/app/base/components/FormCard/FormCard.test.tsx
@@ -1,8 +1,9 @@
 import { shallow } from "enzyme";
 import React from "react";
 
-import { COL_SIZES } from "app/base/constants";
 import FormCard from "./FormCard";
+
+import { COL_SIZES } from "app/base/constants";
 
 describe("FormCard ", () => {
   it("renders", () => {

--- a/ui/src/app/base/components/FormCard/FormCard.tsx
+++ b/ui/src/app/base/components/FormCard/FormCard.tsx
@@ -1,7 +1,8 @@
-import { Card, Col, Row } from "@canonical/react-components";
-import PropTypes from "prop-types";
 import React from "react";
 import type { ReactNode } from "react";
+
+import { Card, Col, Row } from "@canonical/react-components";
+import PropTypes from "prop-types";
 
 import { COL_SIZES } from "app/base/constants";
 

--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -1,8 +1,9 @@
+import React, { useRef } from "react";
+
 import { Input } from "@canonical/react-components";
 import { nanoid } from "@reduxjs/toolkit";
 import { useField } from "formik";
 import PropTypes from "prop-types";
-import React, { useRef } from "react";
 
 import type { TSFixMe } from "app/base/types";
 

--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -1,8 +1,8 @@
 import { Input } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
 import { useField } from "formik";
 import PropTypes from "prop-types";
 import React, { useRef } from "react";
-import { nanoid } from "@reduxjs/toolkit";
 
 import type { TSFixMe } from "app/base/types";
 

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -1,13 +1,14 @@
 import { Formik } from "formik";
-import { Redirect } from "react-router";
-import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import type { ReactNode } from "react";
 import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { Redirect } from "react-router";
 
-import { useSendAnalyticsWhen } from "app/base/hooks";
-import type { TSFixMe } from "app/base/types";
 import FormikFormContent from "app/base/components/FormikFormContent";
+import { useSendAnalyticsWhen } from "app/base/hooks";
+
+import type { TSFixMe } from "app/base/types";
 
 type Props = {
   allowAllEmpty?: boolean;

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -1,7 +1,8 @@
-import { Formik } from "formik";
-import PropTypes from "prop-types";
 import type { ReactNode } from "react";
 import React, { useEffect } from "react";
+
+import { Formik } from "formik";
+import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
 import { Redirect } from "react-router";
 

--- a/ui/src/app/base/components/LabelledList/LabelledList.test.tsx
+++ b/ui/src/app/base/components/LabelledList/LabelledList.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import LabelledList from "./LabelledList";
 

--- a/ui/src/app/base/components/LabelledList/LabelledList.tsx
+++ b/ui/src/app/base/components/LabelledList/LabelledList.tsx
@@ -1,7 +1,8 @@
-import { List } from "@canonical/react-components";
-import classNames from "classnames";
 import React from "react";
 import type { ReactNode } from "react";
+
+import { List } from "@canonical/react-components";
+import classNames from "classnames";
 
 type LabelledListItem = {
   label: ReactNode;

--- a/ui/src/app/base/components/LegacyLink/LegacyLink.test.tsx
+++ b/ui/src/app/base/components/LegacyLink/LegacyLink.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import LegacyLink from "./LegacyLink";
 

--- a/ui/src/app/base/components/LegacyLink/LegacyLink.tsx
+++ b/ui/src/app/base/components/LegacyLink/LegacyLink.tsx
@@ -1,8 +1,7 @@
 import { Link } from "@canonical/react-components";
+import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
 import React from "react";
 import type { ReactNode } from "react";
-
-import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
 
 type Props = {
   children: ReactNode;

--- a/ui/src/app/base/components/LegacyLink/LegacyLink.tsx
+++ b/ui/src/app/base/components/LegacyLink/LegacyLink.tsx
@@ -1,7 +1,8 @@
-import { Link } from "@canonical/react-components";
-import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
 import React from "react";
 import type { ReactNode } from "react";
+
+import { Link } from "@canonical/react-components";
+import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
 
 type Props = {
   children: ReactNode;

--- a/ui/src/app/base/components/Meter/Meter.test.tsx
+++ b/ui/src/app/base/components/Meter/Meter.test.tsx
@@ -1,5 +1,6 @@
-import { mount, shallow } from "enzyme";
 import React from "react";
+
+import { mount, shallow } from "enzyme";
 
 import Meter, { DEFAULT_SEPARATOR_COLOR } from "./Meter";
 

--- a/ui/src/app/base/components/Meter/Meter.tsx
+++ b/ui/src/app/base/components/Meter/Meter.tsx
@@ -1,7 +1,8 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
 import { useListener } from "@canonical/react-components/dist/hooks";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { COLOURS } from "app/base/constants";
 

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
@@ -1,8 +1,10 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import NotificationGroupNotification from "./Notification";
 
 import {
   authState as authStateFactory,
@@ -14,9 +16,9 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { NotificationIdent } from "app/store/notification/types";
-import NotificationGroupNotification from "./Notification";
+
 import type { ConfigState } from "app/store/config/types";
+import { NotificationIdent } from "app/store/notification/types";
 import type { UserState } from "app/store/user/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Notification } from "@canonical/react-components";
 import PropTypes from "prop-types";
-import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -1,14 +1,15 @@
+import { Notification } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Notification } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
-import { isReleaseNotification } from "app/store/utils";
-import { MessageType } from "app/store/message/types";
-import { actions as notificationActions } from "app/store/notification";
 import authSelectors from "app/store/auth/selectors";
+import { actions as notificationActions } from "app/store/notification";
 import notificationSelectors from "app/store/notification/selectors";
+import { isReleaseNotification } from "app/store/utils";
+
+import { MessageType } from "app/store/message/types";
 import type { Notification as NotificationType } from "app/store/notification/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
@@ -1,15 +1,15 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import NotificationGroup from "./NotificationGroup";
 
 import {
   notification as notificationFactory,
   notificationState as notificationStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import NotificationGroup from "./NotificationGroup";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
@@ -1,8 +1,9 @@
+import React from "react";
+
 import { Button, Notification } from "@canonical/react-components";
 import classNames from "classnames";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
-import React from "react";
 import { useDispatch } from "react-redux";
 import type { Dispatch } from "redux";
 

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
@@ -1,17 +1,19 @@
+import { Button, Notification } from "@canonical/react-components";
 import classNames from "classnames";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch } from "react-redux";
-import { Button, Notification } from "@canonical/react-components";
 import type { Dispatch } from "redux";
 
-import { capitaliseFirst } from "app/utils";
+import NotificationGroupNotification from "./Notification";
+
 import { useVisible } from "app/base/hooks";
 import { actions as notificationActions } from "app/store/notification";
-import NotificationGroupNotification from "./Notification";
-import type { Notification as NotificationType } from "app/store/notification/types";
+import { capitaliseFirst } from "app/utils";
+
 import type { MessageType } from "app/store/message/types";
+import type { Notification as NotificationType } from "app/store/notification/types";
 
 const dismissAll = (notifications: NotificationType[], dispatch: Dispatch) => {
   notifications.forEach((notification) => {

--- a/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -1,8 +1,10 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import NotificationList from "./NotificationList";
 
 import {
   config as configFactory,
@@ -15,8 +17,8 @@ import {
   rootState as rootStateFactory,
   routerState as routerStateFactory,
 } from "testing/factories";
+
 import { NotificationIdent } from "app/store/notification/types";
-import NotificationList from "./NotificationList";
 import type { Notification } from "app/store/notification/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/base/components/NotificationList/NotificationList.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.tsx
@@ -1,13 +1,14 @@
 import { Notification } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import type { Dispatch } from "redux";
 
 import { messages as messageActions } from "app/base/actions";
-import { actions as notificationActions } from "app/store/notification";
 import NotificationGroup from "app/base/components/NotificationGroup";
 import messageSelectors from "app/store/message/selectors";
+import { actions as notificationActions } from "app/store/notification";
 import notificationSelectors from "app/store/notification/selectors";
-import type { Dispatch } from "redux";
+
 import type { Message } from "app/store/message/types";
 
 const generateMessages = (messages: Message[], dispatch: Dispatch) =>

--- a/ui/src/app/base/components/NotificationList/NotificationList.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.tsx
@@ -1,5 +1,6 @@
-import { Notification } from "@canonical/react-components";
 import React, { useEffect } from "react";
+
+import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
 

--- a/ui/src/app/base/components/Popover/Popover.test.tsx
+++ b/ui/src/app/base/components/Popover/Popover.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import Popover from "./Popover";
 

--- a/ui/src/app/base/components/Popover/Popover.tsx
+++ b/ui/src/app/base/components/Popover/Popover.tsx
@@ -1,8 +1,7 @@
 import classNames from "classnames";
 import React, { useRef } from "react";
-import usePortal from "react-useportal";
-
 import type { ReactNode } from "react";
+import usePortal from "react-useportal";
 
 type Props = {
   children: ReactNode;

--- a/ui/src/app/base/components/Popover/Popover.tsx
+++ b/ui/src/app/base/components/Popover/Popover.tsx
@@ -1,6 +1,7 @@
-import classNames from "classnames";
 import React, { useRef } from "react";
 import type { ReactNode } from "react";
+
+import classNames from "classnames";
 import usePortal from "react-useportal";
 
 type Props = {

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import SectionHeader from "./SectionHeader";
 

--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -1,7 +1,8 @@
-import { Col, Row, Spinner, Tabs } from "@canonical/react-components";
-import classNames from "classnames";
 import React from "react";
 import type { ReactNode } from "react";
+
+import { Col, Row, Spinner, Tabs } from "@canonical/react-components";
+import classNames from "classnames";
 
 import type { TSFixMe } from "app/base/types";
 

--- a/ui/src/app/base/components/Switch/Switch.test.tsx
+++ b/ui/src/app/base/components/Switch/Switch.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import Switch from "./Switch";
 

--- a/ui/src/app/base/components/Switch/Switch.tsx
+++ b/ui/src/app/base/components/Switch/Switch.tsx
@@ -1,5 +1,6 @@
-import PropTypes from "prop-types";
 import React from "react";
+
+import PropTypes from "prop-types";
 
 type Props = {
   className?: string;

--- a/ui/src/app/base/components/TagSelector/TagSelector.test.tsx
+++ b/ui/src/app/base/components/TagSelector/TagSelector.test.tsx
@@ -1,5 +1,6 @@
-import { mount, shallow } from "enzyme";
 import React from "react";
+
+import { mount, shallow } from "enzyme";
 
 import TagSelector from "./TagSelector";
 

--- a/ui/src/app/base/components/TagSelector/TagSelector.tsx
+++ b/ui/src/app/base/components/TagSelector/TagSelector.tsx
@@ -1,7 +1,8 @@
+import React, { useEffect, useRef, useState } from "react";
+
 import { Button, Input } from "@canonical/react-components";
 import Field from "@canonical/react-components/dist/components/Field";
 import classNames from "classnames";
-import React, { useEffect, useRef, useState } from "react";
 
 export type Tag = {
   id: number;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
@@ -1,5 +1,6 @@
-import { Spinner, Strip } from "@canonical/react-components";
 import React, { useCallback, useEffect, useState } from "react";
+
+import { Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import * as Yup from "yup";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
@@ -4,37 +4,39 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import * as Yup from "yup";
 
+import ComposeFormFields from "./ComposeFormFields";
+import InterfacesTable from "./InterfacesTable";
+import StorageTable from "./StorageTable";
+
+import {
+  general as generalActions,
+  messages as messagesActions,
+} from "app/base/actions";
+import ActionForm from "app/base/components/ActionForm";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import generalSelectors from "app/store/general/selectors";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import { actions as resourcePoolActions } from "app/store/resourcepool";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import { actions as spaceActions } from "app/store/space";
+import spaceSelectors from "app/store/space/selectors";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import { actions as zoneActions } from "app/store/zone";
+import zoneSelectors from "app/store/zone/selectors";
+import { formatBytes } from "app/utils";
+
 import type { RouteParams } from "app/base/types";
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import type { Space } from "app/store/space/types";
 import type { Subnet } from "app/store/subnet/types";
-import { actions as podActions } from "app/store/pod";
-import { actions as resourcePoolActions } from "app/store/resourcepool";
-import { actions as subnetActions } from "app/store/subnet";
-import {
-  general as generalActions,
-  messages as messagesActions,
-} from "app/base/actions";
-import { actions as domainActions } from "app/store/domain";
-import { actions as fabricActions } from "app/store/fabric";
-import { actions as spaceActions } from "app/store/space";
-import { actions as vlanActions } from "app/store/vlan";
-import { actions as zoneActions } from "app/store/zone";
-import domainSelectors from "app/store/domain/selectors";
-import fabricSelectors from "app/store/fabric/selectors";
-import generalSelectors from "app/store/general/selectors";
-import podSelectors from "app/store/pod/selectors";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
-import spaceSelectors from "app/store/space/selectors";
-import subnetSelectors from "app/store/subnet/selectors";
-import vlanSelectors from "app/store/vlan/selectors";
-import zoneSelectors from "app/store/zone/selectors";
-import { formatBytes } from "app/utils";
-import ActionForm from "app/base/components/ActionForm";
-import ComposeFormFields from "./ComposeFormFields";
-import InterfacesTable from "./InterfacesTable";
-import StorageTable from "./StorageTable";
 
 export type Disk = {
   location: string;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -1,10 +1,11 @@
 import { mount } from "enzyme";
 import React from "react";
-import { MemoryRouter, Route } from "react-router-dom";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import type { RootState } from "app/store/root/types";
+import ComposeForm from "../ComposeForm";
+
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -22,7 +23,8 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import ComposeForm from "../ComposeForm";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -1,5 +1,6 @@
-import { Col, Row, Select } from "@canonical/react-components";
 import React from "react";
+
+import { Col, Row, Select } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import type { ComposeFormDefaults } from "../ComposeForm";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -2,12 +2,14 @@ import { Col, Row, Select } from "@canonical/react-components";
 import React from "react";
 import { useSelector } from "react-redux";
 
-import type { Pod } from "app/store/pod/types";
 import type { ComposeFormDefaults } from "../ComposeForm";
+
 import FormikField from "app/base/components/FormikField";
 import domainSelectors from "app/store/domain/selectors";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import zoneSelectors from "app/store/zone/selectors";
+
+import type { Pod } from "app/store/pod/types";
 
 type Props = {
   architectures: Pod["architectures"];

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -1,12 +1,12 @@
-import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 import React from "react";
-import { MemoryRouter, Route } from "react-router-dom";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore, { MockStoreEnhanced } from "redux-mock-store";
 
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
+import ComposeForm from "../ComposeForm";
+
 import {
   domainState as domainStateFactory,
   fabric as fabricFactory,
@@ -26,7 +26,9 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import ComposeForm from "../ComposeForm";
+
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -12,19 +12,22 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
 import type { ComposeFormValues, InterfaceField } from "../ComposeForm";
-import type { PodDetails } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
-import type { VLAN } from "app/store/vlan/types";
+
+import SubnetSelect from "./SubnetSelect";
+
+import FormikField from "app/base/components/FormikField";
+import TableActions from "app/base/components/TableActions";
 import fabricSelectors from "app/store/fabric/selectors";
 import podSelectors from "app/store/pod/selectors";
 import spaceSelectors from "app/store/space/selectors";
 import subnetSelectors from "app/store/subnet/selectors";
 import vlanSelectors from "app/store/vlan/selectors";
-import FormikField from "app/base/components/FormikField";
-import SubnetSelect from "./SubnetSelect";
-import TableActions from "app/base/components/TableActions";
+
+import type { RouteParams } from "app/base/types";
+import type { PodDetails } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import type { VLAN } from "app/store/vlan/types";
 
 /**
  * Generate a new InterfaceField with a given id.

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import {
   Button,
   Select,
@@ -8,7 +10,6 @@ import {
   Tooltip,
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -1,13 +1,14 @@
-import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 import React from "react";
-import { MemoryRouter, Route } from "react-router-dom";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore, { MockStoreEnhanced } from "redux-mock-store";
 
+import ComposeForm from "../../ComposeForm";
+
 import type { MenuLink } from "./SubnetSelect";
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
+
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -26,7 +27,9 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import ComposeForm from "../../ComposeForm";
+
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
@@ -1,6 +1,7 @@
-import { ContextualMenu } from "@canonical/react-components";
 import React from "react";
 import type { MouseEventHandler } from "react";
+
+import { ContextualMenu } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
@@ -1,24 +1,26 @@
 import { ContextualMenu } from "@canonical/react-components";
-import { useParams } from "react-router";
-import { useSelector } from "react-redux";
 import React from "react";
 import type { MouseEventHandler } from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
 import type { InterfaceField } from "../../ComposeForm";
-import type { Fabric } from "app/store/fabric/types";
-import type { PodDetails } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
-import type { Space } from "app/store/space/types";
-import type { Subnet } from "app/store/subnet/types";
-import type { VLAN } from "app/store/vlan/types";
+import { getPxeIconClass } from "../InterfacesTable";
+
 import fabricSelectors from "app/store/fabric/selectors";
 import podSelectors from "app/store/pod/selectors";
 import spaceSelectors from "app/store/space/selectors";
 import subnetSelectors from "app/store/subnet/selectors";
 import vlanSelectors from "app/store/vlan/selectors";
 import { groupAsMap } from "app/utils";
-import { getPxeIconClass } from "../InterfacesTable";
+
+import type { RouteParams } from "app/base/types";
+import type { Fabric } from "app/store/fabric/types";
+import type { PodDetails } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import type { Space } from "app/store/space/types";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
 
 type Props = {
   iface: InterfaceField;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -1,12 +1,12 @@
-import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 import React from "react";
-import { MemoryRouter, Route } from "react-router-dom";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore, { MockStore } from "redux-mock-store";
 
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
+import ComposeForm from "../../ComposeForm";
+
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -24,7 +24,9 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import ComposeForm from "../../ComposeForm";
+
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -4,14 +4,16 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
 import type { ComposeFormValues, DiskField } from "../../ComposeForm";
-import type { PodDetails } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
+
+import Meter from "app/base/components/Meter";
+import { COLOURS } from "app/base/constants";
 import podSelectors from "app/store/pod/selectors";
 import { formatBytes } from "app/utils";
-import { COLOURS } from "app/base/constants";
-import Meter from "app/base/components/Meter";
+
+import type { RouteParams } from "app/base/types";
+import type { PodDetails } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 type RequestMap = { [location: string]: number };
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { ContextualMenu } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -1,12 +1,12 @@
-import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
 import React from "react";
-import { MemoryRouter, Route } from "react-router-dom";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore, { MockStore } from "redux-mock-store";
 
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
+import ComposeForm from "../ComposeForm";
+
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -24,7 +24,9 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import ComposeForm from "../ComposeForm";
+
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -13,14 +13,17 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
 import type { Disk, ComposeFormValues } from "../ComposeForm";
-import type { RootState } from "app/store/root/types";
-import podSelectors from "app/store/pod/selectors";
-import FormikField from "app/base/components/FormikField";
+
 import PoolSelect from "./PoolSelect";
+
+import FormikField from "app/base/components/FormikField";
 import TableActions from "app/base/components/TableActions";
 import TagSelector from "app/base/components/TagSelector";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 type Props = { defaultDisk: Disk };
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import {
   Button,
   Select,
@@ -9,7 +11,6 @@ import {
   Tooltip,
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -2,10 +2,11 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
+import ActionForm from "app/base/components/ActionForm";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import ActionForm from "app/base/components/ActionForm";
+
+import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
@@ -1,8 +1,10 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import KVMActionFormWrapper from "./KVMActionFormWrapper";
 
 import {
   pod as podFactory,
@@ -10,7 +12,6 @@ import {
   podStatus as podStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import KVMActionFormWrapper from "./KVMActionFormWrapper";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -2,10 +2,11 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
+import ActionForm from "app/base/components/ActionForm";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import ActionForm from "app/base/components/ActionForm";
+
+import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.test.tsx
+++ b/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.test.tsx
+++ b/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.test.tsx
@@ -1,8 +1,10 @@
-import React from "react";
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
+import React from "react";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import PodAggregateResources from "./PodAggregateResources";
 
 import {
   machine as machineFactory,
@@ -13,7 +15,6 @@ import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import PodAggregateResources from "./PodAggregateResources";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
+++ b/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
@@ -2,15 +2,16 @@ import { Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import type { Machine } from "app/store/machine/types";
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 import type { PodResourcesCardProps } from "app/kvm/components/PodResourcesCard";
+import PodResourcesCard from "app/kvm/components/PodResourcesCard";
 import { actions as machineActions } from "app/store/machine";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import PodResourcesCard from "app/kvm/components/PodResourcesCard";
 import { formatBytes } from "app/utils";
+
+import type { Machine } from "app/store/machine/types";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
+++ b/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
@@ -1,5 +1,6 @@
-import { Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import type { PodResourcesCardProps } from "app/kvm/components/PodResourcesCard";

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
@@ -1,12 +1,12 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import PodConfiguration from "./PodConfiguration";
-import { RootState } from "app/store/root/types";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -15,6 +15,8 @@ import {
   tagState as tagStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
@@ -4,23 +4,25 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import * as Yup from "yup";
 
-import type { RouteParams } from "app/base/types";
 import PodConfigurationFields from "./PodConfigurationFields";
+
 import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
 import { useWindowTitle } from "app/base/hooks";
-import type { Pod } from "app/store/pod/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
-import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import { formatErrors } from "app/utils";
+
+import type { RouteParams } from "app/base/types";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 const PodConfigurationSchema = Yup.object().shape({
   cpu_over_commit_ratio: Yup.number().required("CPU overcommit ratio required"),

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
@@ -1,5 +1,6 @@
-import { Spinner } from "@canonical/react-components";
 import React, { useCallback, useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import * as Yup from "yup";

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
@@ -1,10 +1,11 @@
-import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import PodConfiguration from "../PodConfiguration";
+
 import {
   pod as podFactory,
   podState as podStateFactory,

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Col, Input, Row, Select, Slider } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 import { useSelector } from "react-redux";
 
 import type { PodConfigurationValues } from "../PodConfiguration";

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
@@ -4,12 +4,13 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import type { PodConfigurationValues } from "../PodConfiguration";
+
+import FormikField from "app/base/components/FormikField";
+import TagSelector from "app/base/components/TagSelector";
 import { formatHostType } from "app/kvm/utils";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import tagSelectors from "app/store/tag/selectors";
 import zoneSelectors from "app/store/zone/selectors";
-import FormikField from "app/base/components/FormikField";
-import TagSelector from "app/base/components/TagSelector";
 
 type Props = { showHostType?: boolean };
 

--- a/ui/src/app/kvm/components/PodDetailsActionMenu/PodDetailsActionMenu.tsx
+++ b/ui/src/app/kvm/components/PodDetailsActionMenu/PodDetailsActionMenu.tsx
@@ -1,5 +1,6 @@
-import { ContextualMenu } from "@canonical/react-components";
 import React from "react";
+
+import { ContextualMenu } from "@canonical/react-components";
 
 type Props = { setSelectedAction: (action: string | null) => void };
 

--- a/ui/src/app/kvm/components/PodMeter/PodMeter.test.tsx
+++ b/ui/src/app/kvm/components/PodMeter/PodMeter.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import PodMeter from "./PodMeter";
 

--- a/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.test.tsx
+++ b/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import PodResourcesCard from "./PodResourcesCard";
 

--- a/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.test.tsx
+++ b/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.test.tsx
@@ -1,8 +1,9 @@
 import { shallow } from "enzyme";
 import React from "react";
 
-import { machine as machineFactory } from "testing/factories";
 import PodResourcesCard from "./PodResourcesCard";
+
+import { machine as machineFactory } from "testing/factories";
 
 describe("PodResourcesCard", () => {
   it("can be given a title", () => {

--- a/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.tsx
+++ b/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.tsx
@@ -3,12 +3,13 @@ import classNames from "classnames";
 import pluralize from "pluralize";
 import React from "react";
 
-import type { Machine } from "app/store/machine/types";
-import { formatBytes } from "app/utils";
-import { COLOURS } from "app/base/constants";
 import DoughnutChart from "app/base/components/DoughnutChart";
+import { COLOURS } from "app/base/constants";
 import PodMeter from "app/kvm/components/PodMeter";
 import { MachineListTable } from "app/machines/views/MachineList/MachineListTable/MachineListTable";
+import { formatBytes } from "app/utils";
+
+import type { Machine } from "app/store/machine/types";
 
 type ChartValues = {
   allocated: number;

--- a/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.tsx
+++ b/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { Card, ContextualMenu } from "@canonical/react-components";
 import classNames from "classnames";
 import pluralize from "pluralize";
-import React from "react";
 
 import DoughnutChart from "app/base/components/DoughnutChart";
 import { COLOURS } from "app/base/constants";

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.test.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.test.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.test.tsx
@@ -1,9 +1,11 @@
+import { mount } from "enzyme";
 import React from "react";
 import { act } from "react-dom/test-utils";
-import configureStore from "redux-mock-store";
-import { mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import PodStorage, { TRUNCATION_POINT } from "./PodStorage";
 
 import * as hooks from "app/base/hooks";
 import {
@@ -14,7 +16,6 @@ import {
   podStoragePool as podStoragePoolFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import PodStorage, { TRUNCATION_POINT } from "./PodStorage";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
@@ -5,10 +5,11 @@ import { useSelector } from "react-redux";
 
 import { useSendAnalytics } from "app/base/hooks";
 import PodMeter from "app/kvm/components/PodMeter";
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 import podSelectors from "app/store/pod/selectors";
 import { formatBytes } from "app/utils";
+
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 
 export const TRUNCATION_POINT = 3;
 

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
@@ -1,6 +1,7 @@
+import React, { useState } from "react";
+
 import { Button, Card, Spinner } from "@canonical/react-components";
 import pluralize from "pluralize";
-import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
 import { useSendAnalytics } from "app/base/hooks";

--- a/ui/src/app/kvm/views/KVM.tsx
+++ b/ui/src/app/kvm/views/KVM.tsx
@@ -3,6 +3,7 @@ import { Route, Switch } from "react-router-dom";
 
 import KVMDetails from "./KVMDetails";
 import KVMList from "./KVMList";
+
 import NotFound from "app/base/views/NotFound";
 
 const KVM = (): JSX.Element => {

--- a/ui/src/app/kvm/views/KVM.tsx
+++ b/ui/src/app/kvm/views/KVM.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Route, Switch } from "react-router-dom";
 
 import KVMDetails from "./KVMDetails";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
+import React from "react";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import KVMDetails from "./KVMDetails";
+
 import {
   pod as podFactory,
   podState as podStateFactory,

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Redirect, Route, Switch } from "react-router-dom";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -3,14 +3,16 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Redirect, Route, Switch } from "react-router-dom";
 
-import type { RouteParams } from "app/base/types";
-import type { RootState } from "app/store/root/types";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
-import Section from "app/base/components/Section";
-import PodConfiguration from "app/kvm/components/PodConfiguration";
 import KVMDetailsHeader from "./KVMDetailsHeader";
 import KVMSummary from "./KVMSummary";
+
+import Section from "app/base/components/Section";
+import PodConfiguration from "app/kvm/components/PodConfiguration";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 const KVMDetails = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -1,15 +1,17 @@
-import React from "react";
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
-import { MemoryRouter, Route } from "react-router-dom";
+import React from "react";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import KVMDetailsHeader from "./KVMDetailsHeader";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -1,5 +1,6 @@
-import pluralize from "pluralize";
 import React, { useEffect, useState } from "react";
+
+import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -4,13 +4,14 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";
 
-import type { RouteParams } from "app/base/types";
-import type { RootState } from "app/store/root/types";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
+import SectionHeader from "app/base/components/SectionHeader";
 import KVMActionFormWrapper from "app/kvm/components/KVMActionFormWrapper";
 import PodDetailsActionMenu from "app/kvm/components/PodDetailsActionMenu";
-import SectionHeader from "app/base/components/SectionHeader";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 const KVMDetailsHeader = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
@@ -5,8 +5,9 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import * as hooks from "app/base/hooks";
 import KVMNumaResources, { TRUNCATION_POINT } from "./KVMNumaResources";
+
+import * as hooks from "app/base/hooks";
 import {
   config as configFactory,
   configState as configStateFactory,

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -4,15 +4,16 @@ import pluralize from "pluralize";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { useSendAnalytics } from "app/base/hooks";
+import type { PodResourcesCardProps } from "app/kvm/components/PodResourcesCard";
+import PodResourcesCard from "app/kvm/components/PodResourcesCard";
+import { actions as machineActions } from "app/store/machine";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+
 import type { Machine } from "app/store/machine/types";
 import type { Pod, PodNumaNode } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
-import type { PodResourcesCardProps } from "app/kvm/components/PodResourcesCard";
-import { actions as machineActions } from "app/store/machine";
-import { useSendAnalytics } from "app/base/hooks";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
-import PodResourcesCard from "app/kvm/components/PodResourcesCard";
 
 export const TRUNCATION_POINT = 4;
 

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -1,7 +1,8 @@
+import React, { useEffect, useState } from "react";
+
 import { Button, Spinner } from "@canonical/react-components";
 import classNames from "classnames";
 import pluralize from "pluralize";
-import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { useSendAnalytics } from "app/base/hooks";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
@@ -5,6 +5,8 @@ import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
+import KVMSummary from "./KVMSummary";
+
 import * as hooks from "app/base/hooks";
 import {
   config as configFactory,
@@ -14,7 +16,6 @@ import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import KVMSummary from "./KVMSummary";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -4,14 +4,16 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { useStorageState } from "react-storage-hooks";
 
-import type { RouteParams } from "app/base/types";
 import KVMNumaResources from "./KVMNumaResources";
+
 import Switch from "app/base/components/Switch";
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import PodAggregateResources from "app/kvm/components/PodAggregateResources";
 import PodStorage from "app/kvm/components/PodStorage";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
+
+import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const KVMSummary = (): JSX.Element => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -1,5 +1,6 @@
-import { Code, Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
+
+import { Code, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { useStorageState } from "react-storage-hooks";

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
@@ -5,6 +5,7 @@ import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import AddKVMFormFields from "./AddKVMFormFields";
+
 import { general as generalActions } from "app/base/actions";
 import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";
@@ -15,9 +16,7 @@ import {
   usePowerParametersSchema,
   useWindowTitle,
 } from "app/base/hooks";
-import type { TSFixMe } from "app/base/types";
 import generalSelectors from "app/store/general/selectors";
-import type { PowerType } from "app/store/general/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
@@ -25,6 +24,9 @@ import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import { formatErrors, formatPowerParameters } from "app/utils";
+
+import type { TSFixMe } from "app/base/types";
+import type { PowerType } from "app/store/general/types";
 
 const generateAddKVMSchema = (
   parametersSchema: Yup.ObjectSchemaDefinition<TSFixMe>

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
@@ -1,5 +1,6 @@
-import { Spinner } from "@canonical/react-components";
 import React, { useCallback, useEffect, useState } from "react";
+
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 import * as Yup from "yup";

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.test.tsx
@@ -1,10 +1,11 @@
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
 import React from "react";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import AddKVMForm from "../AddKVMForm";
+
 import {
   configState as configStateFactory,
   generalState as generalStateFactory,

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
@@ -1,12 +1,13 @@
 import { Col, Row, Select } from "@canonical/react-components";
-import React from "react";
 import { useFormikContext } from "formik";
+import React from "react";
 import { useSelector } from "react-redux";
 
 import { AddKVMFormValues } from "../AddKVMForm";
+
 import FormikField from "app/base/components/FormikField";
-import generalSelectors from "app/store/general/selectors";
 import PowerTypeFields from "app/machines/components/PowerTypeFields";
+import generalSelectors from "app/store/general/selectors";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import zoneSelectors from "app/store/zone/selectors";
 

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Col, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 import { useSelector } from "react-redux";
 
 import { AddKVMFormValues } from "../AddKVMForm";

--- a/ui/src/app/kvm/views/KVMList/KVMList.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Route, Switch } from "react-router-dom";
 
 import AddKVMForm from "./AddKVMForm";

--- a/ui/src/app/kvm/views/KVMList/KVMList.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMList.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 
-import { useWindowTitle } from "app/base/hooks";
 import AddKVMForm from "./AddKVMForm";
 import KVMListHeader from "./KVMListHeader";
 import KVMListTable from "./KVMListTable";
+
 import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
 
 const KVMList = (): JSX.Element => {
   useWindowTitle("KVM");

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
@@ -1,15 +1,17 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import KVMListActionMenu from "./KVMListActionMenu";
-import { RootState } from "app/store/root/types";
+
 import {
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.tsx
@@ -1,5 +1,6 @@
-import { ContextualMenu, Tooltip } from "@canonical/react-components";
 import React from "react";
+
+import { ContextualMenu, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import podSelectors from "app/store/pod/selectors";

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import * as React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -1,10 +1,11 @@
 import { mount } from "enzyme";
+import * as React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import * as React from "react";
 
 import KVMListHeader from "./KVMListHeader";
+
 import {
   pod as podFactory,
   podState as podStateFactory,

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -1,5 +1,6 @@
-import { Button } from "@canonical/react-components";
 import React, { useEffect, useState } from "react";
+
+import { Button } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -3,12 +3,13 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
+import KVMListActionMenu from "./KVMListActionMenu";
+
+import SectionHeader from "app/base/components/SectionHeader";
+import KVMActionFormWrapper from "app/kvm/components/KVMActionFormWrapper";
 import { getVMHostCount } from "app/kvm/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import KVMActionFormWrapper from "app/kvm/components/KVMActionFormWrapper";
-import KVMListActionMenu from "./KVMListActionMenu";
-import SectionHeader from "app/base/components/SectionHeader";
 
 const KVMListHeader = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
@@ -1,15 +1,17 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import CPUColumn from "./CPUColumn";
+
 import {
   pod as podFactory,
   podHint as podHintFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import CPUPopover from "./CPUPopover";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import podSelectors from "app/store/pod/selectors";
-import type { RootState } from "app/store/root/types";
 import CPUPopover from "./CPUPopover";
+
 import Meter from "app/base/components/Meter";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import CPUPopover from "./CPUPopover";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUPopover/CPUPopover.tsx
@@ -1,5 +1,6 @@
-import PropTypes from "prop-types";
 import React from "react";
+
+import PropTypes from "prop-types";
 
 import Popover from "app/base/components/Popover";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
@@ -1,10 +1,11 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import KVMListTable from "./KVMListTable";
+
 import { nodeStatus } from "app/base/enum";
 import {
   controllerState as controllerStateFactory,
@@ -21,6 +22,7 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect } from "react";
+
 import { Col, Input, MainTable, Row } from "@canonical/react-components";
 import classNames from "classnames";
-import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import CPUColumn from "./CPUColumn";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
@@ -12,21 +12,17 @@ import RAMColumn from "./RAMColumn";
 import StorageColumn from "./StorageColumn";
 import TypeColumn from "./TypeColumn";
 import VMsColumn from "./VMsColumn";
+
 import { general as generalActions } from "app/base/actions";
-import { actions as machineActions } from "app/store/machine";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
-import type { TSFixMe } from "app/base/types";
-import type { Controller } from "app/store/controller/types";
-import generalSelectors from "app/store/general/selectors";
-import type { Machine } from "app/store/machine/types";
-import podSelectors from "app/store/pod/selectors";
-import type { Pod } from "app/store/pod/types";
 import { actions as controllerActions } from "app/store/controller";
+import generalSelectors from "app/store/general/selectors";
+import { actions as machineActions } from "app/store/machine";
 import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
 import { actions as poolActions } from "app/store/resourcepool";
 import poolSelectors from "app/store/resourcepool/selectors";
-import type { ResourcePool } from "app/store/resourcepool/types";
 import { actions as zoneActions } from "app/store/zone";
 import {
   generateCheckboxHandlers,
@@ -34,6 +30,12 @@ import {
   someInArray,
   someNotAll,
 } from "app/utils";
+
+import type { TSFixMe } from "app/base/types";
+import type { Controller } from "app/store/controller/types";
+import type { Machine } from "app/store/machine/types";
+import type { Pod } from "app/store/pod/types";
+import type { ResourcePool } from "app/store/resourcepool/types";
 
 const getSortValue = (
   sortKey: keyof Pod | "cpu" | "os" | "pool" | "power" | "ram" | "storage",

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
@@ -1,14 +1,16 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import NameColumn from "./NameColumn";
+
 import {
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
@@ -1,5 +1,6 @@
-import { Input } from "@canonical/react-components";
 import React from "react";
+
+import { Input } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
@@ -3,10 +3,11 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import DoubleRow from "app/base/components/DoubleRow";
 import podSelectors from "app/store/pod/selectors";
+
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
-import DoubleRow from "app/base/components/DoubleRow";
 
 type Props = {
   handleCheckbox: (podID: Pod["id"]) => void;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
@@ -1,9 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import OSColumn from "./OSColumn";
+
 import { nodeStatus } from "app/base/enum";
 import {
   controllerState as controllerStateFactory,
@@ -14,6 +15,7 @@ import {
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import { getStatusText } from "app/utils";
-import controllerSelectors from "app/store/controller/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
+import controllerSelectors from "app/store/controller/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import { useFormattedOS } from "app/store/machine/utils";
 import podSelectors from "app/store/pod/selectors";
+import { getStatusText } from "app/utils";
+
 import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
@@ -1,9 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import PoolColumn from "./PoolColumn";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -13,6 +14,7 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import poolSelectors from "app/store/resourcepool/selectors";
-import podSelectors from "app/store/pod/selectors";
-import zoneSelectors from "app/store/zone/selectors";
-import type { RootState } from "app/store/root/types";
 import DoubleRow from "app/base/components/DoubleRow";
+import podSelectors from "app/store/pod/selectors";
+import poolSelectors from "app/store/resourcepool/selectors";
+import zoneSelectors from "app/store/zone/selectors";
+
+import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
@@ -1,14 +1,16 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import PowerColumn from "./PowerColumn";
+
 import {
   machine as machineFactory,
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import { capitaliseFirst, getPowerIcon } from "app/utils";
+import DoubleRow from "app/base/components/DoubleRow";
 import controllerSelectors from "app/store/controller/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import podSelectors from "app/store/pod/selectors";
+import { capitaliseFirst, getPowerIcon } from "app/utils";
+
 import type { RootState } from "app/store/root/types";
-import DoubleRow from "app/base/components/DoubleRow";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
@@ -1,15 +1,17 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import RAMColumn from "./RAMColumn";
+
 import {
   pod as podFactory,
   podHint as podHintFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import { formatBytes } from "app/utils";
-import podSelectors from "app/store/pod/selectors";
-import type { RootState } from "app/store/root/types";
-import Meter from "app/base/components/Meter";
 import RAMPopover from "./RAMPopover";
+
+import Meter from "app/base/components/Meter";
+import podSelectors from "app/store/pod/selectors";
+import { formatBytes } from "app/utils";
+
+import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import RAMPopover from "./RAMPopover";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import RAMPopover from "./RAMPopover";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
@@ -1,5 +1,6 @@
-import PropTypes from "prop-types";
 import React from "react";
+
+import PropTypes from "prop-types";
 
 import Popover from "app/base/components/Popover";
 import { formatBytes } from "app/utils";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMPopover/RAMPopover.tsx
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import { formatBytes } from "app/utils";
 import Popover from "app/base/components/Popover";
+import { formatBytes } from "app/utils";
 
 type Props = {
   allocated: number;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
@@ -1,7 +1,9 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import StorageColumn from "./StorageColumn";
 
 import {
   pod as podFactory,
@@ -9,7 +11,6 @@ import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import StorageColumn from "./StorageColumn";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import StoragePopover from "./StoragePopover";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import { formatBytes } from "app/utils";
-import podSelectors from "app/store/pod/selectors";
-import type { RootState } from "app/store/root/types";
-import Meter from "app/base/components/Meter";
 import StoragePopover from "./StoragePopover";
+
+import Meter from "app/base/components/Meter";
+import podSelectors from "app/store/pod/selectors";
+import { formatBytes } from "app/utils";
+
+import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.test.tsx
@@ -1,8 +1,9 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import { podStoragePool as podStoragePoolFactory } from "testing/factories";
 import StoragePopover from "./StoragePopover";
+
+import { podStoragePool as podStoragePoolFactory } from "testing/factories";
 
 describe("StoragePopover", () => {
   const body = document.querySelector("body");

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import StoragePopover from "./StoragePopover";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import type { ReactNode } from "react";
 
-import type { Pod } from "app/store/pod/types";
-import { formatBytes } from "app/utils";
 import Meter from "app/base/components/Meter";
 import Popover from "app/base/components/Popover";
+import { formatBytes } from "app/utils";
+
+import type { Pod } from "app/store/pod/types";
 
 type Props = {
   children: ReactNode;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
@@ -1,14 +1,16 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import TypeColumn from "./TypeColumn";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import podSelectors from "app/store/pod/selectors";
-import type { RootState } from "app/store/root/types";
-import { formatHostType } from "app/kvm/utils";
 import DoubleRow from "app/base/components/DoubleRow";
+import { formatHostType } from "app/kvm/utils";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
@@ -1,14 +1,16 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import React from "react";
 
 import VMsColumn from "./VMsColumn";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import podSelectors from "app/store/pod/selectors";
-import type { RootState } from "app/store/root/types";
 import DoubleRow from "app/base/components/DoubleRow";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -1,12 +1,12 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import ActionFormWrapper from "./ActionFormWrapper";
-import { RootState } from "app/store/root/types";
+
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -18,6 +18,8 @@ import {
   scriptsState as scriptsStateFactory,
   scripts as scriptsFactory,
 } from "testing/factories";
+
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -5,13 +5,6 @@ import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useParams } from "react-router";
 
-import type {
-  SelectedAction,
-  SetSelectedAction,
-} from "app/machines/views/MachineDetails/MachineSummary";
-import { actions as machineActions } from "app/store/machine";
-import type { RouteParams } from "app/base/types";
-import { useMachineActionForm } from "app/machines/hooks";
 import CommissionForm from "./CommissionForm";
 import DeployForm from "./DeployForm";
 import FieldlessForm from "./FieldlessForm";
@@ -21,6 +14,15 @@ import SetPoolForm from "./SetPoolForm";
 import SetZoneForm from "./SetZoneForm";
 import TagForm from "./TagForm";
 import TestForm from "./TestForm";
+
+import { useMachineActionForm } from "app/machines/hooks";
+import type {
+  SelectedAction,
+  SetSelectedAction,
+} from "app/machines/views/MachineDetails/MachineSummary";
+import { actions as machineActions } from "app/store/machine";
+
+import type { RouteParams } from "app/base/types";
 
 const getErrorSentence = (action: SelectedAction, count: number) => {
   const machineString = pluralize("machine", count, true);

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -1,7 +1,8 @@
+import React, { useEffect, useState } from "react";
+
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -1,10 +1,11 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
-import type { RootState } from "app/store/root/types";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import CommissionForm from "./CommissionForm";
 
 import {
   generalState as generalStateFactory,
@@ -18,7 +19,8 @@ import {
   scripts as scriptsFactory,
   scriptsState as scriptsStateFactory,
 } from "testing/factories";
-import CommissionForm from "./CommissionForm";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -3,16 +3,18 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
-import { actions as machineActions } from "app/store/machine";
+import CommissionFormFields from "./CommissionFormFields";
+
 import { scripts as scriptActions } from "app/base/actions";
+import ActionForm from "app/base/components/ActionForm";
 import { useMachineActionForm } from "app/machines/hooks";
-import { simpleSortByKey } from "app/utils";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import scriptSelectors from "app/store/scripts/selectors";
-import ActionForm from "app/base/components/ActionForm";
-import CommissionFormFields from "./CommissionFormFields";
-import type { Scripts } from "app/store/scripts/types";
+import { simpleSortByKey } from "app/utils";
+
 import type { MachineAction } from "app/store/general/types";
+import type { Scripts } from "app/store/scripts/types";
 
 const formatScripts = (scripts: Scripts[]) =>
   scripts.map((script) => ({

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -1,5 +1,6 @@
-import PropTypes from "prop-types";
 import React, { useEffect } from "react";
+
+import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -1,13 +1,13 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeployForm from "./DeployForm";
 
 import * as hooks from "app/base/hooks";
-import DeployForm from "./DeployForm";
-import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -21,6 +21,8 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -1,17 +1,19 @@
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
 
-import { actions as machineActions } from "app/store/machine";
+import DeployFormFields from "./DeployFormFields";
+
 import { general as generalActions } from "app/base/actions";
 import ActionForm from "app/base/components/ActionForm";
 import { useSendAnalytics } from "app/base/hooks";
 import { useMachineActionForm } from "app/machines/hooks";
-import DeployFormFields from "./DeployFormFields";
 import generalSelectors from "app/store/general/selectors";
-import type { MachineAction } from "app/store/general/types";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+
+import type { MachineAction } from "app/store/general/types";
 
 const DeploySchema = Yup.object().shape({
   oSystem: Yup.string().required("OS is required"),

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -1,5 +1,6 @@
-import PropTypes from "prop-types";
 import React, { useEffect } from "react";
+
+import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -1,12 +1,12 @@
-import { act } from "react-dom/test-utils";
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
 import React from "react";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import DeployForm from "../DeployForm";
-import { RootState } from "app/store/root/types";
+
 import {
   authState as authStateFactory,
   configState as configStateFactory,
@@ -18,6 +18,8 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
+
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -1,18 +1,21 @@
 import { Col, Notification, Row, Select } from "@canonical/react-components";
 import classNames from "classnames";
-import React, { useState } from "react";
 import { useFormikContext } from "formik";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import { DeployFormValues } from "../DeployForm";
+
+import UserDataField from "./UserDataField";
+
+import FormikField from "app/base/components/FormikField";
+import LegacyLink from "app/base/components/LegacyLink";
 import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
-import FormikField from "app/base/components/FormikField";
 import generalSelectors from "app/store/general/selectors";
+
 import type { RootState } from "app/store/root/types";
-import LegacyLink from "app/base/components/LegacyLink";
-import UserDataField from "./UserDataField";
 
 export const DeployFormFields = (): JSX.Element => {
   const [userDataVisible, setUserDataVisible] = useState(false);

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -1,7 +1,8 @@
+import React, { useState } from "react";
+
 import { Col, Notification, Row, Select } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
-import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -1,16 +1,18 @@
-import { act } from "react-dom/test-utils";
-import configureStore from "redux-mock-store";
 import { mount, ReactWrapper } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
 import React from "react";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeployForm from "../../DeployForm";
 
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
 } from "testing/factories";
+
 import { TSFixMe } from "app/base/types";
-import DeployForm from "../../DeployForm";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -1,5 +1,6 @@
-import { mount, ReactWrapper } from "enzyme";
 import React from "react";
+
+import { mount, ReactWrapper } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
@@ -1,10 +1,11 @@
 import { Spinner, Textarea } from "@canonical/react-components";
-import { FileRejection, useDropzone } from "react-dropzone";
-import { useFormikContext } from "formik";
 import classNames from "classnames";
+import { useFormikContext } from "formik";
 import React, { useState } from "react";
+import { FileRejection, useDropzone } from "react-dropzone";
 
 import { DeployFormValues } from "../../DeployForm";
+
 import FormikField from "app/base/components/FormikField";
 
 const MAX_SIZE_BYTES = 2000000; // 2MB

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
@@ -1,7 +1,8 @@
+import React, { useState } from "react";
+
 import { Spinner, Textarea } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
-import React, { useState } from "react";
 import { FileRejection, useDropzone } from "react-dropzone";
 
 import { DeployFormValues } from "../../DeployForm";

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -1,12 +1,12 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import MarkBrokenForm from "./MarkBrokenForm";
-import { RootState } from "app/store/root/types";
+
 import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
@@ -16,6 +16,8 @@ import {
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
 } from "testing/factories";
+
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -1,14 +1,16 @@
-import { useDispatch, useSelector } from "react-redux";
-import * as Yup from "yup";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
 
-import { actions as machineActions } from "app/store/machine";
+import MarkBrokenFormFields from "./MarkBrokenFormFields";
+
 import ActionForm from "app/base/components/ActionForm";
 import { useMachineActionForm } from "app/machines/hooks";
-import type { MachineAction } from "app/store/general/types";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import MarkBrokenFormFields from "./MarkBrokenFormFields";
+
+import type { MachineAction } from "app/store/general/types";
 
 const MarkBrokenSchema = Yup.object().shape({
   comment: Yup.string(),

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -1,5 +1,6 @@
-import PropTypes from "prop-types";
 import React, { useEffect } from "react";
+
+import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/MarkBrokenFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/MarkBrokenFormFields.tsx
@@ -1,5 +1,5 @@
-import pluralize from "pluralize";
 import { Col, Row } from "@canonical/react-components";
+import pluralize from "pluralize";
 import React from "react";
 
 import FormikField from "app/base/components/FormikField";

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/MarkBrokenFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields/MarkBrokenFormFields.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Col, Row } from "@canonical/react-components";
 import pluralize from "pluralize";
-import React from "react";
 
 import FormikField from "app/base/components/FormikField";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -1,11 +1,12 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter, Route } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import TestForm from "./TestForm";
+
 import { HardwareType } from "app/base/enum";
 import {
   generalState as generalStateFactory,
@@ -19,8 +20,9 @@ import {
   scriptsState as scriptsStateFactory,
 } from "testing/factories";
 import { ScriptType } from "testing/factories/scripts";
-import { Scripts } from "app/store/scripts/types";
+
 import { RootState } from "app/store/root/types";
+import { Scripts } from "app/store/scripts/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -4,14 +4,16 @@ import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import TestFormFields from "./TestFormFields";
-import { actions as machineActions } from "app/store/machine";
+
 import { scripts as scriptActions } from "app/base/actions";
 import ActionForm from "app/base/components/ActionForm";
 import { HardwareType } from "app/base/enum";
 import { useMachineActionForm } from "app/machines/hooks";
-import { MachineAction } from "app/store/general/types";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import scriptSelectors from "app/store/scripts/selectors";
+
+import { MachineAction } from "app/store/general/types";
 import { Scripts } from "app/store/scripts/types";
 
 const TestFormSchema = Yup.object().shape({

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -1,5 +1,6 @@
-import PropTypes from "prop-types";
 import React, { useEffect } from "react";
+
+import PropTypes from "prop-types";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -1,11 +1,12 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import TestForm from "../TestForm";
+
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -14,6 +15,7 @@ import {
   scriptsState as scriptsStateFactory,
   scripts as scriptsFactory,
 } from "testing/factories";
+
 import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
@@ -1,10 +1,12 @@
 import { Col, Row } from "@canonical/react-components";
-import React from "react";
 import { useFormikContext } from "formik";
+import React from "react";
 
 import type { FormValues } from "../TestForm";
+
 import FormikField from "app/base/components/FormikField";
 import TagSelector from "app/base/components/TagSelector";
+
 import { Scripts } from "app/store/scripts/types";
 
 type ScriptsDisplay = Scripts & { displayName: string };

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 
 import type { FormValues } from "../TestForm";
 

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -1,17 +1,19 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import TakeActionMenu from "./TakeActionMenu";
-import { RootState } from "app/store/root/types";
+
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
   machineAction as machineActionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -4,13 +4,14 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
 import { general as generalActions } from "app/base/actions";
 import { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
 import generalSelectors from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
+
+import type { RouteParams } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";
+import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 const getTakeActionLinks = (

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect } from "react";
+
 import { ContextualMenu, Tooltip } from "@canonical/react-components";
 import PropTypes from "prop-types";
-import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/machines/hooks.tsx
+++ b/ui/src/app/machines/hooks.tsx
@@ -1,9 +1,10 @@
 import { useCallback } from "react";
 import { useSelector } from "react-redux";
 
-import { ACTIONS } from "app/store/machine/slice";
-import type { MachineActionName } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
+import { ACTIONS } from "app/store/machine/slice";
+
+import type { MachineActionName } from "app/store/general/types";
 import type { Machine } from "app/store/machine/types";
 
 /**

--- a/ui/src/app/machines/hooks.tsx
+++ b/ui/src/app/machines/hooks.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+
 import { useSelector } from "react-redux";
 
 import machineSelectors from "app/store/machine/selectors";

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -1,15 +1,17 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import MachineDetails from "./MachineDetails";
 
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import MachineDetails from "./MachineDetails";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -1,19 +1,21 @@
-import { Redirect, Route, Switch } from "react-router-dom";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import React, { useEffect, useState } from "react";
+import { Redirect, Route, Switch } from "react-router-dom";
 
-import type { RouteParams } from "app/base/types";
-import { actions as machineActions } from "app/store/machine";
 import MachineHeader from "./MachineHeader";
 import NetworkNotifications from "./MachineNetwork/NetworkNotifications";
-import StorageNotifications from "./MachineStorage/StorageNotifications";
-import SummaryNotifications from "./MachineSummary/SummaryNotifications";
-import machineSelectors from "app/store/machine/selectors";
 import MachineStorage from "./MachineStorage";
-import MachineTests from "./MachineTests";
+import StorageNotifications from "./MachineStorage/StorageNotifications";
 import MachineSummary, { SelectedAction } from "./MachineSummary";
+import SummaryNotifications from "./MachineSummary/SummaryNotifications";
+import MachineTests from "./MachineTests";
+
 import Section from "app/base/components/Section";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+
+import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const MachineDetails = (): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Redirect, Route, Switch } from "react-router-dom";

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import MachineHeader from "./MachineHeader";
 
 import {
   generalState as generalStateFactory,
@@ -14,7 +16,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import MachineHeader from "./MachineHeader";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,20 +1,23 @@
 import { Icon, Tooltip } from "@canonical/react-components";
-import { Link, useLocation } from "react-router-dom";
+import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import React, { useEffect, useRef, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 
 import { SelectedAction, SetSelectedAction } from "../MachineSummary";
-import { actions as machineActions } from "app/store/machine";
-import { useMachineActions } from "app/base/hooks";
-import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
+
 import MachineName from "./MachineName";
-import machineSelectors from "app/store/machine/selectors";
+
 import SectionHeader from "app/base/components/SectionHeader";
 import TableMenu from "app/base/components/TableMenu";
+import { useMachineActions } from "app/base/hooks";
+import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
 import TakeActionMenu from "app/machines/components/TakeActionMenu";
-import type { RootState } from "app/store/root/types";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+
 import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 type Props = {
   selectedAction: SelectedAction | null;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,5 +1,6 @@
-import { Icon, Tooltip } from "@canonical/react-components";
 import React, { useEffect, useRef, useState } from "react";
+
+import { Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
@@ -1,10 +1,13 @@
-import { act } from "react-dom/test-utils";
 import { mount } from "enzyme";
+import React from "react";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
 
+import MachineName from "./MachineName";
+
+import { actions as machineActions } from "app/store/machine";
 import {
   domain as domainFactory,
   domainState as domainStateFactory,
@@ -15,8 +18,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { actions as machineActions } from "app/store/machine";
-import MachineName from "./MachineName";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
@@ -1,16 +1,18 @@
 import { Button, Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
-import { actions as domainActions } from "app/store/domain";
-import { actions as machineActions } from "app/store/machine";
-import { useCanEdit } from "app/store/machine/utils";
-import domainSelectors from "app/store/domain/selectors";
-import FormikForm from "app/base/components/FormikForm";
 import MachineNameFields from "../MachineNameFields";
+
+import FormikForm from "app/base/components/FormikForm";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { useCanEdit } from "app/store/machine/utils";
+
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect } from "react";
+
 import { Button, Spinner } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
@@ -1,17 +1,19 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
 
+import MachineNameFields from "./MachineNameFields";
+
+import FormikForm from "app/base/components/FormikForm";
 import {
   domainState as domainStateFactory,
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import FormikForm from "app/base/components/FormikForm";
-import MachineNameFields from "./MachineNameFields";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Select, Spinner } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 import { useSelector } from "react-redux";
 
 import type { FormValues } from "../MachineName/MachineName";

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
@@ -1,11 +1,12 @@
 import { Select, Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import { useFormikContext } from "formik";
 import React from "react";
+import { useSelector } from "react-redux";
 
-import domainSelectors from "app/store/domain/selectors";
-import FormikField from "app/base/components/FormikField";
 import type { FormValues } from "../MachineName/MachineName";
+
+import FormikField from "app/base/components/FormikField";
+import domainSelectors from "app/store/domain/selectors";
 
 type Props = {
   saving?: boolean;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
@@ -1,9 +1,12 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
+import NetworkNotifications from "./NetworkNotifications";
+
+import { NodeStatus } from "app/store/types/node";
 import {
   architecturesState as architecturesStateFactory,
   generalState as generalStateFactory,
@@ -14,8 +17,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import NetworkNotifications from "./NetworkNotifications";
-import { NodeStatus } from "app/store/types/node";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
@@ -1,11 +1,12 @@
-import { useSelector } from "react-redux";
 import React from "react";
+import { useSelector } from "react-redux";
 
-import { useIsAllNetworkingDisabled } from "app/store/machine/utils";
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
 import machineSelectors from "app/store/machine/selectors";
-import type { RootState } from "app/store/root/types";
+import { useIsAllNetworkingDisabled } from "app/store/machine/utils";
+
 import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 
 type Props = {
   id: Machine["system_id"];

--- a/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import MachineNotifications from "./MachineNotifications";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.tsx
@@ -1,6 +1,7 @@
-import { Notification } from "@canonical/react-components";
 import React from "react";
 import type { ReactNode } from "react";
+
+import { Notification } from "@canonical/react-components";
 
 type MachineNotification = {
   active: boolean;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,14 +1,16 @@
 import { mount } from "enzyme";
 import React from "react";
 
+import { separateStorageData } from "../utils";
+
+import AvailableStorageTable from "./AvailableStorageTable";
+
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import {
   machineDisk as diskFactory,
   machineFilesystem as fsFactory,
   machinePartition as partitionFactory,
 } from "testing/factories";
-import { separateStorageData } from "../utils";
-import AvailableStorageTable from "./AvailableStorageTable";
 
 describe("AvailableStorageTable", () => {
   it("can show an empty message", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import { separateStorageData } from "../utils";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,15 +1,16 @@
 import { MainTable } from "@canonical/react-components";
 import React from "react";
 
-import DoubleRow from "app/base/components/DoubleRow";
-import TableHeader from "app/base/components/TableHeader";
-import { useTableSort } from "app/base/hooks";
 import BootStatus from "../BootStatus";
 import NumaNodes from "../NumaNodes";
 import TagLinks from "../TagLinks";
 import TestStatus from "../TestStatus";
 import type { NormalisedStorageDevice as StorageDevice } from "../types";
 import { formatSize, formatType } from "../utils";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
 
 const getSortValue = (
   sortKey: keyof StorageDevice,

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,5 +1,6 @@
-import { MainTable } from "@canonical/react-components";
 import React from "react";
+
+import { MainTable } from "@canonical/react-components";
 
 import BootStatus from "../BootStatus";
 import NumaNodes from "../NumaNodes";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
@@ -1,9 +1,11 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import { machineDisk as diskFactory } from "testing/factories";
 import { normaliseStorageDevice } from "../utils";
+
 import BootStatus from "./BootStatus";
+
+import { machineDisk as diskFactory } from "testing/factories";
 
 describe("BootStatus", () => {
   it("shows boot status for boot disks", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import { normaliseStorageDevice } from "../utils";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
@@ -1,5 +1,6 @@
-import { Icon } from "@canonical/react-components";
 import React from "react";
+
+import { Icon } from "@canonical/react-components";
 
 import type { NormalisedStorageDevice } from "../types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import { separateStorageData } from "../utils";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
@@ -1,9 +1,11 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import { machineDisk as diskFactory } from "testing/factories";
 import { separateStorageData } from "../utils";
+
 import CacheSetsTable from "./CacheSetsTable";
+
+import { machineDisk as diskFactory } from "testing/factories";
 
 describe("CacheSetsTable", () => {
   it("can show what the cache set is being used for", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -1,10 +1,11 @@
 import { MainTable } from "@canonical/react-components";
 import React from "react";
 
+import type { NormalisedStorageDevice as StorageDevice } from "../types";
+import { formatSize } from "../utils";
+
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
-import { formatSize } from "../utils";
-import type { NormalisedStorageDevice as StorageDevice } from "../types";
 
 const getSortValue = (
   sortKey: keyof StorageDevice,

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -1,5 +1,6 @@
-import { MainTable } from "@canonical/react-components";
 import React from "react";
+
+import { MainTable } from "@canonical/react-components";
 
 import type { NormalisedStorageDevice as StorageDevice } from "../types";
 import { formatSize } from "../utils";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
@@ -4,6 +4,8 @@ import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import ChangeStorageLayout from "./ChangeStorageLayout";
+
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
@@ -11,7 +13,6 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import ChangeStorageLayout from "./ChangeStorageLayout";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -8,6 +8,7 @@ import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect, useState } from "react";
+
 import { ContextualMenu, Icon } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormCard from "app/base/components/FormCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
@@ -1,12 +1,14 @@
 import { mount } from "enzyme";
 import React from "react";
 
+import { normaliseFilesystem } from "../utils";
+
+import DatastoresTable from "./DatastoresTable";
+
 import {
   machineDisk as diskFactory,
   machineFilesystem as fsFactory,
 } from "testing/factories";
-import { normaliseFilesystem } from "../utils";
-import DatastoresTable from "./DatastoresTable";
 
 describe("DatastoresTable", () => {
   it("renders", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import { normaliseFilesystem } from "../utils";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -1,5 +1,6 @@
-import { MainTable } from "@canonical/react-components";
 import React from "react";
+
+import { MainTable } from "@canonical/react-components";
 
 import { NormalisedFilesystem } from "../types";
 import { formatSize, formatType } from "../utils";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -1,13 +1,15 @@
 import { mount } from "enzyme";
 import React from "react";
 
+import { separateStorageData } from "../utils";
+
+import FilesystemsTable from "./FilesystemsTable";
+
 import {
   machineDisk as diskFactory,
   machineFilesystem as fsFactory,
   machinePartition as partitionFactory,
 } from "testing/factories";
-import { separateStorageData } from "../utils";
-import FilesystemsTable from "./FilesystemsTable";
 
 describe("FilesystemsTable", () => {
   it("can show an empty message", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import { separateStorageData } from "../utils";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -1,5 +1,6 @@
-import { MainTable } from "@canonical/react-components";
 import React from "react";
+
+import { MainTable } from "@canonical/react-components";
 
 import { NormalisedFilesystem } from "../types";
 import { formatSize } from "../utils";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -1,8 +1,11 @@
 import { mount } from "enzyme";
+import React from "react";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import MachineStorage from "./MachineStorage";
 
 import * as hooks from "app/base/hooks";
 import {
@@ -17,8 +20,6 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import MachineStorage from "./MachineStorage";
-import { act } from "react-dom/test-utils";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -1,5 +1,6 @@
-import { Spinner, Strip } from "@canonical/react-components";
 import React from "react";
+
+import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link } from "react-router-dom";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -1,21 +1,23 @@
 import { Spinner, Strip } from "@canonical/react-components";
+import React from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link } from "react-router-dom";
-import React from "react";
 
-import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
-import type { RouteParams } from "app/base/types";
-import machineSelectors from "app/store/machine/selectors";
-import { useCanEditStorage } from "app/store/machine/utils";
-import type { RootState } from "app/store/root/types";
-import { separateStorageData } from "./utils";
 import AvailableStorageTable from "./AvailableStorageTable";
 import CacheSetsTable from "./CacheSetsTable";
 import ChangeStorageLayout from "./ChangeStorageLayout";
 import DatastoresTable from "./DatastoresTable";
 import FilesystemsTable from "./FilesystemsTable";
 import UsedStorageTable from "./UsedStorageTable";
+import { separateStorageData } from "./utils";
+
+import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
+import machineSelectors from "app/store/machine/selectors";
+import { useCanEditStorage } from "app/store/machine/utils";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 const MachineStorage = (): JSX.Element => {
   const params = useParams<RouteParams>();

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
@@ -1,9 +1,11 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import { machineDisk as diskFactory } from "testing/factories";
 import { normaliseStorageDevice } from "../utils";
+
 import NumaNodes from "./NumaNodes";
+
+import { machineDisk as diskFactory } from "testing/factories";
 
 describe("NumaNodes", () => {
   it("can show a single numa node", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import { normaliseStorageDevice } from "../utils";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
@@ -1,5 +1,6 @@
-import { Tooltip } from "@canonical/react-components";
 import React from "react";
+
+import { Tooltip } from "@canonical/react-components";
 
 import type { NormalisedStorageDevice } from "../types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
@@ -1,8 +1,10 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import StorageNotifications from "./StorageNotifications";
 
 import { nodeStatus } from "app/base/enum";
 import {
@@ -11,7 +13,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import StorageNotifications from "./StorageNotifications";
+
 import type { MachineDetails } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useSelector } from "react-redux";
 
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
@@ -1,16 +1,17 @@
-import { useSelector } from "react-redux";
 import React from "react";
+import { useSelector } from "react-redux";
 
+import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
+import machineSelectors from "app/store/machine/selectors";
 import {
   canOsSupportBcacheZFS,
   canOsSupportStorageConfig,
   isMachineStorageConfigurable,
   useCanEdit,
 } from "app/store/machine/utils";
-import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
-import machineSelectors from "app/store/machine/selectors";
-import type { RootState } from "app/store/root/types";
+
 import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 
 type Props = {
   id: Machine["system_id"];

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.test.tsx
@@ -2,9 +2,11 @@ import { mount } from "enzyme";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
-import { machineDisk as diskFactory } from "testing/factories";
 import { normaliseStorageDevice } from "../utils";
+
 import TagLinks from "./TagLinks";
+
+import { machineDisk as diskFactory } from "testing/factories";
 
 describe("TagLinks", () => {
   it("shows links to filter machine list by storage tag", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { MemoryRouter } from "react-router-dom";
 
 import { normaliseStorageDevice } from "../utils";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { filtersToQueryString } from "app/machines/search";
 import type { NormalisedStorageDevice } from "../types";
+
+import { filtersToQueryString } from "app/machines/search";
 
 type Props = { tags: NormalisedStorageDevice["tags"] };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Link } from "react-router-dom";
 
 import type { NormalisedStorageDevice } from "../types";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
@@ -1,8 +1,9 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import { scriptStatus } from "app/base/enum";
 import TestStatus from "./TestStatus";
+
+import { scriptStatus } from "app/base/enum";
 
 describe("TestStatus", () => {
   it("can show passed test status", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import TestStatus from "./TestStatus";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
-import { scriptStatus } from "app/base/enum";
 import type { NormalisedStorageDevice } from "../types";
+
+import { scriptStatus } from "app/base/enum";
 
 type Props = { testStatus: NormalisedStorageDevice["testStatus"] };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 
 import { separateStorageData } from "../utils";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,10 +1,12 @@
 import { mount } from "enzyme";
 import React from "react";
 
+import { separateStorageData } from "../utils";
+
+import UsedStorageTable from "./UsedStorageTable";
+
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import { machineDisk as diskFactory } from "testing/factories";
-import { separateStorageData } from "../utils";
-import UsedStorageTable from "./UsedStorageTable";
 
 describe("UsedStorageTable", () => {
   it("can show an empty message", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
@@ -1,15 +1,16 @@
 import { MainTable } from "@canonical/react-components";
 import React from "react";
 
-import DoubleRow from "app/base/components/DoubleRow";
-import TableHeader from "app/base/components/TableHeader";
-import { useTableSort } from "app/base/hooks";
 import BootStatus from "../BootStatus";
 import NumaNodes from "../NumaNodes";
 import TagLinks from "../TagLinks";
 import TestStatus from "../TestStatus";
 import type { NormalisedStorageDevice as StorageDevice } from "../types";
 import { formatSize, formatType } from "../utils";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
 
 const getSortValue = (
   sortKey: keyof StorageDevice,

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
@@ -1,5 +1,6 @@
-import { MainTable } from "@canonical/react-components";
 import React from "react";
+
+import { MainTable } from "@canonical/react-components";
 
 import BootStatus from "../BootStatus";
 import NumaNodes from "../NumaNodes";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -1,9 +1,3 @@
-import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
-import {
-  machineDisk as diskFactory,
-  machineFilesystem as fsFactory,
-  machinePartition as partitionFactory,
-} from "testing/factories";
 import {
   formatSize,
   formatType,
@@ -13,6 +7,13 @@ import {
   separateStorageData,
   storageDeviceInUse,
 } from "./utils";
+
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import {
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+  machinePartition as partitionFactory,
+} from "testing/factories";
 
 describe("Machine storage utils", () => {
   describe("formatSize", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -1,11 +1,13 @@
-import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
-import type { Disk, Filesystem, Partition } from "app/store/machine/types";
-import { formatBytes } from "app/utils";
 import type {
   NormalisedFilesystem,
   NormalisedStorageDevice,
   SeparatedDiskData,
 } from "./types";
+
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { formatBytes } from "app/utils";
+
+import type { Disk, Filesystem, Partition } from "app/store/machine/types";
 
 /**
  * Formats a storage device's size for use in tables.

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -1,15 +1,17 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import MachineSummary from "./MachineSummary";
 
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import MachineSummary from "./MachineSummary";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -1,18 +1,20 @@
 import { Spinner } from "@canonical/react-components";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import React, { useEffect } from "react";
 
 import NetworkCard from "./NetworkCard";
 import NumaCard from "./NumaCard";
 import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
-import { actions as machineActions } from "app/store/machine";
+
 import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+
 import type { RouteParams } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";
-import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 
 export type SelectedAction = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -1,5 +1,6 @@
-import { Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import NetworkCard from "./NetworkCard";
 
 import {
   fabricState as fabricStateFactory,
@@ -13,7 +15,7 @@ import {
   vlanState as vlanStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-import NetworkCard from "./NetworkCard";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -1,18 +1,21 @@
 import { Card, Spinner } from "@canonical/react-components";
+import React, { Fragment, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import React, { Fragment, useEffect } from "react";
 
-import NetworkCardTable from "./NetworkCardTable";
 import { SetSelectedAction } from "../MachineSummary";
 import TestResults from "../TestResults";
+
+import NetworkCardTable from "./NetworkCardTable";
+
 import { HardwareType } from "app/base/enum";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine, NetworkInterface } from "app/store/machine/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
+
+import type { Machine, NetworkInterface } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type InterfaceGroup = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -1,5 +1,6 @@
-import { Card, Spinner } from "@canonical/react-components";
 import React, { Fragment, useEffect } from "react";
+
+import { Card, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import NetworkCardTable from "./NetworkCardTable";
 
 import {
   fabric as fabricFactory,
@@ -10,7 +12,7 @@ import {
   rootState as rootStateFactory,
   vlan as vlanFactory,
 } from "testing/factories";
-import NetworkCardTable from "./NetworkCardTable";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import {
   Table,
   TableCell,
@@ -5,7 +7,6 @@ import {
   TableRow,
   Tooltip,
 } from "@canonical/react-components";
-import React from "react";
 import { useSelector } from "react-redux";
 
 import fabricSelectors from "app/store/fabric/selectors";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
@@ -5,15 +5,16 @@ import {
   TableRow,
   Tooltip,
 } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import React from "react";
+import { useSelector } from "react-redux";
 
-import type { NetworkInterface } from "app/store/machine/types";
 import fabricSelectors from "app/store/fabric/selectors";
-import type { Fabric } from "app/store/fabric/types";
 import vlanSelectors from "app/store/vlan/selectors";
-import type { VLAN } from "app/store/vlan/types";
 import { formatSpeedUnits } from "app/utils";
+
+import type { Fabric } from "app/store/fabric/types";
+import type { NetworkInterface } from "app/store/machine/types";
+import type { VLAN } from "app/store/vlan/types";
 
 /**
  * Returns the name of an interface's fabric.

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import NumaCard from "./NumaCard";
 
 import {
   machineDetails as machineDetailsFactory,
@@ -10,7 +12,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import NumaCard from "./NumaCard";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Card, List, Spinner } from "@canonical/react-components";
 import pluralize from "pluralize";
-import React from "react";
 import { useSelector } from "react-redux";
 
 import NumaCardDetails from "./NumaCardDetails";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.tsx
@@ -1,10 +1,12 @@
 import { Card, List, Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import pluralize from "pluralize";
 import React from "react";
+import { useSelector } from "react-redux";
 
 import NumaCardDetails from "./NumaCardDetails";
+
 import machineSelectors from "app/store/machine/selectors";
+
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import NumaCardDetails from "./NumaCardDetails";
 
 import {
   machineDetails as machineDetailsFactory,
@@ -10,7 +12,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import NumaCardDetails from "./NumaCardDetails";
+
 import type { MachineNumaNode } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.tsx
@@ -1,7 +1,8 @@
+import React, { useState } from "react";
+
 import { Spinner } from "@canonical/react-components";
 import classNames from "classnames";
 import pluralize from "pluralize";
-import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
 import LabelledList from "app/base/components/LabelledList";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.tsx
@@ -1,12 +1,13 @@
 import { Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import classNames from "classnames";
 import pluralize from "pluralize";
 import React, { useState } from "react";
+import { useSelector } from "react-redux";
 
-import { formatBytes, getRanges } from "app/utils";
 import LabelledList from "app/base/components/LabelledList";
 import machineSelectors from "app/store/machine/selectors";
+import { formatBytes, getRanges } from "app/utils";
+
 import type { Machine, MachineNumaNode } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import CpuCard from "./CpuCard";
 
 import {
   machineDetails as machineDetailsFactory,
@@ -10,7 +12,7 @@ import {
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-import CpuCard from "./CpuCard";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -2,9 +2,11 @@ import pluralize from "pluralize";
 import React from "react";
 
 import type { SetSelectedAction } from "../../MachineSummary";
-import type { MachineDetails } from "app/store/machine/types";
-import { HardwareType } from "app/base/enum";
 import TestResults from "../../TestResults";
+
+import { HardwareType } from "app/base/enum";
+
+import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -1,5 +1,6 @@
-import pluralize from "pluralize";
 import React from "react";
+
+import pluralize from "pluralize";
 
 import type { SetSelectedAction } from "../../MachineSummary";
 import TestResults from "../../TestResults";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DetailsCard from "./DetailsCard";
+
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -15,6 +16,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -1,5 +1,6 @@
-import { extractPowerType } from "@maas-ui/maas-ui-shared";
 import React, { useEffect } from "react";
+
+import { extractPowerType } from "@maas-ui/maas-ui-shared";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -1,16 +1,16 @@
+import { extractPowerType } from "@maas-ui/maas-ui-shared";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { extractPowerType } from "@maas-ui/maas-ui-shared";
-
 import { general as generalActions } from "app/base/actions";
 import { useSendAnalytics } from "app/base/hooks";
 import generalSelectors from "app/store/general/selectors";
-import type { MachineDetails } from "app/store/machine/types";
 import { getPodNumaID, useCanEdit } from "app/store/machine/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
+
+import type { MachineDetails } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import MemoryCard from "./MemoryCard";
 
 import {
   machineDetails as machineDetailsFactory,
@@ -10,7 +12,7 @@ import {
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-import MemoryCard from "./MemoryCard";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
@@ -2,7 +2,9 @@ import React from "react";
 
 import type { SetSelectedAction } from "../../MachineSummary";
 import TestResults from "../../TestResults";
+
 import { HardwareType } from "app/base/enum";
+
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -1,5 +1,6 @@
-import { Card, Spinner } from "@canonical/react-components";
 import React from "react";
+
+import { Card, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import type { SetSelectedAction } from "../MachineSummary";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -1,14 +1,17 @@
 import { Card, Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import React from "react";
+import { useSelector } from "react-redux";
+
+import type { SetSelectedAction } from "../MachineSummary";
 
 import CpuCard from "./CpuCard";
 import DetailsCard from "./DetailsCard";
 import MemoryCard from "./MemoryCard";
 import StatusCard from "./StatusCard";
 import StorageCard from "./StorageCard";
-import type { SetSelectedAction } from "../MachineSummary";
+
 import machineSelectors from "app/store/machine/selectors";
+
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -1,9 +1,12 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
 
+import StatusCard from "./StatusCard";
+
+import { NodeStatus } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -12,8 +15,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import StatusCard from "./StatusCard";
-import { NodeStatus } from "app/store/types/node";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 
 import { nodeStatus, scriptStatus } from "app/base/enum";
-import type { MachineDetails } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
+
+import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
@@ -1,8 +1,10 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import StorageCard from "./StorageCard";
 
 import {
   machineDetails as machineDetailsFactory,
@@ -10,7 +12,7 @@ import {
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-import StorageCard from "./StorageCard";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
@@ -3,7 +3,9 @@ import React from "react";
 
 import type { SetSelectedAction } from "../../MachineSummary";
 import TestResults from "../../TestResults";
+
 import { HardwareType } from "app/base/enum";
+
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
@@ -1,5 +1,6 @@
-import pluralize from "pluralize";
 import React from "react";
+
+import pluralize from "pluralize";
 
 import type { SetSelectedAction } from "../../MachineSummary";
 import TestResults from "../../TestResults";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -1,8 +1,10 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import SummaryNotifications from "./SummaryNotifications";
 
 import {
   architecturesState as architecturesStateFactory,
@@ -14,7 +16,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import SummaryNotifications from "./SummaryNotifications";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -1,19 +1,20 @@
-import { Link } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
 import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import { general as generalActions } from "app/base/actions";
+import LegacyLink from "app/base/components/LegacyLink";
+import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
+import generalSelectors from "app/store/general/selectors";
+import machineSelectors from "app/store/machine/selectors";
 import {
   useCanEdit,
   useHasInvalidArchitecture,
   useIsRackControllerConnected,
 } from "app/store/machine/utils";
-import generalSelectors from "app/store/general/selectors";
-import LegacyLink from "app/base/components/LegacyLink";
-import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
-import machineSelectors from "app/store/machine/selectors";
-import type { RootState } from "app/store/root/types";
+
 import type { Event, Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 
 type Props = {
   id: Machine["system_id"];

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.test.tsx
@@ -1,15 +1,17 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
+
+import SystemCard from "./SystemCard";
 
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import SystemCard from "./SystemCard";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
@@ -1,9 +1,10 @@
 import { Card, Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import React from "react";
+import { useSelector } from "react-redux";
 
 import LabelledList from "app/base/components/LabelledList";
 import machineSelectors from "app/store/machine/selectors";
+
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
@@ -1,5 +1,6 @@
-import { Card, Spinner } from "@canonical/react-components";
 import React from "react";
+
+import { Card, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import LabelledList from "app/base/components/LabelledList";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -1,18 +1,20 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
 
+import TestResults from "./TestResults";
+
+import { HardwareType } from "app/base/enum";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-import TestResults from "./TestResults";
+
 import type { RootState } from "app/store/root/types";
-import { HardwareType } from "app/base/enum";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,5 +1,6 @@
-import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 import React from "react";
+
+import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "..";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,13 +1,14 @@
+import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
-
 import type { SetSelectedAction } from "..";
-import { capitaliseFirst } from "app/utils";
-import { useSendAnalytics } from "app/base/hooks";
-import type { MachineDetails } from "app/store/machine/types";
+
 import { HardwareType } from "app/base/enum";
+import { useSendAnalytics } from "app/base/hooks";
+import { capitaliseFirst } from "app/utils";
+
+import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {
   machine: MachineDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -1,5 +1,6 @@
-import { Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -1,14 +1,15 @@
 import { Spinner } from "@canonical/react-components";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import React, { useEffect } from "react";
 
 import { useWindowTitle } from "app/base/hooks";
-import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
-import type { RootState } from "app/store/root/types";
 import { actions as nodeResultActions } from "app/store/noderesult";
 import nodeResultSelectors from "app/store/noderesult/selectors";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 const MachineTests = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.test.tsx
@@ -1,5 +1,6 @@
-import { shallow } from "enzyme";
 import React from "react";
+
+import { shallow } from "enzyme";
 
 import AddHardwareMenu from "./AddHardwareMenu";
 

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.tsx
@@ -1,5 +1,6 @@
-import { ContextualMenu } from "@canonical/react-components";
 import React from "react";
+
+import { ContextualMenu } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,10 +1,15 @@
 import { Button } from "@canonical/react-components";
-import PropTypes from "prop-types";
 import pluralize from "pluralize";
+import PropTypes from "prop-types";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
+import AddHardware from "./AddHardwareMenu";
+
+import SectionHeader from "app/base/components/SectionHeader";
+import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
+import TakeActionMenu from "app/machines/components/TakeActionMenu";
 import {
   filtersToString,
   getCurrentFilters,
@@ -13,14 +18,11 @@ import {
 import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
-import type { Machine } from "app/store/machine/types";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
+
 import type { MachineAction } from "app/store/general/types";
-import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
-import AddHardware from "./AddHardwareMenu";
-import SectionHeader from "app/base/components/SectionHeader";
-import TakeActionMenu from "app/machines/components/TakeActionMenu";
+import type { Machine } from "app/store/machine/types";
 
 const getMachineCount = (
   machines: Machine[],

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,7 +1,8 @@
+import React, { useEffect } from "react";
+
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
-import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -1,13 +1,12 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import { StatusColumn } from "./StatusColumn";
 
 import { nodeStatus, scriptStatus } from "app/base/enum";
-import { StatusColumn } from "./StatusColumn";
-import type { Machine } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 import type { TestResult } from "app/store/types/node";
 import { NodeStatus } from "app/store/types/node";
 import {
@@ -18,6 +17,9 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { Spinner, Tooltip } from "@canonical/react-components";
 import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
 import PropTypes from "prop-types";
-import React from "react";
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -1,17 +1,18 @@
 import { Spinner, Tooltip } from "@canonical/react-components";
-import { useSelector } from "react-redux";
-import React from "react";
-import PropTypes from "prop-types";
-
 import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
-import { getStatusText } from "app/utils";
+import PropTypes from "prop-types";
+import React from "react";
+import { useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
 import { nodeStatus, scriptStatus } from "app/base/enum";
 import { useMachineActions } from "app/base/hooks";
 import { useToggleMenu } from "app/machines/hooks";
-import DoubleRow from "app/base/components/DoubleRow";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
+import { getStatusText } from "app/utils";
+
+import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 // Node statuses for which the failed test warning is not shown.

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx
@@ -1,9 +1,11 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DeleteForm from "./DeleteForm";
 
 import {
   pod as podFactory,
@@ -12,7 +14,6 @@ import {
   podStatuses as podStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import DeleteForm from "./DeleteForm";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -2,10 +2,11 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
+import ActionForm from "app/base/components/ActionForm";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import ActionForm from "app/base/components/ActionForm";
+
+import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.test.tsx
@@ -1,8 +1,10 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import RSDActionFormWrapper from "./RSDActionFormWrapper";
 
 import {
   pod as podFactory,
@@ -10,7 +12,6 @@ import {
   podStatus as podStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import RSDActionFormWrapper from "./RSDActionFormWrapper";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RSDActionFormWrapper.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 
-import ComposeForm from "app/kvm/components/KVMActionFormWrapper/ComposeForm";
 import DeleteForm from "./DeleteForm";
 import RefreshForm from "./RefreshForm";
+
+import ComposeForm from "app/kvm/components/KVMActionFormWrapper/ComposeForm";
 
 type Props = {
   selectedAction: string;

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.test.tsx
@@ -1,9 +1,11 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import RefreshForm from "./RefreshForm";
 
 import {
   pod as podFactory,
@@ -12,7 +14,6 @@ import {
   podStatuses as podStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import RefreshForm from "./RefreshForm";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.test.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -2,10 +2,11 @@ import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
+import ActionForm from "app/base/components/ActionForm";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import ActionForm from "app/base/components/ActionForm";
+
+import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/rsd/views/RSD.tsx
+++ b/ui/src/app/rsd/views/RSD.tsx
@@ -3,6 +3,7 @@ import { Route, Switch } from "react-router-dom";
 
 import RSDDetails from "./RSDDetails";
 import RSDList from "./RSDList";
+
 import NotFound from "app/base/views/NotFound";
 
 const RSD = (): JSX.Element => {

--- a/ui/src/app/rsd/views/RSD.tsx
+++ b/ui/src/app/rsd/views/RSD.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Route, Switch } from "react-router-dom";
 
 import RSDDetails from "./RSDDetails";

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetails.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetails.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetails.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetails.test.tsx
@@ -1,14 +1,15 @@
-import React from "react";
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
+import React from "react";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import RSDDetails from "./RSDDetails";
 
 import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import RSDDetails from "./RSDDetails";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetails.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetails.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Redirect, Route, Switch } from "react-router-dom";

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetails.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetails.tsx
@@ -3,14 +3,16 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Redirect, Route, Switch } from "react-router-dom";
 
-import type { RouteParams } from "app/base/types";
-import type { RootState } from "app/store/root/types";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
-import Section from "app/base/components/Section";
-import PodConfiguration from "app/kvm/components/PodConfiguration";
 import RSDDetailsHeader from "./RSDDetailsHeader";
 import RSDSummary from "./RSDSummary";
+
+import Section from "app/base/components/Section";
+import PodConfiguration from "app/kvm/components/PodConfiguration";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 const RSDDetails = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.test.tsx
@@ -1,16 +1,18 @@
-import React from "react";
-import configureStore from "redux-mock-store";
 import { mount } from "enzyme";
-import { MemoryRouter, Route } from "react-router-dom";
+import React from "react";
 import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
-import type { RootState } from "app/store/root/types";
+import RSDDetailsHeader from "./RSDDetailsHeader";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import RSDDetailsHeader from "./RSDDetailsHeader";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.tsx
@@ -1,5 +1,6 @@
-import pluralize from "pluralize";
 import React, { useEffect, useState } from "react";
+
+import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.tsx
@@ -4,13 +4,14 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";
 
-import type { RouteParams } from "app/base/types";
-import type { RootState } from "app/store/root/types";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
+import SectionHeader from "app/base/components/SectionHeader";
 import PodDetailsActionMenu from "app/kvm/components/PodDetailsActionMenu";
 import RSDActionFormWrapper from "app/rsd/components/RSDActionFormWrapper";
-import SectionHeader from "app/base/components/SectionHeader";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 const RSDDetailsHeader = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.test.tsx
@@ -4,12 +4,13 @@ import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
+import RSDSummary from "./RSDSummary";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import RSDSummary from "./RSDSummary";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.tsx
@@ -3,13 +3,14 @@ import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { RouteParams } from "app/base/types";
-import type { RootState } from "app/store/root/types";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
 import { useWindowTitle } from "app/base/hooks";
 import PodAggregateResources from "app/kvm/components/PodAggregateResources";
 import PodStorage from "app/kvm/components/PodStorage";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 const RSDSummary = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.tsx
@@ -1,5 +1,6 @@
-import { Code, Spinner } from "@canonical/react-components";
 import React, { useEffect } from "react";
+
+import { Code, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
@@ -1,16 +1,17 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddRSDForm from "./AddRSDForm";
 
 import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import AddRSDForm from "./AddRSDForm";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
@@ -5,6 +5,7 @@ import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import AddRSDFormFields from "./AddRSDFormFields";
+
 import { general as generalActions } from "app/base/actions";
 import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDForm.tsx
@@ -1,5 +1,6 @@
-import { Spinner } from "@canonical/react-components";
 import React, { useCallback, useEffect, useState } from "react";
+
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 import * as Yup from "yup";

--- a/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/AddRSDFormFields.tsx
+++ b/ui/src/app/rsd/views/RSDList/AddRSDForm/AddRSDFormFields/AddRSDFormFields.tsx
@@ -1,5 +1,6 @@
-import { Col, Row, Select } from "@canonical/react-components";
 import React from "react";
+
+import { Col, Row, Select } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";

--- a/ui/src/app/rsd/views/RSDList/RSDList.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDList.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 
-import { useWindowTitle } from "app/base/hooks";
 import AddRSDForm from "./AddRSDForm";
 import RSDListHeader from "./RSDListHeader";
 import RSDListTable from "./RSDListTable";
+
 import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
 
 const RSDList = (): JSX.Element => {
   useWindowTitle("RSD");

--- a/ui/src/app/rsd/views/RSDList/RSDList.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Route, Switch } from "react-router-dom";
 
 import AddRSDForm from "./AddRSDForm";

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.test.tsx
@@ -1,15 +1,16 @@
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import RSDListActionMenu from "./RSDListActionMenu";
 
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import RSDListActionMenu from "./RSDListActionMenu";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListActionMenu/RSDListActionMenu.tsx
@@ -1,5 +1,6 @@
-import { ContextualMenu, Tooltip } from "@canonical/react-components";
 import React from "react";
+
+import { ContextualMenu, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import podSelectors from "app/store/pod/selectors";

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import * as React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.test.tsx
@@ -1,15 +1,16 @@
 import { mount } from "enzyme";
+import * as React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import * as React from "react";
+
+import RSDListHeader from "./RSDListHeader";
 
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import RSDListHeader from "./RSDListHeader";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.tsx
@@ -3,12 +3,13 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
+import RSDListActionMenu from "./RSDListActionMenu";
+
+import SectionHeader from "app/base/components/SectionHeader";
 import { getVMHostCount } from "app/kvm/utils";
+import RSDActionFormWrapper from "app/rsd/components/RSDActionFormWrapper";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import RSDActionFormWrapper from "app/rsd/components/RSDActionFormWrapper";
-import RSDListActionMenu from "./RSDListActionMenu";
-import SectionHeader from "app/base/components/SectionHeader";
 
 const RSDListHeader = (): JSX.Element => {
   const dispatch = useDispatch();

--- a/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListHeader/RSDListHeader.tsx
@@ -1,5 +1,6 @@
-import { Button } from "@canonical/react-components";
 import React, { useEffect, useState } from "react";
+
+import { Button } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
@@ -1,10 +1,11 @@
 import { mount } from "enzyme";
+import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import React from "react";
 
-import type { RootState } from "app/store/root/types";
+import RSDListTable from "./RSDListTable";
+
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -14,7 +15,8 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import RSDListTable from "./RSDListTable";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect } from "react";
+
 import { Col, Input, MainTable, Row } from "@canonical/react-components";
 import classNames from "classnames";
-import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import TableHeader from "app/base/components/TableHeader";

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
@@ -3,22 +3,23 @@ import classNames from "classnames";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
 import CPUColumn from "app/kvm/views/KVMList/KVMListTable/CPUColumn";
 import NameColumn from "app/kvm/views/KVMList/KVMListTable/NameColumn";
 import PoolColumn from "app/kvm/views/KVMList/KVMListTable/PoolColumn";
 import RAMColumn from "app/kvm/views/KVMList/KVMListTable/RAMColumn";
 import StorageColumn from "app/kvm/views/KVMList/KVMListTable/StorageColumn";
 import VMsColumn from "app/kvm/views/KVMList/KVMListTable/VMsColumn";
-import TableHeader from "app/base/components/TableHeader";
-import { useTableSort } from "app/base/hooks";
-import podSelectors from "app/store/pod/selectors";
-import type { Pod } from "app/store/pod/types";
 import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
 import { actions as poolActions } from "app/store/resourcepool";
 import poolSelectors from "app/store/resourcepool/selectors";
-import type { ResourcePool } from "app/store/resourcepool/types";
 import { actions as zoneActions } from "app/store/zone";
 import { generateCheckboxHandlers, someInArray, someNotAll } from "app/utils";
+
+import type { Pod } from "app/store/pod/types";
+import type { ResourcePool } from "app/store/resourcepool/types";
 
 const getSortValue = (
   sortKey: keyof Pod | "cpu" | "pool" | "ram" | "storage",

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -1,9 +1,11 @@
+import { TSFixMe } from "@canonical/react-components";
 import { mount } from "enzyme";
 import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import CommissioningForm from "./CommissioningForm";
+
 import {
   configState as configStateFactory,
   generalState as generalStateFactory,
@@ -11,8 +13,8 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
-import { TSFixMe } from "@canonical/react-components";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { TSFixMe } from "@canonical/react-components";
 import { mount } from "enzyme";
-import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
@@ -1,11 +1,12 @@
-import { useDispatch, useSelector } from "react-redux";
 import React from "react";
+import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import Fields from "../CommissioningFormFields";
+
+import FormikForm from "app/base/components/FormikForm";
 import { config as configActions } from "app/settings/actions";
 import configSelectors from "app/store/config/selectors";
-import Fields from "../CommissioningFormFields";
-import FormikForm from "app/base/components/FormikForm";
 
 const CommissioningSchema = Yup.object().shape({
   commissioning_distro_series: Yup.string(),

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import CommissioningForm from "../CommissioningForm";
-import type { RootState } from "app/store/root/types";
+
 import {
   configState as configStateFactory,
   generalState as generalStateFactory,
@@ -12,6 +12,8 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -1,14 +1,16 @@
 import { Link, Select, Tooltip } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import { useFormikContext } from "formik";
 import React from "react";
+import { useSelector } from "react-redux";
 
 import type { CommissioningFormValues } from "../CommissioningForm";
-import configSelectors from "app/store/config/selectors";
+
 import FormikField from "app/base/components/FormikField";
+import configSelectors from "app/store/config/selectors";
 import generalSelectors from "app/store/general/selectors";
-import { RootState } from "app/store/root/types";
+
 import { TSFixMe } from "app/base/types";
+import { RootState } from "app/store/root/types";
 
 const CommissioningFormFields = (): JSX.Element => {
   const formikProps = useFormikContext<CommissioningFormValues>();

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Link, Select, Tooltip } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import React from "react";
 import { useSelector } from "react-redux";
 
 import type { CommissioningFormValues } from "../CommissioningForm";

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -3,12 +3,14 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import GeneralForm from "./GeneralForm";
+
 import {
   config as configFactory,
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import GeneralForm from "./GeneralForm";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -1,5 +1,6 @@
-import { shallow, mount } from "enzyme";
 import React from "react";
+
+import { shallow, mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -1,15 +1,15 @@
 import { Link } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
-import React, { useEffect, useRef } from "react";
-import * as Yup from "yup";
 import type { UsabillaLive } from "@maas-ui/maas-ui-shared";
+import React, { useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
 
-import { config as configActions } from "app/settings/actions";
-import configSelectors from "app/store/config/selectors";
-import { useSendAnalytics } from "app/base/hooks";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
+import { useSendAnalytics } from "app/base/hooks";
+import { config as configActions } from "app/settings/actions";
+import configSelectors from "app/store/config/selectors";
 
 declare global {
   interface Window {

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -1,7 +1,8 @@
+import React, { useEffect, useRef } from "react";
+
 import { Link } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import type { UsabillaLive } from "@maas-ui/maas-ui-shared";
-import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
@@ -5,12 +5,14 @@ import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LicenseKeyList from ".";
+
 import {
   generalState as generalStateFactory,
   licenseKeys as licenseKeysFactory,
   licenseKeysState as licenseKeysStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
 import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -3,14 +3,16 @@ import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import type { RootState } from "app/store/root/types";
+
+import ScriptsList from ".";
 
 import {
   scripts as scriptsFactory,
   scriptsState as scriptsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import ScriptsList from ".";
+
+import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -1,7 +1,8 @@
+import React, { useEffect, useState } from "react";
+
 import { Code, Col, Row } from "@canonical/react-components";
 import { format, parse } from "date-fns";
 import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
 

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -1,18 +1,18 @@
 import { Code, Col, Row } from "@canonical/react-components";
 import { format, parse } from "date-fns";
-import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
 
-import { useAddMessage } from "app/base/hooks";
-import { useWindowTitle } from "app/base/hooks";
 import { scripts as scriptActions } from "app/base/actions";
-import scriptSelectors from "app/store/scripts/selectors";
 import ColumnToggle from "app/base/components/ColumnToggle";
-import SettingsTable from "app/settings/components/SettingsTable";
 import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+import { useWindowTitle, useAddMessage } from "app/base/hooks";
+import SettingsTable from "app/settings/components/SettingsTable";
+import scriptSelectors from "app/store/scripts/selectors";
+
 import type { RootState } from "app/store/root/types";
 import type { Scripts } from "app/store/scripts/types";
 

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -1,17 +1,19 @@
-import { act } from "react-dom/test-utils";
-import { MemoryRouter } from "react-router-dom";
 import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import React from "react";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import { UserForm } from "./UserForm";
 import type { UserWithPassword } from "./UserForm";
-import { RootState } from "app/store/root/types";
+
 import {
   user as userFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -1,5 +1,6 @@
-import { mount } from "enzyme";
 import React from "react";
+
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
@@ -1,17 +1,17 @@
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
-import React, { useState } from "react";
 
 import { auth as authActions } from "app/base/actions";
-import { actions as userActions } from "app/store/user";
-import type { User } from "app/store/user/types";
-import userSelectors from "app/store/user/selectors";
-import { useAddMessage } from "app/base/hooks";
-import { UserShape } from "app/base/proptypes";
-import { useWindowTitle } from "app/base/hooks";
 import FormCard from "app/base/components/FormCard";
-import BaseUserForm from "app/base/components/UserForm";
 import FormCardButtons from "app/base/components/FormCardButtons";
+import BaseUserForm from "app/base/components/UserForm";
+import { useAddMessage, useWindowTitle } from "app/base/hooks";
+import { UserShape } from "app/base/proptypes";
+import { actions as userActions } from "app/store/user";
+import userSelectors from "app/store/user/selectors";
+
+import type { User } from "app/store/user/types";
 
 export type UserWithPassword = User & {
   password1: string;

--- a/ui/src/app/store/auth/selectors.test.ts
+++ b/ui/src/app/store/auth/selectors.test.ts
@@ -1,10 +1,11 @@
+import auth from "./selectors";
+
 import {
   authState as authStateFactory,
   rootState as rootStateFactory,
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import auth from "./selectors";
 
 describe("auth", () => {
   it("can get the current user details", () => {

--- a/ui/src/app/store/auth/selectors.ts
+++ b/ui/src/app/store/auth/selectors.ts
@@ -1,5 +1,5 @@
-import type { RootState } from "app/store/root/types";
 import type { TSFixMe } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 import type { User } from "app/store/user/types";
 
 /**

--- a/ui/src/app/store/config/selectors.test.ts
+++ b/ui/src/app/store/config/selectors.test.ts
@@ -1,9 +1,10 @@
+import config from "./selectors";
+
 import {
   config as configFactory,
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import config from "./selectors";
 
 describe("config selectors", () => {
   describe("all", () => {

--- a/ui/src/app/store/config/types.ts
+++ b/ui/src/app/store/config/types.ts
@@ -1,4 +1,5 @@
 import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type ConfigChoice = [string | number, string];

--- a/ui/src/app/store/controller/reducers.test.ts
+++ b/ui/src/app/store/controller/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   controller as controllerFactory,
   controllerState as controllerStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("controller reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/controller/selectors.test.ts
+++ b/ui/src/app/store/controller/selectors.test.ts
@@ -1,9 +1,10 @@
+import controller from "./selectors";
+
 import {
   rootState as rootStateFactory,
   controller as controllerFactory,
   controllerState as controllerStateFactory,
 } from "testing/factories";
-import controller from "./selectors";
 
 describe("controller selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/controller/selectors.ts
+++ b/ui/src/app/store/controller/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Controller, ControllerState } from "app/store/controller/types";
 
 const searchFunction = (controller: Controller, term: string) =>

--- a/ui/src/app/store/controller/slice.ts
+++ b/ui/src/app/store/controller/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Controller, ControllerState } from "./types";
 
 type ControllerReducers = SliceCaseReducers<ControllerState>;

--- a/ui/src/app/store/controller/types.ts
+++ b/ui/src/app/store/controller/types.ts
@@ -1,5 +1,6 @@
 import type { BaseNode } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type Controller = BaseNode & {

--- a/ui/src/app/store/device/reducers.test.ts
+++ b/ui/src/app/store/device/reducers.test.ts
@@ -1,5 +1,6 @@
-import { device as deviceFactory } from "testing/factories";
 import reducers, { actions } from "./";
+
+import { device as deviceFactory } from "testing/factories";
 
 describe("device reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/device/selectors.test.ts
+++ b/ui/src/app/store/device/selectors.test.ts
@@ -1,9 +1,10 @@
+import device from "./selectors";
+
 import {
   rootState as rootStateFactory,
   device as deviceFactory,
   deviceState as deviceStateFactory,
 } from "testing/factories";
-import device from "./selectors";
 
 describe("device selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/device/selectors.ts
+++ b/ui/src/app/store/device/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Device, DeviceState } from "app/store/device/types";
 
 const searchFunction = (device: Device, term: string) =>

--- a/ui/src/app/store/device/slice.ts
+++ b/ui/src/app/store/device/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Device, DeviceState } from "./types";
 
 type DeviceReducers = SliceCaseReducers<DeviceState>;

--- a/ui/src/app/store/device/types.ts
+++ b/ui/src/app/store/device/types.ts
@@ -1,6 +1,7 @@
-import type { GenericState } from "app/store/types/state";
 import type { ModelRef } from "app/store/types/model";
 import type { SimpleNode } from "app/store/types/node";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type Device = SimpleNode & {

--- a/ui/src/app/store/dhcpsnippet/reducers.test.ts
+++ b/ui/src/app/store/dhcpsnippet/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   dhcpSnippet as dhcpSnippetFactory,
   dhcpSnippetState as dhcpSnippetStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("dhcpSnippet reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/dhcpsnippet/selectors.test.ts
+++ b/ui/src/app/store/dhcpsnippet/selectors.test.ts
@@ -1,9 +1,10 @@
+import dhcpsnippet from "./selectors";
+
 import {
   dhcpSnippet as dhcpSnippetFactory,
   dhcpSnippetState as dhcpSnippetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import dhcpsnippet from "./selectors";
 
 describe("dhcpsnippet selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/dhcpsnippet/selectors.ts
+++ b/ui/src/app/store/dhcpsnippet/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type {
   DHCPSnippet,
   DHCPSnippetState,

--- a/ui/src/app/store/dhcpsnippet/slice.ts
+++ b/ui/src/app/store/dhcpsnippet/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { DHCPSnippet, DHCPSnippetState } from "./types";
 
 type DHCPSnippetReducers = SliceCaseReducers<DHCPSnippetState>;

--- a/ui/src/app/store/dhcpsnippet/types.ts
+++ b/ui/src/app/store/dhcpsnippet/types.ts
@@ -1,9 +1,10 @@
-import type { Device } from "app/store/device/types";
-import type { GenericState } from "app/store/types/state";
 import type { Host } from "app/store/types/host";
 import type { Model } from "app/store/types/model";
-import type { Subnet } from "app/store/subnet/types";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
+import type { Device } from "app/store/device/types";
+import type { Subnet } from "app/store/subnet/types";
 
 export type DHCPSnippetHistory = Model & {
   created: string;

--- a/ui/src/app/store/domain/reducers.test.ts
+++ b/ui/src/app/store/domain/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   domain as domainFactory,
   domainState as domainStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("domain reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/domain/selectors.test.ts
+++ b/ui/src/app/store/domain/selectors.test.ts
@@ -1,9 +1,10 @@
+import domain from "./selectors";
+
 import {
   domain as domainFactory,
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import domain from "./selectors";
 
 describe("domain selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/domain/selectors.ts
+++ b/ui/src/app/store/domain/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Domain, DomainState } from "app/store/domain/types";
 
 const searchFunction = (domain: Domain, term: string) =>

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -1,5 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
+
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Domain, DomainState } from "./types";
 
 type DomainReducers = SliceCaseReducers<DomainState>;

--- a/ui/src/app/store/domain/types.ts
+++ b/ui/src/app/store/domain/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type Domain = Model & {

--- a/ui/src/app/store/fabric/reducers.test.ts
+++ b/ui/src/app/store/fabric/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("fabric reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/fabric/selectors.test.ts
+++ b/ui/src/app/store/fabric/selectors.test.ts
@@ -1,9 +1,10 @@
+import fabric from "./selectors";
+
 import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import fabric from "./selectors";
 
 describe("fabric selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/fabric/selectors.ts
+++ b/ui/src/app/store/fabric/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Fabric, FabricState } from "app/store/fabric/types";
 
 const searchFunction = (fabric: Fabric, term: string) =>

--- a/ui/src/app/store/fabric/slice.ts
+++ b/ui/src/app/store/fabric/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Fabric, FabricState } from "./types";
 
 type FabricReducers = SliceCaseReducers<FabricState>;

--- a/ui/src/app/store/fabric/types.ts
+++ b/ui/src/app/store/fabric/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type Fabric = Model & {

--- a/ui/src/app/store/general/selectors/architectures.test.ts
+++ b/ui/src/app/store/general/selectors/architectures.test.ts
@@ -1,9 +1,10 @@
+import architectures from "./architectures";
+
 import {
   generalState as generalStateFactory,
   architecturesState as architecturesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import architectures from "./architectures";
 
 describe("architectures selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/componentsToDisable.test.ts
+++ b/ui/src/app/store/general/selectors/componentsToDisable.test.ts
@@ -1,10 +1,11 @@
+import componentsToDisable from "./componentsToDisable";
+
 import {
   componentToDisable as componentToDisableFactory,
   componentsToDisableState as componentsToDisableStateFactory,
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import componentsToDisable from "./componentsToDisable";
 
 describe("componentsToDisable selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/defaultMinHweKernel.test.ts
+++ b/ui/src/app/store/general/selectors/defaultMinHweKernel.test.ts
@@ -1,9 +1,10 @@
+import defaultMinHweKernel from "./defaultMinHweKernel";
+
 import {
   defaultMinHweKernelState as defaultMinHweKernelStateFactory,
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import defaultMinHweKernel from "./defaultMinHweKernel";
 
 describe("defaultMinHweKernel selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/hweKernels.test.ts
+++ b/ui/src/app/store/general/selectors/hweKernels.test.ts
@@ -1,10 +1,11 @@
+import hweKernels from "./hweKernels";
+
 import {
   generalState as generalStateFactory,
   hweKernelsState as hweKernelsStateFactory,
   hweKernel as hweKernelFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import hweKernels from "./hweKernels";
 
 describe("hweKernels selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/knownArchitectures.test.ts
+++ b/ui/src/app/store/general/selectors/knownArchitectures.test.ts
@@ -1,10 +1,11 @@
+import knownArchitectures from "./knownArchitectures";
+
 import {
   generalState as generalStateFactory,
   knownArchitecture as knownArchitectureFactory,
   knownArchitecturesState as knownArchitecturesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import knownArchitectures from "./knownArchitectures";
 
 describe("knownArchitectures selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/machineActions.test.ts
+++ b/ui/src/app/store/general/selectors/machineActions.test.ts
@@ -1,10 +1,11 @@
+import machineActions from "./machineActions";
+
 import {
   generalState as generalStateFactory,
   machineActionsState as machineActionsStateFactory,
   machineAction as machineActionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import machineActions from "./machineActions";
 
 describe("machineActions selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/machineActions.ts
+++ b/ui/src/app/store/general/selectors/machineActions.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import { generateGeneralSelector } from "./utils";
+
 import type { MachineAction } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/store/general/selectors/navigationOptions.test.ts
+++ b/ui/src/app/store/general/selectors/navigationOptions.test.ts
@@ -1,10 +1,11 @@
+import navigationOptions from "./navigationOptions";
+
 import {
   generalState as generalStateFactory,
   navigationOptionsState as navigationOptionsStateFactory,
   navigationOptions as navigationOptionsFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import navigationOptions from "./navigationOptions";
 
 describe("navigationOptions selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/osInfo.test.ts
+++ b/ui/src/app/store/general/selectors/osInfo.test.ts
@@ -1,10 +1,12 @@
+import osInfo from "./osInfo";
+
 import {
   generalState as generalStateFactory,
   osInfoState as osInfoStateFactory,
   osInfo as osInfoFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import osInfo from "./osInfo";
+
 import type { RootState } from "app/store/root/types";
 
 describe("osInfo selectors", () => {

--- a/ui/src/app/store/general/selectors/osInfo.ts
+++ b/ui/src/app/store/general/selectors/osInfo.ts
@@ -4,13 +4,14 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import { generateGeneralSelector } from "./utils";
-import type { RootState } from "app/store/root/types";
+
 import type {
   OSInfo,
   OSInfoOsKernelEntry,
   OSInfoOSystem,
   OSInfoRelease,
 } from "app/store/general/types";
+import type { RootState } from "app/store/root/types";
 
 const generalSelectors = generateGeneralSelector<"osInfo">("osInfo");
 

--- a/ui/src/app/store/general/selectors/pocketsToDisable.test.ts
+++ b/ui/src/app/store/general/selectors/pocketsToDisable.test.ts
@@ -1,10 +1,11 @@
+import pocketsToDisable from "./pocketsToDisable";
+
 import {
   generalState as generalStateFactory,
   pocketToDisable as pocketToDisableFactory,
   pocketsToDisableState as pocketsToDisableStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import pocketsToDisable from "./pocketsToDisable";
 
 describe("pocketsToDisable selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/powerTypes.test.ts
+++ b/ui/src/app/store/general/selectors/powerTypes.test.ts
@@ -1,10 +1,11 @@
+import powerTypes from "./powerTypes";
+
 import {
   generalState as generalStateFactory,
   powerTypesState as powerTypesStateFactory,
   powerType as powerTypeFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import powerTypes from "./powerTypes";
 
 describe("powerTypes selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/general/selectors/utils.ts
+++ b/ui/src/app/store/general/selectors/utils.ts
@@ -1,5 +1,5 @@
-import type { GeneralState } from "app/store/general/types";
 import type { TSFixMe } from "app/base/types";
+import type { GeneralState } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
 
 type GeneralSelector<T extends keyof GeneralState> = {

--- a/ui/src/app/store/general/selectors/version.test.ts
+++ b/ui/src/app/store/general/selectors/version.test.ts
@@ -1,9 +1,10 @@
+import version from "./version";
+
 import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
   versionState as versionStateFactory,
 } from "testing/factories";
-import version from "./version";
 
 describe("version selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/licensekeys/selectors.test.ts
+++ b/ui/src/app/store/licensekeys/selectors.test.ts
@@ -1,9 +1,10 @@
+import licensekeys from "./selectors";
+
 import {
   licenseKeys as licenseKeysFactory,
   licenseKeysState as licenseKeysStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import licensekeys from "./selectors";
 
 describe("licensekeys selectors", () => {
   describe("all", () => {

--- a/ui/src/app/store/licensekeys/selectors.ts
+++ b/ui/src/app/store/licensekeys/selectors.ts
@@ -1,5 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
+
 import { generateBaseSelectors } from "app/store/utils";
+
 import type {
   LicenseKeys,
   LicenseKeysState,

--- a/ui/src/app/store/licensekeys/types.ts
+++ b/ui/src/app/store/licensekeys/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type LicenseKeys = Model & {

--- a/ui/src/app/store/machine/reducers.test.ts
+++ b/ui/src/app/store/machine/reducers.test.ts
@@ -1,4 +1,5 @@
 import reducers, { actions } from "./slice";
+
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -1,3 +1,5 @@
+import machine from "./selectors";
+
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -5,7 +7,6 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import machine from "./selectors";
 
 describe("machine selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -1,8 +1,9 @@
 import { createSelector, Selector } from "@reduxjs/toolkit";
 
-import { generateBaseSelectors } from "app/store/utils";
-import { ACTIONS } from "app/store/machine/slice";
 import filterNodes from "app/machines/filter-nodes";
+import { ACTIONS } from "app/store/machine/slice";
+import { generateBaseSelectors } from "app/store/utils";
+
 import type {
   Machine,
   MachineState,

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -5,13 +5,15 @@ import type {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
-import { generateSlice, generateStatusHandlers } from "app/store/utils";
-import { kebabToCamelCase } from "app/utils";
-import type { GenericSlice } from "app/store/utils";
 import type { Machine, MachineState } from "./types";
+
+import { generateSlice, generateStatusHandlers } from "app/store/utils";
+import type { GenericSlice } from "app/store/utils";
+import type { StatusHandlers } from "app/store/utils/slice";
+import { kebabToCamelCase } from "app/utils";
+
 import type { ScriptResult } from "app/store/scriptresults/types";
 import type { Scripts } from "app/store/scripts/types";
-import type { StatusHandlers } from "app/store/utils/slice";
 
 export type ScriptInput = {
   [x: string]: { url: string };

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -1,8 +1,9 @@
+import type { Model, ModelRef } from "app/store/types/model";
 import type { BaseNode, TestStatus } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
-import type { Model, ModelRef } from "app/store/types/model";
-import type { Subnet } from "app/store/subnet/types";
+
 import type { TSFixMe } from "app/base/types";
+import type { Subnet } from "app/store/subnet/types";
 
 export type IpAddresses = {
   ip: string;

--- a/ui/src/app/store/machine/utils.test.tsx
+++ b/ui/src/app/store/machine/utils.test.tsx
@@ -1,6 +1,7 @@
-import { renderHook } from "@testing-library/react-hooks";
 import React from "react";
 import type { ReactNode } from "react";
+
+import { renderHook } from "@testing-library/react-hooks";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import type { MockStoreEnhanced } from "redux-mock-store";

--- a/ui/src/app/store/machine/utils.test.tsx
+++ b/ui/src/app/store/machine/utils.test.tsx
@@ -1,10 +1,23 @@
-import { Provider } from "react-redux";
 import { renderHook } from "@testing-library/react-hooks";
-import configureStore from "redux-mock-store";
 import React from "react";
-import type { MockStoreEnhanced } from "redux-mock-store";
 import type { ReactNode } from "react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import type { MockStoreEnhanced } from "redux-mock-store";
 
+import {
+  canOsSupportBcacheZFS,
+  canOsSupportStorageConfig,
+  isMachineStorageConfigurable,
+  useCanEdit,
+  useFormattedOS,
+  useHasInvalidArchitecture,
+  useIsAllNetworkingDisabled,
+  useIsRackControllerConnected,
+} from "./utils";
+
+import { nodeStatus } from "app/base/enum";
+import { NodeStatus } from "app/store/types/node";
 import {
   architecturesState as architecturesStateFactory,
   generalState as generalStateFactory,
@@ -17,21 +30,9 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { nodeStatus } from "app/base/enum";
-import { NodeStatus } from "app/store/types/node";
+
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-
-import {
-  canOsSupportBcacheZFS,
-  canOsSupportStorageConfig,
-  isMachineStorageConfigurable,
-  useCanEdit,
-  useFormattedOS,
-  useHasInvalidArchitecture,
-  useIsAllNetworkingDisabled,
-  useIsRackControllerConnected,
-} from "./utils";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -4,11 +4,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { general as generalActions } from "app/base/actions";
 import { nodeStatus } from "app/base/enum";
 import generalSelectors from "app/store/general/selectors";
+import type { Host } from "app/store/types/host";
+import { NodeStatus } from "app/store/types/node";
+
 import type { Machine } from "app/store/machine/types";
 import { Pod } from "app/store/pod/types";
 import { RootState } from "app/store/root/types";
-import type { Host } from "app/store/types/host";
-import { NodeStatus } from "app/store/types/node";
 
 /**
  * Check if a machine has an invalid architecture.

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 
 import { general as generalActions } from "app/base/actions";

--- a/ui/src/app/store/message/selectors.test.ts
+++ b/ui/src/app/store/message/selectors.test.ts
@@ -1,9 +1,10 @@
+import messages from "./selectors";
+
 import {
   message as messageFactory,
   messageState as messageStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import messages from "./selectors";
 
 describe("messages", () => {
   it("can get all messages", () => {

--- a/ui/src/app/store/message/selectors.ts
+++ b/ui/src/app/store/message/selectors.ts
@@ -1,5 +1,5 @@
-import type { RootState } from "app/store/root/types";
 import type { Message } from "app/store/message/types";
+import type { RootState } from "app/store/root/types";
 
 /**
  * Get the global messages.

--- a/ui/src/app/store/noderesult/reducers.test.ts
+++ b/ui/src/app/store/noderesult/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   nodeResult as nodeResultFactory,
   nodeResultState as nodeResultStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("script results reducer", () => {
   it("returns the initial state", () => {

--- a/ui/src/app/store/noderesult/selectors.test.tsx
+++ b/ui/src/app/store/noderesult/selectors.test.tsx
@@ -1,3 +1,5 @@
+import selectors from "./selectors";
+
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -5,7 +7,6 @@ import {
   nodeResult as nodeResultFactory,
   nodeResultState as nodeResultStateFactory,
 } from "testing/factories";
-import selectors from "./selectors";
 
 describe("nodeResults selectors", () => {
   it("returns all node results", () => {

--- a/ui/src/app/store/noderesult/selectors.ts
+++ b/ui/src/app/store/noderesult/selectors.ts
@@ -1,9 +1,11 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import type { RootState } from "app/store/root/types";
-import type { TSFixMe } from "app/base/types";
-import { NodeResults } from "./types";
 import { Machine } from "../machine/types";
+
+import { NodeResults } from "./types";
+
+import type { TSFixMe } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 /**
  * Returns list of all node results.

--- a/ui/src/app/store/noderesult/slice.ts
+++ b/ui/src/app/store/noderesult/slice.ts
@@ -1,7 +1,9 @@
 import { PayloadAction, SliceCaseReducers } from "@reduxjs/toolkit";
 
-import type { NodeResult, NodeResults, NodeResultState } from "./types";
 import { generateSlice, GenericItemMeta, GenericSlice } from "../utils";
+
+import type { NodeResult, NodeResults, NodeResultState } from "./types";
+
 import { Machine } from "app/store/machine/types";
 
 type NodeResultReducers = SliceCaseReducers<NodeResultState>;

--- a/ui/src/app/store/noderesult/types.ts
+++ b/ui/src/app/store/noderesult/types.ts
@@ -1,6 +1,8 @@
-import type { Model } from "app/store/types/model";
-import type { TSFixMe } from "app/base/types";
 import type { Machine, NetworkInterface } from "../machine/types";
+
+import type { Model } from "app/store/types/model";
+
+import type { TSFixMe } from "app/base/types";
 
 export type NodeScriptResult = {
   name: string;

--- a/ui/src/app/store/notification/reducers.test.ts
+++ b/ui/src/app/store/notification/reducers.test.ts
@@ -1,5 +1,4 @@
 import reducers, { actions } from "./slice";
-
 import type { NotificationState } from "./types";
 
 import {

--- a/ui/src/app/store/notification/selectors.test.ts
+++ b/ui/src/app/store/notification/selectors.test.ts
@@ -1,3 +1,5 @@
+import notification from "./selectors";
+
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -7,8 +9,8 @@ import {
   rootState as rootStateFactory,
   routerState as routerStateFactory,
 } from "testing/factories";
+
 import { NotificationIdent } from "app/store/notification/types";
-import notification from "./selectors";
 
 describe("notification selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/notification/selectors.ts
+++ b/ui/src/app/store/notification/selectors.ts
@@ -1,7 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { generateBaseSelectors } from "app/store/utils";
 import configSelectors from "app/store/config/selectors";
+import { generateBaseSelectors } from "app/store/utils";
+
 import {
   NotificationIdent,
   ReleaseNotificationPaths,

--- a/ui/src/app/store/notification/slice.ts
+++ b/ui/src/app/store/notification/slice.ts
@@ -5,8 +5,10 @@ import type {
 } from "@reduxjs/toolkit";
 
 import { generateSlice } from "../utils";
-import type { GenericSlice } from "app/store/utils";
+
 import type { Notification, NotificationState } from "./types";
+
+import type { GenericSlice } from "app/store/utils";
 
 type NotificationReducers = SliceCaseReducers<NotificationState> & {
   // Overrides for reducers that don't take a payload.

--- a/ui/src/app/store/notification/types.ts
+++ b/ui/src/app/store/notification/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 import type { User } from "app/store/user/types";
 

--- a/ui/src/app/store/packagerepository/reducers.test.ts
+++ b/ui/src/app/store/packagerepository/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   packageRepository as packageRepositoryFactory,
   packageRepositoryState as packageRepositoryStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("packagerepository reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/packagerepository/selectors.test.ts
+++ b/ui/src/app/store/packagerepository/selectors.test.ts
@@ -1,9 +1,10 @@
+import packagerepository from "./selectors";
+
 import {
   packageRepository as packageRepositoryFactory,
   packageRepositoryState as packageRepositoryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import packagerepository from "./selectors";
 
 describe("packagerepository selectors", () => {
   it("can get repository items", () => {

--- a/ui/src/app/store/packagerepository/selectors.ts
+++ b/ui/src/app/store/packagerepository/selectors.ts
@@ -1,5 +1,7 @@
-import { generateBaseSelectors } from "app/store/utils";
 import { getRepoDisplayName } from "./utils";
+
+import { generateBaseSelectors } from "app/store/utils";
+
 import type {
   PackageRepository,
   PackageRepositoryState,

--- a/ui/src/app/store/packagerepository/slice.ts
+++ b/ui/src/app/store/packagerepository/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { PackageRepository, PackageRepositoryState } from "./types";
 
 type PackageRepositoryReducers = SliceCaseReducers<PackageRepositoryState>;

--- a/ui/src/app/store/packagerepository/types.ts
+++ b/ui/src/app/store/packagerepository/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type PackageRepository = Model & {

--- a/ui/src/app/store/pod/reducers.test.ts
+++ b/ui/src/app/store/pod/reducers.test.ts
@@ -1,10 +1,11 @@
+import reducers, { actions } from "./slice";
+
 import {
   pod as podFactory,
   podDetails as podDetailsFactory,
   podState as podStateFactory,
   podStatus as podStatusFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("pod reducer", () => {
   it("returns the initial state", () => {

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -1,3 +1,5 @@
+import pod from "./selectors";
+
 import {
   controller as controllerFactory,
   controllerState as controllerStateFactory,
@@ -7,7 +9,6 @@ import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import pod from "./selectors";
 
 describe("pod selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -1,10 +1,11 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { generateBaseSelectors } from "app/store/utils";
 import controller from "app/store/controller/selectors";
 import machine from "app/store/machine/selectors";
-import type { Controller } from "app/store/controller/types";
 import type { Host } from "app/store/types/host";
+import { generateBaseSelectors } from "app/store/utils";
+
+import type { Controller } from "app/store/controller/types";
 import type { Machine } from "app/store/machine/types";
 import type { Pod, PodState } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";

--- a/ui/src/app/store/pod/slice.ts
+++ b/ui/src/app/store/pod/slice.ts
@@ -4,9 +4,10 @@ import type {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
+import type { Pod, PodState } from "./types";
+
 import { generateSlice, generateStatusHandlers } from "app/store/utils";
 import type { GenericItemMeta, GenericSlice } from "app/store/utils";
-import type { Pod, PodState } from "./types";
 
 export const DEFAULT_STATUSES = {
   composing: false,

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -1,5 +1,6 @@
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type PodHint = {

--- a/ui/src/app/store/resourcepool/reducers.test.ts
+++ b/ui/src/app/store/resourcepool/reducers.test.ts
@@ -1,9 +1,10 @@
+import reducers, { actions } from "./slice";
+
 import {
   machine as machineFactory,
   resourcePool as resourcePoolFactory,
   resourcePoolState as resourcePoolStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("resourcePool reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/resourcepool/selectors.test.ts
+++ b/ui/src/app/store/resourcepool/selectors.test.ts
@@ -1,9 +1,10 @@
+import resourcepool from "./selectors";
+
 import {
   resourcePool as resourcePoolFactory,
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import resourcepool from "./selectors";
 
 describe("resourcepool selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/resourcepool/selectors.ts
+++ b/ui/src/app/store/resourcepool/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type {
   ResourcePool,
   ResourcePoolState,

--- a/ui/src/app/store/resourcepool/slice.ts
+++ b/ui/src/app/store/resourcepool/slice.ts
@@ -1,6 +1,8 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
+
 import { Machine } from "../machine/types";
 import { generateSlice, GenericSlice } from "../utils";
+
 import { ResourcePool, ResourcePoolState } from "./types";
 
 type ResourcePoolReducers = SliceCaseReducers<ResourcePoolState>;

--- a/ui/src/app/store/resourcepool/types.ts
+++ b/ui/src/app/store/resourcepool/types.ts
@@ -1,6 +1,7 @@
-import type { GenericState } from "app/store/types/state";
-import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
+import type { TSFixMe } from "app/base/types";
 
 export type ResourcePool = Model & {
   created: string;

--- a/ui/src/app/store/scriptresults/reducers.test.ts
+++ b/ui/src/app/store/scriptresults/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   scriptResult as scriptResultFactory,
   scriptResultsState as scriptResultsStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("script results reducer", () => {
   it("returns the initial state", () => {

--- a/ui/src/app/store/scriptresults/selectors.test.tsx
+++ b/ui/src/app/store/scriptresults/selectors.test.tsx
@@ -1,3 +1,5 @@
+import selectors from "./selectors";
+
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -5,7 +7,6 @@ import {
   scriptResults as scriptResultsFactory,
   scriptResultsState as scriptResultsStateFactory,
 } from "testing/factories";
-import selectors from "./selectors";
 
 describe("scriptResults selectors", () => {
   it("returns all script results", () => {

--- a/ui/src/app/store/scriptresults/selectors.ts
+++ b/ui/src/app/store/scriptresults/selectors.ts
@@ -1,9 +1,11 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import type { RootState } from "app/store/root/types";
-import type { TSFixMe } from "app/base/types";
-import { ScriptResults } from "./types";
 import { Machine } from "../machine/types";
+
+import { ScriptResults } from "./types";
+
+import type { TSFixMe } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 /**
  * Returns list of all script results.

--- a/ui/src/app/store/scriptresults/slice.ts
+++ b/ui/src/app/store/scriptresults/slice.ts
@@ -1,12 +1,13 @@
 import { PayloadAction, SliceCaseReducers } from "@reduxjs/toolkit";
 
+import type { Machine } from "../machine/types";
+import { generateSlice, GenericSlice } from "../utils";
+
 import type {
   ScriptResultsResponse,
   ScriptResults,
   ScriptResultsState,
 } from "./types";
-import type { Machine } from "../machine/types";
-import { generateSlice, GenericSlice } from "../utils";
 
 type Reducers = SliceCaseReducers<ScriptResultsState>;
 

--- a/ui/src/app/store/scriptresults/types.ts
+++ b/ui/src/app/store/scriptresults/types.ts
@@ -1,7 +1,9 @@
-import type { GenericState } from "app/store/types/state";
-import type { Model } from "app/store/types/model";
-import type { TSFixMe } from "app/base/types";
 import type { Machine } from "../machine/types";
+
+import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
+import type { TSFixMe } from "app/base/types";
 
 export type ScriptResultResult = {
   name: string;

--- a/ui/src/app/store/scripts/selectors.test.ts
+++ b/ui/src/app/store/scripts/selectors.test.ts
@@ -1,9 +1,10 @@
+import scripts from "./selectors";
+
 import {
   scripts as scriptsFactory,
   scriptsState as scriptsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import scripts from "./selectors";
 
 describe("scripts selectors", () => {
   describe("all", () => {

--- a/ui/src/app/store/scripts/selectors.ts
+++ b/ui/src/app/store/scripts/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { RootState } from "app/store/root/types";
 import type { Scripts, ScriptsState } from "app/store/scripts/types";
 

--- a/ui/src/app/store/scripts/types.ts
+++ b/ui/src/app/store/scripts/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type ScriptsHistory = Model & {

--- a/ui/src/app/store/service/reducers.test.ts
+++ b/ui/src/app/store/service/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   service as serviceFactory,
   serviceState as serviceStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("service reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/service/selectors.test.ts
+++ b/ui/src/app/store/service/selectors.test.ts
@@ -1,9 +1,10 @@
+import service from "./selectors";
+
 import {
   rootState as rootStateFactory,
   service as serviceFactory,
   serviceState as serviceStateFactory,
 } from "testing/factories";
-import service from "./selectors";
 
 describe("service selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/service/selectors.ts
+++ b/ui/src/app/store/service/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Service, ServiceState } from "app/store/service/types";
 
 const searchFunction = (service: Service, term: string) =>

--- a/ui/src/app/store/service/slice.ts
+++ b/ui/src/app/store/service/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Service, ServiceState } from "./types";
 
 type ServiceReducers = SliceCaseReducers<ServiceState>;

--- a/ui/src/app/store/service/types.ts
+++ b/ui/src/app/store/service/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type Service = Model & {

--- a/ui/src/app/store/space/reducers.test.ts
+++ b/ui/src/app/store/space/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   space as spaceFactory,
   spaceState as spaceStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("space reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/space/selectors.test.ts
+++ b/ui/src/app/store/space/selectors.test.ts
@@ -1,9 +1,10 @@
+import space from "./selectors";
+
 import {
   space as spaceFactory,
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import space from "./selectors";
 
 describe("space selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/space/selectors.ts
+++ b/ui/src/app/store/space/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Space, SpaceState } from "app/store/space/types";
 
 const searchFunction = (space: Space, term: string) =>

--- a/ui/src/app/store/space/slice.ts
+++ b/ui/src/app/store/space/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Space, SpaceState } from "./types";
 
 type SpaceReducers = SliceCaseReducers<SpaceState>;

--- a/ui/src/app/store/space/types.ts
+++ b/ui/src/app/store/space/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type Space = Model & {

--- a/ui/src/app/store/sshkey/reducers.test.ts
+++ b/ui/src/app/store/sshkey/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   sshKey as sshKeyFactory,
   sshKeyState as sshKeyStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("sshkey reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/sshkey/selectors.test.ts
+++ b/ui/src/app/store/sshkey/selectors.test.ts
@@ -1,9 +1,10 @@
+import sshkey from "./selectors";
+
 import {
   rootState as rootStateFactory,
   sshKey as sshKeyFactory,
   sshKeyState as sshKeyStateFactory,
 } from "testing/factories";
-import sshkey from "./selectors";
 
 describe("sshkey selectors", () => {
   describe("all", () => {

--- a/ui/src/app/store/sshkey/selectors.ts
+++ b/ui/src/app/store/sshkey/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { SSHKey, SSHKeyState } from "app/store/sshkey/types";
 
 const searchFunction = (sshkey: SSHKey, term: string) =>

--- a/ui/src/app/store/sshkey/slice.ts
+++ b/ui/src/app/store/sshkey/slice.ts
@@ -5,8 +5,10 @@ import type {
 } from "@reduxjs/toolkit";
 
 import { generateSlice } from "../utils";
-import type { GenericSlice } from "app/store/utils";
+
 import type { KeySource, SSHKey, SSHKeyState } from "./types";
+
+import type { GenericSlice } from "app/store/utils";
 
 type SSHKeyReducers = SliceCaseReducers<SSHKeyState> & {
   // Overrides for reducers that don't take a payload.

--- a/ui/src/app/store/sshkey/types.ts
+++ b/ui/src/app/store/sshkey/types.ts
@@ -1,7 +1,8 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
-import type { User } from "app/store/user/types";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
+import type { User } from "app/store/user/types";
 
 export type KeySource = {
   auth_id: string;

--- a/ui/src/app/store/sslkey/reducers.test.ts
+++ b/ui/src/app/store/sslkey/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   sslKey as sslKeyFactory,
   sslKeyState as sslKeyStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("sslkey reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/sslkey/selectors.test.ts
+++ b/ui/src/app/store/sslkey/selectors.test.ts
@@ -1,9 +1,10 @@
+import sslkey from "./selectors";
+
 import {
   rootState as rootStateFactory,
   sslKey as sslKeyFactory,
   sslKeyState as sslKeyStateFactory,
 } from "testing/factories";
-import sslkey from "./selectors";
 
 describe("sslkey selectors", () => {
   describe("all", () => {

--- a/ui/src/app/store/sslkey/selectors.ts
+++ b/ui/src/app/store/sslkey/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { SSLKey, SSLKeyState } from "app/store/sslkey/types";
 
 const searchFunction = (sslkey: SSLKey, term: string) =>

--- a/ui/src/app/store/sslkey/slice.ts
+++ b/ui/src/app/store/sslkey/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { SSLKey, SSLKeyState } from "./types";
 
 type SSLKeyReducers = SliceCaseReducers<SSLKeyState>;

--- a/ui/src/app/store/sslkey/types.ts
+++ b/ui/src/app/store/sslkey/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 import type { User } from "app/store/user/types";
 

--- a/ui/src/app/store/status/selectors.test.ts
+++ b/ui/src/app/store/status/selectors.test.ts
@@ -1,8 +1,9 @@
+import status from "./selectors";
+
 import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import status from "./selectors";
 
 describe("status", () => {
   it("can get the connected status", () => {

--- a/ui/src/app/store/subnet/reducers.test.ts
+++ b/ui/src/app/store/subnet/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("subnet reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/subnet/selectors.test.ts
+++ b/ui/src/app/store/subnet/selectors.test.ts
@@ -1,10 +1,11 @@
+import subnet from "./selectors";
+
 import {
   podDetails as podDetailsFactory,
   rootState as rootStateFactory,
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import subnet from "./selectors";
 
 describe("subnet selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import type { Subnet, SubnetState } from "app/store/subnet/types";

--- a/ui/src/app/store/subnet/slice.ts
+++ b/ui/src/app/store/subnet/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Subnet, SubnetState } from "./types";
 
 type SubnetReducers = SliceCaseReducers<SubnetState>;

--- a/ui/src/app/store/subnet/types.ts
+++ b/ui/src/app/store/subnet/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type SubnetStatisticsRange = {

--- a/ui/src/app/store/tag/reducers.test.ts
+++ b/ui/src/app/store/tag/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("tag reducer", () => {
   it("returns the initial state", () => {

--- a/ui/src/app/store/tag/selectors.test.ts
+++ b/ui/src/app/store/tag/selectors.test.ts
@@ -1,9 +1,10 @@
+import tag from "./selectors";
+
 import {
   rootState as rootStateFactory,
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import tag from "./selectors";
 
 describe("tag selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/tag/selectors.ts
+++ b/ui/src/app/store/tag/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Tag, TagState } from "app/store/tag/types";
 
 const searchFunction = (tag: Tag, term: string) => tag.name.includes(term);

--- a/ui/src/app/store/tag/slice.ts
+++ b/ui/src/app/store/tag/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Tag, TagState } from "./types";
 
 type TagReducers = SliceCaseReducers<TagState>;

--- a/ui/src/app/store/tag/types.ts
+++ b/ui/src/app/store/tag/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type Tag = Model & {

--- a/ui/src/app/store/token/reducers.test.ts
+++ b/ui/src/app/store/token/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   token as tokenFactory,
   tokenState as tokenStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("token reducer", () => {
   it("should return the initial state", () => {

--- a/ui/src/app/store/token/selectors.test.ts
+++ b/ui/src/app/store/token/selectors.test.ts
@@ -1,9 +1,10 @@
+import token from "./selectors";
+
 import {
   rootState as rootStateFactory,
   token as tokenFactory,
   tokenState as tokenStateFactory,
 } from "testing/factories";
-import token from "./selectors";
 
 describe("token selectors", () => {
   describe("all", () => {

--- a/ui/src/app/store/token/selectors.ts
+++ b/ui/src/app/store/token/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Token, TokenState } from "app/store/token/types";
 
 const selectors = generateBaseSelectors<TokenState, Token, "id">("token", "id");

--- a/ui/src/app/store/token/slice.ts
+++ b/ui/src/app/store/token/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Token, TokenState } from "./types";
 
 type TokenReducers = SliceCaseReducers<TokenState>;

--- a/ui/src/app/store/token/types.ts
+++ b/ui/src/app/store/token/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type TokenConsumer = {

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -1,7 +1,8 @@
+import type { Model, ModelRef } from "app/store/types/model";
+
 import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
 import type { Machine } from "app/store/machine/types";
-import type { Model, ModelRef } from "app/store/types/model";
 
 export type TestResult = -1 | 0 | 1 | 2 | 3;
 

--- a/ui/src/app/store/user/selectors.test.ts
+++ b/ui/src/app/store/user/selectors.test.ts
@@ -1,4 +1,5 @@
 import user from "./selectors";
+
 import {
   user as userFactory,
   userState as userStateFactory,

--- a/ui/src/app/store/user/selectors.ts
+++ b/ui/src/app/store/user/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { User, UserState } from "app/store/user/types";
 
 const searchFunction = (user: User, term: string) =>

--- a/ui/src/app/store/user/slice.ts
+++ b/ui/src/app/store/user/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import type { User, UserState } from "./types";
 
 type UserReducers = SliceCaseReducers<UserState>;

--- a/ui/src/app/store/user/types.ts
+++ b/ui/src/app/store/user/types.ts
@@ -1,6 +1,7 @@
-import type { GenericState } from "app/store/types/state";
-import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
+import type { TSFixMe } from "app/base/types";
 
 export type User = Model & {
   completed_intro: boolean;

--- a/ui/src/app/store/utils/identifiers.ts
+++ b/ui/src/app/store/utils/identifiers.ts
@@ -1,6 +1,7 @@
-import { NotificationIdent } from "app/store/notification/types";
 import type { Host } from "app/store/types/host";
+
 import type { Machine } from "app/store/machine/types";
+import { NotificationIdent } from "app/store/notification/types";
 import type { Notification } from "app/store/notification/types";
 
 /**

--- a/ui/src/app/store/utils/selectors.ts
+++ b/ui/src/app/store/utils/selectors.ts
@@ -4,8 +4,9 @@ import {
   Selector,
 } from "@reduxjs/toolkit";
 
-import type { RootState } from "app/store/root/types";
 import type { CommonStates, CommonStateTypes } from "app/store/utils";
+
+import type { RootState } from "app/store/root/types";
 
 /**
  * @template I - A model item type e.g. DHCPSnippet

--- a/ui/src/app/store/utils/slice.test.ts
+++ b/ui/src/app/store/utils/slice.test.ts
@@ -4,6 +4,8 @@ import {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
+import { generateSlice, generateStatusHandlers } from "app/store/utils";
+import type { GenericSlice } from "app/store/utils";
 import {
   token as tokenFactory,
   tokenState as tokenStateFactory,
@@ -11,8 +13,7 @@ import {
   podState as podStateFactory,
   podStatus as podStatusFactory,
 } from "testing/factories";
-import { generateSlice, generateStatusHandlers } from "app/store/utils";
-import type { GenericSlice } from "app/store/utils";
+
 import type { Pod, PodState } from "app/store/pod/types";
 import type { Token, TokenState } from "app/store/token/types";
 

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -8,9 +8,10 @@ import {
   ValidateSliceCaseReducers,
 } from "@reduxjs/toolkit";
 
-import type { RootState } from "app/store/root/types";
 import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
+import type { RootState } from "app/store/root/types";
 
 export type GenericItemMeta<I> = {
   item: I;

--- a/ui/src/app/store/vlan/reducers.test.ts
+++ b/ui/src/app/store/vlan/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("vlan reducer", () => {
   describe("initial", () => {

--- a/ui/src/app/store/vlan/selectors.test.ts
+++ b/ui/src/app/store/vlan/selectors.test.ts
@@ -1,9 +1,10 @@
+import vlan from "./selectors";
+
 import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import vlan from "./selectors";
 
 describe("vlan selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/vlan/selectors.ts
+++ b/ui/src/app/store/vlan/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { VLAN, VLANState } from "app/store/vlan/types";
 
 const searchFunction = (vlan: VLAN, term: string) => vlan.name.includes(term);

--- a/ui/src/app/store/vlan/slice.ts
+++ b/ui/src/app/store/vlan/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { VLAN, VLANState } from "./types";
 
 type VLANReducers = SliceCaseReducers<VLANState>;

--- a/ui/src/app/store/vlan/types.ts
+++ b/ui/src/app/store/vlan/types.ts
@@ -1,5 +1,6 @@
-import type { GenericState } from "app/store/types/state";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
 import type { TSFixMe } from "app/base/types";
 
 export type VLAN = Model & {

--- a/ui/src/app/store/zone/reducers.test.ts
+++ b/ui/src/app/store/zone/reducers.test.ts
@@ -1,8 +1,9 @@
+import reducers, { actions } from "./slice";
+
 import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import reducers, { actions } from "./slice";
 
 describe("zone reducer", () => {
   it("returns the initial state", () => {

--- a/ui/src/app/store/zone/selectors.test.ts
+++ b/ui/src/app/store/zone/selectors.test.ts
@@ -1,9 +1,10 @@
+import zone from "./selectors";
+
 import {
   rootState as rootStateFactory,
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import zone from "./selectors";
 
 describe("zone selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/zone/selectors.ts
+++ b/ui/src/app/store/zone/selectors.ts
@@ -1,4 +1,5 @@
 import { generateBaseSelectors } from "app/store/utils";
+
 import type { Zone, ZoneState } from "app/store/zone/types";
 
 const searchFunction = (zone: Zone, term: string) => zone.name.includes(term);

--- a/ui/src/app/store/zone/slice.ts
+++ b/ui/src/app/store/zone/slice.ts
@@ -1,6 +1,7 @@
 import { SliceCaseReducers } from "@reduxjs/toolkit";
 
 import { generateSlice, GenericSlice } from "../utils";
+
 import { Zone, ZoneState } from "./types";
 
 type ZoneReducers = SliceCaseReducers<ZoneState>;

--- a/ui/src/app/store/zone/types.ts
+++ b/ui/src/app/store/zone/types.ts
@@ -1,6 +1,7 @@
-import type { GenericState } from "app/store/types/state";
-import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
+import type { TSFixMe } from "app/base/types";
 
 export type Zone = Model & {
   controllers_count: number;

--- a/ui/src/app/utils/getStatusText.test.ts
+++ b/ui/src/app/utils/getStatusText.test.ts
@@ -1,7 +1,8 @@
-import { nodeStatus } from "app/base/enum";
-import { machine as machineFactory } from "testing/factories";
 import { getStatusText } from "./getStatusText";
+
+import { nodeStatus } from "app/base/enum";
 import { NodeStatus } from "app/store/types/node";
+import { machine as machineFactory } from "testing/factories";
 
 describe("getStatusText", () => {
   it("displays the machine's status if not deploying or deployed", () => {

--- a/ui/src/testing/factories/dhcpsnippet.ts
+++ b/ui/src/testing/factories/dhcpsnippet.ts
@@ -1,11 +1,13 @@
 import { array, extend } from "cooky-cutter";
 
 import { model } from "./model";
+
+import type { Model } from "app/store/types/model";
+
 import type {
   DHCPSnippet,
   DHCPSnippetHistory,
 } from "app/store/dhcpsnippet/types";
-import type { Model } from "app/store/types/model";
 
 export const dhcpSnippetHistory = extend<Model, DHCPSnippetHistory>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/domain.ts
+++ b/ui/src/testing/factories/domain.ts
@@ -1,8 +1,10 @@
 import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
-import type { Domain } from "app/store/domain/types";
+
 import type { Model } from "app/store/types/model";
+
+import type { Domain } from "app/store/domain/types";
 
 export const domain = extend<Model, Domain>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/fabric.ts
+++ b/ui/src/testing/factories/fabric.ts
@@ -1,8 +1,10 @@
 import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
-import type { Fabric } from "app/store/fabric/types";
+
 import type { Model } from "app/store/types/model";
+
+import type { Fabric } from "app/store/fabric/types";
 
 export const fabric = extend<Model, Fabric>(model, {
   class_type: "10g",

--- a/ui/src/testing/factories/licensekeys.ts
+++ b/ui/src/testing/factories/licensekeys.ts
@@ -1,8 +1,10 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
-import type { LicenseKeys } from "app/store/licensekeys/types";
+
 import type { Model } from "app/store/types/model";
+
+import type { LicenseKeys } from "app/store/licensekeys/types";
 
 export const licenseKeys = extend<Model, LicenseKeys>(model, {
   distro_series: "win2012",

--- a/ui/src/testing/factories/message.ts
+++ b/ui/src/testing/factories/message.ts
@@ -1,7 +1,9 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { Message } from "app/store/message/types";
 
 export const message = extend<Model, Message>(model, {

--- a/ui/src/testing/factories/noderesult.ts
+++ b/ui/src/testing/factories/noderesult.ts
@@ -1,7 +1,9 @@
 import { array, define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type {
   NodeResult,
   NodeResults,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -1,5 +1,15 @@
 import { define, extend, random, sequence } from "cooky-cutter";
 
+import { model, modelRef } from "./model";
+
+import type { Model } from "app/store/types/model";
+import {
+  BaseNode,
+  SimpleNode,
+  TestStatus,
+  NodeStatus,
+} from "app/store/types/node";
+
 import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
 import type {
@@ -22,10 +32,6 @@ import type {
   PodNumaNode,
   PodStoragePool,
 } from "app/store/pod/types";
-import type { Model } from "app/store/types/model";
-import { BaseNode, SimpleNode, TestStatus } from "app/store/types/node";
-import { model, modelRef } from "./model";
-import { NodeStatus } from "app/store/types/node";
 
 export const testStatus = define<TestStatus>({
   status: 0,

--- a/ui/src/testing/factories/notification.ts
+++ b/ui/src/testing/factories/notification.ts
@@ -1,9 +1,11 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
-import type { Notification } from "app/store/notification/types";
 import { user } from "testing/factories/user";
+
+import type { Notification } from "app/store/notification/types";
 
 export const notification = extend<Model, Notification>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/packagerepository.ts
+++ b/ui/src/testing/factories/packagerepository.ts
@@ -1,7 +1,9 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { PackageRepository } from "app/store/packagerepository/types";
 
 export const packageRepository = extend<Model, PackageRepository>(model, {

--- a/ui/src/testing/factories/resourcepool.ts
+++ b/ui/src/testing/factories/resourcepool.ts
@@ -1,7 +1,9 @@
 import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { ResourcePool } from "app/store/resourcepool/types";
 
 export const resourcePool = extend<Model, ResourcePool>(model, {

--- a/ui/src/testing/factories/scriptresults.ts
+++ b/ui/src/testing/factories/scriptresults.ts
@@ -1,7 +1,9 @@
 import { array, define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type {
   ScriptResult,
   ScriptResults,

--- a/ui/src/testing/factories/scripts.ts
+++ b/ui/src/testing/factories/scripts.ts
@@ -1,7 +1,9 @@
 import { array, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { Scripts, ScriptsHistory } from "app/store/scripts/types";
 
 export enum ScriptType {

--- a/ui/src/testing/factories/service.ts
+++ b/ui/src/testing/factories/service.ts
@@ -1,7 +1,9 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { Service } from "app/store/service/types";
 
 export const service = extend<Model, Service>(model, {

--- a/ui/src/testing/factories/space.ts
+++ b/ui/src/testing/factories/space.ts
@@ -1,8 +1,10 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
-import type { Space } from "app/store/space/types";
+
 import type { Model } from "app/store/types/model";
+
+import type { Space } from "app/store/space/types";
 
 export const space = extend<Model, Space>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/sshkey.ts
+++ b/ui/src/testing/factories/sshkey.ts
@@ -1,7 +1,9 @@
 import { define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { SSHKey, KeySource } from "app/store/sshkey/types";
 
 export const keySource = define<KeySource>({

--- a/ui/src/testing/factories/sslkey.ts
+++ b/ui/src/testing/factories/sslkey.ts
@@ -1,7 +1,9 @@
 import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { SSLKey } from "app/store/sslkey/types";
 
 export const sslKey = extend<Model, SSLKey>(model, {

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -1,17 +1,31 @@
-import { array, define } from "cooky-cutter";
 import type { RouterState } from "connected-react-router";
+import { array, define } from "cooky-cutter";
 import { Location } from "history";
 
 import { message } from "./message";
 import { notification } from "./notification";
 import { user } from "./user";
-import type { AuthState, UserState } from "app/store/user/types";
+
 import type { ConfigState } from "app/store/config/types";
 import type { ControllerState } from "app/store/controller/types";
 import type { DeviceState } from "app/store/device/types";
 import type { DHCPSnippetState } from "app/store/dhcpsnippet/types";
 import type { DomainState } from "app/store/domain/types";
 import type { FabricState } from "app/store/fabric/types";
+import type {
+  ArchitecturesState,
+  ComponentsToDisableState,
+  DefaultMinHweKernelState,
+  GeneralState,
+  HWEKernelsState,
+  KnownArchitecturesState,
+  MachineActionsState,
+  NavigationOptionsState,
+  OSInfoState,
+  PocketsToDisableState,
+  PowerTypesState,
+  VersionState,
+} from "app/store/general/types";
 import type { LicenseKeysState } from "app/store/licensekeys/types";
 import type {
   MachineState,
@@ -35,22 +49,9 @@ import type { StatusState } from "app/store/status/types";
 import type { SubnetState } from "app/store/subnet/types";
 import type { TagState } from "app/store/tag/types";
 import type { TokenState } from "app/store/token/types";
+import type { AuthState, UserState } from "app/store/user/types";
 import type { VLANState } from "app/store/vlan/types";
 import type { ZoneState } from "app/store/zone/types";
-import type {
-  ArchitecturesState,
-  ComponentsToDisableState,
-  DefaultMinHweKernelState,
-  GeneralState,
-  HWEKernelsState,
-  KnownArchitecturesState,
-  MachineActionsState,
-  NavigationOptionsState,
-  OSInfoState,
-  PocketsToDisableState,
-  PowerTypesState,
-  VersionState,
-} from "app/store/general/types";
 
 const defaultState = {
   errors: () => ({}),

--- a/ui/src/testing/factories/subnet.ts
+++ b/ui/src/testing/factories/subnet.ts
@@ -1,7 +1,9 @@
 import { array, define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type {
   Subnet,
   SubnetStatistics,

--- a/ui/src/testing/factories/tag.ts
+++ b/ui/src/testing/factories/tag.ts
@@ -1,7 +1,9 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { Tag } from "app/store/tag/types";
 
 export const tag = extend<Model, Tag>(model, {

--- a/ui/src/testing/factories/token.ts
+++ b/ui/src/testing/factories/token.ts
@@ -1,7 +1,9 @@
 import { define, extend } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { Token, TokenConsumer } from "app/store/token/types";
 
 export const tokenConsumer = define<TokenConsumer>({

--- a/ui/src/testing/factories/user.ts
+++ b/ui/src/testing/factories/user.ts
@@ -1,7 +1,9 @@
 import { extend } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { User } from "app/store/user/types";
 
 const globalPermissions = () => ["machine_create"];

--- a/ui/src/testing/factories/vlan.ts
+++ b/ui/src/testing/factories/vlan.ts
@@ -1,8 +1,10 @@
 import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
-import type { VLAN } from "app/store/vlan/types";
+
 import type { Model } from "app/store/types/model";
+
+import type { VLAN } from "app/store/vlan/types";
 
 export const vlan = extend<Model, VLAN>(model, {
   created: "Thu, 13 Feb. 2020 14:56:05",

--- a/ui/src/testing/factories/zone.ts
+++ b/ui/src/testing/factories/zone.ts
@@ -1,7 +1,9 @@
 import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
+
 import type { Model } from "app/store/types/model";
+
 import type { Zone } from "app/store/zone/types";
 
 export const zone = extend<Model, Zone>(model, {


### PR DESCRIPTION
## Done
Do we want to discuss this @huwshimi, @Caleb-Ellis? 

The default groupings here are essentially what we've been doing manually, i.e.

```
["builtin", "external", "parent", "sibling", "index"]
```
 
## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
