### PR TITLE
refactor(ui): use enums for machine action types

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -7,6 +7,7 @@ import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
 import { useProcessing } from "app/base/hooks";
 import type { AnalyticsEvent, TSFixMe } from "app/base/types";
+import { NodeActions } from "app/store/types/node";
 import { formatErrors } from "app/utils";
 
 const getLabel = (
@@ -30,57 +31,57 @@ const getLabel = (
   }
 
   switch (actionName) {
-    case "abort":
+    case NodeActions.ABORT:
       return `${processing ? "Aborting" : "Abort"} actions for ${modelString}`;
-    case "acquire":
+    case NodeActions.ACQUIRE:
       return `${processing ? "Acquiring" : "Acquire"} ${modelString}`;
-    case "commission":
+    case NodeActions.COMMISSION:
       return `${
         processing ? "Starting" : "Start"
       } commissioning for ${modelString}`;
     case "compose":
       return `${processing ? "Composing" : "Compose"} ${modelString}`;
-    case "delete":
+    case NodeActions.DELETE:
       return `${processing ? "Deleting" : "Delete"} ${modelString}`;
-    case "deploy":
+    case NodeActions.DEPLOY:
       return `${
         processing ? "Starting" : "Start"
       } deployment for ${modelString}`;
-    case "exit-rescue-mode":
+    case NodeActions.EXIT_RESCUE_MODE:
       return `${
         processing ? "Exiting" : "Exit"
       } rescue mode for ${modelString}`;
-    case "lock":
+    case NodeActions.LOCK:
       return `${processing ? "Locking" : "Lock"} ${modelString}`;
-    case "on":
+    case NodeActions.ON:
       return `${processing ? "Powering" : "Power"} on ${modelString}`;
-    case "off":
+    case NodeActions.OFF:
       return `${processing ? "Powering" : "Power"} off ${modelString}`;
-    case "mark-broken":
+    case NodeActions.MARK_BROKEN:
       return `${processing ? "Marking" : "Mark"} ${modelString} broken`;
-    case "mark-fixed":
+    case NodeActions.MARK_FIXED:
       return `${processing ? "Marking" : "Mark"} ${modelString} fixed`;
-    case "override-failed-testing":
+    case NodeActions.OVERRIDE_FAILED_TESTING:
       return `${
         processing ? "Overriding" : "Override"
       } failed tests for ${modelString}`;
-    case "release":
+    case NodeActions.RELEASE:
       return `${processing ? "Releasing" : "Release"} ${modelString}`;
     case "refresh":
       return `${processing ? "Refreshing" : "Refresh"} ${modelString}`;
-    case "rescue-mode":
+    case NodeActions.RESCUE_MODE:
       return `${
         processing ? "Entering" : "Enter"
       } rescue mode for ${modelString}`;
-    case "set-pool":
+    case NodeActions.SET_POOL:
       return `${processing ? "Setting" : "Set"} pool for ${modelString}`;
-    case "set-zone":
+    case NodeActions.SET_ZONE:
       return `${processing ? "Setting" : "Set"} zone for ${modelString}`;
-    case "tag":
+    case NodeActions.TAG:
       return `${processing ? "Tagging" : "Tag"} ${modelString}`;
-    case "test":
+    case NodeActions.TEST:
       return `${processing ? "Starting" : "Start"} tests for ${modelString}`;
-    case "unlock":
+    case NodeActions.UNLOCK:
       return `${processing ? "Unlocking" : "Unlock"} ${modelString}`;
     default:
       return `${processing ? "Processing" : "Process"} ${modelString}`;

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -9,6 +9,7 @@ import configureStore from "redux-mock-store";
 import ActionFormWrapper from "./ActionFormWrapper";
 
 import { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -32,7 +33,7 @@ describe("ActionFormWrapper", () => {
         machineActions: machineActionsStateFactory({
           data: [
             machineActionFactory({
-              name: "commission",
+              name: NodeActions.COMMISSION,
             }),
           ],
         }),
@@ -81,7 +82,7 @@ describe("ActionFormWrapper", () => {
   action`, () => {
     const state = { ...initialState };
     state.machine.items = [
-      machineFactory({ system_id: "a", actions: ["commission"] }),
+      machineFactory({ system_id: "a", actions: [NodeActions.COMMISSION] }),
       machineFactory({ system_id: "b", actions: [] }),
     ];
     state.machine.selected = ["a", "b"];
@@ -93,7 +94,7 @@ describe("ActionFormWrapper", () => {
         >
           <ActionFormWrapper
             selectedAction={{
-              name: "commission",
+              name: NodeActions.COMMISSION,
             }}
             setSelectedAction={jest.fn()}
           />
@@ -109,7 +110,7 @@ describe("ActionFormWrapper", () => {
     can perform selected action`, async () => {
     const state = { ...initialState };
     state.machine.items = [
-      machineFactory({ system_id: "a", actions: ["commission"] }),
+      machineFactory({ system_id: "a", actions: [NodeActions.COMMISSION] }),
       machineFactory({ system_id: "b", actions: [] }),
     ];
     state.machine.selected = ["a", "b"];
@@ -129,7 +130,7 @@ describe("ActionFormWrapper", () => {
         >
           <ActionFormWrapper
             selectedAction={{
-              name: "commission",
+              name: NodeActions.COMMISSION,
             }}
             setSelectedAction={jest.fn()}
           />
@@ -148,7 +149,7 @@ describe("ActionFormWrapper", () => {
   it("can set selected machines to those that can perform action", () => {
     const state = { ...initialState };
     state.machine.items = [
-      machineFactory({ system_id: "a", actions: ["commission"] }),
+      machineFactory({ system_id: "a", actions: [NodeActions.COMMISSION] }),
       machineFactory({ system_id: "b", actions: [] }),
     ];
     state.machine.selected = ["a", "b"];
@@ -160,7 +161,7 @@ describe("ActionFormWrapper", () => {
         >
           <ActionFormWrapper
             selectedAction={{
-              name: "commission",
+              name: NodeActions.COMMISSION,
             }}
             setSelectedAction={jest.fn()}
           />

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -23,24 +23,25 @@ import type {
   SetSelectedAction,
 } from "app/machines/views/MachineDetails/MachineSummary";
 import { actions as machineActions } from "app/store/machine";
+import { NodeActions } from "app/store/types/node";
 
 const getErrorSentence = (action: SelectedAction, count: number) => {
   const machineString = pluralize("machine", count, true);
 
   switch (action.name) {
-    case "exit-rescue-mode":
+    case NodeActions.EXIT_RESCUE_MODE:
       return `${machineString} cannot exit rescue mode`;
-    case "lock":
+    case NodeActions.LOCK:
       return `${machineString} cannot be locked`;
-    case "override-failed-testing":
+    case NodeActions.OVERRIDE_FAILED_TESTING:
       return `Cannot override failed tests on ${machineString}`;
-    case "rescue-mode":
+    case NodeActions.RESCUE_MODE:
       return `${machineString} cannot be put in rescue mode`;
-    case "set-pool":
+    case NodeActions.SET_POOL:
       return `Cannot set pool of ${machineString}`;
-    case "set-zone":
+    case NodeActions.SET_ZONE:
       return `Cannot set zone of ${machineString}`;
-    case "unlock":
+    case NodeActions.UNLOCK:
       return `${machineString} cannot be unlocked`;
     default:
       return `${machineString} cannot be ${action.sentence}`;
@@ -97,21 +98,21 @@ export const ActionFormWrapper = ({
   const getFormComponent = () => {
     if (selectedAction && selectedAction.name) {
       switch (selectedAction.name) {
-        case "commission":
+        case NodeActions.COMMISSION:
           return <CommissionForm setSelectedAction={setSelectedAction} />;
-        case "deploy":
+        case NodeActions.DEPLOY:
           return <DeployForm setSelectedAction={setSelectedAction} />;
-        case "mark-broken":
+        case NodeActions.MARK_BROKEN:
           return <MarkBrokenForm setSelectedAction={setSelectedAction} />;
-        case "override-failed-testing":
+        case NodeActions.OVERRIDE_FAILED_TESTING:
           return <OverrideTestForm setSelectedAction={setSelectedAction} />;
-        case "set-pool":
+        case NodeActions.SET_POOL:
           return <SetPoolForm setSelectedAction={setSelectedAction} />;
-        case "set-zone":
+        case NodeActions.SET_ZONE:
           return <SetZoneForm setSelectedAction={setSelectedAction} />;
-        case "tag":
+        case NodeActions.TAG:
           return <TagForm setSelectedAction={setSelectedAction} />;
-        case "test":
+        case NodeActions.TEST:
           return (
             <TestForm
               setSelectedAction={setSelectedAction}

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -9,6 +9,7 @@ import configureStore from "redux-mock-store";
 import CommissionForm from "./CommissionForm";
 
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -32,7 +33,7 @@ describe("CommissionForm", () => {
         machineActions: machineActionsStateFactory({
           data: [
             machineActionFactory({
-              name: "commission",
+              name: NodeActions.COMMISSION,
               title: "Commission",
             }),
           ],
@@ -134,7 +135,7 @@ describe("CommissionForm", () => {
         },
         payload: {
           params: {
-            action: "commission",
+            action: NodeActions.COMMISSION,
             extra: {
               enable_ssh: true,
               skip_bmc_config: true,
@@ -160,7 +161,7 @@ describe("CommissionForm", () => {
         },
         payload: {
           params: {
-            action: "commission",
+            action: NodeActions.COMMISSION,
             extra: {
               enable_ssh: true,
               skip_bmc_config: true,
@@ -229,7 +230,7 @@ describe("CommissionForm", () => {
         },
         payload: {
           params: {
-            action: "commission",
+            action: NodeActions.COMMISSION,
             extra: {
               enable_ssh: true,
               skip_bmc_config: true,

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -14,6 +14,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import scriptSelectors from "app/store/scripts/selectors";
 import type { Scripts } from "app/store/scripts/types";
+import { NodeActions } from "app/store/types/node";
 import { simpleSortByKey } from "app/utils";
 
 const formatScripts = (scripts: Scripts[]) =>
@@ -75,7 +76,7 @@ export const CommissionForm = ({ setSelectedAction }: Props): JSX.Element => {
   const urlScripts = useSelector(scriptSelectors.testingWithUrl);
   const testingScripts = useSelector(scriptSelectors.testing);
   const { machinesToAction, processingCount } = useMachineActionForm(
-    "commission"
+    NodeActions.COMMISSION
   );
 
   const preselectedTestingScripts = [
@@ -102,7 +103,7 @@ export const CommissionForm = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <ActionForm
-      actionName="commission"
+      actionName={NodeActions.COMMISSION}
       allowUnchanged
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -10,6 +10,7 @@ import DeployForm from "./DeployForm";
 
 import * as hooks from "app/base/hooks";
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import {
   config as configFactory,
   configState as configStateFactory,
@@ -55,7 +56,7 @@ describe("DeployForm", () => {
         machineActions: machineActionsStateFactory({
           data: [
             machineActionFactory({
-              name: "deploy",
+              name: NodeActions.DEPLOY,
               title: "Deploy",
             }),
           ],
@@ -167,7 +168,7 @@ describe("DeployForm", () => {
         },
         payload: {
           params: {
-            action: "deploy",
+            action: NodeActions.DEPLOY,
             extra: {
               osystem: "ubuntu",
               distro_series: "bionic",
@@ -186,7 +187,7 @@ describe("DeployForm", () => {
         },
         payload: {
           params: {
-            action: "deploy",
+            action: NodeActions.DEPLOY,
             extra: {
               osystem: "ubuntu",
               distro_series: "bionic",
@@ -239,7 +240,7 @@ describe("DeployForm", () => {
         },
         payload: {
           params: {
-            action: "deploy",
+            action: NodeActions.DEPLOY,
             extra: {
               osystem: "ubuntu",
               distro_series: "bionic",
@@ -287,7 +288,7 @@ describe("DeployForm", () => {
         },
         payload: {
           params: {
-            action: "deploy",
+            action: NodeActions.DEPLOY,
             extra: {
               osystem: "ubuntu",
               distro_series: "bionic",
@@ -336,7 +337,7 @@ describe("DeployForm", () => {
         },
         payload: {
           params: {
-            action: "deploy",
+            action: NodeActions.DEPLOY,
             extra: {
               osystem: "ubuntu",
               distro_series: "bionic",

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -56,7 +56,7 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
   const osInfoLoaded = useSelector(generalSelectors.osInfo.loaded);
   const sendAnalytics = useSendAnalytics();
   const { machinesToAction, processingCount } = useMachineActionForm(
-    NodeActions.DELETE
+    NodeActions.DEPLOY
   );
 
   useEffect(() => {
@@ -84,7 +84,7 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <ActionForm
-      actionName={NodeActions.DELETE}
+      actionName={NodeActions.DEPLOY}
       allowUnchanged={osystems?.length !== 0 && releases?.length !== 0}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -14,6 +14,7 @@ import generalSelectors from "app/store/general/selectors";
 import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { NodeActions } from "app/store/types/node";
 
 const DeploySchema = Yup.object().shape({
   oSystem: Yup.string().required("OS is required"),
@@ -54,7 +55,9 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
   );
   const osInfoLoaded = useSelector(generalSelectors.osInfo.loaded);
   const sendAnalytics = useSendAnalytics();
-  const { machinesToAction, processingCount } = useMachineActionForm("deploy");
+  const { machinesToAction, processingCount } = useMachineActionForm(
+    NodeActions.DELETE
+  );
 
   useEffect(() => {
     dispatch(generalActions.fetchDefaultMinHweKernel());
@@ -81,7 +84,7 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <ActionForm
-      actionName="deploy"
+      actionName={NodeActions.DELETE}
       allowUnchanged={osystems?.length !== 0 && releases?.length !== 0}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.js
@@ -8,22 +8,24 @@ import { useMachineActionForm } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import ActionForm from "app/base/components/ActionForm";
 
+import { NodeActions } from "app/store/types/node";
+
 // List of machine actions that do not require any extra parameters sent through
 // the websocket apart from machine system id. All other actions will have
 // their own form components.
 const fieldlessActions = [
-  "abort",
-  "acquire",
-  "delete",
-  "exit-rescue-mode",
-  "lock",
-  "mark-broken",
-  "mark-fixed",
-  "off",
-  "on",
-  "release",
-  "rescue-mode",
-  "unlock",
+  NodeActions.ABORT,
+  NodeActions.ACQUIRE,
+  NodeActions.DELETE,
+  NodeActions.EXIT_RESCUE_MODE,
+  NodeActions.LOCK,
+  NodeActions.MARK_BROKEN,
+  NodeActions.MARK_FIXED,
+  NodeActions.OFF,
+  NodeActions.ON,
+  NodeActions.RELEASE,
+  NodeActions.RESCUE_MODE,
+  NodeActions.UNLOCK,
 ];
 
 export const FieldlessForm = ({ selectedAction, setSelectedAction }) => {
@@ -58,7 +60,7 @@ export const FieldlessForm = ({ selectedAction, setSelectedAction }) => {
       processingCount={processingCount}
       selectedCount={machinesToAction.length}
       submitAppearance={
-        selectedAction.name === "delete" ? "negative" : "positive"
+        selectedAction.name === NodeActions.DELETE ? "negative" : "positive"
       }
     />
   );

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.test.js
@@ -15,6 +15,8 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 
+import { NodeActions } from "app/store/types/node";
+
 const mockStore = configureStore();
 
 describe("FieldlessForm", () => {
@@ -37,20 +39,32 @@ describe("FieldlessForm", () => {
       general: generalStateFactory({
         machineActions: machineActionsStateFactory({
           data: [
-            machineActionFactory({ name: "abort", title: "Abort" }),
-            machineActionFactory({ name: "acquire", title: "Acquire" }),
-            machineActionFactory({ name: "delete", title: "Delete" }),
+            machineActionFactory({ name: NodeActions.ABORT, title: "Abort" }),
             machineActionFactory({
-              name: "exit-rescue-mode",
+              name: NodeActions.ACQUIRE,
+              title: "Acquire",
+            }),
+            machineActionFactory({ name: NodeActions.DELETE, title: "Delete" }),
+            machineActionFactory({
+              name: NodeActions.EXIT_RESCUE_MODE,
               title: "Exit rescue mode",
             }),
-            machineActionFactory({ name: "lock", title: "Lock" }),
-            machineActionFactory({ name: "mark-fixed", title: "Mark fixed" }),
-            machineActionFactory({ name: "off", title: "Power off" }),
-            machineActionFactory({ name: "on", title: "Power on" }),
-            machineActionFactory({ name: "release", title: "Release" }),
-            machineActionFactory({ name: "rescue-mode", title: "Rescue mode" }),
-            machineActionFactory({ name: "unlock", title: "Unlock" }),
+            machineActionFactory({ name: NodeActions.LOCK, title: "Lock" }),
+            machineActionFactory({
+              name: NodeActions.MARK_FIXED,
+              title: "Mark fixed",
+            }),
+            machineActionFactory({ name: NodeActions.OFF, title: "Power off" }),
+            machineActionFactory({ name: NodeActions.ON, title: "Power on" }),
+            machineActionFactory({
+              name: NodeActions.RELEASE,
+              title: "Release",
+            }),
+            machineActionFactory({
+              name: NodeActions.RESCUE_MODE,
+              title: "Rescue mode",
+            }),
+            machineActionFactory({ name: NodeActions.UNLOCK, title: "Unlock" }),
           ],
         }),
       }),
@@ -66,7 +80,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "release" }}
+            selectedAction={{ name: NodeActions.RELEASE }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -77,7 +91,7 @@ describe("FieldlessForm", () => {
 
   it("can unset the selected action", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "a", actions: ["release"] }];
+    state.machine.items = [{ system_id: "a", actions: [NodeActions.RELEASE] }];
     state.machine.selected = ["a"];
     state.machine.statuses = { a: {} };
     const store = mockStore(state);
@@ -88,7 +102,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "release" }}
+            selectedAction={{ name: NodeActions.RELEASE }}
             setSelectedAction={setSelectedAction}
           />
         </MemoryRouter>
@@ -101,7 +115,9 @@ describe("FieldlessForm", () => {
 
   it("displays a negative submit button if selected action is delete", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["delete"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.DELETE] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const setSelectedAction = jest.fn();
@@ -111,7 +127,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "delete" }}
+            selectedAction={{ name: NodeActions.DELETE }}
             setSelectedAction={setSelectedAction}
           />
         </MemoryRouter>
@@ -122,7 +138,9 @@ describe("FieldlessForm", () => {
 
   it("can dispatch abort action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["abort"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.ABORT] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -131,7 +149,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "abort" }}
+            selectedAction={{ name: NodeActions.ABORT }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -150,7 +168,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "abort",
+            action: NodeActions.ABORT,
             extra: {},
             system_id: "abc123",
           },
@@ -174,7 +192,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "abort" }}
+                selectedAction={{ name: NodeActions.ABORT }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -195,7 +213,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "abort",
+            action: NodeActions.ABORT,
             extra: {},
             system_id: "abc123",
           },
@@ -206,7 +224,9 @@ describe("FieldlessForm", () => {
 
   it("can dispatch acquire action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["acquire"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.ACQUIRE] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -215,7 +235,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "acquire" }}
+            selectedAction={{ name: NodeActions.ACQUIRE }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -234,7 +254,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "acquire",
+            action: NodeActions.ACQUIRE,
             extra: {},
             system_id: "abc123",
           },
@@ -258,7 +278,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "acquire" }}
+                selectedAction={{ name: NodeActions.ACQUIRE }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -280,7 +300,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "acquire",
+            action: NodeActions.ACQUIRE,
             extra: {},
             system_id: "abc123",
           },
@@ -291,7 +311,9 @@ describe("FieldlessForm", () => {
 
   it("can dispatch delete action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["delete"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.DELETE] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -300,7 +322,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "delete" }}
+            selectedAction={{ name: NodeActions.DELETE }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -319,7 +341,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "delete",
+            action: NodeActions.DELETE,
             extra: {},
             system_id: "abc123",
           },
@@ -343,7 +365,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "delete" }}
+                selectedAction={{ name: NodeActions.DELETE }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -365,7 +387,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "delete",
+            action: NodeActions.DELETE,
             extra: {},
             system_id: "abc123",
           },
@@ -377,7 +399,7 @@ describe("FieldlessForm", () => {
   it("can dispatch exit rescue mode action on selected machines", () => {
     const state = { ...initialState };
     state.machine.items = [
-      { system_id: "abc123", actions: ["exit-rescue-mode"] },
+      { system_id: "abc123", actions: [NodeActions.EXIT_RESCUE_MODE] },
     ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
@@ -387,7 +409,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "exit-rescue-mode" }}
+            selectedAction={{ name: NodeActions.EXIT_RESCUE_MODE }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -406,7 +428,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "exit-rescue-mode",
+            action: NodeActions.EXIT_RESCUE_MODE,
             extra: {},
             system_id: "abc123",
           },
@@ -430,7 +452,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "exit-rescue-mode" }}
+                selectedAction={{ name: NodeActions.EXIT_RESCUE_MODE }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -452,7 +474,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "exit-rescue-mode",
+            action: NodeActions.EXIT_RESCUE_MODE,
             extra: {},
             system_id: "abc123",
           },
@@ -463,7 +485,9 @@ describe("FieldlessForm", () => {
 
   it("can dispatch lock action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["lock"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.LOCK] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -472,7 +496,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "lock" }}
+            selectedAction={{ name: NodeActions.LOCK }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -491,7 +515,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "lock",
+            action: NodeActions.LOCK,
             extra: {},
             system_id: "abc123",
           },
@@ -515,7 +539,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "lock" }}
+                selectedAction={{ name: NodeActions.LOCK }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -537,7 +561,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "lock",
+            action: NodeActions.LOCK,
             extra: {},
             system_id: "abc123",
           },
@@ -548,7 +572,9 @@ describe("FieldlessForm", () => {
 
   it("can dispatch mark fixed action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["mark-fixed"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.MARK_FIXED] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -557,7 +583,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "mark-fixed" }}
+            selectedAction={{ name: NodeActions.MARK_FIXED }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -576,7 +602,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "mark-fixed",
+            action: NodeActions.MARK_FIXED,
             extra: {},
             system_id: "abc123",
           },
@@ -600,7 +626,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "mark-fixed" }}
+                selectedAction={{ name: NodeActions.MARK_FIXED }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -622,7 +648,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "mark-fixed",
+            action: NodeActions.MARK_FIXED,
             extra: {},
             system_id: "abc123",
           },
@@ -633,7 +659,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch power off action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["off"] }];
+    state.machine.items = [{ system_id: "abc123", actions: [NodeActions.OFF] }];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -642,7 +668,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "off" }}
+            selectedAction={{ name: NodeActions.OFF }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -661,7 +687,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "off",
+            action: NodeActions.OFF,
             extra: {},
             system_id: "abc123",
           },
@@ -685,7 +711,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "off" }}
+                selectedAction={{ name: NodeActions.OFF }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -707,7 +733,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "off",
+            action: NodeActions.OFF,
             extra: {},
             system_id: "abc123",
           },
@@ -718,7 +744,7 @@ describe("FieldlessForm", () => {
 
   it("can dispatch power on action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["on"] }];
+    state.machine.items = [{ system_id: "abc123", actions: [NodeActions.ON] }];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -727,7 +753,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "on" }}
+            selectedAction={{ name: NodeActions.ON }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -746,7 +772,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "on",
+            action: NodeActions.ON,
             extra: {},
             system_id: "abc123",
           },
@@ -770,7 +796,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "on" }}
+                selectedAction={{ name: NodeActions.ON }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -792,7 +818,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "on",
+            action: NodeActions.ON,
             extra: {},
             system_id: "abc123",
           },
@@ -803,7 +829,9 @@ describe("FieldlessForm", () => {
 
   it("can dispatch release action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["release"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.RELEASE] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -812,7 +840,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "release" }}
+            selectedAction={{ name: NodeActions.RELEASE }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -831,7 +859,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "release",
+            action: NodeActions.RELEASE,
             extra: {},
             system_id: "abc123",
           },
@@ -855,7 +883,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "release" }}
+                selectedAction={{ name: NodeActions.RELEASE }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -877,7 +905,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "release",
+            action: NodeActions.RELEASE,
             extra: {},
             system_id: "abc123",
           },
@@ -888,7 +916,9 @@ describe("FieldlessForm", () => {
 
   it("can dispatch unlock action on selected machines", () => {
     const state = { ...initialState };
-    state.machine.items = [{ system_id: "abc123", actions: ["unlock"] }];
+    state.machine.items = [
+      { system_id: "abc123", actions: [NodeActions.UNLOCK] },
+    ];
     state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -897,7 +927,7 @@ describe("FieldlessForm", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <FieldlessForm
-            selectedAction={{ name: "unlock" }}
+            selectedAction={{ name: NodeActions.UNLOCK }}
             setSelectedAction={jest.fn()}
           />
         </MemoryRouter>
@@ -916,7 +946,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "unlock",
+            action: NodeActions.UNLOCK,
             extra: {},
             system_id: "abc123",
           },
@@ -940,7 +970,7 @@ describe("FieldlessForm", () => {
             path="/machine/:id"
             component={() => (
               <FieldlessForm
-                selectedAction={{ name: "unlock" }}
+                selectedAction={{ name: NodeActions.UNLOCK }}
                 setSelectedAction={jest.fn()}
               />
             )}
@@ -962,7 +992,7 @@ describe("FieldlessForm", () => {
         },
         payload: {
           params: {
-            action: "unlock",
+            action: NodeActions.UNLOCK,
             extra: {},
             system_id: "abc123",
           },

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -9,6 +9,7 @@ import configureStore from "redux-mock-store";
 import MarkBrokenForm from "./MarkBrokenForm";
 
 import { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
@@ -29,7 +30,7 @@ describe("MarkBrokenForm", () => {
         machineActions: machineActionsStateFactory({
           data: [
             machineActionFactory({
-              name: "mark-broken",
+              name: NodeActions.MARK_BROKEN,
               title: "Mark broken",
               sentence: "marked broken",
               type: "testing",
@@ -78,7 +79,7 @@ describe("MarkBrokenForm", () => {
         },
         payload: {
           params: {
-            action: "mark-broken",
+            action: NodeActions.MARK_BROKEN,
             extra: {
               message: "machine is on fire",
             },
@@ -94,7 +95,7 @@ describe("MarkBrokenForm", () => {
         },
         payload: {
           params: {
-            action: "mark-broken",
+            action: NodeActions.MARK_BROKEN,
             extra: {
               message: "machine is on fire",
             },
@@ -133,7 +134,7 @@ describe("MarkBrokenForm", () => {
         },
         payload: {
           params: {
-            action: "mark-broken",
+            action: NodeActions.MARK_BROKEN,
             extra: {
               message: "",
             },
@@ -178,7 +179,7 @@ describe("MarkBrokenForm", () => {
         },
         payload: {
           params: {
-            action: "mark-broken",
+            action: NodeActions.MARK_BROKEN,
             extra: {
               message: "machine is on fire",
             },

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -11,6 +11,7 @@ import { useMachineActionForm } from "app/machines/hooks";
 import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { NodeActions } from "app/store/types/node";
 
 const MarkBrokenSchema = Yup.object().shape({
   comment: Yup.string(),
@@ -30,7 +31,7 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
   const machineErrors = useSelector(machineSelectors.errors);
   const errors = Object.keys(machineErrors).length > 0 ? machineErrors : null;
   const { machinesToAction, processingCount } = useMachineActionForm(
-    "mark-broken"
+    NodeActions.MARK_BROKEN
   );
 
   useEffect(
@@ -42,7 +43,7 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <ActionForm
-      actionName="mark-broken"
+      actionName={NodeActions.MARK_BROKEN}
       allowAllEmpty
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -14,6 +14,8 @@ import scriptResultsSelectors from "app/store/scriptresults/selectors";
 import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
 
+import { NodeActions } from "app/store/types/node";
+
 const generateFailedTestsMessage = (numFailedTests, selectedMachines) => {
   const singleMachine = selectedMachines.length === 1 && selectedMachines[0];
   if (numFailedTests > 0) {
@@ -64,7 +66,7 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
   const errors = useSelector(machineSelectors.errors);
   const scriptResultsLoaded = useSelector(scriptResultsSelectors.loaded);
   const { machinesToAction, processingCount } = useMachineActionForm(
-    "override-failed-testing"
+    NodeActions.OVERRIDE_FAILED_TESTING
   );
   const machineIDs = machinesToAction.map((machine) => machine.system_id);
   const scriptResults = useSelector((state) =>
@@ -82,7 +84,7 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
-      actionName="override-failed-testing"
+      actionName={NodeActions.OVERRIDE_FAILED_TESTING}
       allowUnchanged
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -16,6 +16,8 @@ import {
   scriptResultsState as scriptResultsStateFactory,
 } from "testing/factories";
 
+import { NodeActions } from "app/store/types/node";
+
 const mockStore = configureStore();
 
 describe("OverrideTestForm", () => {
@@ -26,7 +28,10 @@ describe("OverrideTestForm", () => {
       general: generalStateFactory({
         machineActions: {
           data: [
-            { name: "override-failed-testing", sentence: "change those pools" },
+            {
+              name: NodeActions.OVERRIDE_FAILED_TESTING,
+              sentence: "change those pools",
+            },
           ],
         },
       }),
@@ -183,7 +188,7 @@ describe("OverrideTestForm", () => {
         },
         payload: {
           params: {
-            action: "override-failed-testing",
+            action: NodeActions.OVERRIDE_FAILED_TESTING,
             extra: {},
             system_id: "abc123",
           },
@@ -197,7 +202,7 @@ describe("OverrideTestForm", () => {
         },
         payload: {
           params: {
-            action: "override-failed-testing",
+            action: NodeActions.OVERRIDE_FAILED_TESTING,
             extra: {},
             system_id: "def456",
           },
@@ -285,7 +290,7 @@ describe("OverrideTestForm", () => {
         },
         payload: {
           params: {
-            action: "override-failed-testing",
+            action: NodeActions.OVERRIDE_FAILED_TESTING,
             extra: {},
             system_id: "abc123",
           },

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.js
@@ -11,6 +11,8 @@ import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import ActionForm from "app/base/components/ActionForm";
 import SetPoolFormFields from "./SetPoolFormFields";
 
+import { NodeActions } from "app/store/types/node";
+
 const SetPoolSchema = Yup.object().shape({
   description: Yup.string(),
   name: Yup.string().required("Resource pool required"),
@@ -32,7 +34,7 @@ export const SetPoolForm = ({ setSelectedAction }) => {
   const errors =
     Object.keys(machineErrors).length > 0 ? machineErrors : poolErrors;
   const { machinesToAction, processingCount } = useMachineActionForm(
-    "set-pool"
+    NodeActions.SET_POOL
   );
 
   useEffect(() => {
@@ -49,7 +51,7 @@ export const SetPoolForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
-      actionName="set-pool"
+      actionName={NodeActions.SET_POOL}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}
       errors={errors}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.test.js
@@ -17,6 +17,8 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 
+import { NodeActions } from "app/store/types/node";
+
 const mockStore = configureStore();
 
 describe("SetPoolForm", () => {
@@ -27,7 +29,7 @@ describe("SetPoolForm", () => {
         machineActions: machineActionsStateFactory({
           data: [
             machineActionFactory({
-              name: "set-pool",
+              name: NodeActions.SET_POOL,
               sentence: "change those pools",
               title: "Set pool",
             }),
@@ -111,7 +113,7 @@ describe("SetPoolForm", () => {
         },
         payload: {
           params: {
-            action: "set-pool",
+            action: NodeActions.SET_POOL,
             extra: {
               pool_id: 1,
             },
@@ -127,7 +129,7 @@ describe("SetPoolForm", () => {
         },
         payload: {
           params: {
-            action: "set-pool",
+            action: NodeActions.SET_POOL,
             extra: {
               pool_id: 1,
             },
@@ -175,7 +177,7 @@ describe("SetPoolForm", () => {
         },
         payload: {
           params: {
-            action: "set-pool",
+            action: NodeActions.SET_POOL,
             extra: {
               pool_id: 1,
             },

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -24,7 +24,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
   const zones = useSelector(zoneSelectors.all);
   const zonesLoaded = useSelector(zoneSelectors.loaded);
   const { machinesToAction, processingCount } = useMachineActionForm(
-    NodeActions.SET_POOL
+    NodeActions.SET_ZONE
   );
 
   useEffect(() => {
@@ -42,7 +42,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
-      actionName={NodeActions.SET_POOL}
+      actionName={NodeActions.SET_ZONE}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}
       errors={errors}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -7,6 +7,7 @@ import React, { useEffect } from "react";
 import { actions as machineActions } from "app/store/machine";
 import { useMachineActionForm } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
+import { NodeActions } from "app/store/types/node";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import ActionForm from "app/base/components/ActionForm";
@@ -23,7 +24,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
   const zones = useSelector(zoneSelectors.all);
   const zonesLoaded = useSelector(zoneSelectors.loaded);
   const { machinesToAction, processingCount } = useMachineActionForm(
-    "set-zone"
+    NodeActions.SET_POOL
   );
 
   useEffect(() => {
@@ -41,7 +42,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
-      actionName="set-zone"
+      actionName={NodeActions.SET_POOL}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}
       errors={errors}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.test.js
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import SetZoneForm from "./SetZoneForm";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -25,7 +26,12 @@ describe("SetZoneForm", () => {
     state = rootStateFactory({
       general: generalStateFactory({
         machineActions: machineActionsStateFactory({
-          data: [machineActionFactory({ name: "set-zone", title: "Set zone" })],
+          data: [
+            machineActionFactory({
+              name: NodeActions.SET_ZONE,
+              title: "Set zone",
+            }),
+          ],
         }),
       }),
       machine: machineStateFactory({
@@ -85,7 +91,7 @@ describe("SetZoneForm", () => {
         },
         payload: {
           params: {
-            action: "set-zone",
+            action: NodeActions.SET_ZONE,
             extra: {
               zone_id: 1,
             },
@@ -101,7 +107,7 @@ describe("SetZoneForm", () => {
         },
         payload: {
           params: {
-            action: "set-zone",
+            action: NodeActions.SET_ZONE,
             extra: {
               zone_id: 1,
             },
@@ -146,7 +152,7 @@ describe("SetZoneForm", () => {
         },
         payload: {
           params: {
-            action: "set-zone",
+            action: NodeActions.SET_ZONE,
             extra: {
               zone_id: 1,
             },

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.js
@@ -10,6 +10,7 @@ import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import ActionForm from "app/base/components/ActionForm";
 import TagFormFields from "./TagFormFields";
+import { NodeActions } from "app/store/types/node";
 
 const TagFormSchema = Yup.object().shape({
   tags: Yup.array()
@@ -29,7 +30,9 @@ export const TagForm = ({ setSelectedAction }) => {
   const [initialValues, setInitialValues] = useState({ tags: [] });
   const errors = useSelector(machineSelectors.errors);
   const tagsLoaded = useSelector(tagSelectors.loaded);
-  const { machinesToAction, processingCount } = useMachineActionForm("tag");
+  const { machinesToAction, processingCount } = useMachineActionForm(
+    NodeActions.TAG
+  );
 
   const formErrors = { ...errors };
   if (formErrors && formErrors.name) {
@@ -43,7 +46,7 @@ export const TagForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
-      actionName="tag"
+      actionName={NodeActions.TAG}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}
       errors={formErrors}

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.js
@@ -15,6 +15,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { NodeActions } from "app/store/types/node";
 
 const mockStore = configureStore();
 
@@ -25,7 +26,7 @@ describe("TagForm", () => {
     initialState = rootStateFactory({
       general: generalStateFactory({
         machineActions: machineActionsStateFactory({
-          data: [machineActionFactory({ name: "tag", title: "Tag" })],
+          data: [machineActionFactory({ name: NodeActions.TAG, title: "Tag" })],
         }),
       }),
       machine: machineStateFactory({
@@ -96,7 +97,7 @@ describe("TagForm", () => {
         },
         payload: {
           params: {
-            action: "tag",
+            action: NodeActions.TAG,
             extra: {
               tags: ["tag1", "tag2"],
             },
@@ -112,7 +113,7 @@ describe("TagForm", () => {
         },
         payload: {
           params: {
-            action: "tag",
+            action: NodeActions.TAG,
             extra: {
               tags: ["tag1", "tag2"],
             },
@@ -162,7 +163,7 @@ describe("TagForm", () => {
         },
         payload: {
           params: {
-            action: "tag",
+            action: NodeActions.TAG,
             extra: {
               tags: ["tag1", "tag2"],
             },

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -11,6 +11,7 @@ import TestForm from "./TestForm";
 import { HardwareType } from "app/base/enum";
 import { RootState } from "app/store/root/types";
 import { Scripts } from "app/store/scripts/types";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -33,7 +34,9 @@ describe("TestForm", () => {
     initialState = rootStateFactory({
       general: generalStateFactory({
         machineActions: machineActionsStateFactory({
-          data: [machineActionFactory({ name: "test", title: "Test" })],
+          data: [
+            machineActionFactory({ name: NodeActions.TEST, title: "Test" }),
+          ],
         }),
       }),
       machine: machineStateFactory({
@@ -116,7 +119,7 @@ describe("TestForm", () => {
         },
         payload: {
           params: {
-            action: "test",
+            action: NodeActions.TEST,
             extra: {
               enable_ssh: true,
               testing_scripts: state.scripts.items.map((script) => script.id),
@@ -137,7 +140,7 @@ describe("TestForm", () => {
         },
         payload: {
           params: {
-            action: "test",
+            action: NodeActions.TEST,
             extra: {
               enable_ssh: true,
               testing_scripts: state.scripts.items.map((script) => script.id),
@@ -237,7 +240,7 @@ describe("TestForm", () => {
         },
         payload: {
           params: {
-            action: "test",
+            action: NodeActions.TEST,
             extra: {
               enable_ssh: true,
               testing_scripts: state.scripts.items.map((script) => script.id),

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -15,6 +15,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import scriptSelectors from "app/store/scripts/selectors";
 import { Scripts } from "app/store/scripts/types";
+import { NodeActions } from "app/store/types/node";
 
 const TestFormSchema = Yup.object().shape({
   enableSSH: Yup.boolean(),
@@ -54,7 +55,9 @@ export const TestForm = ({
   const scripts = useSelector(scriptSelectors.testing);
   const scriptsLoaded = useSelector(scriptSelectors.loaded);
   const urlScripts = useSelector(scriptSelectors.testingWithUrl);
-  const { machinesToAction, processingCount } = useMachineActionForm("test");
+  const { machinesToAction, processingCount } = useMachineActionForm(
+    NodeActions.TEST
+  );
 
   const formattedScripts = scripts.map((script) => ({
     ...script,
@@ -86,7 +89,7 @@ export const TestForm = ({
 
   return (
     <ActionForm
-      actionName="test"
+      actionName={NodeActions.TEST}
       allowUnchanged
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 import TakeActionMenu from "./TakeActionMenu";
 
 import { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -77,25 +78,28 @@ describe("TakeActionMenu", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
       machineActionFactory({
-        name: "lifecycle1",
+        name: NodeActions.ON,
         title: "Lifecycle 1",
         type: "lifecycle",
       }),
       machineActionFactory({
-        name: "lifecycle2",
+        name: NodeActions.OFF,
         title: "Lifecycle 2",
         type: "lifecycle",
       }),
       machineActionFactory({
-        name: "lifecycle3",
+        name: NodeActions.ABORT,
         title: "Lifecycle 3",
         type: "lifecycle",
       }),
     ];
     // No machine can perform "lifecycle3" action
     state.machine.items = [
-      machineFactory({ system_id: "a", actions: ["lifecycle1", "lifecycle2"] }),
-      machineFactory({ system_id: "b", actions: ["lifecycle1"] }),
+      machineFactory({
+        system_id: "a",
+        actions: [NodeActions.ON, NodeActions.OFF],
+      }),
+      machineFactory({ system_id: "b", actions: [NodeActions.ON] }),
       machineFactory({ system_id: "c", actions: ["other"] }),
     ];
     state.machine.selected = ["a", "b", "c"];
@@ -111,13 +115,13 @@ describe("TakeActionMenu", () => {
     );
     wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
     expect(wrapper.find("button.p-contextual-menu__link").length).toBe(3);
-    expect(wrapper.find("[data-test='action-title-lifecycle1']").text()).toBe(
+    expect(wrapper.find("[data-test='action-title-on']").text()).toBe(
       "Lifecycle 1"
     );
-    expect(wrapper.find("[data-test='action-title-lifecycle2']").text()).toBe(
+    expect(wrapper.find("[data-test='action-title-off']").text()).toBe(
       "Lifecycle 2"
     );
-    expect(wrapper.find("[data-test='action-title-lifecycle3']").text()).toBe(
+    expect(wrapper.find("[data-test='action-title-abort']").text()).toBe(
       "Lifecycle 3"
     );
     // Lifecycle 3 action displays, but is disabled
@@ -130,23 +134,30 @@ describe("TakeActionMenu", () => {
     perform the action`, () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
-      machineActionFactory({ name: "on", title: "Power on...", type: "power" }),
       machineActionFactory({
-        name: "off",
+        name: NodeActions.ON,
+        title: "Power on...",
+        type: "power",
+      }),
+      machineActionFactory({
+        name: NodeActions.OFF,
         title: "Power off...",
         type: "power",
       }),
       machineActionFactory({
-        name: "house",
+        name: NodeActions.ABORT,
         title: "Power house...",
         type: "power",
       }),
     ];
     // No machine can perform "house" action
     state.machine.items = [
-      machineFactory({ system_id: "a", actions: ["on", "off"] }),
-      machineFactory({ system_id: "b", actions: ["on"] }),
-      machineFactory({ system_id: "c", actions: ["off"] }),
+      machineFactory({
+        system_id: "a",
+        actions: [NodeActions.ON, NodeActions.OFF],
+      }),
+      machineFactory({ system_id: "b", actions: [NodeActions.ON] }),
+      machineFactory({ system_id: "c", actions: [NodeActions.OFF] }),
     ];
     state.machine.selected = ["a", "b", "c"];
     const store = mockStore(state);
@@ -173,17 +184,17 @@ describe("TakeActionMenu", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
       machineActionFactory({
-        name: "commission",
+        name: NodeActions.COMMISSION,
         title: "Commission...",
         type: "lifecycle",
       }),
       machineActionFactory({
-        name: "release",
+        name: NodeActions.RELEASE,
         title: "Release...",
         type: "lifecycle",
       }),
       machineActionFactory({
-        name: "deploy",
+        name: NodeActions.DEPLOY,
         title: "Deploy...",
         type: "lifecycle",
       }),
@@ -192,10 +203,17 @@ describe("TakeActionMenu", () => {
     state.machine.items = [
       machineFactory({
         system_id: "a",
-        actions: ["commission", "release", "deploy"],
+        actions: [
+          NodeActions.COMMISSION,
+          NodeActions.RELEASE,
+          NodeActions.DEPLOY,
+        ],
       }),
-      machineFactory({ system_id: "b", actions: ["commission", "release"] }),
-      machineFactory({ system_id: "c", actions: ["commission"] }),
+      machineFactory({
+        system_id: "b",
+        actions: [NodeActions.COMMISSION, NodeActions.RELEASE],
+      }),
+      machineFactory({ system_id: "c", actions: [NodeActions.COMMISSION] }),
     ];
     state.machine.selected = ["a", "b", "c"];
     const store = mockStore(state);
@@ -222,19 +240,19 @@ describe("TakeActionMenu", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
       machineActionFactory({
-        name: "action1",
+        name: NodeActions.ON,
         title: "Action 1",
         type: "power",
       }),
       machineActionFactory({
-        name: "action2",
+        name: NodeActions.OFF,
         title: "Action 2",
         type: "power",
       }),
     ];
     // No machine can perform "lifecycle3" action
     state.machine.items = [
-      machineFactory({ system_id: "a", actions: ["action1"] }),
+      machineFactory({ system_id: "a", actions: [NodeActions.ON] }),
     ];
     state.machine.selected = ["a"];
     const store = mockStore(state);
@@ -248,42 +266,52 @@ describe("TakeActionMenu", () => {
       </Provider>
     );
     wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
-    expect(wrapper.find("[data-test='action-title-action1']").text()).toBe(
+    expect(wrapper.find("[data-test='action-title-on']").text()).toBe(
       "Action 1"
     );
-    expect(wrapper.find("[data-test='action-count-action1']").exists()).toBe(
-      false
-    );
+    expect(wrapper.find("[data-test='action-count-on']").exists()).toBe(false);
   });
 
   it("groups actions by type", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
       machineActionFactory({
-        name: "commission",
+        name: NodeActions.COMMISSION,
         title: "Commission...",
         type: "lifecycle",
       }),
-      machineActionFactory({ name: "on", title: "Power on...", type: "power" }),
       machineActionFactory({
-        name: "off",
+        name: NodeActions.ON,
         title: "Power on...",
         type: "power",
       }),
-      machineActionFactory({ name: "test", title: "Test...", type: "testing" }),
-      machineActionFactory({ name: "lock", title: "Lock...", type: "lock" }),
       machineActionFactory({
-        name: "set-pool",
+        name: NodeActions.OFF,
+        title: "Power on...",
+        type: "power",
+      }),
+      machineActionFactory({
+        name: NodeActions.TEST,
+        title: "Test...",
+        type: "testing",
+      }),
+      machineActionFactory({
+        name: NodeActions.LOCK,
+        title: "Lock...",
+        type: "lock",
+      }),
+      machineActionFactory({
+        name: NodeActions.SET_POOL,
         title: "Set pool...",
         type: "misc",
       }),
       machineActionFactory({
-        name: "set-zone",
+        name: NodeActions.SET_ZONE,
         title: "Set zone...",
         type: "misc",
       }),
       machineActionFactory({
-        name: "delete",
+        name: NodeActions.DELETE,
         title: "Delete...",
         type: "misc",
       }),
@@ -292,14 +320,14 @@ describe("TakeActionMenu", () => {
       machineFactory({
         system_id: "a",
         actions: [
-          "commission",
-          "on",
-          "off",
-          "test",
-          "lock",
-          "set-pool",
-          "set-zone",
-          "delete",
+          NodeActions.COMMISSION,
+          NodeActions.ON,
+          NodeActions.OFF,
+          NodeActions.TEST,
+          NodeActions.LOCK,
+          NodeActions.SET_POOL,
+          NodeActions.SET_ZONE,
+          NodeActions.DELETE,
         ],
       }),
     ];
@@ -328,13 +356,13 @@ describe("TakeActionMenu", () => {
     const state = { ...initialState };
     state.general.machineActions.data = [
       machineActionFactory({
-        name: "commission",
+        name: NodeActions.COMMISSION,
         title: "Commission...",
         type: "lifecycle",
       }),
     ];
     state.machine.items = [
-      machineFactory({ system_id: "a", actions: ["commission"] }),
+      machineFactory({ system_id: "a", actions: [NodeActions.COMMISSION] }),
     ];
     state.machine.selected = ["a"];
     const setSelectedAction = jest.fn();

--- a/ui/src/app/machines/hooks.tsx
+++ b/ui/src/app/machines/hooks.tsx
@@ -33,7 +33,7 @@ export const useToggleMenu = (
  * processing machines.
  */
 export const useMachineActionForm = (
-  actionName: MachineActionName
+  actionName: MachineActionName | "check-power"
 ): {
   machinesToAction: Machine[];
   processingCount: number;

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -8,6 +8,7 @@ import configureStore from "redux-mock-store";
 import MachineHeader from "./MachineHeader";
 
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -142,7 +143,7 @@ describe("MachineHeader", () => {
 
   describe("power menu", () => {
     it("can dispatch the power on action", () => {
-      state.machine.items[0].actions = ["on"];
+      state.machine.items[0].actions = [NodeActions.ON];
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
@@ -177,7 +178,7 @@ describe("MachineHeader", () => {
     });
 
     it("can dispatch the power off action", () => {
-      state.machine.items[0].actions = ["off"];
+      state.machine.items[0].actions = [NodeActions.OFF];
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -18,6 +18,7 @@ import TakeActionMenu from "app/machines/components/TakeActionMenu";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 
 type Props = {
   selectedAction: SelectedAction | null;
@@ -40,7 +41,10 @@ const MachineHeader = ({
     machineSelectors.getStatuses(state, id)
   );
   const powerMenuRef = useRef<HTMLSpanElement>(null);
-  const powerMenuLinks = useMachineActions(id, ["off", "on"]);
+  const powerMenuLinks = useMachineActions(id, [
+    NodeActions.OFF,
+    NodeActions.ON,
+  ]);
 
   useEffect(() => {
     dispatch(machineActions.get(id));

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -8,6 +8,7 @@ import type { SetSelectedAction } from "..";
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
 import type { MachineDetails } from "app/store/machine/types";
+import { NodeActions } from "app/store/types/node";
 import { capitaliseFirst } from "app/utils";
 
 type Props = {
@@ -118,7 +119,7 @@ const TestResults = ({
           <li className="p-inline-list__item">
             <Tooltip
               message={
-                !machine.actions.includes("test")
+                !machine.actions.includes(NodeActions.TEST)
                   ? "Machine cannot run tests at this time."
                   : null
               }
@@ -126,11 +127,11 @@ const TestResults = ({
             >
               <Button
                 className="p-button--link"
-                disabled={!machine.actions.includes("test")}
+                disabled={!machine.actions.includes(NodeActions.TEST)}
                 onClick={() => {
                   setSelectedAction(
                     {
-                      name: "test",
+                      name: NodeActions.TEST,
                       formProps: { hardwareType: hardwareType },
                     },
                     false

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.js
@@ -17,6 +17,8 @@ import {
   zoneState as zoneStateFactory,
 } from "testing/factories";
 
+import { NodeActions } from "app/store/types/node";
+
 const mockStore = configureStore();
 
 describe("MachineListHeader", () => {
@@ -264,7 +266,7 @@ describe("MachineListHeader", () => {
       wrapper
         .find("TakeActionMenu")
         .props()
-        .setSelectedAction({ name: "set-pool" })
+        .setSelectedAction({ name: NodeActions.SET_POOL })
     );
     expect(setSearchFilter).toHaveBeenCalledWith("in:(selected)");
   });

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.js
@@ -8,6 +8,8 @@ import { useMachineActions } from "app/base/hooks";
 import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 
+import { NodeActions } from "app/store/types/node";
+
 export const OwnerColumn = ({ onToggleMenu, systemId }) => {
   const [updating, setUpdating] = useState(null);
   const machine = useSelector((state) =>
@@ -20,7 +22,7 @@ export const OwnerColumn = ({ onToggleMenu, systemId }) => {
 
   const menuLinks = useMachineActions(
     systemId,
-    ["acquire", "release"],
+    [NodeActions.ACQUIRE, NodeActions.RELEASE],
     "No owner actions available",
     () => {
       setUpdating(machine.status);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.js
@@ -6,6 +6,8 @@ import React from "react";
 
 import { OwnerColumn } from "./OwnerColumn";
 
+import { NodeActions } from "app/store/types/node";
+
 const mockStore = configureStore();
 
 describe("OwnerColumn", () => {
@@ -18,8 +20,8 @@ describe("OwnerColumn", () => {
       general: {
         machineActions: {
           data: [
-            { name: "acquire", title: "Acquire..." },
-            { name: "release", title: "Release..." },
+            { name: NodeActions.ACQUIRE, title: "Acquire..." },
+            { name: NodeActions.RELEASE, title: "Release..." },
           ],
         },
       },
@@ -87,7 +89,7 @@ describe("OwnerColumn", () => {
   });
 
   it("can show a menu item to acquire a machine", () => {
-    state.machine.items[0].actions = ["acquire"];
+    state.machine.items[0].actions = [NodeActions.ACQUIRE];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -106,7 +108,7 @@ describe("OwnerColumn", () => {
   });
 
   it("can show a menu item to release a machine", () => {
-    state.machine.items[0].actions = ["release"];
+    state.machine.items[0].actions = [NodeActions.RELEASE];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.js
@@ -10,6 +10,8 @@ import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
 
+import { NodeActions } from "app/store/types/node";
+
 export const PoolColumn = ({ onToggleMenu, systemId }) => {
   const dispatch = useDispatch();
   const [updating, setUpdating] = useState(null);
@@ -20,7 +22,7 @@ export const PoolColumn = ({ onToggleMenu, systemId }) => {
   const toggleMenu = useToggleMenu(onToggleMenu, systemId);
 
   let poolLinks = resourcePools.filter((pool) => pool.id !== machine.pool.id);
-  if (machine.actions.includes("set-pool")) {
+  if (machine.actions.includes(NodeActions.SET_POOL)) {
     if (poolLinks.length !== 0) {
       poolLinks = poolLinks.map((pool) => ({
         children: pool.name,

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.test.js
@@ -7,6 +7,8 @@ import React from "react";
 
 import { PoolColumn } from "./PoolColumn";
 
+import { NodeActions } from "app/store/types/node";
+
 const mockStore = configureStore();
 
 describe("PoolColumn", () => {
@@ -25,7 +27,7 @@ describe("PoolColumn", () => {
             system_id: "abc123",
             pool: { id: 0, name: "default" },
             description: "Firmware old",
-            actions: ["set-pool"],
+            actions: [NodeActions.SET_POOL],
           },
         ],
       },
@@ -161,7 +163,7 @@ describe("PoolColumn", () => {
       },
       payload: {
         params: {
-          action: "set-pool",
+          action: NodeActions.SET_POOL,
           extra: {
             pool_id: 1,
           },

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.js
@@ -8,6 +8,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
+import { NodeActions } from "app/store/types/node";
 
 export const PowerColumn = ({ onToggleMenu, systemId }) => {
   const dispatch = useDispatch();
@@ -21,8 +22,8 @@ export const PowerColumn = ({ onToggleMenu, systemId }) => {
 
   const menuLinks = [];
 
-  const hasOnAction = machine.actions.includes("on");
-  const hasOffAction = machine.actions.includes("off");
+  const hasOnAction = machine.actions.includes(NodeActions.ON);
+  const hasOffAction = machine.actions.includes(NodeActions.OFF);
   const powerState = machine.power_state;
   if (hasOnAction && powerState !== "on") {
     menuLinks.push({

--- a/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.test.js
@@ -6,6 +6,7 @@ import React from "react";
 
 import { machine as machineFactory } from "testing/factories";
 import { PowerColumn } from "./PowerColumn";
+import { NodeActions } from "app/store/types/node";
 
 const mockStore = configureStore();
 
@@ -82,7 +83,7 @@ describe("PowerColumn", () => {
   });
 
   it("can show a menu item to turn a machine on", () => {
-    state.machine.items[0].actions = ["on"];
+    state.machine.items[0].actions = [NodeActions.ON];
     state.machine.items[0].power_state = "off";
     const store = mockStore(state);
 
@@ -104,7 +105,7 @@ describe("PowerColumn", () => {
   });
 
   it("can show a menu item to turn a machine off", () => {
-    state.machine.items[0].actions = ["off"];
+    state.machine.items[0].actions = [NodeActions.OFF];
     const store = mockStore(state);
 
     const wrapper = mount(

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -11,7 +11,7 @@ import { nodeStatus, scriptStatus } from "app/base/enum";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import type { TestResult } from "app/store/types/node";
-import { NodeStatus } from "app/store/types/node";
+import { NodeActions, NodeStatus } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -262,19 +262,19 @@ describe("StatusColumn", () => {
 
   it("can show a menu with all possible options", () => {
     machine.actions = [
-      "abort",
-      "acquire",
-      "commission",
-      "deploy",
-      "exit-rescue-mode",
-      "lock",
-      "mark-broken",
-      "mark-fixed",
-      "override-failed-testing",
-      "release",
-      "rescue-mode",
-      "test",
-      "unlock",
+      NodeActions.ABORT,
+      NodeActions.ACQUIRE,
+      NodeActions.COMMISSION,
+      NodeActions.DEPLOY,
+      NodeActions.EXIT_RESCUE_MODE,
+      NodeActions.LOCK,
+      NodeActions.MARK_BROKEN,
+      NodeActions.MARK_FIXED,
+      NodeActions.OVERRIDE_FAILED_TESTING,
+      NodeActions.RELEASE,
+      NodeActions.RESCUE_MODE,
+      NodeActions.TEST,
+      NodeActions.UNLOCK,
     ];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -13,6 +13,7 @@ import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 import { getStatusText } from "app/utils";
 
 // Node statuses for which the failed test warning is not shown.
@@ -91,19 +92,19 @@ export const StatusColumn = ({
   const formattedOS = useFormattedOS(machine);
   const toggleMenu = useToggleMenu(onToggleMenu, systemId);
   const actionLinks = useMachineActions(systemId, [
-    "abort",
-    "acquire",
-    "commission",
-    "deploy",
-    "exit-rescue-mode",
-    "lock",
-    "mark-broken",
-    "mark-fixed",
-    "override-failed-testing",
-    "release",
-    "rescue-mode",
-    "test",
-    "unlock",
+    NodeActions.ABORT,
+    NodeActions.ACQUIRE,
+    NodeActions.COMMISSION,
+    NodeActions.DEPLOY,
+    NodeActions.EXIT_RESCUE_MODE,
+    NodeActions.LOCK,
+    NodeActions.MARK_BROKEN,
+    NodeActions.MARK_FIXED,
+    NodeActions.OVERRIDE_FAILED_TESTING,
+    NodeActions.RELEASE,
+    NodeActions.RESCUE_MODE,
+    NodeActions.TEST,
+    NodeActions.UNLOCK,
   ]);
 
   const statusText = getStatusText(machine, formattedOS);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { NodeActions } from "app/store/types/node";
 import zoneSelectors from "app/store/zone/selectors";
 import { useToggleMenu } from "app/machines/hooks";
 import DoubleRow from "app/base/components/DoubleRow";
@@ -35,7 +36,7 @@ export const ZoneColumn = ({ onToggleMenu, systemId }) => {
   const zones = useSelector(zoneSelectors.all);
   const toggleMenu = useToggleMenu(onToggleMenu, systemId);
   let zoneLinks = zones.filter((zone) => zone.id !== machine.zone.id);
-  if (machine.actions.includes("set-zone")) {
+  if (machine.actions.includes(NodeActions.SET_ZONE)) {
     if (zoneLinks.length !== 0) {
       zoneLinks = zoneLinks.map((zone) => ({
         children: zone.name,

--- a/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.test.js
@@ -7,6 +7,8 @@ import React from "react";
 
 import { ZoneColumn } from "./ZoneColumn";
 
+import { NodeActions } from "app/store/types/node";
+
 const mockStore = configureStore();
 
 describe("ZoneColumn", () => {
@@ -25,7 +27,7 @@ describe("ZoneColumn", () => {
             system_id: "abc123",
             zone: { name: "zone-north", id: 0 },
             spaces: ["management"],
-            actions: ["set-zone"],
+            actions: [NodeActions.SET_ZONE],
           },
         ],
       },
@@ -170,7 +172,7 @@ describe("ZoneColumn", () => {
       },
       payload: {
         params: {
-          action: "set-zone",
+          action: NodeActions.SET_ZONE,
           extra: {
             zone_id: 1,
           },

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import React from "react";
 
 import Machines from "./Machines";
+import { NodeActions } from "app/store/types/node";
 import { nodeStatus, scriptStatus } from "app/base/enum";
 import {
   generalState as generalStateFactory,
@@ -334,7 +335,7 @@ describe("Machines", () => {
       wrapper
         .find("TakeActionMenu")
         .props()
-        .setSelectedAction({ name: "set-pool" })
+        .setSelectedAction({ name: NodeActions.SET_POOL })
     );
     wrapper.update();
     expect(wrapper.find("ActionFormWrapper").exists()).toBe(true);

--- a/ui/src/app/store/general/selectors/machineActions.test.ts
+++ b/ui/src/app/store/general/selectors/machineActions.test.ts
@@ -1,5 +1,6 @@
 import machineActions from "./machineActions";
 
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machineActionsState as machineActionsStateFactory,
@@ -67,19 +68,19 @@ describe("machineActions selectors", () => {
   it("can return actions by name", () => {
     const data = [
       {
-        name: "commission",
+        name: NodeActions.COMMISSION,
         title: "Commission...",
         sentence: "commissioned",
         type: "lifecycle",
       },
       {
-        name: "acquire",
+        name: NodeActions.ACQUIRE,
         title: "Acquire...",
         sentence: "acquired",
         type: "lifecycle",
       },
       {
-        name: "deploy",
+        name: NodeActions.DEPLOY,
         title: "Deploy...",
         sentence: "deployed",
         type: "lifecycle",
@@ -92,8 +93,8 @@ describe("machineActions selectors", () => {
         }),
       }),
     });
-    expect(machineActions.getByName(state, "acquire")).toStrictEqual({
-      name: "acquire",
+    expect(machineActions.getByName(state, NodeActions.ACQUIRE)).toStrictEqual({
+      name: NodeActions.ACQUIRE,
       title: "Acquire...",
       sentence: "acquired",
       type: "lifecycle",

--- a/ui/src/app/store/general/types.ts
+++ b/ui/src/app/store/general/types.ts
@@ -1,4 +1,5 @@
 import type { TSFixMe } from "app/base/types";
+import type { NodeActions } from "app/store/types/node";
 
 export type Architecture = string;
 
@@ -51,27 +52,7 @@ export type KnownArchitecturesState = {
   loading: boolean;
 };
 
-export type MachineActionName =
-  | "abort"
-  | "acquire"
-  | "check-power"
-  | "commission"
-  | "delete"
-  | "deploy"
-  | "exit-rescue-mode"
-  | "lock"
-  | "mark-broken"
-  | "mark-fixed"
-  | "off"
-  | "on"
-  | "override-failed-testing"
-  | "release"
-  | "rescue-mode"
-  | "set-pool"
-  | "set-zone"
-  | "tag"
-  | "test"
-  | "unlock";
+export type MachineActionName = Exclude<NodeActions, NodeActions.IMPORT_IMAGES>;
 
 export type MachineAction = {
   name: MachineActionName;

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -1,5 +1,7 @@
 import { actions } from "./slice";
 
+import { NodeActions } from "app/store/types/node";
+
 describe("machine actions", () => {
   it("should handle fetching machines", () => {
     expect(actions.fetch()).toEqual({
@@ -68,7 +70,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "set-pool",
+          action: NodeActions.SET_POOL,
           extra: {
             pool_id: 909,
           },
@@ -87,7 +89,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "set-zone",
+          action: NodeActions.SET_ZONE,
           extra: {
             zone_id: 909,
           },
@@ -106,7 +108,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "on",
+          action: NodeActions.ON,
           extra: {},
           system_id: "abc123",
         },
@@ -123,7 +125,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "off",
+          action: NodeActions.OFF,
           extra: {},
           system_id: "abc123",
         },
@@ -155,7 +157,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "acquire",
+          action: NodeActions.ACQUIRE,
           extra: {},
           system_id: "abc123",
         },
@@ -172,7 +174,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "release",
+          action: NodeActions.RELEASE,
           extra: {},
           system_id: "abc123",
         },
@@ -194,7 +196,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "deploy",
+          action: NodeActions.DEPLOY,
           extra,
           system_id: "abc123",
         },
@@ -211,7 +213,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "abort",
+          action: NodeActions.ABORT,
           extra: {},
           system_id: "abc123",
         },
@@ -246,7 +248,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "commission",
+          action: NodeActions.COMMISSION,
           extra: {
             enable_ssh: true,
             skip_bmc_config: false,
@@ -282,7 +284,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "test",
+          action: NodeActions.TEST,
           extra: {
             enable_ssh: true,
             script_input: { "test-0": { url: "www.url.com" } },
@@ -324,7 +326,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "rescue-mode",
+          action: NodeActions.RESCUE_MODE,
           extra: {},
           system_id: "abc123",
         },
@@ -341,7 +343,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "exit-rescue-mode",
+          action: NodeActions.EXIT_RESCUE_MODE,
           extra: {},
           system_id: "abc123",
         },
@@ -358,7 +360,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "mark-broken",
+          action: NodeActions.MARK_BROKEN,
           extra: {
             message: "machine is on fire",
           },
@@ -377,7 +379,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "mark-fixed",
+          action: NodeActions.MARK_FIXED,
           extra: {},
           system_id: "abc123",
         },
@@ -394,7 +396,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "override-failed-testing",
+          action: NodeActions.OVERRIDE_FAILED_TESTING,
           extra: {},
           system_id: "abc123",
         },
@@ -411,7 +413,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "lock",
+          action: NodeActions.LOCK,
           extra: {},
           system_id: "abc123",
         },
@@ -428,7 +430,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "unlock",
+          action: NodeActions.UNLOCK,
           extra: {},
           system_id: "abc123",
         },
@@ -445,7 +447,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "delete",
+          action: NodeActions.DELETE,
           extra: {},
           system_id: "abc123",
         },
@@ -462,7 +464,7 @@ describe("machine actions", () => {
       },
       payload: {
         params: {
-          action: "tag",
+          action: NodeActions.TAG,
           extra: { tags: ["tag1", "tag2"] },
           system_id: "abc123",
         },

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -9,6 +9,7 @@ import type { Machine, MachineState } from "./types";
 
 import type { ScriptResult } from "app/store/scriptresults/types";
 import type { Scripts } from "app/store/scripts/types";
+import { NodeActions } from "app/store/types/node";
 import { generateSlice, generateStatusHandlers } from "app/store/utils";
 import type { GenericSlice } from "app/store/utils";
 import type { StatusHandlers } from "app/store/utils/slice";
@@ -20,11 +21,11 @@ export type ScriptInput = {
 
 export const ACTIONS = [
   {
-    name: "abort",
+    name: NodeActions.ABORT,
     status: "aborting",
   },
   {
-    name: "acquire",
+    name: NodeActions.ACQUIRE,
     status: "acquiring",
   },
   {
@@ -36,7 +37,7 @@ export const ACTIONS = [
     status: "checkingPower",
   },
   {
-    name: "commission",
+    name: NodeActions.COMMISSION,
     status: "commissioning",
   },
   {
@@ -68,7 +69,7 @@ export const ACTIONS = [
     status: "creatingVolumeGroup",
   },
   {
-    name: "delete",
+    name: NodeActions.DELETE,
     status: "deleting",
   },
   {
@@ -92,27 +93,27 @@ export const ACTIONS = [
     status: "deletingVolumeGroup",
   },
   {
-    name: "deploy",
+    name: NodeActions.DEPLOY,
     status: "deploying",
   },
   {
-    name: "rescue-mode",
+    name: NodeActions.RESCUE_MODE,
     status: "enteringRescueMode",
   },
   {
-    name: "exit-rescue-mode",
+    name: NodeActions.EXIT_RESCUE_MODE,
     status: "exitingRescueMode",
   },
   {
-    name: "lock",
+    name: NodeActions.LOCK,
     status: "locking",
   },
   {
-    name: "mark-broken",
+    name: NodeActions.MARK_BROKEN,
     status: "markingBroken",
   },
   {
-    name: "mark-fixed",
+    name: NodeActions.MARK_FIXED,
     status: "markingFixed",
   },
   {
@@ -120,11 +121,11 @@ export const ACTIONS = [
     status: "mountingSpecial",
   },
   {
-    name: "override-failed-testing",
+    name: NodeActions.OVERRIDE_FAILED_TESTING,
     status: "overridingFailedTesting",
   },
   {
-    name: "release",
+    name: NodeActions.RELEASE,
     status: "releasing",
   },
   {
@@ -132,31 +133,31 @@ export const ACTIONS = [
     status: "settingBootDisk",
   },
   {
-    name: "set-pool",
+    name: NodeActions.SET_POOL,
     status: "settingPool",
   },
   {
-    name: "set-zone",
+    name: NodeActions.SET_ZONE,
     status: "settingZone",
   },
   {
-    name: "tag",
+    name: NodeActions.TAG,
     status: "tagging",
   },
   {
-    name: "test",
+    name: NodeActions.TEST,
     status: "testing",
   },
   {
-    name: "off",
+    name: NodeActions.OFF,
     status: "turningOff",
   },
   {
-    name: "on",
+    name: NodeActions.ON,
     status: "turningOn",
   },
   {
-    name: "unlock",
+    name: NodeActions.UNLOCK,
     status: "unlocking",
   },
   {
@@ -305,7 +306,7 @@ const statusHandlers = generateStatusHandlers<
           system_id: systemId,
         });
         break;
-      case "commission":
+      case NodeActions.COMMISSION:
         handler.prepare = (
           systemId: Machine["system_id"],
           enableSSH: boolean,
@@ -532,14 +533,14 @@ const statusHandlers = generateStatusHandlers<
           volume_group_id: params.volumeGroupId,
         });
         break;
-      case "deploy":
+      case NodeActions.DEPLOY:
         handler.prepare = (systemId: Machine["system_id"], extra = {}) => ({
           action: action.name,
           extra,
           system_id: systemId,
         });
         break;
-      case "mark-broken":
+      case NodeActions.MARK_BROKEN:
         handler.prepare = (systemId: Machine["system_id"], message) => ({
           action: action.name,
           extra: { message },
@@ -570,21 +571,21 @@ const statusHandlers = generateStatusHandlers<
           system_id: params.systemId,
         });
         break;
-      case "set-pool":
+      case NodeActions.SET_POOL:
         handler.prepare = (systemId: Machine["system_id"], poolId) => ({
           action: action.name,
           extra: { pool_id: poolId },
           system_id: systemId,
         });
         break;
-      case "set-zone":
+      case NodeActions.SET_ZONE:
         handler.prepare = (systemId: Machine["system_id"], zoneId) => ({
           action: action.name,
           extra: { zone_id: zoneId },
           system_id: systemId,
         });
         break;
-      case "tag":
+      case NodeActions.TAG:
         handler.prepare = (systemId: Machine["system_id"], tags: string[]) => ({
           action: action.name,
           extra: {
@@ -593,7 +594,7 @@ const statusHandlers = generateStatusHandlers<
           system_id: systemId,
         });
         break;
-      case "test":
+      case NodeActions.TEST:
         handler.prepare = (
           systemId: Machine["system_id"],
           scripts: Scripts[],

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -54,6 +54,29 @@ export enum NodeStatus {
   TESTING = "Testing",
 }
 
+export enum NodeActions {
+  ABORT = "abort",
+  ACQUIRE = "acquire",
+  COMMISSION = "commission",
+  DELETE = "delete",
+  DEPLOY = "deploy",
+  EXIT_RESCUE_MODE = "exit-rescue-mode",
+  IMPORT_IMAGES = "import-images",
+  LOCK = "lock",
+  MARK_BROKEN = "mark-broken",
+  MARK_FIXED = "mark-fixed",
+  OFF = "off",
+  ON = "on",
+  OVERRIDE_FAILED_TESTING = "override-failed-testing",
+  RELEASE = "release",
+  RESCUE_MODE = "rescue-mode",
+  SET_POOL = "set-pool",
+  SET_ZONE = "set-zone",
+  TAG = "tag",
+  TEST = "test",
+  UNLOCK = "unlock",
+}
+
 /**
  * BaseNode represents the intersection of Machines and Controllers
  */

--- a/ui/src/testing/factories/general.ts
+++ b/ui/src/testing/factories/general.ts
@@ -17,6 +17,7 @@ import {
   PowerType,
   Version,
 } from "app/store/general/types";
+import { NodeActions } from "app/store/types/node";
 
 export const architecture = define<Architecture>("amd64");
 
@@ -29,7 +30,7 @@ export const hweKernel = define<HWEKernel>(["ga-18.04", "bionic"]);
 export const knownArchitecture = define<KnownArchitecture>("amd64");
 
 export const machineAction = define<MachineAction>({
-  name: "commission",
+  name: NodeActions.COMMISSION,
   sentence: "commissioned",
   title: "Commission...",
   type: "lifecycle",


### PR DESCRIPTION
## Done

- Replace the machine action strings with enums, using this list for reference:
https://git.launchpad.net/maas/tree/src/maasserver/node_action.py#n933

## QA

n/a

## Fixes

Fixes: canonical-web-and-design/maas-ui#1921.