### PR TITLE
refactor(ui): create common components between storage tables

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -81,7 +81,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1489314622": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -326,10 +326,10 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2917642452": [
       [46, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:2194644238": [
-      [97, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
-      [131, 30, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
-      [148, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
+    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:2833644018": [
+      [144, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
+      [178, 30, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
+      [195, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from "enzyme";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import {
@@ -17,16 +16,6 @@ describe("AvailableStorageTable", () => {
 
     expect(wrapper.find("[data-test='no-available']").text()).toBe(
       "No available disks or partitions."
-    );
-  });
-
-  it("shows boot status for physical disks", () => {
-    const disks = [diskFactory({ is_boot: true, type: "physical" })];
-    const { available } = separateStorageData(disks);
-    const wrapper = mount(<AvailableStorageTable storageDevices={available} />);
-
-    expect(wrapper.find("[data-test='boot'] .p-icon--tick").exists()).toBe(
-      true
     );
   });
 
@@ -103,42 +92,6 @@ describe("AvailableStorageTable", () => {
 
     expect(wrapper.find("[data-test='type']").at(0).prop("primary")).toBe(
       "RAID 0"
-    );
-  });
-
-  it("shows a warning if volume is spread over multiple NUMA nodes", () => {
-    const disks = [
-      diskFactory({
-        available_size: MIN_PARTITION_SIZE + 1,
-        numa_node: undefined,
-        numa_nodes: [0, 1],
-        type: "lvm-vg",
-      }),
-    ];
-    const { available } = separateStorageData(disks);
-    const wrapper = mount(<AvailableStorageTable storageDevices={available} />);
-
-    expect(wrapper.find("[data-test='numa-warning']").prop("message")).toBe(
-      "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
-    );
-  });
-
-  it("can show links to filter machine list by storage tag", () => {
-    const disks = [
-      diskFactory({ available_size: MIN_PARTITION_SIZE + 1, tags: ["tag-1"] }),
-    ];
-    const { available } = separateStorageData(disks);
-    const wrapper = mount(
-      <MemoryRouter
-        initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-      >
-        <AvailableStorageTable storageDevices={available} />
-      </MemoryRouter>
-    );
-
-    expect(wrapper.find("[data-test='health'] Link").exists()).toBe(true);
-    expect(wrapper.find("[data-test='health'] Link").prop("to")).toBe(
-      "/machines?storage_tags=%3Dtag-1"
     );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,13 +1,15 @@
-import { MainTable, Tooltip } from "@canonical/react-components";
+import { MainTable } from "@canonical/react-components";
 import React from "react";
-import type { ReactNode } from "react";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
-import { formatBytes } from "app/utils";
+import BootStatus from "../BootStatus";
+import NumaNodes from "../NumaNodes";
+import TagLinks from "../TagLinks";
+import TestStatus from "../TestStatus";
 import type { NormalisedStorageDevice as StorageDevice } from "../types";
-import { formatTags, formatTestStatus, formatType } from "../MachineStorage";
+import { formatSize, formatType } from "../utils";
 
 const getSortValue = (
   sortKey: keyof StorageDevice,
@@ -116,16 +118,6 @@ const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
           },
         ]}
         rows={sortedStorageDevices.map((storageDevice) => {
-          const size = formatBytes(storageDevice.size, "B");
-          let boot: ReactNode = "—";
-          if (storageDevice.type === "physical") {
-            boot = storageDevice.boot ? (
-              <i className="p-icon--tick"></i>
-            ) : (
-              <i className="p-icon--close"></i>
-            );
-          }
-
           return {
             columns: [
               {
@@ -150,7 +142,7 @@ const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
                 content: (
                   <DoubleRow
                     data-test="boot"
-                    primary={boot}
+                    primary={<BootStatus storageDevice={storageDevice} />}
                     primaryClassName="u-align--center"
                   />
                 ),
@@ -159,7 +151,7 @@ const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
                 content: (
                   <DoubleRow
                     data-test="size"
-                    primary={`${size.value} ${size.unit}`}
+                    primary={formatSize(storageDevice.size)}
                   />
                 ),
               },
@@ -172,19 +164,7 @@ const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
                       storageDevice.parentType
                     )}
                     secondary={
-                      <>
-                        {storageDevice.numaNodes.length > 1 && (
-                          <Tooltip
-                            data-test="numa-warning"
-                            message={
-                              "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
-                            }
-                          >
-                            <i className="p-icon--warning is-inline"></i>
-                          </Tooltip>
-                        )}
-                        <span>{storageDevice.numaNodes.join(", ")}</span>
-                      </>
+                      <NumaNodes numaNodes={storageDevice.numaNodes} />
                     }
                   />
                 ),
@@ -194,11 +174,9 @@ const AvailableStorageTable = ({ storageDevices }: Props): JSX.Element => {
                   <DoubleRow
                     data-test="health"
                     primary={
-                      storageDevice.type === "physical"
-                        ? formatTestStatus(storageDevice.testStatus)
-                        : "—"
+                      <TestStatus testStatus={storageDevice.testStatus} />
                     }
-                    secondary={formatTags(storageDevice.tags)}
+                    secondary={<TagLinks tags={storageDevice.tags} />}
                   />
                 ),
               },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
@@ -1,0 +1,32 @@
+import { mount } from "enzyme";
+import React from "react";
+
+import { machineDisk as diskFactory } from "testing/factories";
+import { normaliseStorageDevice } from "../utils";
+import BootStatus from "./BootStatus";
+
+describe("BootStatus", () => {
+  it("shows boot status for boot disks", () => {
+    const disk = diskFactory({ is_boot: true, type: "physical" });
+    const normalised = normaliseStorageDevice(disk);
+    const wrapper = mount(<BootStatus storageDevice={normalised} />);
+
+    expect(wrapper.find("Icon").prop("name")).toBe("tick");
+  });
+
+  it("shows boot status for non-boot disks", () => {
+    const disk = diskFactory({ is_boot: false, type: "physical" });
+    const normalised = normaliseStorageDevice(disk);
+    const wrapper = mount(<BootStatus storageDevice={normalised} />);
+
+    expect(wrapper.find("Icon").prop("name")).toBe("close");
+  });
+
+  it("shows boot status for non-physical disks", () => {
+    const disk = diskFactory({ is_boot: false, type: "virtual" });
+    const normalised = normaliseStorageDevice(disk);
+    const wrapper = mount(<BootStatus storageDevice={normalised} />);
+
+    expect(wrapper.find("span").text()).toBe("—");
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
@@ -1,0 +1,15 @@
+import { Icon } from "@canonical/react-components";
+import React from "react";
+
+import type { NormalisedStorageDevice } from "../types";
+
+type Props = { storageDevice: NormalisedStorageDevice };
+
+const BootCell = ({ storageDevice }: Props): JSX.Element => {
+  if (storageDevice.type === "physical") {
+    return storageDevice.boot ? <Icon name="tick" /> : <Icon name="close" />;
+  }
+  return <span>—</span>;
+};
+
+export default BootCell;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BootStatus";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -1,8 +1,8 @@
 import { MainTable } from "@canonical/react-components";
 import React from "react";
 
-import { formatBytes } from "app/utils";
 import { NormalisedFilesystem } from "../types";
+import { formatSize } from "../utils";
 
 type Props = { filesystems: NormalisedFilesystem[] };
 
@@ -38,12 +38,11 @@ const FilesystemsTable = ({ filesystems }: Props): JSX.Element => {
           },
         ]}
         rows={filesystems.map((fs) => {
-          const size = fs.size && formatBytes(fs.size, "B");
           return {
             columns: [
               { content: fs.name || "—" },
               {
-                content: size ? `${size.value} ${size.unit}` : "—",
+                content: formatSize(fs.size),
               },
               { content: fs.fstype },
               { content: fs.mountPoint },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -4,110 +4,14 @@ import { useParams } from "react-router";
 import { Link } from "react-router-dom";
 import React from "react";
 
-import { scriptStatus } from "app/base/enum";
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
-import { filtersToQueryString } from "app/machines/search";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
-import type { NormalisedStorageDevice as StorageDevice } from "./types";
 import { separateStorageData } from "./utils";
 import AvailableStorageTable from "./AvailableStorageTable";
 import FilesystemsTable from "./FilesystemsTable";
 import UsedStorageTable from "./UsedStorageTable";
-
-export const formatTags = (tags: StorageDevice["tags"]): JSX.Element[] =>
-  tags.map((tag, i) => {
-    const filter = filtersToQueryString({ storage_tags: `=${tag}` });
-    return (
-      <span key={tag}>
-        <Link to={`/machines${filter}`}>{tag}</Link>
-        {i !== tags.length - 1 && ", "}
-      </span>
-    );
-  });
-
-export const formatTestStatus = (
-  testStatus: StorageDevice["testStatus"]
-): JSX.Element => {
-  switch (testStatus) {
-    case scriptStatus.PENDING:
-      return <i className="p-icon--pending"></i>;
-    case scriptStatus.RUNNING:
-    case scriptStatus.APPLYING_NETCONF:
-    case scriptStatus.INSTALLING:
-      return <i className="p-icon--running"></i>;
-    case scriptStatus.PASSED:
-      return (
-        <>
-          <i className="p-icon--success is-inline"></i>
-          <span>OK</span>
-        </>
-      );
-    case scriptStatus.FAILED:
-    case scriptStatus.ABORTED:
-    case scriptStatus.DEGRADED:
-    case scriptStatus.FAILED_APPLYING_NETCONF:
-    case scriptStatus.FAILED_INSTALLING:
-      return (
-        <>
-          <i className="p-icon--error is-inline"></i>
-          <span>Error</span>
-        </>
-      );
-    case scriptStatus.TIMEDOUT:
-      return (
-        <>
-          <i className="p-icon--timed-out is-inline"></i>
-          <span>Timed out</span>
-        </>
-      );
-    case scriptStatus.SKIPPED:
-      return (
-        <>
-          <i className="p-icon--warning is-inline"></i>
-          <span>Skipped</span>
-        </>
-      );
-    default:
-      return (
-        <>
-          <i className="p-icon--power-unknown is-inline"></i>
-          <span>Unknown</span>
-        </>
-      );
-  }
-};
-
-export const formatType = (
-  type: StorageDevice["type"],
-  parentType?: StorageDevice["parentType"]
-): string => {
-  let typeToFormat = type;
-  if (type === "virtual" && !!parentType) {
-    if (parentType === "lvm-vg") {
-      return "Logical volume";
-    } else if (parentType.includes("raid-")) {
-      return `RAID ${parentType.split("-")[1]}`;
-    }
-    typeToFormat = parentType;
-  }
-
-  switch (typeToFormat) {
-    case "iscsi":
-      return "ISCSI";
-    case "lvm-vg":
-      return "Volume group";
-    case "partition":
-      return "Partition";
-    case "physical":
-      return "Physical";
-    case "virtual":
-      return "Virtual";
-    default:
-      return type;
-  }
-};
 
 const MachineStorage = (): JSX.Element => {
   const params = useParams<RouteParams>();

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
@@ -1,0 +1,31 @@
+import { mount } from "enzyme";
+import React from "react";
+
+import { machineDisk as diskFactory } from "testing/factories";
+import { normaliseStorageDevice } from "../utils";
+import NumaNodes from "./NumaNodes";
+
+describe("NumaNodes", () => {
+  it("can show a single numa node", () => {
+    const disk = diskFactory({ is_boot: true, numa_node: 5, type: "physical" });
+    const normalised = normaliseStorageDevice(disk);
+    const wrapper = mount(<NumaNodes numaNodes={normalised.numaNodes} />);
+
+    expect(wrapper.find("[data-test='numa-nodes']").text()).toBe("5");
+  });
+
+  it("can show multiple numa nodes with a warning", () => {
+    const disk = diskFactory({
+      numa_node: undefined,
+      numa_nodes: [0, 1],
+      type: "lvm-vg",
+    });
+    const normalised = normaliseStorageDevice(disk);
+    const wrapper = mount(<NumaNodes numaNodes={normalised.numaNodes} />);
+
+    expect(wrapper.find("[data-test='numa-nodes']").text()).toBe("0, 1");
+    expect(wrapper.find("[data-test='numa-warning']").prop("message")).toBe(
+      "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
@@ -1,0 +1,26 @@
+import { Tooltip } from "@canonical/react-components";
+import React from "react";
+
+import type { NormalisedStorageDevice } from "../types";
+
+type Props = { numaNodes: NormalisedStorageDevice["numaNodes"] };
+
+const NumaNodes = ({ numaNodes }: Props): JSX.Element => {
+  return (
+    <>
+      {numaNodes.length > 1 && (
+        <Tooltip
+          data-test="numa-warning"
+          message={
+            "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
+          }
+        >
+          <i className="p-icon--warning is-inline"></i>
+        </Tooltip>
+      )}
+      <span data-test="numa-nodes">{numaNodes.join(", ")}</span>
+    </>
+  );
+};
+
+export default NumaNodes;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NumaNodes";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.test.tsx
@@ -1,0 +1,26 @@
+import { mount } from "enzyme";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import { machineDisk as diskFactory } from "testing/factories";
+import { normaliseStorageDevice } from "../utils";
+import TagLinks from "./TagLinks";
+
+describe("TagLinks", () => {
+  it("shows links to filter machine list by storage tag", () => {
+    const disk = diskFactory({ tags: ["tag-1", "tag-2"] });
+    const normalised = normaliseStorageDevice(disk);
+    const wrapper = mount(
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+      >
+        <TagLinks tags={normalised.tags} />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find("Link").length).toBe(2);
+    expect(wrapper.find("Link").at(0).prop("to")).toBe(
+      "/machines?storage_tags=%3Dtag-1"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/TagLinks.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import { filtersToQueryString } from "app/machines/search";
+import type { NormalisedStorageDevice } from "../types";
+
+type Props = { tags: NormalisedStorageDevice["tags"] };
+
+const TagLinks = ({ tags }: Props): JSX.Element => {
+  return (
+    <>
+      {tags.map((tag, i) => {
+        const filter = filtersToQueryString({ storage_tags: `=${tag}` });
+        return (
+          <span key={tag}>
+            <Link to={`/machines${filter}`}>{tag}</Link>
+            {i !== tags.length - 1 && ", "}
+          </span>
+        );
+      })}
+    </>
+  );
+};
+
+export default TagLinks;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TagLinks/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagLinks";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
@@ -1,0 +1,49 @@
+import { mount } from "enzyme";
+import React from "react";
+
+import { scriptStatus } from "app/base/enum";
+import TestStatus from "./TestStatus";
+
+describe("TestStatus", () => {
+  it("can show passed test status", () => {
+    const wrapper = mount(<TestStatus testStatus={scriptStatus.PASSED} />);
+
+    expect(wrapper.find(".p-icon--success").exists()).toBe(true);
+  });
+
+  it("can show running test status", () => {
+    const wrapper = mount(<TestStatus testStatus={scriptStatus.RUNNING} />);
+
+    expect(wrapper.find(".p-icon--running").exists()).toBe(true);
+  });
+
+  it("can show pending test status", () => {
+    const wrapper = mount(<TestStatus testStatus={scriptStatus.PENDING} />);
+
+    expect(wrapper.find(".p-icon--pending").exists()).toBe(true);
+  });
+
+  it("can show error test status", () => {
+    const wrapper = mount(<TestStatus testStatus={scriptStatus.FAILED} />);
+
+    expect(wrapper.find(".p-icon--error").exists()).toBe(true);
+  });
+
+  it("can show timed out test status", () => {
+    const wrapper = mount(<TestStatus testStatus={scriptStatus.TIMEDOUT} />);
+
+    expect(wrapper.find(".p-icon--timed-out").exists()).toBe(true);
+  });
+
+  it("can show warning test status", () => {
+    const wrapper = mount(<TestStatus testStatus={scriptStatus.SKIPPED} />);
+
+    expect(wrapper.find(".p-icon--warning").exists()).toBe(true);
+  });
+
+  it("can show unknown test status", () => {
+    const wrapper = mount(<TestStatus testStatus={scriptStatus.NONE} />);
+
+    expect(wrapper.find(".p-icon--power-unknown").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+import { scriptStatus } from "app/base/enum";
+import type { NormalisedStorageDevice } from "../types";
+
+type Props = { testStatus: NormalisedStorageDevice["testStatus"] };
+
+const TestStatus = ({ testStatus }: Props): JSX.Element => {
+  switch (testStatus) {
+    case scriptStatus.PENDING:
+      return <i className="p-icon--pending"></i>;
+    case scriptStatus.RUNNING:
+    case scriptStatus.APPLYING_NETCONF:
+    case scriptStatus.INSTALLING:
+      return <i className="p-icon--running"></i>;
+    case scriptStatus.PASSED:
+      return (
+        <>
+          <i className="p-icon--success is-inline"></i>
+          <span>OK</span>
+        </>
+      );
+    case scriptStatus.FAILED:
+    case scriptStatus.ABORTED:
+    case scriptStatus.DEGRADED:
+    case scriptStatus.FAILED_APPLYING_NETCONF:
+    case scriptStatus.FAILED_INSTALLING:
+      return (
+        <>
+          <i className="p-icon--error is-inline"></i>
+          <span>Error</span>
+        </>
+      );
+    case scriptStatus.TIMEDOUT:
+      return (
+        <>
+          <i className="p-icon--timed-out is-inline"></i>
+          <span>Timed out</span>
+        </>
+      );
+    case scriptStatus.SKIPPED:
+      return (
+        <>
+          <i className="p-icon--warning is-inline"></i>
+          <span>Skipped</span>
+        </>
+      );
+    default:
+      return (
+        <>
+          <i className="p-icon--power-unknown is-inline"></i>
+          <span>Unknown</span>
+        </>
+      );
+  }
+};
+
+export default TestStatus;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TestStatus";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from "enzyme";
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import { machineDisk as diskFactory } from "testing/factories";
@@ -13,42 +12,6 @@ describe("UsedStorageTable", () => {
 
     expect(wrapper.find("[data-test='no-used']").text()).toBe(
       "No disk or partition has been fully utilised."
-    );
-  });
-
-  it("shows a warning if volume is spread over multiple NUMA nodes", () => {
-    const disks = [
-      diskFactory({
-        available_size: MIN_PARTITION_SIZE - 1,
-        numa_node: undefined,
-        numa_nodes: [0, 1],
-        type: "lvm-vg",
-      }),
-    ];
-    const { used } = separateStorageData(disks);
-    const wrapper = mount(<UsedStorageTable storageDevices={used} />);
-
-    expect(wrapper.find("[data-test='numa-warning']").prop("message")).toBe(
-      "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
-    );
-  });
-
-  it("can show links to filter machine list by storage tag", () => {
-    const disks = [
-      diskFactory({ available_size: MIN_PARTITION_SIZE - 1, tags: ["tag-1"] }),
-    ];
-    const { used } = separateStorageData(disks);
-    const wrapper = mount(
-      <MemoryRouter
-        initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-      >
-        <UsedStorageTable storageDevices={used} />
-      </MemoryRouter>
-    );
-
-    expect(wrapper.find("[data-test='health'] Link").exists()).toBe(true);
-    expect(wrapper.find("[data-test='health'] Link").prop("to")).toBe(
-      "/machines?storage_tags=%3Dtag-1"
     );
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.tsx
@@ -1,13 +1,15 @@
-import { MainTable, Tooltip } from "@canonical/react-components";
+import { MainTable } from "@canonical/react-components";
 import React from "react";
-import type { ReactNode } from "react";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
-import { formatBytes } from "app/utils";
+import BootStatus from "../BootStatus";
+import NumaNodes from "../NumaNodes";
+import TagLinks from "../TagLinks";
+import TestStatus from "../TestStatus";
 import type { NormalisedStorageDevice as StorageDevice } from "../types";
-import { formatTags, formatTestStatus, formatType } from "../MachineStorage";
+import { formatSize, formatType } from "../utils";
 
 const getSortValue = (
   sortKey: keyof StorageDevice,
@@ -115,16 +117,6 @@ const UsedStorageTable = ({ storageDevices }: Props): JSX.Element => {
           },
         ]}
         rows={sortedStorageDevices.map((storageDevice) => {
-          const size = formatBytes(storageDevice.size, "B");
-          let boot: ReactNode = "—";
-          if (storageDevice.type === "physical") {
-            boot = storageDevice.boot ? (
-              <i className="p-icon--tick"></i>
-            ) : (
-              <i className="p-icon--close"></i>
-            );
-          }
-
           return {
             columns: [
               {
@@ -149,7 +141,7 @@ const UsedStorageTable = ({ storageDevices }: Props): JSX.Element => {
                 content: (
                   <DoubleRow
                     data-test="boot"
-                    primary={boot}
+                    primary={<BootStatus storageDevice={storageDevice} />}
                     primaryClassName="u-align--center"
                   />
                 ),
@@ -158,7 +150,7 @@ const UsedStorageTable = ({ storageDevices }: Props): JSX.Element => {
                 content: (
                   <DoubleRow
                     data-test="size"
-                    primary={`${size.value} ${size.unit}`}
+                    primary={formatSize(storageDevice.size)}
                   />
                 ),
               },
@@ -171,19 +163,7 @@ const UsedStorageTable = ({ storageDevices }: Props): JSX.Element => {
                       storageDevice.parentType
                     )}
                     secondary={
-                      <>
-                        {storageDevice.numaNodes.length > 1 && (
-                          <Tooltip
-                            data-test="numa-warning"
-                            message={
-                              "This volume is spread over multiple NUMA nodes which may cause suboptimal performance."
-                            }
-                          >
-                            <i className="p-icon--warning is-inline"></i>
-                          </Tooltip>
-                        )}
-                        <span>{storageDevice.numaNodes.join(", ")}</span>
-                      </>
+                      <NumaNodes numaNodes={storageDevice.numaNodes} />
                     }
                   />
                 ),
@@ -193,11 +173,9 @@ const UsedStorageTable = ({ storageDevices }: Props): JSX.Element => {
                   <DoubleRow
                     data-test="health"
                     primary={
-                      storageDevice.type === "physical"
-                        ? formatTestStatus(storageDevice.testStatus)
-                        : "—"
+                      <TestStatus testStatus={storageDevice.testStatus} />
                     }
-                    secondary={formatTags(storageDevice.tags)}
+                    secondary={<TagLinks tags={storageDevice.tags} />}
                   />
                 ),
               },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -5,6 +5,8 @@ import {
   machinePartition as partitionFactory,
 } from "testing/factories";
 import {
+  formatSize,
+  formatType,
   hasMountedFilesystem,
   normaliseFilesystem,
   normaliseStorageDevice,
@@ -13,6 +15,44 @@ import {
 } from "./utils";
 
 describe("Machine storage utils", () => {
+  describe("formatSize", () => {
+    it("handles null case", () => {
+      expect(formatSize(null)).toBe("—");
+      expect(formatSize(0)).toBe("—");
+    });
+
+    it("can format size", () => {
+      expect(formatSize(100)).toBe("100 B");
+      expect(formatSize(10000)).toBe("10 KB");
+    });
+  });
+
+  describe("formatType", () => {
+    it("handles physical disks", () => {
+      expect(formatType("physical")).toBe("Physical");
+    });
+
+    it("handles partitions", () => {
+      expect(formatType("partition")).toBe("Partition");
+    });
+
+    it("handles volume groups", () => {
+      expect(formatType("lvm-vg")).toBe("Volume group");
+    });
+
+    it("handles logical volumes", () => {
+      expect(formatType("virtual", "lvm-vg")).toBe("Logical volume");
+    });
+
+    it("handles RAIDs", () => {
+      expect(formatType("virtual", "raid-0")).toBe("RAID 0");
+    });
+
+    it("handles ISCSIs", () => {
+      expect(formatType("iscsi")).toBe("ISCSI");
+    });
+  });
+
   describe("hasMountedFilesystem", () => {
     it("handles null case", () => {
       expect(hasMountedFilesystem(null)).toBe(false);

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -1,10 +1,57 @@
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import type { Disk, Filesystem, Partition } from "app/store/machine/types";
+import { formatBytes } from "app/utils";
 import type {
   NormalisedFilesystem,
   NormalisedStorageDevice,
   SeparatedDiskData,
 } from "./types";
+
+/**
+ * Formats a storage device's size for use in tables.
+ * @param size - the size of the storage device in bytes.
+ * @returns formatted size string.
+ */
+export const formatSize = (size: number | null): string => {
+  const formatted = !!size && formatBytes(size, "B");
+  return formatted ? `${formatted.value} ${formatted.unit}` : "—";
+};
+
+/**
+ * Formats a storage device's type for use in tables.
+ * @param type - the type of the storage device
+ * @param parentType - the type of the storage device's parent, if applicable
+ * @returns formatted type string
+ */
+export const formatType = (
+  type: NormalisedStorageDevice["type"],
+  parentType?: NormalisedStorageDevice["parentType"]
+): string => {
+  let typeToFormat = type;
+  if (type === "virtual" && !!parentType) {
+    if (parentType === "lvm-vg") {
+      return "Logical volume";
+    } else if (parentType.includes("raid-")) {
+      return `RAID ${parentType.split("-")[1]}`;
+    }
+    typeToFormat = parentType;
+  }
+
+  switch (typeToFormat) {
+    case "iscsi":
+      return "ISCSI";
+    case "lvm-vg":
+      return "Volume group";
+    case "partition":
+      return "Partition";
+    case "physical":
+      return "Physical";
+    case "virtual":
+      return "Virtual";
+    default:
+      return type;
+  }
+};
 
 /**
  * Returns whether a storage device has a mounted filesystem. If a filesystem is


### PR DESCRIPTION
## Done

- Created common components between storage tables
  - `BootStatus`
  - `NumaNodes`
  - `TagLinks`
  - `TestStatus`
- Moved a couple of formatting utils out of `MachineStorage` and into `utils`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the storage tab still shows the correct information for filesystems, available disks and partitions, and used disks and partitions

## Fixes

Fixes #1898 