### PR TITLE
refactor(ui): add testing result selectors to noderesult selectors

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -329,9 +329,9 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:2183522574": [
       [114, 18, 5, "Type \'MenuLink<null>[]\' is not assignable to type \'(string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined)[]\'.\\n  Type \'MenuLink<null>\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n    Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n      Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }>\'.\\n        Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'Partial<InferPropsInner<Pick<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }, \\"children\\" | ... 7 more ... | \\"inline\\">>>\'.\\n          Types of property \'element\' are incompatible.\\n            Type \'\\"symbol\\" | \\"object\\" | \\"metadata\\" | \\"map\\" | \\"filter\\" | \\"path\\" | \\"label\\" | \\"data\\" | \\"a\\" | \\"abbr\\" | \\"address\\" | \\"area\\" | \\"article\\" | \\"aside\\" | \\"audio\\" | \\"b\\" | \\"base\\" | \\"bdi\\" | \\"bdo\\" | ... 160 more ... | undefined\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n              Type \'FunctionComponent<null>\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n                Type \'FunctionComponent<null>\' is not assignable to type \'(props: any, context?: any) => any\'.\\n                  Types of parameters \'props\' and \'props\' are incompatible.\\n                    Type \'any\' is not assignable to type \'never\'.", "173192470"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:540121013": [
-      [14, 2, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'NetworkInterface\'.\\n  No index signature with a parameter of type \'string\' was found on type \'NetworkInterface\'.", "3729243690"],
-      [14, 17, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'NetworkInterface\'.\\n  No index signature with a parameter of type \'string\' was found on type \'NetworkInterface\'.", "3729243690"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:3412899083": [
+      [15, 2, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'NetworkInterface\'.\\n  No index signature with a parameter of type \'string\' was found on type \'NetworkInterface\'.", "3729243690"],
+      [15, 17, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'NetworkInterface\'.\\n  No index signature with a parameter of type \'string\' was found on type \'NetworkInterface\'.", "3729243690"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:2100928998": [
       [62, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -340,7 +340,7 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx:639270117": [
       [44, 6, 89, "Cannot invoke an object which is possibly \'undefined\'.", "2274220369"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:1716738471": [
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:3355242033": [
       [154, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx:211560400": [
@@ -620,9 +620,9 @@ exports[`no TSFixMe types`] = {
       [321, 34, 8, "RegExp match", "1152173309"],
       [324, 25, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/noderesult/selectors.ts:3542853452": [
-      [6, 13, 8, "RegExp match", "1152173309"],
-      [59, 34, 8, "RegExp match", "1152173309"]
+    "src/app/store/noderesult/selectors.ts:2866544023": [
+      [7, 13, 8, "RegExp match", "1152173309"],
+      [60, 34, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/noderesult/types.ts:2068501750": [
       [2, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -54,7 +54,7 @@ describe("MachineTests", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it.only("renders headings for each hardware type", () => {
+  it("renders headings for each hardware type", () => {
     state.noderesult.items = [
       nodeResultsFactory({
         id: "abc123",

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -54,7 +54,7 @@ describe("MachineTests", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it("renders headings for each hardware type", () => {
+  it.only("renders headings for each hardware type", () => {
     state.noderesult.items = [
       nodeResultsFactory({
         id: "abc123",

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -38,7 +38,7 @@ describe("MachineTests", () => {
     });
   });
 
-  it("renders", () => {
+  it.only("renders", () => {
     const store = mockStore(state);
 
     const wrapper = mount(

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -59,7 +59,11 @@ const MachineTests = (): JSX.Element => {
     }
   }, [dispatch, hardwareResults, storageResults, otherResults, loading, id]);
 
-  if (hardwareResults || storageResults || otherResults) {
+  if (
+    hardwareResults.length > 0 ||
+    storageResults.length > 0 ||
+    otherResults.length > 0
+  ) {
     return (
       <div>
         {hardwareResults.length > 0

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -6,13 +6,13 @@ import { useParams } from "react-router";
 
 import MachineTestsTable from "./MachineTestsTable";
 
-import { HardwareType, ResultType } from "app/base/enum";
+import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import { actions as nodeResultActions } from "app/store/noderesult";
 import nodeResultSelectors from "app/store/noderesult/selectors";
-import type { NodeResult, NodeResults } from "app/store/noderesult/types";
+import type { NodeResult } from "app/store/noderesult/types";
 import type { RootState } from "app/store/root/types";
 
 /**
@@ -27,38 +27,6 @@ const groupByKey = <I,>(items: I[], key: keyof I): { [x: string]: I[] } =>
     return obj;
   }, Object.create(null));
 
-const getTestingResults = (nodeResults: NodeResults): NodeResult[] =>
-  nodeResults.results.filter(
-    (result) => result.result_type === ResultType.Testing
-  );
-
-const getHardwareResults = (nodeResults: NodeResults) =>
-  groupByKey(
-    getTestingResults(nodeResults).filter(
-      (result) =>
-        result.hardware_type === HardwareType.CPU ||
-        result.hardware_type === HardwareType.Memory ||
-        result.hardware_type === HardwareType.Network
-    ),
-    "hardware_type"
-  );
-
-const getStorageResults = (nodeResults: NodeResults) =>
-  groupByKey(
-    getTestingResults(nodeResults).filter(
-      (result) => result.hardware_type === HardwareType.Storage
-    ),
-    "physical_blockdevice"
-  );
-
-const getOtherResults = (nodeResults: NodeResults) =>
-  groupByKey(
-    getTestingResults(nodeResults).filter(
-      (result) => result.hardware_type === HardwareType.Node
-    ),
-    "hardware_type"
-  );
-
 const MachineTests = (): JSX.Element => {
   const dispatch = useDispatch();
   const params = useParams<RouteParams>();
@@ -69,8 +37,16 @@ const MachineTests = (): JSX.Element => {
   );
   useWindowTitle(`${machine?.fqdn || "Machine"} tests`);
 
-  const nodeResults = useSelector((state: RootState) =>
-    nodeResultSelectors.get(state, id)
+  const hardwareResults = useSelector((state: RootState) =>
+    nodeResultSelectors.getHardwareTestingResults(state, id)
+  );
+
+  const storageResults = useSelector((state: RootState) =>
+    nodeResultSelectors.getStorageTestingResults(state, id)
+  );
+
+  const otherResults = useSelector((state: RootState) =>
+    nodeResultSelectors.getOtherTestingResults(state, id)
   );
 
   const loading = useSelector((state: RootState) =>
@@ -78,34 +54,34 @@ const MachineTests = (): JSX.Element => {
   );
 
   useEffect(() => {
-    if (!nodeResults && !loading) {
+    if ((!hardwareResults || storageResults || otherResults) && !loading) {
       dispatch(nodeResultActions.get(id));
     }
-  }, [dispatch, nodeResults, loading, id]);
+  }, [dispatch, hardwareResults, storageResults, otherResults, loading, id]);
 
-  if (nodeResults) {
-    const allResults = getHardwareResults(nodeResults);
-    const storageResults = getStorageResults(nodeResults);
-    const otherResults = getOtherResults(nodeResults);
-
+  if (hardwareResults || storageResults || otherResults) {
     return (
       <div>
-        {Object.entries(allResults).map(
-          ([hardware_type, nodeResults]: [string, NodeResult[]]) => {
-            return (
-              <div key={hardware_type}>
-                <h4 data-test="hardware-heading">
-                  {HardwareType[parseInt(hardware_type, 0)]}
-                </h4>
-                <MachineTestsTable nodeResults={nodeResults} />
-              </div>
-            );
-          }
-        )}
-        {Object.keys(storageResults).length !== 0 ? (
+        {hardwareResults.length > 0
+          ? Object.entries(groupByKey(hardwareResults, "hardware_type")).map(
+              ([hardware_type, nodeResults]: [string, NodeResult[]]) => {
+                return (
+                  <div key={hardware_type}>
+                    <h4 data-test="hardware-heading">
+                      {HardwareType[parseInt(hardware_type, 0)]}
+                    </h4>
+                    <MachineTestsTable nodeResults={nodeResults} />
+                  </div>
+                );
+              }
+            )
+          : null}
+        {storageResults.length > 0 ? (
           <>
             <h4 data-test="hardware-heading">Storage</h4>
-            {Object.entries(storageResults).map(
+            {Object.entries(
+              groupByKey(storageResults, "physical_blockdevice")
+            ).map(
               ([physical_blockdevice, nodeResults]: [string, NodeResult[]]) => {
                 return (
                   <div key={physical_blockdevice}>
@@ -117,10 +93,10 @@ const MachineTests = (): JSX.Element => {
             )}
           </>
         ) : null}
-        {Object.keys(otherResults).length !== 0 ? (
+        {otherResults.length > 0 ? (
           <>
             <h4 data-test="hardware-heading">Other Results</h4>
-            {Object.entries(otherResults).map(
+            {Object.entries(groupByKey(otherResults, "hardware_type")).map(
               ([hardware_type, nodeResults]: [string, NodeResult[]]) => {
                 return (
                   <div key={hardware_type}>

--- a/ui/src/app/store/noderesult/selectors.test.tsx
+++ b/ui/src/app/store/noderesult/selectors.test.tsx
@@ -1,5 +1,6 @@
 import selectors from "./selectors";
 
+import { HardwareType, ResultType } from "app/base/enum";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -83,5 +84,105 @@ describe("nodeResults selectors", () => {
     });
 
     expect(selectors.errors(state)).toStrictEqual("Data is incorrect");
+  });
+
+  describe("testing results", () => {
+    it("returns hardware testing results", () => {
+      const cpuResult = nodeResultFactory({
+        hardware_type: HardwareType.CPU,
+        result_type: ResultType.Testing,
+      });
+      const memoryResult = nodeResultFactory({
+        hardware_type: HardwareType.Memory,
+        result_type: ResultType.Testing,
+      });
+      const storageResult = nodeResultFactory({
+        hardware_type: HardwareType.Storage,
+        result_type: ResultType.Testing,
+      });
+      const commissioningResult = nodeResultFactory({
+        result_type: ResultType.Commissioning,
+      });
+
+      const results = [
+        cpuResult,
+        memoryResult,
+        storageResult,
+        commissioningResult,
+      ];
+
+      const state = rootStateFactory({
+        noderesult: nodeResultStateFactory({
+          items: [{ id: "foo", results }],
+        }),
+      });
+
+      expect(selectors.getHardwareTestingResults(state, "foo")).toEqual([
+        cpuResult,
+        memoryResult,
+      ]);
+    });
+
+    it("returns storage testing results", () => {
+      const cpuResult = nodeResultFactory({
+        hardware_type: HardwareType.CPU,
+        result_type: ResultType.Testing,
+      });
+      const memoryResult = nodeResultFactory({
+        hardware_type: HardwareType.Memory,
+        result_type: ResultType.Testing,
+      });
+      const storageResult = nodeResultFactory({
+        hardware_type: HardwareType.Storage,
+        result_type: ResultType.Testing,
+      });
+      const commissioningResult = nodeResultFactory({
+        result_type: ResultType.Commissioning,
+      });
+
+      const results = [
+        cpuResult,
+        memoryResult,
+        storageResult,
+        commissioningResult,
+      ];
+
+      const state = rootStateFactory({
+        noderesult: nodeResultStateFactory({
+          items: [{ id: "foo", results }],
+        }),
+      });
+
+      expect(selectors.getStorageTestingResults(state, "foo")).toEqual([
+        storageResult,
+      ]);
+    });
+
+    it("returns 'other' testing results", () => {
+      const cpuResult = nodeResultFactory({
+        hardware_type: HardwareType.CPU,
+        result_type: ResultType.Testing,
+      });
+      const nodeResult = nodeResultFactory({
+        hardware_type: HardwareType.Node,
+        result_type: ResultType.Testing,
+      });
+      const nodeCommissioningResult = nodeResultFactory({
+        hardware_type: HardwareType.Node,
+        result_type: ResultType.Commissioning,
+      });
+
+      const results = [cpuResult, nodeResult, nodeCommissioningResult];
+
+      const state = rootStateFactory({
+        noderesult: nodeResultStateFactory({
+          items: [{ id: "foo", results }],
+        }),
+      });
+
+      expect(selectors.getOtherTestingResults(state, "foo")).toEqual([
+        nodeResult,
+      ]);
+    });
   });
 });

--- a/ui/src/app/store/noderesult/selectors.ts
+++ b/ui/src/app/store/noderesult/selectors.ts
@@ -4,6 +4,7 @@ import type { Machine } from "../machine/types";
 
 import type { NodeResults } from "./types";
 
+import { HardwareType, ResultType } from "app/base/enum";
 import type { TSFixMe } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 
@@ -69,9 +70,74 @@ const hasErrors = createSelector(
   (errors) => Object.entries(errors).length > 0
 );
 
+/**
+ * Returns hardware testing results (CPU, Memory, Network) by machine id
+ * @param state - Redux state
+ * @param machineId - machine system id
+ * @returns Node results
+ */
+const getHardwareTestingResults = createSelector(
+  [all, (_: RootState, machineID: Machine["system_id"]) => machineID],
+  (noderesults, machineID) => {
+    const nodeResult = noderesults.find((result) => machineID === result.id);
+    return (
+      nodeResult?.results.filter(
+        (result) =>
+          result.result_type === ResultType.Testing &&
+          (result.hardware_type === HardwareType.CPU ||
+            result.hardware_type === HardwareType.Memory ||
+            result.hardware_type === HardwareType.Network)
+      ) || []
+    );
+  }
+);
+
+/**
+ * Returns storage testing results by machine id
+ * @param state - Redux state
+ * @param machineId - machine system id
+ * @returns Node results
+ */
+const getStorageTestingResults = createSelector(
+  [all, (_: RootState, machineID: Machine["system_id"]) => machineID],
+  (noderesults, machineID) => {
+    const nodeResult = noderesults.find((result) => machineID === result.id);
+    return (
+      nodeResult?.results.filter(
+        (result) =>
+          result.result_type === ResultType.Testing &&
+          result.hardware_type === HardwareType.Storage
+      ) || []
+    );
+  }
+);
+
+/**
+ * Returns other testing results (Node) by machine id
+ * @param state - Redux state
+ * @param machineId - machine system id
+ * @returns Node results
+ */
+const getOtherTestingResults = createSelector(
+  [all, (_: RootState, machineID: Machine["system_id"]) => machineID],
+  (noderesults, machineID) => {
+    const nodeResult = noderesults.find((result) => machineID === result.id);
+    return (
+      nodeResult?.results.filter(
+        (result) =>
+          result.result_type === ResultType.Testing &&
+          result.hardware_type === HardwareType.Node
+      ) || []
+    );
+  }
+);
+
 const noderesult = {
   all,
   get,
+  getHardwareTestingResults,
+  getStorageTestingResults,
+  getOtherTestingResults,
   getByIds,
   errors,
   hasErrors,


### PR DESCRIPTION
## Done

- add testing result selectors to noderesult selectors

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine details testing tab, results should render as expected

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
