### PR TITLE
feat(ui): add link speed column to the network tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -4,9 +4,11 @@ import configureStore from "redux-mock-store";
 
 import NetworkTable from "./NetworkTable";
 
+import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -42,5 +44,77 @@ describe("NetworkTable", () => {
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+
+  it("can display a disconnected icon in the speed column", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            link_connected: false,
+            type: NetworkInterfaceTypes.PHYSICAL,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='speed'] Icon").prop("name")).toBe(
+      "disconnected"
+    );
+  });
+
+  it("can display a slow icon in the speed column", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            interface_speed: 2,
+            link_speed: 1,
+            link_connected: true,
+            type: NetworkInterfaceTypes.PHYSICAL,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='speed'] Icon").prop("name")).toBe(
+      "warning"
+    );
+  });
+
+  it("can display no icon in the speed column", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            link_connected: true,
+            type: NetworkInterfaceTypes.PHYSICAL,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow[data-test='speed']").exists()).toBe(true);
+    expect(wrapper.find("DoubleRow[data-test='speed'] Icon").exists()).toBe(
+      false
+    );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -1,4 +1,6 @@
-import { Icon, MainTable, Spinner } from "@canonical/react-components";
+import type { ReactNode } from "react";
+
+import { Icon, MainTable, Spinner, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
@@ -6,25 +8,123 @@ import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import type { NetworkInterface, Machine } from "app/store/machine/types";
-import { isBootInterface } from "app/store/machine/utils";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import { isBootInterface, isInterfaceConnected } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
+import { formatSpeedUnits } from "app/utils";
 
-// TODO: update the sortKey type with the correct values once sorting is
-// implemented in this component.
-type SortKey = keyof NetworkInterface | string;
+type NetworkRowSortData = {
+  name: NetworkInterface["name"];
+  pxe: boolean;
+  speed: NetworkInterface["link_speed"];
+  type: null;
+  fabric: null;
+  subnet: null;
+  ip: null;
+  dhcp: null;
+};
 
-const getSortValue = (sortKey: SortKey, nic: NetworkInterface) =>
-  nic[sortKey] ? nic[sortKey] : null;
+// TODO: This should eventually extend the react-components table row type
+// when it has been migrated to TypeScript.
+type NetworkRow = {
+  columns: { content: ReactNode }[];
+  key: NetworkInterface["id"];
+  sortData: NetworkRowSortData;
+};
+
+type SortKey = keyof NetworkRowSortData;
+
+const getSortValue = (sortKey: SortKey, row: NetworkRow) =>
+  row.sortData[sortKey];
+
+const generateRows = (machine: Machine): NetworkRow[] => {
+  if (!machine || !("interfaces" in machine)) {
+    return [];
+  }
+  return machine.interfaces.map((nic: NetworkInterface) => {
+    const isBoot = isBootInterface(machine, nic);
+    return {
+      columns: [
+        {
+          content: (
+            <DoubleRow
+              data-test="name"
+              primary={nic.name}
+              secondary={nic.mac_address}
+            />
+          ),
+        },
+        {
+          content: isBoot ? (
+            <span className="u-align--center">
+              <Icon name="success" />
+            </span>
+          ) : null,
+        },
+        {
+          content: [
+            NetworkInterfaceTypes.BOND,
+            NetworkInterfaceTypes.BRIDGE,
+            NetworkInterfaceTypes.VLAN,
+          ].includes(nic.type) ? null : (
+            <DoubleRow
+              data-test="speed"
+              icon={
+                <>
+                  {isInterfaceConnected(nic) ? null : (
+                    <Tooltip
+                      position="top-left"
+                      message="This interface is disconnected."
+                    >
+                      <Icon name="disconnected" />
+                    </Tooltip>
+                  )}
+                  {isInterfaceConnected(nic) &&
+                  nic.link_speed < nic.interface_speed ? (
+                    <Tooltip
+                      position="top-left"
+                      message="Link connected to slow interface."
+                    >
+                      <Icon name="warning" />
+                    </Tooltip>
+                  ) : null}
+                </>
+              }
+              iconSpace={true}
+              primary={
+                <>
+                  {formatSpeedUnits(nic.link_speed)}/
+                  {formatSpeedUnits(nic.interface_speed)}
+                </>
+              }
+            />
+          ),
+        },
+      ],
+      key: nic.id,
+      sortData: {
+        name: nic.name,
+        pxe: isBoot,
+        speed: nic.link_speed,
+        type: null,
+        fabric: null,
+        subnet: null,
+        ip: null,
+        dhcp: null,
+      },
+    };
+  });
+};
 
 type Props = { systemId: Machine["system_id"] };
 
 const NetworkTable = ({ systemId }: Props): JSX.Element => {
   const { currentSort, sortRows, updateSort } = useTableSort<
-    NetworkInterface,
+    NetworkRow,
     SortKey
   >(getSortValue, {
     key: "name",
-    direction: "descending",
+    direction: "ascending",
   });
 
   const machine = useSelector((state: RootState) =>
@@ -33,7 +133,7 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
   if (!machine || !("interfaces" in machine)) {
     return <Spinner text="Loading..." />;
   }
-  const sortedRows = sortRows(machine.interfaces);
+  const sortedRows = sortRows(generateRows(machine));
   return (
     <MainTable
       defaultSort="name"
@@ -70,6 +170,7 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
         {
           content: (
             <TableHeader
+              className="p-double-row__header-spacer"
               currentSort={currentSort}
               onClick={() => updateSort("speed")}
               sortKey="speed"
@@ -150,29 +251,7 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
           className: "u-align--right",
         },
       ]}
-      rows={sortedRows.map((nic: NetworkInterface) => {
-        return {
-          columns: [
-            {
-              content: (
-                <DoubleRow
-                  data-test="name"
-                  primary={nic.name}
-                  secondary={nic.mac_address}
-                />
-              ),
-            },
-            {
-              content: isBootInterface(machine, nic) ? (
-                <span className="u-align--center">
-                  <Icon name="success" />
-                </span>
-              ) : null,
-            },
-          ],
-          key: nic.id,
-        };
-      })}
+      rows={sortedRows}
     />
   );
 };

--- a/ui/src/app/store/machine/utils.test.tsx
+++ b/ui/src/app/store/machine/utils.test.tsx
@@ -10,6 +10,7 @@ import {
   canOsSupportStorageConfig,
   getInterfaceMembers,
   isBootInterface,
+  isInterfaceConnected,
   isMachineStorageConfigurable,
   useCanEdit,
   useFormattedOS,
@@ -437,6 +438,22 @@ describe("machine utils", () => {
       interfaces.push(nic);
       const machine = machineDetailsFactory({ interfaces });
       expect(isBootInterface(machine, nic)).toBe(false);
+    });
+  });
+
+  describe("isInterfaceConnected", () => {
+    it("checks if the interface itself is connected", () => {
+      const nic = machineInterfaceFactory({
+        link_connected: true,
+      });
+      expect(isInterfaceConnected(nic)).toEqual(true);
+    });
+
+    it("checks if the interface itself is not connected", () => {
+      const nic = machineInterfaceFactory({
+        link_connected: false,
+      });
+      expect(isInterfaceConnected(nic)).toEqual(false);
     });
   });
 });

