### PR TITLE
feat(ui): build used disks and partitions list in machine storage tab

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -337,9 +337,10 @@ exports[`stricter compilation`] = {
       [42, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"],
       [112, 48, 10, "Property \'checkPower\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "953482588"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx:1626600482": [
-      [64, 27, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
-      [73, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
+    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:2874409179": [
+      [97, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
+      [131, 30, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
+      [148, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2917642452": [
       [46, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]

--- a/ui/src/app/base/hooks.js
+++ b/ui/src/app/base/hooks.js
@@ -395,10 +395,10 @@ export const useTableSort = (sortValueGetter, initialSort) => {
       if (direction === "none") {
         return 0;
       }
-      if (sortA < sortB) {
+      if (sortA < sortB || sortA === null) {
         return direction === "descending" ? -1 : 1;
       }
-      if (sortA > sortB) {
+      if (sortA > sortB || sortB === null) {
         return direction === "descending" ? 1 : -1;
       }
       return 0;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -6,13 +6,12 @@ import {
   machineFilesystem as fsFactory,
   machinePartition as partitionFactory,
 } from "testing/factories";
+import { separateStorageData } from "../utils";
 import FilesystemsTable from "./FilesystemsTable";
 
 describe("FilesystemsTable", () => {
   it("can show an empty message", () => {
-    const wrapper = mount(
-      <FilesystemsTable disks={[]} specialFilesystems={[]} />
-    );
+    const wrapper = mount(<FilesystemsTable filesystems={[]} />);
 
     expect(wrapper.find("[data-test='no-filesystems']").text()).toBe(
       "No filesystems defined."
@@ -27,9 +26,8 @@ describe("FilesystemsTable", () => {
         partitions: [],
       }),
     ];
-    const wrapper = mount(
-      <FilesystemsTable disks={disks} specialFilesystems={[]} />
-    );
+    const { filesystems } = separateStorageData(disks);
+    const wrapper = mount(<FilesystemsTable filesystems={filesystems} />);
 
     expect(wrapper.find("TableRow TableCell").at(0).text()).toBe("disk-fs");
     expect(wrapper.find("TableRow TableCell").at(3).text()).toBe(
@@ -49,9 +47,8 @@ describe("FilesystemsTable", () => {
         ],
       }),
     ];
-    const wrapper = mount(
-      <FilesystemsTable disks={disks} specialFilesystems={[]} />
-    );
+    const { filesystems } = separateStorageData(disks);
+    const wrapper = mount(<FilesystemsTable filesystems={filesystems} />);
 
     expect(wrapper.find("TableRow TableCell").at(0).text()).toBe(
       "partition-fs"
@@ -65,9 +62,8 @@ describe("FilesystemsTable", () => {
     const specialFilesystems = [
       fsFactory({ mount_point: "/special-fs/path", fstype: "tmpfs" }),
     ];
-    const wrapper = mount(
-      <FilesystemsTable disks={[]} specialFilesystems={specialFilesystems} />
-    );
+    const { filesystems } = separateStorageData([], specialFilesystems);
+    const wrapper = mount(<FilesystemsTable filesystems={filesystems} />);
 
     expect(wrapper.find("TableRow TableCell").at(0).text()).toBe("—");
     expect(wrapper.find("TableRow TableCell").at(3).text()).toBe(

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -2,102 +2,11 @@ import { MainTable } from "@canonical/react-components";
 import React from "react";
 
 import { formatBytes } from "app/utils";
-import type { Disk, Filesystem, Partition } from "app/store/machine/types";
+import { NormalisedFilesystem } from "../types";
 
-type FilesystemDetails = {
-  fstype: Filesystem["fstype"];
-  id: Filesystem["id"];
-  mountOptions: Filesystem["mount_options"];
-  mountPoint: Filesystem["mount_point"];
-  name: string;
-  size: number;
-};
+type Props = { filesystems: NormalisedFilesystem[] };
 
-type Props = {
-  disks: Disk[];
-  specialFilesystems: Filesystem[];
-};
-
-/**
- * Returns whether a storage device has a mounted filesystem. If a filesystem is
- * unmounted, it will show in the "Available disks and partitions" table.
- * @param storageDevice - the storage device to check.
- * @returns whether the storage device has a mounted filesystem.
- */
-const hasMountedFilesystem = (storageDevice: Disk | Partition) =>
-  !!storageDevice?.filesystem?.mount_point;
-
-/**
- * Formats a filesystem for use in the filesystems table.
- * @param filesystem - the base filesystem object.
- * @param name - the name to give the filesystem.
- * @param size - the size to give the filesystem.
- * @returns formatted filesystem object.
- */
-const formatFilesystem = (
-  filesystem: Filesystem,
-  name: string,
-  size: number
-): FilesystemDetails => ({
-  fstype: filesystem.fstype,
-  id: filesystem.id,
-  mountPoint: filesystem.mount_point,
-  mountOptions: filesystem.mount_options,
-  name,
-  size,
-});
-
-/**
- * Returns a combined list of special filesystems, and filesystems associated
- * with disks and partitions.
- * @param disks - disks to check for filesystems
- * @param specialFilesystems - tmpfs or ramfs filesystems
- * @returns list of filesystems with extra details for use in table
- */
-const getFilesystems = (
-  disks: Disk[],
-  specialFilesystems: Filesystem[]
-): FilesystemDetails[] => {
-  const filesystems = disks.reduce(
-    (diskFilesystems: FilesystemDetails[], disk: Disk) => {
-      if (hasMountedFilesystem(disk)) {
-        diskFilesystems.push(
-          formatFilesystem(disk.filesystem, disk.name, disk.size)
-        );
-      }
-
-      if (disk.partitions) {
-        disk.partitions.forEach((partition) => {
-          if (hasMountedFilesystem(partition)) {
-            diskFilesystems.push(
-              formatFilesystem(
-                partition.filesystem,
-                partition.name,
-                partition.size
-              )
-            );
-          }
-        });
-      }
-
-      return diskFilesystems;
-    },
-    []
-  );
-
-  specialFilesystems.forEach((fs) => {
-    filesystems.push(formatFilesystem(fs, "—", 0));
-  });
-
-  return filesystems;
-};
-
-const FilesystemsTable = ({
-  disks,
-  specialFilesystems,
-}: Props): JSX.Element => {
-  const filesystems = getFilesystems(disks, specialFilesystems);
-
+const FilesystemsTable = ({ filesystems }: Props): JSX.Element => {
   return (
     <>
       <MainTable
@@ -129,12 +38,12 @@ const FilesystemsTable = ({
           },
         ]}
         rows={filesystems.map((fs) => {
-          const size = formatBytes(fs.size, "B");
+          const size = fs.size && formatBytes(fs.size, "B");
           return {
             columns: [
-              { content: fs.name },
+              { content: fs.name || "—" },
               {
-                content: fs.size === 0 ? "—" : `${size.value} ${size.unit}`,
+                content: size ? `${size.value} ${size.unit}` : "—",
               },
               { content: fs.fstype },
               { content: fs.mountPoint },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -4,33 +4,109 @@ import { useParams } from "react-router";
 import { Link } from "react-router-dom";
 import React from "react";
 
+import { scriptStatus } from "app/base/enum";
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
+import { filtersToQueryString } from "app/machines/search";
 import machineSelectors from "app/store/machine/selectors";
-import type { Disk, Partition } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import type { NormalisedStorageDevice as StorageDevice } from "./types";
+import { separateStorageData } from "./utils";
 import AvailableStorageTable from "./AvailableStorageTable";
 import FilesystemsTable from "./FilesystemsTable";
+import UsedStorageTable from "./UsedStorageTable";
 
-// From models/partition.py. This should ideally be available over the websocket.
-// https://github.com/canonical-web-and-design/maas-ui/issues/1866
-export const MIN_PARTITION_SIZE = 4 * 1024 * 1024;
-
-export const storageDeviceInUse = (
-  storageDevice: Disk | Partition
-): boolean => {
-  const { filesystem, type } = storageDevice;
-
-  if (type === "cache-set") {
-    return true;
-  }
-  if (!!filesystem) {
+export const formatTags = (tags: StorageDevice["tags"]): JSX.Element[] =>
+  tags.map((tag, i) => {
+    const filter = filtersToQueryString({ storage_tags: `=${tag}` });
     return (
-      (!!filesystem.is_format_fstype && !!filesystem.mount_point) ||
-      !filesystem.is_format_fstype
+      <span key={tag}>
+        <Link to={`/machines${filter}`}>{tag}</Link>
+        {i !== tags.length - 1 && ", "}
+      </span>
     );
+  });
+
+export const formatTestStatus = (
+  testStatus: StorageDevice["testStatus"]
+): JSX.Element => {
+  switch (testStatus) {
+    case scriptStatus.PENDING:
+      return <i className="p-icon--pending"></i>;
+    case scriptStatus.RUNNING:
+    case scriptStatus.APPLYING_NETCONF:
+    case scriptStatus.INSTALLING:
+      return <i className="p-icon--running"></i>;
+    case scriptStatus.PASSED:
+      return (
+        <>
+          <i className="p-icon--success is-inline"></i>
+          <span>OK</span>
+        </>
+      );
+    case scriptStatus.FAILED:
+    case scriptStatus.ABORTED:
+    case scriptStatus.DEGRADED:
+    case scriptStatus.FAILED_APPLYING_NETCONF:
+    case scriptStatus.FAILED_INSTALLING:
+      return (
+        <>
+          <i className="p-icon--error is-inline"></i>
+          <span>Error</span>
+        </>
+      );
+    case scriptStatus.TIMEDOUT:
+      return (
+        <>
+          <i className="p-icon--timed-out is-inline"></i>
+          <span>Timed out</span>
+        </>
+      );
+    case scriptStatus.SKIPPED:
+      return (
+        <>
+          <i className="p-icon--warning is-inline"></i>
+          <span>Skipped</span>
+        </>
+      );
+    default:
+      return (
+        <>
+          <i className="p-icon--power-unknown is-inline"></i>
+          <span>Unknown</span>
+        </>
+      );
   }
-  return (storageDevice as Disk).available_size < MIN_PARTITION_SIZE;
+};
+
+export const formatType = (
+  type: StorageDevice["type"],
+  parentType?: StorageDevice["parentType"]
+): string => {
+  let typeToFormat = type;
+  if (type === "virtual" && !!parentType) {
+    if (parentType === "lvm-vg") {
+      return "Logical volume";
+    } else if (parentType.includes("raid-")) {
+      return `RAID ${parentType.split("-")[1]}`;
+    }
+    typeToFormat = parentType;
+  }
+
+  switch (typeToFormat) {
+    case "iscsi":
+      return "ISCSI";
+    case "lvm-vg":
+      return "Volume group";
+    case "partition":
+      return "Partition";
+    case "physical":
+      return "Physical";
+    case "virtual":
+      return "Virtual";
+    default:
+      return type;
+  }
 };
 
 const MachineStorage = (): JSX.Element => {
@@ -44,42 +120,50 @@ const MachineStorage = (): JSX.Element => {
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} storage`);
 
   if (machine && "disks" in machine && "special_filesystems" in machine) {
+    const { available, filesystems, used } = separateStorageData(
+      machine.disks,
+      machine.special_filesystems
+    );
+
     return (
       <>
         <Strip shallow>
           <h4>Filesystems</h4>
-          <FilesystemsTable
-            disks={machine.disks}
-            specialFilesystems={machine.special_filesystems}
-          />
+          <FilesystemsTable filesystems={filesystems} />
         </Strip>
         <Strip shallow>
           <h4>Available disks and partitions</h4>
-          <AvailableStorageTable disks={machine.disks} />
+          <AvailableStorageTable storageDevices={available} />
         </Strip>
-        <p>
-          Learn more about deploying{" "}
-          <a
-            className="p-link--external"
-            data-test="docs-footer-link"
-            href="https://maas.io/docs/images"
-            onClick={() =>
-              sendAnalytics(
-                "Machine storage",
-                "Click link to MAAS docs",
-                "Windows"
-              )
-            }
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Windows
-          </a>
-        </p>
-        <p>
-          Change the default layout in{" "}
-          <Link to="/settings/storage">Settings &rsaquo; Storage</Link>
-        </p>
+        <Strip shallow>
+          <h4>Used disks and partitions</h4>
+          <UsedStorageTable storageDevices={used} />
+        </Strip>
+        <Strip shallow>
+          <p>
+            Learn more about deploying{" "}
+            <a
+              className="p-link--external"
+              data-test="docs-footer-link"
+              href="https://maas.io/docs/images"
+              onClick={() =>
+                sendAnalytics(
+                  "Machine storage",
+                  "Click link to MAAS docs",
+                  "Windows"
+                )
+              }
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Windows
+            </a>
+          </p>
+          <p>
+            Change the default layout in{" "}
+            <Link to="/settings/storage">Settings &rsaquo; Storage</Link>
+          </p>
+        </Strip>
       </>
     );
   }

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,0 +1,69 @@
+import { mount } from "enzyme";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { machineDisk as diskFactory } from "testing/factories";
+import { separateStorageData } from "../utils";
+import UsedStorageTable from "./UsedStorageTable";
+
+describe("UsedStorageTable", () => {
+  it("can show an empty message", () => {
+    const wrapper = mount(<UsedStorageTable storageDevices={[]} />);
+
+    expect(wrapper.find("[data-test='no-used']").text()).toBe(
+      "No disk or partition has been fully utilised."
+    );
+  });
+
+  it("shows a warning if volume is spread over multiple NUMA nodes", () => {
+    const disks = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE - 1,
+        numa_node: undefined,
+        numa_nodes: [0, 1],
+        type: "lvm-vg",
+      }),
+    ];
+    const { used } = separateStorageData(disks);
+    const wrapper = mount(<UsedStorageTable storageDevices={used} />);
+
+    expect(wrapper.find("[data-test='numa-warning']").prop("message")).toBe(
+      "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
+    );
+  });
+
+  it("can show links to filter machine list by storage tag", () => {
+    const disks = [
+      diskFactory({ available_size: MIN_PARTITION_SIZE - 1, tags: ["tag-1"] }),
+    ];
+    const { used } = separateStorageData(disks);
+    const wrapper = mount(
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+      >
+        <UsedStorageTable storageDevices={used} />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find("[data-test='health'] Link").exists()).toBe(true);
+    expect(wrapper.find("[data-test='health'] Link").prop("to")).toBe(
+      "/machines?storage_tags=%3Dtag-1"
+    );
+  });
+
+  it("can show what the disk is being used for", () => {
+    const disks = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE - 1,
+        used_for: "nefarious purposes",
+      }),
+    ];
+    const { used } = separateStorageData(disks);
+    const wrapper = mount(<UsedStorageTable storageDevices={used} />);
+
+    expect(wrapper.find("[data-test='used-for']").text()).toBe(
+      "nefarious purposes"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
@@ -16,7 +16,7 @@ const getSortValue = (
 
 type Props = { storageDevices: StorageDevice[] };
 
-const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
+const UsedStorageTable = ({ storageDevices }: Props): JSX.Element => {
   const { currentSort, sortRows, updateSort } = useTableSort(getSortValue, {
     key: "name",
     direction: "descending",
@@ -111,8 +111,7 @@ const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
             ),
           },
           {
-            className: "u-align--right",
-            content: <TableHeader>Actions</TableHeader>,
+            content: <TableHeader>Used for</TableHeader>,
           },
         ]}
         rows={sortedStorageDevices.map((storageDevice) => {
@@ -202,19 +201,25 @@ const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
                   />
                 ),
               },
-              { content: "" },
+              {
+                content: (
+                  <span data-test="used-for">
+                    {storageDevice.usedFor || "—"}
+                  </span>
+                ),
+              },
             ],
             key: storageDevice.id,
           };
         })}
       />
       {sortedStorageDevices.length === 0 && (
-        <div className="u-nudge-right--small" data-test="no-available">
-          No available disks or partitions.
+        <div className="u-nudge-right--small" data-test="no-used">
+          No disk or partition has been fully utilised.
         </div>
       )}
     </>
   );
 };
 
-export default AvailableStorageTable;
+export default UsedStorageTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UsedStorageTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
@@ -1,0 +1,32 @@
+import type { Filesystem } from "app/store/machine/types";
+
+export type NormalisedFilesystem = {
+  fstype: Filesystem["fstype"];
+  id: Filesystem["id"];
+  mountOptions: Filesystem["mount_options"];
+  mountPoint: Filesystem["mount_point"];
+  name: string | null;
+  size: number | null;
+};
+
+export type NormalisedStorageDevice = {
+  boot: boolean | null;
+  firmware: string | null;
+  id: number;
+  model: string | null;
+  name: string;
+  numaNodes: number[];
+  parentType: string | null;
+  serial: string | null;
+  size: number;
+  tags: string[];
+  testStatus: number | null;
+  type: string;
+  usedFor: string;
+};
+
+export type SeparatedDiskData = {
+  available: NormalisedStorageDevice[];
+  filesystems: NormalisedFilesystem[];
+  used: NormalisedStorageDevice[];
+};

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -1,0 +1,295 @@
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import {
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+  machinePartition as partitionFactory,
+} from "testing/factories";
+import {
+  hasMountedFilesystem,
+  normaliseFilesystem,
+  normaliseStorageDevice,
+  separateStorageData,
+  storageDeviceInUse,
+} from "./utils";
+
+describe("Machine storage utils", () => {
+  describe("hasMountedFilesystem", () => {
+    it("handles null case", () => {
+      expect(hasMountedFilesystem(null)).toBe(false);
+    });
+
+    it("handles storage devices that have a filesystem with a mount point", () => {
+      const disk = diskFactory({
+        filesystem: fsFactory({ mount_point: "/path" }),
+      });
+      const partition = partitionFactory({
+        filesystem: fsFactory({ mount_point: "/path" }),
+      });
+      expect(hasMountedFilesystem(disk)).toBe(true);
+      expect(hasMountedFilesystem(partition)).toBe(true);
+    });
+
+    it(`handles storage device that do not have a filesystem, or the filesystem
+      does not have a mount point`, () => {
+      const disk1 = diskFactory({
+        filesystem: null,
+      });
+      const disk2 = diskFactory({
+        filesystem: fsFactory({ mount_point: "" }),
+      });
+      expect(hasMountedFilesystem(disk1)).toBe(false);
+      expect(hasMountedFilesystem(disk2)).toBe(false);
+    });
+  });
+
+  describe("storageDeviceInUse", () => {
+    it("handles null case", () => {
+      expect(storageDeviceInUse(null)).toBe(false);
+    });
+
+    it("handles cache sets", () => {
+      const disk = diskFactory({
+        type: "cache-set",
+      });
+      expect(storageDeviceInUse(disk)).toBe(true);
+    });
+
+    it(`handles storage device that have a filesystem, and that filesystem
+      has a formatted type and mount point`, () => {
+      const disk1 = diskFactory({
+        filesystem: fsFactory({ is_format_fstype: true, mount_point: "/" }),
+      });
+      const disk2 = diskFactory({
+        filesystem: fsFactory({ is_format_fstype: true, mount_point: "" }),
+      });
+      expect(storageDeviceInUse(disk1)).toBe(true);
+      expect(storageDeviceInUse(disk2)).toBe(false);
+    });
+
+    it(`handles storage devices that have a filesystem, but the filesystem
+      does not have a formatted type`, () => {
+      const disk1 = diskFactory({
+        filesystem: fsFactory({ is_format_fstype: false }),
+      });
+      const disk2 = diskFactory({
+        filesystem: fsFactory({ is_format_fstype: true, mount_point: "" }),
+      });
+      expect(storageDeviceInUse(disk1)).toBe(true);
+      expect(storageDeviceInUse(disk2)).toBe(false);
+    });
+
+    it(`handles storage devices that do not have a filesystem, but it has more
+      than the minimum available space for a partition`, () => {
+      const disk1 = diskFactory({
+        available_size: MIN_PARTITION_SIZE - 1,
+        filesystem: null,
+      });
+      const disk2 = diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        filesystem: null,
+      });
+      expect(storageDeviceInUse(disk1)).toBe(true);
+      expect(storageDeviceInUse(disk2)).toBe(false);
+    });
+  });
+
+  describe("normaliseFilesystem", () => {
+    it("can normalise a filesystem", () => {
+      const filesystem = fsFactory();
+      expect(normaliseFilesystem(filesystem, "fs-name", 1000)).toStrictEqual({
+        fstype: filesystem.fstype,
+        id: filesystem.id,
+        mountOptions: filesystem.mount_options,
+        mountPoint: filesystem.mount_point,
+        name: "fs-name",
+        size: 1000,
+      });
+    });
+  });
+
+  describe("normaliseStorageDevice", () => {
+    it("can normalise a single disk", () => {
+      const disk = diskFactory({
+        numa_node: 0,
+        numa_nodes: undefined,
+        test_status: 0,
+      });
+      expect(normaliseStorageDevice(disk)).toStrictEqual({
+        boot: disk.is_boot,
+        firmware: disk.firmware_version,
+        id: disk.id,
+        model: disk.model,
+        name: disk.name,
+        numaNodes: [disk.numa_node],
+        parentType: null,
+        serial: disk.serial,
+        size: disk.size,
+        tags: disk.tags,
+        testStatus: disk.test_status,
+        type: disk.type,
+        usedFor: disk.used_for,
+      });
+    });
+
+    it("can normalise a volume group", () => {
+      const disk = diskFactory({
+        numa_node: undefined,
+        numa_nodes: [0, 1],
+        type: "lvm-vg",
+      });
+      expect(normaliseStorageDevice(disk)).toStrictEqual({
+        boot: disk.is_boot,
+        firmware: disk.firmware_version,
+        id: disk.id,
+        model: disk.model,
+        name: disk.name,
+        numaNodes: disk.numa_nodes,
+        parentType: null,
+        serial: disk.serial,
+        size: disk.size,
+        tags: disk.tags,
+        testStatus: disk.test_status,
+        type: disk.type,
+        usedFor: disk.used_for,
+      });
+    });
+
+    it("can normalise a virtual disk", () => {
+      const disk = diskFactory({
+        numa_node: 0,
+        numa_nodes: undefined,
+        parent: {
+          id: 1,
+          type: "lvm-vg",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      expect(normaliseStorageDevice(disk)).toStrictEqual({
+        boot: disk.is_boot,
+        firmware: disk.firmware_version,
+        id: disk.id,
+        model: disk.model,
+        name: disk.name,
+        numaNodes: [disk.numa_node],
+        parentType: disk.parent?.type,
+        serial: disk.serial,
+        size: disk.size,
+        tags: disk.tags,
+        testStatus: disk.test_status,
+        type: disk.type,
+        usedFor: disk.used_for,
+      });
+    });
+
+    it("can normalise a partition", () => {
+      const partition = partitionFactory();
+      expect(normaliseStorageDevice(partition)).toStrictEqual({
+        boot: null,
+        firmware: null,
+        id: partition.id,
+        model: null,
+        name: partition.name,
+        numaNodes: [],
+        parentType: null,
+        serial: null,
+        size: partition.size,
+        tags: partition.tags,
+        testStatus: null,
+        type: partition.type,
+        usedFor: partition.used_for,
+      });
+    });
+  });
+
+  describe("separateStorageData", () => {
+    it("can separate out available storage devices", () => {
+      const [availablePartition, unavailablePartition] = [
+        partitionFactory({
+          filesystem: fsFactory({ mount_point: "" }),
+          name: "available-partition",
+        }),
+        partitionFactory({
+          filesystem: fsFactory({ mount_point: "/path" }),
+          name: "used-partition",
+        }),
+      ];
+      const disks = [
+        diskFactory({
+          available_size: MIN_PARTITION_SIZE + 1,
+          name: "available-disk",
+          partitions: [availablePartition, unavailablePartition],
+        }),
+        diskFactory({
+          available_size: MIN_PARTITION_SIZE - 1,
+          name: "used-disk",
+          partitions: [],
+        }),
+      ];
+      const { available } = separateStorageData(disks);
+      expect(available.length).toBe(2);
+      expect(available[0].name).toBe("available-disk");
+      expect(available[1].name).toBe("available-partition");
+    });
+
+    it("can separate out used storage devices", () => {
+      const [availablePartition, unavailablePartition] = [
+        partitionFactory({
+          filesystem: fsFactory({ mount_point: "" }),
+          name: "available-partition",
+        }),
+        partitionFactory({
+          filesystem: fsFactory({ mount_point: "/path" }),
+          name: "used-partition",
+        }),
+      ];
+      const disks = [
+        diskFactory({
+          available_size: MIN_PARTITION_SIZE + 1,
+          name: "available-disk",
+          partitions: [availablePartition, unavailablePartition],
+        }),
+        diskFactory({
+          available_size: MIN_PARTITION_SIZE - 1,
+          name: "used-disk",
+          partitions: [],
+        }),
+      ];
+      const { used } = separateStorageData(disks);
+      expect(used.length).toBe(2);
+      expect(used[0].name).toBe("used-partition");
+      expect(used[1].name).toBe("used-disk");
+    });
+
+    it("can separate out filesystems", () => {
+      const disks = [
+        diskFactory({
+          filesystem: fsFactory({ mount_point: "/disk-fs/path" }),
+          name: "disk-fs",
+          partitions: [],
+        }),
+        diskFactory({
+          filesystem: null,
+          partitions: [
+            partitionFactory({
+              filesystem: fsFactory({ mount_point: "/partition-fs/path" }),
+              name: "partition-fs",
+            }),
+          ],
+        }),
+      ];
+      const specialFilesystems = [
+        fsFactory({
+          fstype: "tmpfs",
+          mount_point: "/special-fs/path",
+        }),
+      ];
+      const { filesystems } = separateStorageData(disks, specialFilesystems);
+
+      expect(filesystems.length).toBe(3);
+      expect(filesystems[0].mountPoint).toBe("/disk-fs/path");
+      expect(filesystems[1].mountPoint).toBe("/partition-fs/path");
+      expect(filesystems[2].mountPoint).toBe("/special-fs/path");
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -1,0 +1,170 @@
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import type { Disk, Filesystem, Partition } from "app/store/machine/types";
+import type {
+  NormalisedFilesystem,
+  NormalisedStorageDevice,
+  SeparatedDiskData,
+} from "./types";
+
+/**
+ * Returns whether a storage device has a mounted filesystem. If a filesystem is
+ * unmounted, it will show in the "Available disks and partitions" table.
+ * @param storageDevice - the storage device to check.
+ * @returns whether the storage device has a mounted filesystem.
+ */
+export const hasMountedFilesystem = (
+  storageDevice: Disk | Partition | null
+): boolean => !!storageDevice?.filesystem?.mount_point;
+
+/**
+ * Returns whether a storage device is currently in use.
+ * @param storageDevice - the storage device to check.
+ * @returns whether the storage device is currently in use.
+ */
+export const storageDeviceInUse = (
+  storageDevice: Disk | Partition | null
+): boolean => {
+  if (!storageDevice) {
+    return false;
+  }
+
+  const { filesystem, type } = storageDevice;
+
+  if (type === "cache-set") {
+    return true;
+  }
+  if (!!filesystem) {
+    return (
+      (!!filesystem.is_format_fstype && !!filesystem.mount_point) ||
+      !filesystem.is_format_fstype
+    );
+  }
+  return (storageDevice as Disk).available_size < MIN_PARTITION_SIZE;
+};
+
+/**
+ * Normalises a filesystem for use in the filesystems table.
+ * @param filesystem - the base filesystem object.
+ * @param name - the name to give the filesystem.
+ * @param size - the size to give the filesystem.
+ * @returns Normalised filesystem object.
+ */
+export const normaliseFilesystem = (
+  filesystem: Filesystem,
+  name?: string,
+  size?: number
+): NormalisedFilesystem => ({
+  fstype: filesystem.fstype,
+  id: filesystem.id,
+  mountPoint: filesystem.mount_point,
+  mountOptions: filesystem.mount_options,
+  name: name || null,
+  size: size || null,
+});
+
+/**
+ * Normalises storage device for use in available/used disk and partition tables.
+ * @param storageDevice - the base storage device object.
+ * @param name - the name to give the filesystem.
+ * @param size - the size to give the filesystem.
+ * @returns Normalised storage device object.
+ */
+export const normaliseStorageDevice = (
+  storageDevice: Disk | Partition
+): NormalisedStorageDevice => {
+  let numaNodes: NormalisedStorageDevice["numaNodes"] = [];
+  if (
+    "numa_node" in storageDevice &&
+    typeof storageDevice.numa_node === "number"
+  ) {
+    numaNodes = [storageDevice.numa_node];
+  } else if (
+    "numa_nodes" in storageDevice &&
+    Array.isArray(storageDevice.numa_nodes)
+  ) {
+    numaNodes = storageDevice.numa_nodes;
+  }
+
+  return {
+    boot: "is_boot" in storageDevice ? storageDevice.is_boot : null,
+    firmware:
+      "firmware_version" in storageDevice
+        ? storageDevice.firmware_version
+        : null,
+    id: storageDevice.id,
+    model: "model" in storageDevice ? storageDevice.model : null,
+    name: storageDevice.name,
+    numaNodes,
+    parentType: "parent" in storageDevice ? storageDevice.parent.type : null,
+    serial: "serial" in storageDevice ? storageDevice.serial : null,
+    size: storageDevice.size,
+    tags: storageDevice.tags,
+    testStatus:
+      "test_status" in storageDevice ? storageDevice.test_status : null,
+    type: storageDevice.type,
+    usedFor: storageDevice.used_for,
+  };
+};
+
+/**
+ * Separates machine storage data for use in different sections of the storage
+ * tab.
+ * @param disks - the machine's disks.
+ * @param specialFilesystems - the machine's special filesystems.
+ * @returns Storage data separated by filesystems, available and used.
+ */
+export const separateStorageData = (
+  disks: Disk[] = [],
+  specialFilesystems: Filesystem[] = []
+): SeparatedDiskData => {
+  const data = disks.reduce(
+    (data: SeparatedDiskData, disk: Disk) => {
+      const normalisedDisk = normaliseStorageDevice(disk);
+
+      if (storageDeviceInUse(disk)) {
+        data.used.push(normalisedDisk);
+      } else {
+        data.available.push(normalisedDisk);
+      }
+
+      if (hasMountedFilesystem(disk)) {
+        data.filesystems.push(
+          normaliseFilesystem(disk.filesystem, disk.name, disk.size)
+        );
+      }
+
+      if (disk.partitions && disk.partitions.length > 0) {
+        disk.partitions.forEach((partition) => {
+          const normalisedPartition = normaliseStorageDevice(partition);
+
+          if (storageDeviceInUse(partition)) {
+            data.used.push(normalisedPartition);
+          } else {
+            data.available.push(normalisedPartition);
+          }
+
+          if (hasMountedFilesystem(partition)) {
+            data.filesystems.push(
+              normaliseFilesystem(
+                partition.filesystem,
+                partition.name,
+                partition.size
+              )
+            );
+          }
+        });
+      }
+
+      return data;
+    },
+    { available: [], filesystems: [], used: [] }
+  );
+
+  if (specialFilesystems.length > 0) {
+    specialFilesystems.forEach((specialFilesystem) => {
+      data.filesystems.push(normaliseFilesystem(specialFilesystem));
+    });
+  }
+
+  return data;
+};

--- a/ui/src/app/store/machine/constants.ts
+++ b/ui/src/app/store/machine/constants.ts
@@ -1,0 +1,3 @@
+// From models/partition.py. This should ideally be available over the websocket.
+// https://github.com/canonical-web-and-design/maas-ui/issues/1866
+export const MIN_PARTITION_SIZE = 4 * 1024 * 1024;


### PR DESCRIPTION
## Done

- Built used disks and partitions list in machine storage tab.
- Refactored a few common elements into utils, and created a helper function to separate machine storage data into disparate bits while only iterating through the disks array once

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the react used disks and partitions list shows the same data as the angular version. You might need a `make sampledata`'d MAAS to see things like volume groups and RAIDs.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2158

## Screenshot
![Screenshot_2020-11-13 honest-corgi ubnt storage focal-maas MAAS](https://user-images.githubusercontent.com/25733845/99037613-c2b48300-25cf-11eb-9719-2ce5f70d78e9.png)
