### PR TITLE
feat(ui): add the fabric column to the network tab

### DIFF
--- a/ui/src/app/base/components/LegacyLink/LegacyLink.tsx
+++ b/ui/src/app/base/components/LegacyLink/LegacyLink.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import type { ReactNode } from "react";
+import type { HTMLProps, ReactNode } from "react";
 
 import { Link } from "@canonical/react-components";
 import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
@@ -7,7 +7,7 @@ import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
 type Props = {
   children: ReactNode;
   route: string;
-};
+} & HTMLProps<HTMLAnchorElement>;
 
 const LegacyLink = ({ children, route, ...linkProps }: Props): JSX.Element => (
   <Link

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -7,6 +7,8 @@ import NetworkTable from "./NetworkTable";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
+  fabric as fabricFactory,
+  vlan as vlanFactory,
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
   machineState as machineStateFactory,
@@ -164,5 +166,31 @@ describe("NetworkTable", () => {
     expect(wrapper.find("DoubleRow[data-test='type'] Icon").exists()).toBe(
       false
     );
+  });
+
+  it("can display fabric and vlan details", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    state.vlan.items = [vlan];
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    const links = wrapper.find("DoubleRow[data-test='fabric'] LegacyLink");
+    expect(links.at(0).text()).toBe("fabric-name");
+    expect(links.at(1).text()).toBe("2 (vlan-name)");
   });
 });

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -130,17 +130,19 @@ describe("UserForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    wrapper.find("UserForm").at(1).props().onSave(
-      {
-        isSuperuser: true,
-        email: "test@example.com",
-        fullName: "Miss Wallaby",
-        password: "test1234",
-        passwordConfirm: "test1234",
-        username: "admin",
-      },
-      {},
-      true
+    act(() =>
+      wrapper.find("UserForm").at(1).props().onSave(
+        {
+          isSuperuser: true,
+          email: "test@example.com",
+          fullName: "Miss Wallaby",
+          password: "test1234",
+          passwordConfirm: "test1234",
+          username: "admin",
+        },
+        {},
+        true
+      )
     );
 
     expect(store.getActions()).toEqual([
@@ -174,17 +176,19 @@ describe("UserForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    wrapper.find("UserForm").at(1).props().onSave(
-      {
-        isSuperuser: true,
-        email: "test@example.com",
-        fullName: "Miss Wallaby",
-        password: "test1234",
-        passwordConfirm: "test1234",
-        username: "admin",
-      },
-      { password: "test1234", passwordConfirm: "test1234" },
-      true
+    act(() =>
+      wrapper.find("UserForm").at(1).props().onSave(
+        {
+          isSuperuser: true,
+          email: "test@example.com",
+          fullName: "Miss Wallaby",
+          password: "test1234",
+          passwordConfirm: "test1234",
+          username: "admin",
+        },
+        { password: "test1234", passwordConfirm: "test1234" },
+        true
+      )
     );
 
     expect(store.getActions()).toEqual([

--- a/ui/src/app/store/vlan/types.ts
+++ b/ui/src/app/store/vlan/types.ts
@@ -2,6 +2,10 @@ import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
+export enum VlanVid {
+  UNTAGGED = 0,
+}
+
 export type VLAN = Model & {
   created: string;
   description: string;
@@ -16,7 +20,7 @@ export type VLAN = Model & {
   secondary_rack: string | null;
   space: number;
   updated: string;
-  vid: number;
+  vid: VlanVid.UNTAGGED | number;
 };
 
 export type VLANState = GenericState<VLAN, TSFixMe>;

--- a/ui/src/app/store/vlan/utils.test.ts
+++ b/ui/src/app/store/vlan/utils.test.ts
@@ -1,5 +1,6 @@
 import { getVLANDisplay } from "./utils";
 
+import { VlanVid } from "app/store/vlan/types";
 import { vlan as vlanFactory } from "testing/factories";
 
 describe("vlan utils", () => {
@@ -11,6 +12,11 @@ describe("vlan utils", () => {
     it("returns just vid", () => {
       const vlan = vlanFactory({ vid: 5, name: "" });
       expect(getVLANDisplay(vlan)).toBe("5");
+    });
+
+    it("can display as untagged", () => {
+      const vlan = vlanFactory({ vid: VlanVid.UNTAGGED });
+      expect(getVLANDisplay(vlan)).toBe("untagged");
     });
 
     it("returns vid + name", () => {

--- a/ui/src/app/store/vlan/utils.test.ts
+++ b/ui/src/app/store/vlan/utils.test.ts
@@ -1,0 +1,21 @@
+import { getVLANDisplay } from "./utils";
+
+import { vlan as vlanFactory } from "testing/factories";
+
+describe("vlan utils", () => {
+  describe("getVLANDisplay", () => {
+    it("returns nothing if vlan undefined", () => {
+      expect(getVLANDisplay(null)).toBe(null);
+    });
+
+    it("returns just vid", () => {
+      const vlan = vlanFactory({ vid: 5, name: "" });
+      expect(getVLANDisplay(vlan)).toBe("5");
+    });
+
+    it("returns vid + name", () => {
+      const vlan = vlanFactory({ vid: 5, name: "vlan-name" });
+      expect(getVLANDisplay(vlan)).toBe("5 (vlan-name)");
+    });
+  });
+});

--- a/ui/src/app/store/vlan/utils.ts
+++ b/ui/src/app/store/vlan/utils.ts
@@ -1,0 +1,19 @@
+import type { VLAN } from "app/store/vlan/types";
+
+/**
+ * Get the VLAN display text.
+ * @param vlan - A VLAN.
+ * @return The VLAN display text.
+ */
+export const getVLANDisplay = (vlan: VLAN | null): string | null => {
+  if (!vlan) {
+    return null;
+  }
+  if (vlan.vid === 0) {
+    return "untagged";
+  } else if (vlan.name) {
+    return `${vlan.vid} (${vlan.name})`;
+  } else {
+    return vlan.vid.toString();
+  }
+};

--- a/ui/src/app/store/vlan/utils.ts
+++ b/ui/src/app/store/vlan/utils.ts
@@ -1,4 +1,5 @@
 import type { VLAN } from "app/store/vlan/types";
+import { VlanVid } from "app/store/vlan/types";
 
 /**
  * Get the VLAN display text.
@@ -9,7 +10,7 @@ export const getVLANDisplay = (vlan: VLAN | null): string | null => {
   if (!vlan) {
     return null;
   }
-  if (vlan.vid === 0) {
+  if (vlan.vid === VlanVid.UNTAGGED) {
     return "untagged";
   } else if (vlan.name) {
     return `${vlan.vid} (${vlan.name})`;


### PR DESCRIPTION
## Done

- Add the fabric and vlan column to the network table in machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go the the network tab for a machine.
- You should see fabric/vlan details with links to the correct pages.

## Fixes

Fixes: #1955.