### PR TITLE
refactor(ui): maintain disk/partition hierarchy in storage tables

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -315,12 +315,12 @@ exports[`stricter compilation`] = {
       [54, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
       [63, 4, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:3079250790": [
-      [70, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [71, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "2579426038"]
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:2920055126": [
+      [64, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [65, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "2579426038"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx:2179234147": [
-      [50, 6, 89, "Cannot invoke an object which is possibly \'undefined\'.", "2274220369"]
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx:2793243989": [
+      [46, 6, 89, "Cannot invoke an object which is possibly \'undefined\'.", "2274220369"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx:4033417679": [
       [76, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
@@ -34,11 +34,7 @@ describe("AddPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition
-          closeExpanded={jest.fn()}
-          diskId={disk.id}
-          systemId="abc123"
-        />
+        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
       </Provider>
     );
 
@@ -60,11 +56,7 @@ describe("AddPartition", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition
-          closeExpanded={jest.fn()}
-          diskId={disk.id}
-          systemId="abc123"
-        />
+        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -23,7 +23,7 @@ export type AddPartitionValues = {
 
 type Props = {
   closeExpanded: () => void;
-  diskId: Disk["id"];
+  disk: Disk;
   systemId: Machine["system_id"];
 };
 
@@ -48,7 +48,7 @@ const AddPartitionSchema = Yup.object().shape({
 
 export const AddPartition = ({
   closeExpanded,
-  diskId,
+  disk,
   systemId,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
@@ -70,14 +70,13 @@ export const AddPartition = ({
     }
   }, [closeExpanded, saved]);
 
-  if (machine && "disks" in machine && "supported_filesystems" in machine) {
+  if (machine && "supported_filesystems" in machine) {
     const filesystemOptions = machine.supported_filesystems.map(
       (filesystem) => ({
         label: filesystem.ui,
         value: filesystem.key,
       })
     );
-    const disk = machine.disks.find((disk) => disk.id === diskId);
     const partitionName = disk
       ? `${disk.name}-part${(disk.partitions?.length || 0) + 1}`
       : "partition";
@@ -110,7 +109,7 @@ export const AddPartition = ({
           // Convert size into bytes before dispatching action
           const size = partitionSize * Math.pow(1000, Number(unit));
           const params = {
-            blockId: diskId,
+            blockId: disk.id,
             partitionSize: size,
             systemId: machine.system_id,
             ...(filesystemType && { filesystemType }),

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
@@ -38,11 +36,7 @@ describe("AddPartitionFields", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <AddPartition
-          closeExpanded={jest.fn()}
-          diskId={disk.id}
-          systemId="abc123"
-        />
+        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,276 +1,250 @@
 import { useState } from "react";
 
 import { MainTable } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 
 import BootStatus from "../BootStatus";
 import NumaNodes from "../NumaNodes";
 import TagLinks from "../TagLinks";
 import TestStatus from "../TestStatus";
-import type { NormalisedStorageDevice as StorageDevice } from "../types";
-import { formatSize, formatType } from "../utils";
+import {
+  canBePartitioned,
+  diskAvailable,
+  formatType,
+  formatSize,
+  isDatastore,
+  partitionAvailable,
+} from "../utils-new";
 
 import AddPartition from "./AddPartition";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import TableHeader from "app/base/components/TableHeader";
 import TableMenu from "app/base/components/TableMenu";
-import { useTableSort } from "app/base/hooks";
-import type { Machine } from "app/store/machine/types";
+import type { TSFixMe } from "app/base/types";
+import machineSelectors from "app/store/machine/selectors";
+import type { Disk, Machine, Partition } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 
 type Expanded = {
   content: "addPartition";
-  id: number;
-};
+  id: string;
+} | null;
 
 type Props = {
   canEditStorage: boolean;
-  storageDevices: StorageDevice[];
   systemId: Machine["system_id"];
 };
 
-/**
- * Generate the actions that a given storage device can perform.
- * @param storageDevice - the storage device to check.
- * @param setExpanded - function to set the expanded table row and content.
- * @returns list of action links.
- */
-const getActionLinks = (
-  storageDevice: StorageDevice,
+const getDiskActions = (
+  disk: Disk,
+  rowId: string,
   setExpanded: (expanded: Expanded) => void
-) => {
-  const actionLinks = [];
-
-  if (storageDevice.actions.includes("addPartition")) {
-    actionLinks.push({
+): TSFixMe[] => {
+  const actions = [];
+  if (canBePartitioned(disk)) {
+    actions.push({
       children: "Add partition...",
-      onClick: () => {
-        setExpanded({
-          content: "addPartition",
-          id: storageDevice.id,
-        });
-      },
+      onClick: () => setExpanded({ content: "addPartition", id: rowId }),
     });
   }
-
-  return actionLinks;
+  return actions;
 };
 
-const getSortValue = (
-  sortKey: keyof StorageDevice,
-  storageDevice: StorageDevice
-) => storageDevice[sortKey];
+const normaliseColumns = (
+  storageDevice: Disk | Partition,
+  canEditStorage: boolean,
+  actions: TSFixMe[] = []
+) => {
+  return [
+    {
+      content: (
+        <DoubleRow
+          primary={storageDevice.name}
+          secondary={"serial" in storageDevice && storageDevice.serial}
+        />
+      ),
+    },
+    {
+      content: (
+        <DoubleRow
+          primary={"model" in storageDevice ? storageDevice.model : "—"}
+          secondary={
+            "firmware_version" in storageDevice &&
+            storageDevice.firmware_version
+          }
+        />
+      ),
+    },
+    {
+      className: "u-align--center",
+      content: (
+        <DoubleRow
+          primary={
+            "is_boot" in storageDevice ? (
+              <BootStatus disk={storageDevice} />
+            ) : (
+              "—"
+            )
+          }
+        />
+      ),
+    },
+    {
+      content: <DoubleRow primary={formatSize(storageDevice.size)} />,
+    },
+    {
+      content: (
+        <DoubleRow
+          primary={formatType(storageDevice)}
+          secondary={
+            ("numa_node" in storageDevice || "numa_nodes" in storageDevice) && (
+              <NumaNodes disk={storageDevice} />
+            )
+          }
+        />
+      ),
+    },
+    {
+      content: (
+        <DoubleRow
+          primary={
+            "test_status" in storageDevice ? (
+              <TestStatus testStatus={storageDevice.test_status} />
+            ) : (
+              "—"
+            )
+          }
+          secondary={<TagLinks tags={storageDevice.tags} />}
+        />
+      ),
+    },
+    {
+      className: "u-align--right",
+      content: (
+        <TableMenu
+          disabled={!canEditStorage || actions.length === 0}
+          links={actions}
+          position="right"
+          title="Take action:"
+        />
+      ),
+    },
+  ];
+};
 
 const AvailableStorageTable = ({
   canEditStorage,
-  storageDevices,
   systemId,
-}: Props): JSX.Element => {
-  const [expanded, setExpanded] = useState<Expanded | null>(null);
-  const { currentSort, sortRows, updateSort } = useTableSort(getSortValue, {
-    key: "name",
-    direction: "descending",
-  });
-  // TODO: update useTableSort to TS with generics
-  // https://github.com/canonical-web-and-design/maas-ui/issues/1869
-  const sortedStorageDevices = sortRows(storageDevices) as StorageDevice[];
-  const closeExpanded = () => setExpanded(null);
-
-  return (
-    <>
-      <MainTable
-        className="p-table-expanding--light"
-        defaultSort="name"
-        defaultSortDirection="ascending"
-        expanding
-        headers={[
-          {
-            content: (
-              <div>
-                <TableHeader
-                  currentSort={currentSort}
-                  onClick={() => updateSort("name")}
-                  sortKey="name"
-                >
-                  Name
-                </TableHeader>
-                <TableHeader>Serial</TableHeader>
-              </div>
-            ),
-          },
-          {
-            content: (
-              <div>
-                <TableHeader
-                  currentSort={currentSort}
-                  onClick={() => updateSort("model")}
-                  sortKey="model"
-                >
-                  Model
-                </TableHeader>
-                <TableHeader>Firmware</TableHeader>
-              </div>
-            ),
-          },
-          {
-            className: "u-align--center",
-            content: (
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => updateSort("boot")}
-                sortKey="boot"
-              >
-                Boot
-              </TableHeader>
-            ),
-          },
-          {
-            content: (
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => updateSort("size")}
-                sortKey="size"
-              >
-                Size
-              </TableHeader>
-            ),
-          },
-          {
-            content: (
-              <div>
-                <TableHeader
-                  currentSort={currentSort}
-                  onClick={() => updateSort("type")}
-                  sortKey="type"
-                >
-                  Type
-                </TableHeader>
-                <TableHeader>NUMA node</TableHeader>
-              </div>
-            ),
-          },
-          {
-            content: (
-              <div>
-                <TableHeader
-                  currentSort={currentSort}
-                  onClick={() => updateSort("testStatus")}
-                  sortKey="testStatus"
-                >
-                  Health
-                </TableHeader>
-                <TableHeader>Tags</TableHeader>
-              </div>
-            ),
-          },
-          {
-            className: "u-align--right",
-            content: <TableHeader>Actions</TableHeader>,
-          },
-        ]}
-        rows={sortedStorageDevices.map((storageDevice) => {
-          const actionLinks = getActionLinks(storageDevice, setExpanded);
-
-          return {
-            className:
-              expanded?.id === storageDevice.id
-                ? "p-table__row is-active"
-                : null,
-            columns: [
-              {
-                content: (
-                  <DoubleRow
-                    data-test="name"
-                    primary={storageDevice.name}
-                    secondary={storageDevice.serial}
-                  />
-                ),
-              },
-              {
-                content: (
-                  <DoubleRow
-                    data-test="model"
-                    primary={storageDevice.model || "—"}
-                    secondary={storageDevice.firmware}
-                  />
-                ),
-              },
-              {
-                className: "u-align--center",
-                content: (
-                  <DoubleRow
-                    data-test="boot"
-                    primary={<BootStatus storageDevice={storageDevice} />}
-                  />
-                ),
-              },
-              {
-                content: (
-                  <DoubleRow
-                    data-test="size"
-                    primary={formatSize(storageDevice.size)}
-                  />
-                ),
-              },
-              {
-                content: (
-                  <DoubleRow
-                    data-test="type"
-                    primary={formatType(
-                      storageDevice.type,
-                      storageDevice.parentType
-                    )}
-                    secondary={
-                      <NumaNodes numaNodes={storageDevice.numaNodes} />
-                    }
-                  />
-                ),
-              },
-              {
-                content: (
-                  <DoubleRow
-                    data-test="health"
-                    primary={
-                      <TestStatus testStatus={storageDevice.testStatus} />
-                    }
-                    secondary={<TagLinks tags={storageDevice.tags} />}
-                  />
-                ),
-              },
-              {
-                className: "u-align--right",
-                content: (
-                  <TableMenu
-                    disabled={!canEditStorage || actionLinks.length === 0}
-                    links={actionLinks}
-                    position="right"
-                    title="Take action:"
-                  />
-                ),
-              },
-            ],
-            expanded: expanded?.id === storageDevice.id,
-            expandedContent: expanded?.content ? (
-              <div className="u-flex--grow">
-                {expanded.content === "addPartition" && (
-                  <AddPartition
-                    closeExpanded={closeExpanded}
-                    diskId={storageDevice.id}
-                    systemId={systemId}
-                  />
-                )}
-              </div>
-            ) : null,
-            key: storageDevice.id,
-          };
-        })}
-      />
-      {sortedStorageDevices.length === 0 && (
-        <div className="u-nudge-right--small" data-test="no-available">
-          No available disks or partitions.
-        </div>
-      )}
-    </>
+}: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
   );
+  const [expanded, setExpanded] = useState<Expanded>(null);
+
+  if (machine && "disks" in machine && "supported_filesystems" in machine) {
+    const rows: TSFixMe[] = [];
+
+    machine.disks.forEach((disk) => {
+      if (diskAvailable(disk) && !isDatastore(disk.filesystem)) {
+        const rowId = `${disk.type}-${disk.id}`;
+        const diskActions = getDiskActions(disk, rowId, setExpanded);
+        const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
+        rows.push({
+          className: isExpanded ? "p-table__row is-active" : null,
+          columns: normaliseColumns(disk, canEditStorage, diskActions),
+          expanded: isExpanded,
+          expandedContent: isExpanded ? (
+            <div className="u-flex--grow">
+              {expanded?.content === "addPartition" && (
+                <AddPartition
+                  closeExpanded={() => setExpanded(null)}
+                  disk={disk}
+                  systemId={machine.system_id}
+                />
+              )}
+            </div>
+          ) : null,
+          key: rowId,
+        });
+      }
+
+      if (disk.partitions) {
+        disk.partitions.forEach((partition) => {
+          if (
+            partitionAvailable(partition) &&
+            !isDatastore(partition.filesystem)
+          ) {
+            const rowId = `${partition.type}-${partition.id}`;
+            rows.push({
+              columns: normaliseColumns(partition, canEditStorage),
+              key: rowId,
+            });
+          }
+        });
+      }
+    });
+
+    return (
+      <>
+        <MainTable
+          className="p-table-expanding--light"
+          expanding
+          headers={[
+            {
+              content: (
+                <div>
+                  <div>Name</div>
+                  <div>Serial</div>
+                </div>
+              ),
+            },
+            {
+              content: (
+                <div>
+                  <div>Model</div>
+                  <div>Firmware</div>
+                </div>
+              ),
+            },
+            {
+              className: "u-align--center",
+              content: <div>Boot</div>,
+            },
+            {
+              content: <div>Size</div>,
+            },
+            {
+              content: (
+                <div>
+                  <div>Type</div>
+                  <div>NUMA node</div>
+                </div>
+              ),
+            },
+            {
+              content: (
+                <div>
+                  <div>Health</div>
+                  <div>Tags</div>
+                </div>
+              ),
+            },
+            {
+              className: "u-align--right",
+              content: <div>Actions</div>,
+            },
+          ]}
+          rows={rows}
+        />
+        {rows.length === 0 && (
+          <div className="u-nudge-right--small" data-test="no-available">
+            No available disks or partitions.
+          </div>
+        )}
+      </>
+    );
+  }
+  return null;
 };
 
 export default AvailableStorageTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
@@ -1,7 +1,5 @@
 import { mount } from "enzyme";
 
-import { normaliseStorageDevice } from "../utils";
-
 import BootStatus from "./BootStatus";
 
 import { machineDisk as diskFactory } from "testing/factories";
@@ -9,24 +7,21 @@ import { machineDisk as diskFactory } from "testing/factories";
 describe("BootStatus", () => {
   it("shows boot status for boot disks", () => {
     const disk = diskFactory({ is_boot: true, type: "physical" });
-    const normalised = normaliseStorageDevice(disk);
-    const wrapper = mount(<BootStatus storageDevice={normalised} />);
+    const wrapper = mount(<BootStatus disk={disk} />);
 
     expect(wrapper.find("Icon").prop("name")).toBe("tick");
   });
 
   it("shows boot status for non-boot disks", () => {
     const disk = diskFactory({ is_boot: false, type: "physical" });
-    const normalised = normaliseStorageDevice(disk);
-    const wrapper = mount(<BootStatus storageDevice={normalised} />);
+    const wrapper = mount(<BootStatus disk={disk} />);
 
     expect(wrapper.find("Icon").prop("name")).toBe("close");
   });
 
   it("shows boot status for non-physical disks", () => {
     const disk = diskFactory({ is_boot: false, type: "virtual" });
-    const normalised = normaliseStorageDevice(disk);
-    const wrapper = mount(<BootStatus storageDevice={normalised} />);
+    const wrapper = mount(<BootStatus disk={disk} />);
 
     expect(wrapper.find("span").text()).toBe("—");
   });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
@@ -1,14 +1,14 @@
 import { Icon } from "@canonical/react-components";
 
-import type { NormalisedStorageDevice } from "../types";
+import type { Disk } from "app/store/machine/types";
 
-type Props = { storageDevice: NormalisedStorageDevice };
+type Props = { disk: Disk };
 
-const BootCell = ({ storageDevice }: Props): JSX.Element => {
-  if (storageDevice.type === "physical") {
-    return storageDevice.boot ? <Icon name="tick" /> : <Icon name="close" />;
+const BootStatus = ({ disk }: Props): JSX.Element => {
+  if (disk.type === "physical") {
+    return disk.is_boot ? <Icon name="tick" /> : <Icon name="close" />;
   }
   return <span>—</span>;
 };
 
-export default BootCell;
+export default BootStatus;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -29,13 +29,10 @@ const MachineStorage = (): JSX.Element => {
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} storage`);
 
   if (machine && "disks" in machine && "special_filesystems" in machine) {
-    const {
-      available,
-      cacheSets,
-      datastores,
-      filesystems,
-      used,
-    } = separateStorageData(machine.disks, machine.special_filesystems);
+    const { cacheSets, datastores, filesystems } = separateStorageData(
+      machine.disks,
+      machine.special_filesystems
+    );
 
     return (
       <>
@@ -67,13 +64,12 @@ const MachineStorage = (): JSX.Element => {
           <h4>Available disks and partitions</h4>
           <AvailableStorageTable
             canEditStorage={canEditStorage}
-            storageDevices={available}
             systemId={id}
           />
         </Strip>
         <Strip shallow>
           <h4>Used disks and partitions</h4>
-          <UsedStorageTable storageDevices={used} />
+          <UsedStorageTable systemId={id} />
         </Strip>
         <Strip shallow>
           <p>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.test.tsx
@@ -1,16 +1,16 @@
 import { mount } from "enzyme";
 
-import { normaliseStorageDevice } from "../utils";
-
 import NumaNodes from "./NumaNodes";
 
 import { machineDisk as diskFactory } from "testing/factories";
 
 describe("NumaNodes", () => {
   it("can show a single numa node", () => {
-    const disk = diskFactory({ is_boot: true, numa_node: 5, type: "physical" });
-    const normalised = normaliseStorageDevice(disk);
-    const wrapper = mount(<NumaNodes numaNodes={normalised.numaNodes} />);
+    const disk = diskFactory({
+      numa_node: 5,
+      numa_nodes: undefined,
+    });
+    const wrapper = mount(<NumaNodes disk={disk} />);
 
     expect(wrapper.find("[data-test='numa-nodes']").text()).toBe("5");
   });
@@ -19,10 +19,8 @@ describe("NumaNodes", () => {
     const disk = diskFactory({
       numa_node: undefined,
       numa_nodes: [0, 1],
-      type: "lvm-vg",
     });
-    const normalised = normaliseStorageDevice(disk);
-    const wrapper = mount(<NumaNodes numaNodes={normalised.numaNodes} />);
+    const wrapper = mount(<NumaNodes disk={disk} />);
 
     expect(wrapper.find("[data-test='numa-nodes']").text()).toBe("0, 1");
     expect(wrapper.find("[data-test='numa-warning']").prop("message")).toBe(

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
@@ -1,10 +1,17 @@
 import { Tooltip } from "@canonical/react-components";
 
-import type { NormalisedStorageDevice } from "../types";
+import type { Disk } from "app/store/machine/types";
 
-type Props = { numaNodes: NormalisedStorageDevice["numaNodes"] };
+type Props = { disk: Disk };
 
-const NumaNodes = ({ numaNodes }: Props): JSX.Element => {
+const NumaNodes = ({ disk }: Props): JSX.Element => {
+  let numaNodes: number[] = [];
+  if ("numa_nodes" in disk && disk.numa_nodes !== undefined) {
+    numaNodes = disk.numa_nodes;
+  } else if ("numa_node" in disk && disk.numa_node !== undefined) {
+    numaNodes = [disk.numa_node];
+  }
+
   return (
     <>
       {numaNodes.length > 1 && (

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,33 +1,78 @@
 import { mount } from "enzyme";
-
-import { separateStorageData } from "../utils";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
 import UsedStorageTable from "./UsedStorageTable";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
-import { machineDisk as diskFactory } from "testing/factories";
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
 
 describe("UsedStorageTable", () => {
   it("can show an empty message", () => {
-    const wrapper = mount(<UsedStorageTable storageDevices={[]} />);
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UsedStorageTable systemId="abc123" />
+      </Provider>
+    );
 
     expect(wrapper.find("[data-test='no-used']").text()).toBe(
       "No disk or partition has been fully utilised."
     );
   });
 
-  it("can show what the disk is being used for", () => {
-    const disks = [
+  it("only shows disks that are being used", () => {
+    const [availableDisk, usedDisk] = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        name: "available-disk",
+        filesystem: null,
+        type: "physical",
+      }),
       diskFactory({
         available_size: MIN_PARTITION_SIZE - 1,
-        used_for: "nefarious purposes",
+        filesystem: null,
+        name: "used-disk",
+        type: "physical",
       }),
     ];
-    const { used } = separateStorageData(disks);
-    const wrapper = mount(<UsedStorageTable storageDevices={used} />);
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [availableDisk, usedDisk],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UsedStorageTable systemId="abc123" />
+      </Provider>
+    );
 
-    expect(wrapper.find("[data-test='used-for']").text()).toBe(
-      "nefarious purposes"
+    expect(wrapper.find("tbody TableRow").length).toBe(1);
+    expect(wrapper.find("TableCell DoubleRow").at(0).prop("primary")).toBe(
+      usedDisk.name
     );
   });
 });


### PR DESCRIPTION
## Done

- Refactored Available/Used disks and partitions tables to no longer use the `separateStorageData` util, which flattened the data hierarchy.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a ready or allocated machine
- Check that the data in the available and used disks and partitions tables remains the same
- Check that changing the storage layout updates the tables correctly
- Check that adding a partition to a disk still works as before

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2282
Fixes canonical-web-and-design/MAAS-squad#2283
