### PR TITLE
Backport to 2.9: fix for websocket errors when closed

### DIFF
--- a/legacy/src/app/services/managerhelper.js
+++ b/legacy/src/app/services/managerhelper.js
@@ -79,6 +79,11 @@ function ManagerHelperService($q, $timeout, ErrorService, RegionConnection) {
       } else {
         throw new Error("Unknown manager type: " + manager._type);
       }
+    },
+    function (error) {
+      // If there's an error with the connection then handle it with the error
+      // service.
+      ErrorService.raiseError(error);
     });
     return defer.promise;
   };

--- a/legacy/src/app/services/region.js
+++ b/legacy/src/app/services/region.js
@@ -258,7 +258,10 @@ class RegionConnection {
       websocket.onopen = () => onopen();
     }
     websocket.onerror = (evt) => {
-      this.log.error("WebSocket error: ", evt);
+      if (this.getWebSocket().readyState === WebSocket.OPEN) {
+        // Only show an error to the user if there's an issue while it's open.
+        this.log.warn("WebSocket error: ", evt);
+      }
       angular.forEach(this.handlers.error, (func) => {
         func(evt);
       });

--- a/legacy/src/app/services/tests/test_managerhelper.js
+++ b/legacy/src/app/services/tests/test_managerhelper.js
@@ -19,10 +19,11 @@ describe("ManagerHelperService", function () {
   }));
 
   // Load the ManagerHelperService.
-  var ManagerHelperService, RegionConnection;
+  var ManagerHelperService, RegionConnection, ErrorService;
   beforeEach(inject(function ($injector) {
     ManagerHelperService = $injector.get("ManagerHelperService");
     RegionConnection = $injector.get("RegionConnection");
+    ErrorService = $injector.get("ErrorService");
   }));
 
   // Makes a fake manager.
@@ -263,6 +264,21 @@ describe("ManagerHelperService", function () {
       $scope.$digest();
       expect(manager._scopes).toEqual([$otherScope]);
       expect(manager.stopPolling).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loadManager - error", function () {
+    it("calls ErrorService.raiseError", function () {
+      spyOn(ErrorService, "raiseError");
+      const deferred = $q.defer()
+      spyOn(RegionConnection, "defaultConnect").and.returnValue(
+        deferred.promise
+      );
+      var manager = makeManager("poll");
+      ManagerHelperService.loadManager($scope, manager);
+      deferred.reject();
+      $scope.$digest();
+      expect(ErrorService.raiseError).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Done

- Catch websocket errors from managers and pass them to the error service.

## Fixes

Fixes: canonical-web-and-design/maas-ui#1850.
Fixes: canonical-web-and-design/maas-ui#1874.