### PR TITLE
feat(ui): build cache sets list in machine storage tab

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -323,13 +323,13 @@ exports[`stricter compilation`] = {
       [45, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [49, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2917642452": [
-      [46, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2924641761": [
+      [80, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:2833644018": [
-      [144, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
-      [178, 30, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
-      [195, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
+    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:3111838099": [
+      [146, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
+      [182, 30, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
+      [199, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
@@ -1,0 +1,23 @@
+import { mount } from "enzyme";
+import React from "react";
+
+import { machineDisk as diskFactory } from "testing/factories";
+import { separateStorageData } from "../utils";
+import CacheSetsTable from "./CacheSetsTable";
+
+describe("CacheSetsTable", () => {
+  it("can show what the cache set is being used for", () => {
+    const disks = [
+      diskFactory({
+        type: "cache-set",
+        used_for: "nefarious purposes",
+      }),
+    ];
+    const { cacheSets } = separateStorageData(disks);
+    const wrapper = mount(<CacheSetsTable cacheSets={cacheSets} />);
+
+    expect(wrapper.find("[data-test='used-for']").text()).toBe(
+      "nefarious purposes"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -1,0 +1,87 @@
+import { MainTable } from "@canonical/react-components";
+import React from "react";
+
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
+import { formatSize } from "../utils";
+import type { NormalisedStorageDevice as StorageDevice } from "../types";
+
+const getSortValue = (
+  sortKey: keyof StorageDevice,
+  storageDevice: StorageDevice
+) => storageDevice[sortKey];
+
+type Props = { cacheSets: StorageDevice[] };
+
+const CacheSetsTable = ({ cacheSets }: Props): JSX.Element => {
+  const { currentSort, sortRows, updateSort } = useTableSort(getSortValue, {
+    key: "name",
+    direction: "descending",
+  });
+  // TODO: update useTableSort to TS with generics
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1869
+  const sortedCacheSets = sortRows(cacheSets) as StorageDevice[];
+
+  return (
+    <MainTable
+      headers={[
+        {
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("name")}
+                sortKey="name"
+              >
+                Name
+              </TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              onClick={() => updateSort("size")}
+              sortKey="size"
+            >
+              Size
+            </TableHeader>
+          ),
+        },
+        {
+          content: <TableHeader>Used for</TableHeader>,
+        },
+        {
+          className: "u-align--right",
+          content: "Actions",
+        },
+      ]}
+      rows={sortedCacheSets.map((cacheSet) => {
+        return {
+          columns: [
+            {
+              content: <span data-test="name">{cacheSet.name}</span>,
+            },
+            {
+              content: (
+                <span data-test="size">{formatSize(cacheSet.size)}</span>
+              ),
+            },
+            {
+              content: (
+                <span data-test="used-for">{cacheSet.usedFor || "—"}</span>
+              ),
+            },
+            {
+              content: "",
+            },
+          ],
+          key: cacheSet.id,
+        };
+      })}
+    />
+  );
+};
+
+export default CacheSetsTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CacheSetsTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import * as hooks from "app/base/hooks";
 import {
   machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -33,6 +34,39 @@ describe("MachineStorage", () => {
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("renders a list of cache sets if any exist", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [diskFactory({ name: "quiche-cache", type: "cache-set" })],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/storage", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/storage"
+            component={() => <MachineStorage />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("CacheSetsTable").exists()).toBe(true);
+    expect(wrapper.find("CacheSetsTable [data-test='name']").at(0).text()).toBe(
+      "quiche-cache"
+    );
   });
 
   it("sends an analytics event when clicking on the MAAS docs footer link", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -10,6 +10,7 @@ import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 import { separateStorageData } from "./utils";
 import AvailableStorageTable from "./AvailableStorageTable";
+import CacheSetsTable from "./CacheSetsTable";
 import FilesystemsTable from "./FilesystemsTable";
 import UsedStorageTable from "./UsedStorageTable";
 
@@ -24,7 +25,7 @@ const MachineStorage = (): JSX.Element => {
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} storage`);
 
   if (machine && "disks" in machine && "special_filesystems" in machine) {
-    const { available, filesystems, used } = separateStorageData(
+    const { available, cacheSets, filesystems, used } = separateStorageData(
       machine.disks,
       machine.special_filesystems
     );
@@ -35,6 +36,12 @@ const MachineStorage = (): JSX.Element => {
           <h4>Filesystems</h4>
           <FilesystemsTable filesystems={filesystems} />
         </Strip>
+        {cacheSets.length > 0 && (
+          <Strip shallow>
+            <h4>Available cache sets</h4>
+            <CacheSetsTable cacheSets={cacheSets} />
+          </Strip>
+        )}
         <Strip shallow>
           <h4>Available disks and partitions</h4>
           <AvailableStorageTable storageDevices={available} />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
@@ -27,6 +27,7 @@ export type NormalisedStorageDevice = {
 
 export type SeparatedDiskData = {
   available: NormalisedStorageDevice[];
+  cacheSets: NormalisedStorageDevice[];
   filesystems: NormalisedFilesystem[];
   used: NormalisedStorageDevice[];
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -331,5 +331,22 @@ describe("Machine storage utils", () => {
       expect(filesystems[1].mountPoint).toBe("/partition-fs/path");
       expect(filesystems[2].mountPoint).toBe("/special-fs/path");
     });
+
+    it("can separate out cache sets", () => {
+      const disks = [
+        diskFactory({
+          name: "cache0",
+          type: "cache-set",
+        }),
+        diskFactory({
+          name: "not-a-cache-set",
+          type: "physical",
+        }),
+      ];
+      const { cacheSets } = separateStorageData(disks);
+
+      expect(cacheSets.length).toBe(1);
+      expect(cacheSets[0].name).toBe("cache0");
+    });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -38,6 +38,8 @@ export const formatType = (
   }
 
   switch (typeToFormat) {
+    case "cache-set":
+      return "Cache set";
     case "iscsi":
       return "ISCSI";
     case "lvm-vg":
@@ -168,7 +170,9 @@ export const separateStorageData = (
     (data: SeparatedDiskData, disk: Disk) => {
       const normalisedDisk = normaliseStorageDevice(disk);
 
-      if (storageDeviceInUse(disk)) {
+      if (disk.type === "cache-set") {
+        data.cacheSets.push(normalisedDisk);
+      } else if (storageDeviceInUse(disk)) {
         data.used.push(normalisedDisk);
       } else {
         data.available.push(normalisedDisk);
@@ -204,7 +208,7 @@ export const separateStorageData = (
 
       return data;
     },
-    { available: [], filesystems: [], used: [] }
+    { available: [], cacheSets: [], filesystems: [], used: [] }
   );
 
   if (specialFilesystems.length > 0) {


### PR DESCRIPTION
## Done

- Built cache sets list in machine storage tab

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine that already has cache sets (e.g. `casual-emu` on bolla), or add one in the legacy storage tab of a ready machine
- Check that a table "Available cache sets" shows with the same data as the angular version

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2264

## Screenshot
![Screenshot_2020-11-17 casual-emu maas storage bolla MAAS](https://user-images.githubusercontent.com/25733845/99466724-a1191a00-2988-11eb-8d00-2924f6895159.png)



