### PR TITLE
feat(ui): add ability to remove filesystems

### DIFF
--- a/ui/src/app/base/components/TableMenu/TableMenu.js
+++ b/ui/src/app/base/components/TableMenu/TableMenu.js
@@ -38,6 +38,7 @@ TableMenu.propTypes = {
     ])
   ),
   onToggleMenu: PropTypes.func,
+  position: PropTypes.oneOf(["center", "left", "right"]),
   positionNode: PropTypes.object,
   title: PropTypes.string,
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+
+import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import ActionConfirm from "./ActionConfirm";
+
+import * as maasUiHooks from "app/base/hooks";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+jest.mock("@canonical/react-components/dist/hooks", () => ({
+  usePrevious: jest.fn(),
+}));
+
+describe("ActionConfirm", () => {
+  it("can show saving state", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory({ deletingFilesystem: true }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActionConfirm
+          closeExpanded={jest.fn()}
+          confirmLabel="Confirm"
+          message="Are you sure you want to do that?"
+          onConfirm={jest.fn()}
+          onSaveAnalytics={{
+            action: "Action",
+            category: "Category",
+            label: "Label",
+          }}
+          statusKey="deletingFilesystem"
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("ActionButton").prop("loading")).toBe(true);
+  });
+
+  it("sends an analytics event when saved", () => {
+    const analyticsEvent = {
+      action: "Action",
+      category: "Category",
+      label: "Label",
+    };
+    const useSendMock = jest.spyOn(maasUiHooks, "useSendAnalyticsWhen");
+    // Mock saved state by simulating "deletingFilesystem" changing from true to false
+    jest
+      .spyOn(reactComponentHooks, "usePrevious")
+      .mockImplementation(() => true);
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory({ deletingFilesystem: false }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const closeExpanded = jest.fn();
+    mount(
+      <Provider store={store}>
+        <ActionConfirm
+          closeExpanded={closeExpanded}
+          confirmLabel="Confirm"
+          message="Are you sure you want to do that?"
+          onConfirm={jest.fn()}
+          onSaveAnalytics={analyticsEvent}
+          statusKey="deletingFilesystem"
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(useSendMock).toHaveBeenCalled();
+    expect(useSendMock.mock.calls[0]).toEqual([
+      true,
+      analyticsEvent.category,
+      analyticsEvent.action,
+      analyticsEvent.label,
+    ]);
+    useSendMock.mockRestore();
+  });
+
+  it("closes the form when saved", () => {
+    // Mock saved state by simulating "deletingFilesystem" changing from true to false
+    jest
+      .spyOn(reactComponentHooks, "usePrevious")
+      .mockImplementation(() => true);
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory({ deletingFilesystem: false }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const closeExpanded = jest.fn();
+    mount(
+      <Provider store={store}>
+        <ActionConfirm
+          closeExpanded={closeExpanded}
+          confirmLabel="Confirm"
+          message="Are you sure you want to do that?"
+          onConfirm={jest.fn()}
+          onSaveAnalytics={{
+            action: "Action",
+            category: "Category",
+            label: "Label",
+          }}
+          statusKey="deletingFilesystem"
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(closeExpanded).toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+
+import { ActionButton, Button, Col, Row } from "@canonical/react-components";
+import { usePrevious } from "@canonical/react-components/dist/hooks";
+import { useSelector } from "react-redux";
+
+import { useSendAnalyticsWhen } from "app/base/hooks";
+import type { AnalyticsEvent } from "app/base/types";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine, MachineStatus } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  confirmLabel: string;
+  message: string;
+  closeExpanded: () => void;
+  onConfirm: () => void;
+  onSaveAnalytics: AnalyticsEvent;
+  statusKey: keyof MachineStatus;
+  systemId: Machine["system_id"];
+};
+
+const ActionConfirm = ({
+  closeExpanded,
+  confirmLabel,
+  message,
+  onConfirm,
+  onSaveAnalytics,
+  statusKey,
+  systemId,
+}: Props): JSX.Element => {
+  const machineStatuses = useSelector((state: RootState) =>
+    machineSelectors.getStatuses(state, systemId)
+  );
+  const saving = (machineStatuses && machineStatuses[statusKey]) || false;
+  const previousSaving = usePrevious(saving);
+  const saved = !saving && previousSaving;
+
+  useSendAnalyticsWhen(
+    saved,
+    onSaveAnalytics.category,
+    onSaveAnalytics.action,
+    onSaveAnalytics.label
+  );
+
+  // Close the form when action has successfully completed.
+  // TODO: Check for machine-specific error, in which case keep form open.
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1842
+  useEffect(() => {
+    if (saved) {
+      closeExpanded();
+    }
+  }, [closeExpanded, saved]);
+
+  return (
+    <Row>
+      <Col size={8}>
+        <p className="u-no-margin--bottom u-no-max-width">
+          <i className="p-icon--warning is-inline">Warning</i>
+          {message}
+        </p>
+      </Col>
+      <Col size={4} className="u-align--right">
+        <Button className="u-no-margin--bottom" onClick={closeExpanded}>
+          Cancel
+        </Button>
+        <ActionButton
+          appearance="negative"
+          className="u-no-margin--bottom"
+          loading={saving}
+          onClick={onConfirm}
+        >
+          {confirmLabel}
+        </ActionButton>
+      </Col>
+    </Row>
+  );
+};
+
+export default ActionConfirm;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ActionConfirm";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
@@ -22,11 +22,7 @@ describe("DatastoresTable", () => {
       partitions: [],
       size: 100,
     });
-    const normalised = normaliseFilesystem(
-      disk.filesystem,
-      disk.name,
-      disk.size
-    );
+    const normalised = normaliseFilesystem(disk.filesystem, disk);
     const wrapper = mount(<DatastoresTable datastores={[normalised]} />);
 
     expect(wrapper).toMatchSnapshot();

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/__snapshots__/DatastoresTable.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/__snapshots__/DatastoresTable.test.tsx.snap
@@ -5,11 +5,16 @@ exports[`DatastoresTable renders 1`] = `
   datastores={
     Array [
       Object {
+        "actions": Array [
+          "remove",
+        ],
         "fstype": "vmfs6",
         "id": 1,
         "mountOptions": "abc",
         "mountPoint": "/vmfs/volumes/datastore",
         "name": "im-a-datastore",
+        "parentId": 2,
+        "parentType": "physical",
         "size": 100,
       },
     ]

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddSpecialFilesystem from "./AddSpecialFilesystem";
@@ -30,17 +29,7 @@ describe("AddSpecialFilesystem", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/storage", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/storage"
-            component={() => <AddSpecialFilesystem closeForm={jest.fn()} />}
-          />
-        </MemoryRouter>
+        <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
@@ -3,16 +3,15 @@ import React, { useEffect } from "react";
 import { Col, Row, Select } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router";
 import * as Yup from "yup";
 
 import FormCard from "app/base/components/FormCard";
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
-import type { RouteParams } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 const AddSpecialFilesystemSchema = Yup.object().shape({
@@ -25,13 +24,16 @@ const AddSpecialFilesystemSchema = Yup.object().shape({
 
 type Props = {
   closeForm: () => void;
+  systemId: Machine["system_id"];
 };
 
-export const AddSpecialFilesystem = ({ closeForm }: Props): JSX.Element => {
+export const AddSpecialFilesystem = ({
+  closeForm,
+  systemId,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const { id } = useParams<RouteParams>();
   const { mountingSpecial } = useSelector((state: RootState) =>
-    machineSelectors.getStatuses(state, id)
+    machineSelectors.getStatuses(state, systemId)
   );
   const previousMountingSpecial = usePrevious(mountingSpecial);
   const saved = !mountingSpecial && previousMountingSpecial;
@@ -66,7 +68,7 @@ export const AddSpecialFilesystem = ({ closeForm }: Props): JSX.Element => {
             filesystemType: values.filesystemType,
             mountOptions: values.mountOptions,
             mountPoint: values.mountPoint,
-            systemId: id,
+            systemId,
           };
           dispatch(machineActions.mountSpecial(params));
         }}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -54,6 +54,7 @@ const MachineStorage = (): JSX.Element => {
               <FilesystemsTable
                 canEditStorage={canEditStorage}
                 filesystems={filesystems}
+                systemId={id}
               />
             </>
           )}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/types.ts
@@ -1,11 +1,14 @@
 import type { Filesystem } from "app/store/machine/types";
 
 export type NormalisedFilesystem = {
+  actions: string[];
   fstype: Filesystem["fstype"];
   id: Filesystem["id"];
   mountOptions: Filesystem["mount_options"];
   mountPoint: Filesystem["mount_point"];
   name: string | null;
+  parentId: number | null;
+  parentType: string | null;
   size: number | null;
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -190,15 +190,34 @@ describe("Machine storage utils", () => {
   });
 
   describe("normaliseFilesystem", () => {
-    it("can normalise a filesystem", () => {
+    it("can normalise a mounted filesystem", () => {
       const filesystem = fsFactory();
-      expect(normaliseFilesystem(filesystem, "fs-name", 1000)).toStrictEqual({
+      const disk = diskFactory({ filesystem });
+      expect(normaliseFilesystem(filesystem, disk)).toStrictEqual({
+        actions: ["remove"],
         fstype: filesystem.fstype,
         id: filesystem.id,
         mountOptions: filesystem.mount_options,
         mountPoint: filesystem.mount_point,
-        name: "fs-name",
-        size: 1000,
+        name: disk.name,
+        parentId: disk.id,
+        parentType: disk.type,
+        size: disk.size,
+      });
+    });
+
+    it("can normalise a special filesystem", () => {
+      const filesystem = fsFactory();
+      expect(normaliseFilesystem(filesystem)).toStrictEqual({
+        actions: ["remove"],
+        fstype: filesystem.fstype,
+        id: filesystem.id,
+        mountOptions: filesystem.mount_options,
+        mountPoint: filesystem.mount_point,
+        name: null,
+        parentId: null,
+        parentType: null,
+        size: null,
       });
     });
   });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -132,16 +132,22 @@ export const canBePartitioned = (storageDevice: Disk | Partition): boolean => {
  */
 export const normaliseFilesystem = (
   filesystem: Filesystem,
-  name?: string,
-  size?: number
-): NormalisedFilesystem => ({
-  fstype: filesystem.fstype,
-  id: filesystem.id,
-  mountPoint: filesystem.mount_point,
-  mountOptions: filesystem.mount_options,
-  name: name || null,
-  size: size || null,
-});
+  parent?: Disk | Partition
+): NormalisedFilesystem => {
+  const actions = ["remove"];
+
+  return {
+    actions,
+    fstype: filesystem.fstype,
+    id: filesystem.id,
+    mountOptions: filesystem.mount_options,
+    mountPoint: filesystem.mount_point,
+    name: parent?.name || null,
+    parentId: parent?.id || null,
+    parentType: parent?.type || null,
+    size: parent?.size || null,
+  };
+};
 
 /**
  * Normalises storage device for use in available/used disk and partition tables.
@@ -217,11 +223,7 @@ export const separateStorageData = (
       }
 
       if (hasMountedFilesystem(disk)) {
-        const normalisedFilesystem = normaliseFilesystem(
-          disk.filesystem,
-          disk.name,
-          disk.size
-        );
+        const normalisedFilesystem = normaliseFilesystem(disk.filesystem, disk);
 
         if (disk.filesystem?.fstype === "vmfs6") {
           data.datastores.push(normalisedFilesystem);
@@ -242,11 +244,7 @@ export const separateStorageData = (
 
           if (hasMountedFilesystem(partition)) {
             data.filesystems.push(
-              normaliseFilesystem(
-                partition.filesystem,
-                partition.name,
-                partition.size
-              )
+              normaliseFilesystem(partition.filesystem, partition)
             );
           }
         });

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -502,9 +502,9 @@ const statusHandlers = generateStatusHandlers<
       case "delete-filesystem":
         handler.method = "delete_filesystem";
         handler.prepare = (params: {
-          blockDeviceId: number;
+          blockDeviceId?: number;
           filesystemId: number;
-          partitionId: number;
+          partitionId?: number;
           systemId: Machine["system_id"];
         }) => ({
           blockdevice_id: params.blockDeviceId,


### PR DESCRIPTION
## Done

- Added ability to remove filesystems
- Built `ActionConfirm` component which should be able to be used for the rest of the delete/remove/unmount actions.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready or Allocated machine
- Add a filesystem to a partition
- Add a special filesystem
- Check that you can remove them both from the action dropdown in the filesystems table

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2276
