### PR TITLE
fix(ui): revert machine list links

### DIFF
--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -1,16 +1,16 @@
 import { Tooltip } from "@canonical/react-components";
 import { Input } from "@canonical/react-components";
-import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import React from "react";
 import { useSelector } from "react-redux";
 
 import machineSelectors from "app/store/machine/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
+import LegacyLink from "app/base/components/LegacyLink";
 
 const generateFQDN = (machine, machineURL) => {
   return (
-    <Link to={machineURL} title={machine.fqdn}>
+    <LegacyLink route={machineURL} title={machine.fqdn}>
       <strong data-test="hostname">
         {machine.locked ? (
           <span title="This machine is locked. You have to unlock it to perform any actions.">
@@ -20,7 +20,7 @@ const generateFQDN = (machine, machineURL) => {
         {machine.hostname}
       </strong>
       <small>.{machine.domain.name}</small>
-    </Link>
+    </LegacyLink>
   );
 };
 
@@ -78,11 +78,14 @@ const generateIPAddresses = (machine) => {
 const generateMAC = (machine, machineURL) => {
   return (
     <>
-      <Link to={machineURL} title={machine.pxe_mac_vendor}>
+      <LegacyLink route={machineURL} title={machine.pxe_mac_vendor}>
         {machine.pxe_mac}
-      </Link>
+      </LegacyLink>
       {machine.extra_macs && machine.extra_macs.length > 0 ? (
-        <Link to={machineURL}> (+{machine.extra_macs.length})</Link>
+        <LegacyLink route={machineURL}>
+          {" "}
+          (+{machine.extra_macs.length})
+        </LegacyLink>
       ) : null}
     </>
   );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -12,8 +12,8 @@ exports[`NameColumn renders 1`] = `
         className="has-inline-label keep-label-opacity"
         id="abc123"
         label={
-          <ForwardRef(Link)
-            to="/undefined/abc123"
+          <LegacyLink
+            route="/undefined/abc123"
           >
             <strong
               data-test="hostname"
@@ -24,7 +24,7 @@ exports[`NameColumn renders 1`] = `
               .
               example
             </small>
-          </ForwardRef(Link)>
+          </LegacyLink>
         }
         onChange={[MockFunction]}
         type="checkbox"
@@ -51,8 +51,8 @@ exports[`NameColumn renders 1`] = `
               className="has-inline-label keep-label-opacity"
               id="abc123"
               label={
-                <ForwardRef(Link)
-                  to="/undefined/abc123"
+                <LegacyLink
+                  route="/undefined/abc123"
                 >
                   <strong
                     data-test="hostname"
@@ -63,7 +63,7 @@ exports[`NameColumn renders 1`] = `
                     .
                     example
                   </small>
-                </ForwardRef(Link)>
+                </LegacyLink>
               }
               onChange={[MockFunction]}
               type="checkbox"
@@ -73,8 +73,8 @@ exports[`NameColumn renders 1`] = `
                 className="u-no-margin--bottom machine-list--inline-input"
                 forId="abc123"
                 label={
-                  <ForwardRef(Link)
-                    to="/undefined/abc123"
+                  <LegacyLink
+                    route="/undefined/abc123"
                   >
                     <strong
                       data-test="hostname"
@@ -85,7 +85,7 @@ exports[`NameColumn renders 1`] = `
                       .
                       example
                     </small>
-                  </ForwardRef(Link)>
+                  </LegacyLink>
                 }
                 labelFirst={false}
               >
@@ -108,15 +108,16 @@ exports[`NameColumn renders 1`] = `
                         className="p-form__label"
                         htmlFor="abc123"
                       >
-                        <Link
-                          to="/undefined/abc123"
+                        <LegacyLink
+                          route="/undefined/abc123"
                         >
-                          <LinkAnchor
-                            href="/undefined/abc123"
-                            navigate={[Function]}
+                          <Link
+                            href="/MAAS/l/undefined/abc123"
+                            onClick={[Function]}
                           >
                             <a
-                              href="/undefined/abc123"
+                              className=""
+                              href="/MAAS/l/undefined/abc123"
                               onClick={[Function]}
                             >
                               <strong
@@ -129,8 +130,8 @@ exports[`NameColumn renders 1`] = `
                                 example
                               </small>
                             </a>
-                          </LinkAnchor>
-                        </Link>
+                          </Link>
+                        </LegacyLink>
                       </label>
                     </Label>
                   </div>

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
@@ -1,5 +1,4 @@
 import { Spinner } from "@canonical/react-components";
-import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -21,9 +20,7 @@ const DhcpTarget = ({ nodeId, subnetId }) => {
       <small>.{target.domain.name}</small>
     </>
   );
-  if (type === "machine") {
-    return <Link to={`/${type}/${nodeId || subnetId}`}>{name}</Link>;
-  }
+
   return (
     <LegacyLink route={`/${type}/${nodeId || subnetId}`}>{name}</LegacyLink>
   );

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.js
@@ -90,8 +90,8 @@ describe("DhcpTarget", () => {
         </MemoryRouter>
       </Provider>
     );
-    const link = wrapper.find("Link");
-    expect(link.prop("to")).toBe("/machine/xyz");
+    const link = wrapper.find("LegacyLink");
+    expect(link.prop("route")).toBe("/machine/xyz");
     expect(link).toMatchSnapshot();
   });
 });

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.js.snap
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.js.snap
@@ -1,15 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DhcpTarget can display a node link 1`] = `
-<Link
-  to="/machine/xyz"
+<LegacyLink
+  route="/machine/xyz"
 >
-  <LinkAnchor
-    href="/machine/xyz"
-    navigate={[Function]}
+  <Link
+    href="/MAAS/l/machine/xyz"
+    onClick={[Function]}
   >
     <a
-      href="/machine/xyz"
+      className=""
+      href="/MAAS/l/machine/xyz"
       onClick={[Function]}
     >
       machine1
@@ -18,6 +19,6 @@ exports[`DhcpTarget can display a node link 1`] = `
         test
       </small>
     </a>
-  </LinkAnchor>
-</Link>
+  </Link>
+</LegacyLink>
 `;


### PR DESCRIPTION
## Done
Machine listing links on master were pointing to the new dev version of machine details, which made for a bit of a broken experience for users on the edge snap.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- From the machine list, click a machine name. 
- Ensure the link navigates to the legacy machine details.

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
