### PR TITLE
feat(ui): build PCI and USB devices tabs

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -7,12 +7,14 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import MachineHeader from "./MachineHeader";
 import MachineNetwork from "./MachineNetwork";
 import NetworkNotifications from "./MachineNetwork/NetworkNotifications";
+import MachinePCIDevices from "./MachinePCIDevices";
 import MachineStorage from "./MachineStorage";
 import StorageNotifications from "./MachineStorage/StorageNotifications";
 import type { SelectedAction } from "./MachineSummary";
 import MachineSummary from "./MachineSummary";
 import SummaryNotifications from "./MachineSummary/SummaryNotifications";
 import MachineTests from "./MachineTests";
+import MachineUSBDevices from "./MachineUSBDevices";
 
 import Section from "app/base/components/Section";
 import type { RouteParams } from "app/base/types";
@@ -73,6 +75,12 @@ const MachineDetails = (): JSX.Element => {
           <Route exact path="/machine/:id/storage">
             <StorageNotifications id={id} />
             <MachineStorage />
+          </Route>
+          <Route exact path="/machine/:id/pci-devices">
+            <MachinePCIDevices />
+          </Route>
+          <Route exact path="/machine/:id/usb-devices">
+            <MachineUSBDevices />
           </Route>
           <Route exact path="/machine/:id/tests">
             <MachineTests />

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -157,6 +157,18 @@ const MachineHeader = ({
           to: `${urlBase}/storage`,
         },
         {
+          active: pathname.startsWith(`${urlBase}/pci-devices`),
+          component: Link,
+          label: "PCI devices",
+          to: `${urlBase}/pci-devices`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/usb-devices`),
+          component: Link,
+          label: "USB",
+          to: `${urlBase}/usb-devices`,
+        },
+        {
           active: pathname.startsWith(`${urlBase}/commissioning`),
           component: Link,
           label: "Commissioning",

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
@@ -1,0 +1,39 @@
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import { useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
+import machineSelectors from "app/store/machine/selectors";
+import type { RootState } from "app/store/root/types";
+
+const MachinePCIDevices = (): JSX.Element => {
+  const params = useParams<RouteParams>();
+  const { id } = params;
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+
+  useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} PCI devices`);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>
+            <div>Vendor</div>
+            <div>ID</div>
+          </th>
+          <th>Product</th>
+          <th>Product ID</th>
+          <th>Driver</th>
+          <th className="u-align--right">NUMA node</th>
+          <th className="u-align--right">PCI address</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  );
+};
+
+export default MachinePCIDevices;

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachinePCIDevices";

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
@@ -1,0 +1,40 @@
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import { useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
+import machineSelectors from "app/store/machine/selectors";
+import type { RootState } from "app/store/root/types";
+
+const MachineUSBDevices = (): JSX.Element => {
+  const params = useParams<RouteParams>();
+  const { id } = params;
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+
+  useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} USB devices`);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>
+            <div>Vendor</div>
+            <div>ID</div>
+          </th>
+          <th>Product</th>
+          <th>Product ID</th>
+          <th>Driver</th>
+          <th className="u-align--right">NUMA node</th>
+          <th className="u-align--right">Bus address</th>
+          <th className="u-align--right">Device address</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  );
+};
+
+export default MachineUSBDevices;

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineUSBDevices";


### PR DESCRIPTION
## Done

- Added "PCI devices" and "USB" tabs to machine summary

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine details page of a machine
- Check there are tabs for "PCI devices" and "USB"
- Check that the URL updates correctly when navigating to them

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2296
