### PR TITLE
feat(ui): move MAAS name and version from footer to status bar

### DIFF
--- a/legacy/src/app/controllers/master.js
+++ b/legacy/src/app/controllers/master.js
@@ -98,7 +98,6 @@ function MasterController(
       <Footer
         debug={debug}
         enableAnalytics={$window.CONFIG.enable_analytics}
-        maasName={$window.CONFIG.maas_name}
         version={$window.CONFIG.version}
       />,
       footerNode
@@ -111,7 +110,10 @@ function MasterController(
       return;
     }
     ReactDOM.render(
-      <StatusBar version={$window.CONFIG.version} />,
+      <StatusBar
+        maasName={$window.CONFIG.maas_name}
+        version={$window.CONFIG.version}
+      />,
       statusBarNode
     );
   };

--- a/shared/src/components/Footer/Footer.test.tsx
+++ b/shared/src/components/Footer/Footer.test.tsx
@@ -14,18 +14,13 @@ describe("Footer", () => {
   });
 
   it("renders", () => {
-    const wrapper = shallow(<Footer maasName="koala-maas" version="2.7.0" />);
+    const wrapper = shallow(<Footer version="2.7.0" />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it("displays the feedback link when analytics enabled", () => {
     const wrapper = shallow(
-      <Footer
-        maasName="koala-maas"
-        version="2.7.0"
-        debug={false}
-        enableAnalytics={true}
-      />
+      <Footer debug={false} enableAnalytics={true} version="2.7.0" />
     );
     expect(
       wrapper
@@ -38,12 +33,7 @@ describe("Footer", () => {
 
   it("hides the feedback link when analytics disabled", () => {
     const wrapper = shallow(
-      <Footer
-        maasName="koala-maas"
-        version="2.7.0"
-        debug={false}
-        enableAnalytics={false}
-      />
+      <Footer debug={false} enableAnalytics={false} version="2.7.0" />
     );
     expect(
       wrapper
@@ -56,12 +46,7 @@ describe("Footer", () => {
 
   it("hides the feedback link in debug mode", () => {
     const wrapper = shallow(
-      <Footer
-        maasName="koala-maas"
-        version="2.7.0"
-        debug={true}
-        enableAnalytics={true}
-      />
+      <Footer debug={true} enableAnalytics={true} version="2.7.0" />
     );
     expect(
       wrapper

--- a/shared/src/components/Footer/Footer.tsx
+++ b/shared/src/components/Footer/Footer.tsx
@@ -14,16 +14,14 @@ declare global {
 }
 
 type Props = {
-  enableAnalytics?: boolean;
   debug?: boolean;
-  maasName: string;
+  enableAnalytics?: boolean;
   version: string;
 };
 
 export const Footer = ({
-  enableAnalytics,
   debug,
-  maasName,
+  enableAnalytics,
   version,
 }: Props): JSX.Element => {
   useEffect(() => {
@@ -45,18 +43,6 @@ export const Footer = ({
     <footer className="p-strip--light is-shallow p-footer">
       <div className="row">
         <div className="col-10 p-footer__nav">
-          <ul className="p-list">
-            <li>
-              <small>
-                MAAS name: <strong>{maasName} MAAS</strong>
-              </small>
-            </li>
-            <li>
-              <small>
-                MAAS version: <strong>{version}</strong>
-              </small>
-            </li>
-          </ul>
           <ul className="p-inline-list--middot">
             <li className="p-inline-list__item">
               <a
@@ -113,7 +99,8 @@ export const Footer = ({
 };
 
 Footer.propTypes = {
-  maasName: PropTypes.string.isRequired,
+  debug: PropTypes.bool,
+  enableAnalytics: PropTypes.bool,
   version: PropTypes.string.isRequired,
 };
 

--- a/shared/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/shared/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -11,27 +11,6 @@ exports[`Footer renders 1`] = `
       className="col-10 p-footer__nav"
     >
       <ul
-        className="p-list"
-      >
-        <li>
-          <small>
-            MAAS name: 
-            <strong>
-              koala-maas
-               MAAS
-            </strong>
-          </small>
-        </li>
-        <li>
-          <small>
-            MAAS version: 
-            <strong>
-              2.7.0
-            </strong>
-          </small>
-        </li>
-      </ul>
-      <ul
         className="p-inline-list--middot"
       >
         <li

--- a/shared/src/components/StatusBar/StatusBar.test.tsx
+++ b/shared/src/components/StatusBar/StatusBar.test.tsx
@@ -4,10 +4,17 @@ import React from "react";
 import StatusBar from "./StatusBar";
 
 describe("StatusBar", () => {
-  it("shows the MAAS major and minor version", () => {
-    const wrapper = shallow(<StatusBar version="2.7.5" />);
+  it("shows the MAAS name", () => {
+    const wrapper = shallow(<StatusBar maasName="foo" version="2.7.5" />);
+    expect(wrapper.find("[data-test='status-bar-maas-name']").text()).toBe(
+      "foo MAAS"
+    );
+  });
+
+  it("shows the MAAS version", () => {
+    const wrapper = shallow(<StatusBar maasName="foo" version="2.7.5" />);
     expect(wrapper.find("[data-test='status-bar-version']").text()).toBe(
-      "MAAS v2.7"
+      "2.7.5"
     );
   });
 });

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -2,22 +2,17 @@ import PropTypes from "prop-types";
 import React from "react";
 
 type Props = {
+  maasName: string;
   version: string;
 };
 
-export const StatusBar = ({ version }: Props): JSX.Element => {
-  const splitVersion = version.split(".");
-  const major = splitVersion[0];
-  const minor = splitVersion[1] || "";
-
+export const StatusBar = ({ maasName, version }: Props): JSX.Element => {
   return (
     <div className="p-status-bar">
       <div className="row">
         <div className="col-12">
-          <span data-test="status-bar-version">
-            MAAS v{major}
-            {minor ? `.${minor}` : ""}
-          </span>
+          <span data-test="status-bar-maas-name">{maasName} MAAS</span>:{" "}
+          <span data-test="status-bar-version">{version}</span>
         </div>
       </div>
     </div>
@@ -25,6 +20,7 @@ export const StatusBar = ({ version }: Props): JSX.Element => {
 };
 
 StatusBar.propTypes = {
+  maasName: PropTypes.string.isRequired,
   version: PropTypes.string.isRequired,
 };
 

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -198,11 +198,10 @@ export const App = (): JSX.Element => {
         <Footer
           debug={debug}
           enableAnalytics={analyticsEnabled as boolean}
-          maasName={maasName as string}
           version={version}
         />
       )}
-      {version && <StatusBar version={version} />}
+      {version && <StatusBar maasName={maasName as string} version={version} />}
     </div>
   );
 };


### PR DESCRIPTION
## Done

- Moved MAAS name and version from footer to status bar

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the status bar shows the MAAS name and full version in both legacy and react apps
- Check that the footer does not show the MAAS name or version

## Fixes

Fixes #2028 

