### PR TITLE
fix(legacy): ensure user commissioning scripts are selected by default

### DIFF
--- a/legacy/src/app/directives/script_select.js
+++ b/legacy/src/app/directives/script_select.js
@@ -133,7 +133,7 @@ export function maasScriptSelect(ScriptsManager, ManagerHelperService) {
             script.script_type === $scope.scriptType &&
             script.for_hardware.length === 0
           ) {
-            if ($scope.scriptType === 0 && script.default) {
+            if ($scope.scriptType === 0 && !script.tags.includes("noauto")) {
               // By default MAAS runs all custom
               // commissioning scripts in addition to all
               // builtin commissioning scripts.


### PR DESCRIPTION
## Done

Ensure user commissioning scripts are selected by default, and noauto scripts are excluded

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the commissioning panel for a machine from machine details. User defined scripts should be selected by default, with the exception of scripts tagged 'noauto'.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
