### PR TITLE
fix(ui): only render status bar if required props have loaded

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -194,14 +194,16 @@ export const App = (): JSX.Element => {
         version={version}
       />
       {content}
-      {maasName && version && (
+      {version && (
         <Footer
           debug={debug}
           enableAnalytics={analyticsEnabled as boolean}
           version={version}
         />
       )}
-      {version && <StatusBar maasName={maasName as string} version={version} />}
+      {maasName && version && (
+        <StatusBar maasName={maasName as string} version={version} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Done

- Only render status bar if required props have loaded

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to any react page and check that there is no error in the console about `maasName` being required but undefined.
