### PR TITLE
feat(ui): add member interface rows

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -277,4 +277,121 @@ describe("NetworkTable", () => {
       true
     );
   });
+
+  it("can display a boot icon", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            is_boot: true,
+            type: NetworkInterfaceTypes.PHYSICAL,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("Icon[name='success']").exists()).toBe(true);
+  });
+
+  describe("member interfaces", () => {
+    beforeEach(() => {
+      state.machine.items = [
+        machineDetailsFactory({
+          interfaces: [
+            machineInterfaceFactory({
+              id: 100,
+              is_boot: false,
+              parents: [101],
+              type: NetworkInterfaceTypes.BOND,
+            }),
+            machineInterfaceFactory({
+              id: 101,
+              children: [100],
+              is_boot: true,
+              type: NetworkInterfaceTypes.PHYSICAL,
+            }),
+          ],
+          system_id: "abc123",
+        }),
+      ];
+    });
+
+    it("does not display a boot icon for member interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable systemId="abc123" />
+        </Provider>
+      );
+      expect(wrapper.find("Icon[name='success']").length).toBe(1);
+    });
+
+    it("display the full type for member interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable systemId="abc123" />
+        </Provider>
+      );
+      expect(
+        wrapper.find("DoubleRow[data-test='type']").at(0).prop("primary")
+      ).toBe("Bonded physical");
+    });
+
+    it("does not display a fabric column for member interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable systemId="abc123" />
+        </Provider>
+      );
+      expect(wrapper.find("DoubleRow[data-test='fabric']").length).toBe(1);
+    });
+
+    it("does not display a DHCP column for member interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable systemId="abc123" />
+        </Provider>
+      );
+      expect(wrapper.find("DoubleRow[data-test='dhcp']").length).toBe(1);
+    });
+
+    it("does not display a subnet column for member interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable systemId="abc123" />
+        </Provider>
+      );
+      expect(wrapper.find("SubnetColumn").length).toBe(1);
+    });
+
+    it("does not display an IP column for member interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable systemId="abc123" />
+        </Provider>
+      );
+      expect(wrapper.find("IPColumn").length).toBe(1);
+    });
+
+    it("does not display an actions menu for member interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable systemId="abc123" />
+        </Provider>
+      );
+      expect(wrapper.find("NetworkTableActions").length).toBe(1);
+    });
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -19,12 +19,12 @@ import machineSelectors from "app/store/machine/selectors";
 import type { NetworkInterface, Machine } from "app/store/machine/types";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import {
-  getConnectingInterface,
+  getBondOrBridgeChild,
   getInterfaceNumaNodes,
   getInterfaceTypeText,
   isBootInterface,
   isInterfaceConnected,
-  isInterfaceMember,
+  isBondOrBridgeParent,
 } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
