### PR TITLE
feat(ui): add ability to unmount filesystems

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -63,7 +63,7 @@ const uniqueId = (storageDevice: Disk | Partition) =>
 const getDiskActions = (
   disk: Disk,
   setExpanded: (expanded: Expanded | null) => void
-): TSFixMe[] => {
+) => {
   const actions = [];
   const actionGenerator = (label: string, content: Expanded["content"]) => ({
     children: label,
@@ -102,7 +102,7 @@ const normaliseRowData = (
   expanded: Expanded | null,
   selected: string[],
   handleRowCheckbox: (rowID: string, selected: string[]) => void,
-  actions: TSFixMe[]
+  actions: TSFixMe[] // Replace TSFixMe with TableMenu actions type when converted to TS
 ) => {
   const rowId = uniqueId(storageDevice);
   const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -157,15 +157,14 @@ describe("FilesystemsTable", () => {
     expect(wrapper.find("AddSpecialFilesystem").exists()).toBe(true);
   });
 
-  it("can show an action to remove a filesystem", () => {
+  it("can remove a disk's filesystem", () => {
     const filesystem = fsFactory({ mount_point: "/disk-fs/path" });
+    const disk = diskFactory({ filesystem, partitions: [] });
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
           machineDetailsFactory({
-            disks: [
-              diskFactory({ filesystem, name: "disk-fs", partitions: [] }),
-            ],
+            disks: [disk],
             system_id: "abc123",
           }),
         ],
@@ -182,13 +181,259 @@ describe("FilesystemsTable", () => {
     );
 
     wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text().includes("Remove")
+      )
+      .simulate("click");
+    wrapper.find("ActionButton").simulate("click");
 
-    expect(wrapper.find("ContextualMenuDropdown Button").at(0).text()).toBe(
-      "Remove filesystem..."
+    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+      "Are you sure you want to remove this filesystem?"
+    );
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/deleteFilesystem")
+    ).toStrictEqual({
+      meta: {
+        method: "delete_filesystem",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          blockdevice_id: disk.id,
+          filesystem_id: filesystem.id,
+          system_id: "abc123",
+        },
+      },
+      type: "machine/deleteFilesystem",
+    });
+  });
+
+  it("can remove a partition's filesystem", () => {
+    const filesystem = fsFactory({ mount_point: "/disk-fs/path" });
+    const partition = partitionFactory({ filesystem });
+    const disk = diskFactory({ filesystem: null, partitions: [partition] });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <FilesystemsTable canEditStorage systemId="abc123" />
+      </Provider>
     );
 
-    wrapper.find("ContextualMenuDropdown button").at(0).simulate("click");
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text().includes("Remove")
+      )
+      .simulate("click");
+    wrapper.find("ActionButton").simulate("click");
 
-    expect(wrapper.find("ActionConfirm").exists()).toBe(true);
+    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+      "Are you sure you want to remove this filesystem?"
+    );
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/deletePartition")
+    ).toStrictEqual({
+      meta: {
+        method: "delete_partition",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          partition_id: partition.id,
+          system_id: "abc123",
+        },
+      },
+      type: "machine/deletePartition",
+    });
+  });
+
+  it("can remove a special filesystem", () => {
+    const filesystem = fsFactory({
+      fstype: "tmpfs",
+      mount_point: "/disk-fs/path",
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [],
+            special_filesystems: [filesystem],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <FilesystemsTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text().includes("Remove")
+      )
+      .simulate("click");
+    wrapper.find("ActionButton").simulate("click");
+
+    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+      "Are you sure you want to remove this special filesystem?"
+    );
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/unmountSpecial")
+    ).toStrictEqual({
+      meta: {
+        method: "unmount_special",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          mount_point: filesystem.mount_point,
+          system_id: "abc123",
+        },
+      },
+      type: "machine/unmountSpecial",
+    });
+  });
+
+  it("can unmount a disk's filesystem", () => {
+    const filesystem = fsFactory({ mount_point: "/disk-fs/path" });
+    const disk = diskFactory({ filesystem, partitions: [] });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <FilesystemsTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text().includes("Unmount")
+      )
+      .simulate("click");
+    wrapper.find("ActionButton").simulate("click");
+
+    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+      "Are you sure you want to unmount this filesystem?"
+    );
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/updateFilesystem")
+    ).toStrictEqual({
+      meta: {
+        method: "update_filesystem",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          block_id: disk.id,
+          mount_options: "",
+          mount_point: "",
+          system_id: "abc123",
+        },
+      },
+      type: "machine/updateFilesystem",
+    });
+  });
+
+  it("can unmount a partition's filesystem", () => {
+    const filesystem = fsFactory({ mount_point: "/disk-fs/path" });
+    const partition = partitionFactory({ filesystem });
+    const disk = diskFactory({ filesystem: null, partitions: [partition] });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <FilesystemsTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text().includes("Unmount")
+      )
+      .simulate("click");
+    wrapper.find("ActionButton").simulate("click");
+
+    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+      "Are you sure you want to unmount this filesystem?"
+    );
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/updateFilesystem")
+    ).toStrictEqual({
+      meta: {
+        method: "update_filesystem",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          mount_options: "",
+          mount_point: "",
+          partition_id: partition.id,
+          system_id: "abc123",
+        },
+      },
+      type: "machine/updateFilesystem",
+    });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -15,6 +15,7 @@ import {
   isRaid,
   isVirtual,
   partitionAvailable,
+  usesStorage,
 } from "./utils";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
