### PR TITLE
feat(ui): add action menu to the network tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -5,6 +5,7 @@ import { Icon, MainTable, Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import IPColumn from "./IPColumn";
+import NetworkTableActions from "./NetworkTableActions";
 import SubnetColumn from "./SubnetColumn";
 
 import DoubleRow from "app/base/components/DoubleRow";
@@ -201,6 +202,12 @@ const generateRows = (
                 primary={getDHCPStatus(vlan, vlans, fabrics)}
               />
             ) : null,
+        },
+        {
+          className: "u-align--right",
+          content: (
+            <NetworkTableActions nic={nic} systemId={machine.system_id} />
+          ),
         },
       ],
       key: nic.id,

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -1,0 +1,61 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import NetworkTableActions from "./NetworkTableActions";
+
+import type { NetworkInterface } from "app/store/machine/types";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import { NodeStatus } from "app/store/types/node";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineInterface as machineInterfaceFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NetworkTableActions", () => {
+  let nic: NetworkInterface;
+  let state: RootState;
+  beforeEach(() => {
+    nic = machineInterfaceFactory();
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            interfaces: [nic],
+            system_id: "abc123",
+          }),
+        ],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("can display the menu", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("TableMenu").exists()).toBe(true);
+    expect(wrapper.find("TableMenu").prop("disabled")).toBe(false);
+  });
+
+  it("disables menu when networking is disabled and limited editing is not allowed", () => {
+    state.machine.items[0].permissions = [];
+    state.machine.items[0].status = NodeStatus.NEW;
+    nic.type = NetworkInterfaceTypes.VLAN;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("TableMenu").prop("disabled")).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -1,0 +1,64 @@
+import { useSelector } from "react-redux";
+
+import TableMenu from "app/base/components/TableMenu";
+import machineSelectors from "app/store/machine/selectors";
+import type { NetworkInterface, Machine } from "app/store/machine/types";
+import {
+  getInterfaceTypeText,
+  useIsAllNetworkingDisabled,
+  useIsLimitedEditingAllowed,
+} from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+
+type Props = { nic: NetworkInterface; systemId: Machine["system_id"] };
+
+const NetworkTableActions = ({ nic, systemId }: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
+  const isLimitedEditingAllowed = useIsLimitedEditingAllowed(nic, machine);
+  // Placeholders for hook results that are not yet implemented.
+  const canAddAliasOrVLAN = true;
+  const canBeRemoved = true;
+  const canMarkAsConnected = true;
+  const canMarkAsDisconnected = true;
+  const cannotEditInterface = false;
+  const actions = [
+    ...(canMarkAsConnected && [
+      {
+        children: "Mark as connected",
+      },
+    ]),
+    ...(canMarkAsDisconnected && [
+      {
+        children: "Mark as disconnected",
+      },
+    ]),
+    ...(canAddAliasOrVLAN && [
+      {
+        children: "Add alias or VLAN",
+      },
+    ]),
+    ...(!cannotEditInterface && [
+      {
+        children: `Edit ${getInterfaceTypeText(nic)}`,
+      },
+    ]),
+    ...(canBeRemoved && [
+      {
+        children: `Remove ${getInterfaceTypeText(nic)}...`,
+      },
+    ]),
+  ];
+  return (
+    <TableMenu
+      disabled={isAllNetworkingDisabled && !isLimitedEditingAllowed}
+      links={[actions]}
+      position="right"
+      title="Take action:"
+    />
+  );
+};
+
+export default NetworkTableActions;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NetworkTableActions";

--- a/ui/src/app/store/machine/utils/hooks.ts
+++ b/ui/src/app/store/machine/utils/hooks.ts
@@ -6,7 +6,8 @@ import { isMachineStorageConfigurable } from "./storage";
 
 import { general as generalActions } from "app/base/actions";
 import generalSelectors from "app/store/general/selectors";
-import type { Machine } from "app/store/machine/types";
+import type { Machine, NetworkInterface } from "app/store/machine/types";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import type { Host } from "app/store/types/host";
 import { NodeStatus } from "app/store/types/node";
@@ -135,4 +136,25 @@ export const useIsRackControllerConnected = (): boolean => {
 
   // If power types exist then a rack controller is connected.
   return powerTypes.length > 0;
+};
+
+/**
+ * Check if only the name or mac address of an interface can
+ * be edited.
+ * @param nic - A network interface.
+ * @param machine - A machine.
+ * @return Whether limited editing is allowed.
+ */
+export const useIsLimitedEditingAllowed = (
+  nic: NetworkInterface | null,
+  machine: Machine | null
+): boolean => {
+  const canEdit = useCanEdit(machine);
+  if (!canEdit) {
+    return false;
+  }
+  return (
+    machine?.status === NodeStatus.DEPLOYED &&
+    nic?.type !== NetworkInterfaceTypes.VLAN
+  );
 };

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -4,6 +4,7 @@ export {
   useFormattedOS,
   useHasInvalidArchitecture,
   useIsAllNetworkingDisabled,
+  useIsLimitedEditingAllowed,
   useIsRackControllerConnected,
 } from "./hooks";
 


### PR DESCRIPTION
## Done

- Add an action menu to the network table in machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the network tab in machine details for a deployed machine.
- You should see an active action menu.
- Visit the network tab in machine details for a failed machine.
- You should see a disabled action menu.

## Fixes

Fixes: #2016.