### PR TITLE
fix(ui): override failed testing scripts only

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -70,7 +70,10 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
   );
   const machineIDs = machinesToAction.map((machine) => machine.system_id);
   const scriptResults = useSelector((state) =>
-    scriptResultsSelectors.getTestingResultsByMachineIds(state, machineIDs)
+    scriptResultsSelectors.getFailedTestingResultsByMachineIds(
+      state,
+      machineIDs
+    )
   );
 
   // Get the number of results for all machines.

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -75,17 +75,11 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
       machineIDs
     )
   );
-
   // Get the number of results for all machines.
   const numFailedTests =
     Object.entries(scriptResults).reduce(
-      (acc, [systemId, results]) =>
-        acc +
-        // Count the results for this machine.
-        results.reduce(
-          (machineResults, { results }) => machineResults + results.length,
-          0
-        ),
+      // Count the results for this machine.
+      (acc, [systemId, results]) => acc + results.length,
       0
     ) || 0;
 

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -139,7 +139,7 @@ describe("OverrideTestForm", () => {
     );
 
     expect(wrapper.find('[data-test-id="failed-results-message"]').text()).toBe(
-      "Machine host1 has failed 2 tests."
+      "Machine host1 has failed 1 test."
     );
     expect(
       wrapper.find('[data-test-id="failed-results-message"] a').props().href
@@ -161,7 +161,7 @@ describe("OverrideTestForm", () => {
     );
 
     expect(wrapper.find('[data-test-id="failed-results-message"]').text()).toBe(
-      "2 machines have failed 2 tests."
+      "2 machines have failed 1 test."
     );
   });
 

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -57,6 +57,7 @@ describe("OverrideTestForm", () => {
         loading: false,
         items: [
           scriptResultFactory({
+            exit_status: 1,
             id: 1,
             result_type: ResultType.Testing,
             results: [

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import OverrideTestForm from "./OverrideTestForm";
 import { ResultType } from "app/base/enum";
+import { ResultStatus } from "app/store/scriptresult/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -57,7 +58,7 @@ describe("OverrideTestForm", () => {
         loading: false,
         items: [
           scriptResultFactory({
-            exit_status: 1,
+            status: ResultStatus.FAILED,
             id: 1,
             result_type: ResultType.Testing,
             results: [

--- a/ui/src/app/store/scriptresult/selectors.test.tsx
+++ b/ui/src/app/store/scriptresult/selectors.test.tsx
@@ -1,7 +1,7 @@
 import selectors from "./selectors";
 
 import { HardwareType, ResultType } from "app/base/enum";
-import { ExitStatus } from "app/store/scriptresult/types";
+import { ResultStatus } from "app/store/scriptresult/types";
 import {
   nodeScriptResultState as nodeScriptResultStateFactory,
   rootState as rootStateFactory,
@@ -195,41 +195,41 @@ describe("scriptResult selectors", () => {
   it("returns failed testing script results for machine ids", () => {
     const items = [
       scriptResultFactory({
-        exit_status: 1,
         id: 1,
         hardware_type: HardwareType.CPU,
         result_type: ResultType.Testing,
+        status: ResultStatus.FAILED,
       }),
       scriptResultFactory({
-        exit_status: 1,
         id: 2,
         hardware_type: HardwareType.Network,
         result_type: ResultType.Testing,
+        status: ResultStatus.FAILED,
       }),
       // Should not be returned because it passed.
       scriptResultFactory({
-        exit_status: ExitStatus.PASSED,
         id: 3,
         hardware_type: HardwareType.Network,
         result_type: ResultType.Testing,
+        status: ResultStatus.PASSED,
       }),
       scriptResultFactory({
-        exit_status: 1,
         id: 4,
         hardware_type: HardwareType.Storage,
         result_type: ResultType.Testing,
+        status: ResultStatus.FAILED,
       }),
       // Should not be returned because it is not a testing script.
       scriptResultFactory({
-        exit_status: 1,
         id: 5,
         result_type: ResultType.Commissioning,
+        status: ResultStatus.FAILED,
       }),
       // Should not be returned because it passed.
       scriptResultFactory({
-        exit_status: ExitStatus.PASSED,
         id: 6,
         result_type: ResultType.Testing,
+        status: ResultStatus.PASSED,
       }),
     ];
     const state = rootStateFactory({

--- a/ui/src/app/store/scriptresult/selectors.ts
+++ b/ui/src/app/store/scriptresult/selectors.ts
@@ -4,7 +4,7 @@ import type { Machine } from "../machine/types";
 import nodeScriptResultSelectors from "../nodescriptresult/selectors";
 
 import type { ScriptResult } from "./types";
-import { ExitStatus } from "./types";
+import { ResultStatusFailed } from "./types";
 
 import { HardwareType, ResultType } from "app/base/enum";
 import type { TSFixMe } from "app/base/types";
@@ -182,8 +182,8 @@ const getFailedTestingResultsByMachineIds = createSelector(
       ]);
       if (results) {
         // Filter for only the failed results.
-        results = results.filter(
-          ({ exit_status }) => exit_status !== ExitStatus.PASSED
+        results = results.filter(({ status }) =>
+          Object.keys(ResultStatusFailed).includes(status.toString())
         );
       }
       if (results) {

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -4,6 +4,10 @@ import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
+export enum ExitStatus {
+  PASSED = 0,
+}
+
 export type ScriptResultResult = {
   name: string;
   title: string;
@@ -16,7 +20,7 @@ export type ScriptResult = Model & {
   ended?: string;
   endtime: number;
   estimated_runtime: string;
-  exit_status?: number | null;
+  exit_status?: ExitStatus | number | null;
   hardware_type: 0 | 1 | 2 | 3 | 4;
   interface?: NetworkInterface | null;
   name: string;

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -8,6 +8,28 @@ export enum ExitStatus {
   PASSED = 0,
 }
 
+export enum ResultStatus {
+  PENDING = 0,
+  RUNNING = 1,
+  PASSED = 2,
+  FAILED = 3,
+  TIMEDOUT = 4,
+  ABORTED = 5,
+  DEGRADED = 6,
+  INSTALLING = 7,
+  FAILED_INSTALLING = 8,
+  SKIPPED = 9,
+  APPLYING_NETCONF = 10,
+  FAILED_APPLYING_NETCONF = 11,
+}
+
+export enum ResultStatusFailed {
+  FAILED = ResultStatus.FAILED,
+  TIMEDOUT = ResultStatus.TIMEDOUT,
+  FAILED_INSTALLING = ResultStatus.FAILED_INSTALLING,
+  FAILED_APPLYING_NETCONF = ResultStatus.FAILED_APPLYING_NETCONF,
+}
+
 export type ScriptResultResult = {
   name: string;
   title: string;
@@ -33,7 +55,7 @@ export type ScriptResult = Model & {
   script_version?: number | null;
   started?: string;
   starttime: number;
-  status: number;
+  status: ResultStatus;
   status_name: string;
   suppressed: boolean;
   tags: string;


### PR DESCRIPTION
## Done

- Update the override test form to only override the failed tests.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the override failed testing form from the machine list of machine details.
- It should allow you to override them.

## Fixes

Fixes: #2006.