### PR TITLE
feat(ui): add ability to remove disks, partitions and volume groups

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,19 +1,22 @@
 import { useState } from "react";
 
 import { MainTable } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
+import ActionConfirm from "../ActionConfirm";
 import BootStatus from "../BootStatus";
 import NumaNodes from "../NumaNodes";
 import TagLinks from "../TagLinks";
 import TestStatus from "../TestStatus";
 import {
+  canBeDeleted,
   canBePartitioned,
   diskAvailable,
   formatType,
   formatSize,
   isDatastore,
   partitionAvailable,
+  isVolumeGroup,
 } from "../utils-new";
 
 import AddPartition from "./AddPartition";
@@ -21,139 +24,190 @@ import AddPartition from "./AddPartition";
 import DoubleRow from "app/base/components/DoubleRow";
 import TableMenu from "app/base/components/TableMenu";
 import type { TSFixMe } from "app/base/types";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Expanded = {
-  content: "addPartition";
+  content:
+    | "addPartition"
+    | "deleteDisk"
+    | "deletePartition"
+    | "deleteVolumeGroup";
   id: string;
-} | null;
+};
 
 type Props = {
   canEditStorage: boolean;
   systemId: Machine["system_id"];
 };
 
+/**
+ * Generate a unique ID for a disk or partition. Since both disks and partitions
+ * are used in the table it's possible for the id number alone to be non-unique.
+ * @param storageDevice - the disk or partition to create a unique ID for.
+ * @returns unique ID for the disk or partition
+ */
+const uniqueId = (storageDevice: Disk | Partition) =>
+  `${storageDevice.type}-${storageDevice.id}`;
+
+/**
+ * Generate the actions that a given disk can perform.
+ * @param disk - the disk to check.
+ * @param setExpanded - function to set the expanded table row and content.
+ * @returns list of action links.
+ */
 const getDiskActions = (
   disk: Disk,
-  rowId: string,
-  setExpanded: (expanded: Expanded) => void
+  setExpanded: (expanded: Expanded | null) => void
 ): TSFixMe[] => {
   const actions = [];
+  const actionGenerator = (label: string, content: Expanded["content"]) => ({
+    children: label,
+    onClick: () => setExpanded({ content, id: uniqueId(disk) }),
+  });
+
   if (canBePartitioned(disk)) {
-    actions.push({
-      children: "Add partition...",
-      onClick: () => setExpanded({ content: "addPartition", id: rowId }),
-    });
+    actions.push(actionGenerator("Add partition...", "addPartition"));
+  }
+
+  if (canBeDeleted(disk)) {
+    if (isVolumeGroup(disk)) {
+      actions.push(
+        actionGenerator("Remove volume group...", "deleteVolumeGroup")
+      );
+    } else {
+      actions.push(
+        actionGenerator(`Remove ${formatType(disk, true)}...`, "deleteDisk")
+      );
+    }
   }
   return actions;
 };
 
