### PR TITLE
refactor(ui): update selected state handling in available storage table

### DIFF
--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -25,6 +25,8 @@ export {
   diskAvailable,
   formatSize,
   formatType,
+  getDiskById,
+  getPartitionById,
   isBcache,
   isCacheSet,
   isDatastore,

--- a/ui/src/app/store/machine/utils/storage.test.ts
+++ b/ui/src/app/store/machine/utils/storage.test.ts
@@ -8,6 +8,8 @@ import {
   diskAvailable,
   formatSize,
   formatType,
+  getDiskById,
+  getPartitionById,
   isBcache,
   isCacheSet,
   isDatastore,
@@ -297,6 +299,33 @@ describe("machine storage utils", () => {
       const disk = diskFactory({ type: DiskTypes.VOLUME_GROUP });
       expect(formatType(disk)).toBe("Volume group");
       expect(formatType(disk, true)).toBe("volume group");
+    });
+  });
+
+  describe("getDiskById", () => {
+    it("returns a machine's disk given the disk's id", () => {
+      const disk1 = diskFactory({ id: 1 });
+      const disk2 = diskFactory({
+        id: 2,
+        partitions: [partitionFactory({ id: 1 })],
+      });
+      expect(getDiskById([disk1, disk2], 1)).toBe(disk1);
+      expect(getDiskById([disk1, disk2], 2)).toBe(disk2);
+      expect(getDiskById([disk1, disk2], 3)).toBe(null);
+    });
+  });
+
+  describe("getPartitionById", () => {
+    it("returns a machine's disk partition given the partition's id", () => {
+      const partition1 = partitionFactory({ id: 1 });
+      const partition2 = partitionFactory({ id: 2 });
+      const disks = [
+        diskFactory({ id: 1, partitions: [partition1] }),
+        diskFactory({ id: 2, partitions: [partition2] }),
+      ];
+      expect(getPartitionById(disks, 1)).toBe(partition1);
+      expect(getPartitionById(disks, 2)).toBe(partition2);
+      expect(getPartitionById(disks, 3)).toBe(null);
     });
   });
 

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -149,6 +149,43 @@ export const formatType = (
 };
 
 /**
+ * Returns a disk given the disk's id.
+ * @param disks - the disks to check.
+ * @param diskId - the disk id.
+ * @returns disk that matches id.
+ */
+export const getDiskById = (disks: Disk[], diskId: Disk["id"]): Disk | null => {
+  if (disks && disks.length > 0) {
+    return disks.find((disk) => disk.id === diskId) || null;
+  }
+  return null;
+};
+
+/**
+ * Returns a disk partition given the partition's id.
+ * @param disks - the disks to check the partitions of.
+ * @param partitionId - the partition id.
+ * @returns partition that matches id.
+ */
+export const getPartitionById = (
+  disks: Disk[],
+  partitionId: Partition["id"]
+): Partition | null => {
+  if (disks && disks.length > 0) {
+    for (const disk of disks) {
+      if (disk.partitions) {
+        for (const partition of disk.partitions) {
+          if (partition.id === partitionId) {
+            return partition;
+          }
+        }
+      }
+    }
+  }
+  return null;
+};
+
+/**
  * Returns whether a disk is a bcache.
  * @param disk - the disk to check.
  * @returns whether the disk is a bcache


### PR DESCRIPTION
## Done

- Updated selected state handling in available storage table.
  - Now the entire storage device object is set in selected state. This is for the actions to come later which will need to know about more than just the id and type.
  - Added a `useEffect` which keeps the selected state from becoming stale, e.g. for when a disk is updated or deleted

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine in Ready or Allocated state
- Change the storage layout to blank
- Add a partition to one available disk
- Check that the header checkbox and individual row checkboxes work as expected
- Check the checkbox for the partition, then open the action dropdown and select "Remove partition..." and confirm. Note that the checkbox doesn't actually serve a purpose for this action, it's just so we can test selected state.
- The partition should be removed from the table, and should also be removed from selected state. It will have worked correctly if the header checkbox is unchecked.
- Create a mounted partition so it goes straight into the filesystems table
- Check the header checkbox to select everything, then unmount the filesystem
- The partition should move to the available table and the header checkbox should change to mixed selection state (`-` instead of a tick)

## Fixes

Fixes #1997 
