### PR TITLE
feat(ui): add the ip column to the network table

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.test.tsx
@@ -1,0 +1,235 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import IPColumn from "./IPColumn";
+
+import { HardwareType, ResultType } from "app/base/enum";
+import { NetworkLinkMode } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import { ResultStatus } from "app/store/scriptresult/types";
+import type { Subnet } from "app/store/subnet/types";
+import {
+  networkDiscoveredIP as networkDiscoveredIPFactory,
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  networkLink as networkLinkFactory,
+  nodeScriptResultState as nodeScriptResultStateFactory,
+  rootState as rootStateFactory,
+  scriptResult as scriptResultFactory,
+  scriptResultState as scriptResultStateFactory,
+  subnetState as subnetStateFactory,
+  subnet as subnetFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("IPColumn", () => {
+  let state: RootState;
+  let subnet: Subnet;
+
+  beforeEach(() => {
+    subnet = subnetFactory();
+    state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: [subnet],
+      }),
+    });
+  });
+
+  it("can display a discovered ip address", () => {
+    const discovered = networkDiscoveredIPFactory({ ip_address: "1.2.3.99" });
+    const nic = machineInterfaceFactory({
+      discovered: [discovered],
+      links: [networkLinkFactory({ subnet_id: subnet.id })],
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <IPColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe(
+      discovered.ip_address
+    );
+  });
+
+  it("can display an ip address from a link", () => {
+    const link = networkLinkFactory({
+      subnet_id: subnet.id,
+      ip_address: "1.2.3.99",
+    });
+    const nic = machineInterfaceFactory({
+      discovered: [],
+      links: [link],
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <IPColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe(link.ip_address);
+  });
+
+  it("displays as unconfigured when there is no link", () => {
+    const nic = machineInterfaceFactory({
+      discovered: [],
+      links: [],
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <IPColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe("Unconfigured");
+  });
+
+  it("can display the link mode", () => {
+    const nic = machineInterfaceFactory({
+      discovered: [],
+      links: [
+        networkLinkFactory({
+          mode: NetworkLinkMode.AUTO,
+          subnet_id: subnet.id,
+        }),
+      ],
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <IPColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe("Auto assign");
+  });
+
+  it("can display the failed network status for multiple tests", () => {
+    const nic = machineInterfaceFactory({
+      discovered: [],
+      links: [
+        networkLinkFactory({
+          subnet_id: subnet.id,
+        }),
+      ],
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    state.scriptresult = scriptResultStateFactory({
+      items: [
+        scriptResultFactory({
+          id: 1,
+          hardware_type: HardwareType.Network,
+          interface: nic,
+          result_type: ResultType.Testing,
+          status: ResultStatus.FAILED,
+        }),
+        scriptResultFactory({
+          id: 2,
+          hardware_type: HardwareType.Network,
+          interface: nic,
+          result_type: ResultType.Testing,
+          status: ResultStatus.FAILED,
+        }),
+      ],
+    });
+    state.nodescriptresult = nodeScriptResultStateFactory({
+      items: { abc123: [1, 2] },
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <IPColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("secondary")).toBe("2 failed tests");
+  });
+
+  it("can display the failed network status for one test", () => {
+    const nic = machineInterfaceFactory({
+      discovered: [],
+      links: [
+        networkLinkFactory({
+          subnet_id: subnet.id,
+        }),
+      ],
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    state.scriptresult = scriptResultStateFactory({
+      items: [
+        scriptResultFactory({
+          id: 1,
+          hardware_type: HardwareType.Network,
+          interface: nic,
+          name: "nic test",
+          result_type: ResultType.Testing,
+          status: ResultStatus.FAILED,
+        }),
+      ],
+    });
+    state.nodescriptresult = nodeScriptResultStateFactory({
+      items: { abc123: [1, 2] },
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <IPColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("secondary")).toBe("nic test failed");
+  });
+
+  it("can not display the failed network status", () => {
+    const nic = machineInterfaceFactory({
+      discovered: [],
+      links: [networkLinkFactory()],
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <IPColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("DoubleRow").prop("secondary")).toBe(null);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import machineSelectors from "app/store/machine/selectors";
+import type { NetworkInterface, Machine } from "app/store/machine/types";
+import { NetworkLinkMode } from "app/store/machine/types";
+import { getLinkModeDisplay } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import { actions as scriptResultActions } from "app/store/scriptresult";
+import scriptResultsSelectors from "app/store/scriptresult/selectors";
+import type { ScriptResult } from "app/store/scriptresult/types";
+import subnetSelectors from "app/store/subnet/selectors";
+
+/**
+ * Get the text for the failed status.
+ * @param nic - A network interface.
+ * @param failedNetworkResults - The failed network testing results.
+ * @return The display text for a link mode.
+ */
+const getNetworkTestingStatus = (
+  nic: NetworkInterface,
+  failedNetworkResults: ScriptResult[] | null
+): string | null => {
+  if (!failedNetworkResults?.length) {
+    return null;
+  }
+  const failedTests = failedNetworkResults.filter(
+    (result) => result.interface?.id === nic.id
+  );
+  if (failedTests.length > 1) {
+    return `${failedTests.length} failed tests`;
+  }
+  if (failedTests.length === 1) {
+    return `${failedTests[0].name} failed`;
+  }
+  return null;
+};
+
+type Props = { nic: NetworkInterface; systemId: Machine["system_id"] };
+
+const IPColumn = ({ nic, systemId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const [scriptResultsRequested, setScriptResultsRequested] = useState(false);
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const failedNetworkResults = useSelector((state: RootState) =>
+    scriptResultsSelectors.getNetworkTestingByMachineId(
+      state,
+      machine?.system_id,
+      true
+    )
+  );
+  // Look for a link to a subnet.
+  const subnetLink = nic?.links.find(
+    ({ subnet_id }) => subnet_id !== undefined && subnet_id !== null
+  );
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, subnetLink?.subnet_id)
+  );
+  const discovered =
+    nic?.discovered?.length && nic.discovered.length > 0
+      ? nic.discovered[0]
+      : null;
+  // If the interface is either disabled or has no links it means the interface
+  // is in LINK_UP mode.
+  const mode = subnetLink?.mode || NetworkLinkMode.LINK_UP;
+
+  useEffect(() => {
+    if (!scriptResultsRequested) {
+      dispatch(scriptResultActions.getByMachineId(systemId));
+      setScriptResultsRequested(true);
+    }
+  }, [dispatch, systemId, scriptResultsRequested]);
+
+  let primary: ReactNode = null;
+  if (subnet && discovered?.ip_address) {
+    primary = discovered.ip_address;
+  } else if (!discovered?.ip_address) {
+    primary = subnetLink?.ip_address || getLinkModeDisplay(mode);
+  }
+
+  return (
+    <DoubleRow
+      primary={primary}
+      secondary={
+        subnet && !discovered?.ip_address
+          ? getNetworkTestingStatus(nic, failedNetworkResults)
+          : null
+      }
+    />
+  );
+};
+
+export default IPColumn;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IPColumn";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { Icon, MainTable, Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
+import IPColumn from "./IPColumn";
 import SubnetColumn from "./SubnetColumn";
 
 import DoubleRow from "app/base/components/DoubleRow";
@@ -175,6 +176,9 @@ const generateRows = (
         },
         {
           content: <SubnetColumn nic={nic} systemId={machine.system_id} />,
+        },
+        {
+          content: <IPColumn nic={nic} systemId={machine.system_id} />,
         },
       ],
       key: nic.id,

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.tsx
@@ -21,7 +21,7 @@ const SubnetColumn = ({ nic, systemId }: Props): JSX.Element | null => {
     machineSelectors.getById(state, systemId)
   );
   const vlan = useSelector((state: RootState) =>
-    vlanSelectors.getById(state, nic.vlan_id)
+    vlanSelectors.getById(state, nic?.vlan_id)
   );
   const fabric = useSelector((state: RootState) =>
     fabricSelectors.getById(state, vlan?.fabric)
@@ -47,13 +47,13 @@ const SubnetColumn = ({ nic, systemId }: Props): JSX.Element | null => {
     subnetSelectors.getById(state, subnetId)
   );
 
-  if (!subnet || (!showSubnetLinks && !showSubnetDisplay)) {
+  if (!showSubnetLinks && !showSubnetDisplay) {
     return null;
   }
 
   let primary: ReactNode = null;
   if (showSubnetLinks) {
-    primary = subnet.cidr ? (
+    primary = subnet?.cidr ? (
       <LegacyLink className="p-link--soft" route={`/subnet/${subnet.id}`}>
         {subnet.cidr}
       </LegacyLink>
@@ -68,7 +68,7 @@ const SubnetColumn = ({ nic, systemId }: Props): JSX.Element | null => {
     <DoubleRow
       primary={primary}
       secondary={
-        showSubnetLinks ? (
+        showSubnetLinks && subnet ? (
           <LegacyLink className="p-link--muted" route={`/subnet/${subnet.id}`}>
             {subnet.name}
           </LegacyLink>

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -15,8 +15,16 @@ export type Vlan = Model & {
   name: string;
 };
 
+export enum NetworkLinkMode {
+  AUTO = "auto",
+  DHCP = "dhcp",
+  LINK_UP = "link_up",
+  STATIC = "static",
+}
+
 export type NetworkLink = Model & {
-  mode: "auto" | "dhcp" | "link_up" | "static";
+  ip_address?: string;
+  mode: NetworkLinkMode;
   subnet_id: Subnet["id"];
 };
 

--- a/ui/src/app/store/machine/utils/hooks.ts
+++ b/ui/src/app/store/machine/utils/hooks.ts
@@ -102,7 +102,7 @@ export const useHasInvalidArchitecture = (
 
 /**
  * Check if the networking information can be edited.
- * @return Wether networking is disabled.
+ * @return Whether networking is disabled.
  */
 export const useIsAllNetworkingDisabled = (
   machine?: Machine | null

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -11,6 +11,7 @@ export {
   getInterfaceMembers,
   getInterfaceNumaNodes,
   getInterfaceTypeText,
+  getLinkModeDisplay,
   isBootInterface,
   isInterfaceConnected,
 } from "./networking";

--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -2,11 +2,16 @@ import {
   getInterfaceMembers,
   getInterfaceNumaNodes,
   getInterfaceTypeText,
+  getLinkModeDisplay,
   isBootInterface,
   isInterfaceConnected,
 } from "./networking";
 
-import { BridgeType, NetworkInterfaceTypes } from "app/store/machine/types";
+import {
+  BridgeType,
+  NetworkInterfaceTypes,
+  NetworkLinkMode,
+} from "app/store/machine/types";
 import {
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
@@ -92,7 +97,7 @@ describe("machine networking utils", () => {
     });
   });
 
-  describe("getInterfaceTypeText", function () {
+  describe("getInterfaceTypeText", () => {
     it("returns the text for standard types", () => {
       const nic = machineInterfaceFactory({
         type: NetworkInterfaceTypes.VLAN,
@@ -194,6 +199,15 @@ describe("machine networking utils", () => {
         link_connected: false,
       });
       expect(isInterfaceConnected(nic)).toEqual(false);
+    });
+  });
+
+  describe("getLinkModeDisplay", () => {
+    it("maps the link modes to display text", () => {
+      expect(getLinkModeDisplay(NetworkLinkMode.AUTO)).toBe("Auto assign");
+      expect(getLinkModeDisplay(NetworkLinkMode.DHCP)).toBe("DHCP");
+      expect(getLinkModeDisplay(NetworkLinkMode.LINK_UP)).toBe("Unconfigured");
+      expect(getLinkModeDisplay(NetworkLinkMode.STATIC)).toBe("Static assign");
     });
   });
 });

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -1,17 +1,17 @@
-import type {
-  Machine,
-  NetworkInterface,
+import type { Machine, NetworkInterface } from "app/store/machine/types";
+import {
+  BridgeType,
+  NetworkInterfaceTypes,
   NetworkLinkMode,
 } from "app/store/machine/types";
-import { BridgeType, NetworkInterfaceTypes } from "app/store/machine/types";
 
 const INTERFACE_TYPE_DISPLAY = {
-  physical: "Physical",
-  bond: "Bond",
-  bridge: "Bridge",
-  vlan: "VLAN",
-  alias: "Alias",
-  ovs: "Open vSwitch",
+  [NetworkInterfaceTypes.PHYSICAL]: "Physical",
+  [NetworkInterfaceTypes.BOND]: "Bond",
+  [NetworkInterfaceTypes.BRIDGE]: "Bridge",
+  [NetworkInterfaceTypes.VLAN]: "VLAN",
+  [NetworkInterfaceTypes.ALIAS]: "Alias",
+  [BridgeType.OVS]: "Open vSwitch",
 };
 
 /**
@@ -136,10 +136,10 @@ export const isInterfaceConnected = (nic: NetworkInterface): boolean => {
 };
 
 const LINK_MODE_DISPLAY = {
-  auto: "Auto assign",
-  dhcp: "DHCP",
-  link_up: "Unconfigured",
-  static: "Static assign",
+  [NetworkLinkMode.AUTO]: "Auto assign",
+  [NetworkLinkMode.DHCP]: "DHCP",
+  [NetworkLinkMode.LINK_UP]: "Unconfigured",
+  [NetworkLinkMode.STATIC]: "Static assign",
 };
 
 /**

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -1,4 +1,8 @@
-import type { Machine, NetworkInterface } from "app/store/machine/types";
+import type {
+  Machine,
+  NetworkInterface,
+  NetworkLinkMode,
+} from "app/store/machine/types";
 import { BridgeType, NetworkInterfaceTypes } from "app/store/machine/types";
 
 const INTERFACE_TYPE_DISPLAY = {
@@ -130,3 +134,18 @@ export const isInterfaceConnected = (nic: NetworkInterface): boolean => {
   }
   return nic.link_connected;
 };
+
+const LINK_MODE_DISPLAY = {
+  auto: "Auto assign",
+  dhcp: "DHCP",
+  link_up: "Unconfigured",
+  static: "Static assign",
+};
+
+/**
+ * Get the text for the link mode of the interface.
+ * @param mode - A network link mode.
+ * @return The display text for a link mode.
+ */
+export const getLinkModeDisplay = (mode: NetworkLinkMode): string | null =>
+  LINK_MODE_DISPLAY[mode] || mode;

--- a/ui/src/app/store/scriptresult/selectors.test.tsx
+++ b/ui/src/app/store/scriptresult/selectors.test.tsx
@@ -124,6 +124,93 @@ describe("scriptResult selectors", () => {
     ).toStrictEqual(hardwareResultsForMachine);
   });
 
+  it("returns failed hardware testing script results by machine id", () => {
+    const items = [
+      scriptResultFactory({
+        id: 1,
+        hardware_type: HardwareType.CPU,
+        result_type: ResultType.Testing,
+        status: ResultStatus.FAILED,
+      }),
+      scriptResultFactory({
+        id: 2,
+        hardware_type: HardwareType.Network,
+        result_type: ResultType.Testing,
+      }),
+    ];
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        items,
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1, 2] },
+      }),
+    });
+    expect(
+      selectors.getHardwareTestingByMachineId(state, "abc123", true)
+    ).toStrictEqual([items[0]]);
+  });
+
+  it("returns network testing script results by machine id", () => {
+    const items = [
+      scriptResultFactory({
+        id: 1,
+        hardware_type: HardwareType.CPU,
+        result_type: ResultType.Testing,
+      }),
+      scriptResultFactory({
+        id: 2,
+        hardware_type: HardwareType.Network,
+        result_type: ResultType.Testing,
+      }),
+      scriptResultFactory({
+        id: 3,
+        hardware_type: HardwareType.Network,
+        result_type: ResultType.Testing,
+      }),
+    ];
+
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        items,
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1, 2] },
+      }),
+    });
+
+    expect(
+      selectors.getNetworkTestingByMachineId(state, "abc123")
+    ).toStrictEqual([items[1]]);
+  });
+
+  it("returns failed network testing script results by machine id", () => {
+    const items = [
+      scriptResultFactory({
+        id: 1,
+        hardware_type: HardwareType.Network,
+        result_type: ResultType.Testing,
+        status: ResultStatus.FAILED,
+      }),
+      scriptResultFactory({
+        id: 2,
+        hardware_type: HardwareType.Network,
+        result_type: ResultType.Testing,
+      }),
+    ];
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        items,
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1, 2] },
+      }),
+    });
+    expect(
+      selectors.getNetworkTestingByMachineId(state, "abc123", true)
+    ).toStrictEqual([items[0]]);
+  });
+
   it("returns storage testing script results by machine id", () => {
     const storageResultsForMachine = scriptResultFactory({
       id: 1,
@@ -158,6 +245,37 @@ describe("scriptResult selectors", () => {
     ).toStrictEqual([storageResultsForMachine]);
   });
 
+  it("returns failed storage testing script results by machine id", () => {
+    const items = [
+      scriptResultFactory({
+        id: 1,
+        hardware_type: HardwareType.Storage,
+        result_type: ResultType.Testing,
+        status: ResultStatus.FAILED,
+      }),
+      scriptResultFactory({
+        id: 2,
+        hardware_type: HardwareType.Storage,
+        result_type: ResultType.Testing,
+      }),
+      scriptResultFactory({
+        id: 3,
+        result_type: ResultType.Commissioning,
+      }),
+    ];
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        items,
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1, 2, 3] },
+      }),
+    });
+    expect(
+      selectors.getStorageTestingByMachineId(state, "abc123", true)
+    ).toStrictEqual([items[0]]);
+  });
+
   it("returns other testing script results by machine id", () => {
     const otherResultsForMachine = scriptResultFactory({
       id: 1,
@@ -190,6 +308,37 @@ describe("scriptResult selectors", () => {
     expect(
       selectors.getOtherTestingByMachineId(state, "abc123")
     ).toStrictEqual([otherResultsForMachine]);
+  });
+
+  it("returns other failed testing script results by machine id", () => {
+    const items = [
+      scriptResultFactory({
+        id: 1,
+        hardware_type: HardwareType.Node,
+        result_type: ResultType.Testing,
+        status: ResultStatus.FAILED,
+      }),
+      scriptResultFactory({
+        id: 2,
+        hardware_type: HardwareType.Node,
+        result_type: ResultType.Testing,
+      }),
+      scriptResultFactory({
+        id: 3,
+        result_type: ResultType.Commissioning,
+      }),
+    ];
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        items,
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1, 2, 3] },
+      }),
+    });
+    expect(
+      selectors.getOtherTestingByMachineId(state, "abc123", true)
+    ).toStrictEqual([items[0]]);
   });
 
   it("returns failed testing script results for machine ids", () => {

--- a/ui/src/app/store/scriptresult/selectors.ts
+++ b/ui/src/app/store/scriptresult/selectors.ts
@@ -123,7 +123,7 @@ const getHardwareTestingByMachineId = createSelector(
     (
       _: RootState,
       machineId: Machine["system_id"] | null | undefined,
-      failed: boolean
+      failed?: boolean
     ) => ({
       failed,
       machineId,
@@ -158,7 +158,7 @@ const getNetworkTestingByMachineId = createSelector(
     (
       _: RootState,
       machineId: Machine["system_id"] | null | undefined,
-      failed: boolean
+      failed?: boolean
     ) => ({
       failed,
       machineId,
@@ -193,7 +193,7 @@ const getStorageTestingByMachineId = createSelector(
     (
       _: RootState,
       machineId: Machine["system_id"] | null | undefined,
-      failed: boolean
+      failed?: boolean
     ) => ({
       failed,
       machineId,
@@ -228,7 +228,7 @@ const getOtherTestingByMachineId = createSelector(
     (
       _: RootState,
       machineId: Machine["system_id"] | null | undefined,
-      failed: boolean
+      failed?: boolean
     ) => ({
       failed,
       machineId,

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -1,5 +1,6 @@
 import type { NetworkInterface } from "../machine/types";
 
+import type { HardwareType, ResultType } from "app/base/enum";
 import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
@@ -43,12 +44,12 @@ export type ScriptResult = Model & {
   endtime: number;
   estimated_runtime: string;
   exit_status?: ExitStatus | number | null;
-  hardware_type: 0 | 1 | 2 | 3 | 4;
+  hardware_type: HardwareType;
   interface?: NetworkInterface | null;
   name: string;
   parameters?: Record<string, unknown>;
   physical_blockdevice?: number | null;
-  result_type: 0 | 1 | 2;
+  result_type: ResultType;
   results: ScriptResultResult[];
   runtime: string;
   script?: number;

--- a/ui/src/app/store/utils/selectors.ts
+++ b/ui/src/app/store/utils/selectors.ts
@@ -101,7 +101,8 @@ export const generateBaseSelectors = <
   const getById = createSelector(
     [all, (_state: RootState, id: I[K] | null | undefined = null) => id],
     (items, id) => {
-      if (!id) {
+      // `0` is a valid id for some models (e.g. fabric) so do a strict check.
+      if (id === null || id === undefined) {
         return null;
       }
       return (items as Array<I>).find((item) => item[indexKey] === id) || null;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -18,7 +18,11 @@ import type {
   NetworkLink,
   Partition,
 } from "app/store/machine/types";
-import { DiskTypes, NetworkInterfaceTypes } from "app/store/machine/types";
+import {
+  DiskTypes,
+  NetworkLinkMode,
+  NetworkInterfaceTypes,
+} from "app/store/machine/types";
 import type {
   Pod,
   PodDetails,
@@ -201,7 +205,7 @@ export const machineDisk = extend<Model, Disk>(model, {
 });
 
 export const networkLink = extend<Model, NetworkLink>(model, {
-  mode: "auto",
+  mode: NetworkLinkMode.AUTO,
   subnet_id: random,
 });
 


### PR DESCRIPTION
## Done

- Add the column to display the ip and status to the network tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the network tab in machine details.
- You should see ip/status data that matches the legacy network table.

## Fixes

Fixes: #1957.