### PR TITLE
feat(ui): add error handling to machine storage forms

### DIFF
--- a/ui/src/app/machines/hooks.test.tsx
+++ b/ui/src/app/machines/hooks.test.tsx
@@ -1,11 +1,12 @@
 import type { ReactNode } from "react";
 
+import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { renderHook } from "@testing-library/react-hooks";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import type { MockStoreEnhanced } from "redux-mock-store";
 
-import { useMachineActionForm } from "./hooks";
+import { useMachineActionForm, useMachineDetailsForm } from "./hooks";
 
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
@@ -18,6 +19,10 @@ import {
 } from "testing/factories";
 
 const mockStore = configureStore();
+
+jest.mock("@canonical/react-components/dist/hooks", () => ({
+  usePrevious: jest.fn(),
+}));
 
 const generateWrapper = (store: MockStoreEnhanced<unknown>) => ({
   children,
@@ -60,6 +65,10 @@ describe("machine utils", () => {
     });
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("useMachineActionForm", () => {
     it("can return errors for an active machine", () => {
       state.machine.active = "abc123";
@@ -83,6 +92,125 @@ describe("machine utils", () => {
         }
       );
       expect(result.current.errors).toStrictEqual("uh oh");
+    });
+  });
+
+  describe("useMachineFormikForm", () => {
+    it("can return saving state for a machine performing an action", () => {
+      state.machine.statuses.abc123.deletingFilesystem = true;
+      const store = mockStore(state);
+      const { result } = renderHook(
+        () =>
+          useMachineDetailsForm(
+            "abc123",
+            "deletingFilesystem",
+            "deleteFilesystem",
+            jest.fn()
+          ),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      expect(result.current.saving).toBe(true);
+    });
+
+    it("can return error state for a machine performing an action", () => {
+      state.machine.eventErrors = [
+        machineEventErrorFactory({
+          error: "front fell off",
+          event: "deleteFilesystem",
+          id: "abc123",
+        }),
+      ];
+      const store = mockStore(state);
+      const { result } = renderHook(
+        () =>
+          useMachineDetailsForm(
+            "abc123",
+            "deletingFilesystem",
+            "deleteFilesystem",
+            jest.fn()
+          ),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      expect(result.current.errors).toBe("front fell off");
+    });
+
+    it("can return saved state for a machine performing an action", () => {
+      // Mock previous saving value to be true
+      jest
+        .spyOn(reactComponentHooks, "usePrevious")
+        .mockImplementation(() => true);
+      state.machine.statuses.abc123.deletingFilesystem = false;
+      const store = mockStore(state);
+      const { result } = renderHook(
+        () =>
+          useMachineDetailsForm(
+            "abc123",
+            "deletingFilesystem",
+            "deleteFilesystem",
+            jest.fn()
+          ),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      expect(result.current.saved).toBe(true);
+    });
+
+    it("runs the onSaved function if successfully saved", () => {
+      // Mock previous saving value to be true
+      jest
+        .spyOn(reactComponentHooks, "usePrevious")
+        .mockImplementation(() => true);
+      state.machine.statuses.abc123.deletingFilesystem = false;
+      const onSaved = jest.fn();
+      const store = mockStore(state);
+      renderHook(
+        () =>
+          useMachineDetailsForm(
+            "abc123",
+            "deletingFilesystem",
+            "deleteFilesystem",
+            onSaved
+          ),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      expect(onSaved).toHaveBeenCalled();
+    });
+
+    it("does not run the onSaved function if errors are present", () => {
+      // Mock previous saving value to be true
+      jest
+        .spyOn(reactComponentHooks, "usePrevious")
+        .mockImplementation(() => true);
+      state.machine.eventErrors = [
+        machineEventErrorFactory({
+          error: "front fell off",
+          event: "deleteFilesystem",
+          id: "abc123",
+        }),
+      ];
+      state.machine.statuses.abc123.deletingFilesystem = false;
+      const onSaved = jest.fn();
+      const store = mockStore(state);
+      renderHook(
+        () =>
+          useMachineDetailsForm(
+            "abc123",
+            "deletingFilesystem",
+            "deleteFilesystem",
+            onSaved
+          ),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      expect(onSaved).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/src/app/machines/hooks.tsx
+++ b/ui/src/app/machines/hooks.tsx
@@ -1,11 +1,16 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 
+import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useSelector } from "react-redux";
 
 import type { MachineActionName } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
 import { ACTIONS } from "app/store/machine/slice";
-import type { Machine, MachineState } from "app/store/machine/types";
+import type {
+  Machine,
+  MachineState,
+  MachineStatus,
+} from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 /**
@@ -25,10 +30,10 @@ export const useToggleMenu = (
 };
 
 /**
- * Determine the machines to perform an action on. If a machine is "active",
- * this means the app is in the machine details view so the action need only be
- * performed on that machine. Otherwise, perform the action on the machines
- * selected in state.
+ * Determine the machines to perform an action on when using the "Take action"
+ * menu. If a machine is "active", this means the app is in the machine details
+ * view so the action need only be performed on that machine. Otherwise, perform
+ * the action on the machines selected in state (checked in the machine list).
  * @param actionName - The name of the machine action e.g. "commission".
  * @returns object with machines to perform action on and count of currently
  * processing machines.
@@ -64,4 +69,43 @@ export const useMachineActionForm = (
     machinesToAction,
     processingCount: processingMachines.length,
   };
+};
+
+/**
+ * Get the error, saved and saving state for a single machine performing a
+ * single action.
+ * @param systemId - system_id of the machine to check.
+ * @param statusName - name of the relevant machine status e.g. "updatingDisk".
+ * @param eventName - name of the machine event to filter errors by e.g. "updateDisk".
+ * @param onSaved - function to execute when form successfully saved.
+ * @returns object with errors, saved and saving state for machine performing
+ * the action
+ */
+export const useMachineDetailsForm = (
+  systemId: Machine["system_id"],
+  statusKey: keyof MachineStatus,
+  eventName?: string,
+  onSaved?: () => void
+): {
+  errors: MachineState["eventErrors"][0]["error"];
+  saved: boolean;
+  saving: boolean;
+} => {
+  const statuses = useSelector((state: RootState) =>
+    machineSelectors.getStatuses(state, systemId)
+  );
+  const errors = useSelector((state: RootState) =>
+    machineSelectors.eventErrorsForIds(state, systemId, eventName)
+  );
+  const saving = statuses[statusKey];
+  const previousSaving = usePrevious(saving);
+  const saved = !saving && previousSaving && errors.length === 0;
+
+  useEffect(() => {
+    if (onSaved && saved) {
+      onSaved();
+    }
+  }, [onSaved, saved]);
+
+  return { errors: errors[0]?.error, saved, saving };
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.test.tsx
@@ -8,6 +8,7 @@ import ActionConfirm from "./ActionConfirm";
 import * as maasUiHooks from "app/base/hooks";
 import {
   machineDetails as machineDetailsFactory,
+  machineEventError as machineEventErrorFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
   machineStatuses as machineStatusesFactory,
@@ -36,6 +37,7 @@ describe("ActionConfirm", () => {
         <ActionConfirm
           closeExpanded={jest.fn()}
           confirmLabel="Confirm"
+          eventName="deleteFilesystem"
           message="Are you sure you want to do that?"
           onConfirm={jest.fn()}
           onSaveAnalytics={{
@@ -50,6 +52,45 @@ describe("ActionConfirm", () => {
     );
 
     expect(wrapper.find("ActionButton").prop("loading")).toBe(true);
+  });
+
+  it("can show errors", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        eventErrors: [
+          machineEventErrorFactory({
+            id: "abc123",
+            event: "deleteFilesystem",
+            error: "uh oh",
+          }),
+        ],
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory({ deletingFilesystem: false }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const closeExpanded = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActionConfirm
+          closeExpanded={closeExpanded}
+          confirmLabel="Confirm"
+          message="Are you sure you want to do that?"
+          onConfirm={jest.fn()}
+          onSaveAnalytics={{
+            action: "Action",
+            category: "Category",
+            label: "Label",
+          }}
+          statusKey="deletingFilesystem"
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='error-message']").text()).toBe("uh oh");
   });
 
   it("sends an analytics event when saved", () => {
@@ -78,6 +119,7 @@ describe("ActionConfirm", () => {
         <ActionConfirm
           closeExpanded={closeExpanded}
           confirmLabel="Confirm"
+          eventName="deleteFilesystem"
           message="Are you sure you want to do that?"
           onConfirm={jest.fn()}
           onSaveAnalytics={analyticsEvent}
@@ -117,6 +159,7 @@ describe("ActionConfirm", () => {
         <ActionConfirm
           closeExpanded={closeExpanded}
           confirmLabel="Confirm"
+          eventName="deleteFilesystem"
           message="Are you sure you want to do that?"
           onConfirm={jest.fn()}
           onSaveAnalytics={{

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
@@ -7,6 +7,7 @@ import AddPartition from "./AddPartition";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
+  machineEventError as machineEventErrorFactory,
   machinePartition as partitionFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
@@ -40,6 +41,35 @@ describe("AddPartition", () => {
 
     expect(wrapper.find("Input[label='Name']").prop("value")).toBe(
       "floppy-disk-part3"
+    );
+  });
+
+  it("can show errors", () => {
+    const disk = diskFactory();
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        eventErrors: [
+          machineEventErrorFactory({
+            error: "it's broken",
+            event: "createPartition",
+            id: "abc123",
+          }),
+        ],
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+      </Provider>
+    );
+
+    expect(wrapper.find("Notification").text().includes("it's broken")).toBe(
+      true
     );
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -250,8 +250,10 @@ const AvailableStorageTable = ({
                 <ActionConfirm
                   closeExpanded={closeExpanded}
                   confirmLabel={`Remove ${diskType}`}
+                  eventName="deleteDisk"
                   message={`Are you sure you want to remove this ${diskType}?`}
                   onConfirm={() => {
+                    dispatch(machineActions.cleanup());
                     dispatch(
                       machineActions.deleteDisk({
                         blockId: disk.id,
@@ -272,8 +274,10 @@ const AvailableStorageTable = ({
                 <ActionConfirm
                   closeExpanded={closeExpanded}
                   confirmLabel="Remove volume group"
+                  eventName="deleteVolumeGroup"
                   message="Are you sure you want to remove this volume group?"
                   onConfirm={() => {
+                    dispatch(machineActions.cleanup());
                     dispatch(
                       machineActions.deleteVolumeGroup({
                         systemId,
@@ -335,8 +339,10 @@ const AvailableStorageTable = ({
                     <ActionConfirm
                       closeExpanded={closeExpanded}
                       confirmLabel="Remove partition"
+                      eventName="deletePartition"
                       message="Are you sure you want to remove this partition?"
                       onConfirm={() => {
+                        dispatch(machineActions.cleanup());
                         dispatch(
                           machineActions.deletePartition({
                             partitionId: partition.id,

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx
@@ -7,6 +7,7 @@ import EditPartition from "./EditPartition";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
+  machineEventError as machineEventErrorFactory,
   machinePartition as partitionFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
@@ -17,6 +18,41 @@ import {
 const mockStore = configureStore();
 
 describe("EditPartition", () => {
+  it("can show errors", () => {
+    const partition = partitionFactory();
+    const disk = diskFactory({ partitions: [partition] });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        eventErrors: [
+          machineEventErrorFactory({
+            error: "didn't work",
+            event: "updateFilesystem",
+            id: "abc123",
+          }),
+        ],
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <EditPartition
+          closeExpanded={jest.fn()}
+          disk={disk}
+          partition={partition}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("Notification").text().includes("didn't work")).toBe(
+      true
+    );
+  });
+
   it("correctly dispatches an action to edit a partition", () => {
     const partition = partitionFactory();
     const disk = diskFactory({ partitions: [partition] });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -72,8 +72,10 @@ const CacheSetsTable = ({
                 <ActionConfirm
                   closeExpanded={closeExpanded}
                   confirmLabel="Remove cache set"
+                  eventName="deleteCacheSet"
                   message="Are you sure you want to remove this cache set?"
                   onConfirm={() => {
+                    dispatch(machineActions.cleanup());
                     dispatch(
                       machineActions.deleteCacheSet({
                         cacheSetId: disk.id,

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
@@ -7,6 +7,7 @@ import ChangeStorageLayout from "./ChangeStorageLayout";
 
 import {
   machineDetails as machineDetailsFactory,
+  machineEventError as machineEventErrorFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
   machineStatuses as machineStatusesFactory,
@@ -28,7 +29,7 @@ describe("ChangeStorageLayout", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ChangeStorageLayout id="abc123" />
+        <ChangeStorageLayout systemId="abc123" />
       </Provider>
     );
 
@@ -46,6 +47,45 @@ describe("ChangeStorageLayout", () => {
     expect(wrapper.find("[data-test='confirmation-form']").exists()).toBe(true);
   });
 
+  it("can show errors", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        eventErrors: [
+          machineEventErrorFactory({
+            error: "not possible",
+            event: "applyStorageLayout",
+            id: "abc123",
+          }),
+        ],
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <ChangeStorageLayout systemId="abc123" />
+      </Provider>
+    );
+
+    // Open storage layout dropdown
+    act(() => {
+      wrapper.find("ContextualMenu Button").simulate("click");
+    });
+    wrapper.update();
+    // Select flat storage layout
+    act(() => {
+      wrapper.find("ContextualMenuDropdown Button").at(0).simulate("click");
+    });
+    wrapper.update();
+
+    expect(wrapper.find("Notification").text().includes("not possible")).toBe(
+      true
+    );
+  });
+
   it("correctly dispatches an action to update a machine's storage layout", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
@@ -58,7 +98,7 @@ describe("ChangeStorageLayout", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <ChangeStorageLayout id="abc123" />
+        <ChangeStorageLayout systemId="abc123" />
       </Provider>
     );
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -73,8 +73,10 @@ const DatastoresTable = ({
                 <ActionConfirm
                   closeExpanded={closeExpanded}
                   confirmLabel="Remove datastore"
+                  eventName="deleteDisk"
                   message="Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
                   onConfirm={() => {
+                    dispatch(machineActions.cleanup());
                     dispatch(
                       machineActions.deleteDisk({
                         blockId: disk.id,

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
@@ -6,6 +6,7 @@ import AddSpecialFilesystem from "./AddSpecialFilesystem";
 
 import {
   machineDetails as machineDetailsFactory,
+  machineEventError as machineEventErrorFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
   machineStatuses as machineStatusesFactory,
@@ -15,6 +16,34 @@ import {
 const mockStore = configureStore();
 
 describe("AddSpecialFilesystem", () => {
+  it("can show errors", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        eventErrors: [
+          machineEventErrorFactory({
+            error: "you can't do that",
+            event: "mountSpecial",
+            id: "abc123",
+          }),
+        ],
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("Notification").text().includes("you can't do that")
+    ).toBe(true);
+  });
+
   it("correctly dispatches an action to mount a special filesystem", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -118,16 +118,18 @@ const FilesystemsTable = ({
                 <ActionConfirm
                   closeExpanded={() => setExpanded(null)}
                   confirmLabel="Remove"
+                  eventName="deleteFilesystem"
                   message="Are you sure you want to remove this filesystem?"
-                  onConfirm={() =>
+                  onConfirm={() => {
+                    dispatch(machineActions.cleanup());
                     dispatch(
                       machineActions.deleteFilesystem({
                         blockDeviceId: disk.id,
                         filesystemId: diskFs.id,
                         systemId,
                       })
-                    )
-                  }
+                    );
+                  }}
                   onSaveAnalytics={{
                     action: "Delete disk filesystem",
                     category: "Machine storage",
@@ -141,8 +143,10 @@ const FilesystemsTable = ({
                 <ActionConfirm
                   closeExpanded={() => setExpanded(null)}
                   confirmLabel="Unmount"
+                  eventName="updateFilesystem"
                   message="Are you sure you want to unmount this filesystem?"
-                  onConfirm={() =>
+                  onConfirm={() => {
+                    dispatch(machineActions.cleanup());
                     dispatch(
                       machineActions.updateFilesystem({
                         blockId: disk.id,
@@ -150,8 +154,8 @@ const FilesystemsTable = ({
                         mountPoint: "",
                         systemId,
                       })
-                    )
-                  }
+                    );
+                  }}
                   onSaveAnalytics={{
                     action: "Unmount disk filesystem",
                     category: "Machine storage",
@@ -192,15 +196,17 @@ const FilesystemsTable = ({
                     <ActionConfirm
                       closeExpanded={() => setExpanded(null)}
                       confirmLabel="Remove"
+                      eventName="deletePartition"
                       message="Are you sure you want to remove this filesystem?"
-                      onConfirm={() =>
+                      onConfirm={() => {
+                        dispatch(machineActions.cleanup());
                         dispatch(
                           machineActions.deletePartition({
                             partitionId: partition.id,
                             systemId,
                           })
-                        )
-                      }
+                        );
+                      }}
                       onSaveAnalytics={{
                         action: "Delete partition filesystem",
                         category: "Machine storage",
@@ -214,8 +220,10 @@ const FilesystemsTable = ({
                     <ActionConfirm
                       closeExpanded={() => setExpanded(null)}
                       confirmLabel="Unmount"
+                      eventName="updateFilesystem"
                       message="Are you sure you want to unmount this filesystem?"
-                      onConfirm={() =>
+                      onConfirm={() => {
+                        dispatch(machineActions.cleanup());
                         dispatch(
                           machineActions.updateFilesystem({
                             mountOptions: "",
@@ -223,8 +231,8 @@ const FilesystemsTable = ({
                             partitionId: partition.id,
                             systemId,
                           })
-                        )
-                      }
+                        );
+                      }}
                       onSaveAnalytics={{
                         action: "Unmount partition filesystem",
                         category: "Machine storage",
@@ -262,15 +270,17 @@ const FilesystemsTable = ({
                 <ActionConfirm
                   closeExpanded={() => setExpanded(null)}
                   confirmLabel="Remove"
+                  eventName="unmountSpecial"
                   message="Are you sure you want to remove this special filesystem?"
-                  onConfirm={() =>
+                  onConfirm={() => {
+                    dispatch(machineActions.cleanup());
                     dispatch(
                       machineActions.unmountSpecial({
                         mountPoint: specialFs.mount_point,
                         systemId,
                       })
-                    )
-                  }
+                    );
+                  }}
                   onSaveAnalytics={{
                     action: "Unmount special filesystem",
                     category: "Machine storage",

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -36,7 +36,7 @@ const MachineStorage = (): JSX.Element => {
 
     return (
       <>
-        {canEditStorage && <ChangeStorageLayout id={machine.system_id} />}
+        {canEditStorage && <ChangeStorageLayout systemId={id} />}
         <Strip shallow>
           {showDatastores ? (
             <>


### PR DESCRIPTION
## Done

- Added `useMachineDetailsForm` hook which returns the saving, saved and error state for a single machine performing a single action. It's slightly different to `useMachineActionForm` because it doesn't handle multiple machines processing.
- Added error messages to storage forms

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a ready or allocated machine
- Mount a special filesystem at "/" if there isn't one already
- Try to mount another special filesystem at "/" and check that an error displays and the form does not close
- Do the same for adding/editing partitions

## Fixes

Fixes #1968 
