### PR TITLE
fix(ui): remove type eslint order grouping

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -65,11 +65,6 @@ module.exports = {
                 position: "before",
               },
               {
-                pattern: "**/types",
-                group: "internal",
-                position: "after",
-              },
-              {
                 pattern: "~/app",
                 group: "internal",
               },

--- a/ui/src/app/App.test.tsx
+++ b/ui/src/app/App.test.tsx
@@ -9,6 +9,7 @@ import configureStore from "redux-mock-store";
 import { App } from "./App";
 
 import { status as statusActions } from "app/base/actions";
+import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
   generalState as generalStateFactory,
@@ -16,8 +17,6 @@ import {
   navigationOptionsState as navigationOptionsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -7,9 +7,8 @@ import configureStore from "redux-mock-store";
 
 import ActionForm from "./ActionForm";
 
-import { rootState as rootStateFactory } from "testing/factories";
-
 import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
 
 let state: RootState;
 const mockStore = configureStore();

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -6,9 +6,8 @@ import { Spinner, Strip } from "@canonical/react-components";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
 import { useProcessing } from "app/base/hooks";
-import { formatErrors } from "app/utils";
-
 import type { AnalyticsEvent, TSFixMe } from "app/base/types";
+import { formatErrors } from "app/utils";
 
 const getLabel = (
   modelName: string,

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -8,7 +8,6 @@ import { Redirect } from "react-router";
 
 import FormikFormContent from "app/base/components/FormikFormContent";
 import { useSendAnalyticsWhen } from "app/base/hooks";
-
 import type { TSFixMe } from "app/base/types";
 
 type Props = {

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
@@ -7,6 +7,9 @@ import configureStore from "redux-mock-store";
 
 import NotificationGroupNotification from "./Notification";
 
+import type { ConfigState } from "app/store/config/types";
+import { NotificationIdent } from "app/store/notification/types";
+import type { UserState } from "app/store/user/types";
 import {
   authState as authStateFactory,
   config as configFactory,
@@ -17,10 +20,6 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-
-import type { ConfigState } from "app/store/config/types";
-import { NotificationIdent } from "app/store/notification/types";
-import type { UserState } from "app/store/user/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -6,13 +6,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import authSelectors from "app/store/auth/selectors";
+import { MessageType } from "app/store/message/types";
 import { actions as notificationActions } from "app/store/notification";
 import notificationSelectors from "app/store/notification/selectors";
-import { isReleaseNotification } from "app/store/utils";
-
-import { MessageType } from "app/store/message/types";
 import type { Notification as NotificationType } from "app/store/notification/types";
 import type { RootState } from "app/store/root/types";
+import { isReleaseNotification } from "app/store/utils";
 
 type Props = {
   id: NotificationType["id"];

--- a/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
+++ b/ui/src/app/base/components/NotificationGroup/NotificationGroup.tsx
@@ -10,11 +10,10 @@ import type { Dispatch } from "redux";
 import NotificationGroupNotification from "./Notification";
 
 import { useVisible } from "app/base/hooks";
-import { actions as notificationActions } from "app/store/notification";
-import { capitaliseFirst } from "app/utils";
-
 import type { MessageType } from "app/store/message/types";
+import { actions as notificationActions } from "app/store/notification";
 import type { Notification as NotificationType } from "app/store/notification/types";
+import { capitaliseFirst } from "app/utils";
 
 const dismissAll = (notifications: NotificationType[], dispatch: Dispatch) => {
   notifications.forEach((notification) => {

--- a/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -7,6 +7,9 @@ import configureStore from "redux-mock-store";
 
 import NotificationList from "./NotificationList";
 
+import { NotificationIdent } from "app/store/notification/types";
+import type { Notification } from "app/store/notification/types";
+import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -18,10 +21,6 @@ import {
   rootState as rootStateFactory,
   routerState as routerStateFactory,
 } from "testing/factories";
-
-import { NotificationIdent } from "app/store/notification/types";
-import type { Notification } from "app/store/notification/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/base/components/NotificationList/NotificationList.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.tsx
@@ -7,10 +7,9 @@ import type { Dispatch } from "redux";
 import { messages as messageActions } from "app/base/actions";
 import NotificationGroup from "app/base/components/NotificationGroup";
 import messageSelectors from "app/store/message/selectors";
+import type { Message } from "app/store/message/types";
 import { actions as notificationActions } from "app/store/notification";
 import notificationSelectors from "app/store/notification/selectors";
-
-import type { Message } from "app/store/message/types";
 
 const generateMessages = (messages: Message[], dispatch: Dispatch) =>
   messages.map(({ id, message, temporary, type }) => (

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx
@@ -14,6 +14,7 @@ import {
   messages as messagesActions,
 } from "app/base/actions";
 import ActionForm from "app/base/components/ActionForm";
+import type { RouteParams } from "app/base/types";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 import { actions as fabricActions } from "app/store/fabric";
@@ -21,23 +22,21 @@ import fabricSelectors from "app/store/fabric/selectors";
 import generalSelectors from "app/store/general/selectors";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import type { RootState } from "app/store/root/types";
 import { actions as spaceActions } from "app/store/space";
 import spaceSelectors from "app/store/space/selectors";
+import type { Space } from "app/store/space/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet } from "app/store/subnet/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import { formatBytes } from "app/utils";
-
-import type { RouteParams } from "app/base/types";
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
-import type { Space } from "app/store/space/types";
-import type { Subnet } from "app/store/subnet/types";
 
 export type Disk = {
   location: string;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import ComposeForm from "../ComposeForm";
 
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -24,8 +25,6 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -7,10 +7,9 @@ import type { ComposeFormDefaults } from "../ComposeForm";
 
 import FormikField from "app/base/components/FormikField";
 import domainSelectors from "app/store/domain/selectors";
+import type { Pod } from "app/store/pod/types";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import zoneSelectors from "app/store/zone/selectors";
-
-import type { Pod } from "app/store/pod/types";
 
 type Props = {
   architectures: Pod["architectures"];

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -8,6 +8,8 @@ import configureStore, { MockStoreEnhanced } from "redux-mock-store";
 
 import ComposeForm from "../ComposeForm";
 
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   fabric as fabricFactory,
@@ -27,9 +29,6 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -72,9 +72,11 @@ export const InterfacesTable = (): JSX.Element => {
   const spaces = useSelector(spaceSelectors.all);
   const vlans = useSelector(vlanSelectors.all);
 
-  const { handleChange, setFieldValue, values } = useFormikContext<
-    ComposeFormValues
-  >();
+  const {
+    handleChange,
+    setFieldValue,
+    values,
+  } = useFormikContext<ComposeFormValues>();
   const { interfaces } = values;
   const cannotDefineInterfaces = podSubnets.length === 0;
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -19,15 +19,14 @@ import SubnetSelect from "./SubnetSelect";
 
 import FormikField from "app/base/components/FormikField";
 import TableActions from "app/base/components/TableActions";
+import type { RouteParams } from "app/base/types";
 import fabricSelectors from "app/store/fabric/selectors";
 import podSelectors from "app/store/pod/selectors";
+import type { PodDetails } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import spaceSelectors from "app/store/space/selectors";
 import subnetSelectors from "app/store/subnet/selectors";
 import vlanSelectors from "app/store/vlan/selectors";
-
-import type { RouteParams } from "app/base/types";
-import type { PodDetails } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 import type { VLAN } from "app/store/vlan/types";
 
 /**
@@ -73,11 +72,9 @@ export const InterfacesTable = (): JSX.Element => {
   const spaces = useSelector(spaceSelectors.all);
   const vlans = useSelector(vlanSelectors.all);
 
-  const {
-    handleChange,
-    setFieldValue,
-    values,
-  } = useFormikContext<ComposeFormValues>();
+  const { handleChange, setFieldValue, values } = useFormikContext<
+    ComposeFormValues
+  >();
   const { interfaces } = values;
   const cannotDefineInterfaces = podSubnets.length === 0;
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -10,6 +10,8 @@ import ComposeForm from "../../ComposeForm";
 
 import type { MenuLink } from "./SubnetSelect";
 
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -28,9 +30,6 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx
@@ -8,20 +8,19 @@ import { useParams } from "react-router";
 import type { InterfaceField } from "../../ComposeForm";
 import { getPxeIconClass } from "../InterfacesTable";
 
-import fabricSelectors from "app/store/fabric/selectors";
-import podSelectors from "app/store/pod/selectors";
-import spaceSelectors from "app/store/space/selectors";
-import subnetSelectors from "app/store/subnet/selectors";
-import vlanSelectors from "app/store/vlan/selectors";
-import { groupAsMap } from "app/utils";
-
 import type { RouteParams } from "app/base/types";
+import fabricSelectors from "app/store/fabric/selectors";
 import type { Fabric } from "app/store/fabric/types";
+import podSelectors from "app/store/pod/selectors";
 import type { PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import spaceSelectors from "app/store/space/selectors";
 import type { Space } from "app/store/space/types";
+import subnetSelectors from "app/store/subnet/selectors";
 import type { Subnet } from "app/store/subnet/types";
+import vlanSelectors from "app/store/vlan/selectors";
 import type { VLAN } from "app/store/vlan/types";
+import { groupAsMap } from "app/utils";
 
 type Props = {
   iface: InterfaceField;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -8,6 +8,8 @@ import configureStore, { MockStore } from "redux-mock-store";
 
 import ComposeForm from "../../ComposeForm";
 
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -25,9 +27,6 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -9,12 +9,11 @@ import type { ComposeFormValues, DiskField } from "../../ComposeForm";
 
 import Meter from "app/base/components/Meter";
 import { COLOURS } from "app/base/constants";
-import podSelectors from "app/store/pod/selectors";
-import { formatBytes } from "app/utils";
-
 import type { RouteParams } from "app/base/types";
+import podSelectors from "app/store/pod/selectors";
 import type { PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import { formatBytes } from "app/utils";
 
 type RequestMap = { [location: string]: number };
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -8,6 +8,8 @@ import configureStore, { MockStore } from "redux-mock-store";
 
 import ComposeForm from "../ComposeForm";
 
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
@@ -25,9 +27,6 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -21,9 +21,8 @@ import PoolSelect from "./PoolSelect";
 import FormikField from "app/base/components/FormikField";
 import TableActions from "app/base/components/TableActions";
 import TagSelector from "app/base/components/TagSelector";
-import podSelectors from "app/store/pod/selectors";
-
 import type { RouteParams } from "app/base/types";
+import podSelectors from "app/store/pod/selectors";
 import type { RootState } from "app/store/root/types";
 
 type Props = { defaultDisk: Disk };

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -4,10 +4,9 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import ActionForm from "app/base/components/ActionForm";
+import type { RouteParams } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -4,10 +4,9 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import ActionForm from "app/base/components/ActionForm";
+import type { RouteParams } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
+++ b/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
@@ -6,13 +6,12 @@ import { useDispatch, useSelector } from "react-redux";
 import type { PodResourcesCardProps } from "app/kvm/components/PodResourcesCard";
 import PodResourcesCard from "app/kvm/components/PodResourcesCard";
 import { actions as machineActions } from "app/store/machine";
+import type { Machine } from "app/store/machine/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import { formatBytes } from "app/utils";
-
-import type { Machine } from "app/store/machine/types";
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import { formatBytes } from "app/utils";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 
 import PodConfiguration from "./PodConfiguration";
 
+import { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -16,8 +17,6 @@ import {
   tagState as tagStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
@@ -11,19 +11,18 @@ import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
 import { useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import { formatErrors } from "app/utils";
-
-import type { RouteParams } from "app/base/types";
-import type { Pod } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 
 const PodConfigurationSchema = Yup.object().shape({
   cpu_over_commit_ratio: Yup.number().required("CPU overcommit ratio required"),

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
@@ -21,9 +21,11 @@ const PodConfigurationFields = ({
   const resourcePools = useSelector(resourcePoolSelectors.all);
   const allTags = useSelector(tagSelectors.all);
   const zones = useSelector(zoneSelectors.all);
-  const { initialValues, setFieldValue, values } = useFormikContext<
-    PodConfigurationValues
-  >();
+  const {
+    initialValues,
+    setFieldValue,
+    values,
+  } = useFormikContext<PodConfigurationValues>();
   // Tags in state is an array of objects
   const allTagsSorted = [...allTags].sort((a, b) =>
     a.name.localeCompare(b.name)

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
@@ -21,11 +21,9 @@ const PodConfigurationFields = ({
   const resourcePools = useSelector(resourcePoolSelectors.all);
   const allTags = useSelector(tagSelectors.all);
   const zones = useSelector(zoneSelectors.all);
-  const {
-    initialValues,
-    setFieldValue,
-    values,
-  } = useFormikContext<PodConfigurationValues>();
+  const { initialValues, setFieldValue, values } = useFormikContext<
+    PodConfigurationValues
+  >();
   // Tags in state is an array of objects
   const allTagsSorted = [...allTags].sort((a, b) =>
     a.name.localeCompare(b.name)

--- a/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.tsx
+++ b/ui/src/app/kvm/components/PodResourcesCard/PodResourcesCard.tsx
@@ -8,9 +8,8 @@ import DoughnutChart from "app/base/components/DoughnutChart";
 import { COLOURS } from "app/base/constants";
 import PodMeter from "app/kvm/components/PodMeter";
 import { MachineListTable } from "app/machines/views/MachineList/MachineListTable/MachineListTable";
-import { formatBytes } from "app/utils";
-
 import type { Machine } from "app/store/machine/types";
+import { formatBytes } from "app/utils";
 
 type ChartValues = {
   allocated: number;

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
@@ -7,10 +7,9 @@ import { useSelector } from "react-redux";
 import { useSendAnalytics } from "app/base/hooks";
 import PodMeter from "app/kvm/components/PodMeter";
 import podSelectors from "app/store/pod/selectors";
-import { formatBytes } from "app/utils";
-
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import { formatBytes } from "app/utils";
 
 export const TRUNCATION_POINT = 3;
 

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -8,11 +8,10 @@ import KVMDetailsHeader from "./KVMDetailsHeader";
 import KVMSummary from "./KVMSummary";
 
 import Section from "app/base/components/Section";
+import type { RouteParams } from "app/base/types";
 import PodConfiguration from "app/kvm/components/PodConfiguration";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const KVMDetails = (): JSX.Element => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -7,13 +7,12 @@ import configureStore from "redux-mock-store";
 
 import KVMDetailsHeader from "./KVMDetailsHeader";
 
+import { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -6,12 +6,11 @@ import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";
 
 import SectionHeader from "app/base/components/SectionHeader";
+import type { RouteParams } from "app/base/types";
 import KVMActionFormWrapper from "app/kvm/components/KVMActionFormWrapper";
 import PodDetailsActionMenu from "app/kvm/components/PodDetailsActionMenu";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const KVMDetailsHeader = (): JSX.Element => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMNumaResources/KVMNumaResources.tsx
@@ -9,10 +9,9 @@ import { useSendAnalytics } from "app/base/hooks";
 import type { PodResourcesCardProps } from "app/kvm/components/PodResourcesCard";
 import PodResourcesCard from "app/kvm/components/PodResourcesCard";
 import { actions as machineActions } from "app/store/machine";
+import type { Machine } from "app/store/machine/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { Machine } from "app/store/machine/types";
 import type { Pod, PodNumaNode } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -9,12 +9,11 @@ import KVMNumaResources from "./KVMNumaResources";
 
 import Switch from "app/base/components/Switch";
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
 import PodAggregateResources from "app/kvm/components/PodAggregateResources";
 import PodStorage from "app/kvm/components/PodStorage";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const KVMSummary = (): JSX.Element => {

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMForm.tsx
@@ -17,7 +17,9 @@ import {
   usePowerParametersSchema,
   useWindowTitle,
 } from "app/base/hooks";
+import type { TSFixMe } from "app/base/types";
 import generalSelectors from "app/store/general/selectors";
+import type { PowerType } from "app/store/general/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
@@ -25,9 +27,6 @@ import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import { formatErrors, formatPowerParameters } from "app/utils";
-
-import type { TSFixMe } from "app/base/types";
-import type { PowerType } from "app/store/general/types";
 
 const generateAddKVMSchema = (
   parametersSchema: Yup.ObjectSchemaDefinition<TSFixMe>

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
@@ -7,12 +7,11 @@ import configureStore from "redux-mock-store";
 
 import KVMListActionMenu from "./KVMListActionMenu";
 
+import { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.test.tsx
@@ -6,14 +6,13 @@ import configureStore from "redux-mock-store";
 
 import CPUColumn from "./CPUColumn";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podHint as podHintFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/CPUColumn/CPUColumn.tsx
@@ -6,7 +6,6 @@ import CPUPopover from "./CPUPopover";
 
 import Meter from "app/base/components/Meter";
 import podSelectors from "app/store/pod/selectors";
-
 import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 import KVMListTable from "./KVMListTable";
 
 import { nodeStatus } from "app/base/enum";
+import type { RootState } from "app/store/root/types";
 import {
   controllerState as controllerStateFactory,
   generalState as generalStateFactory,
@@ -23,8 +24,6 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
@@ -17,13 +17,18 @@ import VMsColumn from "./VMsColumn";
 import { general as generalActions } from "app/base/actions";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
+import type { TSFixMe } from "app/base/types";
 import { actions as controllerActions } from "app/store/controller";
+import type { Controller } from "app/store/controller/types";
 import generalSelectors from "app/store/general/selectors";
 import { actions as machineActions } from "app/store/machine";
+import type { Machine } from "app/store/machine/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
 import { actions as poolActions } from "app/store/resourcepool";
 import poolSelectors from "app/store/resourcepool/selectors";
+import type { ResourcePool } from "app/store/resourcepool/types";
 import { actions as zoneActions } from "app/store/zone";
 import {
   generateCheckboxHandlers,
@@ -31,12 +36,6 @@ import {
   someInArray,
   someNotAll,
 } from "app/utils";
-
-import type { TSFixMe } from "app/base/types";
-import type { Controller } from "app/store/controller/types";
-import type { Machine } from "app/store/machine/types";
-import type { Pod } from "app/store/pod/types";
-import type { ResourcePool } from "app/store/resourcepool/types";
 
 const getSortValue = (
   sortKey: keyof Pod | "cpu" | "os" | "pool" | "power" | "ram" | "storage",

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
@@ -7,12 +7,11 @@ import configureStore from "redux-mock-store";
 
 import NameColumn from "./NameColumn";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
@@ -6,7 +6,6 @@ import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import podSelectors from "app/store/pod/selectors";
-
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import OSColumn from "./OSColumn";
 
 import { nodeStatus } from "app/base/enum";
+import type { RootState } from "app/store/root/types";
 import {
   controllerState as controllerStateFactory,
   generalState as generalStateFactory,
@@ -16,8 +17,6 @@ import {
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx
@@ -7,9 +7,8 @@ import controllerSelectors from "app/store/controller/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import { useFormattedOS } from "app/store/machine/utils";
 import podSelectors from "app/store/pod/selectors";
-import { getStatusText } from "app/utils";
-
 import type { RootState } from "app/store/root/types";
+import { getStatusText } from "app/utils";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import PoolColumn from "./PoolColumn";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -15,8 +16,6 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PoolColumn/PoolColumn.tsx
@@ -5,9 +5,8 @@ import { useSelector } from "react-redux";
 import DoubleRow from "app/base/components/DoubleRow";
 import podSelectors from "app/store/pod/selectors";
 import poolSelectors from "app/store/resourcepool/selectors";
-import zoneSelectors from "app/store/zone/selectors";
-
 import type { RootState } from "app/store/root/types";
+import zoneSelectors from "app/store/zone/selectors";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.test.tsx
@@ -6,13 +6,12 @@ import configureStore from "redux-mock-store";
 
 import PowerColumn from "./PowerColumn";
 
+import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   pod as podFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx
@@ -6,9 +6,8 @@ import DoubleRow from "app/base/components/DoubleRow";
 import controllerSelectors from "app/store/controller/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import podSelectors from "app/store/pod/selectors";
-import { capitaliseFirst, getPowerIcon } from "app/utils";
-
 import type { RootState } from "app/store/root/types";
+import { capitaliseFirst, getPowerIcon } from "app/utils";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.test.tsx
@@ -6,14 +6,13 @@ import configureStore from "redux-mock-store";
 
 import RAMColumn from "./RAMColumn";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podHint as podHintFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/RAMColumn/RAMColumn.tsx
@@ -6,9 +6,8 @@ import RAMPopover from "./RAMPopover";
 
 import Meter from "app/base/components/Meter";
 import podSelectors from "app/store/pod/selectors";
-import { formatBytes } from "app/utils";
-
 import type { RootState } from "app/store/root/types";
+import { formatBytes } from "app/utils";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StorageColumn.tsx
@@ -6,9 +6,8 @@ import StoragePopover from "./StoragePopover";
 
 import Meter from "app/base/components/Meter";
 import podSelectors from "app/store/pod/selectors";
-import { formatBytes } from "app/utils";
-
 import type { RootState } from "app/store/root/types";
+import { formatBytes } from "app/utils";
 
 type Props = { id: number };
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
@@ -3,9 +3,8 @@ import type { ReactNode } from "react";
 
 import Meter from "app/base/components/Meter";
 import Popover from "app/base/components/Popover";
-import { formatBytes } from "app/utils";
-
 import type { Pod } from "app/store/pod/types";
+import { formatBytes } from "app/utils";
 
 type Props = {
   children: ReactNode;

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
@@ -6,13 +6,12 @@ import configureStore from "redux-mock-store";
 
 import TypeColumn from "./TypeColumn";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.tsx
@@ -5,7 +5,6 @@ import { useSelector } from "react-redux";
 import DoubleRow from "app/base/components/DoubleRow";
 import { formatHostType } from "app/kvm/utils";
 import podSelectors from "app/store/pod/selectors";
-
 import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.test.tsx
@@ -6,13 +6,12 @@ import configureStore from "redux-mock-store";
 
 import VMsColumn from "./VMsColumn";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/VMsColumn/VMsColumn.tsx
@@ -4,7 +4,6 @@ import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import podSelectors from "app/store/pod/selectors";
-
 import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 
 import ActionFormWrapper from "./ActionFormWrapper";
 
+import { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -19,8 +20,6 @@ import {
   scriptsState as scriptsStateFactory,
   scripts as scriptsFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -16,14 +16,13 @@ import SetZoneForm from "./SetZoneForm";
 import TagForm from "./TagForm";
 import TestForm from "./TestForm";
 
+import type { RouteParams } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import type {
   SelectedAction,
   SetSelectedAction,
 } from "app/machines/views/MachineDetails/MachineSummary";
 import { actions as machineActions } from "app/store/machine";
-
-import type { RouteParams } from "app/base/types";
 
 const getErrorSentence = (action: SelectedAction, count: number) => {
   const machineString = pluralize("machine", count, true);

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 
 import CommissionForm from "./CommissionForm";
 
+import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -20,8 +21,6 @@ import {
   scripts as scriptsFactory,
   scriptsState as scriptsStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -9,13 +9,12 @@ import CommissionFormFields from "./CommissionFormFields";
 import { scripts as scriptActions } from "app/base/actions";
 import ActionForm from "app/base/components/ActionForm";
 import { useMachineActionForm } from "app/machines/hooks";
+import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import scriptSelectors from "app/store/scripts/selectors";
-import { simpleSortByKey } from "app/utils";
-
-import type { MachineAction } from "app/store/general/types";
 import type { Scripts } from "app/store/scripts/types";
+import { simpleSortByKey } from "app/utils";
 
 const formatScripts = (scripts: Scripts[]) =>
   scripts.map((script) => ({

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -9,6 +9,7 @@ import configureStore from "redux-mock-store";
 import DeployForm from "./DeployForm";
 
 import * as hooks from "app/base/hooks";
+import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -22,8 +23,6 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -11,10 +11,9 @@ import ActionForm from "app/base/components/ActionForm";
 import { useSendAnalytics } from "app/base/hooks";
 import { useMachineActionForm } from "app/machines/hooks";
 import generalSelectors from "app/store/general/selectors";
+import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-
-import type { MachineAction } from "app/store/general/types";
 
 const DeploySchema = Yup.object().shape({
   oSystem: Yup.string().required("OS is required"),

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 
 import DeployForm from "../DeployForm";
 
+import { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
   configState as configStateFactory,
@@ -19,8 +20,6 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -15,7 +15,6 @@ import LegacyLink from "app/base/components/LegacyLink";
 import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
 import generalSelectors from "app/store/general/selectors";
-
 import type { RootState } from "app/store/root/types";
 
 export const DeployFormFields = (): JSX.Element => {

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -8,12 +8,11 @@ import configureStore from "redux-mock-store";
 
 import DeployForm from "../../DeployForm";
 
+import { TSFixMe } from "app/base/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
 } from "testing/factories";
-
-import { TSFixMe } from "app/base/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
@@ -15,9 +15,11 @@ export const UserDataField = (): JSX.Element => {
   const [fileErrors, setFileErrors] = useState(null);
   const [uploadingFile, setUploadingFile] = useState(false);
 
-  const { handleChange, setFieldTouched, setFieldValue } = useFormikContext<
-    DeployFormValues
-  >();
+  const {
+    handleChange,
+    setFieldTouched,
+    setFieldValue,
+  } = useFormikContext<DeployFormValues>();
 
   const onDropAccepted = ([file]) => {
     setUploadingFile(true);

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
@@ -15,11 +15,9 @@ export const UserDataField = (): JSX.Element => {
   const [fileErrors, setFileErrors] = useState(null);
   const [uploadingFile, setUploadingFile] = useState(false);
 
-  const {
-    handleChange,
-    setFieldTouched,
-    setFieldValue,
-  } = useFormikContext<DeployFormValues>();
+  const { handleChange, setFieldTouched, setFieldValue } = useFormikContext<
+    DeployFormValues
+  >();
 
   const onDropAccepted = ([file]) => {
     setUploadingFile(true);

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 
 import MarkBrokenForm from "./MarkBrokenForm";
 
+import { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
@@ -17,8 +18,6 @@ import {
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -8,10 +8,9 @@ import MarkBrokenFormFields from "./MarkBrokenFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
 import { useMachineActionForm } from "app/machines/hooks";
+import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-
-import type { MachineAction } from "app/store/general/types";
 
 const MarkBrokenSchema = Yup.object().shape({
   comment: Yup.string(),

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -9,6 +9,8 @@ import configureStore from "redux-mock-store";
 import TestForm from "./TestForm";
 
 import { HardwareType } from "app/base/enum";
+import { RootState } from "app/store/root/types";
+import { Scripts } from "app/store/scripts/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -21,9 +23,6 @@ import {
   scriptsState as scriptsStateFactory,
 } from "testing/factories";
 import { ScriptType } from "testing/factories/scripts";
-
-import { RootState } from "app/store/root/types";
-import { Scripts } from "app/store/scripts/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -10,11 +10,10 @@ import { scripts as scriptActions } from "app/base/actions";
 import ActionForm from "app/base/components/ActionForm";
 import { HardwareType } from "app/base/enum";
 import { useMachineActionForm } from "app/machines/hooks";
+import { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import scriptSelectors from "app/store/scripts/selectors";
-
-import { MachineAction } from "app/store/general/types";
 import { Scripts } from "app/store/scripts/types";
 
 const TestFormSchema = Yup.object().shape({

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 
 import TestForm from "../TestForm";
 
+import { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -16,8 +17,6 @@ import {
   scriptsState as scriptsStateFactory,
   scripts as scriptsFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
@@ -7,7 +7,6 @@ import type { FormValues } from "../TestForm";
 
 import FormikField from "app/base/components/FormikField";
 import TagSelector from "app/base/components/TagSelector";
-
 import { Scripts } from "app/store/scripts/types";
 
 type ScriptsDisplay = Scripts & { displayName: string };
@@ -19,11 +18,9 @@ export const TestFormFields = ({
   preselected,
   scripts,
 }: Props): JSX.Element => {
-  const {
-    handleChange,
-    setFieldValue,
-    values,
-  } = useFormikContext<FormValues>();
+  const { handleChange, setFieldValue, values } = useFormikContext<
+    FormValues
+  >();
   const urlScriptsSelected = values.scripts.filter((script) =>
     Object.keys(script.parameters).some((key) => key === "url")
   );

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
@@ -18,9 +18,11 @@ export const TestFormFields = ({
   preselected,
   scripts,
 }: Props): JSX.Element => {
-  const { handleChange, setFieldValue, values } = useFormikContext<
-    FormValues
-  >();
+  const {
+    handleChange,
+    setFieldValue,
+    values,
+  } = useFormikContext<FormValues>();
   const urlScriptsSelected = values.scripts.filter((script) =>
     Object.keys(script.parameters).some((key) => key === "url")
   );

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -7,14 +7,13 @@ import configureStore from "redux-mock-store";
 
 import TakeActionMenu from "./TakeActionMenu";
 
+import { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
   machineAction as machineActionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -6,12 +6,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import { general as generalActions } from "app/base/actions";
+import type { RouteParams } from "app/base/types";
 import { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
 import generalSelectors from "app/store/general/selectors";
-import machineSelectors from "app/store/machine/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";
+import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/hooks.tsx
+++ b/ui/src/app/machines/hooks.tsx
@@ -2,10 +2,9 @@ import { useCallback } from "react";
 
 import { useSelector } from "react-redux";
 
+import type { MachineActionName } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import { ACTIONS } from "app/store/machine/slice";
-
-import type { MachineActionName } from "app/store/general/types";
 import type { Machine } from "app/store/machine/types";
 
 /**

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -7,13 +7,12 @@ import configureStore from "redux-mock-store";
 
 import MachineDetails from "./MachineDetails";
 
+import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -13,10 +13,9 @@ import SummaryNotifications from "./MachineSummary/SummaryNotifications";
 import MachineTests from "./MachineTests";
 
 import Section from "app/base/components/Section";
+import type { RouteParams } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const MachineDetails = (): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import MachineHeader from "./MachineHeader";
 
+import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -17,8 +18,6 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -12,12 +12,11 @@ import MachineName from "./MachineName";
 import SectionHeader from "app/base/components/SectionHeader";
 import TableMenu from "app/base/components/TableMenu";
 import { useMachineActions } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
 import ActionFormWrapper from "app/machines/components/ActionFormWrapper";
 import TakeActionMenu from "app/machines/components/TakeActionMenu";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.test.tsx
@@ -9,6 +9,7 @@ import configureStore from "redux-mock-store";
 import MachineName from "./MachineName";
 
 import { actions as machineActions } from "app/store/machine";
+import type { RootState } from "app/store/root/types";
 import {
   domain as domainFactory,
   domainState as domainStateFactory,
@@ -19,8 +20,6 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx
@@ -12,9 +12,8 @@ import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import { useCanEdit } from "app/store/machine/utils";
-
 import type { Machine } from "app/store/machine/types";
+import { useCanEdit } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.test.tsx
@@ -8,14 +8,13 @@ import configureStore from "redux-mock-store";
 import MachineNameFields from "./MachineNameFields";
 
 import FormikForm from "app/base/components/FormikForm";
+import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import NetworkNotifications from "./NetworkNotifications";
 
+import type { RootState } from "app/store/root/types";
 import { NodeStatus } from "app/store/types/node";
 import {
   architecturesState as architecturesStateFactory,
@@ -18,8 +19,6 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkNotifications/NetworkNotifications.tsx
@@ -4,9 +4,8 @@ import { useSelector } from "react-redux";
 
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
 import machineSelectors from "app/store/machine/selectors";
-import { useIsAllNetworkingDisabled } from "app/store/machine/utils";
-
 import type { Machine } from "app/store/machine/types";
+import { useIsAllNetworkingDisabled } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -9,7 +9,6 @@ import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
@@ -10,10 +10,9 @@ import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
+import type { RouteParams } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const AddSpecialFilesystemSchema = Yup.object().shape({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -14,10 +14,9 @@ import UsedStorageTable from "./UsedStorageTable";
 import { separateStorageData } from "./utils";
 
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import { useCanEditStorage } from "app/store/machine/utils";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const MachineStorage = (): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
@@ -8,15 +8,14 @@ import configureStore from "redux-mock-store";
 import StorageNotifications from "./StorageNotifications";
 
 import { nodeStatus } from "app/base/enum";
+import type { MachineDetails } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { MachineDetails } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
@@ -4,14 +4,13 @@ import { useSelector } from "react-redux";
 
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
 import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
 import {
   canOsSupportBcacheZFS,
   canOsSupportStorageConfig,
   isMachineStorageConfigurable,
   useCanEdit,
 } from "app/store/machine/utils";
-
-import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -5,9 +5,8 @@ import type {
 } from "./types";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
-import { formatBytes } from "app/utils";
-
 import type { Disk, Filesystem, Partition } from "app/store/machine/types";
+import { formatBytes } from "app/utils";
 
 /**
  * Formats a storage device's size for use in tables.

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -7,13 +7,12 @@ import configureStore from "redux-mock-store";
 
 import MachineSummary from "./MachineSummary";
 
+import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -11,11 +11,10 @@ import SystemCard from "./SystemCard";
 
 import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
-import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
-
 import type { RouteParams } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 
 export type SelectedAction = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import NetworkCard from "./NetworkCard";
 
+import type { RootState } from "app/store/root/types";
 import {
   fabricState as fabricStateFactory,
   machineDetails as machineDetailsFactory,
@@ -16,8 +17,6 @@ import {
   vlanState as vlanStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -13,11 +13,10 @@ import { HardwareType } from "app/base/enum";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import machineSelectors from "app/store/machine/selectors";
-import { actions as vlanActions } from "app/store/vlan";
-import vlanSelectors from "app/store/vlan/selectors";
-
 import type { Machine, NetworkInterface } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
 
 type InterfaceGroup = {
   firmwareVersion: string;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
@@ -7,14 +7,13 @@ import configureStore from "redux-mock-store";
 
 import NetworkCardTable from "./NetworkCardTable";
 
+import type { RootState } from "app/store/root/types";
 import {
   fabric as fabricFactory,
   machineInterface as machineInterfaceFactory,
   rootState as rootStateFactory,
   vlan as vlanFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.tsx
@@ -10,12 +10,11 @@ import {
 import { useSelector } from "react-redux";
 
 import fabricSelectors from "app/store/fabric/selectors";
-import vlanSelectors from "app/store/vlan/selectors";
-import { formatSpeedUnits } from "app/utils";
-
 import type { Fabric } from "app/store/fabric/types";
 import type { NetworkInterface } from "app/store/machine/types";
+import vlanSelectors from "app/store/vlan/selectors";
 import type { VLAN } from "app/store/vlan/types";
+import { formatSpeedUnits } from "app/utils";
 
 /**
  * Returns the name of an interface's fabric.

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
@@ -7,14 +7,13 @@ import configureStore from "redux-mock-store";
 
 import NumaCard from "./NumaCard";
 
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineNumaNode as machineNumaNodeFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.tsx
@@ -7,7 +7,6 @@ import { useSelector } from "react-redux";
 import NumaCardDetails from "./NumaCardDetails";
 
 import machineSelectors from "app/store/machine/selectors";
-
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
@@ -7,15 +7,14 @@ import configureStore from "redux-mock-store";
 
 import NumaCardDetails from "./NumaCardDetails";
 
+import type { MachineNumaNode } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineNumaNode as machineNumaNodeFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { MachineNumaNode } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.tsx
@@ -7,10 +7,9 @@ import { useSelector } from "react-redux";
 
 import LabelledList from "app/base/components/LabelledList";
 import machineSelectors from "app/store/machine/selectors";
-import { formatBytes, getRanges } from "app/utils";
-
 import type { Machine, MachineNumaNode } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { formatBytes, getRanges } from "app/utils";
 
 type Props = {
   isLast?: boolean;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -7,14 +7,13 @@ import configureStore from "redux-mock-store";
 
 import CpuCard from "./CpuCard";
 
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -6,7 +6,6 @@ import type { SetSelectedAction } from "../../MachineSummary";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";
-
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import DetailsCard from "./DetailsCard";
 
+import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -17,8 +18,6 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -7,11 +7,10 @@ import { Link } from "react-router-dom";
 import { general as generalActions } from "app/base/actions";
 import { useSendAnalytics } from "app/base/hooks";
 import generalSelectors from "app/store/general/selectors";
+import type { MachineDetails } from "app/store/machine/types";
 import { getPodNumaID, useCanEdit } from "app/store/machine/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { MachineDetails } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -7,14 +7,13 @@ import configureStore from "redux-mock-store";
 
 import MemoryCard from "./MemoryCard";
 
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
@@ -4,7 +4,6 @@ import type { SetSelectedAction } from "../../MachineSummary";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";
-
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -12,7 +12,6 @@ import StatusCard from "./StatusCard";
 import StorageCard from "./StorageCard";
 
 import machineSelectors from "app/store/machine/selectors";
-
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import StatusCard from "./StatusCard";
 
+import type { RootState } from "app/store/root/types";
 import { NodeStatus } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
@@ -16,8 +17,6 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 
 import { nodeStatus, scriptStatus } from "app/base/enum";
-import { useFormattedOS } from "app/store/machine/utils";
-
 import type { MachineDetails } from "app/store/machine/types";
+import { useFormattedOS } from "app/store/machine/utils";
 
 type Props = {
   machine: MachineDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.test.tsx
@@ -7,14 +7,13 @@ import configureStore from "redux-mock-store";
 
 import StorageCard from "./StorageCard";
 
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
@@ -6,7 +6,6 @@ import type { SetSelectedAction } from "../../MachineSummary";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";
-
 import type { MachineDetails } from "app/store/machine/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import SummaryNotifications from "./SummaryNotifications";
 
+import type { RootState } from "app/store/root/types";
 import {
   architecturesState as architecturesStateFactory,
   generalState as generalStateFactory,
@@ -17,8 +18,6 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -8,13 +8,12 @@ import LegacyLink from "app/base/components/LegacyLink";
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
 import generalSelectors from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
+import type { Event, Machine } from "app/store/machine/types";
 import {
   useCanEdit,
   useHasInvalidArchitecture,
   useIsRackControllerConnected,
 } from "app/store/machine/utils";
-
-import type { Event, Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.test.tsx
@@ -7,13 +7,12 @@ import configureStore from "redux-mock-store";
 
 import SystemCard from "./SystemCard";
 
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
@@ -5,7 +5,6 @@ import { useSelector } from "react-redux";
 
 import LabelledList from "app/base/components/LabelledList";
 import machineSelectors from "app/store/machine/selectors";
-
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.test.tsx
@@ -8,14 +8,13 @@ import configureStore from "redux-mock-store";
 import TestResults from "./TestResults";
 
 import { HardwareType } from "app/base/enum";
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -7,9 +7,8 @@ import type { SetSelectedAction } from "..";
 
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
-import { capitaliseFirst } from "app/utils";
-
 import type { MachineDetails } from "app/store/machine/types";
+import { capitaliseFirst } from "app/utils";
 
 type Props = {
   machine: MachineDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -5,11 +5,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import { useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import { actions as nodeResultActions } from "app/store/noderesult";
 import nodeResultSelectors from "app/store/noderesult/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const MachineTests = (): JSX.Element => {

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -17,13 +17,12 @@ import {
   toggleFilter,
 } from "app/machines/search";
 import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
+import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
-
-import type { MachineAction } from "app/store/general/types";
-import type { Machine } from "app/store/machine/types";
 
 const getMachineCount = (
   machines: Machine[],

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -8,6 +8,8 @@ import configureStore from "redux-mock-store";
 import { StatusColumn } from "./StatusColumn";
 
 import { nodeStatus, scriptStatus } from "app/base/enum";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 import type { TestResult } from "app/store/types/node";
 import { NodeStatus } from "app/store/types/node";
 import {
@@ -18,9 +20,6 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { Machine } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -10,11 +10,10 @@ import { nodeStatus, scriptStatus } from "app/base/enum";
 import { useMachineActions } from "app/base/hooks";
 import { useToggleMenu } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
-import { useFormattedOS } from "app/store/machine/utils";
-import { getStatusText } from "app/utils";
-
 import type { Machine } from "app/store/machine/types";
+import { useFormattedOS } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
+import { getStatusText } from "app/utils";
 
 // Node statuses for which the failed test warning is not shown.
 const hideFailedTestWarningStatuses = [

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.tsx
@@ -4,10 +4,9 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import ActionForm from "app/base/components/ActionForm";
+import type { RouteParams } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/rsd/components/RSDActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -4,10 +4,9 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import ActionForm from "app/base/components/ActionForm";
+import type { RouteParams } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 
 type Props = {
   setSelectedAction: (action: string | null) => void;

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetails.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetails.tsx
@@ -8,11 +8,10 @@ import RSDDetailsHeader from "./RSDDetailsHeader";
 import RSDSummary from "./RSDSummary";
 
 import Section from "app/base/components/Section";
+import type { RouteParams } from "app/base/types";
 import PodConfiguration from "app/kvm/components/PodConfiguration";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const RSDDetails = (): JSX.Element => {

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.test.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.test.tsx
@@ -7,13 +7,12 @@ import configureStore from "redux-mock-store";
 
 import RSDDetailsHeader from "./RSDDetailsHeader";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDDetailsHeader/RSDDetailsHeader.tsx
@@ -6,12 +6,11 @@ import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";
 
 import SectionHeader from "app/base/components/SectionHeader";
+import type { RouteParams } from "app/base/types";
 import PodDetailsActionMenu from "app/kvm/components/PodDetailsActionMenu";
 import RSDActionFormWrapper from "app/rsd/components/RSDActionFormWrapper";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const RSDDetailsHeader = (): JSX.Element => {

--- a/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.tsx
+++ b/ui/src/app/rsd/views/RSDDetails/RSDSummary/RSDSummary.tsx
@@ -5,12 +5,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import { useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
 import PodAggregateResources from "app/kvm/components/PodAggregateResources";
 import PodStorage from "app/kvm/components/PodStorage";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-
-import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
 const RSDSummary = (): JSX.Element => {

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import RSDListTable from "./RSDListTable";
 
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -16,8 +17,6 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
@@ -14,13 +14,12 @@ import StorageColumn from "app/kvm/views/KVMList/KVMListTable/StorageColumn";
 import VMsColumn from "app/kvm/views/KVMList/KVMListTable/VMsColumn";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
 import { actions as poolActions } from "app/store/resourcepool";
 import poolSelectors from "app/store/resourcepool/selectors";
+import type { ResourcePool } from "app/store/resourcepool/types";
 import { actions as zoneActions } from "app/store/zone";
 import { generateCheckboxHandlers, someInArray, someNotAll } from "app/utils";
-
-import type { Pod } from "app/store/pod/types";
-import type { ResourcePool } from "app/store/resourcepool/types";
 
 const getSortValue = (
   sortKey: keyof Pod | "cpu" | "pool" | "ram" | "storage",

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import CommissioningForm from "./CommissioningForm";
 
+import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
   generalState as generalStateFactory,
@@ -14,8 +15,6 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import CommissioningForm from "../CommissioningForm";
 
+import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
   generalState as generalStateFactory,
@@ -13,8 +14,6 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -7,10 +7,9 @@ import { useSelector } from "react-redux";
 import type { CommissioningFormValues } from "../CommissioningForm";
 
 import FormikField from "app/base/components/FormikField";
+import { TSFixMe } from "app/base/types";
 import configSelectors from "app/store/config/selectors";
 import generalSelectors from "app/store/general/selectors";
-
-import { TSFixMe } from "app/base/types";
 import { RootState } from "app/store/root/types";
 
 const CommissioningFormFields = (): JSX.Element => {

--- a/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -6,13 +6,12 @@ import configureStore from "redux-mock-store";
 
 import GeneralForm from "./GeneralForm";
 
+import type { RootState } from "app/store/root/types";
 import {
   config as configFactory,
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
+++ b/ui/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
@@ -7,14 +7,13 @@ import configureStore from "redux-mock-store";
 
 import LicenseKeyList from ".";
 
+import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   licenseKeys as licenseKeysFactory,
   licenseKeysState as licenseKeysStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -7,13 +7,12 @@ import configureStore from "redux-mock-store";
 
 import ScriptsList from ".";
 
+import type { RootState } from "app/store/root/types";
 import {
   scripts as scriptsFactory,
   scriptsState as scriptsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -12,9 +12,8 @@ import TableActions from "app/base/components/TableActions";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import { useWindowTitle, useAddMessage } from "app/base/hooks";
 import SettingsTable from "app/settings/components/SettingsTable";
-import scriptSelectors from "app/store/scripts/selectors";
-
 import type { RootState } from "app/store/root/types";
+import scriptSelectors from "app/store/scripts/selectors";
 import type { Scripts } from "app/store/scripts/types";
 
 type Props = {

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -9,12 +9,11 @@ import configureStore from "redux-mock-store";
 import { UserForm } from "./UserForm";
 import type { UserWithPassword } from "./UserForm";
 
+import { RootState } from "app/store/root/types";
 import {
   user as userFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.tsx
@@ -11,7 +11,6 @@ import { useAddMessage, useWindowTitle } from "app/base/hooks";
 import { UserShape } from "app/base/proptypes";
 import { actions as userActions } from "app/store/user";
 import userSelectors from "app/store/user/selectors";
-
 import type { User } from "app/store/user/types";
 
 export type UserWithPassword = User & {

--- a/ui/src/app/store/config/types.ts
+++ b/ui/src/app/store/config/types.ts
@@ -1,6 +1,5 @@
-import type { GenericState } from "app/store/types/state";
-
 import type { TSFixMe } from "app/base/types";
+import type { GenericState } from "app/store/types/state";
 
 export type ConfigChoice = [string | number, string];
 

--- a/ui/src/app/store/controller/selectors.ts
+++ b/ui/src/app/store/controller/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Controller, ControllerState } from "app/store/controller/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (controller: Controller, term: string) =>
   controller.fqdn.includes(term);

--- a/ui/src/app/store/controller/types.ts
+++ b/ui/src/app/store/controller/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { BaseNode } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Controller = BaseNode & {
   last_image_sync: string;

--- a/ui/src/app/store/device/selectors.ts
+++ b/ui/src/app/store/device/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Device, DeviceState } from "app/store/device/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (device: Device, term: string) =>
   device.fqdn.includes(term);

--- a/ui/src/app/store/device/types.ts
+++ b/ui/src/app/store/device/types.ts
@@ -1,8 +1,7 @@
+import type { TSFixMe } from "app/base/types";
 import type { ModelRef } from "app/store/types/model";
 import type { SimpleNode } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Device = SimpleNode & {
   extra_macs: string[];

--- a/ui/src/app/store/dhcpsnippet/selectors.ts
+++ b/ui/src/app/store/dhcpsnippet/selectors.ts
@@ -1,9 +1,8 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type {
   DHCPSnippet,
   DHCPSnippetState,
 } from "app/store/dhcpsnippet/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (snippet: DHCPSnippet, term: string) =>
   snippet.name.includes(term) || snippet.description.includes(term);

--- a/ui/src/app/store/dhcpsnippet/types.ts
+++ b/ui/src/app/store/dhcpsnippet/types.ts
@@ -1,10 +1,9 @@
-import type { Host } from "app/store/types/host";
-import type { Model } from "app/store/types/model";
-import type { GenericState } from "app/store/types/state";
-
 import type { TSFixMe } from "app/base/types";
 import type { Device } from "app/store/device/types";
 import type { Subnet } from "app/store/subnet/types";
+import type { Host } from "app/store/types/host";
+import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
 
 export type DHCPSnippetHistory = Model & {
   created: string;

--- a/ui/src/app/store/domain/selectors.ts
+++ b/ui/src/app/store/domain/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Domain, DomainState } from "app/store/domain/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (domain: Domain, term: string) =>
   domain.name.includes(term);

--- a/ui/src/app/store/domain/types.ts
+++ b/ui/src/app/store/domain/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Domain = Model & {
   created: string;

--- a/ui/src/app/store/fabric/selectors.ts
+++ b/ui/src/app/store/fabric/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Fabric, FabricState } from "app/store/fabric/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (fabric: Fabric, term: string) =>
   fabric.name.includes(term);

--- a/ui/src/app/store/fabric/types.ts
+++ b/ui/src/app/store/fabric/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Fabric = Model & {
   class_type: string | null;

--- a/ui/src/app/store/general/selectors/osInfo.test.ts
+++ b/ui/src/app/store/general/selectors/osInfo.test.ts
@@ -1,13 +1,12 @@
 import osInfo from "./osInfo";
 
+import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
   osInfoState as osInfoStateFactory,
   osInfo as osInfoFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { RootState } from "app/store/root/types";
 
 describe("osInfo selectors", () => {
   describe("get", () => {

--- a/ui/src/app/store/licensekeys/selectors.ts
+++ b/ui/src/app/store/licensekeys/selectors.ts
@@ -1,12 +1,11 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { generateBaseSelectors } from "app/store/utils";
-
 import type {
   LicenseKeys,
   LicenseKeysState,
 } from "app/store/licensekeys/types";
 import type { RootState } from "app/store/root/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (licenseKey: LicenseKeys, term: string) =>
   licenseKey.osystem.includes(term) || licenseKey.distro_series.includes(term);

--- a/ui/src/app/store/licensekeys/types.ts
+++ b/ui/src/app/store/licensekeys/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type LicenseKeys = Model & {
   distro_series: string;

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -2,8 +2,6 @@ import { createSelector, Selector } from "@reduxjs/toolkit";
 
 import filterNodes from "app/machines/filter-nodes";
 import { ACTIONS } from "app/store/machine/slice";
-import { generateBaseSelectors } from "app/store/utils";
-
 import type {
   Machine,
   MachineState,
@@ -11,6 +9,7 @@ import type {
   MachineStatuses,
 } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const defaultSelectors = generateBaseSelectors<
   MachineState,

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -7,13 +7,12 @@ import type {
 
 import type { Machine, MachineState } from "./types";
 
+import type { ScriptResult } from "app/store/scriptresults/types";
+import type { Scripts } from "app/store/scripts/types";
 import { generateSlice, generateStatusHandlers } from "app/store/utils";
 import type { GenericSlice } from "app/store/utils";
 import type { StatusHandlers } from "app/store/utils/slice";
 import { kebabToCamelCase } from "app/utils";
-
-import type { ScriptResult } from "app/store/scriptresults/types";
-import type { Scripts } from "app/store/scripts/types";
 
 export type ScriptInput = {
   [x: string]: { url: string };

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -1,9 +1,8 @@
+import type { TSFixMe } from "app/base/types";
+import type { Subnet } from "app/store/subnet/types";
 import type { Model, ModelRef } from "app/store/types/model";
 import type { BaseNode, TestStatus } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
-import type { Subnet } from "app/store/subnet/types";
 
 export type IpAddresses = {
   ip: string;

--- a/ui/src/app/store/machine/utils.test.tsx
+++ b/ui/src/app/store/machine/utils.test.tsx
@@ -18,6 +18,8 @@ import {
 } from "./utils";
 
 import { nodeStatus } from "app/base/enum";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 import { NodeStatus } from "app/store/types/node";
 import {
   architecturesState as architecturesStateFactory,
@@ -31,9 +33,6 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-import type { Machine } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 
 const mockStore = configureStore();
 

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -5,12 +5,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { general as generalActions } from "app/base/actions";
 import { nodeStatus } from "app/base/enum";
 import generalSelectors from "app/store/general/selectors";
-import type { Host } from "app/store/types/host";
-import { NodeStatus } from "app/store/types/node";
-
 import type { Machine } from "app/store/machine/types";
 import { Pod } from "app/store/pod/types";
 import { RootState } from "app/store/root/types";
+import type { Host } from "app/store/types/host";
+import { NodeStatus } from "app/store/types/node";
 
 /**
  * Check if a machine has an invalid architecture.

--- a/ui/src/app/store/noderesult/types.ts
+++ b/ui/src/app/store/noderesult/types.ts
@@ -1,8 +1,7 @@
 import type { Machine, NetworkInterface } from "../machine/types";
 
-import type { Model } from "app/store/types/model";
-
 import type { TSFixMe } from "app/base/types";
+import type { Model } from "app/store/types/model";
 
 export type NodeScriptResult = {
   name: string;

--- a/ui/src/app/store/notification/selectors.test.ts
+++ b/ui/src/app/store/notification/selectors.test.ts
@@ -1,5 +1,6 @@
 import notification from "./selectors";
 
+import { NotificationIdent } from "app/store/notification/types";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -9,8 +10,6 @@ import {
   rootState as rootStateFactory,
   routerState as routerStateFactory,
 } from "testing/factories";
-
-import { NotificationIdent } from "app/store/notification/types";
 
 describe("notification selectors", () => {
   it("can get all items", () => {

--- a/ui/src/app/store/notification/selectors.ts
+++ b/ui/src/app/store/notification/selectors.ts
@@ -1,8 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import configSelectors from "app/store/config/selectors";
-import { generateBaseSelectors } from "app/store/utils";
-
 import {
   NotificationIdent,
   ReleaseNotificationPaths,
@@ -12,6 +10,7 @@ import type {
   NotificationState,
 } from "app/store/notification/types";
 import type { RootState } from "app/store/root/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const defaultSelectors = generateBaseSelectors<
   NotificationState,

--- a/ui/src/app/store/notification/types.ts
+++ b/ui/src/app/store/notification/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 import type { User } from "app/store/user/types";
 
 export enum NotificationIdent {

--- a/ui/src/app/store/packagerepository/selectors.ts
+++ b/ui/src/app/store/packagerepository/selectors.ts
@@ -1,11 +1,10 @@
 import { getRepoDisplayName } from "./utils";
 
-import { generateBaseSelectors } from "app/store/utils";
-
 import type {
   PackageRepository,
   PackageRepositoryState,
 } from "app/store/packagerepository/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (repo: PackageRepository, term: string) =>
   getRepoDisplayName(repo).includes(term) ||

--- a/ui/src/app/store/packagerepository/types.ts
+++ b/ui/src/app/store/packagerepository/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type PackageRepository = Model & {
   arches: string[];

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -1,14 +1,13 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import controller from "app/store/controller/selectors";
-import machine from "app/store/machine/selectors";
-import type { Host } from "app/store/types/host";
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Controller } from "app/store/controller/types";
+import machine from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { Pod, PodState } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import type { Host } from "app/store/types/host";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (pod: Pod, term: string) => pod.name.includes(term);
 

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type PodHint = {
   cores: number;

--- a/ui/src/app/store/resourcepool/selectors.ts
+++ b/ui/src/app/store/resourcepool/selectors.ts
@@ -1,9 +1,8 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type {
   ResourcePool,
   ResourcePoolState,
 } from "app/store/resourcepool/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (resourcepool: ResourcePool, term: string) =>
   resourcepool.name.includes(term);

--- a/ui/src/app/store/resourcepool/types.ts
+++ b/ui/src/app/store/resourcepool/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type ResourcePool = Model & {
   created: string;

--- a/ui/src/app/store/scriptresults/types.ts
+++ b/ui/src/app/store/scriptresults/types.ts
@@ -1,9 +1,8 @@
 import type { Machine } from "../machine/types";
 
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type ScriptResultResult = {
   name: string;

--- a/ui/src/app/store/scripts/selectors.ts
+++ b/ui/src/app/store/scripts/selectors.ts
@@ -1,9 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { RootState } from "app/store/root/types";
 import type { Scripts, ScriptsState } from "app/store/scripts/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 enum SCRIPT_TYPES {
   COMMISSIONING = 0,

--- a/ui/src/app/store/scripts/types.ts
+++ b/ui/src/app/store/scripts/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type ScriptsHistory = Model & {
   comment: string | null;

--- a/ui/src/app/store/service/selectors.ts
+++ b/ui/src/app/store/service/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Service, ServiceState } from "app/store/service/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (service: Service, term: string) =>
   service.name.includes(term);

--- a/ui/src/app/store/service/types.ts
+++ b/ui/src/app/store/service/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Service = Model & {
   name: string;

--- a/ui/src/app/store/space/selectors.ts
+++ b/ui/src/app/store/space/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Space, SpaceState } from "app/store/space/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (space: Space, term: string) =>
   space.name.includes(term);

--- a/ui/src/app/store/space/types.ts
+++ b/ui/src/app/store/space/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Space = Model & {
   created: string;

--- a/ui/src/app/store/sshkey/selectors.ts
+++ b/ui/src/app/store/sshkey/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { SSHKey, SSHKeyState } from "app/store/sshkey/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (sshkey: SSHKey, term: string) =>
   sshkey.display.includes(term);

--- a/ui/src/app/store/sshkey/types.ts
+++ b/ui/src/app/store/sshkey/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 import type { User } from "app/store/user/types";
 
 export type KeySource = {

--- a/ui/src/app/store/sslkey/selectors.ts
+++ b/ui/src/app/store/sslkey/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { SSLKey, SSLKeyState } from "app/store/sslkey/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (sslkey: SSLKey, term: string) =>
   sslkey.display.includes(term);

--- a/ui/src/app/store/sslkey/types.ts
+++ b/ui/src/app/store/sslkey/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 import type { User } from "app/store/user/types";
 
 export type SSLKey = Model & {

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -1,10 +1,9 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { PodDetails } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import type { Subnet, SubnetState } from "app/store/subnet/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (subnet: Subnet, term: string) =>
   subnet.name.includes(term);

--- a/ui/src/app/store/subnet/types.ts
+++ b/ui/src/app/store/subnet/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type SubnetStatisticsRange = {
   end: string;

--- a/ui/src/app/store/tag/selectors.ts
+++ b/ui/src/app/store/tag/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Tag, TagState } from "app/store/tag/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (tag: Tag, term: string) => tag.name.includes(term);
 

--- a/ui/src/app/store/tag/types.ts
+++ b/ui/src/app/store/tag/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Tag = Model & {
   created: string;

--- a/ui/src/app/store/token/selectors.ts
+++ b/ui/src/app/store/token/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { Token, TokenState } from "app/store/token/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const selectors = generateBaseSelectors<TokenState, Token, "id">("token", "id");
 

--- a/ui/src/app/store/token/types.ts
+++ b/ui/src/app/store/token/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type TokenConsumer = {
   key: string;

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -1,8 +1,7 @@
-import type { Model, ModelRef } from "app/store/types/model";
-
 import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
 import type { Machine } from "app/store/machine/types";
+import type { Model, ModelRef } from "app/store/types/model";
 
 export type TestResult = -1 | 0 | 1 | 2 | 3;
 

--- a/ui/src/app/store/user/selectors.ts
+++ b/ui/src/app/store/user/selectors.ts
@@ -1,6 +1,5 @@
-import { generateBaseSelectors } from "app/store/utils";
-
 import type { User, UserState } from "app/store/user/types";
+import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (user: User, term: string) =>
   user.username.includes(term) ||

--- a/ui/src/app/store/user/types.ts
+++ b/ui/src/app/store/user/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type User = Model & {
   completed_intro: boolean;

--- a/ui/src/app/store/utils/identifiers.ts
+++ b/ui/src/app/store/utils/identifiers.ts
@@ -1,8 +1,7 @@
-import type { Host } from "app/store/types/host";
-
 import type { Machine } from "app/store/machine/types";
 import { NotificationIdent } from "app/store/notification/types";
 import type { Notification } from "app/store/notification/types";
+import type { Host } from "app/store/types/host";
 
 /**
  * Type guard to determine if host is a machine.

--- a/ui/src/app/store/utils/selectors.ts
+++ b/ui/src/app/store/utils/selectors.ts
@@ -4,9 +4,8 @@ import {
   Selector,
 } from "@reduxjs/toolkit";
 
-import type { CommonStates, CommonStateTypes } from "app/store/utils";
-
 import type { RootState } from "app/store/root/types";
+import type { CommonStates, CommonStateTypes } from "app/store/utils";
 
 /**
  * @template I - A model item type e.g. DHCPSnippet

--- a/ui/src/app/store/utils/slice.test.ts
+++ b/ui/src/app/store/utils/slice.test.ts
@@ -4,6 +4,8 @@ import {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
+import type { Pod, PodState } from "app/store/pod/types";
+import type { Token, TokenState } from "app/store/token/types";
 import { generateSlice, generateStatusHandlers } from "app/store/utils";
 import type { GenericSlice } from "app/store/utils";
 import {
@@ -13,9 +15,6 @@ import {
   podState as podStateFactory,
   podStatus as podStatusFactory,
 } from "testing/factories";
-
-import type { Pod, PodState } from "app/store/pod/types";
-import type { Token, TokenState } from "app/store/token/types";
 
 describe("slice", () => {
   describe("base reducers", () => {

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -8,10 +8,9 @@ import {
   ValidateSliceCaseReducers,
 } from "@reduxjs/toolkit";
 
-import type { GenericState } from "app/store/types/state";
-
 import type { TSFixMe } from "app/base/types";
 import type { RootState } from "app/store/root/types";
+import type { GenericState } from "app/store/types/state";
 
 export type GenericItemMeta<I> = {
   item: I;

--- a/ui/src/app/store/vlan/selectors.ts
+++ b/ui/src/app/store/vlan/selectors.ts
@@ -1,5 +1,4 @@
 import { generateBaseSelectors } from "app/store/utils";
-
 import type { VLAN, VLANState } from "app/store/vlan/types";
 
 const searchFunction = (vlan: VLAN, term: string) => vlan.name.includes(term);

--- a/ui/src/app/store/vlan/types.ts
+++ b/ui/src/app/store/vlan/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type VLAN = Model & {
   created: string;

--- a/ui/src/app/store/zone/selectors.ts
+++ b/ui/src/app/store/zone/selectors.ts
@@ -1,5 +1,4 @@
 import { generateBaseSelectors } from "app/store/utils";
-
 import type { Zone, ZoneState } from "app/store/zone/types";
 
 const searchFunction = (zone: Zone, term: string) => zone.name.includes(term);

--- a/ui/src/app/store/zone/types.ts
+++ b/ui/src/app/store/zone/types.ts
@@ -1,7 +1,6 @@
+import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
-
-import type { TSFixMe } from "app/base/types";
 
 export type Zone = Model & {
   controllers_count: number;

--- a/ui/src/app/utils/generateCheckboxHandlers.test.ts
+++ b/ui/src/app/utils/generateCheckboxHandlers.test.ts
@@ -2,9 +2,10 @@ import { generateCheckboxHandlers } from "./generateCheckboxHandlers";
 
 describe("generateCheckboxHandlers", () => {
   const onChange = jest.fn();
-  const { handleGroupCheckbox, handleRowCheckbox } = generateCheckboxHandlers<
-    number
-  >((newIDs) => onChange(newIDs));
+  const {
+    handleGroupCheckbox,
+    handleRowCheckbox,
+  } = generateCheckboxHandlers<number>((newIDs) => onChange(newIDs));
 
   describe("handleGroupCheckbox", () => {
     it("correctly runs onChange with all ids in a group if none already selected", () => {

--- a/ui/src/app/utils/generateCheckboxHandlers.test.ts
+++ b/ui/src/app/utils/generateCheckboxHandlers.test.ts
@@ -2,10 +2,9 @@ import { generateCheckboxHandlers } from "./generateCheckboxHandlers";
 
 describe("generateCheckboxHandlers", () => {
   const onChange = jest.fn();
-  const {
-    handleGroupCheckbox,
-    handleRowCheckbox,
-  } = generateCheckboxHandlers<number>((newIDs) => onChange(newIDs));
+  const { handleGroupCheckbox, handleRowCheckbox } = generateCheckboxHandlers<
+    number
+  >((newIDs) => onChange(newIDs));
 
   describe("handleGroupCheckbox", () => {
     it("correctly runs onChange with all ids in a group if none already selected", () => {

--- a/ui/src/testing/factories/dhcpsnippet.ts
+++ b/ui/src/testing/factories/dhcpsnippet.ts
@@ -2,12 +2,11 @@ import { array, extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type {
   DHCPSnippet,
   DHCPSnippetHistory,
 } from "app/store/dhcpsnippet/types";
+import type { Model } from "app/store/types/model";
 
 export const dhcpSnippetHistory = extend<Model, DHCPSnippetHistory>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/domain.ts
+++ b/ui/src/testing/factories/domain.ts
@@ -2,9 +2,8 @@ import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Domain } from "app/store/domain/types";
+import type { Model } from "app/store/types/model";
 
 export const domain = extend<Model, Domain>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/fabric.ts
+++ b/ui/src/testing/factories/fabric.ts
@@ -2,9 +2,8 @@ import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Fabric } from "app/store/fabric/types";
+import type { Model } from "app/store/types/model";
 
 export const fabric = extend<Model, Fabric>(model, {
   class_type: "10g",

--- a/ui/src/testing/factories/licensekeys.ts
+++ b/ui/src/testing/factories/licensekeys.ts
@@ -2,9 +2,8 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { LicenseKeys } from "app/store/licensekeys/types";
+import type { Model } from "app/store/types/model";
 
 export const licenseKeys = extend<Model, LicenseKeys>(model, {
   distro_series: "win2012",

--- a/ui/src/testing/factories/message.ts
+++ b/ui/src/testing/factories/message.ts
@@ -2,9 +2,8 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Message } from "app/store/message/types";
+import type { Model } from "app/store/types/model";
 
 export const message = extend<Model, Message>(model, {
   message: "Test message",

--- a/ui/src/testing/factories/noderesult.ts
+++ b/ui/src/testing/factories/noderesult.ts
@@ -2,13 +2,12 @@ import { array, define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type {
   NodeResult,
   NodeResults,
   NodeScriptResult,
 } from "app/store/noderesult/types";
+import type { Model } from "app/store/types/model";
 
 export const nodeScriptResult = define<NodeScriptResult>({
   name: "test name",

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -2,14 +2,6 @@ import { define, extend, random, sequence } from "cooky-cutter";
 
 import { model, modelRef } from "./model";
 
-import type { Model } from "app/store/types/model";
-import {
-  BaseNode,
-  SimpleNode,
-  TestStatus,
-  NodeStatus,
-} from "app/store/types/node";
-
 import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
 import type {
@@ -32,6 +24,13 @@ import type {
   PodNumaNode,
   PodStoragePool,
 } from "app/store/pod/types";
+import type { Model } from "app/store/types/model";
+import {
+  BaseNode,
+  SimpleNode,
+  TestStatus,
+  NodeStatus,
+} from "app/store/types/node";
 
 export const testStatus = define<TestStatus>({
   status: 0,

--- a/ui/src/testing/factories/notification.ts
+++ b/ui/src/testing/factories/notification.ts
@@ -2,10 +2,9 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
+import type { Notification } from "app/store/notification/types";
 import type { Model } from "app/store/types/model";
 import { user } from "testing/factories/user";
-
-import type { Notification } from "app/store/notification/types";
 
 export const notification = extend<Model, Notification>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/packagerepository.ts
+++ b/ui/src/testing/factories/packagerepository.ts
@@ -2,9 +2,8 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { PackageRepository } from "app/store/packagerepository/types";
+import type { Model } from "app/store/types/model";
 
 export const packageRepository = extend<Model, PackageRepository>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/resourcepool.ts
+++ b/ui/src/testing/factories/resourcepool.ts
@@ -2,9 +2,8 @@ import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { ResourcePool } from "app/store/resourcepool/types";
+import type { Model } from "app/store/types/model";
 
 export const resourcePool = extend<Model, ResourcePool>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/scriptresults.ts
+++ b/ui/src/testing/factories/scriptresults.ts
@@ -2,13 +2,12 @@ import { array, define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type {
   ScriptResult,
   ScriptResults,
   ScriptResultResult,
 } from "app/store/scriptresults/types";
+import type { Model } from "app/store/types/model";
 
 export const scriptResultResult = define<ScriptResultResult>({
   name: "test name",

--- a/ui/src/testing/factories/scripts.ts
+++ b/ui/src/testing/factories/scripts.ts
@@ -2,9 +2,8 @@ import { array, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Scripts, ScriptsHistory } from "app/store/scripts/types";
+import type { Model } from "app/store/types/model";
 
 export enum ScriptType {
   Commissioning = 0,

--- a/ui/src/testing/factories/service.ts
+++ b/ui/src/testing/factories/service.ts
@@ -2,9 +2,8 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Service } from "app/store/service/types";
+import type { Model } from "app/store/types/model";
 
 export const service = extend<Model, Service>(model, {
   name: "test name",

--- a/ui/src/testing/factories/space.ts
+++ b/ui/src/testing/factories/space.ts
@@ -2,9 +2,8 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Space } from "app/store/space/types";
+import type { Model } from "app/store/types/model";
 
 export const space = extend<Model, Space>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/sshkey.ts
+++ b/ui/src/testing/factories/sshkey.ts
@@ -2,9 +2,8 @@ import { define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { SSHKey, KeySource } from "app/store/sshkey/types";
+import type { Model } from "app/store/types/model";
 
 export const keySource = define<KeySource>({
   auth_id: "test auth id",

--- a/ui/src/testing/factories/sslkey.ts
+++ b/ui/src/testing/factories/sslkey.ts
@@ -2,9 +2,8 @@ import { extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { SSLKey } from "app/store/sslkey/types";
+import type { Model } from "app/store/types/model";
 
 export const sslKey = extend<Model, SSLKey>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/subnet.ts
+++ b/ui/src/testing/factories/subnet.ts
@@ -2,13 +2,12 @@ import { array, define, extend, random } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type {
   Subnet,
   SubnetStatistics,
   SubnetStatisticsRange,
 } from "app/store/subnet/types";
+import type { Model } from "app/store/types/model";
 
 export const subnetStatisticsRange = define<SubnetStatisticsRange>({
   end: "172.16.2.1",

--- a/ui/src/testing/factories/tag.ts
+++ b/ui/src/testing/factories/tag.ts
@@ -2,9 +2,8 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Tag } from "app/store/tag/types";
+import type { Model } from "app/store/types/model";
 
 export const tag = extend<Model, Tag>(model, {
   created: "Wed, 08 Jul. 2020 05:35:4",

--- a/ui/src/testing/factories/token.ts
+++ b/ui/src/testing/factories/token.ts
@@ -2,9 +2,8 @@ import { define, extend } from "cooky-cutter";
 
 import { model } from "./model";
 
-import type { Model } from "app/store/types/model";
-
 import type { Token, TokenConsumer } from "app/store/token/types";
+import type { Model } from "app/store/types/model";
 
 export const tokenConsumer = define<TokenConsumer>({
   key: "consumer key",

--- a/ui/src/testing/factories/user.ts
+++ b/ui/src/testing/factories/user.ts
@@ -3,7 +3,6 @@ import { extend } from "cooky-cutter";
 import { model } from "./model";
 
 import type { Model } from "app/store/types/model";
-
 import type { User } from "app/store/user/types";
 
 const globalPermissions = () => ["machine_create"];

--- a/ui/src/testing/factories/vlan.ts
+++ b/ui/src/testing/factories/vlan.ts
@@ -3,7 +3,6 @@ import { extend, random } from "cooky-cutter";
 import { model } from "./model";
 
 import type { Model } from "app/store/types/model";
-
 import type { VLAN } from "app/store/vlan/types";
 
 export const vlan = extend<Model, VLAN>(model, {

--- a/ui/src/testing/factories/zone.ts
+++ b/ui/src/testing/factories/zone.ts
@@ -3,7 +3,6 @@ import { extend, random } from "cooky-cutter";
 import { model } from "./model";
 
 import type { Model } from "app/store/types/model";
-
 import type { Zone } from "app/store/zone/types";
 
 export const zone = extend<Model, Zone>(model, {


### PR DESCRIPTION
## Done
Unfortunately there is no way to reliably group type imports
together currently, so this removes the regex match for files containing 'type'.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

n/a

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