@@ -69,8 +69,8 @@ const generateRows = (
     return [];
   }
   return machine.interfaces.map((nic: NetworkInterface) => {
-    const isMember = isInterfaceMember(machine, nic);
-    const connectingInterface = getConnectingInterface(machine, nic);
+    const isABondOrBridgeParent = isBondOrBridgeParent(machine, nic);
+    const connectingInterface = getBondOrBridgeChild(machine, nic);
     const isBoot = isBootInterface(machine, nic);
     const numaNodes = getInterfaceNumaNodes(machine, nic);
     const vlan = vlans.find(({ id }) => id === nic.vlan_id);
@@ -88,7 +88,7 @@ const generateRows = (
         },
         {
           content:
-            !isMember && isBoot ? (
+            !isABondOrBridgeParent && isBoot ? (
               <span className="u-align--center">
                 <Icon name="success" />
               </span>
@@ -149,7 +149,7 @@ const generateRows = (
               }
               iconSpace={true}
               primary={
-                isMember && connectingInterface
+                isABondOrBridgeParent && connectingInterface
                   ? getInterfaceTypeText(connectingInterface, nic)
                   : getInterfaceTypeText(nic)
               }
@@ -158,7 +158,7 @@ const generateRows = (
           ),
         },
         {
-          content: !isMember && (
+          content: !isABondOrBridgeParent && (
             <DoubleRow
               data-test="fabric"
               primary={
@@ -187,18 +187,18 @@ const generateRows = (
           ),
         },
         {
-          content: !isMember && (
+          content: !isABondOrBridgeParent && (
             <SubnetColumn nic={nic} systemId={machine.system_id} />
           ),
         },
         {
-          content: !isMember && (
+          content: !isABondOrBridgeParent && (
             <IPColumn nic={nic} systemId={machine.system_id} />
           ),
         },
         {
           content:
-            !isMember && fabricsLoaded && vlansLoaded ? (
+            !isABondOrBridgeParent && fabricsLoaded && vlansLoaded ? (
               <DoubleRow
                 data-test="dhcp"
                 icon={
@@ -218,7 +218,7 @@ const generateRows = (
         },
         {
           className: "u-align--right",
-          content: !isMember && (
+          content: !isABondOrBridgeParent && (
             <NetworkTableActions nic={nic} systemId={machine.system_id} />
           ),
         },

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -86,7 +86,7 @@ export type NetworkInterfaceParams = {
 };
 
 export type NetworkInterface = Model & {
-  children: string[];
+  children: Model["id"][];
   discovered?: DiscoveredIP[] | null; // Only shown when machine is in ephemeral state.
   enabled: boolean;
   firmware_version: string | null;

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -9,12 +9,14 @@ export {
 } from "./hooks";
 
 export {
+  getConnectingInterface,
   getInterfaceMembers,
   getInterfaceNumaNodes,
   getInterfaceTypeText,
   getLinkModeDisplay,
   isBootInterface,
   isInterfaceConnected,
+  isInterfaceMember,
 } from "./networking";
 
 export {

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -9,14 +9,14 @@ export {
 } from "./hooks";
 
 export {
-  getConnectingInterface,
-  getInterfaceMembers,
+  getBondOrBridgeChild,
+  getBondOrBridgeParents,
   getInterfaceNumaNodes,
   getInterfaceTypeText,
   getLinkModeDisplay,
   isBootInterface,
   isInterfaceConnected,
-  isInterfaceMember,
+  isBondOrBridgeParent,
 } from "./networking";
 
 export {

--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -1,12 +1,12 @@
 import {
-  getConnectingInterface,
-  getInterfaceMembers,
+  getBondOrBridgeChild,
+  getBondOrBridgeParents,
   getInterfaceNumaNodes,
   getInterfaceTypeText,
   getLinkModeDisplay,
   isBootInterface,
   isInterfaceConnected,
-  isInterfaceMember,
+  isBondOrBridgeParent,
 } from "./networking";
 
 import {
@@ -20,8 +20,8 @@ import {
 } from "testing/factories";
 
 describe("machine networking utils", () => {
-  describe("getInterfaceMembers", () => {
-    it("gets members for a bond", () => {
+  describe("getBondOrBridgeParents", () => {
+    it("gets parents for a bond", () => {
       const interfaces = [
         machineInterfaceFactory(),
         machineInterfaceFactory(),
@@ -33,13 +33,13 @@ describe("machine networking utils", () => {
       });
       interfaces.push(nic);
       const machine = machineDetailsFactory({ interfaces });
-      expect(getInterfaceMembers(machine, nic)).toStrictEqual([
+      expect(getBondOrBridgeParents(machine, nic)).toStrictEqual([
         interfaces[0],
         interfaces[2],
       ]);
     });
 
-    it("gets members for a bridge", () => {
+    it("gets parents for a bridge", () => {
       const interfaces = [
         machineInterfaceFactory(),
         machineInterfaceFactory(),
@@ -51,13 +51,13 @@ describe("machine networking utils", () => {
       });
       interfaces.push(nic);
       const machine = machineDetailsFactory({ interfaces });
-      expect(getInterfaceMembers(machine, nic)).toStrictEqual([
+      expect(getBondOrBridgeParents(machine, nic)).toStrictEqual([
         interfaces[0],
         interfaces[2],
       ]);
     });
 
-    it("does not get members for other types", () => {
+    it("does not get parents for other types", () => {
       const interfaces = [
         machineInterfaceFactory(),
         machineInterfaceFactory(),
@@ -69,67 +69,67 @@ describe("machine networking utils", () => {
       });
       interfaces.push(nic);
       const machine = machineDetailsFactory({ interfaces });
-      expect(getInterfaceMembers(machine, nic)).toStrictEqual([]);
+      expect(getBondOrBridgeParents(machine, nic)).toStrictEqual([]);
     });
   });
 
-  describe("getConnectingInterface", () => {
-    it("gets the connecting interface for a member", () => {
+  describe("getBondOrBridgeChild", () => {
+    it("gets the child interface for a parent", () => {
       const nic = machineInterfaceFactory({
         parents: [99],
         type: NetworkInterfaceTypes.BOND,
       });
-      const member = machineInterfaceFactory({
+      const parent = machineInterfaceFactory({
         children: [nic.id],
         id: 99,
         type: NetworkInterfaceTypes.PHYSICAL,
       });
-      const machine = machineDetailsFactory({ interfaces: [nic, member] });
-      expect(getConnectingInterface(machine, member)).toStrictEqual(nic);
+      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      expect(getBondOrBridgeChild(machine, parent)).toStrictEqual(nic);
     });
   });
 
-  describe("isInterfaceMember", () => {
-    it("can be an interface member", () => {
+  describe("isBondOrBridgeParent", () => {
+    it("can be an interface parent", () => {
       const nic = machineInterfaceFactory({
         parents: [99],
         type: NetworkInterfaceTypes.BOND,
       });
-      const member = machineInterfaceFactory({
+      const parent = machineInterfaceFactory({
         children: [nic.id],
         id: 99,
         type: NetworkInterfaceTypes.PHYSICAL,
       });
-      const machine = machineDetailsFactory({ interfaces: [nic, member] });
-      expect(isInterfaceMember(machine, member)).toBe(true);
+      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      expect(isBondOrBridgeParent(machine, parent)).toBe(true);
     });
 
-    it("is not an interface member when there are multiple children", () => {
+    it("is not an interface parent when there are multiple children", () => {
       const nic = machineInterfaceFactory({
         parents: [99],
         type: NetworkInterfaceTypes.BOND,
       });
-      const member = machineInterfaceFactory({
+      const parent = machineInterfaceFactory({
         children: [nic.id, 101],
         id: 99,
         type: NetworkInterfaceTypes.PHYSICAL,
       });
-      const machine = machineDetailsFactory({ interfaces: [nic, member] });
-      expect(isInterfaceMember(machine, member)).toBe(false);
+      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      expect(isBondOrBridgeParent(machine, parent)).toBe(false);
     });
 
-    it("is not an interface member when the connecting interface is not a bond or bridge", () => {
+    it("is not an interface parent when the child interface is not a bond or bridge", () => {
       const nic = machineInterfaceFactory({
         parents: [99],
         type: NetworkInterfaceTypes.ALIAS,
       });
-      const member = machineInterfaceFactory({
+      const parent = machineInterfaceFactory({
         children: [nic.id, 101],
         id: 99,
         type: NetworkInterfaceTypes.PHYSICAL,
       });
-      const machine = machineDetailsFactory({ interfaces: [nic, member] });
-      expect(isInterfaceMember(machine, member)).toBe(false);
+      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      expect(isBondOrBridgeParent(machine, parent)).toBe(false);
     });
   });
 
@@ -215,7 +215,7 @@ describe("machine networking utils", () => {
       expect(isBootInterface(machine, nic)).toBe(false);
     });
 
-    it("checks members for a boot interface", () => {
+    it("checks parents for a boot interface", () => {
       const interfaces = [
         machineInterfaceFactory(),
         machineInterfaceFactory(),
@@ -231,7 +231,7 @@ describe("machine networking utils", () => {
       expect(isBootInterface(machine, nic)).toBe(true);
     });
 
-    it("is not a boot interface if there are no members with is_boot", () => {
+    it("is not a boot interface if there are no parents with is_boot", () => {
       const interfaces = [
         machineInterfaceFactory({ is_boot: false }),
         machineInterfaceFactory(),


### PR DESCRIPTION
## Done

- Display member interface rows correctly in the network table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the network tab for a few machines both the react and legacy clients.
- The bond/bridge members should say "Bonded physical" or "Bridged physical" and not have most columns.
- Note: the table ordering has not yet been implemented (issue: https://github.com/canonical-web-and-design/maas-ui/issues/1946).

## Fixes

Fixes: #1950.