### PR TITLE
feat(ui): add edit partition functionality

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -343,6 +343,13 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:1716738471": [
       [154, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx:211560400": [
+      [42, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [43, 6, 15, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "1103269280"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/EditPartitionFields.test.tsx:2078291524": [
+      [51, 6, 81, "Cannot invoke an object which is possibly \'undefined\'.", "878884295"]
+    ],
     "src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx:4033417679": [
       [76, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [76, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.tsx
@@ -45,7 +45,7 @@ const ActionConfirm = ({
 
   // Close the form when action has successfully completed.
   // TODO: Check for machine-specific error, in which case keep form open.
-  // https://github.com/canonical-web-and-design/maas-ui/issues/1842
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1968
   useEffect(() => {
     if (saved) {
       closeExpanded();

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -63,7 +63,7 @@ export const AddPartition = ({
 
   // Close the form when partition has successfully been created.
   // TODO: Check for machine-specific error, in which case keep form open.
-  // https://github.com/canonical-web-and-design/maas-ui/issues/1842
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1968
   useEffect(() => {
     if (saved) {
       closeExpanded();

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -208,6 +208,38 @@ describe("AvailableStorageTable", () => {
     expect(wrapper.find("AddPartition").exists()).toBe(true);
   });
 
+  it("can open the edit partition form if partition can be edited", () => {
+    const partition = partitionFactory({ filesystem: null });
+    const disk = diskFactory({
+      available_size: MIN_PARTITION_SIZE - 1,
+      partitions: [partition],
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AvailableStorageTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text() === "Edit partition..."
+      )
+      .simulate("click");
+
+    expect(wrapper.find("EditPartition").exists()).toBe(true);
+  });
+
   it("can delete a disk", () => {
     const disk = diskFactory({
       available_size: MIN_PARTITION_SIZE + 1,

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "../utils";
 
 import AddPartition from "./AddPartition";
+import EditPartition from "./EditPartition";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import TableMenu from "app/base/components/TableMenu";
@@ -36,7 +37,8 @@ type Expanded = {
     | "addPartition"
     | "deleteDisk"
     | "deletePartition"
-    | "deleteVolumeGroup";
+    | "deleteVolumeGroup"
+    | "editPartition";
   id: string;
 };
 
@@ -308,6 +310,14 @@ const AvailableStorageTable = ({
                     id: uniqueId(partition),
                   }),
               },
+              {
+                children: "Edit partition...",
+                onClick: () =>
+                  setExpanded({
+                    content: "editPartition",
+                    id: uniqueId(partition),
+                  }),
+              },
             ];
 
             rows.push({
@@ -341,6 +351,14 @@ const AvailableStorageTable = ({
                       }}
                       statusKey="deletingPartition"
                       systemId={systemId}
+                    />
+                  )}
+                  {expanded?.content === "editPartition" && (
+                    <EditPartition
+                      closeExpanded={() => setExpanded(null)}
+                      disk={disk}
+                      partition={partition}
+                      systemId={machine.system_id}
                     />
                   )}
                 </div>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx
@@ -1,0 +1,71 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import EditPartition from "./EditPartition";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machinePartition as partitionFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("EditPartition", () => {
+  it("correctly dispatches an action to edit a partition", () => {
+    const partition = partitionFactory();
+    const disk = diskFactory({ partitions: [partition] });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <EditPartition
+          closeExpanded={jest.fn()}
+          disk={disk}
+          partition={partition}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    wrapper.find("Formik").prop("onSubmit")({
+      fstype: "fat32",
+      mountOptions: "noexec",
+      mountPoint: "/path",
+    });
+
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/updateFilesystem")
+    ).toStrictEqual({
+      meta: {
+        method: "update_filesystem",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          block_id: disk.id,
+          partition_id: partition.id,
+          fstype: "fat32",
+          mount_options: "noexec",
+          mount_point: "/path",
+          system_id: "abc123",
+        },
+      },
+      type: "machine/updateFilesystem",
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from "react";
+
+import { usePrevious } from "@canonical/react-components/dist/hooks";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import EditPartitionFields from "../EditPartitionFields";
+
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { Disk, Machine, Partition } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+export type EditPartitionValues = {
+  fstype?: string;
+  mountOptions?: string;
+  mountPoint?: string;
+};
+
+type Props = {
+  closeExpanded: () => void;
+  disk: Disk;
+  partition: Partition;
+  systemId: Machine["system_id"];
+};
+
+const EditPartitionSchema = Yup.object().shape({
+  fstype: Yup.string(),
+  mountOptions: Yup.string(),
+  mountPoint: Yup.string().when("fstype", {
+    is: (val) => Boolean(val),
+    then: Yup.string()
+      .matches(/^\//, "Mount point must start with /")
+      .required("Mount point is required if filesystem type is defined"),
+  }),
+});
+
+export const EditPartition = ({
+  closeExpanded,
+  disk,
+  partition,
+  systemId,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const { updatingFilesystem } = useSelector((state: RootState) =>
+    machineSelectors.getStatuses(state, systemId)
+  );
+  const previousUpdatingFilesystem = usePrevious(updatingFilesystem);
+  const saved = !updatingFilesystem && previousUpdatingFilesystem;
+
+  // Close the form when partition has successfully been edited.
+  // TODO: Check for machine-specific error, in which case keep form open.
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1968
+  useEffect(() => {
+    if (saved) {
+      closeExpanded();
+    }
+  }, [closeExpanded, saved]);
+
+  if (machine && "supported_filesystems" in machine) {
+    const filesystemOptions = machine.supported_filesystems.map(
+      (filesystem) => ({
+        label: filesystem.ui,
+        value: filesystem.key,
+      })
+    );
+    const fs = partition.filesystem;
+
+    return (
+      <FormikForm
+        buttons={FormCardButtons}
+        cleanup={machineActions.cleanup}
+        initialValues={{
+          fstype: fs?.fstype || "",
+          mountOptions: fs?.mount_options || "",
+          mountPoint: fs?.mount_point || "",
+        }}
+        onCancel={closeExpanded}
+        onSaveAnalytics={{
+          action: "Edit partition",
+          category: "Machine storage",
+          label: "Edit partition",
+        }}
+        onSubmit={(values: EditPartitionValues) => {
+          const { fstype, mountOptions, mountPoint } = values;
+          const params = {
+            blockId: disk.id,
+            fstype,
+            partitionId: partition.id,
+            systemId: machine.system_id,
+            ...(fstype && mountOptions && { mountOptions }),
+            ...(fstype && mountPoint && { mountPoint }),
+          };
+
+          dispatch(machineActions.updateFilesystem(params));
+        }}
+        saved={saved}
+        saving={updatingFilesystem}
+        submitLabel="Edit partition"
+        validationSchema={EditPartitionSchema}
+      >
+        <EditPartitionFields
+          filesystemOptions={filesystemOptions}
+          partition={partition}
+        />
+      </FormikForm>
+    );
+  }
+  return null;
+};
+
+export default EditPartition;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./EditPartition";
+export type { EditPartitionValues } from "./EditPartition";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/EditPartitionFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/EditPartitionFields.test.tsx
@@ -1,0 +1,64 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import EditPartition from "../EditPartition";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machinePartition as partitionFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("EditPartitionFields", () => {
+  it("renders mount point and options if filesystem type is selected", async () => {
+    const partition = partitionFactory();
+    const disk = diskFactory({ partitions: [partition] });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            supported_filesystems: [{ key: "fat32", ui: "fat32" }],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <EditPartition
+          closeExpanded={jest.fn()}
+          disk={disk}
+          partition={partition}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    // Select a filesystem type
+    await act(async () => {
+      wrapper
+        .find("select[name='fstype']")
+        .props()
+        .onChange({
+          target: { name: "fstype", value: "fat32" },
+        } as React.ChangeEvent<HTMLSelectElement>);
+    });
+    wrapper.update();
+
+    expect(wrapper.find("Input[name='mountOptions']").exists()).toBe(true);
+    expect(wrapper.find("Input[name='mountPoint']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/EditPartitionFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/EditPartitionFields.tsx
@@ -1,0 +1,78 @@
+import { Col, Input, Row, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import { formatSize, formatType } from "../../utils";
+import type { EditPartitionValues } from "../EditPartition";
+
+import FormikField from "app/base/components/FormikField";
+import type { Partition } from "app/store/machine/types";
+
+type Props = {
+  filesystemOptions: { label: string; value: string }[];
+  partition: Partition;
+};
+
+export const EditPartitionFields = ({
+  filesystemOptions,
+  partition,
+}: Props): JSX.Element => {
+  const { values } = useFormikContext<EditPartitionValues>();
+
+  return (
+    <Row>
+      <Col size="5">
+        <Input disabled label="Name" value={partition.name} type="text" />
+        <Input
+          disabled
+          label="Type"
+          value={formatType(partition)}
+          type="text"
+        />
+        <Input
+          disabled
+          label="Size"
+          value={formatSize(partition.size)}
+          type="text"
+        />
+      </Col>
+      <Col emptyLarge="7" size="5">
+        <FormikField
+          component={Select}
+          label="Filesystem"
+          name="fstype"
+          options={[
+            {
+              label: "Select filesystem type",
+              value: null,
+              disabled: true,
+            },
+            {
+              label: "Unformatted",
+              value: "",
+            },
+            ...filesystemOptions,
+          ]}
+        />
+        {Boolean(values.fstype) && (
+          <>
+            <FormikField
+              label="Mount point"
+              name="mountPoint"
+              placeholder="/path/to/partition"
+              required
+              type="text"
+            />
+            <FormikField
+              help='Comma-separated list without spaces, e.g. "noexec,size=1024k".'
+              label="Mount options"
+              name="mountOptions"
+              type="text"
+            />
+          </>
+        )}
+      </Col>
+    </Row>
+  );
+};
+
+export default EditPartitionFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditPartitionFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -50,7 +50,7 @@ export const ChangeStorageLayout = ({ id }: Props): JSX.Element => {
 
   // Close the form when storage layout has successfully changed.
   // TODO: Check for machine-specific error, in which case keep form open.
-  // https://github.com/canonical-web-and-design/maas-ui/issues/1842
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1968
   useEffect(() => {
     if (saved) {
       setSelectedLayout(null);

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
@@ -40,7 +40,7 @@ export const AddSpecialFilesystem = ({
 
   // Close the form when special filesystem has successfully mounted.
   // TODO: Check for machine-specific error, in which case keep form open.
-  // https://github.com/canonical-web-and-design/maas-ui/issues/1842
+  // https://github.com/canonical-web-and-design/maas-ui/issues/1968
   useEffect(() => {
     if (saved) {
       closeForm();


### PR DESCRIPTION
## Done

- Added `EditPartition` and `EditPartitionFields` components. I originally wanted to make a generic `PartitionForm` component that housed the bits shared between the add and edit forms, but I think the differences ended up being large enough to warrant separate components.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready or Allocated machine and create an unmounted partition if one does not already exist
- Check that you can edit the filesystem of the partition from the action dropdown

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2162
