### PR TITLE
feat(ui): add checkboxes to available disks and partitons table

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -315,12 +315,15 @@ exports[`stricter compilation`] = {
       [54, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
       [63, 4, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:2920055126": [
-      [64, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [65, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "2579426038"]
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:2100928998": [
+      [62, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [63, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "2579426038"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx:2793243989": [
-      [46, 6, 89, "Cannot invoke an object which is possibly \'undefined\'.", "2274220369"]
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx:639270117": [
+      [44, 6, 89, "Cannot invoke an object which is possibly \'undefined\'.", "2274220369"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:1716738471": [
+      [154, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx:4033417679": [
       [76, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -74,9 +74,86 @@ describe("AvailableStorageTable", () => {
     );
 
     expect(wrapper.find("tbody TableRow").length).toBe(1);
-    expect(wrapper.find("TableCell DoubleRow").at(0).prop("primary")).toBe(
+    expect(wrapper.find("TableCell DoubleRow").at(0).find("label").text()).toBe(
       availableDisk.name
     );
+  });
+
+  it("can select a single disk", () => {
+    const disk = diskFactory({
+      available_size: MIN_PARTITION_SIZE + 1,
+      filesystem: null,
+      type: "physical",
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AvailableStorageTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper
+      .find("TableCell input")
+      .at(0)
+      .simulate("change", {
+        target: { name: disk.id },
+      });
+
+    expect(wrapper.find("TableCell Input").prop("checked")).toBe(true);
+  });
+
+  it("can select all disks", () => {
+    const disks = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        filesystem: null,
+        type: "physical",
+      }),
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        filesystem: null,
+        type: "physical",
+      }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: disks,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AvailableStorageTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper
+      .find("TableHeader input")
+      .at(0)
+      .simulate("change", {
+        target: { name: "all-disks-checkbox" },
+      });
+
+    expect(
+      wrapper
+        .find("TableCell Input")
+        .everyWhere((input) => input.prop("checked"))
+    ).toBe(true);
   });
 
   it("disables action dropdown if storage cannot be edited", () => {


### PR DESCRIPTION
## Done

- Added checkboxes to the available disks and partitions table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
- Go to the machine details page of a machine in ready or allocated state
- Check that you can check individual disk checkboxes
- Check that you can check all checkboxes via the header checkbox

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2286
