### PR TITLE
feat(ui): add PXE column to network tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -1,4 +1,4 @@
-import { MainTable, Spinner } from "@canonical/react-components";
+import { Icon, MainTable, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
@@ -6,6 +6,7 @@ import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import type { NetworkInterface, Machine } from "app/store/machine/types";
+import { isBootInterface } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 // TODO: update the sortKey type with the correct values once sorting is
@@ -160,6 +161,13 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
                   secondary={nic.mac_address}
                 />
               ),
+            },
+            {
+              content: isBootInterface(machine, nic) ? (
+                <span className="u-align--center">
+                  <Icon name="success" />
+                </span>
+              ) : null,
             },
           ],
           key: nic.id,

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -25,6 +25,14 @@ export type DiscoveredIP = {
   subnet_id: number;
 };
 
+export enum NetworkInterfaceTypes {
+  ALIAS = "alias",
+  BOND = "bond",
+  BRIDGE = "bridge",
+  PHYSICAL = "physical",
+  VLAN = "vlan",
+}
+
 export type NetworkInterface = Model & {
   children: string[];
   discovered?: DiscoveredIP[]; // Only shown when machine is in ephemeral state.
@@ -39,11 +47,11 @@ export type NetworkInterface = Model & {
   name: string;
   numa_node: number;
   params: string;
-  parents: string[];
+  parents: Model["id"][];
   product: string | null;
   sriov_max_vf: number;
   tags: string[];
-  type: string;
+  type: NetworkInterfaceTypes;
   vendor: string | null;
   vlan_id: number;
 };

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -16,6 +16,7 @@ import type {
   NetworkInterface,
   Partition,
 } from "app/store/machine/types";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type {
   Pod,
   PodDetails,
@@ -215,7 +216,7 @@ export const machineInterface = extend<Model, NetworkInterface>(model, {
   product: "Product",
   sriov_max_vf: 0,
   tags: () => [],
-  type: "physical",
+  type: NetworkInterfaceTypes.PHYSICAL,
   vendor: "Vendor",
   vlan_id: 5001,
 });


### PR DESCRIPTION
## Done

- Add the PXE column to the network tab of a machine details page.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the machine details network tab.
- You should see a green tick icon for boot interfaces in the PXE column.

## Fixes

Fixes: #1952.