### PR TITLE
feat(ui): add subnet column to the network tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -6,13 +6,17 @@ import NetworkTable from "./NetworkTable";
 
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { NodeStatus } from "app/store/types/node";
 import {
+  networkDiscoveredIP as networkDiscoveredIPFactory,
   fabric as fabricFactory,
   vlan as vlanFactory,
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
   machineState as machineStateFactory,
+  networkLink as networkLinkFactory,
   rootState as rootStateFactory,
+  subnet as subnetFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -192,5 +196,98 @@ describe("NetworkTable", () => {
     const links = wrapper.find("DoubleRow[data-test='fabric'] LegacyLink");
     expect(links.at(0).text()).toBe("fabric-name");
     expect(links.at(1).text()).toBe("2 (vlan-name)");
+  });
+
+  it("can display subnet links", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
+    state.vlan.items = [vlan];
+    state.subnet.items = [subnet];
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            discovered: null,
+            links: [networkLinkFactory({ subnet_id: subnet.id })],
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    const links = wrapper.find("DoubleRow[data-test='subnet'] LegacyLink");
+    expect(links.at(0).text()).toBe("subnet-cidr");
+    expect(links.at(1).text()).toBe("subnet-name");
+  });
+
+  it("can display an unconfigured subnet", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    state.vlan.items = [vlan];
+    state.subnet.items = [];
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            discovered: null,
+            links: [networkLinkFactory({ subnet_id: 99 })],
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow[data-test='subnet']").prop("primary")).toBe(
+      "Unconfigured"
+    );
+  });
+
+  it("can display the subnet name only", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
+    state.vlan.items = [vlan];
+    state.subnet.items = [subnet];
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            discovered: [networkDiscoveredIPFactory({ subnet_id: subnet.id })],
+            links: [],
+            vlan_id: vlan.id,
+          }),
+        ],
+        status: NodeStatus.DEPLOYING,
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(
+      wrapper.find("DoubleRow[data-test='subnet'] LegacyLink").exists()
+    ).toBe(false);
+    expect(wrapper.find("DoubleRow[data-test='subnet']").prop("primary")).toBe(
+      "subnet-cidr (subnet-name)"
+    );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -6,17 +6,13 @@ import NetworkTable from "./NetworkTable";
 
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-import { NodeStatus } from "app/store/types/node";
 import {
-  networkDiscoveredIP as networkDiscoveredIPFactory,
   fabric as fabricFactory,
   vlan as vlanFactory,
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
   machineState as machineStateFactory,
-  networkLink as networkLinkFactory,
   rootState as rootStateFactory,
-  subnet as subnetFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -31,6 +27,7 @@ describe("NetworkTable", () => {
       }),
     });
   });
