### PR TITLE
Add noderesult slice

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -58,9 +58,6 @@ exports[`stricter compilation`] = {
       [31, 4, 11, "Type \'number\' is not assignable to type \'null\'.", "1179509236"],
       [33, 4, 12, "Type \'number\' is not assignable to type \'null\'.", "304100367"]
     ],
-    "src/app/base/components/SectionHeader/SectionHeader.tsx:1865526444": [
-      [73, 16, 3, "Type \'string | number | null\' is not assignable to type \'string | number | undefined\'.\\n  Type \'null\' is not assignable to type \'string | number | undefined\'.", "193424690"]
-    ],
     "src/app/base/components/TagSelector/TagSelector.test.tsx:846439984": [
       [6, 6, 4, "Variable \'tags\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2087952548"],
       [21, 14, 4, "Variable \'tags\' implicitly has an \'any\' type.", "2087952548"],
@@ -81,7 +78,7 @@ exports[`stricter compilation`] = {
       [214, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1489314622": [
-      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [1, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [37, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [38, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [39, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -419,9 +416,12 @@ exports[`stricter compilation`] = {
     "src/app/store/general/selectors/machineActions.test.ts:3658604617": [
       [89, 10, 4, "Type \'{ name: string; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: string; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: string; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'string\' is not assignable to type \'MachineActionName\'.", "2087377941"]
     ],
-    "src/app/store/machine/slice.ts:10489408": [
-      [302, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'{ errors: any; items: ({ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; system_id: string; ... 41 more ...; zone: { ...; }; } | { ...; })[]; loaded: boolean; loading: boolean; saved: boolean; s...\' is missing the following properties from type \'{ active: string | null; errors: any; items: ({ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; ... 42 more ...; zone: { ...; }; } | { ...; })[]; ... 5 more ...; statuses: { ...; }; }\': active, selected, statuses", "4102082497"],
-      [304, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ active: null; selected: never[]; statuses: {}; }\' is missing the following properties from type \'MachineState\': errors, items, loaded, loading, and 2 more.", "1433951465"]
+    "src/app/store/machine/slice.ts:2364558725": [
+      [302, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, selected, statuses", "4102082497"],
+      [306, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ active: null; selected: never[]; statuses: {}; }\' is missing the following properties from type \'GenericState<Machine, any>\': errors, items, loaded, loading, and 2 more.", "1433951465"]
+    ],
+    "src/app/store/noderesult/slice.ts:1885676869": [
+      [55, 4, 10, "Type \'(state: NodeResultState, action: PayloadAction<NodeResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<NodeResultState, { payload: any; type: string; }> | CaseReducerWithPrepare<NodeResultState, PayloadAction<any, string, any, any>>\'.\\n  Type \'(state: NodeResultState, action: PayloadAction<NodeResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<NodeResultState, { payload: any; type: string; }>\'.\\n    Types of parameters \'action\' and \'action\' are incompatible.\\n      Type \'{ payload: any; type: string; }\' is not assignable to type \'PayloadAction<NodeResult[], string, GenericItemMeta<ItemMeta>, never>\'.\\n        Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.", "2529327088"]
     ],
     "src/app/store/notification/selectors.ts:3467721382": [
       [25, 39, 12, "Object is possibly \'undefined\'.", "964199671"]
@@ -429,9 +429,9 @@ exports[`stricter compilation`] = {
     "src/app/store/pod/reducers.test.ts:25266970": [
       [77, 38, 10, "Expected 1 arguments, but got 0.", "2565503122"]
     ],
-    "src/app/store/pod/slice.ts:995813338": [
-      [55, 56, 11, "Type \'PodReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Pod, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'{ errors: any; items: ({ id: number; architectures: string[]; available: { cores: number; local_storage: number; local_storage_gb: string; memory: number; memory_gb: string; }; capabilities: string[]; ... 24 more ...; zone: number; } | { ...; })[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is missing the following properties from type \'{ active: number | null; selected: number[]; statuses: { [x: number]: { composing: boolean; deleting: boolean; refreshing: boolean; }; }; errors: any; items: ({ id: number; architectures: string[]; available: { ...; }; ... 25 more ...; zone: number; } | { ...; })[]; loaded: boolean; loading: boolean; saved: boolean;...\': active, selected, statuses", "1022550047"],
-      [56, 16, 71, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'PodState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ active: null; selected: never[]; statuses: {}; }\' is missing the following properties from type \'GenericState<Pod, any>\': errors, items, loaded, loading, and 2 more.", "3283281399"]
+    "src/app/store/pod/slice.ts:1150649699": [
+      [55, 56, 11, "Type \'PodReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Pod, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Pod, any>>\' is missing the following properties from type \'WritableDraft<PodState>\': active, selected, statuses", "1022550047"],
+      [57, 16, 71, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'PodState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ active: null; selected: never[]; statuses: {}; }\' is missing the following properties from type \'GenericState<Pod, any>\': errors, items, loaded, loading, and 2 more.", "3283281399"]
     ],
     "src/app/store/resourcepool/actions.test.ts:9201512": [
       [71, 52, 24, "Expected 1 arguments, but got 2.", "3295119724"]
@@ -471,28 +471,28 @@ exports[`stricter compilation`] = {
       [197, 11, 5, "Variable \'state\' implicitly has an \'any\' type.", "195031250"],
       [205, 13, 5, "Variable \'state\' implicitly has an \'any\' type.", "195031250"]
     ],
-    "src/app/store/user/slice.ts:88241433": [
-      [9, 59, 12, "Type \'SliceCaseReducers<UserState>\' does not satisfy the constraint \'SliceCaseReducers<GenericState<User, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<UserState, { payload: any; type: string; }> | CaseReducerWithPrepare<UserState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<User, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<UserState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<User, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<UserState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Property \'auth\' is missing in type \'{ errors: any; items: { id: number; completed_intro: boolean; email: string; global_permissions: string[]; is_local: boolean; is_superuser: boolean; last_name: string; last_login: string; machines_count: number; sshkeys_count: number; username: string; }[]; loaded: boolean; loading: boolean; saved: boolean; saving: ...\' but required in type \'{ auth: { errors: any; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; user: { id: number; completed_intro: boolean; email: string; global_permissions: string[]; is_local: boolean; ... 5 more ...; username: string; }; }; ... 5 more ...; saving: boolean; }\'.", "1934442805"]
+    "src/app/store/user/slice.ts:951706592": [
+      [9, 59, 12, "Type \'SliceCaseReducers<UserState>\' does not satisfy the constraint \'SliceCaseReducers<GenericState<User, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<UserState, { payload: any; type: string; }> | CaseReducerWithPrepare<UserState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<User, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<UserState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<User, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<UserState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Property \'auth\' is missing in type \'WritableDraft<GenericState<User, any>>\' but required in type \'WritableDraft<UserState>\'.", "1934442805"]
     ],
-    "src/app/store/utils/slice.test.ts:1988551168": [
-      [250, 10, 6, "Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'{ errors: unknown; items: ({ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; system_id: string; ... 41 more ...; zone: { ...; }; } | ... 20 more ... | { ...; })[]; loaded: boolean; loading: bool...\' is not assignable to type \'TokenState\'.\\n        Types of property \'items\' are incompatible.\\n          Type \'({ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; system_id: string; tags: string[]; ... 40 more ...; zone: { ...; }; } | ... 20 more ... | { ...; })[]\' is not assignable to type \'Token[]\'.\\n            Type \'{ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; system_id: string; tags: string[]; ... 40 more ...; zone: { ...; }; } | ... 20 more ... | { ...; }\' is not assignable to type \'Token\'.\\n              Type \'{ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; system_id: string; tags: string[]; ... 40 more ...; zone: { ...; }; }\' is not assignable to type \'Token\'.\\n                Type \'{ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; system_id: string; tags: string[]; ... 40 more ...; zone: { ...; }; }\' is missing the following properties from type \'{ consumer: TokenConsumer; key: string; secret: string; }\': consumer, key, secret", "1551012726"],
-      [256, 53, 8, "Expected 1 arguments, but got 0.", "1130710519"],
-      [270, 10, 10, "Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'{ errors: unknown; items: ({ id: number; actions: string[]; domain: { id: number; name: string; }; hostname: string; fqdn: string; link_type: string; node_type_display: string; permissions: string[]; system_id: string; ... 41 more ...; zone: { ...; }; } | ... 20 more ... | { ...; })[]; loaded: boolean; loading: bool...\' is not assignable to type \'TokenState\'.", "3510326721"],
-      [394, 10, 7, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "1380666520"],
-      [395, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "662888088"],
-      [396, 10, 14, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "368191931"],
-      [397, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "678288096"]
+    "src/app/store/utils/slice.test.ts:1198843864": [
+      [252, 10, 6, "Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'WritableDraft<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>>\' is not assignable to type \'GenericState<Token, any>\'.\\n        Types of property \'items\' are incompatible.\\n          Type \'(WritableDraft<BaseMachine> | WritableDraft<Subnet> | WritableDraft<ResourcePool> | WritableDraft<...> | ... 17 more ... | WritableDraft<...>)[]\' is not assignable to type \'Token[]\'.\\n            Type \'WritableDraft<BaseMachine> | WritableDraft<Subnet> | WritableDraft<ResourcePool> | WritableDraft<...> | ... 17 more ... | WritableDraft<...>\' is not assignable to type \'Token\'.\\n              Type \'WritableDraft<BaseMachine>\' is not assignable to type \'Token\'.\\n                Type \'WritableDraft<BaseMachine>\' is missing the following properties from type \'{ consumer: TokenConsumer; key: string; secret: string; }\': consumer, key, secret", "1551012726"],
+      [258, 53, 8, "Expected 1 arguments, but got 0.", "1130710519"],
+      [273, 10, 10, "Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'WritableDraft<GenericState<User | Notification | Device | Subnet | BaseMachine | Controller | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>>\' is not assignable to type \'GenericState<Token, any>\'.", "3510326721"],
+      [399, 10, 7, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "1380666520"],
+      [400, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "662888088"],
+      [401, 10, 14, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "368191931"],
+      [402, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "678288096"]
     ],
-    "src/app/store/utils/slice.ts:237729359": [
-      [162, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [202, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [240, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [254, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [259, 2, 181, "Type \'Slice<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>, \\"machine\\" | ... 21 more ... | \\"zone\\">\' is not assignable to type \'Slice<GenericState<I, E>, R, \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"notification\\" | ... 12 more ... | \\"zone\\">\'.\\n  The types returned by \'reducer(...)\' are incompatible between these types.\\n    Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.\\n      Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.", "3918538176"],
-      [265, 4, 8, "Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup: (state: Generi...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>>\'.\\n  Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup: (state: Generi...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>>\'.\\n    Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup: (state: Generi...\' is not assignable to type \'SliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\'.\\n      Property \'fetchStart\' is incompatible with index signature.\\n        Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { ...; }> | CaseReducerWithPrepare<...>\'.\\n          Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { ...; }>\'.\\n            Types of parameters \'state\' and \'state\' are incompatible.\\n              Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: Draft<E>; items: Draft<I>[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.\\n                Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.\\n                  Types of property \'errors\' are incompatible.\\n                    Type \'null\' is not assignable to type \'E\'.\\n                      \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "2838615652"],
-      [352, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ [x: string]: { aborting: boolean; acquiring: boolean; applyingStorageLayout: boolean; checkingPower: boolean; commissioning: boolean; deleting: boolean; deploying: boolean; enteringRescueMode: boolean; ... 12 more ...; unlocking: boolean; }; } | { ...; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ [x: string]: { aborting: boolean; acquiring: boolean; applyingStorageLayout: boolean; checkingPower: boolean; commissioning: boolean; deleting: boolean; deploying: boolean; enteringRescueMode: boolean; ... 12 more ...; unlocking: boolean; }; } | { ...; }\'.", "3883490613"],
-      [371, 27, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ [x: string]: { aborting: boolean; acquiring: boolean; applyingStorageLayout: boolean; checkingPower: boolean; commissioning: boolean; deleting: boolean; deploying: boolean; enteringRescueMode: boolean; ... 12 more ...; unlocking: boolean; }; } | { ...; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ [x: string]: { aborting: boolean; acquiring: boolean; applyingStorageLayout: boolean; checkingPower: boolean; commissioning: boolean; deleting: boolean; deploying: boolean; enteringRescueMode: boolean; ... 12 more ...; unlocking: boolean; }; } | { ...; }\'.", "3883490613"],
-      [395, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ [x: string]: { aborting: boolean; acquiring: boolean; applyingStorageLayout: boolean; checkingPower: boolean; commissioning: boolean; deleting: boolean; deploying: boolean; enteringRescueMode: boolean; ... 12 more ...; unlocking: boolean; }; } | { ...; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ [x: string]: { aborting: boolean; acquiring: boolean; applyingStorageLayout: boolean; checkingPower: boolean; commissioning: boolean; deleting: boolean; deploying: boolean; enteringRescueMode: boolean; ... 12 more ...; unlocking: boolean; }; } | { ...; }\'.", "3883490613"]
+    "src/app/store/utils/slice.ts:4209978183": [
+      [166, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [206, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [244, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [255, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [260, 2, 181, "Type \'Slice<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>, \\"machine\\" | ... 22 more ... | \\"zone\\">\' is not assignable to type \'Slice<GenericState<I, E>, R, \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | ... 13 more ... | \\"zone\\">\'.\\n  The types returned by \'reducer(...)\' are incompatible between these types.\\n    Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.\\n      Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.", "3918538176"],
+      [266, 4, 8, "Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>>\'.\\n  Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>>\'.\\n    Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'SliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\'.\\n      Property \'fetchStart\' is incompatible with index signature.\\n        Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { ...; }> | CaseReducerWithPrepare<...>\'.\\n          Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { ...; }>\'.\\n            Types of parameters \'state\' and \'state\' are incompatible.\\n              Type \'WritableDraft<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }> | WritableDraft<{ errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\' is not assignable to type \'GenericState<I, E>\'.\\n                Type \'WritableDraft<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\' is not assignable to type \'GenericState<I, E>\'.\\n                  Types of property \'errors\' are incompatible.\\n                    Type \'null\' is not assignable to type \'E\'.\\n                      \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "2838615652"],
+      [353, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
+      [372, 27, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
+      [396, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"]
     ],
     "src/app/utils/getCookie.ts:940992619": [
       [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
@@ -506,11 +506,11 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:2660496186": [
       [10, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:3487124000": [
-      [234, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
-      [312, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2158674347"],
-      [314, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<PoorMansUnknown>, string>\'.", "2087809207"],
-      [319, 2, 6, "Type \'null\' is not assignable to type \'\\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | ArrayFactory<never> | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<PoorMansUnknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:3923575803": [
+      [235, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
+      [317, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
+      [319, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
+      [324, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -524,29 +524,29 @@ exports[`no TSFixMe types`] = {
       [1, 13, 8, "RegExp match", "1152173309"],
       [30, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/config/types.ts:1539107873": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [11, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/controller/types.ts:3342242320": [
+    "src/app/store/config/types.ts:4138985665": [
       [1, 13, 8, "RegExp match", "1152173309"],
-      [13, 9, 8, "RegExp match", "1152173309"]
+      [11, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/device/types.ts:2870407164": [
+    "src/app/store/controller/types.ts:3920578608": [
       [2, 13, 8, "RegExp match", "1152173309"],
-      [19, 9, 8, "RegExp match", "1152173309"]
+      [13, 54, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/dhcpsnippet/types.ts:2041796238": [
-      [4, 13, 8, "RegExp match", "1152173309"],
-      [24, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/device/types.ts:2393841436": [
+      [3, 13, 8, "RegExp match", "1152173309"],
+      [19, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/domain/types.ts:2438698325": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [16, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/dhcpsnippet/types.ts:3769834766": [
+      [5, 13, 8, "RegExp match", "1152173309"],
+      [24, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/fabric/types.ts:1013745005": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [14, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/domain/types.ts:2417784725": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [16, 46, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/fabric/types.ts:693854797": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [14, 46, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/general/selectors/utils.ts:4114489802": [
       [1, 13, 8, "RegExp match", "1152173309"],
@@ -566,96 +566,104 @@ exports[`no TSFixMe types`] = {
       [166, 9, 8, "RegExp match", "1152173309"],
       [175, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/licensekeys/types.ts:2257386395": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [11, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/licensekeys/types.ts:2302677435": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:4161201506": [
+    "src/app/store/machine/types.ts:3534572008": [
+      [4, 13, 8, "RegExp match", "1152173309"],
+      [305, 25, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/noderesult/selectors.ts:2110253132": [
       [3, 13, 8, "RegExp match", "1152173309"],
-      [302, 9, 8, "RegExp match", "1152173309"]
+      [57, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/notification/types.ts:2586887406": [
+    "src/app/store/noderesult/types.ts:3402346236": [
       [1, 13, 8, "RegExp match", "1152173309"],
-      [28, 9, 8, "RegExp match", "1152173309"]
+      [43, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/packagerepository/types.ts:3950087859": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [20, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/notification/types.ts:3327433646": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [28, 58, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/packagerepository/types.ts:2816846035": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [20, 68, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/pod/types.ts:251284093": [
       [2, 13, 8, "RegExp match", "1152173309"],
       [119, 21, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/resourcepool/types.ts:4045616415": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [15, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/resourcepool/types.ts:2790999903": [
+      [1, 13, 8, "RegExp match", "1152173309"],
+      [15, 58, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scriptresults/selectors.ts:2575868080": [
       [3, 13, 8, "RegExp match", "1152173309"],
       [52, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresults/types.ts:276248988": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [33, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/scripts/types.ts:2264904018": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [15, 14, 8, "RegExp match", "1152173309"],
-      [20, 14, 8, "RegExp match", "1152173309"],
-      [52, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/service/types.ts:3748751936": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [10, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/space/types.ts:3394511147": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [13, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/sshkey/types.ts:2805027575": [
+    "src/app/store/scriptresults/types.ts:3922382396": [
       [2, 13, 8, "RegExp match", "1152173309"],
-      [19, 9, 8, "RegExp match", "1152173309"]
+      [33, 60, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/sslkey/types.ts:518217640": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [13, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/scripts/types.ts:3956382354": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [16, 14, 8, "RegExp match", "1152173309"],
+      [21, 14, 8, "RegExp match", "1152173309"],
+      [52, 48, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/service/types.ts:1265104096": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [10, 48, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/space/types.ts:2063576235": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [13, 44, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/sshkey/types.ts:4098552279": [
+      [3, 13, 8, "RegExp match", "1152173309"],
+      [19, 46, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/sslkey/types.ts:2644033832": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [13, 46, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/status/types.ts:3358556468": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [5, 22, 8, "RegExp match", "1152173309"],
       [8, 8, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/subnet/types.ts:587705301": [
+    "src/app/store/subnet/types.ts:2671265173": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [46, 46, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/tag/types.ts:790258888": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [13, 40, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/token/types.ts:2001195164": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [15, 44, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/user/types.ts:3113131478": [
       [1, 13, 8, "RegExp match", "1152173309"],
-      [46, 9, 8, "RegExp match", "1152173309"]
+      [18, 9, 8, "RegExp match", "1152173309"],
+      [28, 22, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/tag/types.ts:2533761736": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [13, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/token/types.ts:4281996604": [
-      [1, 13, 8, "RegExp match", "1152173309"],
-      [15, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/user/types.ts:3473477916": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [17, 9, 8, "RegExp match", "1152173309"],
-      [27, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/utils/slice.ts:237729359": [
+    "src/app/store/utils/slice.ts:4209978183": [
       [12, 13, 8, "RegExp match", "1152173309"],
-      [140, 23, 8, "RegExp match", "1152173309"],
-      [180, 23, 8, "RegExp match", "1152173309"],
-      [286, 20, 8, "RegExp match", "1152173309"],
-      [321, 24, 8, "RegExp match", "1152173309"]
+      [144, 23, 8, "RegExp match", "1152173309"],
+      [184, 23, 8, "RegExp match", "1152173309"],
+      [287, 20, 8, "RegExp match", "1152173309"],
+      [322, 24, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/vlan/types.ts:2757450993": [
+    "src/app/store/vlan/types.ts:2480104305": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [21, 42, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/zone/types.ts:3483169305": [
       [1, 13, 8, "RegExp match", "1152173309"],
-      [21, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/zone/types.ts:80244761": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [14, 9, 8, "RegExp match", "1152173309"]
+      [14, 42, 8, "RegExp match", "1152173309"]
     ]
   }`
 };

--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -138,6 +138,14 @@ Object {
   "messages": Object {
     "items": Array [],
   },
+  "noderesult": Object {
+    "errors": null,
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
   "notification": Object {
     "errors": null,
     "items": Array [],

--- a/ui/src/app/base/sagas/websockets.js
+++ b/ui/src/app/base/sagas/websockets.js
@@ -347,8 +347,8 @@ export function* sendMessage(socketClient, action, nextActionCreators) {
   let params = payload ? payload.params : null;
   const { method, model } = meta;
   // If method is 'list' and data has loaded/is loading, do not fetch again
-  // unless this is fetching a new batch.
-  if (method.endsWith("list") && (!params || !params.start)) {
+  // unless this is fetching a new batch, unless 'nocache' is specified
+  if (method.endsWith("list") && (!params || !params.start) && !meta?.nocache) {
     if (isLoaded(model)) {
       return;
     }

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -142,6 +142,23 @@ describe("websocket sagas", () => {
     expect(saga.next().done).toBe(true);
   });
 
+  it("fetches list methods if no-cache is set", () => {
+    const action = {
+      type: "FETCH_TEST",
+      meta: {
+        model: "test",
+        method: "test.list",
+        type: MESSAGE_TYPES.REQUEST,
+        nocache: true,
+      },
+    };
+    const previous = sendMessage(socketClient, action);
+    previous.next();
+    const saga = sendMessage(socketClient, action);
+    // The saga should not have finished.
+    expect(saga.next().done).toBe(false);
+  });
+
   it("allows batch messages even if data has already been fetched", () => {
     const action = {
       type: "FETCH_TEST",

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -7,8 +7,8 @@ import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
-import { actions as scriptResultsActions } from "app/store/scriptresults";
-import scriptResultsSelectors from "app/store/scriptresults/selectors";
+import { actions as nodeResultActions } from "app/store/noderesult";
+import nodeResultSelectors from "app/store/noderesult/selectors";
 
 const MachineTests = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -18,19 +18,33 @@ const MachineTests = (): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
-
   useWindowTitle(`${machine?.fqdn || "Machine"} tests`);
 
-  const results = useSelector((state: RootState) =>
-    scriptResultsSelectors.getByIds(state, [id])
+  const result = useSelector((state: RootState) =>
+    nodeResultSelectors.get(state, id)
+  );
+
+  const loading = useSelector((state: RootState) =>
+    nodeResultSelectors.loading(state)
   );
 
   useEffect(() => {
-    dispatch(scriptResultsActions.get([id]));
-  }, [dispatch, id]);
+    if (!result && !loading) {
+      dispatch(nodeResultActions.get(id));
+    }
+  }, [dispatch, result, loading, id]);
 
-  if (results) {
-    return <>{results.map((result) => result.results[0].name)}</>;
+  if (result) {
+    const testResults = result.results.filter(
+      (result) => result.result_type === 2
+    );
+    return (
+      <ul>
+        {testResults.map((result) => (
+          <li key={result.id}>{result.name}</li>
+        ))}
+      </ul>
+    );
   }
   return <Spinner text="Loading..." />;
 };

--- a/ui/src/app/store/noderesult/index.ts
+++ b/ui/src/app/store/noderesult/index.ts
@@ -1,0 +1,1 @@
+export { default, actions } from "./slice";

--- a/ui/src/app/store/noderesult/reducers.test.ts
+++ b/ui/src/app/store/noderesult/reducers.test.ts
@@ -1,0 +1,64 @@
+import {
+  nodeResult as nodeResultFactory,
+  nodeResultState as nodeResultStateFactory,
+} from "testing/factories";
+import reducers, { actions } from "./slice";
+
+describe("script results reducer", () => {
+  it("returns the initial state", () => {
+    expect(reducers(undefined, { type: "" })).toEqual({
+      errors: null,
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+    });
+  });
+
+  it("reduces getStart", () => {
+    const nodeResultState = nodeResultStateFactory({
+      items: [],
+      loading: false,
+    });
+
+    expect(reducers(nodeResultState, actions.getStart(null))).toEqual(
+      nodeResultStateFactory({ loading: true })
+    );
+  });
+
+  it("reduces getSuccess", () => {
+    const newNodeResult = nodeResultFactory();
+
+    const nodeResultState = nodeResultStateFactory({
+      items: [],
+      loading: true,
+    });
+
+    // meta is set by a redux saga, so we insert it manually here
+    const actionResult = {
+      meta: { item: { system_id: "machine1" } },
+      ...actions.getSuccess([newNodeResult]),
+    };
+
+    expect(reducers(nodeResultState, actionResult)).toEqual(
+      nodeResultStateFactory({
+        items: [{ id: "machine1", results: [newNodeResult] }],
+        loading: false,
+      })
+    );
+  });
+
+  it("reduces getError", () => {
+    const nodeResultState = nodeResultStateFactory({ loading: true });
+
+    expect(
+      reducers(nodeResultState, actions.getError("Could not get node results"))
+    ).toEqual(
+      nodeResultStateFactory({
+        errors: "Could not get node results",
+        loading: false,
+      })
+    );
+  });
+});

--- a/ui/src/app/store/noderesult/selectors.test.tsx
+++ b/ui/src/app/store/noderesult/selectors.test.tsx
@@ -1,0 +1,86 @@
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  nodeResult as nodeResultFactory,
+  nodeResultState as nodeResultStateFactory,
+} from "testing/factories";
+import selectors from "./selectors";
+
+describe("nodeResults selectors", () => {
+  it("returns all node results", () => {
+    const fooResults = [nodeResultFactory(), nodeResultFactory()];
+    const barResults = [nodeResultFactory(), nodeResultFactory()];
+
+    const state = rootStateFactory({
+      noderesult: nodeResultStateFactory({
+        items: [
+          { id: "foo", results: fooResults },
+          { id: "bar", results: barResults },
+        ],
+      }),
+    });
+
+    expect(selectors.all(state)).toEqual([
+      {
+        id: "foo",
+        results: fooResults,
+      },
+      { id: "bar", results: barResults },
+    ]);
+  });
+
+  it("returns node results for given machines ids", () => {
+    const result1 = nodeResultFactory({ id: 1 });
+    const result2 = nodeResultFactory({ id: 2 });
+    const result3 = nodeResultFactory({ id: 3 });
+
+    const items = [
+      machineFactory({ system_id: "foo" }),
+      machineFactory({ system_id: "bar" }),
+      machineFactory({ system_id: "baz" }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items,
+      }),
+      noderesult: nodeResultStateFactory({
+        items: [
+          {
+            id: "foo",
+            results: [result1],
+          },
+          {
+            id: "bar",
+            results: [result2],
+          },
+          { id: "baz", results: [result3] },
+        ],
+      }),
+    });
+
+    expect(selectors.getByIds(state, ["foo", "baz"])).toHaveLength(2);
+    expect(selectors.getByIds(state, ["foo", "bar"])[0].id).toEqual("foo");
+    expect(selectors.getByIds(state, ["foo", "baz"])[1].id).toEqual("baz");
+  });
+
+  it("returns the loading state", () => {
+    const state = rootStateFactory({
+      noderesult: nodeResultStateFactory({
+        loading: true,
+      }),
+    });
+
+    expect(selectors.loading(state)).toEqual(true);
+  });
+
+  it("returns the errors state", () => {
+    const state = rootStateFactory({
+      noderesult: nodeResultStateFactory({
+        errors: "Data is incorrect",
+      }),
+    });
+
+    expect(selectors.errors(state)).toStrictEqual("Data is incorrect");
+  });
+});

--- a/ui/src/app/store/noderesult/selectors.ts
+++ b/ui/src/app/store/noderesult/selectors.ts
@@ -1,0 +1,80 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import type { RootState } from "app/store/root/types";
+import type { TSFixMe } from "app/base/types";
+import { NodeResults } from "./types";
+import { Machine } from "../machine/types";
+
+/**
+ * Returns list of all node results.
+ * @param state - Redux state
+ * @returns Node results
+ */
+const all = (state: RootState): NodeResults[] => state.noderesult.items;
+
+/**
+ * Returns a node result by machine id
+ * @param state - Redux state
+ * @param machineId - machine system id
+ * @returns Node results
+ */
+const get = createSelector(
+  [all, (_: RootState, machineID: Machine["system_id"]) => machineID],
+  (noderesults, machineID) =>
+    noderesults.find((result) => machineID === result.id)
+);
+
+/**
+ * Returns node results by machine ids
+ * @param state - Redux state
+ * @returns Node results
+ */
+const getByIds = createSelector(
+  [all, (_: RootState, machineIDs: Machine["system_id"][]) => machineIDs],
+  (noderesults, machineIDs) =>
+    noderesults.filter((result) => machineIDs.includes(result.id))
+);
+
+/**
+ * Returns true if node results are loading
+ * @param state - Redux state
+ * @returns {NodeResultState["loading"]} Node results are loading
+ */
+
+const loading = (state: RootState): boolean => state.noderesult.loading;
+
+/**
+ * Returns true if node results have saved
+ * @param state - Redux state
+ * @returns {NodeResultState["saved"]} Node results have saved
+ */
+const saved = (state: RootState): boolean => state.noderesult.saved;
+
+/**
+ * Returns node result errors.
+ * @param state - The redux state.
+ * @returns {NodeResultState["errors"]} Errors for a node result.
+ */
+const errors = (state: RootState): TSFixMe => state.noderesult.errors;
+
+/**
+ * Returns true if node results have errors
+ * @param state - Redux state
+ * @returns {Boolean} Node results have errors
+ */
+const hasErrors = createSelector(
+  [errors],
+  (errors) => Object.entries(errors).length > 0
+);
+
+const noderesult = {
+  all,
+  get,
+  getByIds,
+  errors,
+  hasErrors,
+  loading,
+  saved,
+};
+
+export default noderesult;

--- a/ui/src/app/store/noderesult/slice.ts
+++ b/ui/src/app/store/noderesult/slice.ts
@@ -1,0 +1,79 @@
+import { PayloadAction, SliceCaseReducers } from "@reduxjs/toolkit";
+
+import type { NodeResult, NodeResults, NodeResultState } from "./types";
+import { generateSlice, GenericItemMeta, GenericSlice } from "../utils";
+import { Machine } from "app/store/machine/types";
+
+type NodeResultReducers = SliceCaseReducers<NodeResultState>;
+
+type ItemMeta = {
+  system_id: string;
+};
+
+export type NodeResultSlice = GenericSlice<
+  NodeResultState,
+  NodeResults,
+  NodeResultReducers
+>;
+
+const nodeResultSlice = generateSlice<
+  NodeResults,
+  NodeResultState["errors"],
+  NodeResultReducers,
+  "id"
+>({
+  indexKey: "id",
+  name: "noderesult",
+  reducers: {
+    get: {
+      prepare: (machineID: Machine["system_id"]) => ({
+        meta: {
+          model: "noderesult",
+          method: "list",
+          nocache: true,
+        },
+        payload: {
+          params: {
+            system_id: machineID,
+          },
+        },
+      }),
+      reducer: () => {
+        // no state changes needed
+      },
+    },
+    getStart: (state: NodeResultState, _action: PayloadAction<null>) => {
+      state.loading = true;
+    },
+    getError: (
+      state: NodeResultState,
+      action: PayloadAction<NodeResultState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.loading = false;
+      state.saving = false;
+    },
+    getSuccess: (
+      state: NodeResultState,
+      action: PayloadAction<NodeResult[], string, GenericItemMeta<ItemMeta>>
+    ) => {
+      const results = action.payload;
+      const machineId = action.meta.item.system_id;
+      // If the item already exists, update it, otherwise
+      // add it to the store.
+      const i = state.items.findIndex(
+        (draftItem: NodeResults) => draftItem.id === machineId
+      );
+      if (i !== -1) {
+        state.items[i] = { id: machineId, results };
+      } else {
+        state.items.push({ id: machineId, results });
+      }
+      state.loading = false;
+    },
+  },
+}) as NodeResultSlice;
+
+export const { actions } = nodeResultSlice;
+
+export default nodeResultSlice.reducer;

--- a/ui/src/app/store/noderesult/types.ts
+++ b/ui/src/app/store/noderesult/types.ts
@@ -1,0 +1,55 @@
+import type { Model } from "app/store/types/model";
+import type { TSFixMe } from "app/base/types";
+import type { Machine, NetworkInterface } from "../machine/types";
+
+export type NodeScriptResult = {
+  name: string;
+  title: string;
+  description: string;
+  value: string;
+  surfaced: boolean;
+};
+
+export type NodeResult = Model & {
+  ended: string;
+  endtime: number;
+  estimated_runtime: string;
+  exit_status: number | null;
+  hardware_type: 0 | 1 | 2 | 3 | 4;
+  interface: NetworkInterface | null;
+  name: string;
+  parameters: Record<string, unknown>;
+  physical_blockdevice: number | null;
+  result_type: 0 | 1 | 2;
+  results: NodeScriptResult[];
+  runtime: string;
+  script: number;
+  script_version: number | null;
+  started: string;
+  starttime: number;
+  status: number;
+  status_name: string;
+  suppressed: boolean;
+  tags: string;
+  updated: string;
+};
+
+// Node results are keyed by machine id
+export type NodeResults = {
+  id: Machine["system_id"];
+  results: NodeResult[];
+};
+
+export type NodeResultState = {
+  errors: TSFixMe;
+  items: NodeResults[];
+  loaded: boolean;
+  loading: boolean;
+  saved: boolean;
+  saving: boolean;
+};
+
+// response from server
+export type NodeResultResponse = {
+  [x: string]: NodeResult[];
+};

--- a/ui/src/app/store/root/types.ts
+++ b/ui/src/app/store/root/types.ts
@@ -10,6 +10,7 @@ import type { GeneralState } from "app/store/general/types";
 import type { LicenseKeysState } from "app/store/licensekeys/types";
 import type { MachineState } from "app/store/machine/types";
 import type { MessageState } from "app/store/message/types";
+import type { NodeResultState } from "app/store/noderesult/types";
 import type { NotificationState } from "app/store/notification/types";
 import type { PackageRepositoryState } from "app/store/packagerepository/types";
 import type { PodState } from "app/store/pod/types";
@@ -39,6 +40,7 @@ export type RootState = {
   licensekeys: LicenseKeysState;
   machine: MachineState;
   messages: MessageState;
+  noderesult: NodeResultState;
   notification: NotificationState;
   packagerepository: PackageRepositoryState;
   pod: PodState;

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -18,6 +18,7 @@ import dhcpsnippet from "app/store/dhcpsnippet";
 import domain from "app/store/domain";
 import fabric from "app/store/fabric";
 import machine from "app/store/machine";
+import noderesult from "app/store/noderesult";
 import notification from "app/store/notification";
 import packagerepository from "app/store/packagerepository";
 import pod from "app/store/pod";
@@ -46,6 +47,7 @@ const createAppReducer = (history) =>
     licensekeys,
     machine,
     messages,
+    noderesult,
     notification,
     packagerepository,
     pod,

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -20,6 +20,7 @@ export {
   machineStatuses,
   messageState,
   navigationOptionsState,
+  nodeResultState,
   notificationState,
   osInfoState,
   packageRepositoryState,
@@ -89,6 +90,7 @@ export {
   version,
 } from "./general";
 export { message } from "./message";
+export { nodeResult, nodeResults, nodeScriptResult } from "./noderesult";
 export { notification } from "./notification";
 export { packageRepository } from "./packagerepository";
 export { resourcePool } from "./resourcepool";

--- a/ui/src/testing/factories/noderesult.ts
+++ b/ui/src/testing/factories/noderesult.ts
@@ -1,0 +1,46 @@
+import { array, define, extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+import type { Model } from "app/store/types/model";
+import type {
+  NodeResult,
+  NodeResults,
+  NodeScriptResult,
+} from "app/store/noderesult/types";
+
+export const nodeScriptResult = define<NodeScriptResult>({
+  name: "test name",
+  title: "test title",
+  description: "test description",
+  value: "test value",
+  surfaced: false,
+});
+
+export const nodeResult = extend<Model, NodeResult>(model, {
+  ended: "Fri, 13 Nov. 2020 04:50:27",
+  endtime: 1605243027.158285,
+  estimated_runtime: "test runtime",
+  exit_status: 0,
+  hardware_type: 3,
+  interface: null,
+  name: "test name",
+  parameters: () => ({}),
+  physical_blockdevice: 2451,
+  result_type: 1,
+  results: array(nodeScriptResult),
+  runtime: "0:00:00",
+  script: random,
+  script_version: random,
+  started: "Fri, 13 Nov. 2020 04:50:26",
+  starttime: 605243026.966467,
+  status: 2,
+  status_name: "test status",
+  suppressed: false,
+  tags: "test, tags",
+  updated: "Fri, 13 Nov. 2020 04:50:27",
+});
+
+export const nodeResults = define<NodeResults>({
+  id: "foo",
+  results: array(nodeResult),
+});

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -19,6 +19,7 @@ import type {
   MachineStatuses,
 } from "app/store/machine/types";
 import type { MessageState } from "app/store/message/types";
+import type { NodeResultState } from "app/store/noderesult/types";
 import type { NotificationState } from "app/store/notification/types";
 import type { PackageRepositoryState } from "app/store/packagerepository/types";
 import type { PodState, PodStatus, PodStatuses } from "app/store/pod/types";
@@ -278,6 +279,10 @@ export const domainState = define<DomainState>({
   ...defaultState,
 });
 
+export const nodeResultState = define<NodeResultState>({
+  ...defaultState,
+});
+
 export const resourcePoolState = define<ResourcePoolState>({
   ...defaultState,
 });
@@ -332,6 +337,7 @@ export const rootState = define<RootState>({
   machine: machineState,
   messages: messageState,
   notification: notificationState,
+  noderesult: nodeResultState,
   packagerepository: packageRepositoryState,
   pod: podState,
   resourcepool: resourcePoolState,


### PR DESCRIPTION
## Done

- Add noderesult slice (note, scriptResults slice will be removed in a followup PR)
- Add a `nocache` meta param, which prevents allows `list` methods to be optionally called repeatedly

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- visit the machine details testing tab
- ensure nodeResults for that machine appear in redux state
- visit the machine details testing tab for a different machine
- ensure those nodeResult appear, and that the previous machine's are still in state

## Fixes

Fixes: canonical-web-and-design/maas-ui#1901.

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
