### PR TITLE
feat(ui): add the DHCP column to the machine network tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCardTable/NetworkCardTable.test.tsx
@@ -103,7 +103,8 @@ describe("NetworkCardInterface", () => {
     it("can show DHCP relay information with a tooltip", () => {
       state.fabric.items = [fabricFactory({ id: 1, name: "fabrice" })];
       state.vlan.items = [
-        vlanFactory({ fabric: 1, id: 2, name: "flan-vlan", relay_vlan: 3 }),
+        vlanFactory({ id: 2, name: "flan-vlan", relay_vlan: 3 }),
+        vlanFactory({ fabric: 1, id: 3, vid: 99, name: "" }),
       ];
       const store = mockStore(state);
       const iface = machineInterfaceFactory({ vlan_id: 2 });
@@ -121,7 +122,7 @@ describe("NetworkCardInterface", () => {
 
       expect(wrapper.find("TableCell.dhcp").text()).toBe("Relayed");
       expect(wrapper.find("TableCell.dhcp Tooltip").prop("message")).toBe(
-        "Relayed via fabrice.flan-vlan"
+        "Relayed via fabrice.99"
       );
     });
 

--- a/ui/src/app/store/fabric/utils.test.ts
+++ b/ui/src/app/store/fabric/utils.test.ts
@@ -1,0 +1,21 @@
+import { getFabricDisplay } from "./utils";
+
+import { fabric as fabricFactory } from "testing/factories";
+
+describe("fabric utils", () => {
+  describe("getFabricDisplay", function () {
+    it("returns undefined if no object is passed in", function () {
+      expect(getFabricDisplay(null)).toBe(null);
+    });
+
+    it("returns name if name exists", function () {
+      const fabric = fabricFactory({ name: "fabric-name" });
+      expect(getFabricDisplay(fabric)).toBe("fabric-name");
+    });
+
+    it("returns name if name is null", function () {
+      const fabric = fabricFactory({ id: 99, name: "" });
+      expect(getFabricDisplay(fabric)).toBe("fabric-99");
+    });
+  });
+});

--- a/ui/src/app/store/fabric/utils.ts
+++ b/ui/src/app/store/fabric/utils.ts
@@ -1,0 +1,19 @@
+import type { Fabric } from "app/store/fabric/types";
+
+/**
+ * Get the Fabric display text.
+ * @param vlan - A VLAN.
+ * @return The VLAN display text.
+ */
+export const getFabricDisplay = (
+  fabric: Fabric | null | undefined
+): string | null => {
+  if (!fabric) {
+    return null;
+  }
+  if (fabric.name) {
+    return fabric.name;
+  } else {
+    return `fabric-${fabric.id}`;
+  }
+};

--- a/ui/src/app/store/vlan/utils.test.ts
+++ b/ui/src/app/store/vlan/utils.test.ts
@@ -1,7 +1,10 @@
-import { getVLANDisplay } from "./utils";
+import { getDHCPStatus, getFullVLANName, getVLANDisplay } from "./utils";
 
 import { VlanVid } from "app/store/vlan/types";
-import { vlan as vlanFactory } from "testing/factories";
+import {
+  fabric as fabricFactory,
+  vlan as vlanFactory,
+} from "testing/factories";
 
 describe("vlan utils", () => {
   describe("getVLANDisplay", () => {
@@ -22,6 +25,70 @@ describe("vlan utils", () => {
     it("returns vid + name", () => {
       const vlan = vlanFactory({ vid: 5, name: "vlan-name" });
       expect(getVLANDisplay(vlan)).toBe("5 (vlan-name)");
+    });
+  });
+
+  describe("getFullVLANName", () => {
+    it("generates a full name for a vlan", () => {
+      const fabrics = [fabricFactory({ id: 99, name: "fabric-name" })];
+      const vlan = vlanFactory({ fabric: 99, name: "vlan-name", vid: 101 });
+      expect(getFullVLANName(vlan.id, [vlan], fabrics)).toBe(
+        "fabric-name.101 (vlan-name)"
+      );
+    });
+
+    it("handles a vlan that is not found", () => {
+      const fabrics = [fabricFactory({ id: 99, name: "fabric-name" })];
+      const vlan = vlanFactory({
+        id: 10,
+        fabric: 99,
+        name: "vlan-name",
+        vid: 101,
+      });
+      expect(getFullVLANName(11, [vlan], fabrics)).toBe(null);
+    });
+
+    it("handles a fabric that is not found", () => {
+      const fabrics = [fabricFactory({ id: 100, name: "fabric-name" })];
+      const vlan = vlanFactory({ fabric: 99, name: "vlan-name", vid: 101 });
+      expect(getFullVLANName(vlan.id, [vlan], fabrics)).toBe(null);
+    });
+  });
+
+  describe("getDHCPStatus", () => {
+    it("returns correct text if dhcp is provided by MAAS", () => {
+      const vlan = vlanFactory({ external_dhcp: null, dhcp_on: true });
+      expect(getDHCPStatus(vlan, [], [])).toEqual("MAAS-provided");
+    });
+
+    it("returns correct text if dhcp is provided externally", () => {
+      const vlan = vlanFactory({ external_dhcp: "127.0.0.1", dhcp_on: true });
+      expect(getDHCPStatus(vlan, [], [])).toEqual("External (127.0.0.1)");
+    });
+
+    it("returns correct text if dhcp is disabled", () => {
+      const vlan = vlanFactory({ external_dhcp: null, dhcp_on: false });
+      expect(getDHCPStatus(vlan, [], [])).toEqual("No DHCP");
+    });
+
+    it("returns correct text if vlan is null", () => {
+      expect(getDHCPStatus(null, [], [])).toEqual("No DHCP");
+    });
+
+    it("returns correct text if DHCP is relayed", () => {
+      const vlan = vlanFactory({ fabric: 1, relay_vlan: 5001 });
+      expect(getDHCPStatus(vlan, [], [])).toEqual("Relayed");
+    });
+
+    it("returns correct text if DHCP is relayed and full name required", () => {
+      const fabrics = [fabricFactory({ id: 1, name: "fabric-1" })];
+      const vlans = [
+        vlanFactory({ id: 2, relay_vlan: 3, vid: 99 }),
+        vlanFactory({ fabric: 1, id: 3, vid: 101 }),
+      ];
+      expect(getDHCPStatus(vlans[0], vlans, fabrics, true)).toEqual(
+        "Relayed via fabric-1.101 (test-vlan)"
+      );
     });
   });
 });

--- a/ui/src/app/store/vlan/utils.ts
+++ b/ui/src/app/store/vlan/utils.ts
@@ -1,3 +1,5 @@
+import type { Fabric } from "app/store/fabric/types";
+import { getFabricDisplay } from "app/store/fabric/utils";
 import type { VLAN } from "app/store/vlan/types";
 import { VlanVid } from "app/store/vlan/types";
 
@@ -6,7 +8,9 @@ import { VlanVid } from "app/store/vlan/types";
  * @param vlan - A VLAN.
  * @return The VLAN display text.
  */
-export const getVLANDisplay = (vlan: VLAN | null): string | null => {
+export const getVLANDisplay = (
+  vlan: VLAN | null | undefined
+): string | null => {
   if (!vlan) {
     return null;
   }
@@ -17,4 +21,52 @@ export const getVLANDisplay = (vlan: VLAN | null): string | null => {
   } else {
     return vlan.vid.toString();
   }
+};
+
+/**
+ * Get the text full name for a VLAN.
+ * @param vlanId - A VLAN's id.
+ * @return A VLAN's full name.
+ */
+export const getFullVLANName = (
+  vlanId: VLAN["id"],
+  vlans: VLAN[],
+  fabrics: Fabric[]
+): string | null => {
+  const vlan = vlans.find(({ id }) => id === vlanId);
+  if (!vlan) {
+    return null;
+  }
+  const fabric = fabrics.find(({ id }) => id === vlan.fabric);
+  if (!fabric) {
+    return null;
+  }
+  return `${getFabricDisplay(fabric)}.${getVLANDisplay(vlan)}`;
+};
+
+/**
+ * Get the text for the link mode of the interface.
+ * @param nic - A network interface.
+ * @return The display text for a link mode.
+ */
+export const getDHCPStatus = (
+  vlan: VLAN | null | undefined,
+  vlans: VLAN[],
+  fabrics: Fabric[],
+  fullName = false
+): string => {
+  if (vlan?.external_dhcp) {
+    return `External (${vlan.external_dhcp})`;
+  }
+  if (vlan?.dhcp_on) {
+    return "MAAS-provided";
+  }
+  if (vlan?.relay_vlan) {
+    if (fullName) {
+      return `Relayed via ${getFullVLANName(vlan.relay_vlan, vlans, fabrics)}`;
+    } else {
+      return "Relayed";
+    }
+  }
+  return "No DHCP";
 };

--- a/ui/src/app/store/vlan/utils.ts
+++ b/ui/src/app/store/vlan/utils.ts
@@ -26,6 +26,8 @@ export const getVLANDisplay = (
 /**
  * Get the text full name for a VLAN.
  * @param vlanId - A VLAN's id.
+ * @param vlans - The available vlans.
+ * @param fabrics - The available fabrics.
  * @return A VLAN's full name.
  */
 export const getFullVLANName = (
@@ -46,14 +48,17 @@ export const getFullVLANName = (
 
 /**
  * Get the text for the link mode of the interface.
- * @param nic - A network interface.
+ * @param vlan - A VLAN.
+ * @param vlans - The available vlans.
+ * @param fabrics - The available fabrics.
+ * @param showVLANName - Whether to show the relayed VLAN's name.
  * @return The display text for a link mode.
  */
 export const getDHCPStatus = (
   vlan: VLAN | null | undefined,
   vlans: VLAN[],
   fabrics: Fabric[],
-  fullName = false
+  showVLANName = false
 ): string => {
   if (vlan?.external_dhcp) {
     return `External (${vlan.external_dhcp})`;
@@ -62,7 +67,7 @@ export const getDHCPStatus = (
     return "MAAS-provided";
   }
   if (vlan?.relay_vlan) {
-    if (fullName) {
+    if (showVLANName) {
       return `Relayed via ${getFullVLANName(vlan.relay_vlan, vlans, fabrics)}`;
     } else {
       return "Relayed";


### PR DESCRIPTION
## Done

- Add the DHCP details to the network table in machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the network tab in machine details for a few machines.
- You should see the DHCP column and the data should be the same as legacy.

## Fixes

Fixes: #1958.