### PR TITLE
feat(shared): build StatusBar component

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -9,6 +9,7 @@ import {
   Header,
   navigateToLegacy,
   navigateToNew,
+  StatusBar,
 } from "@maas-ui/maas-ui-shared";
 
 /* @ngInject */
@@ -104,10 +105,22 @@ function MasterController(
     );
   };
 
+  const renderStatusBar = () => {
+    const statusBarNode = document.querySelector("#status-bar");
+    if (!statusBarNode) {
+      return;
+    }
+    ReactDOM.render(
+      <StatusBar version={$window.CONFIG.version} />,
+      statusBarNode
+    );
+  };
+
   const displayTemplate = () => {
     $rootScope.site = window.CONFIG.maas_name;
     renderHeader();
     renderFooter();
+    renderStatusBar();
   };
 
   $transitions.onStart({}, () => {

--- a/legacy/src/app/partials/layout.html
+++ b/legacy/src/app/partials/layout.html
@@ -49,4 +49,5 @@
     <div class="push"></div>
   </main>
   <div id="footer"></div>
+  <div id="status-bar"></div>
 </div>

--- a/legacy/src/scss/_patterns_status-bar.scss
+++ b/legacy/src/scss/_patterns_status-bar.scss
@@ -1,0 +1,14 @@
+@mixin maas-status-bar {
+  #status-bar {
+    bottom: 0;
+    left: 0;
+    position: sticky;
+    right: 0;
+    z-index: 1;
+  }
+
+  .p-status-bar {
+    background-color: $color-mid-x-light;
+    padding: $spv-inner--small 0;
+  }
+}

--- a/legacy/src/scss/build.scss
+++ b/legacy/src/scss/build.scss
@@ -46,6 +46,7 @@
 @import "patterns_space-between";
 @import "patterns_filter";
 @import "patterns_slider";
+@import "patterns_status-bar";
 
 // Include local patterns
 @include maas;
@@ -71,4 +72,5 @@
 @include maas-p-search-box;
 @include maas-p-sticky-footer;
 @include maas-p-filter;
+@include maas-status-bar;
 @include patterns_space-between;

--- a/shared/src/components/StatusBar/StatusBar.test.tsx
+++ b/shared/src/components/StatusBar/StatusBar.test.tsx
@@ -1,0 +1,13 @@
+import { shallow } from "enzyme";
+import React from "react";
+
+import StatusBar from "./StatusBar";
+
+describe("StatusBar", () => {
+  it("shows the MAAS major and minor version", () => {
+    const wrapper = shallow(<StatusBar version="2.7.5" />);
+    expect(wrapper.find("[data-test='status-bar-version']").text()).toBe(
+      "MAAS v2.7"
+    );
+  });
+});

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,31 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+type Props = {
+  version: string;
+};
+
+export const StatusBar = ({ version }: Props): JSX.Element => {
+  const splitVersion = version.split(".");
+  const major = splitVersion[0];
+  const minor = splitVersion[1] || "";
+
+  return (
+    <div className="p-status-bar">
+      <div className="row">
+        <div className="col-12">
+          <span data-test="status-bar-version">
+            MAAS v{major}
+            {minor ? `.${minor}` : ""}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+StatusBar.propTypes = {
+  version: PropTypes.string.isRequired,
+};
+
+export default StatusBar;

--- a/shared/src/components/StatusBar/index.ts
+++ b/shared/src/components/StatusBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StatusBar";

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,6 @@
 export { default as Header } from "./components/Header";
 export { default as Footer } from "./components/Footer";
+export { default as StatusBar } from "./components/StatusBar";
 export {
   BASENAME,
   extractPowerType,

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -7,6 +7,7 @@ import {
   generateLegacyURL,
   Header,
   navigateToLegacy,
+  StatusBar,
 } from "@maas-ui/maas-ui-shared";
 import * as Sentry from "@sentry/browser";
 import { useDispatch, useSelector } from "react-redux";
@@ -201,6 +202,7 @@ export const App = (): JSX.Element => {
           version={version}
         />
       )}
+      {version && <StatusBar version={version} />}
     </div>
   );
 };

--- a/ui/src/scss/_patterns_status-bar.scss
+++ b/ui/src/scss/_patterns_status-bar.scss
@@ -1,0 +1,11 @@
+@mixin maas-status-bar {
+  .p-status-bar {
+    background-color: $color-mid-x-light;
+    bottom: 0;
+    left: 0;
+    padding: $spv-inner--small 0;
+    position: sticky;
+    right: 0;
+    z-index: 1;
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -32,6 +32,7 @@
 @import "./patterns_lists";
 @import "./patterns_navigation";
 @import "./patterns_notifications";
+@import "./patterns_status-bar";
 @import "./patterns_switches";
 @import "./patterns_table-actions";
 @import "./patterns_tables";
@@ -50,6 +51,7 @@
 @include maas-lists;
 @include maas-navigation;
 @include maas-notifications;
+@include maas-status-bar;
 @include maas-switches;
 @include maas-table-actions;
 @include maas-tables;


### PR DESCRIPTION
## Done

- Built StatusBar component, which at the moment only displays the MAAS major+minor version

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to some legacy and react pages and check that there is a status bar at the bottom of the page that shows the MAAS version
- Check that it matches the [design](https://app.zeplin.io/project/5f9af2ae43654ab5edbcfd29/screen/5fd0a9eee9fc0650e2ecbf94)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2301
