### PR TITLE
feat(ui): Add ability to remove datastores

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
@@ -9,6 +9,8 @@ import {
   machineDisk as diskFactory,
   machineFilesystem as fsFactory,
   machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -36,11 +38,58 @@ describe("DatastoresTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DatastoresTable systemId="abc123" />
+        <DatastoresTable canEditStorage systemId="abc123" />
       </Provider>
     );
 
     expect(wrapper.find("tbody TableRow").length).toBe(1);
     expect(wrapper.find("TableCell").at(0).text()).toBe("datastore");
+  });
+
+  it("can remove a datastore", () => {
+    const datastore = fsFactory({ fstype: "vmfs6" });
+    const disk = diskFactory({ filesystem: datastore });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DatastoresTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text().includes("Remove")
+      )
+      .simulate("click");
+    wrapper.find("ActionButton").simulate("click");
+
+    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+      "Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
+    );
+    expect(
+      store.getActions().find((action) => action.type === "machine/deleteDisk")
+    ).toStrictEqual({
+      meta: {
+        method: "delete_disk",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          block_id: disk.id,
+          system_id: "abc123",
+        },
+      },
+      type: "machine/deleteDisk",
+    });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -1,36 +1,98 @@
-import { MainTable } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useState } from "react";
 
+import { MainTable } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import ActionConfirm from "../ActionConfirm";
 import { formatSize, isDatastore } from "../utils";
 
+import TableMenu from "app/base/components/TableMenu";
 import type { TSFixMe } from "app/base/types";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
-type Props = { systemId: Machine["system_id"] };
+type Expanded = {
+  content: "deleteDisk";
+  id: string;
+};
 
-const DatastoresTable = ({ systemId }: Props): JSX.Element | null => {
+type Props = {
+  canEditStorage: boolean;
+  systemId: Machine["system_id"];
+};
+
+const DatastoresTable = ({
+  canEditStorage,
+  systemId,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
+  const [expanded, setExpanded] = useState<Expanded | null>(null);
+
+  const closeExpanded = () => setExpanded(null);
 
   if (machine && "disks" in machine) {
     const rows = machine.disks.reduce<TSFixMe[]>((rows, disk) => {
       if (isDatastore(disk.filesystem)) {
         const fs = disk.filesystem;
         const rowId = `${fs.fstype}-${fs.id}`;
+        const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
+        const datastoreActions = [
+          {
+            children: "Remove datastore...",
+            onClick: () => setExpanded({ content: "deleteDisk", id: rowId }),
+          },
+        ];
         rows.push({
+          className: isExpanded ? "p-table__row is-active" : null,
           columns: [
             { content: disk.name },
             { content: "VMFS6" },
             { content: formatSize(disk.size) },
             { content: fs.mount_point },
             {
-              content: "",
+              content: (
+                <TableMenu
+                  disabled={!canEditStorage}
+                  links={datastoreActions}
+                  position="right"
+                  title="Take action:"
+                />
+              ),
               className: "u-align--right",
             },
           ],
+          expanded: isExpanded,
+          expandedContent: (
+            <div className="u-flex--grow">
+              {expanded?.content === "deleteDisk" && (
+                <ActionConfirm
+                  closeExpanded={closeExpanded}
+                  confirmLabel="Remove datastore"
+                  message="Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
+                  onConfirm={() => {
+                    dispatch(
+                      machineActions.deleteDisk({
+                        blockId: disk.id,
+                        systemId,
+                      })
+                    );
+                  }}
+                  onSaveAnalytics={{
+                    action: "Delete datastore",
+                    category: "Machine storage",
+                    label: "Remove datastore",
+                  }}
+                  statusKey="deletingDisk"
+                  systemId={systemId}
+                />
+              )}
+            </div>
+          ),
           key: rowId,
         });
       }
@@ -40,6 +102,8 @@ const DatastoresTable = ({ systemId }: Props): JSX.Element | null => {
     return (
       <>
         <MainTable
+          className="p-table-expanding--light"
+          expanding
           headers={[
             { content: "Name" },
             { content: "Filesystem" },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -41,7 +41,7 @@ const MachineStorage = (): JSX.Element => {
           {showDatastores ? (
             <>
               <h4>Datastores</h4>
-              <DatastoresTable systemId={id} />
+              <DatastoresTable canEditStorage={canEditStorage} systemId={id} />
             </>
           ) : (
             <>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -286,6 +286,11 @@ describe("Machine storage utils", () => {
       expect(isMounted(notMounted)).toBe(false);
       expect(isMounted(mounted)).toBe(true);
     });
+
+    it("handles reserved filesystems", () => {
+      const reserved = fsFactory({ mount_point: "RESERVED" });
+      expect(isMounted(reserved)).toBe(false);
+    });
   });
 
   describe("isPartition", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -154,8 +154,16 @@ export const isLogicalVolume = (disk: Disk | null): boolean =>
  * @param fs - the filesystem to check.
  * @returns whether the filesystem is mounted
  */
-export const isMounted = (fs: Filesystem | null): fs is Filesystem =>
-  !!fs?.mount_point;
+export const isMounted = (fs: Filesystem | null): fs is Filesystem => {
+  if (!fs) {
+    return false;
+  }
+
+  // VMware ESXi does not directly mount the partitions used. As MAAS can't
+  // model that, a placeholder "RESERVED" is used for datastores so we know that
+  // these partitions are in use.
+  return fs.mount_point !== "" && fs.mount_point !== "RESERVED";
+};
 
 /**
  * Returns whether a storage device is a partition.


### PR DESCRIPTION
## Done

- Added ability to remove datastores from the datastores list

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Change the storage layout of a machine to VMFS6 and check that a Datastores table appears
- Open the action menu of the datastore and click "Remove datastore" and confirm
- Check that the datastore is removed and placed back into Available disks and partitions

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2171