-const normaliseColumns = (
+/**
+ * Normalise rendered row data so that both disks and partitions can be displayed.
+ * @param storageDevice - the disk or partition to normalise.
+ * @param canEditStorage - whether storage can be edited.
+ * @param expanded - the currently expanded row and content.
+ * @param actions - list of actions the storage device can perform.
+ * @returns normalised row data
+ */
+const normaliseRowData = (
   storageDevice: Disk | Partition,
   canEditStorage: boolean,
-  actions: TSFixMe[] = []
+  expanded: Expanded | null,
+  actions: TSFixMe[]
 ) => {
-  return [
-    {
-      content: (
-        <DoubleRow
-          primary={storageDevice.name}
-          secondary={"serial" in storageDevice && storageDevice.serial}
-        />
-      ),
-    },
-    {
-      content: (
-        <DoubleRow
-          primary={"model" in storageDevice ? storageDevice.model : "—"}
-          secondary={
-            "firmware_version" in storageDevice &&
-            storageDevice.firmware_version
-          }
-        />
-      ),
-    },
-    {
-      className: "u-align--center",
-      content: (
-        <DoubleRow
-          primary={
-            "is_boot" in storageDevice ? (
-              <BootStatus disk={storageDevice} />
-            ) : (
-              "—"
-            )
-          }
-        />
-      ),
-    },
-    {
-      content: <DoubleRow primary={formatSize(storageDevice.size)} />,
-    },
-    {
-      content: (
-        <DoubleRow
-          primary={formatType(storageDevice)}
-          secondary={
-            ("numa_node" in storageDevice || "numa_nodes" in storageDevice) && (
-              <NumaNodes disk={storageDevice} />
-            )
-          }
-        />
-      ),
-    },
-    {
-      content: (
-        <DoubleRow
-          primary={
-            "test_status" in storageDevice ? (
-              <TestStatus testStatus={storageDevice.test_status} />
-            ) : (
-              "—"
-            )
-          }
-          secondary={<TagLinks tags={storageDevice.tags} />}
-        />
-      ),
-    },
-    {
-      className: "u-align--right",
-      content: (
-        <TableMenu
-          disabled={!canEditStorage || actions.length === 0}
-          links={actions}
-          position="right"
-          title="Take action:"
-        />
-      ),
-    },
-  ];
+  const rowId = uniqueId(storageDevice);
+  const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
+
+  return {
+    className: isExpanded ? "p-table__row is-active" : null,
+    columns: [
+      {
+        content: (
+          <DoubleRow
+            primary={storageDevice.name}
+            secondary={"serial" in storageDevice && storageDevice.serial}
+          />
+        ),
+      },
+      {
+        content: (
+          <DoubleRow
+            primary={"model" in storageDevice ? storageDevice.model : "—"}
+            secondary={
+              "firmware_version" in storageDevice &&
+              storageDevice.firmware_version
+            }
+          />
+        ),
+      },
+      {
+        className: "u-align--center",
+        content: (
+          <DoubleRow
+            primary={
+              "is_boot" in storageDevice ? (
+                <BootStatus disk={storageDevice} />
+              ) : (
+                "—"
+              )
+            }
+          />
+        ),
+      },
+      {
+        content: <DoubleRow primary={formatSize(storageDevice.size)} />,
+      },
+      {
+        content: (
+          <DoubleRow
+            primary={formatType(storageDevice)}
+            secondary={
+              ("numa_node" in storageDevice ||
+                "numa_nodes" in storageDevice) && (
+                <NumaNodes disk={storageDevice} />
+              )
+            }
+          />
+        ),
+      },
+      {
+        content: (
+          <DoubleRow
+            primary={
+              "test_status" in storageDevice ? (
+                <TestStatus testStatus={storageDevice.test_status} />
+              ) : (
+                "—"
+              )
+            }
+            secondary={<TagLinks tags={storageDevice.tags} />}
+          />
+        ),
+      },
+      {
+        className: "u-align--right",
+        content: (
+          <TableMenu
+            disabled={!canEditStorage || actions.length === 0}
+            links={actions}
+            position="right"
+            title="Take action:"
+          />
+        ),
+      },
+    ],
+    expanded: isExpanded,
+    key: rowId,
+  };
 };
 
 const AvailableStorageTable = ({
   canEditStorage,
   systemId,
 }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
-  const [expanded, setExpanded] = useState<Expanded>(null);
+  const [expanded, setExpanded] = useState<Expanded | null>(null);
+  const closeExpanded = () => setExpanded(null);
 
   if (machine && "disks" in machine && "supported_filesystems" in machine) {
     const rows: TSFixMe[] = [];
 
     machine.disks.forEach((disk) => {
       if (diskAvailable(disk) && !isDatastore(disk.filesystem)) {
-        const rowId = `${disk.type}-${disk.id}`;
-        const diskActions = getDiskActions(disk, rowId, setExpanded);
-        const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
+        const diskActions = getDiskActions(disk, setExpanded);
+        const diskType = formatType(disk, true);
+
         rows.push({
-          className: isExpanded ? "p-table__row is-active" : null,
-          columns: normaliseColumns(disk, canEditStorage, diskActions),
-          expanded: isExpanded,
-          expandedContent: isExpanded ? (
+          ...normaliseRowData(disk, canEditStorage, expanded, diskActions),
+          expandedContent: (
             <div className="u-flex--grow">
               {expanded?.content === "addPartition" && (
                 <AddPartition
@@ -162,9 +216,52 @@ const AvailableStorageTable = ({
                   systemId={machine.system_id}
                 />
               )}
+              {expanded?.content === "deleteDisk" && (
+                <ActionConfirm
+                  closeExpanded={closeExpanded}
+                  confirmLabel={`Remove ${diskType}`}
+                  message={`Are you sure you want to remove this ${diskType}?`}
+                  onConfirm={() => {
+                    dispatch(
+                      machineActions.deleteDisk({
+                        blockId: disk.id,
+                        systemId,
+                      })
+                    );
+                  }}
+                  onSaveAnalytics={{
+                    action: `Delete ${diskType}`,
+                    category: "Machine storage",
+                    label: `Remove ${diskType}`,
+                  }}
+                  statusKey="deletingDisk"
+                  systemId={systemId}
+                />
+              )}
+              {expanded?.content === "deleteVolumeGroup" && (
+                <ActionConfirm
+                  closeExpanded={closeExpanded}
+                  confirmLabel="Remove volume group"
+                  message="Are you sure you want to remove this volume group?"
+                  onConfirm={() => {
+                    dispatch(
+                      machineActions.deleteVolumeGroup({
+                        systemId,
+                        volumeGroupId: disk.id,
+                      })
+                    );
+                  }}
+                  onSaveAnalytics={{
+                    action: "Delete volume group",
+                    category: "Machine storage",
+                    label: "Remove volume group",
+                  }}
+                  statusKey="deletingVolumeGroup"
+                  systemId={systemId}
+                />
+              )}
             </div>
-          ) : null,
-          key: rowId,
+          ),
         });
       }
 
@@ -174,10 +271,50 @@ const AvailableStorageTable = ({
             partitionAvailable(partition) &&
             !isDatastore(partition.filesystem)
           ) {
-            const rowId = `${partition.type}-${partition.id}`;
+            const partitionActions = [
+              {
+                children: "Remove partition...",
+                onClick: () =>
+                  setExpanded({
+                    content: "deletePartition",
+                    id: uniqueId(partition),
+                  }),
+              },
+            ];
+
             rows.push({
-              columns: normaliseColumns(partition, canEditStorage),
-              key: rowId,
+              ...normaliseRowData(
+                partition,
+                canEditStorage,
+                expanded,
+                partitionActions
+              ),
+              expandedContent: (
+                <div className="u-flex--grow">
+                  {expanded?.content === "deletePartition" && (
+                    <ActionConfirm
+                      closeExpanded={closeExpanded}
+                      confirmLabel="Remove partition"
+                      message="Are you sure you want to remove this partition?"
+                      onConfirm={() => {
+                        dispatch(
+                          machineActions.deletePartition({
+                            partitionId: partition.id,
+                            systemId,
+                          })
+                        );
+                      }}
+                      onSaveAnalytics={{
+                        action: "Delete partition",
+                        category: "Machine storage",
+                        label: "Remove partition",
+                      }}
+                      statusKey="deletingPartition"
+                      systemId={systemId}
+                    />
+                  )}
+                </div>
+              ),
             });
           }
         });


### PR DESCRIPTION
## Done

- Added ability to remove disks, partitions and volume groups from the "Available disks and partitions" table
- Updated `formatType()` util to be able to return a type in sentence form
- Fixed a bug where available partitions were ending up in the used table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- In the angular client go to the storage tab of a machine in ready or allocated state
- Add a partition but don't mount it anywhere
- Check the checkbox for the partition and click "Create volume group" and confirm. A volume group should show up in "Available disks and partitions"
- Go to the react version of the storage tab and check that you can remove the volume group. The partition should reappear.
- Check that you can remove the partition. You should only have the physical disk left.
- Check that you can remove the disk. Note that once it's been removed you will need to recommission the machine to get it back.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2163
