### PR TITLE
refactor(ui): add enum for disk types

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/canonical/local/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -319,47 +319,43 @@ exports[`stricter compilation`] = {
       [87, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"],
       [98, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
-    "src/app/machines/hooks.tsx:1523402407": [
-      [48, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 55 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 55 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
-      [48, 37, 6, "Object is possibly \'undefined\'.", "1314712411"],
-      [48, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
-      [54, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
-      [63, 4, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
+    "src/app/machines/hooks.tsx:4039767025": [
+      [53, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 55 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 55 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
+      [53, 37, 6, "Object is possibly \'undefined\'.", "1314712411"],
+      [53, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
+      [59, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
+      [68, 4, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:2183522574": [
       [114, 18, 5, "Type \'MenuLink<null>[]\' is not assignable to type \'(string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined)[]\'.\\n  Type \'MenuLink<null>\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n    Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n      Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }>\'.\\n        Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'Partial<InferPropsInner<Pick<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }, \\"children\\" | ... 7 more ... | \\"inline\\">>>\'.\\n          Types of property \'element\' are incompatible.\\n            Type \'\\"symbol\\" | \\"object\\" | \\"metadata\\" | \\"map\\" | \\"filter\\" | \\"path\\" | \\"label\\" | \\"data\\" | \\"a\\" | \\"abbr\\" | \\"address\\" | \\"area\\" | \\"article\\" | \\"aside\\" | \\"audio\\" | \\"b\\" | \\"base\\" | \\"bdi\\" | \\"bdo\\" | ... 160 more ... | undefined\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n              Type \'FunctionComponent<null>\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n                Type \'FunctionComponent<null>\' is not assignable to type \'(props: any, context?: any) => any\'.\\n                  Types of parameters \'props\' and \'props\' are incompatible.\\n                    Type \'any\' is not assignable to type \'never\'.", "173192470"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:3412899083": [
-      [15, 2, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'NetworkInterface\'.\\n  No index signature with a parameter of type \'string\' was found on type \'NetworkInterface\'.", "3729243690"],
-      [15, 17, 12, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'NetworkInterface\'.\\n  No index signature with a parameter of type \'string\' was found on type \'NetworkInterface\'.", "3729243690"]
-    ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:2100928998": [
-      [62, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [63, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "2579426038"]
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx:149111759": [
+      [92, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [93, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "2579426038"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartitionFields/AddPartitionFields.test.tsx:639270117": [
       [44, 6, 89, "Cannot invoke an object which is possibly \'undefined\'.", "2274220369"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:3355242033": [
-      [154, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:44044127": [
+      [155, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx:211560400": [
-      [42, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [43, 6, 15, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "1103269280"]
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.test.tsx:3531893588": [
+      [78, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [79, 6, 15, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "1103269280"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartitionFields/EditPartitionFields.test.tsx:2078291524": [
       [51, 6, 81, "Cannot invoke an object which is possibly \'undefined\'.", "878884295"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx:4033417679": [
-      [76, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [76, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
+    "src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx:2970206867": [
+      [116, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [116, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx:2514535204": [
-      [33, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [34, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "3144942680"]
+    "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx:1462154962": [
+      [62, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [63, 6, 23, "Argument of type \'{ filesystemType: string; mountOptions: string; mountPoint: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'filesystemType\' does not exist in type \'FormEvent<{}>\'.", "3144942680"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:1827491893": [
-      [165, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2261070022": [
+      [168, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:3437058613": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
@@ -615,10 +611,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:1948192154": [
+    "src/app/store/machine/types.ts:58892152": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [321, 34, 8, "RegExp match", "1152173309"],
-      [324, 25, 8, "RegExp match", "1152173309"]
+      [344, 34, 8, "RegExp match", "1152173309"],
+      [347, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/noderesult/selectors.ts:2866544023": [
       [7, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 import AvailableStorageTable from "./AvailableStorageTable";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { DiskTypes } from "app/store/machine/types";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
@@ -47,13 +48,13 @@ describe("AvailableStorageTable", () => {
         available_size: MIN_PARTITION_SIZE + 1,
         name: "available-disk",
         filesystem: null,
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       }),
       diskFactory({
         available_size: MIN_PARTITION_SIZE - 1,
         filesystem: null,
         name: "used-disk",
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       }),
     ];
     const state = rootStateFactory({
@@ -83,7 +84,7 @@ describe("AvailableStorageTable", () => {
     const disk = diskFactory({
       available_size: MIN_PARTITION_SIZE + 1,
       filesystem: null,
-      type: "physical",
+      type: DiskTypes.PHYSICAL,
     });
     const state = rootStateFactory({
       machine: machineStateFactory({
@@ -117,12 +118,12 @@ describe("AvailableStorageTable", () => {
       diskFactory({
         available_size: MIN_PARTITION_SIZE + 1,
         filesystem: null,
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       }),
       diskFactory({
         available_size: MIN_PARTITION_SIZE + 1,
         filesystem: null,
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       }),
     ];
     const state = rootStateFactory({
@@ -180,7 +181,7 @@ describe("AvailableStorageTable", () => {
   it("can open the add partition form if disk can be partitioned", () => {
     const disk = diskFactory({
       available_size: MIN_PARTITION_SIZE + 1,
-      type: "physical",
+      type: DiskTypes.PHYSICAL,
     });
     const state = rootStateFactory({
       machine: machineStateFactory({
@@ -244,7 +245,7 @@ describe("AvailableStorageTable", () => {
     const disk = diskFactory({
       available_size: MIN_PARTITION_SIZE + 1,
       partitions: [],
-      type: "physical",
+      type: DiskTypes.PHYSICAL,
     });
     const state = rootStateFactory({
       machine: machineStateFactory({
@@ -293,7 +294,7 @@ describe("AvailableStorageTable", () => {
   it("can delete a volume group", () => {
     const disk = diskFactory({
       available_size: MIN_PARTITION_SIZE + 1,
-      type: "lvm-vg",
+      type: DiskTypes.VOLUME_GROUP,
       used_size: 0,
     });
     const state = rootStateFactory({
@@ -352,7 +353,7 @@ describe("AvailableStorageTable", () => {
               diskFactory({
                 available_size: MIN_PARTITION_SIZE - 1,
                 partitions: [partition],
-                type: "physical",
+                type: DiskTypes.PHYSICAL,
               }),
             ],
             system_id: "abc123",

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.test.tsx
@@ -2,25 +2,26 @@ import { mount } from "enzyme";
 
 import BootStatus from "./BootStatus";
 
+import { DiskTypes } from "app/store/machine/types";
 import { machineDisk as diskFactory } from "testing/factories";
 
 describe("BootStatus", () => {
   it("shows boot status for boot disks", () => {
-    const disk = diskFactory({ is_boot: true, type: "physical" });
+    const disk = diskFactory({ is_boot: true, type: DiskTypes.PHYSICAL });
     const wrapper = mount(<BootStatus disk={disk} />);
 
     expect(wrapper.find("Icon").prop("name")).toBe("tick");
   });
 
   it("shows boot status for non-boot disks", () => {
-    const disk = diskFactory({ is_boot: false, type: "physical" });
+    const disk = diskFactory({ is_boot: false, type: DiskTypes.PHYSICAL });
     const wrapper = mount(<BootStatus disk={disk} />);
 
     expect(wrapper.find("Icon").prop("name")).toBe("close");
   });
 
   it("shows boot status for non-physical disks", () => {
-    const disk = diskFactory({ is_boot: false, type: "virtual" });
+    const disk = diskFactory({ is_boot: false, type: DiskTypes.VIRTUAL });
     const wrapper = mount(<BootStatus disk={disk} />);
 
     expect(wrapper.find("span").text()).toBe("—");

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/BootStatus/BootStatus.tsx
@@ -1,11 +1,12 @@
 import { Icon } from "@canonical/react-components";
 
+import { DiskTypes } from "app/store/machine/types";
 import type { Disk } from "app/store/machine/types";
 
 type Props = { disk: Disk };
 
 const BootStatus = ({ disk }: Props): JSX.Element => {
-  if (disk.type === "physical") {
+  if (disk.type === DiskTypes.PHYSICAL) {
     return disk.is_boot ? <Icon name="tick" /> : <Icon name="close" />;
   }
   return <span>—</span>;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.test.tsx
@@ -4,6 +4,7 @@ import configureStore from "redux-mock-store";
 
 import CacheSetsTable from "./CacheSetsTable";
 
+import { DiskTypes } from "app/store/machine/types";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
@@ -20,11 +21,11 @@ describe("CacheSetsTable", () => {
     const [cacheSet, notCacheSet] = [
       diskFactory({
         name: "quiche",
-        type: "cache-set",
+        type: DiskTypes.CACHE_SET,
       }),
       diskFactory({
         name: "frittata",
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       }),
     ];
     const state = rootStateFactory({
@@ -50,7 +51,7 @@ describe("CacheSetsTable", () => {
 
   it("can delete a cache set", () => {
     const disk = diskFactory({
-      type: "cache-set",
+      type: DiskTypes.CACHE_SET,
     });
     const state = rootStateFactory({
       machine: machineStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import MachineStorage from "./MachineStorage";
 
 import * as hooks from "app/base/hooks";
+import { DiskTypes } from "app/store/machine/types";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -48,7 +49,9 @@ describe("MachineStorage", () => {
       machine: machineStateFactory({
         items: [
           machineDetailsFactory({
-            disks: [diskFactory({ name: "quiche-cache", type: "cache-set" })],
+            disks: [
+              diskFactory({ name: "quiche-cache", type: DiskTypes.CACHE_SET }),
+            ],
             system_id: "abc123",
           }),
         ],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/UsedStorageTable/UsedStorageTable.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 import UsedStorageTable from "./UsedStorageTable";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { DiskTypes } from "app/store/machine/types";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
@@ -44,13 +45,13 @@ describe("UsedStorageTable", () => {
         available_size: MIN_PARTITION_SIZE + 1,
         name: "available-disk",
         filesystem: null,
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       }),
       diskFactory({
         available_size: MIN_PARTITION_SIZE - 1,
         filesystem: null,
         name: "used-disk",
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       }),
     ];
     const state = rootStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./utils";
 
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { DiskTypes } from "app/store/machine/types";
 import {
   machineDisk as diskFactory,
   machineFilesystem as fsFactory,
@@ -32,16 +33,25 @@ describe("Machine storage utils", () => {
     });
 
     it("returns whether a volume group can be deleted", () => {
-      const deletable = diskFactory({ type: "lvm-vg", used_size: 0 });
-      const nonDeletable = diskFactory({ type: "lvm-vg", used_size: 1000 });
+      const deletable = diskFactory({
+        type: DiskTypes.VOLUME_GROUP,
+        used_size: 0,
+      });
+      const nonDeletable = diskFactory({
+        type: DiskTypes.VOLUME_GROUP,
+        used_size: 1000,
+      });
       expect(canBeDeleted(deletable)).toBe(true);
       expect(canBeDeleted(nonDeletable)).toBe(false);
     });
 
     it("returns whether a non-volume group disk can be deleted", () => {
-      const deletable = diskFactory({ type: "physical", partitions: [] });
+      const deletable = diskFactory({
+        type: DiskTypes.PHYSICAL,
+        partitions: [],
+      });
       const nonDeletable = diskFactory({
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
         partitions: [partitionFactory()],
       });
       expect(canBeDeleted(deletable)).toBe(true);
@@ -70,7 +80,7 @@ describe("Machine storage utils", () => {
     it("handles physical disks with available space", () => {
       const disk = diskFactory({
         available_size: MIN_PARTITION_SIZE + 1,
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       });
       expect(canBePartitioned(disk)).toBe(true);
     });
@@ -83,7 +93,7 @@ describe("Machine storage utils", () => {
     it("handles volume groups", () => {
       const disk = diskFactory({
         available_size: MIN_PARTITION_SIZE + 1,
-        type: "lvm-vg",
+        type: DiskTypes.VOLUME_GROUP,
       });
       expect(canBePartitioned(disk)).toBe(false);
     });
@@ -93,10 +103,10 @@ describe("Machine storage utils", () => {
         available_size: MIN_PARTITION_SIZE + 1,
         parent: {
           id: 1,
-          type: "lvm-vg",
+          type: DiskTypes.VOLUME_GROUP,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
       expect(canBePartitioned(disk)).toBe(false);
     });
@@ -106,10 +116,10 @@ describe("Machine storage utils", () => {
         available_size: MIN_PARTITION_SIZE + 1,
         parent: {
           id: 1,
-          type: "bcache",
+          type: DiskTypes.BCACHE,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
       expect(canBePartitioned(disk)).toBe(false);
     });
@@ -123,13 +133,13 @@ describe("Machine storage utils", () => {
     it("handles disks with available space", () => {
       const disk = diskFactory({
         available_size: MIN_PARTITION_SIZE + 1,
-        type: "physical",
+        type: DiskTypes.PHYSICAL,
       });
       expect(diskAvailable(disk)).toBe(true);
     });
 
     it("handles cache sets", () => {
-      const cacheSet = diskFactory({ type: "cache-set" });
+      const cacheSet = diskFactory({ type: DiskTypes.CACHE_SET });
       expect(diskAvailable(cacheSet)).toBe(false);
     });
 
@@ -159,13 +169,13 @@ describe("Machine storage utils", () => {
     });
 
     it("handles cache sets", () => {
-      const disk = diskFactory({ type: "cache-set" });
+      const disk = diskFactory({ type: DiskTypes.CACHE_SET });
       expect(formatType(disk)).toBe("Cache set");
       expect(formatType(disk, true)).toBe("cache set");
     });
 
     it("handles ISCSIs", () => {
-      const disk = diskFactory({ type: "iscsi" });
+      const disk = diskFactory({ type: DiskTypes.ISCSI });
       expect(formatType(disk)).toBe("ISCSI");
     });
 
@@ -173,10 +183,10 @@ describe("Machine storage utils", () => {
       const disk = diskFactory({
         parent: {
           id: 1,
-          type: "lvm-vg",
+          type: DiskTypes.VOLUME_GROUP,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
       expect(formatType(disk)).toBe("Logical volume");
       expect(formatType(disk, true)).toBe("logical volume");
@@ -189,7 +199,7 @@ describe("Machine storage utils", () => {
     });
 
     it("handles physical disks", () => {
-      const disk = diskFactory({ type: "physical" });
+      const disk = diskFactory({ type: DiskTypes.PHYSICAL });
       expect(formatType(disk)).toBe("Physical");
       expect(formatType(disk, true)).toBe("physical disk");
     });
@@ -198,10 +208,10 @@ describe("Machine storage utils", () => {
       const disk = diskFactory({
         parent: {
           id: 1,
-          type: "raid-0",
+          type: DiskTypes.RAID_0,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
       expect(formatType(disk)).toBe("RAID 0");
     });
@@ -212,13 +222,13 @@ describe("Machine storage utils", () => {
     });
 
     it("handles virtual disks", () => {
-      const disk = diskFactory({ type: "virtual" });
+      const disk = diskFactory({ type: DiskTypes.VIRTUAL });
       expect(formatType(disk)).toBe("Virtual");
       expect(formatType(disk, true)).toBe("virtual disk");
     });
 
     it("handles volume groups", () => {
-      const disk = diskFactory({ type: "lvm-vg" });
+      const disk = diskFactory({ type: DiskTypes.VOLUME_GROUP });
       expect(formatType(disk)).toBe("Volume group");
       expect(formatType(disk, true)).toBe("volume group");
     });
@@ -229,12 +239,12 @@ describe("Machine storage utils", () => {
       const bcache = diskFactory({
         parent: {
           id: 1,
-          type: "bcache",
+          type: DiskTypes.BCACHE,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
-      const notBcache = diskFactory({ type: "physical" });
+      const notBcache = diskFactory({ type: DiskTypes.PHYSICAL });
       expect(isBcache(null)).toBe(false);
       expect(isBcache(notBcache)).toBe(false);
       expect(isBcache(bcache)).toBe(true);
@@ -243,8 +253,8 @@ describe("Machine storage utils", () => {
 
   describe("isCacheSet", () => {
     it("returns whether a disk is a cache set", () => {
-      const cacheSet = diskFactory({ type: "cache-set" });
-      const notCacheSet = diskFactory({ type: "physical" });
+      const cacheSet = diskFactory({ type: DiskTypes.CACHE_SET });
+      const notCacheSet = diskFactory({ type: DiskTypes.PHYSICAL });
       expect(isCacheSet(null)).toBe(false);
       expect(isCacheSet(notCacheSet)).toBe(false);
       expect(isCacheSet(cacheSet)).toBe(true);
@@ -266,12 +276,12 @@ describe("Machine storage utils", () => {
       const logicalVolume = diskFactory({
         parent: {
           id: 1,
-          type: "lvm-vg",
+          type: DiskTypes.VOLUME_GROUP,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
-      const notLogicalVolume = diskFactory({ type: "physical" });
+      const notLogicalVolume = diskFactory({ type: DiskTypes.PHYSICAL });
       expect(isLogicalVolume(null)).toBe(false);
       expect(isLogicalVolume(notLogicalVolume)).toBe(false);
       expect(isLogicalVolume(logicalVolume)).toBe(true);
@@ -295,7 +305,7 @@ describe("Machine storage utils", () => {
 
   describe("isPartition", () => {
     it("returns whether a storage device is a partition", () => {
-      const disk = diskFactory({ type: "physical" });
+      const disk = diskFactory({ type: DiskTypes.PHYSICAL });
       const partition = partitionFactory({ type: "partition" });
       expect(isPartition(null)).toBe(false);
       expect(isPartition(disk)).toBe(false);
@@ -308,12 +318,12 @@ describe("Machine storage utils", () => {
       const raid = diskFactory({
         parent: {
           id: 1,
-          type: "raid-0",
+          type: DiskTypes.RAID_0,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
-      const notRaid = diskFactory({ type: "physical" });
+      const notRaid = diskFactory({ type: DiskTypes.PHYSICAL });
       expect(isRaid(null)).toBe(false);
       expect(isRaid(notRaid)).toBe(false);
       expect(isRaid(raid)).toBe(true);
@@ -322,8 +332,8 @@ describe("Machine storage utils", () => {
 
   describe("isPhysical", () => {
     it("returns whether a disk is a physical disk", () => {
-      const physical = diskFactory({ type: "physical" });
-      const notPhysical = diskFactory({ type: "virtual" });
+      const physical = diskFactory({ type: DiskTypes.PHYSICAL });
+      const notPhysical = diskFactory({ type: DiskTypes.VIRTUAL });
       expect(isPhysical(null)).toBe(false);
       expect(isPhysical(notPhysical)).toBe(false);
       expect(isPhysical(physical)).toBe(true);
@@ -335,12 +345,12 @@ describe("Machine storage utils", () => {
       const virtual = diskFactory({
         parent: {
           id: 1,
-          type: "raid-0",
+          type: DiskTypes.RAID_0,
           uuid: "abc123",
         },
-        type: "virtual",
+        type: DiskTypes.VIRTUAL,
       });
-      const notVirtual = diskFactory({ type: "physical" });
+      const notVirtual = diskFactory({ type: DiskTypes.PHYSICAL });
       expect(isVirtual(null)).toBe(false);
       expect(isVirtual(notVirtual)).toBe(false);
       expect(isVirtual(virtual)).toBe(true);

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/utils.ts
@@ -1,4 +1,5 @@
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { DiskTypes } from "app/store/machine/types";
 import type { Disk, Filesystem, Partition } from "app/store/machine/types";
 import { formatBytes } from "app/utils";
 
@@ -83,34 +84,34 @@ export const formatType = (
     return "Unknown";
   }
 
+  if (isPartition(storageDevice)) {
+    return sentenceForm ? "partition" : "Partition";
+  }
+
   let typeToFormat = storageDevice.type;
-  if (!isPartition(storageDevice)) {
-    const disk = storageDevice as Disk;
-    if (isVirtual(disk)) {
-      if (isLogicalVolume(disk)) {
-        return sentenceForm ? "logical volume" : "Logical volume";
-      } else if (isRaid(disk)) {
-        const raidLevel = disk.parent?.type.split("-")[1];
-        return raidLevel ? `RAID ${raidLevel}` : "RAID";
-      }
-      typeToFormat = disk.parent?.type || "Unknown";
+  const disk = storageDevice as Disk;
+  if (isVirtual(disk)) {
+    if (isLogicalVolume(disk)) {
+      return sentenceForm ? "logical volume" : "Logical volume";
+    } else if (isRaid(disk)) {
+      const raidLevel = disk.parent?.type.split("-")[1];
+      return raidLevel ? `RAID ${raidLevel}` : "RAID";
     }
+    typeToFormat = disk.parent?.type || "Unknown";
   }
 
   switch (typeToFormat) {
-    case "cache-set":
+    case DiskTypes.CACHE_SET:
       return sentenceForm ? "cache set" : "Cache set";
-    case "iscsi":
+    case DiskTypes.ISCSI:
       return "ISCSI";
-    case "lvm-vg":
+    case DiskTypes.VOLUME_GROUP:
       return sentenceForm ? "volume group" : "Volume group";
-    case "partition":
-      return sentenceForm ? "partition" : "Partition";
-    case "physical":
+    case DiskTypes.PHYSICAL:
       return sentenceForm ? "physical disk" : "Physical";
-    case "virtual":
+    case DiskTypes.VIRTUAL:
       return sentenceForm ? "virtual disk" : "Virtual";
-    case "vmfs6":
+    case DiskTypes.VMFS6:
       return "VMFS6";
     default:
       return typeToFormat;
@@ -123,7 +124,7 @@ export const formatType = (
  * @returns whether the disk is a bcache
  */
 export const isBcache = (disk: Disk | null): boolean =>
-  isVirtual(disk) && disk?.parent?.type === "bcache";
+  isVirtual(disk) && disk?.parent?.type === DiskTypes.BCACHE;
 
 /**
  * Returns whether a disk is a cache set.
@@ -131,7 +132,7 @@ export const isBcache = (disk: Disk | null): boolean =>
  * @returns whether the disk is a cache set
  */
 export const isCacheSet = (disk: Disk | null): boolean =>
-  disk?.type === "cache-set";
+  disk?.type === DiskTypes.CACHE_SET;
 
 /**
  * Returns whether a filesystem is a VMFS6 datastore.
@@ -147,7 +148,7 @@ export const isDatastore = (fs: Filesystem | null): fs is Filesystem =>
  * @returns whether the disk is a logical volume
  */
 export const isLogicalVolume = (disk: Disk | null): boolean =>
-  (isVirtual(disk) && disk?.parent?.type === "lvm-vg") || false;
+  (isVirtual(disk) && disk?.parent?.type === DiskTypes.VOLUME_GROUP) || false;
 
 /**
  * Returns whether a filesystem is mounted.
@@ -179,7 +180,7 @@ export const isPartition = (storageDevice: Disk | Partition | null): boolean =>
  * @returns whether the disk is a physical disk
  */
 export const isPhysical = (disk: Disk | null): boolean =>
-  disk?.type === "physical";
+  disk?.type === DiskTypes.PHYSICAL;
 
 /**
  * Returns whether a disk is a RAID.
@@ -195,7 +196,7 @@ export const isRaid = (disk: Disk | null): boolean =>
  * @returns whether the disk is a virtual disk
  */
 export const isVirtual = (disk: Disk | null): boolean =>
-  disk?.type === "virtual" && "parent" in disk;
+  disk?.type === DiskTypes.VIRTUAL && "parent" in disk;
 
 /**
  * Returns whether a disk is a volume group.
@@ -203,7 +204,7 @@ export const isVirtual = (disk: Disk | null): boolean =>
  * @returns whether the disk is a volume group
  */
 export const isVolumeGroup = (disk: Disk | null): boolean =>
-  disk?.type === "lvm-vg";
+  disk?.type === DiskTypes.VOLUME_GROUP;
 
 /**
  * Returns whether a partition is available to use.

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -76,6 +76,21 @@ export type Partition = Model & {
   used_for: string;
 };
 
+export enum DiskTypes {
+  BCACHE = "bcache",
+  CACHE_SET = "cache-set",
+  ISCSI = "iscsi",
+  PHYSICAL = "physical",
+  RAID_0 = "raid-0",
+  RAID_1 = "raid-1",
+  RAID_5 = "raid-5",
+  RAID_6 = "raid-6",
+  RAID_10 = "raid-10",
+  VIRTUAL = "virtual",
+  VMFS6 = "vmfs6",
+  VOLUME_GROUP = "lvm-vg",
+}
+
 export type Disk = Model & {
   available_size_human: string;
   available_size: number;
@@ -90,7 +105,7 @@ export type Disk = Model & {
   parent?: {
     id: number;
     uuid: string;
-    type: string;
+    type: DiskTypes;
   };
   partition_table_type: string;
   partitions: Partition[] | null;
@@ -100,7 +115,7 @@ export type Disk = Model & {
   size: number;
   tags: string[];
   test_status: number;
-  type: string;
+  type: DiskTypes;
   used_for: string;
   used_size_human: string;
   used_size: number;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -16,7 +16,7 @@ import type {
   NetworkInterface,
   Partition,
 } from "app/store/machine/types";
-import { NetworkInterfaceTypes } from "app/store/machine/types";
+import { DiskTypes, NetworkInterfaceTypes } from "app/store/machine/types";
 import type {
   Pod,
   PodDetails,
@@ -178,7 +178,7 @@ export const machineDisk = extend<Model, Disk>(model, {
   is_boot: true,
   name: "sda",
   tags: () => [],
-  type: "physical",
+  type: DiskTypes.PHYSICAL,
   path: "/dev/disk/by-dname/sda",
   size: 100000000000,
   size_human: "100 GB",


### PR DESCRIPTION
## Done

- Added an enum for disk types and replaced instances of disk type strings with it 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Shouldn't need a QA - just need tests to pass

## Fixes

Fixes #1986 
