### PR TITLE
fix(ui): correctly request script results from the override form

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -11,7 +11,6 @@ import { useMachineActionForm } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultsSelectors from "app/store/scriptresult/selectors";
-import nodeScriptResultsSelectors from "app/store/nodescriptresult/selectors";
 import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
 
@@ -65,7 +64,6 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
   const dispatch = useDispatch();
   const [requestedScriptResults, setRequestedScriptResults] = useState([]);
   const activeMachine = useSelector(machineSelectors.active);
-  const nodeScriptResults = useSelector(nodeScriptResultsSelectors.all);
   const scriptResultsLoaded = useSelector(scriptResultsSelectors.loaded);
   const scriptResultsLoading = useSelector(scriptResultsSelectors.loading);
   const { errors, machinesToAction, processingCount } = useMachineActionForm(
@@ -89,8 +87,10 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
   useEffect(() => {
     const newRequests = [];
     machineIDs.forEach((id) => {
-      // Check that the results don't already exist or haven't been requsted.
-      if (!(id in nodeScriptResults) && !requestedScriptResults.includes(id)) {
+      // Check that the results haven't already been requested.
+      // This fetches the results even if they've been loaded previously so that
+      // we make sure the data is not stale.
+      if (!requestedScriptResults.includes(id)) {
         dispatch(scriptResultActions.getByMachineId(id));
         newRequests.push(id);
       }
@@ -99,13 +99,7 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
       // Store the requested ids so that they're not requested again.
       setRequestedScriptResults(requestedScriptResults.concat(newRequests));
     }
-  }, [
-    dispatch,
-    scriptResultsLoading,
-    machineIDs,
-    nodeScriptResults,
-    requestedScriptResults,
-  ]);
+  }, [dispatch, scriptResultsLoading, machineIDs, requestedScriptResults]);
 
   return (
     <ActionForm

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -250,7 +250,7 @@ describe("OverrideTestForm", () => {
     ).toBe(2);
   });
 
-  it("does not dispatch actions when script results have been fetched", () => {
+  it("does not dispatch actions once script results have been requested", () => {
     const state = { ...initialState };
     state.machine.selected = ["abc123", "def456"];
     state.nodescriptresult.items = { abc123: [1], def456: [2] };
@@ -264,12 +264,21 @@ describe("OverrideTestForm", () => {
         </MemoryRouter>
       </Provider>
     );
+    const origionalDispatches = store
+      .getActions()
+      .filter((action) => action.type === "scriptresult/getByMachineId").length;
+    expect(origionalDispatches).toBe(2);
+    act(() => {
+      // Fire a fake action so that the useEffect runs again.
+      store.dispatch({ type: "" });
+    });
+    // There should not be any new dispatches.
     expect(
       store
         .getActions()
         .filter((action) => action.type === "scriptresult/getByMachineId")
         .length
-    ).toBe(0);
+    ).toBe(origionalDispatches);
   });
 
   it("dispatches actions to suppress script results for selected machines", () => {


### PR DESCRIPTION
## Done

- Request script results that haven't already been loaded In the override failed test form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list, check a machine with failed tests and open the form to override the failed tests.
- The form should show the number of failed tests.
- Cancel the form, uncheck the first machine and check a second machine with failed tests and open the form again.
- The form should show the number of failed tests.

## Fixes

Fixes: #2012.