### PR TITLE
refactor(ui): refactor filesystems table to use new utils

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -329,15 +329,12 @@ exports[`stricter compilation`] = {
       [76, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [76, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx:2401482664": [
-      [22, 43, 15, "Argument of type \'Filesystem | null\' is not assignable to parameter of type \'Filesystem\'.\\n  Type \'null\' is not assignable to type \'Filesystem\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "3886268349"]
-    ],
     "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx:2514535204": [
       [33, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [34, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "3144942680"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:4085310440": [
-      [171, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2397002110": [
+      [168, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/utils.ts:2581007750": [
       [190, 44, 20, "Object is possibly \'undefined\'.", "861603158"],
@@ -425,7 +422,7 @@ exports[`stricter compilation`] = {
     "src/app/store/general/selectors/machineActions.test.ts:638190955": [
       [91, 10, 4, "Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: NodeActions; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'NodeActions\' is not assignable to type \'NodeActions.ABORT | NodeActions.ACQUIRE | NodeActions.COMMISSION | NodeActions.DELETE | NodeActions.DEPLOY | NodeActions.EXIT_RESCUE_MODE | NodeActions.LOCK | ... 11 more ... | NodeActions.UNLOCK\'.", "2087377941"]
     ],
-    "src/app/store/machine/slice.ts:1835973179": [
+    "src/app/store/machine/slice.ts:194880456": [
       [705, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
       [713, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
       [717, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -2,11 +2,8 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import { normaliseFilesystem } from "../utils";
-
 import FilesystemsTable from "./FilesystemsTable";
 
-import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
@@ -21,24 +18,26 @@ import {
 const mockStore = configureStore();
 
 describe("FilesystemsTable", () => {
-  let state: RootState;
-
-  beforeEach(() => {
-    state = rootStateFactory({
+  it("can show an empty message", () => {
+    const state = rootStateFactory({
       machine: machineStateFactory({
-        items: [machineDetailsFactory({ system_id: "abc123" })],
-        statuses: machineStatusesFactory({
-          abc123: machineStatusFactory(),
-        }),
+        items: [
+          machineDetailsFactory({
+            disks: [
+              diskFactory({
+                filesystem: null,
+                partitions: [partitionFactory({ filesystem: null })],
+              }),
+            ],
+            system_id: "abc123",
+          }),
+        ],
       }),
     });
-  });
-
-  it("can show an empty message", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage filesystems={[]} systemId="abc123" />
+        <FilesystemsTable canEditStorage systemId="abc123" />
       </Provider>
     );
 
@@ -48,21 +47,23 @@ describe("FilesystemsTable", () => {
   });
 
   it("can show filesystems associated with disks", () => {
-    const store = mockStore(state);
     const filesystem = fsFactory({ mount_point: "/disk-fs/path" });
-    const disk = diskFactory({
-      filesystem,
-      name: "disk-fs",
-      partitions: [],
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [
+              diskFactory({ filesystem, name: "disk-fs", partitions: [] }),
+            ],
+            system_id: "abc123",
+          }),
+        ],
+      }),
     });
-    const normalised = normaliseFilesystem(filesystem, disk);
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FilesystemsTable
-          canEditStorage
-          filesystems={[normalised]}
-          systemId="abc123"
-        />
+        <FilesystemsTable canEditStorage systemId="abc123" />
       </Provider>
     );
 
@@ -73,20 +74,28 @@ describe("FilesystemsTable", () => {
   });
 
   it("can show filesystems associated with partitions", () => {
-    const store = mockStore(state);
     const filesystem = fsFactory({ mount_point: "/partition-fs/path" });
-    const partition = partitionFactory({
-      filesystem,
-      name: "partition-fs",
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [
+              diskFactory({
+                filesystem: null,
+                partitions: [
+                  partitionFactory({ filesystem, name: "partition-fs" }),
+                ],
+              }),
+            ],
+            system_id: "abc123",
+          }),
+        ],
+      }),
     });
-    const normalised = normaliseFilesystem(filesystem, partition);
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FilesystemsTable
-          canEditStorage
-          filesystems={[normalised]}
-          systemId="abc123"
-        />
+        <FilesystemsTable canEditStorage systemId="abc123" />
       </Provider>
     );
 
@@ -99,19 +108,25 @@ describe("FilesystemsTable", () => {
   });
 
   it("can show special filesystems", () => {
-    const store = mockStore(state);
     const specialFilesystem = fsFactory({
       mount_point: "/special-fs/path",
       fstype: "tmpfs",
     });
-    const filesystem = normaliseFilesystem(specialFilesystem);
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [diskFactory()],
+            special_filesystems: [specialFilesystem],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FilesystemsTable
-          canEditStorage
-          filesystems={[filesystem]}
-          systemId="abc123"
-        />
+        <FilesystemsTable canEditStorage systemId="abc123" />
       </Provider>
     );
 
@@ -122,10 +137,18 @@ describe("FilesystemsTable", () => {
   });
 
   it("can show an add special filesystem form if storage can be edited", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FilesystemsTable canEditStorage filesystems={[]} systemId="abc123" />
+        <FilesystemsTable canEditStorage systemId="abc123" />
       </Provider>
     );
 
@@ -135,17 +158,26 @@ describe("FilesystemsTable", () => {
   });
 
   it("can show an action to remove a filesystem", () => {
-    const store = mockStore(state);
     const filesystem = fsFactory({ mount_point: "/disk-fs/path" });
-    const disk = diskFactory({ filesystem });
-    const normalised = normaliseFilesystem(filesystem, disk);
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [
+              diskFactory({ filesystem, name: "disk-fs", partitions: [] }),
+            ],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FilesystemsTable
-          canEditStorage
-          filesystems={[normalised]}
-          systemId="abc123"
-        />
+        <FilesystemsTable canEditStorage systemId="abc123" />
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -30,7 +30,7 @@ const MachineStorage = (): JSX.Element => {
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} storage`);
 
   if (machine && "disks" in machine && "special_filesystems" in machine) {
-    const { cacheSets, filesystems } = separateStorageData(
+    const { cacheSets } = separateStorageData(
       machine.disks,
       machine.special_filesystems
     );
@@ -50,11 +50,7 @@ const MachineStorage = (): JSX.Element => {
           ) : (
             <>
               <h4>Filesystems</h4>
-              <FilesystemsTable
-                canEditStorage={canEditStorage}
-                filesystems={filesystems}
-                systemId={id}
-              />
+              <FilesystemsTable canEditStorage={canEditStorage} systemId={id} />
             </>
           )}
         </Strip>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils-new.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils-new.ts
@@ -154,7 +154,8 @@ export const isLogicalVolume = (disk: Disk | null): boolean =>
  * @param fs - the filesystem to check.
  * @returns whether the filesystem is mounted
  */
-export const isMounted = (fs: Filesystem | null): boolean => !!fs?.mount_point;
+export const isMounted = (fs: Filesystem | null): fs is Filesystem =>
+  !!fs?.mount_point;
 
 /**
  * Returns whether a storage device is a partition.

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -531,10 +531,10 @@ const statusHandlers = generateStatusHandlers<
           partitionId?: number;
           systemId: Machine["system_id"];
         }) => ({
-          blockdevice_id: params.blockDeviceId,
-          filesystem_id: params.filesystemId,
-          partition_id: params.partitionId,
           system_id: params.systemId,
+          filesystem_id: params.filesystemId,
+          ...(params.blockDeviceId && { blockdevice_id: params.blockDeviceId }),
+          ...(params.partitionId && { partition_id: params.partitionId }),
         });
         break;
       case "delete-partition":


### PR DESCRIPTION
## Done

- Refactored filesystems table to no longer use the `separateStorageData` util.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a ready or allocated machine
- Change the storage layout and check that the filesystems update correctly (you can use the angular version for reference)
- Check that you can still add special filesystems
- Check that you can still remove disk, partition and special filesystems

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2279
