### PR TITLE
feat(ui): build vmfs6 datastores list in machine storage tab

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -323,13 +323,16 @@ exports[`stricter compilation`] = {
       [45, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [49, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2924641761": [
-      [80, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    "src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx:487685193": [
+      [22, 6, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:3111838099": [
-      [146, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
-      [182, 30, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
-      [199, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
+    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2593787382": [
+      [126, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:4107166857": [
+      [150, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
+      [186, 10, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
+      [211, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:2502469861": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
@@ -1,0 +1,31 @@
+import { mount } from "enzyme";
+import React from "react";
+
+import {
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+} from "testing/factories";
+import { normaliseFilesystem } from "../utils";
+import DatastoresTable from "./DatastoresTable";
+
+describe("DatastoresTable", () => {
+  it("renders", () => {
+    const disk = diskFactory({
+      filesystem: fsFactory({
+        fstype: "vmfs6",
+        mount_point: "/vmfs/volumes/datastore",
+      }),
+      name: "im-a-datastore",
+      partitions: [],
+      size: 100,
+    });
+    const normalised = normaliseFilesystem(
+      disk.filesystem,
+      disk.name,
+      disk.size
+    );
+    const wrapper = mount(<DatastoresTable datastores={[normalised]} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -1,0 +1,77 @@
+import { MainTable } from "@canonical/react-components";
+import React from "react";
+
+import { NormalisedFilesystem } from "../types";
+import { formatSize, formatType } from "../utils";
+
+type Props = { datastores: NormalisedFilesystem[] };
+
+const DatastoresTable = ({ datastores }: Props): JSX.Element => {
+  return (
+    <>
+      <MainTable
+        defaultSort="name"
+        defaultSortDirection="ascending"
+        headers={[
+          {
+            content: "Name",
+            sortKey: "name",
+          },
+          {
+            content: "Filesystem",
+            sortKey: "fstype",
+          },
+          {
+            content: "Size",
+            sortKey: "size",
+          },
+          {
+            content: "Mount point",
+            sortKey: "mountPoint",
+          },
+          {
+            content: "Actions",
+            className: "u-align--right",
+          },
+        ]}
+        rows={datastores.map((datastore) => {
+          return {
+            columns: [
+              {
+                content: <span data-test="name">{datastore.name || "—"}</span>,
+              },
+              {
+                content: (
+                  <span data-test="type">{formatType(datastore.fstype)}</span>
+                ),
+              },
+              {
+                content: (
+                  <span data-test="size">{formatSize(datastore.size)}</span>
+                ),
+              },
+              {
+                content: (
+                  <span data-test="mount-point">{datastore.mountPoint}</span>
+                ),
+              },
+              {
+                content: "",
+                className: "u-align--right",
+              },
+            ],
+            key: datastore.id,
+            sortData: {
+              mountPoint: datastore.mountPoint,
+              name: datastore.name,
+              size: datastore.size,
+            },
+          };
+        })}
+        sortable
+      />
+    </>
+  );
+};
+
+export default DatastoresTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/__snapshots__/DatastoresTable.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/__snapshots__/DatastoresTable.test.tsx.snap
@@ -1,0 +1,259 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatastoresTable renders 1`] = `
+<DatastoresTable
+  datastores={
+    Array [
+      Object {
+        "fstype": "vmfs6",
+        "id": 1,
+        "mountOptions": "abc",
+        "mountPoint": "/vmfs/volumes/datastore",
+        "name": "im-a-datastore",
+        "size": 100,
+      },
+    ]
+  }
+>
+  <MainTable
+    defaultSort="name"
+    defaultSortDirection="ascending"
+    headers={
+      Array [
+        Object {
+          "content": "Name",
+          "sortKey": "name",
+        },
+        Object {
+          "content": "Filesystem",
+          "sortKey": "fstype",
+        },
+        Object {
+          "content": "Size",
+          "sortKey": "size",
+        },
+        Object {
+          "content": "Mount point",
+          "sortKey": "mountPoint",
+        },
+        Object {
+          "className": "u-align--right",
+          "content": "Actions",
+        },
+      ]
+    }
+    rows={
+      Array [
+        Object {
+          "columns": Array [
+            Object {
+              "content": <span
+                data-test="name"
+              >
+                im-a-datastore
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="type"
+              >
+                VMFS6
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="size"
+              >
+                100 B
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="mount-point"
+              >
+                /vmfs/volumes/datastore
+              </span>,
+            },
+            Object {
+              "className": "u-align--right",
+              "content": "",
+            },
+          ],
+          "key": 1,
+          "sortData": Object {
+            "mountPoint": "/vmfs/volumes/datastore",
+            "name": "im-a-datastore",
+            "size": 100,
+          },
+        },
+      ]
+    }
+    sortable={true}
+  >
+    <Table
+      className="p-main-table"
+      sortable={true}
+    >
+      <table
+        className="p-main-table p-table--sortable"
+        role="grid"
+      >
+        <thead>
+          <TableRow>
+            <tr
+              role="row"
+            >
+              <TableHeader
+                key="0"
+                onClick={[Function]}
+                sort="ascending"
+              >
+                <th
+                  aria-sort="ascending"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Name
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="1"
+                onClick={[Function]}
+                sort="none"
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Filesystem
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="2"
+                onClick={[Function]}
+                sort="none"
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Size
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="3"
+                onClick={[Function]}
+                sort="none"
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Mount point
+                </th>
+              </TableHeader>
+              <TableHeader
+                className="u-align--right"
+                key="4"
+                onClick={[Function]}
+              >
+                <th
+                  aria-sort="none"
+                  className="u-align--right"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Actions
+                </th>
+              </TableHeader>
+            </tr>
+          </TableRow>
+        </thead>
+        <tbody>
+          <TableRow
+            key="1"
+          >
+            <tr
+              role="row"
+            >
+              <TableCell
+                key="0"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="name"
+                  >
+                    im-a-datastore
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="1"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="type"
+                  >
+                    VMFS6
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="2"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="size"
+                  >
+                    100 B
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="3"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="mount-point"
+                  >
+                    /vmfs/volumes/datastore
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                className="u-align--right"
+                key="4"
+              >
+                <td
+                  aria-hidden={false}
+                  className="u-align--right"
+                  role="gridcell"
+                />
+              </TableCell>
+            </tr>
+          </TableRow>
+        </tbody>
+      </table>
+    </Table>
+  </MainTable>
+</DatastoresTable>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DatastoresTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -8,6 +8,7 @@ import * as hooks from "app/base/hooks";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -33,6 +34,7 @@ describe("MachineStorage", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
@@ -63,10 +65,54 @@ describe("MachineStorage", () => {
         </MemoryRouter>
       </Provider>
     );
+
     expect(wrapper.find("CacheSetsTable").exists()).toBe(true);
     expect(wrapper.find("CacheSetsTable [data-test='name']").at(0).text()).toBe(
       "quiche-cache"
     );
+  });
+
+  it("renders a list of datastores if any exist", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+            disks: [
+              diskFactory({
+                filesystem: fsFactory({
+                  fstype: "vmfs6",
+                  mount_point: "/path",
+                }),
+                name: "datastore1",
+                size: 100,
+              }),
+            ],
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/storage", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/storage"
+            component={() => <MachineStorage />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("DatastoresTable").exists()).toBe(true);
+    expect(
+      wrapper.find("DatastoresTable [data-test='name']").at(0).text()
+    ).toBe("datastore1");
   });
 
   it("sends an analytics event when clicking on the MAAS docs footer link", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -11,6 +11,7 @@ import type { RootState } from "app/store/root/types";
 import { separateStorageData } from "./utils";
 import AvailableStorageTable from "./AvailableStorageTable";
 import CacheSetsTable from "./CacheSetsTable";
+import DatastoresTable from "./DatastoresTable";
 import FilesystemsTable from "./FilesystemsTable";
 import UsedStorageTable from "./UsedStorageTable";
 
@@ -25,16 +26,28 @@ const MachineStorage = (): JSX.Element => {
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} storage`);
 
   if (machine && "disks" in machine && "special_filesystems" in machine) {
-    const { available, cacheSets, filesystems, used } = separateStorageData(
-      machine.disks,
-      machine.special_filesystems
-    );
+    const {
+      available,
+      cacheSets,
+      datastores,
+      filesystems,
+      used,
+    } = separateStorageData(machine.disks, machine.special_filesystems);
 
     return (
       <>
         <Strip shallow>
-          <h4>Filesystems</h4>
-          <FilesystemsTable filesystems={filesystems} />
+          {datastores.length > 0 ? (
+            <>
+              <h4>Datastores</h4>
+              <DatastoresTable datastores={datastores} />
+            </>
+          ) : (
+            <>
+              <h4>Filesystems</h4>
+              <FilesystemsTable filesystems={filesystems} />
+            </>
+          )}
         </Strip>
         {cacheSets.length > 0 && (
           <Strip shallow>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
@@ -28,6 +28,7 @@ export type NormalisedStorageDevice = {
 export type SeparatedDiskData = {
   available: NormalisedStorageDevice[];
   cacheSets: NormalisedStorageDevice[];
+  datastores: NormalisedFilesystem[];
   filesystems: NormalisedFilesystem[];
   used: NormalisedStorageDevice[];
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -348,5 +348,30 @@ describe("Machine storage utils", () => {
       expect(cacheSets.length).toBe(1);
       expect(cacheSets[0].name).toBe("cache0");
     });
+
+    it("can separate out datastores", () => {
+      const disks = [
+        diskFactory({
+          filesystem: fsFactory({
+            fstype: "vmfs6",
+            mount_point: "/vmfs/volumes/datastore",
+          }),
+          name: "im-a-datastore",
+          partitions: [],
+        }),
+        diskFactory({
+          filesystem: fsFactory({
+            fstype: "fat32",
+            mount_point: "/",
+          }),
+          name: "not-a-datastore",
+          partitions: [],
+        }),
+      ];
+      const { datastores } = separateStorageData(disks);
+
+      expect(datastores.length).toBe(1);
+      expect(datastores[0].mountPoint).toBe("/vmfs/volumes/datastore");
+    });
   });
 });


### PR DESCRIPTION
## Done

- Added datastores list to machine storage, which should only appear if the machine has its storage layout set to "vmfs6"

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Change a machine's storage layout to VMFS6 using the angular client (fun-mammal on bolla already has this layout)
- Check that a datastore table shows instead of a filesystems table
- Check that the data is identical between the angular and react versions

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2170

## Screenshot
![Screenshot_2020-11-18 fun-mammal maas storage bolla MAAS](https://user-images.githubusercontent.com/25733845/99484047-4ba23480-29ab-11eb-8601-358f7529b3ea.png)

