### PR TITLE
feat(ui): add footer links to machine storage tab

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -81,7 +81,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2755544058": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -340,6 +340,9 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx:1626600482": [
       [64, 27, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
       [73, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2917642452": [
+      [46, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx:2439231865": [
       [42, 28, 3, "Property \'get\' does not exist on type \'{ fetch: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { model: any; method: string; }>; create: ActionCreatorWithPreparedPayload<[params?: any], { params: any; }, string, never, { ...; }>; update: ActionCreatorWithPreparedPayload<...>; delete: ActionCreatorWithPreparedPayload<......\'.", "193411891"]

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -1,14 +1,17 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import React from "react";
 
+import * as hooks from "app/base/hooks";
 import {
+  machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 import MachineStorage from "./MachineStorage";
+import { act } from "react-dom/test-utils";
 
 const mockStore = configureStore();
 
@@ -30,5 +33,48 @@ describe("MachineStorage", () => {
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("sends an analytics event when clicking on the MAAS docs footer link", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const mockSendAnalytics = jest.fn();
+    const mockUseSendAnalytics = (hooks.useSendAnalytics = jest.fn(
+      () => mockSendAnalytics
+    ));
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/storage", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/storage"
+            component={() => <MachineStorage />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => {
+      wrapper.find("[data-test='docs-footer-link']").simulate("click");
+    });
+    wrapper.update();
+
+    expect(mockSendAnalytics).toHaveBeenCalled();
+    expect(mockSendAnalytics.mock.calls[0]).toEqual([
+      "Machine storage",
+      "Click link to MAAS docs",
+      "Windows",
+    ]);
+
+    mockUseSendAnalytics.mockRestore();
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -1,9 +1,10 @@
 import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
+import { Link } from "react-router-dom";
 import React from "react";
 
-import { useWindowTitle } from "app/base/hooks";
+import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Partition } from "app/store/machine/types";
@@ -35,6 +36,7 @@ export const storageDeviceInUse = (
 const MachineStorage = (): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
+  const sendAnalytics = useSendAnalytics();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
@@ -55,6 +57,29 @@ const MachineStorage = (): JSX.Element => {
           <h4>Available disks and partitions</h4>
           <AvailableStorageTable disks={machine.disks} />
         </Strip>
+        <p>
+          Learn more about deploying{" "}
+          <a
+            className="p-link--external"
+            data-test="docs-footer-link"
+            href="https://maas.io/docs/images"
+            onClick={() =>
+              sendAnalytics(
+                "Machine storage",
+                "Click link to MAAS docs",
+                "Windows"
+              )
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Windows
+          </a>
+        </p>
+        <p>
+          Change the default layout in{" "}
+          <Link to="/settings/storage">Settings &rsaquo; Storage</Link>
+        </p>
       </>
     );
   }


### PR DESCRIPTION
## Done

- added footer links to machine storage tab + analytics event when clicking on the docs link

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine and check that the two links at the bottom are the same as in the angular version (except the react docs link doesn't need to redirect)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2159
