### PR TITLE
feat(ui): add storage update actions to machine slice

### DIFF
--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -850,6 +850,116 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle setting a boot disk", () => {
+    expect(
+      actions.setBootDisk({
+        blockId: 1,
+        systemId: "abc123",
+      })
+    ).toEqual({
+      type: "machine/setBootDisk",
+      meta: {
+        model: "machine",
+        method: "set_boot_disk",
+      },
+      payload: {
+        params: {
+          block_id: 1,
+          system_id: "abc123",
+        },
+      },
+    });
+  });
+
+  it("can handle updating a disk", () => {
+    expect(
+      actions.updateDisk({
+        blockId: 1,
+        filesystemType: "fat32",
+        mountOptions: "noexec",
+        mountPoint: "/path",
+        name: "disk1",
+        systemId: "abc123",
+        tags: ["tag1", "tag2"],
+      })
+    ).toEqual({
+      type: "machine/updateDisk",
+      meta: {
+        model: "machine",
+        method: "update_disk",
+      },
+      payload: {
+        params: {
+          block_id: 1,
+          fstype: "fat32",
+          mount_options: "noexec",
+          mount_point: "/path",
+          name: "disk1",
+          system_id: "abc123",
+          tags: ["tag1", "tag2"],
+        },
+      },
+    });
+  });
+
+  it("can handle updating a filesystem", () => {
+    expect(
+      actions.updateFilesystem({
+        blockId: 1,
+        filesystemType: "fat32",
+        mountOptions: "noexec",
+        mountPoint: "/path",
+        partitionID: 2,
+        systemId: "abc123",
+        tags: ["tag1", "tag2"],
+      })
+    ).toEqual({
+      type: "machine/updateFilesystem",
+      meta: {
+        model: "machine",
+        method: "update_filesystem",
+      },
+      payload: {
+        params: {
+          block_id: 1,
+          fstype: "fat32",
+          mount_options: "noexec",
+          mount_point: "/path",
+          partition_id: 2,
+          system_id: "abc123",
+          tags: ["tag1", "tag2"],
+        },
+      },
+    });
+  });
+
+  it("can handle updating a VMFS datastore", () => {
+    expect(
+      actions.updateVmfsDatastore({
+        addBlockDeviceIDs: [1, 2],
+        addPartitionIDs: [3, 4],
+        name: "datastore1",
+        systemId: "abc123",
+        vmfsDatastoreId: 5,
+      })
+    ).toEqual({
+      type: "machine/updateVmfsDatastore",
+      meta: {
+        model: "machine",
+        method: "update_vmfs_datastore",
+      },
+      payload: {
+        params: {
+          add_block_devices: [1, 2],
+          add_partitions: [3, 4],
+          name: "datastore1",
+          system_id: "abc123",
+          vmfs_datastore_id: 5,
+        },
+      },
+    });
+  });
+
   it("can handle cleaning machines", () => {
     expect(actions.cleanup()).toEqual({
       type: "machine/cleanup",

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -129,6 +129,10 @@ export const ACTIONS = [
     status: "releasing",
   },
   {
+    name: "set-boot-disk",
+    status: "settingBootDisk",
+  },
+  {
     name: "set-pool",
     status: "settingPool",
   },
@@ -160,6 +164,18 @@ export const ACTIONS = [
     name: "unmount-special",
     status: "unmountingSpecial",
   },
+  {
+    name: "update-disk",
+    status: "updatingDisk",
+  },
+  {
+    name: "update-filesystem",
+    status: "updatingFilesystem",
+  },
+  {
+    name: "update-vmfs-datastore",
+    status: "updatingVMFSDatastore",
+  },
 ];
 
 const DEFAULT_STATUSES = {
@@ -190,6 +206,7 @@ const DEFAULT_STATUSES = {
   mountingSpecial: false,
   overridingFailedTesting: false,
   releasing: false,
+  settingBootDisk: false,
   settingPool: false,
   settingZone: false,
   tagging: false,
@@ -198,6 +215,9 @@ const DEFAULT_STATUSES = {
   turningOn: false,
   unlocking: false,
   unmountingSpecial: false,
+  updatingDisk: false,
+  updatingFilesystem: false,
+  updatingVmfsDatastore: false,
 };
 
 type WithPrepare = {
@@ -236,6 +256,7 @@ type MachineReducers = SliceCaseReducers<MachineState> & {
   mountSpecial: WithPrepare;
   overrideFailedTesting: WithPrepare;
   release: WithPrepare;
+  setBootDisk: WithPrepare;
   setPool: WithPrepare;
   setZone: WithPrepare;
   suppressScriptResults: WithPrepare;
@@ -245,6 +266,9 @@ type MachineReducers = SliceCaseReducers<MachineState> & {
   on: WithPrepare;
   unlock: WithPrepare;
   unmountSpecial: WithPrepare;
+  updateDisk: WithPrepare;
+  updateFilesystem: WithPrepare;
+  updateVmfsDatastore: WithPrepare;
 };
 
 const statusHandlers = generateStatusHandlers<
@@ -537,6 +561,16 @@ const statusHandlers = generateStatusHandlers<
           system_id: params.systemId,
         });
         break;
+      case "set-boot-disk":
+        handler.method = "set_boot_disk";
+        handler.prepare = (params: {
+          blockId: number;
+          systemId: Machine["system_id"];
+        }) => ({
+          block_id: params.blockId,
+          system_id: params.systemId,
+        });
+        break;
       case "set-pool":
         handler.prepare = (systemId: Machine["system_id"], poolId) => ({
           action: action.name,
@@ -584,6 +618,62 @@ const statusHandlers = generateStatusHandlers<
         }) => ({
           mount_point: params.mountPoint,
           system_id: params.systemId,
+        });
+        break;
+      case "update-disk":
+        handler.method = "update_disk";
+        handler.prepare = (params: {
+          blockId: number;
+          filesystemType: string;
+          mountOptions: string;
+          mountPoint: string;
+          name: string;
+          systemId: Machine["system_id"];
+          tags: string[];
+        }) => ({
+          block_id: params.blockId,
+          fstype: params.filesystemType,
+          mount_options: params.mountOptions,
+          mount_point: params.mountPoint,
+          name: params.name,
+          system_id: params.systemId,
+          tags: params.tags,
+        });
+        break;
+      case "update-filesystem":
+        handler.method = "update_filesystem";
+        handler.prepare = (params: {
+          blockId: number;
+          filesystemType: string;
+          mountOptions: string;
+          mountPoint: string;
+          partitionID: number;
+          systemId: Machine["system_id"];
+          tags: string[];
+        }) => ({
+          block_id: params.blockId,
+          fstype: params.filesystemType,
+          mount_options: params.mountOptions,
+          mount_point: params.mountPoint,
+          partition_id: params.partitionID,
+          system_id: params.systemId,
+          tags: params.tags,
+        });
+        break;
+      case "update-vmfs-datastore":
+        handler.method = "update_vmfs_datastore";
+        handler.prepare = (params: {
+          addBlockDeviceIDs: number[];
+          addPartitionIDs: number[];
+          name: string;
+          systemId: Machine["system_id"];
+          vmfsDatastoreId: number;
+        }) => ({
+          add_block_devices: params.addBlockDeviceIDs,
+          add_partitions: params.addPartitionIDs,
+          name: params.name,
+          system_id: params.systemId,
+          vmfs_datastore_id: params.vmfsDatastoreId,
         });
         break;
     }
@@ -717,6 +807,10 @@ const machineSlice = generateSlice<
     rescueModeStart: statusHandlers.rescueModeStart,
     rescueModeSuccess: statusHandlers.rescueModeSuccess,
     rescueModeError: statusHandlers.rescueModeError,
+    setBootDisk: statusHandlers.setBootDisk,
+    setBootDiskStart: statusHandlers.setBootDiskStart,
+    setBootDiskSuccess: statusHandlers.setBootDiskSuccess,
+    setBootDiskError: statusHandlers.setBootDiskError,
     setPool: statusHandlers.setPool,
     setPoolStart: statusHandlers.setPoolStart,
     setPoolSuccess: statusHandlers.setPoolSuccess,
@@ -749,6 +843,18 @@ const machineSlice = generateSlice<
     unmountSpecialStart: statusHandlers.unmountSpecialStart,
     unmountSpecialSuccess: statusHandlers.unmountSpecialSuccess,
     unmountSpecialError: statusHandlers.unmountSpecialError,
+    updateDisk: statusHandlers.updateDisk,
+    updateDiskStart: statusHandlers.updateDiskStart,
+    updateDiskSuccess: statusHandlers.updateDiskSuccess,
+    updateDiskError: statusHandlers.updateDiskError,
+    updateFilesystem: statusHandlers.updateFilesystem,
+    updateFilesystemStart: statusHandlers.updateFilesystemStart,
+    updateFilesystemSuccess: statusHandlers.updateFilesystemSuccess,
+    updateFilesystemError: statusHandlers.updateFilesystemError,
+    updateVmfsDatastore: statusHandlers.updateVmfsDatastore,
+    updateVmfsDatastoreStart: statusHandlers.updateVmfsDatastoreStart,
+    updateVmfsDatastoreSuccess: statusHandlers.updateVmfsDatastoreSuccess,
+    updateVmfsDatastoreError: statusHandlers.updateVmfsDatastoreError,
     fetch: {
       prepare: () => ({
         meta: {

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -300,6 +300,7 @@ export type MachineStatus = {
   mountingSpecial: boolean;
   overridingFailedTesting: boolean;
   releasing: boolean;
+  settingBootDisk: boolean;
   settingPool: boolean;
   settingZone: boolean;
   tagging: boolean;
@@ -308,6 +309,9 @@ export type MachineStatus = {
   turningOn: boolean;
   unlocking: boolean;
   unmountingSpecial: boolean;
+  updatingDisk: boolean;
+  updatingFilesystem: boolean;
+  updatingVmfsDatastore: boolean;
 };
 
 export type MachineStatuses = {

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -130,6 +130,7 @@ export const machineStatus = define<MachineStatus>({
   mountingSpecial: false,
   overridingFailedTesting: false,
   releasing: false,
+  settingBootDisk: false,
   settingPool: false,
   settingZone: false,
   tagging: false,
@@ -138,6 +139,9 @@ export const machineStatus = define<MachineStatus>({
   turningOn: false,
   unlocking: false,
   unmountingSpecial: false,
+  updatingDisk: false,
+  updatingFilesystem: false,
+  updatingVmfsDatastore: false,
 });
 
 export const machineStatuses = define<MachineStatuses>({


### PR DESCRIPTION
## Done

- Copied storage update actions from legacy `NodesManager` and `MachinesManager` to machine slice

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2272