### PR TITLE
feat(ui): add type/numa column to the network tab

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -615,10 +615,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:58892152": [
+    "src/app/store/machine/types.ts:123189544": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [344, 34, 8, "RegExp match", "1152173309"],
-      [347, 25, 8, "RegExp match", "1152173309"]
+      [388, 34, 8, "RegExp match", "1152173309"],
+      [391, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/noderesult/selectors.ts:2866544023": [
       [7, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -117,4 +117,52 @@ describe("NetworkTable", () => {
       false
     );
   });
+
+  it("displays an icon when bond is over multiple numa nodes", () => {
+    const interfaces = [machineInterfaceFactory({ numa_node: 1 })];
+    const nic = machineInterfaceFactory({
+      numa_node: 2,
+      parents: [interfaces[0].id],
+    });
+    interfaces.push(nic);
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces,
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow[data-test='type']").exists()).toBe(true);
+    expect(wrapper.find("DoubleRow[data-test='type'] Icon").exists()).toBe(
+      true
+    );
+  });
+
+  it("does not display an icon for single numa nodes", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            numa_node: 2,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow[data-test='type']").exists()).toBe(true);
+    expect(wrapper.find("DoubleRow[data-test='type'] Icon").exists()).toBe(
+      false
+    );
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -9,7 +9,12 @@ import { useTableSort } from "app/base/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import type { NetworkInterface, Machine } from "app/store/machine/types";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
-import { isBootInterface, isInterfaceConnected } from "app/store/machine/utils";
+import {
+  getInterfaceNumaNodes,
+  getInterfaceTypeText,
+  isBootInterface,
+  isInterfaceConnected,
+} from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { formatSpeedUnits } from "app/utils";
 
@@ -43,6 +48,7 @@ const generateRows = (machine: Machine): NetworkRow[] => {
   }
   return machine.interfaces.map((nic: NetworkInterface) => {
     const isBoot = isBootInterface(machine, nic);
+    const numaNodes = getInterfaceNumaNodes(machine, nic);
     return {
       columns: [
         {
@@ -97,6 +103,26 @@ const generateRows = (machine: Machine): NetworkRow[] => {
                   {formatSpeedUnits(nic.interface_speed)}
                 </>
               }
+            />
+          ),
+        },
+        {
+          content: (
+            <DoubleRow
+              data-test="type"
+              icon={
+                numaNodes.length > 1 ? (
+                  <Tooltip
+                    position="top-left"
+                    message="This bond is spread over multiple NUMA nodes. This may lead to suboptimal performance."
+                  >
+                    <Icon name="warning" />
+                  </Tooltip>
+                ) : null
+              }
+              iconSpace={true}
+              primary={getInterfaceTypeText(nic)}
+              secondary={numaNodes.join(", ")}
             />
           ),
         },
@@ -183,6 +209,7 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
           content: (
             <>
               <TableHeader
+                className="p-double-row__header-spacer"
                 currentSort={currentSort}
                 onClick={() => updateSort("type")}
                 sortKey="type"

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -33,6 +33,50 @@ export enum NetworkInterfaceTypes {
   VLAN = "vlan",
 }
 
+export enum BondMode {
+  BALANCE_RR = "balance-rr",
+  ACTIVE_BACKUP = "active-backup",
+  BALANCE_XOR = "balance-xor",
+  BROADCAST = "broadcast",
+  LINK_AGGREGATION = "802.3ad",
+  BALANCE_TLB = "balance-tlb",
+  BALANCE_ALB = "balance-alb",
+}
+
+export enum BondLacpRate {
+  SLOW = "slow",
+  FAST = "fast",
+}
+
+export enum BondXmitHashPolicy {
+  LAYER2 = "layer2",
+  LAYER2_3 = "layer2+3",
+  LAYER3_4 = "layer3+4",
+  ENCAP2_3 = "encap2+3",
+  ENCAP3_4 = "encap3+4",
+}
+
+export enum BridgeType {
+  STANDARD = "standard",
+  OVS = "ovs",
+}
+
+export type NetworkInterfaceParams = {
+  bridge_type?: BridgeType;
+  bridge_stp?: boolean;
+  bridge_fd?: number;
+  mtu?: number;
+  accept_ra?: boolean;
+  autoconf?: boolean;
+  bond_mode?: BondMode;
+  bond_miimon?: number;
+  bond_downdelay?: number;
+  bond_updelay?: number;
+  bond_lacp_rate?: BondLacpRate;
+  bond_xmit_hash_policy?: BondXmitHashPolicy;
+  bond_num_grat_arp?: number;
+};
+
 export type NetworkInterface = Model & {
   children: string[];
   discovered?: DiscoveredIP[]; // Only shown when machine is in ephemeral state.
@@ -46,7 +90,7 @@ export type NetworkInterface = Model & {
   mac_address: string;
   name: string;
   numa_node: number;
-  params: string;
+  params: NetworkInterfaceParams | null;
   parents: Model["id"][];
   product: string | null;
   sriov_max_vf: number;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -211,7 +211,7 @@ export const machineInterface = extend<Model, NetworkInterface>(model, {
   mac_address: "00.00.00.00.00.00",
   name: (i: number) => `eth${i}`,
   numa_node: 0,
-  params: "",
+  params: null,
   parents: () => [],
   product: "Product",
   sriov_max_vf: 0,


### PR DESCRIPTION
## Done

- Add the column to display the interface type and numa node on the network tab of the machine
details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab in machine details.
- You should see the type/numa node column. The details will appear bit different to the legacy page as the rows don't yet account for the bond/bridge hierarchy.

## Fixes

Fixes: #1954.