### PR TITLE
feat(ui): build add partition form in machine storage

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,58 +1,58 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
-    "src/app/App.test.tsx:3744146010": [
-      [33, 16, 24, "Type \'Factory<NavigationOptions>\' is not assignable to type \'NavigationOptions | ArrayFactory<never> | AttributeFunction<NavigationOptions | null> | Factory<NavigationOptions | null> | DerivedFunction<...> | null | undefined\'.\\n  Type \'Factory<NavigationOptions>\' is not assignable to type \'Factory<NavigationOptions | null>\'.\\n    Types of parameters \'override\' and \'override\' are incompatible.\\n      Type \'Partial<Config<NavigationOptions>> | null | undefined\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.\\n        Type \'null\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.", "3717115723"],
-      [152, 4, 36, "Object is possibly \'null\'.", "1039669632"],
-      [165, 4, 36, "Object is possibly \'null\'.", "1039669632"]
+    "src/app/App.test.tsx:612185328": [
+      [32, 16, 24, "Type \'Factory<NavigationOptions>\' is not assignable to type \'NavigationOptions | ArrayFactory<never> | AttributeFunction<NavigationOptions | null> | Factory<NavigationOptions | null> | DerivedFunction<...> | null | undefined\'.\\n  Type \'Factory<NavigationOptions>\' is not assignable to type \'Factory<NavigationOptions | null>\'.\\n    Types of parameters \'override\' and \'override\' are incompatible.\\n      Type \'Partial<Config<NavigationOptions>> | null | undefined\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.\\n        Type \'null\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.", "3717115723"],
+      [151, 4, 36, "Object is possibly \'null\'.", "1039669632"],
+      [164, 4, 36, "Object is possibly \'null\'.", "1039669632"]
     ],
     "src/app/App.tsx:491251433": [
       [189, 17, 17, "Object is possibly \'null\'.", "2133029343"],
       [194, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
-    "src/app/base/components/ActionForm/ActionForm.test.tsx:3253444044": [
-      [56, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [56, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
-      [70, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
-      [84, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [84, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
-      [95, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
-      [109, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [109, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
-      [120, 21, 6, "Binding element \'errors\' implicitly has an \'any\' type.", "1168132398"],
-      [120, 29, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
-      [135, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [135, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
+    "src/app/base/components/ActionForm/ActionForm.test.tsx:3038409030": [
+      [55, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [55, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [69, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [83, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [83, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [94, 21, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [108, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [108, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"],
+      [119, 21, 6, "Binding element \'errors\' implicitly has an \'any\' type.", "1168132398"],
+      [119, 29, 15, "Binding element \'processingCount\' implicitly has an \'any\' type.", "1847077069"],
+      [134, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [134, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/base/components/ActionForm/ActionForm.tsx:2207355091": [
-      [18, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
-      [22, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
-      [25, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
-      [25, 22, 15, "Object is possibly \'undefined\'.", "1847077069"],
-      [27, 13, 13, "Object is possibly \'undefined\'.", "3155939599"],
-      [135, 39, 6, "Argument of type \'{ [x: string]: any; } | undefined\' is not assignable to parameter of type \'string | object | string[]\'.\\n  Type \'undefined\' is not assignable to type \'string | object | string[]\'.", "1168132398"],
-      [138, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
+    "src/app/base/components/ActionForm/ActionForm.tsx:268435385": [
+      [17, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
+      [21, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
+      [24, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
+      [24, 22, 15, "Object is possibly \'undefined\'.", "1847077069"],
+      [26, 13, 13, "Object is possibly \'undefined\'.", "3155939599"],
+      [134, 39, 6, "Argument of type \'{ [x: string]: any; } | undefined\' is not assignable to parameter of type \'string | object | string[]\'.\\n  Type \'undefined\' is not assignable to type \'string | object | string[]\'.", "1168132398"],
+      [137, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
     "src/app/base/components/DoughnutChart/DoughnutChart.tsx:3302461445": [
       [87, 8, 11, "Type \'(() => void) | null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.\\n  Type \'null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.", "2109816907"],
       [90, 34, 7, "Argument of type \'string\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2045491664"],
       [94, 8, 10, "Type \'(() => void) | null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.\\n  Type \'null\' is not assignable to type \'((event: MouseEvent<SVGCircleElement, MouseEvent>) => void) | undefined\'.", "4228750763"]
     ],
-    "src/app/base/components/FormikForm/FormikForm.tsx:3512906486": [
-      [79, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
+    "src/app/base/components/FormikForm/FormikForm.tsx:1638906300": [
+      [78, 4, 5, "Argument of type \'boolean | undefined\' is not assignable to parameter of type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "195688512"]
     ],
-    "src/app/base/components/NotificationGroup/Notification/Notification.tsx:4238047801": [
-      [28, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
-      [33, 8, 12, "Object is possibly \'null\'.", "148512008"],
-      [42, 43, 12, "Object is possibly \'null\'.", "148512008"]
+    "src/app/base/components/NotificationGroup/Notification/Notification.tsx:2540344083": [
+      [27, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
+      [32, 8, 12, "Object is possibly \'null\'.", "148512008"],
+      [41, 43, 12, "Object is possibly \'null\'.", "148512008"]
     ],
-    "src/app/base/components/NotificationList/NotificationList.test.tsx:2497242062": [
-      [73, 47, 5, "Property \'close\' does not exist on type \'HTMLAttributes\'.", "176908083"]
+    "src/app/base/components/NotificationList/NotificationList.test.tsx:2872787908": [
+      [72, 47, 5, "Property \'close\' does not exist on type \'HTMLAttributes\'.", "176908083"]
     ],
-    "src/app/base/components/NotificationList/NotificationList.tsx:2768681539": [
-      [58, 21, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"],
-      [59, 12, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"],
-      [64, 29, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"]
+    "src/app/base/components/NotificationList/NotificationList.tsx:56535113": [
+      [57, 21, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"],
+      [58, 12, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"],
+      [63, 29, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"]
     ],
     "src/app/base/components/Popover/Popover.tsx:3747607323": [
       [31, 4, 11, "Type \'number\' is not assignable to type \'null\'.", "1179509236"],
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [215, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2456091220": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm install @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -98,75 +98,75 @@ exports[`stricter compilation`] = {
       [227, 21, 1, "Parameter \'e\' implicitly has an \'any\' type.", "177600"],
       [229, 23, 1, "Parameter \'e\' implicitly has an \'any\' type.", "177600"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:606591330": [
-      [141, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [141, 27, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [141, 41, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [141, 59, 4, "Object is possibly \'undefined\'.", "2087386672"],
-      [218, 8, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4165046927"],
-      [266, 34, 27, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4259134870"],
-      [275, 19, 5, "Variable \'error\' is used before being assigned.", "165548477"],
-      [322, 8, 8, "Type \'(values: ComposeFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ComposeFormValues\'.", "1301647696"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:3740554888": [
+      [140, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [140, 27, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [140, 41, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [140, 59, 4, "Object is possibly \'undefined\'.", "2087386672"],
+      [217, 8, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4165046927"],
+      [265, 34, 27, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "4259134870"],
+      [274, 19, 5, "Variable \'error\' is used before being assigned.", "165548477"],
+      [321, 8, 8, "Type \'(values: ComposeFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ComposeFormValues\'.", "1301647696"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx:148629756": [
-      [97, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.\\n    The types returned by \'getState()\' are incompatible between these types.\\n      Type \'unknown\' is not assignable to type \'{}\'.", "195037722"],
-      [115, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [129, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [177, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [199, 6, 5, "Object is of type \'unknown\'.", "173192470"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx:2888641878": [
+      [96, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.\\n    The types returned by \'getState()\' are incompatible between these types.\\n      Type \'unknown\' is not assignable to type \'{}\'.", "195037722"],
+      [114, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
+      [128, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
+      [176, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
+      [198, 6, 5, "Object is of type \'unknown\'.", "173192470"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx:1015133008": [
-      [174, 22, 12, "Type \'(subnetID: number) => void\' is not assignable to type \'(subnetID?: number | undefined) => void\'.\\n  Types of parameters \'subnetID\' and \'subnetID\' are incompatible.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.", "564221494"],
-      [186, 55, 4, "Argument of type \'VLAN | undefined\' is not assignable to parameter of type \'VLAN\'.\\n  Type \'undefined\' is not assignable to type \'VLAN\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "2088175728"],
-      [216, 8, 7, "Type \'false | \\"There are no available subnets on this KVM\'s attached VLANs.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx:3432557654": [
+      [175, 22, 12, "Type \'(subnetID: number) => void\' is not assignable to type \'(subnetID?: number | undefined) => void\'.\\n  Types of parameters \'subnetID\' and \'subnetID\' are incompatible.\\n    Type \'number | undefined\' is not assignable to type \'number\'.\\n      Type \'undefined\' is not assignable to type \'number\'.", "564221494"],
+      [187, 55, 4, "Argument of type \'VLAN | undefined\' is not assignable to parameter of type \'VLAN\'.\\n  Type \'undefined\' is not assignable to type \'VLAN\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "2088175728"],
+      [217, 8, 7, "Type \'false | \\"There are no available subnets on this KVM\'s attached VLANs.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx:2119988850": [
-      [109, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [139, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
-      [158, 6, 99, "Cannot invoke an object which is possibly \'undefined\'.", "375215550"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx:3622706872": [
+      [108, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
+      [138, 36, 5, "Argument of type \'MockStoreEnhanced<unknown, {}>\' is not assignable to parameter of type \'MockStoreEnhanced<{}, {}>\'.\\n  Type \'MockStoreEnhanced<unknown, {}>\' is not assignable to type \'MockStore<{}, AnyAction>\'.", "195037722"],
+      [157, 6, 99, "Cannot invoke an object which is possibly \'undefined\'.", "375215550"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx:2241193092": [
-      [78, 47, 4, "Argument of type \'VLAN | undefined\' is not assignable to parameter of type \'VLAN\'.\\n  Type \'undefined\' is not assignable to type \'VLAN\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "2088175728"],
-      [145, 8, 71, "Argument of type \'(a: { name: string; subnets: any; }, b: { name: string; subnets: any; }) => false | 1 | -1\' is not assignable to parameter of type \'(a: { name: string; subnets: any; }, b: { name: string; subnets: any; }) => number\'.\\n  Type \'number | boolean\' is not assignable to type \'number\'.\\n    Type \'boolean\' is not assignable to type \'number\'.", "998825862"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.tsx:3231840782": [
+      [77, 47, 4, "Argument of type \'VLAN | undefined\' is not assignable to parameter of type \'VLAN\'.\\n  Type \'undefined\' is not assignable to type \'VLAN\'.\\n    Type \'undefined\' is not assignable to type \'Model\'.", "2088175728"],
+      [144, 8, 71, "Argument of type \'(a: { name: string; subnets: any; }, b: { name: string; subnets: any; }) => false | 1 | -1\' is not assignable to parameter of type \'(a: { name: string; subnets: any; }, b: { name: string; subnets: any; }) => number\'.\\n  Type \'number | boolean\' is not assignable to type \'number\'.\\n    Type \'boolean\' is not assignable to type \'number\'.", "998825862"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx:1857316240": [
-      [107, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
-      [202, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx:1605498138": [
+      [106, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
+      [201, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx:4228007390": [
-      [63, 27, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [64, 30, 4, "Object is possibly \'undefined\'.", "2088098233"],
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx:4069517428": [
+      [62, 27, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [63, 30, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [66, 41, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [66, 54, 4, "Object is possibly \'undefined\'.", "2088098233"],
       [67, 41, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [67, 54, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [68, 41, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [69, 37, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [70, 35, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [78, 31, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [79, 38, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [86, 38, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [86, 62, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [89, 49, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [92, 17, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [140, 56, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [163, 8, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"],
-      [164, 6, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"],
-      [166, 6, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"]
+      [68, 37, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [69, 35, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [77, 31, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [78, 38, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [85, 38, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [85, 62, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [88, 49, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [91, 17, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [139, 56, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [162, 8, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"],
+      [163, 6, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"],
+      [165, 6, 23, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "1151056647"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx:1979034219": [
-      [161, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
-      [191, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
-      [226, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
-      [237, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "2561676462"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx:2757950401": [
+      [160, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
+      [190, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
+      [225, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
+      [236, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "2561676462"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx:563267937": [
-      [138, 24, 10, "Type \'(poolName: string) => void\' is not assignable to type \'SelectPool\'.\\n  Types of parameters \'poolName\' and \'poolName\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1972538641"],
-      [192, 10, 7, "Type \'false | \\"For the Beta version of LXD VM hosts each VM can only be assigned a single block device.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"]
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx:3747358283": [
+      [137, 24, 10, "Type \'(poolName: string) => void\' is not assignable to type \'SelectPool\'.\\n  Types of parameters \'poolName\' and \'poolName\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1972538641"],
+      [191, 10, 7, "Type \'false | \\"For the Beta version of LXD VM hosts each VM can only be assigned a single block device.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"]
     ],
-    "src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx:3217674102": [
-      [102, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [106, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"],
-      [158, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [162, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
+    "src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx:1067605052": [
+      [101, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [105, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"],
+      [157, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [161, 10, 24, "Argument of type \'{ cpu_over_commit_ratio: number; memory_over_commit_ratio: number; password: string; pool: string; power_address: string; tags: string[]; type: string; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cpu_over_commit_ratio\' does not exist in type \'FormEvent<{}>\'.", "1500730218"]
     ],
     "src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx:64795914": [
       [21, 6, 12, "Variable \'initialState\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2722999692"],
@@ -205,120 +205,127 @@ exports[`stricter compilation`] = {
       [35, 6, 7, "Type \'false | Element[]\' is not assignable to type \'Element[] | null | undefined\'.\\n  Type \'false\' is not assignable to type \'Element[] | null | undefined\'.", "2807267104"],
       [54, 6, 11, "Type \'\\"\\" | Element | null\' is not assignable to type \'Element | null | undefined\'.\\n  Type \'\\"\\"\' is not assignable to type \'Element | null | undefined\'.", "3453098368"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:3419954839": [
-      [101, 6, 88, "Object is possibly \'undefined\'.", "465871270"],
-      [334, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
-      [356, 6, 98, "Object is possibly \'undefined\'.", "1041189900"]
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.test.tsx:2264661885": [
+      [100, 6, 88, "Object is possibly \'undefined\'.", "465871270"],
+      [333, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
+      [355, 6, 98, "Object is possibly \'undefined\'.", "1041189900"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:1196566218": [
-      [20, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
-    ],
-    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:2915918780": [
+    "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:947272896": [
       [19, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx:2669312087": [
-      [45, 34, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [46, 42, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [47, 37, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [47, 50, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [48, 38, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [51, 35, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [56, 44, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [56, 68, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [63, 23, 4, "Object is possibly \'undefined\'.", "2088098233"],
-      [67, 48, 4, "Object is possibly \'undefined\'.", "2088098233"]
+    "src/app/kvm/views/KVMList/KVMListTable/PowerColumn/PowerColumn.tsx:2436932342": [
+      [18, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:4255646153": [
-      [68, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [103, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"],
-      [133, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"]
+    "src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx:1732085149": [
+      [44, 34, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [45, 42, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [46, 37, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [46, 50, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [47, 38, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [50, 35, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [55, 44, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [55, 68, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [62, 23, 4, "Object is possibly \'undefined\'.", "2088098233"],
+      [66, 48, 4, "Object is possibly \'undefined\'.", "2088098233"]
     ],
-    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2508956927": [
-      [109, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [113, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
-      [204, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [208, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
+    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:3317752163": [
+      [67, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
+      [102, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"],
+      [132, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"]
     ],
-    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx:1032464947": [
-      [128, 6, 8, "Type \'(values: CommissionFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'CommissionFormValues\'.", "1301647696"],
-      [162, 42, 25, "Argument of type \'(Scripts | undefined)[]\' is not assignable to parameter of type \'Scripts[]\'.\\n  Type \'Scripts | undefined\' is not assignable to type \'Scripts\'.\\n    Type \'undefined\' is not assignable to type \'Scripts\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "4025185665"]
+    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2631498325": [
+      [108, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [112, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
+      [203, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [207, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
-    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx:765558469": [
-      [152, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [153, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
-      [223, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [224, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
-      [270, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [271, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
-      [319, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [320, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"],
-      [357, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"],
-      [372, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [373, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"]
+    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx:2699267004": [
+      [127, 6, 8, "Type \'(values: CommissionFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'CommissionFormValues\'.", "1301647696"],
+      [161, 42, 25, "Argument of type \'(Scripts | undefined)[]\' is not assignable to parameter of type \'Scripts[]\'.\\n  Type \'Scripts | undefined\' is not assignable to type \'Scripts\'.\\n    Type \'undefined\' is not assignable to type \'Scripts\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "4025185665"]
     ],
-    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx:2493669916": [
-      [103, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"]
+    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx:3722742895": [
+      [151, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [152, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
+      [222, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [223, 8, 17, "Argument of type \'{ oSystem: string; release: string; kernel: string; installKVM: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'oSystem\' does not exist in type \'FormEvent<{}>\'.", "4147515896"],
+      [269, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [270, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"],
+      [318, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [319, 8, 22, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "486161855"],
+      [356, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"],
+      [371, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [372, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"]
     ],
-    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx:1594062349": [
-      [122, 10, 19, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2609332470"]
+    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx:523014742": [
+      [102, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"]
     ],
-    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx:282943439": [
-      [21, 27, 4, "Binding element \'file\' implicitly has an \'any\' type.", "2087597251"],
-      [23, 4, 16, "Object is possibly \'null\'.", "4019370437"],
-      [28, 20, 23, "Argument of type \'\\"Reading file aborted.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2851093748"],
-      [32, 20, 21, "Argument of type \'\\"Error reading file.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2974791143"],
-      [55, 18, 6, "Argument of type \'string\' is not assignable to parameter of type \'SetStateAction<null>\'.", "1168132398"],
-      [69, 4, 14, "Type \'([file]: [any]) => void\' is not assignable to type \'<T extends File>(files: T[], event: DropEvent) => void\'.\\n  Types of parameters \'__0\' and \'files\' are incompatible.\\n    Type \'T[]\' is not assignable to type \'[any]\'.\\n      Target requires 1 element(s) but source may have fewer.", "3837758380"],
-      [102, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
+    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx:679208775": [
+      [121, 10, 19, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2609332470"]
     ],
-    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx:1530015442": [
-      [67, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [68, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"],
-      [122, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [123, 8, 11, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "942845580"],
-      [167, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [168, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"]
+    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx:3739738371": [
+      [23, 27, 4, "Binding element \'file\' implicitly has an \'any\' type.", "2087597251"],
+      [25, 4, 16, "Object is possibly \'null\'.", "4019370437"],
+      [30, 20, 23, "Argument of type \'\\"Reading file aborted.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2851093748"],
+      [34, 20, 21, "Argument of type \'\\"Error reading file.\\"\' is not assignable to parameter of type \'SetStateAction<null>\'.", "2974791143"],
+      [57, 18, 6, "Argument of type \'string\' is not assignable to parameter of type \'SetStateAction<null>\'.", "1168132398"],
+      [71, 4, 14, "Type \'([file]: [any]) => void\' is not assignable to type \'<T extends File>(files: T[], event: DropEvent) => void\'.\\n  Types of parameters \'__0\' and \'files\' are incompatible.\\n    Type \'T[]\' is not assignable to type \'[any]\'.\\n      Target requires 1 element(s) but source may have fewer.", "3837758380"],
+      [104, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
     ],
-    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:1088456105": [
-      [59, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"]
+    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx:3252860536": [
+      [66, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [67, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"],
+      [121, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [122, 8, 11, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "942845580"],
+      [166, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [167, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"]
     ],
-    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:803180952": [
-      [97, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [101, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
-      [218, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
-      [222, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
+    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:3773800803": [
+      [58, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"]
     ],
-    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:1601481196": [
-      [78, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"],
-      [106, 6, 8, "Type \'(values: FormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'FormValues\'.", "1301647696"],
-      [123, 22, 11, "Type \'({ displayName: string; id: number; apply_configured_networking: boolean; default: boolean; description: string; destructive: boolean; for_hardware: string[]; hardware_type_name: \\"Node\\" | \\"CPU\\" | \\"Memory\\" | \\"Storage\\" | \\"Network\\"; ... 15 more ...; type: number; } | undefined)[]\' is not assignable to type \'ScriptsDisplay[]\'.\\n  Type \'{ displayName: string; id: number; apply_configured_networking: boolean; default: boolean; description: string; destructive: boolean; for_hardware: string[]; hardware_type_name: \\"Node\\" | \\"CPU\\" | \\"Memory\\" | \\"Storage\\" | \\"Network\\"; ... 15 more ...; type: number; } | undefined\' is not assignable to type \'ScriptsDisplay\'.\\n    Type \'undefined\' is not assignable to type \'ScriptsDisplay\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"]
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:2050223282": [
+      [96, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [100, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
+      [217, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [221, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx:478824359": [
-      [80, 8, 4, "Type \'\\"lifecycle1\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
-      [85, 8, 4, "Type \'\\"lifecycle2\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
-      [90, 8, 4, "Type \'\\"lifecycle3\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
-      [140, 8, 4, "Type \'\\"house\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
-      [225, 8, 4, "Type \'\\"action1\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
-      [230, 8, 4, "Type \'\\"action2\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:2129044518": [
+      [77, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"],
+      [105, 6, 8, "Type \'(values: FormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'FormValues\'.", "1301647696"],
+      [122, 22, 11, "Type \'({ displayName: string; id: number; apply_configured_networking: boolean; default: boolean; description: string; destructive: boolean; for_hardware: string[]; hardware_type_name: \\"Node\\" | \\"CPU\\" | \\"Memory\\" | \\"Storage\\" | \\"Network\\"; ... 15 more ...; type: number; } | undefined)[]\' is not assignable to type \'ScriptsDisplay[]\'.\\n  Type \'{ displayName: string; id: number; apply_configured_networking: boolean; default: boolean; description: string; destructive: boolean; for_hardware: string[]; hardware_type_name: \\"Node\\" | \\"CPU\\" | \\"Memory\\" | \\"Storage\\" | \\"Network\\"; ... 15 more ...; type: number; } | undefined\' is not assignable to type \'ScriptsDisplay\'.\\n    Type \'undefined\' is not assignable to type \'ScriptsDisplay\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"]
+    ],
+    "src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx:231665325": [
+      [79, 8, 4, "Type \'\\"lifecycle1\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
+      [84, 8, 4, "Type \'\\"lifecycle2\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
+      [89, 8, 4, "Type \'\\"lifecycle3\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
+      [139, 8, 4, "Type \'\\"house\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
+      [224, 8, 4, "Type \'\\"action1\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
+      [229, 8, 4, "Type \'\\"action2\\"\' is not assignable to type \'\\"on\\" | \\"off\\" | \\"abort\\" | \\"acquire\\" | \\"check-power\\" | \\"commission\\" | \\"delete\\" | \\"deploy\\" | \\"exit-rescue-mode\\" | \\"lock\\" | \\"mark-broken\\" | \\"mark-fixed\\" | \\"override-failed-testing\\" | ... 11 more ... | undefined\'.", "2087876002"],
+      [319, 11, 5, "Object is of type \'unknown\'.", "173192470"],
       [320, 11, 5, "Object is of type \'unknown\'.", "173192470"],
       [321, 11, 5, "Object is of type \'unknown\'.", "173192470"],
       [322, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [323, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [324, 11, 5, "Object is of type \'unknown\'.", "173192470"]
+      [323, 11, 5, "Object is of type \'unknown\'.", "173192470"]
     ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:3299274039": [
-      [40, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
-      [41, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
-      [56, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
-      [57, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
-      [88, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"],
-      [99, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
+    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:3233241181": [
+      [39, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
+      [40, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
+      [55, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
+      [56, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
+      [87, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"],
+      [98, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
-    "src/app/machines/hooks.tsx:3979753974": [
-      [47, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
-      [47, 37, 6, "Object is possibly \'undefined\'.", "1314712411"],
-      [47, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
-      [51, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
+    "src/app/machines/hooks.tsx:454037372": [
+      [46, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 53 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
+      [46, 37, 6, "Object is possibly \'undefined\'.", "1314712411"],
+      [46, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
+      [50, 11, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:3404377046": [
+      [72, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [73, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "2579426038"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx:2350215035": [
+      [50, 6, 89, "Cannot invoke an object which is possibly \'undefined\'.", "2274220369"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx:2084328255": [
       [78, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -334,32 +341,32 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:76605336": [
       [173, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:1385649737": [
-      [152, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
-      [188, 10, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
-      [213, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
+    "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:2196235682": [
+      [184, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
+      [220, 10, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"],
+      [245, 16, 20, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3626142890"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:152685935": [
-      [36, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
+    "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:3222508165": [
+      [35, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
     ],
-    "src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx:2959660279": [
-      [20, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [39, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [53, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [59, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [60, 10, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [75, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [76, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [82, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
-      [96, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"]
+    "src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx:2135127901": [
+      [19, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [38, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [52, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [58, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [59, 10, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [74, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [75, 18, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [81, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
+      [95, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"]
     ],
-    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:434322272": [
-      [107, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
-      [128, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.", "167402512"],
-      [133, 42, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
+    "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:3939471626": [
+      [106, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
+      [127, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.", "167402512"],
+      [132, 42, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
-    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:2902929152": [
-      [92, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
+    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:939584426": [
+      [91, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
     ],
     "src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx:3894467335": [
       [42, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -377,58 +384,58 @@ exports[`stricter compilation`] = {
       [72, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [73, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; power_pass: string; power_user: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "244873512"]
     ],
-    "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:3169156074": [
-      [90, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [95, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
+    "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:2742996384": [
+      [89, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [94, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
     ],
-    "src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx:1882910801": [
-      [28, 10, 4, "Type \'{ osystems: [string, string][]; releases: [string, string][]; }\' is missing the following properties from type \'OSInfo\': kernels, default_osystem, default_release", "2087377941"]
+    "src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx:3669606747": [
+      [27, 10, 4, "Type \'{ osystems: [string, string][]; releases: [string, string][]; }\' is missing the following properties from type \'OSInfo\': kernels, default_osystem, default_release", "2087377941"]
     ],
-    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx:253010761": [
-      [104, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [104, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
-      [106, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [106, 6, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
-      [122, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [122, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
-      [124, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [124, 6, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
-      [127, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [127, 6, 41, "Element implicitly has an \'any\' type because expression of type \'1\' can\'t be used to index type \'Number\'.\\n  Property \'1\' does not exist on type \'Number\'.", "2704435541"],
-      [143, 14, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [143, 14, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
-      [147, 10, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [147, 10, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
-      [240, 14, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [240, 14, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
-      [244, 10, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [244, 10, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"]
+    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx:1291094115": [
+      [103, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [103, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
+      [105, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [105, 6, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
+      [121, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [121, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
+      [123, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [123, 6, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
+      [126, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [126, 6, 41, "Element implicitly has an \'any\' type because expression of type \'1\' can\'t be used to index type \'Number\'.\\n  Property \'1\' does not exist on type \'Number\'.", "2704435541"],
+      [142, 14, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [142, 14, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
+      [146, 10, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [146, 10, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
+      [239, 14, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [239, 14, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
+      [243, 10, 38, "Object is possibly \'undefined\'.", "1978148098"],
+      [243, 10, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"]
     ],
-    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx:2816048067": [
-      [87, 19, 10, "Variable \'uploadedOn\' is used before being assigned.", "867434918"],
-      [121, 53, 9, "Variable \'scriptSrc\' is used before being assigned.", "1382917992"],
-      [129, 21, 10, "Variable \'uploadedOn\' is used before being assigned.", "867434918"],
-      [164, 4, 4, "Argument of type \'null\' is not assignable to parameter of type \'Function\'.", "2087897566"],
-      [205, 8, 10, "Argument of type \'null\' is not assignable to parameter of type \'number\'.", "668428687"]
+    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx:293872425": [
+      [86, 19, 10, "Variable \'uploadedOn\' is used before being assigned.", "867434918"],
+      [120, 53, 9, "Variable \'scriptSrc\' is used before being assigned.", "1382917992"],
+      [128, 21, 10, "Variable \'uploadedOn\' is used before being assigned.", "867434918"],
+      [163, 4, 4, "Argument of type \'null\' is not assignable to parameter of type \'Function\'.", "2087897566"],
+      [204, 8, 10, "Argument of type \'null\' is not assignable to parameter of type \'number\'.", "668428687"]
     ],
-    "src/app/settings/views/Users/UserForm/UserForm.test.tsx:3509668198": [
-      [87, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
-      [132, 43, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
-      [176, 43, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
-      [238, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"]
+    "src/app/settings/views/Users/UserForm/UserForm.test.tsx:3105084236": [
+      [86, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
+      [131, 43, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
+      [175, 43, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
+      [237, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"]
     ],
     "src/app/store/general/selectors/machineActions.test.ts:3573821059": [
       [90, 10, 4, "Type \'{ name: string; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: string; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: string; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'string\' is not assignable to type \'MachineActionName\'.", "2087377941"]
     ],
-    "src/app/store/machine/slice.ts:2067121244": [
-      [324, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, selected, statuses", "4102082497"],
-      [328, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ active: null; selected: never[]; statuses: {}; }\' is missing the following properties from type \'GenericState<Machine, any>\': errors, items, loaded, loading, and 2 more.", "1433951465"]
+    "src/app/store/machine/slice.ts:3401351412": [
+      [687, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, selected, statuses", "4102082497"],
+      [691, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Type \'{ active: null; selected: never[]; statuses: {}; }\' is missing the following properties from type \'GenericState<Machine, any>\': errors, items, loaded, loading, and 2 more.", "1433951465"]
     ],
     "src/app/store/noderesult/slice.ts:2700398629": [
       [57, 4, 10, "Type \'(state: NodeResultState, action: PayloadAction<NodeResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<NodeResultState, { payload: any; type: string; }> | CaseReducerWithPrepare<NodeResultState, PayloadAction<any, string, any, any>>\'.\\n  Type \'(state: NodeResultState, action: PayloadAction<NodeResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<NodeResultState, { payload: any; type: string; }>\'.\\n    Types of parameters \'action\' and \'action\' are incompatible.\\n      Type \'{ payload: any; type: string; }\' is not assignable to type \'PayloadAction<NodeResult[], string, GenericItemMeta<ItemMeta>, never>\'.\\n        Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.", "2529327088"]
     ],
-    "src/app/store/notification/selectors.ts:3079939596": [
-      [26, 39, 12, "Object is possibly \'undefined\'.", "964199671"]
+    "src/app/store/notification/selectors.ts:2780531046": [
+      [25, 39, 12, "Object is possibly \'undefined\'.", "964199671"]
     ],
     "src/app/store/pod/reducers.test.ts:4078104144": [
       [78, 38, 10, "Expected 1 arguments, but got 0.", "2565503122"]
@@ -478,25 +485,25 @@ exports[`stricter compilation`] = {
     "src/app/store/user/slice.ts:2225428906": [
       [10, 59, 12, "Type \'SliceCaseReducers<UserState>\' does not satisfy the constraint \'SliceCaseReducers<GenericState<User, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<UserState, { payload: any; type: string; }> | CaseReducerWithPrepare<UserState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<User, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<UserState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<User, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<UserState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<User, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Property \'auth\' is missing in type \'WritableDraft<GenericState<User, any>>\' but required in type \'WritableDraft<UserState>\'.", "1934442805"]
     ],
-    "src/app/store/utils/slice.test.ts:4111103378": [
-      [253, 10, 6, "Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<Controller | Device | BaseMachine | Subnet | User | Notification | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<Controller | Device | BaseMachine | Subnet | User | Notification | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'WritableDraft<GenericState<Controller | Device | BaseMachine | Subnet | User | Notification | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>>\' is not assignable to type \'GenericState<Token, any>\'.\\n        Types of property \'items\' are incompatible.\\n          Type \'(WritableDraft<BaseMachine> | WritableDraft<Subnet> | WritableDraft<ResourcePool> | WritableDraft<...> | ... 17 more ... | WritableDraft<...>)[]\' is not assignable to type \'Token[]\'.\\n            Type \'WritableDraft<BaseMachine> | WritableDraft<Subnet> | WritableDraft<ResourcePool> | WritableDraft<...> | ... 17 more ... | WritableDraft<...>\' is not assignable to type \'Token\'.\\n              Type \'WritableDraft<BaseMachine>\' is not assignable to type \'Token\'.\\n                Type \'WritableDraft<BaseMachine>\' is missing the following properties from type \'{ consumer: TokenConsumer; key: string; secret: string; }\': consumer, key, secret", "1551012726"],
-      [259, 53, 8, "Expected 1 arguments, but got 0.", "1130710519"],
-      [274, 10, 10, "Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<Controller | Device | BaseMachine | Subnet | User | Notification | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<Controller | Device | BaseMachine | Subnet | User | Notification | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'WritableDraft<GenericState<Controller | Device | BaseMachine | Subnet | User | Notification | DHCPSnippet | Domain | ... 13 more ... | Zone, unknown>>\' is not assignable to type \'GenericState<Token, any>\'.", "3510326721"],
-      [400, 10, 7, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "1380666520"],
-      [401, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "662888088"],
-      [402, 10, 14, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "368191931"],
-      [403, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "678288096"]
+    "src/app/store/utils/slice.test.ts:3343688984": [
+      [252, 10, 6, "Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<Subnet | Controller | Device | BaseMachine | ScriptResults | Scripts | User | Notification | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, _action: PayloadAction<undefined>) => void\' is not assignable to type \'CaseReducer<GenericState<Subnet | Controller | Device | BaseMachine | ScriptResults | Scripts | User | Notification | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'WritableDraft<GenericState<Subnet | Controller | Device | BaseMachine | ScriptResults | Scripts | User | Notification | ... 13 more ... | Zone, unknown>>\' is not assignable to type \'GenericState<Token, any>\'.\\n        Types of property \'items\' are incompatible.\\n          Type \'(WritableDraft<BaseMachine> | WritableDraft<Subnet> | WritableDraft<ResourcePool> | WritableDraft<...> | ... 17 more ... | WritableDraft<...>)[]\' is not assignable to type \'Token[]\'.\\n            Type \'WritableDraft<BaseMachine> | WritableDraft<Subnet> | WritableDraft<ResourcePool> | WritableDraft<...> | ... 17 more ... | WritableDraft<...>\' is not assignable to type \'Token\'.\\n              Type \'WritableDraft<BaseMachine>\' is not assignable to type \'Token\'.\\n                Type \'WritableDraft<BaseMachine>\' is missing the following properties from type \'{ consumer: TokenConsumer; key: string; secret: string; }\': consumer, key, secret", "1551012726"],
+      [258, 53, 8, "Expected 1 arguments, but got 0.", "1130710519"],
+      [273, 10, 10, "Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<Subnet | Controller | Device | BaseMachine | ScriptResults | Scripts | User | Notification | ... 13 more ... | Zone, unknown>, { ...; }> | CaseReducerWithPrepare<...>\'.\\n  Type \'(state: TokenState, action: PayloadAction<string>) => void\' is not assignable to type \'CaseReducer<GenericState<Subnet | Controller | Device | BaseMachine | ScriptResults | Scripts | User | Notification | ... 13 more ... | Zone, unknown>, { ...; }>\'.\\n    Types of parameters \'state\' and \'state\' are incompatible.\\n      Type \'WritableDraft<GenericState<Subnet | Controller | Device | BaseMachine | ScriptResults | Scripts | User | Notification | ... 13 more ... | Zone, unknown>>\' is not assignable to type \'GenericState<Token, any>\'.", "3510326721"],
+      [399, 10, 7, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "1380666520"],
+      [400, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "662888088"],
+      [401, 10, 14, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "368191931"],
+      [402, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n  Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.", "678288096"]
     ],
-    "src/app/store/utils/slice.ts:3280477229": [
-      [167, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [207, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [245, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [256, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
-      [261, 2, 181, "Type \'Slice<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>, \\"machine\\" | ... 22 more ... | \\"zone\\">\' is not assignable to type \'Slice<GenericState<I, E>, R, \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | ... 13 more ... | \\"zone\\">\'.\\n  The types returned by \'reducer(...)\' are incompatible between these types.\\n    Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.\\n      Type \'{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.", "3918538176"],
-      [267, 4, 8, "Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>>\'.\\n  Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<...>>\'.\\n    Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'SliceCaseReducers<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\'.\\n      Property \'fetchStart\' is incompatible with index signature.\\n        Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { ...; }> | CaseReducerWithPrepare<...>\'.\\n          Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; } | { errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { ...; }>\'.\\n            Types of parameters \'state\' and \'state\' are incompatible.\\n              Type \'WritableDraft<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }> | WritableDraft<{ errors: E; items: I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\' is not assignable to type \'GenericState<I, E>\'.\\n                Type \'WritableDraft<{ errors: null; items: never[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\' is not assignable to type \'GenericState<I, E>\'.\\n                  Types of property \'errors\' are incompatible.\\n                    Type \'null\' is not assignable to type \'E\'.\\n                      \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "2838615652"],
-      [354, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
-      [373, 27, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
-      [397, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"]
+    "src/app/store/utils/slice.ts:599382983": [
+      [166, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [206, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [244, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [255, 6, 12, "Type \'null\' is not assignable to type \'E\'.\\n  \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "1158883607"],
+      [260, 2, 181, "Type \'Slice<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>, \\"machine\\" | ... 22 more ... | \\"zone\\">\' is not assignable to type \'Slice<GenericState<I, E>, R, \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | ... 13 more ... | \\"zone\\">\'.\\n  The types returned by \'reducer(...)\' are incompatible between these types.\\n    Type \'{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.", "3918538176"],
+      [266, 4, 8, "Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>>\'.\\n  Type \'{ fetch: { prepare: () => { meta: { model: \\"machine\\" | \\"tag\\" | \\"pod\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"domain\\" | \\"fabric\\" | \\"licensekeys\\" | \\"noderesult\\" | \\"notification\\" | \\"packagerepository\\" | ... 11 more ... | \\"zone\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup:...\' is not assignable to type \'SliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\'.\\n    Property \'fetchStart\' is incompatible with index signature.\\n      Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { payload: any; type: string; }> | CaseReducerWithPrepare<{ errors: E | null; ... 4 more ...; saving: boolean; }, PayloadAction<...>>\'.\\n        Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\' is not assignable to type \'GenericState<I, E>\'.\\n              Types of property \'errors\' are incompatible.\\n                Type \'Draft<E> | null\' is not assignable to type \'E\'.\\n                  \'Draft<E> | null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.\\n                    Type \'null\' is not assignable to type \'E\'.\\n                      \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "2838615652"],
+      [353, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
+      [372, 27, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
+      [396, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"]
     ],
     "src/app/utils/getCookie.ts:940992619": [
       [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
@@ -507,14 +514,14 @@ exports[`stricter compilation`] = {
     "src/app/utils/someNotAll.ts:3892711037": [
       [7, 2, 71, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "1467649629"]
     ],
-    "src/testing/factories/notification.ts:945808506": [
-      [12, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
+    "src/testing/factories/notification.ts:3029786704": [
+      [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:1470307036": [
-      [237, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
-      [319, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
-      [321, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
-      [326, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:1457793581": [
+      [254, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
+      [336, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
+      [338, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
+      [343, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -528,29 +535,29 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [30, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/config/types.ts:2243720459": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [12, 46, 8, "RegExp match", "1152173309"]
+    "src/app/store/config/types.ts:3058322945": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [11, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/controller/types.ts:2161878618": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [14, 54, 8, "RegExp match", "1152173309"]
+    "src/app/store/controller/types.ts:3390626256": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [13, 54, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/device/types.ts:2514806262": [
-      [4, 13, 8, "RegExp match", "1152173309"],
-      [20, 46, 8, "RegExp match", "1152173309"]
+    "src/app/store/device/types.ts:4061080604": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [19, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/dhcpsnippet/types.ts:1876114564": [
-      [4, 13, 8, "RegExp match", "1152173309"],
-      [25, 56, 8, "RegExp match", "1152173309"]
+    "src/app/store/dhcpsnippet/types.ts:3868562318": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [24, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/domain/types.ts:3251056735": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [17, 46, 8, "RegExp match", "1152173309"]
+    "src/app/store/domain/types.ts:3895070165": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [16, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/fabric/types.ts:746969223": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [15, 46, 8, "RegExp match", "1152173309"]
+    "src/app/store/fabric/types.ts:4166410381": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [14, 46, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/general/selectors/utils.ts:1977532362": [
       [0, 13, 8, "RegExp match", "1152173309"],
@@ -570,104 +577,104 @@ exports[`no TSFixMe types`] = {
       [166, 9, 8, "RegExp match", "1152173309"],
       [175, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/licensekeys/types.ts:4095108657": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [12, 56, 8, "RegExp match", "1152173309"]
+    "src/app/store/licensekeys/types.ts:1152996219": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:494976385": [
-      [4, 13, 8, "RegExp match", "1152173309"],
-      [307, 25, 8, "RegExp match", "1152173309"]
+    "src/app/store/machine/types.ts:637385364": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [323, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/noderesult/selectors.ts:3260337324": [
       [6, 13, 8, "RegExp match", "1152173309"],
       [59, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/noderesult/types.ts:2482787868": [
-      [4, 13, 8, "RegExp match", "1152173309"],
-      [45, 9, 8, "RegExp match", "1152173309"]
+    "src/app/store/noderesult/types.ts:2478354230": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [44, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/notification/types.ts:475719844": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [29, 58, 8, "RegExp match", "1152173309"]
+    "src/app/store/notification/types.ts:3936731246": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [28, 58, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/packagerepository/types.ts:223419801": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [21, 68, 8, "RegExp match", "1152173309"]
+    "src/app/store/packagerepository/types.ts:3365432595": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [20, 68, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/pod/types.ts:1538849015": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [120, 21, 8, "RegExp match", "1152173309"]
+    "src/app/store/pod/types.ts:1967938237": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [119, 21, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/resourcepool/types.ts:1682108053": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [16, 58, 8, "RegExp match", "1152173309"]
+    "src/app/store/resourcepool/types.ts:1043464479": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [15, 58, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scriptresults/selectors.ts:23899312": [
       [6, 13, 8, "RegExp match", "1152173309"],
       [54, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresults/types.ts:1844911068": [
-      [5, 13, 8, "RegExp match", "1152173309"],
-      [35, 60, 8, "RegExp match", "1152173309"]
+    "src/app/store/scriptresults/types.ts:872539638": [
+      [2, 13, 8, "RegExp match", "1152173309"],
+      [34, 60, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scripts/types.ts:3885399320": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [17, 14, 8, "RegExp match", "1152173309"],
-      [22, 14, 8, "RegExp match", "1152173309"],
-      [53, 48, 8, "RegExp match", "1152173309"]
+    "src/app/store/scripts/types.ts:980490450": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [16, 14, 8, "RegExp match", "1152173309"],
+      [21, 14, 8, "RegExp match", "1152173309"],
+      [52, 48, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/service/types.ts:270479210": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [11, 48, 8, "RegExp match", "1152173309"]
+    "src/app/store/service/types.ts:3965282464": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [10, 48, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/space/types.ts:1637461793": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [14, 44, 8, "RegExp match", "1152173309"]
+    "src/app/store/space/types.ts:578851947": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [13, 44, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/sshkey/types.ts:2512593693": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [20, 46, 8, "RegExp match", "1152173309"]
+    "src/app/store/sshkey/types.ts:832292503": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [19, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/sslkey/types.ts:1546661026": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [14, 46, 8, "RegExp match", "1152173309"]
+    "src/app/store/sslkey/types.ts:3189641576": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [13, 46, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/status/types.ts:3358556468": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [5, 22, 8, "RegExp match", "1152173309"],
       [8, 8, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/subnet/types.ts:2296558495": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [47, 46, 8, "RegExp match", "1152173309"]
+    "src/app/store/subnet/types.ts:1043348821": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [46, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/tag/types.ts:2730381634": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [14, 40, 8, "RegExp match", "1152173309"]
+    "src/app/store/tag/types.ts:3275525000": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [13, 40, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/token/types.ts:1779512214": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [16, 44, 8, "RegExp match", "1152173309"]
+    "src/app/store/token/types.ts:1575725788": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [15, 44, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/user/types.ts:315374108": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [19, 9, 8, "RegExp match", "1152173309"],
-      [29, 22, 8, "RegExp match", "1152173309"]
+    "src/app/store/user/types.ts:3624100118": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [18, 9, 8, "RegExp match", "1152173309"],
+      [28, 22, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/utils/slice.ts:3280477229": [
-      [12, 13, 8, "RegExp match", "1152173309"],
-      [145, 23, 8, "RegExp match", "1152173309"],
-      [185, 23, 8, "RegExp match", "1152173309"],
-      [288, 20, 8, "RegExp match", "1152173309"],
-      [323, 24, 8, "RegExp match", "1152173309"]
+    "src/app/store/utils/slice.ts:599382983": [
+      [10, 13, 8, "RegExp match", "1152173309"],
+      [144, 23, 8, "RegExp match", "1152173309"],
+      [184, 23, 8, "RegExp match", "1152173309"],
+      [287, 20, 8, "RegExp match", "1152173309"],
+      [322, 24, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/vlan/types.ts:334580859": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [22, 42, 8, "RegExp match", "1152173309"]
+    "src/app/store/vlan/types.ts:2496706865": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [21, 42, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/zone/types.ts:122131539": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [15, 42, 8, "RegExp match", "1152173309"]
+    "src/app/store/zone/types.ts:3660426969": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [14, 42, 8, "RegExp match", "1152173309"]
     ]
   }`
 };

--- a/ui/src/app/base/components/TableMenu/TableMenu.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.js
@@ -3,23 +3,33 @@ import PropTypes from "prop-types";
 import React from "react";
 import classNames from "classnames";
 
-const TableMenu = ({ className, links, title, onToggleMenu, positionNode }) => {
+const TableMenu = ({
+  className,
+  disabled = false,
+  links,
+  title,
+  onToggleMenu,
+  position = "left",
+  positionNode,
+}) => {
   return (
     <ContextualMenu
       className={classNames("p-table-menu", className)}
       hasToggleIcon
       links={[title, ...links]}
       onToggleMenu={onToggleMenu}
-      position="left"
+      position={position}
       positionNode={positionNode}
       toggleAppearance="base"
       toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+      toggleDisabled={disabled}
     />
   );
 };
 
 TableMenu.propTypes = {
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   links: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.string,

--- a/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
+++ b/ui/src/app/base/components/TableMenu/__snapshots__/TableMenu.test.js.snap
@@ -15,5 +15,6 @@ exports[`TableMenu  renders 1`] = `
   position="left"
   toggleAppearance="base"
   toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+  toggleDisabled={false}
 />
 `;

--- a/ui/src/app/base/components/TableMenu/_index.scss
+++ b/ui/src/app/base/components/TableMenu/_index.scss
@@ -7,7 +7,6 @@
   }
 
   .p-table-menu .p-contextual-menu__dropdown {
-    right: auto;
     margin-left: -$sph-inner;
     min-width: 13rem;
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import AddPartition from "./AddPartition";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machinePartition as partitionFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AddPartition", () => {
+  it("sets the partition name correctly", () => {
+    const disk = diskFactory({
+      id: 1,
+      name: "floppy-disk",
+      partitions: [partitionFactory(), partitionFactory()],
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddPartition
+          closeExpanded={jest.fn()}
+          diskId={disk.id}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("Input[label='Name']").prop("value")).toBe(
+      "floppy-disk-part3"
+    );
+  });
+
+  it("correctly dispatches an action to create a partition", () => {
+    const disk = diskFactory({ id: 1 });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddPartition
+          closeExpanded={jest.fn()}
+          diskId={disk.id}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    wrapper.find("Formik").prop("onSubmit")({
+      filesystemType: "fat32",
+      mountOptions: "noexec",
+      mountPoint: "/path",
+      partitionSize: 5,
+      unit: "3",
+    });
+
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/createPartition")
+    ).toStrictEqual({
+      meta: {
+        method: "create_partition",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          block_id: 1,
+          fstype: "fat32",
+          mount_options: "noexec",
+          mount_point: "/path",
+          partition_size: 5000000000,
+          system_id: "abc123",
+        },
+      },
+      type: "machine/createPartition",
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect } from "react";
+
+import { usePrevious } from "@canonical/react-components/dist/hooks";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import AddPartitionFields from "../AddPartitionFields";
+
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { Disk, Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+export type AddPartitionValues = {
+  filesystemType?: string;
+  mountOptions?: string;
+  mountPoint?: string;
+  partitionSize: number;
+  unit: string;
+};
+
+type Props = {
+  closeExpanded: () => void;
+  diskId: Disk["id"];
+  systemId: Machine["system_id"];
+};
+
+const AddPartitionSchema = Yup.object().shape({
+  filesystemType: Yup.string(),
+  mountOptions: Yup.string(),
+  mountPoint: Yup.string().when("filesystemType", {
+    is: (val) => !!val,
+    then: Yup.string()
+      .matches(/^\//, "Mount point must start with /")
+      .required("Mount point is required if filesystem type is defined"),
+  }),
+  partitionSize: Yup.number()
+    .required("Size is required")
+    .when("unit", {
+      is: "2",
+      then: Yup.number().min(5, "Partition must be at least 5MB"),
+      otherwise: Yup.number().min(0, "Size must greater than 0"),
+    }),
+  unit: Yup.string().required(),
+});
+
+export const AddPartition = ({
+  closeExpanded,
+  diskId,
+  systemId,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const { creatingPartition } = useSelector((state: RootState) =>
+    machineSelectors.getStatuses(state, systemId)
+  );
+  const previousCreatingPartition = usePrevious(creatingPartition);
+  const saved = !creatingPartition && previousCreatingPartition;
+
+  // Close the form when partition has successfully been created.
+  // TODO: Check for machine-specific error, in which case keep form open.
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1842
+  useEffect(() => {
+    if (saved) {
+      closeExpanded();
+    }
+  }, [closeExpanded, saved]);
+
+  if (machine && "disks" in machine && "supported_filesystems" in machine) {
+    const filesystemOptions = machine.supported_filesystems.map(
+      (filesystem) => ({
+        label: filesystem.ui,
+        value: filesystem.key,
+      })
+    );
+    const disk = machine.disks.find((disk) => disk.id === diskId);
+    const partitionName = disk
+      ? `${disk.name}-part${(disk.partitions?.length || 0) + 1}`
+      : "partition";
+
+    return (
+      <FormikForm
+        buttons={FormCardButtons}
+        cleanup={machineActions.cleanup}
+        initialValues={{
+          filesystemType: "",
+          mountOptions: "",
+          mountPoint: "",
+          partitionSize: "",
+          unit: "3",
+        }}
+        onCancel={closeExpanded}
+        onSaveAnalytics={{
+          action: "Add partition",
+          category: "Machine storage",
+          label: "Add partition",
+        }}
+        onSubmit={(values: AddPartitionValues) => {
+          const {
+            filesystemType,
+            mountOptions,
+            mountPoint,
+            partitionSize,
+            unit,
+          } = values;
+          // Convert size into bytes before dispatching action
+          const size = partitionSize * Math.pow(1000, Number(unit));
+          const params = {
+            blockId: diskId,
+            partitionSize: size,
+            systemId: machine.system_id,
+            ...(filesystemType && { filesystemType }),
+            ...(filesystemType && mountOptions && { mountOptions }),
+            ...(filesystemType && mountPoint && { mountPoint }),
+          };
+
+          dispatch(machineActions.createPartition(params));
+        }}
+        saved={saved}
+        saving={creatingPartition}
+        submitLabel="Add partition"
+        validationSchema={AddPartitionSchema}
+      >
+        <AddPartitionFields
+          filesystemOptions={filesystemOptions}
+          partitionName={partitionName}
+        />
+      </FormikForm>
+    );
+  }
+  return null;
+};
+
+export default AddPartition;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./AddPartition";
+export type { AddPartitionValues } from "./AddPartition";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import AddPartition from "../AddPartition";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AddPartitionFields", () => {
+  it("renders mount point and options if filesystem type is selected", async () => {
+    const disk = diskFactory();
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            supported_filesystems: [{ key: "fat32", ui: "fat32" }],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddPartition
+          closeExpanded={jest.fn()}
+          diskId={disk.id}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    // Select a filesystem type
+    await act(async () => {
+      wrapper
+        .find("select[name='filesystemType']")
+        .props()
+        .onChange({
+          target: { name: "filesystemType", value: "fat32" },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+
+    expect(wrapper.find("Input[name='mountOptions']").exists()).toBe(true);
+    expect(wrapper.find("Input[name='mountPoint']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+import { Col, Input, Row, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { AddPartitionValues } from "../AddPartition";
+
+import FormikField from "app/base/components/FormikField";
+
+type Props = {
+  filesystemOptions: { label: string; value: string }[];
+  partitionName: string;
+};
+
+export const AddPartitionFields = ({
+  filesystemOptions,
+  partitionName,
+}: Props): JSX.Element => {
+  const { values } = useFormikContext<AddPartitionValues>();
+
+  return (
+    <Row>
+      <Col size="5">
+        <Input disabled label="Name" value={partitionName} type="text" />
+        <Input disabled label="Type" value="Partition" type="text" />
+        <FormikField
+          label="Size"
+          min="0"
+          name="partitionSize"
+          required
+          type="number"
+        />
+        <FormikField
+          component={Select}
+          label="Unit"
+          name="unit"
+          options={[
+            {
+              label: "Select partition size unit",
+              value: null,
+              disabled: true,
+            },
+            { label: "MB", value: "2" },
+            { label: "GB", value: "3" },
+            { label: "TB", value: "4" },
+          ]}
+        />
+      </Col>
+      <Col emptyLarge="7" size="5">
+        <FormikField
+          component={Select}
+          label="Filesystem"
+          name="filesystemType"
+          options={[
+            {
+              label: "Select filesystem type",
+              value: null,
+              disabled: true,
+            },
+            {
+              label: "Unformatted",
+              value: "",
+            },
+            ...filesystemOptions,
+          ]}
+        />
+        {!!values.filesystemType && (
+          <>
+            <FormikField
+              label="Mount point"
+              name="mountPoint"
+              placeholder="/path/to/partition"
+              required
+              type="text"
+            />
+            <FormikField
+              help='Comma-separated list without spaces, e.g. "noexec,size=1024k".'
+              label="Mount options"
+              name="mountOptions"
+              type="text"
+            />
+          </>
+        )}
+      </Col>
+    </Row>
+  );
+};
+
+export default AddPartitionFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddPartitionFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -25,7 +25,7 @@ const mockStore = configureStore();
 describe("FilesystemsTable", () => {
   it("can show an empty message", () => {
     const wrapper = mount(
-      <FilesystemsTable editable={false} filesystems={[]} />
+      <FilesystemsTable canEditStorage={false} filesystems={[]} />
     );
 
     expect(wrapper.find("[data-test='no-filesystems']").text()).toBe(
@@ -43,7 +43,7 @@ describe("FilesystemsTable", () => {
     ];
     const { filesystems } = separateStorageData(disks);
     const wrapper = mount(
-      <FilesystemsTable editable={false} filesystems={filesystems} />
+      <FilesystemsTable canEditStorage={false} filesystems={filesystems} />
     );
 
     expect(wrapper.find("TableRow TableCell").at(0).text()).toBe("disk-fs");
@@ -66,7 +66,7 @@ describe("FilesystemsTable", () => {
     ];
     const { filesystems } = separateStorageData(disks);
     const wrapper = mount(
-      <FilesystemsTable editable={false} filesystems={filesystems} />
+      <FilesystemsTable canEditStorage={false} filesystems={filesystems} />
     );
 
     expect(wrapper.find("TableRow TableCell").at(0).text()).toBe(
@@ -83,7 +83,7 @@ describe("FilesystemsTable", () => {
     ];
     const { filesystems } = separateStorageData([], specialFilesystems);
     const wrapper = mount(
-      <FilesystemsTable editable={false} filesystems={filesystems} />
+      <FilesystemsTable canEditStorage={false} filesystems={filesystems} />
     );
 
     expect(wrapper.find("TableRow TableCell").at(0).text()).toBe("—");
@@ -92,7 +92,7 @@ describe("FilesystemsTable", () => {
     );
   });
 
-  it("can show an add special filesystem form if storage is editable", () => {
+  it("can show an add special filesystem form if storage can be edited", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [machineDetailsFactory({ system_id: "abc123" })],
@@ -112,7 +112,9 @@ describe("FilesystemsTable", () => {
           <Route
             exact
             path="/machine/:id/storage"
-            component={() => <FilesystemsTable editable filesystems={[]} />}
+            component={() => (
+              <FilesystemsTable canEditStorage filesystems={[]} />
+            )}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -8,11 +8,14 @@ import { formatSize } from "../utils";
 import AddSpecialFilesystem from "./AddSpecialFilesystem";
 
 type Props = {
-  editable: boolean;
+  canEditStorage: boolean;
   filesystems: NormalisedFilesystem[];
 };
 
-const FilesystemsTable = ({ editable, filesystems }: Props): JSX.Element => {
+const FilesystemsTable = ({
+  canEditStorage,
+  filesystems,
+}: Props): JSX.Element => {
   const [addSpecialFormOpen, setAddSpecialFormOpen] = useState<boolean>(false);
 
   const closeAddSpecialForm = () => setAddSpecialFormOpen(false);
@@ -79,7 +82,7 @@ const FilesystemsTable = ({ editable, filesystems }: Props): JSX.Element => {
           No filesystems defined.
         </p>
       )}
-      {editable && !addSpecialFormOpen && (
+      {canEditStorage && !addSpecialFormOpen && (
         <Tooltip message="Create a tmpfs or ramfs filesystem.">
           <Button
             appearance="neutral"

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -52,7 +52,7 @@ const MachineStorage = (): JSX.Element => {
             <>
               <h4>Filesystems</h4>
               <FilesystemsTable
-                editable={canEditStorage}
+                canEditStorage={canEditStorage}
                 filesystems={filesystems}
               />
             </>
@@ -66,7 +66,11 @@ const MachineStorage = (): JSX.Element => {
         )}
         <Strip shallow>
           <h4>Available disks and partitions</h4>
-          <AvailableStorageTable storageDevices={available} />
+          <AvailableStorageTable
+            canEditStorage={canEditStorage}
+            storageDevices={available}
+            systemId={id}
+          />
         </Strip>
         <Strip shallow>
           <h4>Used disks and partitions</h4>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
@@ -10,6 +10,7 @@ export type NormalisedFilesystem = {
 };
 
 export type NormalisedStorageDevice = {
+  actions: string[];
   boot: boolean | null;
   firmware: string | null;
   id: number;

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -85,6 +85,7 @@ exports[`OwnerColumn renders 1`] = `
               positionNode={null}
               toggleAppearance="base"
               toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+              toggleDisabled={false}
             >
               <span
                 className="p-table-menu p-contextual-menu p-contextual-menu--left"
@@ -100,6 +101,7 @@ exports[`OwnerColumn renders 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  disabled={false}
                   hasIcon={true}
                   onClick={[Function]}
                   type="button"
@@ -109,6 +111,7 @@ exports[`OwnerColumn renders 1`] = `
                     aria-expanded="false"
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/__snapshots__/PoolColumn.test.js.snap
@@ -108,6 +108,7 @@ exports[`PoolColumn renders 1`] = `
               positionNode={null}
               toggleAppearance="base"
               toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+              toggleDisabled={false}
             >
               <span
                 className="p-table-menu p-contextual-menu p-contextual-menu--left"
@@ -123,6 +124,7 @@ exports[`PoolColumn renders 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  disabled={false}
                   hasIcon={true}
                   onClick={[Function]}
                   type="button"
@@ -132,6 +134,7 @@ exports[`PoolColumn renders 1`] = `
                     aria-expanded="false"
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.js.snap
@@ -118,6 +118,7 @@ exports[`PowerColumn renders 1`] = `
               positionNode={null}
               toggleAppearance="base"
               toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+              toggleDisabled={false}
             >
               <span
                 className="p-table-menu p-table-menu--hasIcon p-contextual-menu p-contextual-menu--left"
@@ -133,6 +134,7 @@ exports[`PowerColumn renders 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  disabled={false}
                   hasIcon={true}
                   onClick={[Function]}
                   type="button"
@@ -142,6 +144,7 @@ exports[`PowerColumn renders 1`] = `
                     aria-expanded="false"
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
@@ -344,6 +344,7 @@ exports[`StatusColumn renders 1`] = `
               positionNode={null}
               toggleAppearance="base"
               toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+              toggleDisabled={false}
             >
               <span
                 className="p-table-menu p-contextual-menu p-contextual-menu--left"
@@ -359,6 +360,7 @@ exports[`StatusColumn renders 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  disabled={false}
                   hasIcon={true}
                   onClick={[Function]}
                   type="button"
@@ -368,6 +370,7 @@ exports[`StatusColumn renders 1`] = `
                     aria-expanded="false"
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/__snapshots__/ZoneColumn.test.js.snap
@@ -104,6 +104,7 @@ exports[`ZoneColumn renders 1`] = `
               positionNode={null}
               toggleAppearance="base"
               toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+              toggleDisabled={false}
             >
               <span
                 className="p-table-menu p-contextual-menu p-contextual-menu--left"
@@ -119,6 +120,7 @@ exports[`ZoneColumn renders 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                  disabled={false}
                   hasIcon={true}
                   onClick={[Function]}
                   type="button"
@@ -128,6 +130,7 @@ exports[`ZoneColumn renders 1`] = `
                     aria-expanded="false"
                     aria-haspopup="true"
                     className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -411,9 +411,9 @@ const statusHandlers = generateStatusHandlers<
         handler.method = "create_partition";
         handler.prepare = (params: {
           blockId: number;
-          filesystemType: string;
-          mountOptions: string;
-          mountPoint: string;
+          filesystemType?: string;
+          mountOptions?: string;
+          mountPoint?: string;
           partitionSize: number;
           systemId: Machine["system_id"];
         }) => ({


### PR DESCRIPTION
## Done

- Added `actions` parameter to normalised storage devices, which will house the actions that a storage device can perform (similar to how `machine.actions` works)
- Added util for determining whether a storage device can be partitioned
- Added `AddPartition` form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a "Ready" or "Allocated" machine
- Check that physical disks in "Available disks and partitions" have an action dropdown that can open the "Add partition" form
- Check that adding a formatted partition adds it to the "Filesystems" table
- Check that adding an unformatted partition adds it to the "Available disks and partitions" table

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2164

## Screenshot

![Screenshot_2020-11-25 fun-mammal maas storage bolla MAAS](https://user-images.githubusercontent.com/25733845/100172332-d33ff400-2f13-11eb-9807-7017b56f7a6b.png)
