### PR TITLE
fix(legacy): show storage tab for new controllers

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -630,7 +630,7 @@
             <a
               role="tab"
               class="p-tabs__link"
-              data-ng-if="!isDevice && !(isController && node.status === 'New')"
+              data-ng-if="!isDevice"
               data-ng-class="{ 'is-active': section.area === 'storage'}"
               data-ng-click="openSection('storage')"
               >Storage</a


### PR DESCRIPTION
## Done

- Remove conditional that hides the storage tab if a controller is new

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that you can see the storage details of a new controller

## Fixes

Fixes #1290 

## Launchpad bug

https://bugs.launchpad.net/maas/+bug/1874356