--- a/ui/src/app/store/machine/utils.ts
+++ b/ui/src/app/store/machine/utils.ts
@@ -232,3 +232,16 @@ export const isBootInterface = (
   const members = getInterfaceMembers(machine, nic);
   return members.some(({ is_boot }) => is_boot);
 };
+
+/**
+ * Check if an interface is connected.
+ * @param machine - The nic's machine.
+ * @param nic - A network interface.
+ * @return Whether an interface is connected.
+ */
+export const isInterfaceConnected = (nic: NetworkInterface): boolean => {
+  if (!nic) {
+    return false;
+  }
+  return nic.link_connected;
+};

--- a/ui/src/scss/_patterns_icons.scss
+++ b/ui/src/scss/_patterns_icons.scss
@@ -107,6 +107,12 @@
     @include maas-icon-circle($color-positive--faded);
   }
 
+  .p-icon--disconnected {
+    @extend %icon;
+    background-image: url("data:image/svg+xml,%3Csvg id='Disconnect_2' data-name='Disconnect 2' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%23c7162b%7D%3C/style%3E%3C/defs%3E%3Cpath class='cls-1' d='M6.1 13.52l2.71-2.71-3.58-3.58L2.51 10l-.47 2.11-1.61 1.58a1.36 1.36 0 001.92 1.92L4 14l2.11-.47zM15.59 2.36A1.35 1.35 0 0013.68.45l-1.63 1.62-2.05.46-2.78 2.71 3.58 3.58 2.7-2.71L14 4zM13.01 9.48h2.98v1h-2.98z'/%3E%3Cpath class='cls-1' transform='rotate(-45.01 13.332 13.315)' d='M12.83 11.83h1v2.98h-1z'/%3E%3Cpath class='cls-1' d='M9.49 13.03h1v2.98h-1zM.02 5.53H3v1H.02z'/%3E%3Cpath class='cls-1' transform='rotate(-45 2.663 2.687)' d='M2.17 1.2h1v2.98h-1z'/%3E%3Cpath class='cls-1' d='M5.51 0h1v2.98h-1z'/%3E%3C/svg%3E");
+    background-size: 100% 100%;
+  }
+
   [class*="p-circle--"].is-inline,
   [class*="p-icon--"].is-inline {
     margin-right: $sph-inner--small;


### PR DESCRIPTION
## Done

- Add the column for link speed to the network tab of machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab in machine details.
- You should see the link/interface speed column.
- Clicking on the table headers should now also sort the rows.

## Fixes

Fixes: #1953.