### PR TITLE
refactor(ui): refactor storage utils to be more composable

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils-new.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils-new.test.ts
@@ -1,0 +1,328 @@
+import {
+  canBeFormatted,
+  canBePartitioned,
+  diskAvailable,
+  formatSize,
+  formatType,
+  isBcache,
+  isCacheSet,
+  isDatastore,
+  isLogicalVolume,
+  isMounted,
+  isPartition,
+  isPhysical,
+  isRaid,
+  isVirtual,
+  partitionAvailable,
+} from "./utils-new";
+
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import {
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+  machinePartition as partitionFactory,
+} from "testing/factories";
+
+describe("Machine storage utils", () => {
+  describe("canBeFormatted", () => {
+    it("handles null case", () => {
+      expect(canBeFormatted(null)).toBe(false);
+    });
+
+    it("returns whether a filesystem can be formatted", () => {
+      const formattable = fsFactory({ is_format_fstype: true });
+      const notFormattable = fsFactory({ is_format_fstype: false });
+      expect(canBeFormatted(formattable)).toBe(true);
+      expect(canBeFormatted(notFormattable)).toBe(false);
+    });
+  });
+
+  describe("canBePartitioned", () => {
+    it("handles null case", () => {
+      expect(canBePartitioned(null)).toBe(false);
+    });
+
+    it("handles physical disks with available space", () => {
+      const disk = diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        type: "physical",
+      });
+      expect(canBePartitioned(disk)).toBe(true);
+    });
+
+    it("handles formatted disks", () => {
+      const disk = diskFactory({ filesystem: fsFactory({ fstype: "fat32" }) });
+      expect(canBePartitioned(disk)).toBe(false);
+    });
+
+    it("handles volume groups", () => {
+      const disk = diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        type: "lvm-vg",
+      });
+      expect(canBePartitioned(disk)).toBe(false);
+    });
+
+    it("handles logical volumes", () => {
+      const disk = diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        parent: {
+          id: 1,
+          type: "lvm-vg",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      expect(canBePartitioned(disk)).toBe(false);
+    });
+
+    it("handles bcaches", () => {
+      const disk = diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        parent: {
+          id: 1,
+          type: "bcache",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      expect(canBePartitioned(disk)).toBe(false);
+    });
+  });
+
+  describe("diskAvailable", () => {
+    it("handles null case", () => {
+      expect(diskAvailable(null)).toBe(false);
+    });
+
+    it("handles disks with available space", () => {
+      const disk = diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        type: "physical",
+      });
+      expect(diskAvailable(disk)).toBe(true);
+    });
+
+    it("handles cache sets", () => {
+      const cacheSet = diskFactory({ type: "cache-set" });
+      expect(diskAvailable(cacheSet)).toBe(false);
+    });
+
+    it("handles mounted disks", () => {
+      const mounted = diskFactory({
+        filesystem: fsFactory({ mount_point: "/path" }),
+      });
+      expect(diskAvailable(mounted)).toBe(false);
+    });
+  });
+
+  describe("formatSize", () => {
+    it("handles null case", () => {
+      expect(formatSize(null)).toBe("—");
+      expect(formatSize(0)).toBe("—");
+    });
+
+    it("can format size", () => {
+      expect(formatSize(100)).toBe("100 B");
+      expect(formatSize(10000)).toBe("10 KB");
+    });
+  });
+
+  describe("formatType", () => {
+    it("handles null case", () => {
+      expect(formatType(null)).toBe("Unknown");
+    });
+
+    it("handles cache sets", () => {
+      const disk = diskFactory({ type: "cache-set" });
+      expect(formatType(disk)).toBe("Cache set");
+    });
+
+    it("handles ISCSIs", () => {
+      const disk = diskFactory({ type: "iscsi" });
+      expect(formatType(disk)).toBe("ISCSI");
+    });
+
+    it("handles logical volumes", () => {
+      const disk = diskFactory({
+        parent: {
+          id: 1,
+          type: "lvm-vg",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      expect(formatType(disk)).toBe("Logical volume");
+    });
+
+    it("handles partitions", () => {
+      const partition = partitionFactory({ type: "partition" });
+      expect(formatType(partition)).toBe("Partition");
+    });
+
+    it("handles physical disks", () => {
+      const disk = diskFactory({ type: "physical" });
+      expect(formatType(disk)).toBe("Physical");
+    });
+
+    it("handles RAIDs", () => {
+      const disk = diskFactory({
+        parent: {
+          id: 1,
+          type: "raid-0",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      expect(formatType(disk)).toBe("RAID 0");
+    });
+
+    it("handles VMFS6 datastores", () => {
+      const partition = partitionFactory({ type: "vmfs6" });
+      expect(formatType(partition)).toBe("VMFS6");
+    });
+
+    it("handles volume groups", () => {
+      const disk = diskFactory({ type: "lvm-vg" });
+      expect(formatType(disk)).toBe("Volume group");
+    });
+  });
+
+  describe("isBcache", () => {
+    it("returns whether a disk is a bcache", () => {
+      const bcache = diskFactory({
+        parent: {
+          id: 1,
+          type: "bcache",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      const notBcache = diskFactory({ type: "physical" });
+      expect(isBcache(null)).toBe(false);
+      expect(isBcache(notBcache)).toBe(false);
+      expect(isBcache(bcache)).toBe(true);
+    });
+  });
+
+  describe("isCacheSet", () => {
+    it("returns whether a disk is a cache set", () => {
+      const cacheSet = diskFactory({ type: "cache-set" });
+      const notCacheSet = diskFactory({ type: "physical" });
+      expect(isCacheSet(null)).toBe(false);
+      expect(isCacheSet(notCacheSet)).toBe(false);
+      expect(isCacheSet(cacheSet)).toBe(true);
+    });
+  });
+
+  describe("isDatastore", () => {
+    it("returns whether a filesystem is a datastore", () => {
+      const datastore = fsFactory({ fstype: "vmfs6" });
+      const notDatastore = fsFactory({ fstype: "fat32" });
+      expect(isDatastore(null)).toBe(false);
+      expect(isDatastore(notDatastore)).toBe(false);
+      expect(isDatastore(datastore)).toBe(true);
+    });
+  });
+
+  describe("isLogicalVolume", () => {
+    it("returns whether a disk is a logical volume", () => {
+      const logicalVolume = diskFactory({
+        parent: {
+          id: 1,
+          type: "lvm-vg",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      const notLogicalVolume = diskFactory({ type: "physical" });
+      expect(isLogicalVolume(null)).toBe(false);
+      expect(isLogicalVolume(notLogicalVolume)).toBe(false);
+      expect(isLogicalVolume(logicalVolume)).toBe(true);
+    });
+  });
+
+  describe("isMounted", () => {
+    it("returns whether a filesystem is mounted", () => {
+      const mounted = fsFactory({ mount_point: "/" });
+      const notMounted = fsFactory({ mount_point: "" });
+      expect(isMounted(null)).toBe(false);
+      expect(isMounted(notMounted)).toBe(false);
+      expect(isMounted(mounted)).toBe(true);
+    });
+  });
+
+  describe("isPartition", () => {
+    it("returns whether a storage device is a partition", () => {
+      const disk = diskFactory({ type: "physical" });
+      const partition = partitionFactory({ type: "partition" });
+      expect(isPartition(null)).toBe(false);
+      expect(isPartition(disk)).toBe(false);
+      expect(isPartition(partition)).toBe(true);
+    });
+  });
+
+  describe("isRaid", () => {
+    it("returns whether a disk is a RAID", () => {
+      const raid = diskFactory({
+        parent: {
+          id: 1,
+          type: "raid-0",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      const notRaid = diskFactory({ type: "physical" });
+      expect(isRaid(null)).toBe(false);
+      expect(isRaid(notRaid)).toBe(false);
+      expect(isRaid(raid)).toBe(true);
+    });
+  });
+
+  describe("isPhysical", () => {
+    it("returns whether a disk is a physical disk", () => {
+      const physical = diskFactory({ type: "physical" });
+      const notPhysical = diskFactory({ type: "virtual" });
+      expect(isPhysical(null)).toBe(false);
+      expect(isPhysical(notPhysical)).toBe(false);
+      expect(isPhysical(physical)).toBe(true);
+    });
+  });
+
+  describe("isVirtual", () => {
+    it("returns whether a disk is a virtual disk", () => {
+      const virtual = diskFactory({
+        parent: {
+          id: 1,
+          type: "raid-0",
+          uuid: "abc123",
+        },
+        type: "virtual",
+      });
+      const notVirtual = diskFactory({ type: "physical" });
+      expect(isVirtual(null)).toBe(false);
+      expect(isVirtual(notVirtual)).toBe(false);
+      expect(isVirtual(virtual)).toBe(true);
+    });
+  });
+
+  describe("partitionAvailable", () => {
+    it("handles null case", () => {
+      expect(partitionAvailable(null)).toBe(false);
+    });
+
+    it("handles mounted partitions", () => {
+      const partition = partitionFactory({
+        filesystem: fsFactory({ mount_point: "/path" }),
+      });
+      expect(partitionAvailable(partition)).toBe(false);
+    });
+
+    it("handles unmounted partitions that can be formatted", () => {
+      const partition = partitionFactory({
+        filesystem: fsFactory({ is_format_fstype: true, mount_point: "" }),
+      });
+      expect(partitionAvailable(partition)).toBe(true);
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils-new.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils-new.ts
@@ -1,0 +1,191 @@
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import type { Disk, Filesystem, Partition } from "app/store/machine/types";
+import { formatBytes } from "app/utils";
+
+/**
+ * Returns whether a filesystem can be formatted.
+ * @param fs - the filesystem to check.
+ * @returns whether the filesystem can be formatted
+ */
+export const canBeFormatted = (fs: Filesystem | null): boolean =>
+  fs?.is_format_fstype || false;
+
+/**
+ * Returns whether a disk can be partitioned.
+ * @param disk - the disk to check.
+ * @returns whether the disk can be partitioned.
+ */
+export const canBePartitioned = (disk: Disk | null): boolean => {
+  if (
+    !disk ||
+    isBcache(disk) ||
+    isLogicalVolume(disk) ||
+    isVolumeGroup(disk) ||
+    isMounted(disk.filesystem)
+  ) {
+    return false;
+  }
+
+  // TODO: This does not take into account space that needs to be reserved.
+  // https://github.com/canonical-web-and-design/MAAS-squad/issues/2274
+  return disk.available_size >= MIN_PARTITION_SIZE;
+};
+
+/**
+ * Returns whether a disk is available to use.
+ * @param disk - the disk to check.
+ * @returns whether the disk is available to use
+ */
+export const diskAvailable = (disk: Disk | null): boolean => {
+  if (!disk || isCacheSet(disk) || isMounted(disk.filesystem)) {
+    return false;
+  }
+
+  return disk.available_size >= MIN_PARTITION_SIZE;
+};
+
+/**
+ * Formats a storage device's size for use in tables.
+ * @param size - the size of the storage device in bytes.
+ * @returns formatted size string.
+ */
+export const formatSize = (size: number | null): string => {
+  const formatted = !!size && formatBytes(size, "B");
+  return formatted ? `${formatted.value} ${formatted.unit}` : "—";
+};
+
+/**
+ * Formats a storage device's type for use in tables.
+ * @param storageDevice - the storage device to check.
+ * @returns formatted type string.
+ */
+export const formatType = (storageDevice: Disk | Partition | null): string => {
+  if (!storageDevice) {
+    return "Unknown";
+  }
+
+  let typeToFormat = storageDevice.type;
+  if (!isPartition(storageDevice)) {
+    const disk = storageDevice as Disk;
+    if (isVirtual(disk)) {
+      if (isLogicalVolume(disk)) {
+        return "Logical volume";
+      } else if (isRaid(disk)) {
+        const raidLevel = disk.parent?.type.split("-")[1];
+        return raidLevel ? `RAID ${raidLevel}` : "RAID";
+      }
+      typeToFormat = disk.parent?.type || "Unknown";
+    }
+  }
+
+  switch (typeToFormat) {
+    case "cache-set":
+      return "Cache set";
+    case "iscsi":
+      return "ISCSI";
+    case "lvm-vg":
+      return "Volume group";
+    case "partition":
+      return "Partition";
+    case "physical":
+      return "Physical";
+    case "virtual":
+      return "Virtual";
+    case "vmfs6":
+      return "VMFS6";
+    default:
+      return typeToFormat;
+  }
+};
+
+/**
+ * Returns whether a disk is a bcache.
+ * @param disk - the disk to check.
+ * @returns whether the disk is a bcache
+ */
+export const isBcache = (disk: Disk | null): boolean =>
+  isVirtual(disk) && disk?.parent?.type === "bcache";
+
+/**
+ * Returns whether a disk is a cache set.
+ * @param disk - the disk to check.
+ * @returns whether the disk is a cache set
+ */
+export const isCacheSet = (disk: Disk | null): boolean =>
+  disk?.type === "cache-set";
+
+/**
+ * Returns whether a filesystem is a VMFS6 datastore.
+ * @param fs - the filesystem to check.
+ * @returns whether the filesystem is a VMFS6 datastore
+ */
+export const isDatastore = (fs: Filesystem | null): boolean =>
+  fs?.fstype === "vmfs6";
+
+/**
+ * Returns whether a disk is a logical volume.
+ * @param disk - the disk to check.
+ * @returns whether the disk is a logical volume
+ */
+export const isLogicalVolume = (disk: Disk | null): boolean =>
+  (isVirtual(disk) && disk?.parent?.type === "lvm-vg") || false;
+
+/**
+ * Returns whether a filesystem is mounted.
+ * @param fs - the filesystem to check.
+ * @returns whether the filesystem is mounted
+ */
+export const isMounted = (fs: Filesystem | null): boolean => !!fs?.mount_point;
+
+/**
+ * Returns whether a storage device is a partition.
+ * @param storageDevice - the storage device to check.
+ * @returns whether the storage device is a partition
+ */
+export const isPartition = (storageDevice: Disk | Partition | null): boolean =>
+  storageDevice?.type === "partition";
+
+/**
+ * Returns whether a disk is a physical disk.
+ * @param disk - the disk to check.
+ * @returns whether the disk is a physical disk
+ */
+export const isPhysical = (disk: Disk | null): boolean =>
+  disk?.type === "physical";
+
+/**
+ * Returns whether a disk is a RAID.
+ * @param disk - the disk to check.
+ * @returns whether the disk is a RAID
+ */
+export const isRaid = (disk: Disk | null): boolean =>
+  (isVirtual(disk) && disk?.parent?.type.startsWith("raid-")) || false;
+
+/**
+ * Returns whether a disk is a virtual disk.
+ * @param disk - the disk to check.
+ * @returns whether the disk is a virtual disk
+ */
+export const isVirtual = (disk: Disk | null): boolean =>
+  disk?.type === "virtual" && "parent" in disk;
+
+/**
+ * Returns whether a disk is a volume group.
+ * @param disk - the disk to check.
+ * @returns whether the disk is a volume group
+ */
+export const isVolumeGroup = (disk: Disk | null): boolean =>
+  disk?.type === "lvm-vg";
+
+/**
+ * Returns whether a partition is available to use.
+ * @param partition - the partition to check.
+ * @returns whether the partition is available to use
+ */
+export const partitionAvailable = (partition: Partition | null): boolean => {
+  if (!partition || isMounted(partition.filesystem)) {
+    return false;
+  }
+
+  return canBeFormatted(partition.filesystem);
+};


### PR DESCRIPTION
## Done

- Added a temporary `utils-new.ts` file to storage which will eventually replace the current `utils.ts` file once all the tables have been refactored

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- No QA because these aren't used anywhere yet.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2278
