### PR TITLE
feat(ui): add table of testing results

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],

--- a/ui/src/app/base/enum.ts
+++ b/ui/src/app/base/enum.ts
@@ -73,3 +73,9 @@ export enum HardwareType {
   Storage = 3,
   Network = 4,
 }
+
+export enum ResultType {
+  Commissioning = 0,
+  Installation = 1,
+  Testing = 2,
+}

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -1,0 +1,141 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { Route, MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import MachineTests from ".";
+
+import { HardwareType, ResultType } from "app/base/enum";
+import type { RootState } from "app/store/root/types";
+import {
+  machineState as machineStateFactory,
+  machineDetails as machineDetailsFactory,
+  nodeResult as nodeResultFactory,
+  nodeResults as nodeResultsFactory,
+  nodeResultState as nodeResultStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MachineTests", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        loaded: true,
+        items: [
+          machineDetailsFactory({
+            locked: false,
+            permissions: ["edit"],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+      noderesult: nodeResultStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineTests />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("renders headings for each hardware type", () => {
+    state.noderesult.items = [
+      nodeResultsFactory({
+        id: "abc123",
+        results: [
+          nodeResultFactory({
+            result_type: ResultType.Testing,
+            hardware_type: HardwareType.CPU,
+          }),
+          nodeResultFactory({
+            result_type: ResultType.Testing,
+            hardware_type: HardwareType.Network,
+          }),
+          nodeResultFactory({
+            result_type: ResultType.Testing,
+            hardware_type: HardwareType.Node,
+          }),
+        ],
+      }),
+    ];
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineTests />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='hardware-heading']").at(0).text()).toEqual(
+      "CPU"
+    );
+    expect(wrapper.find("[data-test='hardware-heading']").at(1).text()).toEqual(
+      "Network"
+    );
+    expect(wrapper.find("[data-test='hardware-heading']").at(2).text()).toEqual(
+      "Other Results"
+    );
+  });
+
+  it("renders headings for each block device", () => {
+    state.noderesult.items = [
+      nodeResultsFactory({
+        id: "abc123",
+        results: [
+          nodeResultFactory({
+            result_type: ResultType.Testing,
+            hardware_type: HardwareType.Storage,
+            physical_blockdevice: 1,
+          }),
+          nodeResultFactory({
+            result_type: ResultType.Testing,
+            hardware_type: HardwareType.Storage,
+            physical_blockdevice: 2,
+          }),
+        ],
+      }),
+    ];
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineTests />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='storage-heading']").at(0).text()).toEqual(
+      "1"
+    );
+    expect(wrapper.find("[data-test='storage-heading']").at(1).text()).toEqual(
+      "2"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -20,14 +20,14 @@ import type { RootState } from "app/store/root/types";
  * @param results a node results list
  * @param key
  */
-const groupByKey = (items, key: string) =>
+const groupByKey = <I,>(items: I[], key: keyof I): { [x: string]: I[] } =>
   items.reduce((obj, item) => {
     obj[item[key]] = obj[item[key]] || [];
     obj[item[key]].push(item);
     return obj;
   }, Object.create(null));
 
-const getTestingResults = (nodeResults: NodeResults) =>
+const getTestingResults = (nodeResults: NodeResults): NodeResult[] =>
   nodeResults.results.filter(
     (result) => result.result_type === ResultType.Testing
   );
@@ -95,7 +95,7 @@ const MachineTests = (): JSX.Element => {
             return (
               <div key={hardware_type}>
                 <h4 data-test="hardware-heading">
-                  {HardwareType[hardware_type]}
+                  {HardwareType[parseInt(hardware_type, 0)]}
                 </h4>
                 <MachineTestsTable nodeResults={nodeResults} />
               </div>

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -4,12 +4,60 @@ import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import MachineTestsTable from "./MachineTestsTable";
+
+import { HardwareType, ResultType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import { actions as nodeResultActions } from "app/store/noderesult";
 import nodeResultSelectors from "app/store/noderesult/selectors";
+import type { NodeResult, NodeResults } from "app/store/noderesult/types";
 import type { RootState } from "app/store/root/types";
+
+/**
+ * Group items by key
+ * @param results a node results list
+ * @param key
+ */
+const groupByKey = (items, key: string) =>
+  items.reduce((obj, item) => {
+    obj[item[key]] = obj[item[key]] || [];
+    obj[item[key]].push(item);
+    return obj;
+  }, Object.create(null));
+
+const getTestingResults = (nodeResults: NodeResults) =>
+  nodeResults.results.filter(
+    (result) => result.result_type === ResultType.Testing
+  );
+
+const getHardwareResults = (nodeResults: NodeResults) =>
+  groupByKey(
+    getTestingResults(nodeResults).filter(
+      (result) =>
+        result.hardware_type === HardwareType.CPU ||
+        result.hardware_type === HardwareType.Memory ||
+        result.hardware_type === HardwareType.Network
+    ),
+    "hardware_type"
+  );
+
+const getStorageResults = (nodeResults: NodeResults) =>
+  groupByKey(
+    getTestingResults(nodeResults).filter(
+      (result) => result.hardware_type === HardwareType.Storage
+    ),
+    "physical_blockdevice"
+  );
+
+const getOtherResults = (nodeResults: NodeResults) =>
+  groupByKey(
+    getTestingResults(nodeResults).filter(
+      (result) => result.hardware_type === HardwareType.Node
+    ),
+    "hardware_type"
+  );
 
 const MachineTests = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -21,7 +69,7 @@ const MachineTests = (): JSX.Element => {
   );
   useWindowTitle(`${machine?.fqdn || "Machine"} tests`);
 
-  const result = useSelector((state: RootState) =>
+  const nodeResults = useSelector((state: RootState) =>
     nodeResultSelectors.get(state, id)
   );
 
@@ -30,21 +78,60 @@ const MachineTests = (): JSX.Element => {
   );
 
   useEffect(() => {
-    if (!result && !loading) {
+    if (!nodeResults && !loading) {
       dispatch(nodeResultActions.get(id));
     }
-  }, [dispatch, result, loading, id]);
+  }, [dispatch, nodeResults, loading, id]);
 
-  if (result) {
-    const testResults = result.results.filter(
-      (result) => result.result_type === 2
-    );
+  if (nodeResults) {
+    const allResults = getHardwareResults(nodeResults);
+    const storageResults = getStorageResults(nodeResults);
+    const otherResults = getOtherResults(nodeResults);
+
     return (
-      <ul>
-        {testResults.map((result) => (
-          <li key={result.id}>{result.name}</li>
-        ))}
-      </ul>
+      <div>
+        {Object.entries(allResults).map(
+          ([hardware_type, nodeResults]: [string, NodeResult[]]) => {
+            return (
+              <div key={hardware_type}>
+                <h4 data-test="hardware-heading">
+                  {HardwareType[hardware_type]}
+                </h4>
+                <MachineTestsTable nodeResults={nodeResults} />
+              </div>
+            );
+          }
+        )}
+        {Object.keys(storageResults).length !== 0 ? (
+          <>
+            <h4 data-test="hardware-heading">Storage</h4>
+            {Object.entries(storageResults).map(
+              ([physical_blockdevice, nodeResults]: [string, NodeResult[]]) => {
+                return (
+                  <div key={physical_blockdevice}>
+                    <h5 data-test="storage-heading">{physical_blockdevice}</h5>
+                    <MachineTestsTable nodeResults={nodeResults} />
+                  </div>
+                );
+              }
+            )}
+          </>
+        ) : null}
+        {Object.keys(otherResults).length !== 0 ? (
+          <>
+            <h4 data-test="hardware-heading">Other Results</h4>
+            {Object.entries(otherResults).map(
+              ([hardware_type, nodeResults]: [string, NodeResult[]]) => {
+                return (
+                  <div key={hardware_type}>
+                    <MachineTestsTable nodeResults={nodeResults} />
+                  </div>
+                );
+              }
+            )}
+          </>
+        ) : null}
+      </div>
     );
   }
   return <Spinner text="Loading..." />;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
@@ -1,0 +1,17 @@
+import { mount } from "enzyme";
+
+import MachineTestsTable from ".";
+
+import { nodeResult as nodeResultFactory } from "testing/factories";
+
+describe("MachineTestsTable", () => {
+  it("renders", () => {
+    const wrapper = mount(
+      <MachineTestsTable
+        nodeResults={[nodeResultFactory(), nodeResultFactory()]}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
@@ -1,0 +1,98 @@
+import { Input, MainTable } from "@canonical/react-components";
+
+import { scriptStatus } from "app/base/enum";
+import type { NodeResult } from "app/store/noderesult/types";
+
+type Props = { nodeResults: NodeResult[] };
+
+const isSuppressible = (result: NodeResult) =>
+  result.status === scriptStatus.FAILED ||
+  result.status === scriptStatus.FAILED_INSTALLING ||
+  result.status === scriptStatus.TIMEDOUT ||
+  result.status === scriptStatus.FAILED_APPLYING_NETCONF;
+
+const MachineTestsTable = ({ nodeResults }: Props): JSX.Element => {
+  return (
+    <>
+      <MainTable
+        defaultSort="name"
+        defaultSortDirection="ascending"
+        headers={[
+          {
+            content: "Suppress",
+          },
+          {
+            content: "Name",
+            sortKey: "name",
+          },
+          {
+            content: "Tags",
+          },
+          {
+            content: "Runtime",
+          },
+          {
+            content: "Date",
+            sortKey: "date",
+          },
+          {
+            content: "Result",
+          },
+          {
+            content: "Actions",
+            className: "u-align--right",
+          },
+        ]}
+        rows={nodeResults.map((result) => {
+          return {
+            columns: [
+              {
+                content: (
+                  <>
+                    {isSuppressible(result) ? (
+                      <>
+                        <Input
+                          type="checkbox"
+                          label=" "
+                          checked={result.suppressed}
+                          onChange={() => null}
+                        />
+                      </>
+                    ) : null}
+                  </>
+                ),
+              },
+              {
+                content: <span data-test="name">{result.name || "—"}</span>,
+              },
+              {
+                content: <span data-test="tags">{result.tags}</span>,
+              },
+              {
+                content: <span data-test="runtime">{result.runtime}</span>,
+              },
+              {
+                content: <span data-test="date">{result.updated}</span>,
+              },
+              {
+                content: <span data-test="status">{result.status_name}</span>,
+              },
+              {
+                content: "",
+                className: "u-align--right",
+              },
+            ],
+            key: result.id,
+            sortData: {
+              name: result.name,
+              date: result.updated,
+            },
+          };
+        })}
+        sortable
+      />
+    </>
+  );
+};
+
+export default MachineTestsTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
@@ -1,0 +1,583 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineTestsTable renders 1`] = `
+<MachineTestsTable
+  nodeResults={
+    Array [
+      Object {
+        "ended": "Fri, 13 Nov. 2020 04:50:27",
+        "endtime": 1605243027.158285,
+        "estimated_runtime": "test runtime",
+        "exit_status": 0,
+        "hardware_type": 3,
+        "id": 1,
+        "interface": null,
+        "name": "test name",
+        "parameters": Object {},
+        "physical_blockdevice": 2451,
+        "result_type": 1,
+        "results": Array [
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+        ],
+        "runtime": "0:00:00",
+        "script": 1,
+        "script_version": 2,
+        "started": "Fri, 13 Nov. 2020 04:50:26",
+        "starttime": 605243026.966467,
+        "status": 2,
+        "status_name": "test status",
+        "suppressed": false,
+        "tags": "test, tags",
+        "updated": "Fri, 13 Nov. 2020 04:50:27",
+      },
+      Object {
+        "ended": "Fri, 13 Nov. 2020 04:50:27",
+        "endtime": 1605243027.158285,
+        "estimated_runtime": "test runtime",
+        "exit_status": 0,
+        "hardware_type": 3,
+        "id": 2,
+        "interface": null,
+        "name": "test name",
+        "parameters": Object {},
+        "physical_blockdevice": 2451,
+        "result_type": 1,
+        "results": Array [
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+          Object {
+            "description": "test description",
+            "name": "test name",
+            "surfaced": false,
+            "title": "test title",
+            "value": "test value",
+          },
+        ],
+        "runtime": "0:00:00",
+        "script": 1,
+        "script_version": 2,
+        "started": "Fri, 13 Nov. 2020 04:50:26",
+        "starttime": 605243026.966467,
+        "status": 2,
+        "status_name": "test status",
+        "suppressed": false,
+        "tags": "test, tags",
+        "updated": "Fri, 13 Nov. 2020 04:50:27",
+      },
+    ]
+  }
+>
+  <MainTable
+    defaultSort="name"
+    defaultSortDirection="ascending"
+    headers={
+      Array [
+        Object {
+          "content": "Suppress",
+        },
+        Object {
+          "content": "Name",
+          "sortKey": "name",
+        },
+        Object {
+          "content": "Tags",
+        },
+        Object {
+          "content": "Runtime",
+        },
+        Object {
+          "content": "Date",
+          "sortKey": "date",
+        },
+        Object {
+          "content": "Result",
+        },
+        Object {
+          "className": "u-align--right",
+          "content": "Actions",
+        },
+      ]
+    }
+    rows={
+      Array [
+        Object {
+          "columns": Array [
+            Object {
+              "content": <React.Fragment />,
+            },
+            Object {
+              "content": <span
+                data-test="name"
+              >
+                test name
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="tags"
+              >
+                test, tags
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="runtime"
+              >
+                0:00:00
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="date"
+              >
+                Fri, 13 Nov. 2020 04:50:27
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="status"
+              >
+                test status
+              </span>,
+            },
+            Object {
+              "className": "u-align--right",
+              "content": "",
+            },
+          ],
+          "key": 1,
+          "sortData": Object {
+            "date": "Fri, 13 Nov. 2020 04:50:27",
+            "name": "test name",
+          },
+        },
+        Object {
+          "columns": Array [
+            Object {
+              "content": <React.Fragment />,
+            },
+            Object {
+              "content": <span
+                data-test="name"
+              >
+                test name
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="tags"
+              >
+                test, tags
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="runtime"
+              >
+                0:00:00
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="date"
+              >
+                Fri, 13 Nov. 2020 04:50:27
+              </span>,
+            },
+            Object {
+              "content": <span
+                data-test="status"
+              >
+                test status
+              </span>,
+            },
+            Object {
+              "className": "u-align--right",
+              "content": "",
+            },
+          ],
+          "key": 2,
+          "sortData": Object {
+            "date": "Fri, 13 Nov. 2020 04:50:27",
+            "name": "test name",
+          },
+        },
+      ]
+    }
+    sortable={true}
+  >
+    <Table
+      className="p-main-table"
+      sortable={true}
+    >
+      <table
+        className="p-main-table p-table--sortable"
+        role="grid"
+      >
+        <thead>
+          <TableRow>
+            <tr
+              role="row"
+            >
+              <TableHeader
+                key="0"
+                onClick={[Function]}
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Suppress
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="1"
+                onClick={[Function]}
+                sort="ascending"
+              >
+                <th
+                  aria-sort="ascending"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Name
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="2"
+                onClick={[Function]}
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Tags
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="3"
+                onClick={[Function]}
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Runtime
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="4"
+                onClick={[Function]}
+                sort="none"
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Date
+                </th>
+              </TableHeader>
+              <TableHeader
+                key="5"
+                onClick={[Function]}
+              >
+                <th
+                  aria-sort="none"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Result
+                </th>
+              </TableHeader>
+              <TableHeader
+                className="u-align--right"
+                key="6"
+                onClick={[Function]}
+              >
+                <th
+                  aria-sort="none"
+                  className="u-align--right"
+                  onClick={[Function]}
+                  role="columnheader"
+                >
+                  Actions
+                </th>
+              </TableHeader>
+            </tr>
+          </TableRow>
+        </thead>
+        <tbody>
+          <TableRow
+            key="1"
+          >
+            <tr
+              role="row"
+            >
+              <TableCell
+                key="0"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                />
+              </TableCell>
+              <TableCell
+                key="1"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="name"
+                  >
+                    test name
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="2"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="tags"
+                  >
+                    test, tags
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="3"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="runtime"
+                  >
+                    0:00:00
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="4"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="date"
+                  >
+                    Fri, 13 Nov. 2020 04:50:27
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="5"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="status"
+                  >
+                    test status
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                className="u-align--right"
+                key="6"
+              >
+                <td
+                  aria-hidden={false}
+                  className="u-align--right"
+                  role="gridcell"
+                />
+              </TableCell>
+            </tr>
+          </TableRow>
+          <TableRow
+            key="2"
+          >
+            <tr
+              role="row"
+            >
+              <TableCell
+                key="0"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                />
+              </TableCell>
+              <TableCell
+                key="1"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="name"
+                  >
+                    test name
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="2"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="tags"
+                  >
+                    test, tags
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="3"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="runtime"
+                  >
+                    0:00:00
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="4"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="date"
+                  >
+                    Fri, 13 Nov. 2020 04:50:27
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                key="5"
+              >
+                <td
+                  aria-hidden={false}
+                  className=""
+                  role="gridcell"
+                >
+                  <span
+                    data-test="status"
+                  >
+                    test status
+                  </span>
+                </td>
+              </TableCell>
+              <TableCell
+                className="u-align--right"
+                key="6"
+              >
+                <td
+                  aria-hidden={false}
+                  className="u-align--right"
+                  role="gridcell"
+                />
+              </TableCell>
+            </tr>
+          </TableRow>
+        </tbody>
+      </table>
+    </Table>
+  </MainTable>
+</MachineTestsTable>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineTestsTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/__snapshots__/MachineTests.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/__snapshots__/MachineTests.test.tsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineTests renders 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <MemoryRouter
+    initialEntries={
+      Array [
+        Object {
+          "key": "testKey",
+          "pathname": "/machine/abc123",
+        },
+      ]
+    }
+  >
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/machine/abc123",
+              "search": "",
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": "testKey",
+            "pathname": "/machine/abc123",
+            "search": "",
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+    >
+      <MachineTests>
+        <Spinner
+          text="Loading..."
+        >
+          <span
+            className="p-spinner p-text--default"
+          >
+            <i
+              className="p-icon--spinner u-animation--spin"
+            />
+            <span
+              className="p-icon__text"
+            >
+              Loading...
+            </span>
+          </span>
+        </Spinner>
+      </MachineTests>
+    </Router>
+  </MemoryRouter>
+</Provider>
+`;

--- a/ui/src/testing/factories/noderesult.ts
+++ b/ui/src/testing/factories/noderesult.ts
@@ -1,4 +1,4 @@
-import { array, define, extend, random } from "cooky-cutter";
+import { array, define, extend } from "cooky-cutter";
 
 import { model } from "./model";
 
@@ -30,8 +30,8 @@ export const nodeResult = extend<Model, NodeResult>(model, {
   result_type: 1,
   results: array(nodeScriptResult),
   runtime: "0:00:00",
-  script: random,
-  script_version: random,
+  script: 1,
+  script_version: 2,
   started: "Fri, 13 Nov. 2020 04:50:26",
   starttime: 605243026.966467,
   status: 2,


### PR DESCRIPTION
## Done
Add initial table of testing results

Note, a number of features are not working in this branch:

1. actions
2. supressing tests
3. links to logs
4. status icons
5. block device headings render as ids rather than the full string

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine details testing tab
- Ensure testing results are rendered correctly in tables under the appropriate headings
- Ensure block devices are grouped

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2206

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
