### PR TITLE
feat(ui): add network table component

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -4,6 +4,8 @@ import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import NetworkTable from "./NetworkTable";
+
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
@@ -22,7 +24,7 @@ const MachineNetwork = (): JSX.Element => {
     return <Spinner text="Loading..." />;
   }
 
-  return <>Machine network</>;
+  return <NetworkTable systemId={id} />;
 };
 
 export default MachineNetwork;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -1,0 +1,46 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import NetworkTable from "./NetworkTable";
+
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NetworkTable", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        loaded: true,
+      }),
+    });
+  });
+  it("displays a spinner when loading", () => {
+    state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a table when loading", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -1,0 +1,148 @@
+import { MainTable, Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
+import machineSelectors from "app/store/machine/selectors";
+import type { NetworkInterface, Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+const getSortValue = (sortKey: keyof NetworkInterface, nic: NetworkInterface) =>
+  nic[sortKey];
+
+type Props = { systemId: Machine["system_id"] };
+
+const NetworkTable = ({ systemId }: Props): JSX.Element => {
+  const { currentSort, updateSort } = useTableSort(getSortValue, {
+    key: "name",
+    direction: "descending",
+  });
+
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  if (!machine || !("interfaces" in machine)) {
+    return <Spinner text="Loading..." />;
+  }
+  return (
+    <MainTable
+      defaultSort="name"
+      defaultSortDirection="ascending"
+      headers={[
+        {
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("name")}
+                sortKey="name"
+              >
+                Name
+              </TableHeader>
+              <TableHeader>MAC</TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <>
+              <TableHeader
+                className="u-align--center"
+                currentSort={currentSort}
+                onClick={() => updateSort("pxe")}
+                sortKey="pxe"
+              >
+                PXE
+              </TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              onClick={() => updateSort("speed")}
+              sortKey="speed"
+            >
+              Link/interface speed
+            </TableHeader>
+          ),
+        },
+        {
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("type")}
+                sortKey="type"
+              >
+                Type
+              </TableHeader>
+              <TableHeader>NUMA node</TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("fabric")}
+                sortKey="fabric"
+              >
+                Fabric
+              </TableHeader>
+              <TableHeader>VLAN</TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("subnet")}
+                sortKey="subnet"
+              >
+                Subnet
+              </TableHeader>
+              <TableHeader>Name</TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("ip")}
+                sortKey="ip"
+              >
+                IP Address
+              </TableHeader>
+              <TableHeader>Status</TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              onClick={() => updateSort("dhcp")}
+              sortKey="dhcp"
+            >
+              DHCP
+            </TableHeader>
+          ),
+        },
+        {
+          content: "Actions",
+          className: "u-align--right",
+        },
+      ]}
+      rows={[]}
+    />
+  );
+};
+
+export default NetworkTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NetworkTable";


### PR DESCRIPTION
## Done

- Add the network table component with headers.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit a machine details page and go to the network tab.
- You should see the the table headers.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2285.