@@ -358,6 +359,21 @@ describe("Machine storage utils", () => {
         filesystem: fsFactory({ is_format_fstype: true, mount_point: "" }),
       });
       expect(partitionAvailable(partition)).toBe(true);
+    });
+  });
+
+  describe("usesStorage", () => {
+    it("handles null case", () => {
+      expect(usesStorage(null)).toBe(false);
+    });
+
+    it("returns whether a filesystem uses storage", () => {
+      const fs1 = fsFactory({ fstype: "fat32" });
+      const fs2 = fsFactory({ fstype: "ramfs" });
+      const fs3 = fsFactory({ fstype: "tmpfs" });
+      expect(usesStorage(fs1)).toBe(true);
+      expect(usesStorage(fs2)).toBe(false);
+      expect(usesStorage(fs3)).toBe(false);
     });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -209,3 +209,15 @@ export const partitionAvailable = (partition: Partition | null): boolean => {
 
   return partition.filesystem === null || canBeFormatted(partition.filesystem);
 };
+
+/**
+ * Returns whether a filesystem uses storage.
+ * @param fs - the filesystem to check.
+ * @returns whether the filesystem uses storage
+ */
+export const usesStorage = (fs: Filesystem | null): boolean => {
+  if (!fs?.fstype) {
+    return false;
+  }
+  return !["ramfs", "tmpfs"].includes(fs.fstype);
+};

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -908,10 +908,10 @@ describe("machine actions", () => {
     expect(
       actions.updateFilesystem({
         blockId: 1,
-        filesystemType: "fat32",
+        fstype: "fat32",
         mountOptions: "noexec",
         mountPoint: "/path",
-        partitionID: 2,
+        partitionId: 2,
         systemId: "abc123",
         tags: ["tag1", "tag2"],
       })

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -533,8 +533,10 @@ const statusHandlers = generateStatusHandlers<
         }) => ({
           system_id: params.systemId,
           filesystem_id: params.filesystemId,
-          ...(params.blockDeviceId && { blockdevice_id: params.blockDeviceId }),
-          ...(params.partitionId && { partition_id: params.partitionId }),
+          ...("blockDeviceId" in params && {
+            blockdevice_id: params.blockDeviceId,
+          }),
+          ...("partitionId" in params && { partition_id: params.partitionId }),
         });
         break;
       case "delete-partition":
@@ -667,21 +669,23 @@ const statusHandlers = generateStatusHandlers<
       case "update-filesystem":
         handler.method = "update_filesystem";
         handler.prepare = (params: {
-          blockId: number;
-          filesystemType: string;
-          mountOptions: string;
-          mountPoint: string;
-          partitionID: number;
+          blockId?: number;
+          fstype?: string;
+          mountOptions?: string;
+          mountPoint?: string;
+          partitionId?: number;
           systemId: Machine["system_id"];
-          tags: string[];
+          tags?: string[];
         }) => ({
-          block_id: params.blockId,
-          fstype: params.filesystemType,
-          mount_options: params.mountOptions,
-          mount_point: params.mountPoint,
-          partition_id: params.partitionID,
           system_id: params.systemId,
-          tags: params.tags,
+          ...("blockId" in params && { block_id: params.blockId }),
+          ...("fstype" in params && { fstype: params.fstype }),
+          ...("mountOptions" in params && {
+            mount_options: params.mountOptions,
+          }),
+          ...("mountPoint" in params && { mount_point: params.mountPoint }),
+          ...("partitionId" in params && { partition_id: params.partitionId }),
+          ...("tags" in params && { tags: params.tags }),
         });
         break;
       case "update-vmfs-datastore":


### PR DESCRIPTION
## Done

- Added ability to unmount filesystems from the filesystems table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine in Ready or Allocated state
- Change the storage layout to "LVM" which will create a partition and logical volume (a type of virtual disk)
- Check that you can unmount each filesystem, which puts them back into  "Available disks and partitions"

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2275
