### PR TITLE
refactor(ui): add lint rule for type imports

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
             ignoreRestSiblings: true,
           },
         ],
+        "@typescript-eslint/consistent-type-imports": 2,
         "import/namespace": "off",
         "import/no-named-as-default": 0,
         "import/order": [
@@ -69,7 +70,7 @@ module.exports = {
                 group: "internal",
               },
             ],
-            "pathGroupsExcludedImportTypes": ["react"],
+            pathGroupsExcludedImportTypes: ["react"],
             "newlines-between": "always",
             alphabetize: {
               order: "asc",

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import authSelectors from "app/store/auth/selectors";
-import { MessageType } from "app/store/message/types";
+import type { MessageType } from "app/store/message/types";
 import { actions as notificationActions } from "app/store/notification";
 import notificationSelectors from "app/store/notification/selectors";
 import type { Notification as NotificationType } from "app/store/notification/types";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -4,7 +4,8 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import configureStore, { MockStoreEnhanced } from "redux-mock-store";
+import type { MockStoreEnhanced } from "redux-mock-store";
+import configureStore from "redux-mock-store";
 
 import ComposeForm from "../ComposeForm";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -4,7 +4,8 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import configureStore, { MockStoreEnhanced } from "redux-mock-store";
+import type { MockStoreEnhanced } from "redux-mock-store";
+import configureStore from "redux-mock-store";
 
 import ComposeForm from "../../ComposeForm";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -4,7 +4,8 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import configureStore, { MockStore } from "redux-mock-store";
+import type { MockStore } from "redux-mock-store";
+import configureStore from "redux-mock-store";
 
 import ComposeForm from "../../ComposeForm";
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -4,7 +4,8 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import configureStore, { MockStore } from "redux-mock-store";
+import type { MockStore } from "redux-mock-store";
+import configureStore from "redux-mock-store";
 
 import ComposeForm from "../ComposeForm";
 

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx
@@ -8,7 +8,7 @@ import configureStore from "redux-mock-store";
 
 import PodConfiguration from "./PodConfiguration";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -7,7 +7,7 @@ import configureStore from "redux-mock-store";
 
 import KVMDetailsHeader from "./KVMDetailsHeader";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
@@ -4,7 +4,7 @@ import { Col, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
-import { AddKVMFormValues } from "../AddKVMForm";
+import type { AddKVMFormValues } from "../AddKVMForm";
 
 import FormikField from "app/base/components/FormikField";
 import PowerTypeFields from "app/machines/components/PowerTypeFields";

--- a/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListHeader/KVMListActionMenu/KVMListActionMenu.test.tsx
@@ -7,7 +7,7 @@ import configureStore from "redux-mock-store";
 
 import KVMListActionMenu from "./KVMListActionMenu";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   rootState as rootStateFactory,

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -8,7 +8,7 @@ import configureStore from "redux-mock-store";
 
 import ActionFormWrapper from "./ActionFormWrapper";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -8,7 +8,7 @@ import configureStore from "redux-mock-store";
 
 import DeployForm from "../DeployForm";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
   configState as configStateFactory,

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -6,7 +6,7 @@ import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { DeployFormValues } from "../DeployForm";
+import type { DeployFormValues } from "../DeployForm";
 
 import UserDataField from "./UserDataField";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { mount, ReactWrapper } from "enzyme";
+import type { ReactWrapper } from "enzyme";
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -8,7 +9,7 @@ import configureStore from "redux-mock-store";
 
 import DeployForm from "../../DeployForm";
 
-import { TSFixMe } from "app/base/types";
+import type { TSFixMe } from "app/base/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.tsx
@@ -3,9 +3,10 @@ import React, { useState } from "react";
 import { Spinner, Textarea } from "@canonical/react-components";
 import classNames from "classnames";
 import { useFormikContext } from "formik";
-import { FileRejection, useDropzone } from "react-dropzone";
+import type { FileRejection } from "react-dropzone";
+import { useDropzone } from "react-dropzone";
 
-import { DeployFormValues } from "../../DeployForm";
+import type { DeployFormValues } from "../../DeployForm";
 
 import FormikField from "app/base/components/FormikField";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
@@ -8,7 +8,7 @@ import configureStore from "redux-mock-store";
 
 import MarkBrokenForm from "./MarkBrokenForm";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -9,8 +9,8 @@ import configureStore from "redux-mock-store";
 import TestForm from "./TestForm";
 
 import { HardwareType } from "app/base/enum";
-import { RootState } from "app/store/root/types";
-import { Scripts } from "app/store/scripts/types";
+import type { RootState } from "app/store/root/types";
+import type { Scripts } from "app/store/scripts/types";
 import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -8,13 +8,13 @@ import TestFormFields from "./TestFormFields";
 
 import { scripts as scriptActions } from "app/base/actions";
 import ActionForm from "app/base/components/ActionForm";
-import { HardwareType } from "app/base/enum";
+import type { HardwareType } from "app/base/enum";
 import { useMachineActionForm } from "app/machines/hooks";
-import { MachineAction } from "app/store/general/types";
+import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import scriptSelectors from "app/store/scripts/selectors";
-import { Scripts } from "app/store/scripts/types";
+import type { Scripts } from "app/store/scripts/types";
 import { NodeActions } from "app/store/types/node";
 
 const TestFormSchema = Yup.object().shape({

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.test.tsx
@@ -8,7 +8,7 @@ import configureStore from "redux-mock-store";
 
 import TestForm from "../TestForm";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestFormFields/TestFormFields.tsx
@@ -7,7 +7,7 @@ import type { FormValues } from "../TestForm";
 
 import FormikField from "app/base/components/FormikField";
 import TagSelector from "app/base/components/TagSelector";
-import { Scripts } from "app/store/scripts/types";
+import type { Scripts } from "app/store/scripts/types";
 
 type ScriptsDisplay = Scripts & { displayName: string };
 type Props = {

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -7,7 +7,7 @@ import configureStore from "redux-mock-store";
 
 import TakeActionMenu from "./TakeActionMenu";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -7,7 +7,7 @@ import { useParams } from "react-router";
 
 import { general as generalActions } from "app/base/actions";
 import type { RouteParams } from "app/base/types";
-import { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
+import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
 import generalSelectors from "app/store/general/selectors";
 import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -8,7 +8,8 @@ import MachineHeader from "./MachineHeader";
 import NetworkNotifications from "./MachineNetwork/NetworkNotifications";
 import MachineStorage from "./MachineStorage";
 import StorageNotifications from "./MachineStorage/StorageNotifications";
-import MachineSummary, { SelectedAction } from "./MachineSummary";
+import type { SelectedAction } from "./MachineSummary";
+import MachineSummary from "./MachineSummary";
 import SummaryNotifications from "./MachineSummary/SummaryNotifications";
 import MachineTests from "./MachineTests";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";
 
-import { SelectedAction, SetSelectedAction } from "../MachineSummary";
+import type { SelectedAction, SetSelectedAction } from "../MachineSummary";
 
 import MachineName from "./MachineName";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { MainTable } from "@canonical/react-components";
 
-import { NormalisedFilesystem } from "../types";
+import type { NormalisedFilesystem } from "../types";
 import { formatSize, formatType } from "../utils";
 
 type Props = { datastores: NormalisedFilesystem[] };

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import { Button, MainTable, Tooltip } from "@canonical/react-components";
 
-import { NormalisedFilesystem } from "../types";
+import type { NormalisedFilesystem } from "../types";
 import { formatSize } from "../utils";
 
 import AddSpecialFilesystem from "./AddSpecialFilesystem";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -9,7 +9,7 @@ import NumaCard from "./NumaCard";
 import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
 
-import { HardwareType } from "app/base/enum";
+import type { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import type { MachineAction } from "app/store/general/types";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -4,7 +4,7 @@ import { Card, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { SetSelectedAction } from "../MachineSummary";
+import type { SetSelectedAction } from "../MachineSummary";
 import TestResults from "../TestResults";
 
 import NetworkCardTable from "./NetworkCardTable";

--- a/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { TSFixMe } from "@canonical/react-components";
+import type { TSFixMe } from "@canonical/react-components";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";

--- a/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/ui/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -7,10 +7,10 @@ import { useSelector } from "react-redux";
 import type { CommissioningFormValues } from "../CommissioningForm";
 
 import FormikField from "app/base/components/FormikField";
-import { TSFixMe } from "app/base/types";
+import type { TSFixMe } from "app/base/types";
 import configSelectors from "app/store/config/selectors";
 import generalSelectors from "app/store/general/selectors";
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 
 const CommissioningFormFields = (): JSX.Element => {
   const formikProps = useFormikContext<CommissioningFormValues>();

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -9,7 +9,7 @@ import configureStore from "redux-mock-store";
 import { UserForm } from "./UserForm";
 import type { UserWithPassword } from "./UserForm";
 
-import { RootState } from "app/store/root/types";
+import type { RootState } from "app/store/root/types";
 import {
   user as userFactory,
   rootState as rootStateFactory,

--- a/ui/src/app/store/controller/slice.ts
+++ b/ui/src/app/store/controller/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Controller, ControllerState } from "./types";
+import type { Controller, ControllerState } from "./types";
 
 type ControllerReducers = SliceCaseReducers<ControllerState>;
 

--- a/ui/src/app/store/device/slice.ts
+++ b/ui/src/app/store/device/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Device, DeviceState } from "./types";
+import type { Device, DeviceState } from "./types";
 
 type DeviceReducers = SliceCaseReducers<DeviceState>;
 

--- a/ui/src/app/store/dhcpsnippet/slice.ts
+++ b/ui/src/app/store/dhcpsnippet/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { DHCPSnippet, DHCPSnippetState } from "./types";
+import type { DHCPSnippet, DHCPSnippetState } from "./types";
 
 type DHCPSnippetReducers = SliceCaseReducers<DHCPSnippetState>;
 

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Domain, DomainState } from "./types";
+import type { Domain, DomainState } from "./types";
 
 type DomainReducers = SliceCaseReducers<DomainState>;
 

--- a/ui/src/app/store/fabric/slice.ts
+++ b/ui/src/app/store/fabric/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Fabric, FabricState } from "./types";
+import type { Fabric, FabricState } from "./types";
 
 type FabricReducers = SliceCaseReducers<FabricState>;
 

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -1,4 +1,5 @@
-import { createSelector, Selector } from "@reduxjs/toolkit";
+import type { Selector } from "@reduxjs/toolkit";
+import { createSelector } from "@reduxjs/toolkit";
 
 import filterNodes from "app/machines/filter-nodes";
 import { ACTIONS } from "app/store/machine/slice";

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -6,8 +6,8 @@ import { general as generalActions } from "app/base/actions";
 import { nodeStatus } from "app/base/enum";
 import generalSelectors from "app/store/general/selectors";
 import type { Machine } from "app/store/machine/types";
-import { Pod } from "app/store/pod/types";
-import { RootState } from "app/store/root/types";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
 import type { Host } from "app/store/types/host";
 import { NodeStatus } from "app/store/types/node";
 

--- a/ui/src/app/store/noderesult/selectors.ts
+++ b/ui/src/app/store/noderesult/selectors.ts
@@ -1,8 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { Machine } from "../machine/types";
+import type { Machine } from "../machine/types";
 
-import { NodeResults } from "./types";
+import type { NodeResults } from "./types";
 
 import type { TSFixMe } from "app/base/types";
 import type { RootState } from "app/store/root/types";

--- a/ui/src/app/store/noderesult/slice.ts
+++ b/ui/src/app/store/noderesult/slice.ts
@@ -1,10 +1,11 @@
-import { PayloadAction, SliceCaseReducers } from "@reduxjs/toolkit";
+import type { PayloadAction, SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericItemMeta, GenericSlice } from "../utils";
+import type { GenericItemMeta, GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
 import type { NodeResult, NodeResults, NodeResultState } from "./types";
 
-import { Machine } from "app/store/machine/types";
+import type { Machine } from "app/store/machine/types";
 
 type NodeResultReducers = SliceCaseReducers<NodeResultState>;
 

--- a/ui/src/app/store/packagerepository/slice.ts
+++ b/ui/src/app/store/packagerepository/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { PackageRepository, PackageRepositoryState } from "./types";
+import type { PackageRepository, PackageRepositoryState } from "./types";
 
 type PackageRepositoryReducers = SliceCaseReducers<PackageRepositoryState>;
 

--- a/ui/src/app/store/packagerepository/utils.ts
+++ b/ui/src/app/store/packagerepository/utils.ts
@@ -1,4 +1,4 @@
-import { PackageRepository } from "./types";
+import type { PackageRepository } from "./types";
 
 /**
  * Map repositories to names.

--- a/ui/src/app/store/resourcepool/slice.ts
+++ b/ui/src/app/store/resourcepool/slice.ts
@@ -1,9 +1,10 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { Machine } from "../machine/types";
-import { generateSlice, GenericSlice } from "../utils";
+import type { Machine } from "../machine/types";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { ResourcePool, ResourcePoolState } from "./types";
+import type { ResourcePool, ResourcePoolState } from "./types";
 
 type ResourcePoolReducers = SliceCaseReducers<ResourcePoolState>;
 

--- a/ui/src/app/store/scriptresults/selectors.ts
+++ b/ui/src/app/store/scriptresults/selectors.ts
@@ -1,8 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { Machine } from "../machine/types";
+import type { Machine } from "../machine/types";
 
-import { ScriptResults } from "./types";
+import type { ScriptResults } from "./types";
 
 import type { TSFixMe } from "app/base/types";
 import type { RootState } from "app/store/root/types";

--- a/ui/src/app/store/scriptresults/slice.ts
+++ b/ui/src/app/store/scriptresults/slice.ts
@@ -1,7 +1,8 @@
-import { PayloadAction, SliceCaseReducers } from "@reduxjs/toolkit";
+import type { PayloadAction, SliceCaseReducers } from "@reduxjs/toolkit";
 
 import type { Machine } from "../machine/types";
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
 import type {
   ScriptResultsResponse,

--- a/ui/src/app/store/service/slice.ts
+++ b/ui/src/app/store/service/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Service, ServiceState } from "./types";
+import type { Service, ServiceState } from "./types";
 
 type ServiceReducers = SliceCaseReducers<ServiceState>;
 

--- a/ui/src/app/store/space/slice.ts
+++ b/ui/src/app/store/space/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Space, SpaceState } from "./types";
+import type { Space, SpaceState } from "./types";
 
 type SpaceReducers = SliceCaseReducers<SpaceState>;
 

--- a/ui/src/app/store/sslkey/slice.ts
+++ b/ui/src/app/store/sslkey/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { SSLKey, SSLKeyState } from "./types";
+import type { SSLKey, SSLKeyState } from "./types";
 
 type SSLKeyReducers = SliceCaseReducers<SSLKeyState>;
 

--- a/ui/src/app/store/subnet/slice.ts
+++ b/ui/src/app/store/subnet/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Subnet, SubnetState } from "./types";
+import type { Subnet, SubnetState } from "./types";
 
 type SubnetReducers = SliceCaseReducers<SubnetState>;
 

--- a/ui/src/app/store/tag/slice.ts
+++ b/ui/src/app/store/tag/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Tag, TagState } from "./types";
+import type { Tag, TagState } from "./types";
 
 type TagReducers = SliceCaseReducers<TagState>;
 

--- a/ui/src/app/store/token/slice.ts
+++ b/ui/src/app/store/token/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Token, TokenState } from "./types";
+import type { Token, TokenState } from "./types";
 
 type TokenReducers = SliceCaseReducers<TokenState>;
 

--- a/ui/src/app/store/user/slice.ts
+++ b/ui/src/app/store/user/slice.ts
@@ -1,6 +1,7 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
 import type { User, UserState } from "./types";
 

--- a/ui/src/app/store/utils/selectors.ts
+++ b/ui/src/app/store/utils/selectors.ts
@@ -1,8 +1,5 @@
-import {
-  createSelector,
-  OutputParametricSelector,
-  Selector,
-} from "@reduxjs/toolkit";
+import type { OutputParametricSelector, Selector } from "@reduxjs/toolkit";
+import { createSelector } from "@reduxjs/toolkit";
 
 import type { RootState } from "app/store/root/types";
 import type { CommonStates, CommonStateTypes } from "app/store/utils";

--- a/ui/src/app/store/utils/slice.test.ts
+++ b/ui/src/app/store/utils/slice.test.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CaseReducerWithPrepare,
   PayloadAction,
   SliceCaseReducers,

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -1,5 +1,4 @@
-import {
-  createSlice,
+import type {
   CaseReducer,
   Draft,
   PayloadAction,
@@ -7,6 +6,7 @@ import {
   SliceCaseReducers,
   ValidateSliceCaseReducers,
 } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
 
 import type { TSFixMe } from "app/base/types";
 import type { RootState } from "app/store/root/types";

--- a/ui/src/app/store/vlan/slice.ts
+++ b/ui/src/app/store/vlan/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { VLAN, VLANState } from "./types";
+import type { VLAN, VLANState } from "./types";
 
 type VLANReducers = SliceCaseReducers<VLANState>;
 

--- a/ui/src/app/store/zone/slice.ts
+++ b/ui/src/app/store/zone/slice.ts
@@ -1,8 +1,9 @@
-import { SliceCaseReducers } from "@reduxjs/toolkit";
+import type { SliceCaseReducers } from "@reduxjs/toolkit";
 
-import { generateSlice, GenericSlice } from "../utils";
+import type { GenericSlice } from "../utils";
+import { generateSlice } from "../utils";
 
-import { Zone, ZoneState } from "./types";
+import type { Zone, ZoneState } from "./types";
 
 type ZoneReducers = SliceCaseReducers<ZoneState>;
 

--- a/ui/src/testing/factories/general.ts
+++ b/ui/src/testing/factories/general.ts
@@ -1,6 +1,6 @@
 import { array, define } from "cooky-cutter";
 
-import {
+import type {
   Architecture,
   ComponentToDisable,
   DefaultMinHweKernel,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -25,12 +25,8 @@ import type {
   PodStoragePool,
 } from "app/store/pod/types";
 import type { Model } from "app/store/types/model";
-import {
-  BaseNode,
-  SimpleNode,
-  TestStatus,
-  NodeStatus,
-} from "app/store/types/node";
+import type { BaseNode, SimpleNode, TestStatus } from "app/store/types/node";
+import { NodeStatus } from "app/store/types/node";
 
 export const testStatus = define<TestStatus>({
   status: 0,

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -1,6 +1,6 @@
 import type { RouterState } from "connected-react-router";
 import { array, define } from "cooky-cutter";
-import { Location } from "history";
+import type { Location } from "history";
 
 import { message } from "./message";
 import { notification } from "./notification";


### PR DESCRIPTION
##  Done

- Add a lint rule to enforce type imports.
- Fix type import lint errors (using `lint --fix`).

## QA

n/a

## Fixes

Fixes: canonical-web-and-design/maas-ui#1878.