### PR TITLE
feat(ui): add workload annotations card to machine summary

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -8,6 +8,7 @@ import NetworkCard from "./NetworkCard";
 import NumaCard from "./NumaCard";
 import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
+import WorkloadCard from "./WorkloadCard";
 
 import type { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
@@ -55,6 +56,7 @@ const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
       <SystemCard id={id} />
       <NumaCard id={id} />
       <NetworkCard id={id} setSelectedAction={setSelectedAction} />
+      <WorkloadCard id={id} />
     </div>
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/SystemCard.tsx
@@ -80,11 +80,13 @@ const SystemCard = ({ id }: Props): JSX.Element => {
   }
 
   return (
-    <Card className="machine-summary__system-card">
-      <strong className="p-muted-heading u-sv1">System</strong>
-      <hr />
-      {content}
-    </Card>
+    <div className="machine-summary__system-card">
+      <Card>
+        <strong className="p-muted-heading u-sv1">System</strong>
+        <hr />
+        {content}
+      </Card>
+    </div>
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/__snapshots__/SystemCard.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SystemCard/__snapshots__/SystemCard.test.tsx.snap
@@ -4,48 +4,106 @@ exports[`SystemCard renders with system data 1`] = `
 <SystemCard
   id="abc123"
 >
-  <Card
+  <div
     className="machine-summary__system-card"
   >
-    <div
-      className="machine-summary__system-card p-card"
-    >
+    <Card>
       <div
-        className="p-card__content"
+        className="p-card"
       >
-        <strong
-          className="p-muted-heading u-sv1"
+        <div
+          className="p-card__content"
         >
-          System
-        </strong>
-        <hr />
-        <LabelledList
-          items={
-            Array [
-              Object {
-                "label": "Vendor",
-                "value": "QEMU",
-              },
-              Object {
-                "label": "Product",
-                "value": "Standard PC (Q35 + ICH9, 2009)",
-              },
-              Object {
-                "label": "Version",
-                "value": "pc-q35-5.1",
-              },
-              Object {
-                "label": "Serial",
-                "value": "Unknown",
-              },
-            ]
-          }
-        >
-          <List
-            className="p-list--labelled"
+          <strong
+            className="p-muted-heading u-sv1"
+          >
+            System
+          </strong>
+          <hr />
+          <LabelledList
             items={
               Array [
-                <React.Fragment>
+                Object {
+                  "label": "Vendor",
+                  "value": "QEMU",
+                },
+                Object {
+                  "label": "Product",
+                  "value": "Standard PC (Q35 + ICH9, 2009)",
+                },
+                Object {
+                  "label": "Version",
+                  "value": "pc-q35-5.1",
+                },
+                Object {
+                  "label": "Serial",
+                  "value": "Unknown",
+                },
+              ]
+            }
+          >
+            <List
+              className="p-list--labelled"
+              items={
+                Array [
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Vendor
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      QEMU
+                    </div>
+                  </React.Fragment>,
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Product
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      Standard PC (Q35 + ICH9, 2009)
+                    </div>
+                  </React.Fragment>,
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Version
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      pc-q35-5.1
+                    </div>
+                  </React.Fragment>,
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Serial
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      Unknown
+                    </div>
+                  </React.Fragment>,
+                ]
+              }
+            >
+              <ul
+                className="p-list p-list--labelled p-list"
+              >
+                <li
+                  className="p-list__item"
+                  key="0"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -56,8 +114,11 @@ exports[`SystemCard renders with system data 1`] = `
                   >
                     QEMU
                   </div>
-                </React.Fragment>,
-                <React.Fragment>
+                </li>
+                <li
+                  className="p-list__item"
+                  key="1"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -68,8 +129,11 @@ exports[`SystemCard renders with system data 1`] = `
                   >
                     Standard PC (Q35 + ICH9, 2009)
                   </div>
-                </React.Fragment>,
-                <React.Fragment>
+                </li>
+                <li
+                  className="p-list__item"
+                  key="2"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -80,8 +144,11 @@ exports[`SystemCard renders with system data 1`] = `
                   >
                     pc-q35-5.1
                   </div>
-                </React.Fragment>,
-                <React.Fragment>
+                </li>
+                <li
+                  className="p-list__item"
+                  key="3"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -92,118 +159,125 @@ exports[`SystemCard renders with system data 1`] = `
                   >
                     Unknown
                   </div>
-                </React.Fragment>,
+                </li>
+              </ul>
+            </List>
+          </LabelledList>
+          <hr />
+          <span
+            className="u-sv1"
+          >
+            Mainboard
+          </span>
+          <LabelledList
+            className="u-no-margin--bottom"
+            items={
+              Array [
+                Object {
+                  "label": "Vendor",
+                  "value": "Canonical Ltd.",
+                },
+                Object {
+                  "label": "Product",
+                  "value": <div
+                    className="u-sv1"
+                  >
+                    LXD
+                  </div>,
+                },
+                Object {
+                  "label": "Firmware:",
+                  "value": "",
+                },
+                Object {
+                  "label": "Version",
+                  "value": "0.0.0",
+                },
+                Object {
+                  "label": "Date",
+                  "value": "02/06/2015",
+                },
               ]
             }
           >
-            <ul
-              className="p-list p-list--labelled p-list"
+            <List
+              className="p-list--labelled u-no-margin--bottom"
+              items={
+                Array [
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Vendor
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      Canonical Ltd.
+                    </div>
+                  </React.Fragment>,
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Product
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      <div
+                        className="u-sv1"
+                      >
+                        LXD
+                      </div>
+                    </div>
+                  </React.Fragment>,
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Firmware:
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      
+                    </div>
+                  </React.Fragment>,
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Version
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      0.0.0
+                    </div>
+                  </React.Fragment>,
+                  <React.Fragment>
+                    <div
+                      className="p-list__item-label"
+                    >
+                      Date
+                    </div>
+                    <div
+                      className="p-list__item-value"
+                    >
+                      02/06/2015
+                    </div>
+                  </React.Fragment>,
+                ]
+              }
             >
-              <li
-                className="p-list__item"
-                key="0"
+              <ul
+                className="p-list p-list--labelled u-no-margin--bottom p-list"
               >
-                <div
-                  className="p-list__item-label"
+                <li
+                  className="p-list__item"
+                  key="0"
                 >
-                  Vendor
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  QEMU
-                </div>
-              </li>
-              <li
-                className="p-list__item"
-                key="1"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Product
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  Standard PC (Q35 + ICH9, 2009)
-                </div>
-              </li>
-              <li
-                className="p-list__item"
-                key="2"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Version
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  pc-q35-5.1
-                </div>
-              </li>
-              <li
-                className="p-list__item"
-                key="3"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Serial
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  Unknown
-                </div>
-              </li>
-            </ul>
-          </List>
-        </LabelledList>
-        <hr />
-        <span
-          className="u-sv1"
-        >
-          Mainboard
-        </span>
-        <LabelledList
-          className="u-no-margin--bottom"
-          items={
-            Array [
-              Object {
-                "label": "Vendor",
-                "value": "Canonical Ltd.",
-              },
-              Object {
-                "label": "Product",
-                "value": <div
-                  className="u-sv1"
-                >
-                  LXD
-                </div>,
-              },
-              Object {
-                "label": "Firmware:",
-                "value": "",
-              },
-              Object {
-                "label": "Version",
-                "value": "0.0.0",
-              },
-              Object {
-                "label": "Date",
-                "value": "02/06/2015",
-              },
-            ]
-          }
-        >
-          <List
-            className="p-list--labelled u-no-margin--bottom"
-            items={
-              Array [
-                <React.Fragment>
                   <div
                     className="p-list__item-label"
                   >
@@ -214,8 +288,11 @@ exports[`SystemCard renders with system data 1`] = `
                   >
                     Canonical Ltd.
                   </div>
-                </React.Fragment>,
-                <React.Fragment>
+                </li>
+                <li
+                  className="p-list__item"
+                  key="1"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -230,8 +307,11 @@ exports[`SystemCard renders with system data 1`] = `
                       LXD
                     </div>
                   </div>
-                </React.Fragment>,
-                <React.Fragment>
+                </li>
+                <li
+                  className="p-list__item"
+                  key="2"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -239,11 +319,12 @@ exports[`SystemCard renders with system data 1`] = `
                   </div>
                   <div
                     className="p-list__item-value"
-                  >
-                    
-                  </div>
-                </React.Fragment>,
-                <React.Fragment>
+                  />
+                </li>
+                <li
+                  className="p-list__item"
+                  key="3"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -254,8 +335,11 @@ exports[`SystemCard renders with system data 1`] = `
                   >
                     0.0.0
                   </div>
-                </React.Fragment>,
-                <React.Fragment>
+                </li>
+                <li
+                  className="p-list__item"
+                  key="4"
+                >
                   <div
                     className="p-list__item-label"
                   >
@@ -266,95 +350,13 @@ exports[`SystemCard renders with system data 1`] = `
                   >
                     02/06/2015
                   </div>
-                </React.Fragment>,
-              ]
-            }
-          >
-            <ul
-              className="p-list p-list--labelled u-no-margin--bottom p-list"
-            >
-              <li
-                className="p-list__item"
-                key="0"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Vendor
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  Canonical Ltd.
-                </div>
-              </li>
-              <li
-                className="p-list__item"
-                key="1"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Product
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  <div
-                    className="u-sv1"
-                  >
-                    LXD
-                  </div>
-                </div>
-              </li>
-              <li
-                className="p-list__item"
-                key="2"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Firmware:
-                </div>
-                <div
-                  className="p-list__item-value"
-                />
-              </li>
-              <li
-                className="p-list__item"
-                key="3"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Version
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  0.0.0
-                </div>
-              </li>
-              <li
-                className="p-list__item"
-                key="4"
-              >
-                <div
-                  className="p-list__item-label"
-                >
-                  Date
-                </div>
-                <div
-                  className="p-list__item-value"
-                >
-                  02/06/2015
-                </div>
-              </li>
-            </ul>
-          </List>
-        </LabelledList>
+                </li>
+              </ul>
+            </List>
+          </LabelledList>
+        </div>
       </div>