+
   it("displays a spinner when loading", () => {
     state.machine.items = [];
     const store = mockStore(state);
@@ -196,98 +193,5 @@ describe("NetworkTable", () => {
     const links = wrapper.find("DoubleRow[data-test='fabric'] LegacyLink");
     expect(links.at(0).text()).toBe("fabric-name");
     expect(links.at(1).text()).toBe("2 (vlan-name)");
-  });
-
-  it("can display subnet links", () => {
-    const fabric = fabricFactory({ name: "fabric-name" });
-    state.fabric.items = [fabric];
-    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
-    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
-    state.vlan.items = [vlan];
-    state.subnet.items = [subnet];
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [
-          machineInterfaceFactory({
-            discovered: null,
-            links: [networkLinkFactory({ subnet_id: subnet.id })],
-            vlan_id: vlan.id,
-          }),
-        ],
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTable systemId="abc123" />
-      </Provider>
-    );
-    const links = wrapper.find("DoubleRow[data-test='subnet'] LegacyLink");
-    expect(links.at(0).text()).toBe("subnet-cidr");
-    expect(links.at(1).text()).toBe("subnet-name");
-  });
-
-  it("can display an unconfigured subnet", () => {
-    const fabric = fabricFactory({ name: "fabric-name" });
-    state.fabric.items = [fabric];
-    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
-    state.vlan.items = [vlan];
-    state.subnet.items = [];
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [
-          machineInterfaceFactory({
-            discovered: null,
-            links: [networkLinkFactory({ subnet_id: 99 })],
-            vlan_id: vlan.id,
-          }),
-        ],
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTable systemId="abc123" />
-      </Provider>
-    );
-    expect(wrapper.find("DoubleRow[data-test='subnet']").prop("primary")).toBe(
-      "Unconfigured"
-    );
-  });
-
-  it("can display the subnet name only", () => {
-    const fabric = fabricFactory({ name: "fabric-name" });
-    state.fabric.items = [fabric];
-    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
-    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
-    state.vlan.items = [vlan];
-    state.subnet.items = [subnet];
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [
-          machineInterfaceFactory({
-            discovered: [networkDiscoveredIPFactory({ subnet_id: subnet.id })],
-            links: [],
-            vlan_id: vlan.id,
-          }),
-        ],
-        status: NodeStatus.DEPLOYING,
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTable systemId="abc123" />
-      </Provider>
-    );
-    expect(
-      wrapper.find("DoubleRow[data-test='subnet'] LegacyLink").exists()
-    ).toBe(false);
-    expect(wrapper.find("DoubleRow[data-test='subnet']").prop("primary")).toBe(
-      "subnet-cidr (subnet-name)"
-    );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.test.tsx
@@ -1,0 +1,114 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import SubnetColumn from "./SubnetColumn";
+
+import type { RootState } from "app/store/root/types";
+import { NodeStatus } from "app/store/types/node";
+import {
+  networkDiscoveredIP as networkDiscoveredIPFactory,
+  fabric as fabricFactory,
+  vlan as vlanFactory,
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  networkLink as networkLinkFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("SubnetColumn", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory();
+  });
+
+  it("can display subnet links", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
+    state.vlan.items = [vlan];
+    state.subnet.items = [subnet];
+    const nic = machineInterfaceFactory({
+      discovered: null,
+      links: [networkLinkFactory({ subnet_id: subnet.id })],
+      vlan_id: vlan.id,
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SubnetColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    const links = wrapper.find("LegacyLink");
+    expect(links.at(0).text()).toBe("subnet-cidr");
+    expect(links.at(1).text()).toBe("subnet-name");
+  });
+
+  it("can display an unconfigured subnet", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnet = subnetFactory({ cidr: "" });
+    state.vlan.items = [vlan];
+    state.subnet.items = [subnet];
+    const nic = machineInterfaceFactory({
+      discovered: null,
+      links: [networkLinkFactory({ subnet_id: subnet.id })],
+      vlan_id: vlan.id,
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SubnetColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe("Unconfigured");
+  });
+
+  it("can display the subnet name only", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
+    state.vlan.items = [vlan];
+    state.subnet.items = [subnet];
+    const nic = machineInterfaceFactory({
+      discovered: [networkDiscoveredIPFactory({ subnet_id: subnet.id })],
+      links: [],
+      vlan_id: vlan.id,
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        status: NodeStatus.DEPLOYING,
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SubnetColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("LegacyLink").exists()).toBe(false);
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe(
+      "subnet-cidr (subnet-name)"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+
+import { useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import LegacyLink from "app/base/components/LegacyLink";
+import fabricSelectors from "app/store/fabric/selectors";
+import machineSelectors from "app/store/machine/selectors";
+import type { NetworkInterface, Machine } from "app/store/machine/types";
+import { useIsAllNetworkingDisabled } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet } from "app/store/subnet/types";
+import { getSubnetDisplay } from "app/store/subnet/utils";
+import vlanSelectors from "app/store/vlan/selectors";
+
+type Props = { nic: NetworkInterface; systemId: Machine["system_id"] };
+
+const SubnetColumn = ({ nic, systemId }: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, nic.vlan_id)
+  );
+  const fabric = useSelector((state: RootState) =>
+    fabricSelectors.getById(state, vlan?.fabric)
+  );
+  const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
+  const discoveredSubnetId =
+    nic?.discovered?.length && nic.discovered.length > 0
+      ? nic.discovered[0].subnet_id
+      : null;
+  const showSubnetLinks = fabric && !discoveredSubnetId;
+  const showSubnetDisplay = isAllNetworkingDisabled && discoveredSubnetId;
+  let subnetId: Subnet["id"] | null | undefined;
+  if (showSubnetLinks) {
+    // Look for a link to a subnet.
+    const subnetLink = nic?.links.find(
+      ({ subnet_id }) => subnet_id !== undefined && subnet_id !== null
+    );
+    subnetId = subnetLink?.subnet_id;
+  } else if (showSubnetDisplay) {
+    subnetId = discoveredSubnetId;
+  }
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, subnetId)
+  );
+
+  if (!subnet || (!showSubnetLinks && !showSubnetDisplay)) {
+    return null;
+  }
+
+  let primary: ReactNode = null;
+  if (showSubnetLinks) {
+    primary = subnet.cidr ? (
+      <LegacyLink className="p-link--soft" route={`/subnet/${subnet.id}`}>
+        {subnet.cidr}
+      </LegacyLink>
+    ) : (
+      "Unconfigured"
+    );
+  } else if (showSubnetDisplay) {
+    primary = getSubnetDisplay(subnet);
+  }
+
+  return (
+    <DoubleRow
+      primary={primary}
+      secondary={
+        showSubnetLinks ? (
+          <LegacyLink className="p-link--muted" route={`/subnet/${subnet.id}`}>
+            {subnet.name}
+          </LegacyLink>
+        ) : null
+      }
+    />
+  );
+};
+
+export default SubnetColumn;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SubnetColumn";

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -17,7 +17,7 @@ export type Vlan = Model & {
 
 export type NetworkLink = Model & {
   mode: "auto" | "dhcp" | "link_up" | "static";
-  subnet: Subnet;
+  subnet_id: Subnet["id"];
 };
 
 export type DiscoveredIP = {
@@ -79,7 +79,7 @@ export type NetworkInterfaceParams = {
 
 export type NetworkInterface = Model & {
   children: string[];
-  discovered?: DiscoveredIP[]; // Only shown when machine is in ephemeral state.
+  discovered?: DiscoveredIP[] | null; // Only shown when machine is in ephemeral state.
   enabled: boolean;
   firmware_version: string | null;
   interface_speed: number;

--- a/ui/src/app/store/subnet/utils.test.ts
+++ b/ui/src/app/store/subnet/utils.test.ts
@@ -1,0 +1,21 @@
+import { getSubnetDisplay } from "./utils";
+
+import { subnet as subnetFactory } from "testing/factories";
+
+describe("subnet utils", () => {
+  describe("getSubnetDisplay", function () {
+    it("returns 'Unconfigured' for null", function () {
+      expect(getSubnetDisplay(null)).toBe("Unconfigured");
+    });
+
+    it("returns just cidr if name same as cidr", function () {
+      const subnet = subnetFactory({ cidr: "same-name", name: "same-name" });
+      expect(getSubnetDisplay(subnet)).toBe("same-name");
+    });
+
+    it("returns cidr + name", function () {
+      const subnet = subnetFactory({ cidr: "cidr-name", name: "subnet-name" });
+      expect(getSubnetDisplay(subnet)).toBe("cidr-name (subnet-name)");
+    });
+  });
+});

--- a/ui/src/app/store/subnet/utils.ts
+++ b/ui/src/app/store/subnet/utils.ts
@@ -1,0 +1,16 @@
+import type { Subnet } from "app/store/subnet/types";
+
+/**
+ * Get the Subnet display text.
+ * @param subnet - A subnet.
+ * @return The subnet display text.
+ */
+export const getSubnetDisplay = (subnet: Subnet | null | undefined): string => {
+  if (!subnet) {
+    return "Unconfigured";
+  } else if (subnet.cidr !== subnet.name) {
+    return `${subnet.cidr} (${subnet.name})`;
+  } else {
+    return subnet.cidr;
+  }
+};

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -62,6 +62,8 @@ export {
   machineInterface,
   machineNumaNode,
   machinePartition,
+  networkDiscoveredIP,
+  networkLink,
   controller,
   pod,
   podDetails,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -5,6 +5,7 @@ import { model, modelRef } from "./model";
 import type { Controller } from "app/store/controller/types";
 import type { Device } from "app/store/device/types";
 import type {
+  DiscoveredIP,
   Disk,
   Event,
   EventType,
@@ -14,6 +15,7 @@ import type {
   MachineDevice,
   MachineNumaNode,
   NetworkInterface,
+  NetworkLink,
   Partition,
 } from "app/store/machine/types";
 import { DiskTypes, NetworkInterfaceTypes } from "app/store/machine/types";
@@ -196,6 +198,16 @@ export const machineDisk = extend<Model, Disk>(model, {
   partitions: () => [],
   numa_node: 0,
   test_status: 0,
+});
+
+export const networkLink = extend<Model, NetworkLink>(model, {
+  mode: "auto",
+  subnet_id: random,
+});
+
+export const networkDiscoveredIP = define<DiscoveredIP>({
+  ip_address: "1.2.3.4",
+  subnet_id: random,
 });
 
 export const machineInterface = extend<Model, NetworkInterface>(model, {


### PR DESCRIPTION
## Done

- Add the subnet details to the network table in machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the network tab in machine details.
- You should see subnet details.

## Fixes

Fixes: #1956.