### PR TITLE
fix(legacy): fix navigating from legacy to legacy via the header

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -63,13 +63,7 @@ function MasterController(
           </a>
         )}
         generateLegacyLink={(link, linkClass, appendNewBase) => (
-          <a
-            className={linkClass}
-            href={generateLegacyURL(link.url)}
-            onClick={(evt) => {
-              evt.preventDefault();
-            }}
-          >
+          <a className={linkClass} href={generateLegacyURL(link.url)}>
             {link.label}
           </a>
         )}


### PR DESCRIPTION
## Done

- Fix the links in the header so that navigating from one legacy page to another works.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to a legacy page.
- Click on another legacy link in the header.
- It should navigate to that page.

## Fixes

Fixes: #1967.