### PR TITLE
feat(ui): add ability to remove cache sets

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
@@ -8,6 +8,8 @@ import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
   machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -38,11 +40,61 @@ describe("CacheSetsTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CacheSetsTable systemId="abc123" />
+        <CacheSetsTable canEditStorage systemId="abc123" />
       </Provider>
     );
 
     expect(wrapper.find("tbody TableRow").length).toBe(1);
     expect(wrapper.find("TableCell").at(0).text()).toBe(cacheSet.name);
+  });
+
+  it("can delete a cache set", () => {
+    const disk = diskFactory({
+      type: "cache-set",
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CacheSetsTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper
+      .findWhere(
+        (button) =>
+          button.name() === "button" && button.text().includes("Remove")
+      )
+      .simulate("click");
+    wrapper.find("ActionButton").simulate("click");
+
+    expect(wrapper.find("ActionConfirm").prop("message")).toBe(
+      "Are you sure you want to remove this cache set?"
+    );
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/deleteCacheSet")
+    ).toStrictEqual({
+      meta: {
+        method: "delete_cache_set",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          cache_set_id: disk.id,
+          system_id: "abc123",
+        },
+      },
+      type: "machine/deleteCacheSet",
+    });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -1,31 +1,97 @@
-import { MainTable } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useState } from "react";
 
+import { MainTable } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import ActionConfirm from "../ActionConfirm";
 import { formatSize, isCacheSet } from "../utils";
 
+import TableMenu from "app/base/components/TableMenu";
 import type { TSFixMe } from "app/base/types";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
-type Props = { systemId: Machine["system_id"] };
+type Expanded = {
+  content: "deleteCacheSet";
+  id: string;
+};
 
-const CacheSetsTable = ({ systemId }: Props): JSX.Element | null => {
+type Props = {
+  canEditStorage: boolean;
+  systemId: Machine["system_id"];
+};
+
+const CacheSetsTable = ({
+  canEditStorage,
+  systemId,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
+  const [expanded, setExpanded] = useState<Expanded | null>(null);
+  const closeExpanded = () => setExpanded(null);
 
   if (machine && "disks" in machine) {
     const rows = machine.disks.reduce<TSFixMe[]>((rows, disk) => {
       if (isCacheSet(disk)) {
         const rowId = `${disk.type}-${disk.id}`;
+        const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
+        const cacheSetActions = [
+          {
+            children: "Remove cache set...",
+            onClick: () =>
+              setExpanded({ content: "deleteCacheSet", id: rowId }),
+          },
+        ];
+
         rows.push({
+          className: isExpanded ? "p-table__row is-active" : null,
           columns: [
             { content: disk.name },
             { content: formatSize(disk.size) },
             { content: disk.used_for },
-            { content: "" },
+            {
+              className: "u-align--right",
+              content: (
+                <TableMenu
+                  disabled={!canEditStorage}
+                  links={cacheSetActions}
+                  position="right"
+                  title="Take action:"
+                />
+              ),
+            },
           ],
+          expanded: isExpanded,
+          expandedContent: (
+            <div className="u-flex--grow">
+              {expanded?.content === "deleteCacheSet" && (
+                <ActionConfirm
+                  closeExpanded={closeExpanded}
+                  confirmLabel="Remove cache set"
+                  message="Are you sure you want to remove this cache set?"
+                  onConfirm={() => {
+                    dispatch(
+                      machineActions.deleteCacheSet({
+                        cacheSetId: disk.id,
+                        systemId,
+                      })
+                    );
+                  }}
+                  onSaveAnalytics={{
+                    action: "Delete cache set",
+                    category: "Machine storage",
+                    label: "Remove cache set",
+                  }}
+                  statusKey="deletingCacheSet"
+                  systemId={systemId}
+                />
+              )}
+            </div>
+          ),
           key: rowId,
         });
       }
@@ -34,6 +100,8 @@ const CacheSetsTable = ({ systemId }: Props): JSX.Element | null => {
 
     return (
       <MainTable
+        className="p-table-expanding--light"
+        expanding
         headers={[
           { content: "Name" },
           { content: "Size" },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -53,7 +53,7 @@ const MachineStorage = (): JSX.Element => {
         {showCacheSets && (
           <Strip shallow>
             <h4>Available cache sets</h4>
-            <CacheSetsTable systemId={id} />
+            <CacheSetsTable canEditStorage={canEditStorage} systemId={id} />
           </Strip>
         )}
         <Strip shallow>


### PR DESCRIPTION
## Done

- Added ability to remove cache sets

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the angular storage tab and change the storage layout to blank
- Select a disk and click "Create cache set"
- Go to the react version of the storage tab and check that there is a cache sets table
- Open the action menu of the cache set and click "Remove cache set" and confirm
- Check that the cache set is removed and placed back into Available disks and partitions

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2288