-    </div>
-  </Card>
+    </Card>
+  </div>
 </SystemCard>
 `;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.test.tsx
@@ -1,0 +1,113 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import WorkloadCard from "./WorkloadCard";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("WorkloadCard", () => {
+  it("displays a message if the machine has no workload annotations", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+            workload_annotations: {},
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <WorkloadCard id="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='no-workload-annotations']").exists()).toBe(
+      true
+    );
+  });
+
+  it("can display a list of workload annotations", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+            workload_annotations: {
+              key1: "value1",
+              key2: "value2",
+            },
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <WorkloadCard id="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='workload-annotations'] li").length).toBe(
+      2
+    );
+    expect(wrapper.find("[data-test='workload-key']").at(0).text()).toBe(
+      "key1"
+    );
+    expect(wrapper.find("[data-test='workload-value']").at(0).text()).toBe(
+      "value1"
+    );
+  });
+
+  it("displays comma-separated values on new lines", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+            workload_annotations: {
+              separated: "comma,separated,value",
+            },
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <WorkloadCard id="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='workload-value'] div").at(0).text()).toBe(
+      "comma"
+    );
+    expect(wrapper.find("[data-test='workload-value'] div").at(1).text()).toBe(
+      "separated"
+    );
+    expect(wrapper.find("[data-test='workload-value'] div").at(2).text()).toBe(
+      "value"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
@@ -1,0 +1,121 @@
+import {
+  Card,
+  Icon,
+  Link,
+  Spinner,
+  Tooltip,
+} from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import LabelledList from "app/base/components/LabelledList";
+import { useSendAnalytics } from "app/base/hooks";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  id: Machine["system_id"];
+};
+
+const WorkloadCard = ({ id }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+  const sendAnalytics = useSendAnalytics();
+  let content: JSX.Element;
+
+  if (machine && "workload_annotations" in machine) {
+    const workloads = Object.entries(
+      machine.workload_annotations || {}
+    ).sort((a, b) => a[0].localeCompare(b[0]));
+
+    if (workloads.length > 0) {
+      content = (
+        <LabelledList
+          className="u-no-margin--bottom"
+          data-test="workload-annotations"
+          items={workloads.map(([key, value]) => {
+            const separatedValue = value.split(",");
+            return {
+              label: <div data-test="workload-key">{key}</div>,
+              value: (
+                <div data-test="workload-value" key={key}>
+                  {separatedValue.map((val) => (
+                    <div key={`${key}-${val}`}>{val}</div>
+                  ))}
+                </div>
+              ),
+            };
+          })}
+        />
+      );
+    } else {
+      content = (
+        <div data-test="no-workload-annotations">
+          <h4>Workload information not available</h4>
+          <p>
+            Workload annotations are available when a machine is allocated.
+            Learn how to{" "}
+            <Link
+              external
+              href="https://maas.io/docs" // TODO: Replace with real link
+              onClick={() =>
+                sendAnalytics(
+                  "Machine summary",
+                  "Click link to workload annotation docs",
+                  "create machine workload annotations"
+                )
+              }
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              create machine workload annotations
+            </Link>
+            .
+          </p>
+        </div>
+      );
+    }
+  } else {
+    content = <Spinner />;
+  }
+
+  return (
+    <div className="machine-summary__workload-card">
+      <Card>
+        <div className="u-flex--between">
+          <div className="u-sv1">
+            <strong className="p-muted-heading">Workload annotations</strong>
+            <span className="u-nudge-right--small">
+              <Tooltip
+                message="MAAS removes workload annotations when the machine is released."
+                position="top-center"
+              >
+                <Icon name="help" />
+              </Tooltip>
+            </span>
+          </div>
+          <Link
+            external
+            href="https://maas.io/docs" // TODO: Replace with real link
+            onClick={() =>
+              sendAnalytics(
+                "Machine summary",
+                "Click link to workload annotation docs",
+                "Read more"
+              )
+            }
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Read more
+          </Link>
+        </div>
+        <hr />
+        {content}
+      </Card>
+    </div>
+  );
+};
+
+export default WorkloadCard;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./WorkloadCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/_index.scss
@@ -4,6 +4,7 @@
     grid:
       [row1-start] "overview-card overview-card overview-card overview-card" min-content [row1-end]
       [row2-start] "system-card numa-card network-card network-card" min-content [row2-end]
+      [row3-start] "system-card numa-card workload-card workload-card" min-content [row3-end]
       / 1fr 1fr 1fr 1fr;
     padding-left: 0;
     padding-right: 0;
@@ -12,7 +13,8 @@
       grid:
         [row1-start] "overview-card overview-card overview-card" min-content [row1-end]
         [row2-start] "system-card network-card network-card" max-content [row2-end]
-        [row3-start] "numa-card network-card network-card" min-content [row3-end]
+        [row3-start] "system-card network-card network-card" min-content [row3-end]
+        [row4-start] "numa-card workload-card workload-card" min-content [row4-end]
         / 1fr 1fr 1fr;
     }
 
@@ -21,6 +23,7 @@
         [row1-start] "overview-card overview-card" min-content [row1-end]
         [row2-start] "network-card network-card" min-content [row2-end]
         [row3-start] "system-card numa-card" min-content [row3-end]
+        [row4-start] "workload-card workload-card" min-content [row4-end]
         / 1fr 1fr;
     }
 
@@ -30,6 +33,7 @@
         [row2-start] "network-card" min-content [row2-end]
         [row3-start] "system-card" min-content [row3-end]
         [row4-start] "numa-card" min-content [row4-end]
+        [row5-start] "workload-card" min-content [row5-end]
         / 1fr;
     }
   }
@@ -49,5 +53,13 @@
 
   .machine-summary__network-card {
     grid-area: network-card;
+  }
+
+  .machine-summary__workload-card {
+    grid-area: workload-card;
+
+    .p-list--labelled .p-list__item-value {
+      flex-grow: 3;
+    }
   }
 }

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -340,6 +340,7 @@ export type MachineDetails = BaseMachine & {
   }[];
   swap_size: number | null;
   updated: string;
+  workload_annotations: { [x: string]: string };
 };
 
 // Depending on where the user has navigated in the app, machines in state can

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -294,6 +294,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   supported_filesystems: () => [],
   swap_size: null,
   updated: "Fri, 23 Oct. 2020 05:24:41",
+  workload_annotations: () => ({}),
 });
 
 export const controller = extend<BaseNode, Controller>(node, {


### PR DESCRIPTION
## Done

- Added workload annotations card to machine summary page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine that has an owner (e.g. in "Allocated", "Deployed" status) and no workload annotations
- Check that a message displays about there being no annotations
- Add some workload annotations. In the browser dev tools console, run:
``` js
websocket = new WebSocket("<MAAS_WEBSOCKET_URL>");
```
- Then run:
``` js
websocket.send(
  JSON.stringify({
    method: "machine.set_workload_annotations,
    params: {
      workload_annotations: {
        contact: "sre.ubuntu@canonical.com,lmorris@canonical.com",
        created: "apr-22-2020",
        role:
          "archive.ubuntu.com member,archive.u.c internal server (via split DNS)",
        service: "ubuntu-archive",
        "service-component": "ubuntu-archive.ubuntu-mirror",
        "service-instance": "ubuntu-archive.ubuntu-mirror.production",
        type: "production",
      },
      system_id: "<SYSTEM_ID_OF_MACHINE>",
    },
    request_id: 999,
    type: 0,
  })
);
```
- You might need to navigate away and back to the summary tab
- Check that there are now workload annotations, and the values with commas show on new lines

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2263

## Launchpad issue

[lp#1908356](https://bugs.launchpad.net/maas/+bug/1908356)

## Screenshots
### No workload annotations
![Screenshot_2020-12-16 star-glider maas details focal-maas MAAS(1)](https://user-images.githubusercontent.com/25733845/102314771-b6e92180-3fbe-11eb-9ca5-92001369c882.png)


### Workload annotations
![Screenshot_2020-12-16 star-glider maas details focal-maas MAAS(2)](https://user-images.githubusercontent.com/25733845/102314786-bcdf0280-3fbe-11eb-8edd-d002f74f1610.png)


