### PR TITLE
fix(legacy): fix machine logs missing new lines when copied manually

### DIFF
--- a/legacy/src/app/directives/code_lines.js
+++ b/legacy/src/app/directives/code_lines.js
@@ -40,7 +40,7 @@ function maasCodeLines() {
             (insert +=
               newLine +
               '<span class="p-code-numbered__line">' +
-              line +
+              line + "\n" +
               "</span>")
         );
         insert += "</code>";


### PR DESCRIPTION
## Done

- Fixed machine logs missing new lines when copied manually

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the logs page of a machine in legacy
- Copy some of the lines manually (i.e. highlighting some text and pressing  `CTRL+C`)
- Paste into a text editor and check that the newlines copy over correctly
- Click the copy button in the top-right corner of the code block
- Paste into a text editor and check that it still works properly

## Fixes

Fixes #1861 