### PR TITLE
feat(ui): prompt user to commission machine if PCI/USB info unavailable

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -77,10 +77,10 @@ const MachineDetails = (): JSX.Element => {
             <MachineStorage />
           </Route>
           <Route exact path="/machine/:id/pci-devices">
-            <MachinePCIDevices />
+            <MachinePCIDevices setSelectedAction={setSelectedAction} />
           </Route>
           <Route exact path="/machine/:id/usb-devices">
-            <MachineUSBDevices />
+            <MachineUSBDevices setSelectedAction={setSelectedAction} />
           </Route>
           <Route exact path="/machine/:id/tests">
             <MachineTests />

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
@@ -1,0 +1,60 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import MachinePCIDevices from "./MachinePCIDevices";
+
+import { NodeActions } from "app/store/types/node";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MachinePCIDevices", () => {
+  it(`prompts user to commission machine if no PCI info available and machine
+  can be commissioned`, () => {
+    const setSelectedAction = jest.fn();
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            actions: [NodeActions.COMMISSION],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/pci-devices"
+            component={() => (
+              <MachinePCIDevices setSelectedAction={setSelectedAction} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='information-unavailable']").exists()).toBe(
+      true
+    );
+
+    wrapper.find("[data-test='commission-machine'] button").simulate("click");
+
+    expect(setSelectedAction).toHaveBeenCalledWith({
+      name: NodeActions.COMMISSION,
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
@@ -1,12 +1,18 @@
+import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
+
+import type { SetSelectedAction } from "../MachineSummary";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 
-const MachinePCIDevices = (): JSX.Element => {
+type Props = { setSelectedAction: SetSelectedAction };
+
+const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
   const machine = useSelector((state: RootState) =>
@@ -14,25 +20,57 @@ const MachinePCIDevices = (): JSX.Element => {
   );
 
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} PCI devices`);
+  const informationAvailable = false; // TODO: Update when NodeDevice websocket api available
+  const canBeCommissioned = machine?.actions.includes(NodeActions.COMMISSION);
 
   return (
-    <table>
-      <thead>
-        <tr>
-          <th></th>
-          <th>
-            <div>Vendor</div>
-            <div>ID</div>
-          </th>
-          <th>Product</th>
-          <th>Product ID</th>
-          <th>Driver</th>
-          <th className="u-align--right">NUMA node</th>
-          <th className="u-align--right">PCI address</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>
+              <div>Vendor</div>
+              <div>ID</div>
+            </th>
+            <th>Product</th>
+            <th>Product ID</th>
+            <th>Driver</th>
+            <th className="u-align--right">NUMA node</th>
+            <th className="u-align--right">PCI address</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      {!informationAvailable && (
+        <Strip data-test="information-unavailable" shallow>
+          <Row>
+            <Col className="u-flex" emptyLarge={4} size={6}>
+              <h4>
+                <Icon name="warning" />
+              </h4>
+              <div className="u-flex--grow u-nudge-right">
+                <h4>PCI information not available</h4>
+                <p className="u-sv1">
+                  Try commissioning this machine to load PCI information.
+                </p>
+                {canBeCommissioned && (
+                  <Button
+                    appearance="positive"
+                    data-test="commission-machine"
+                    onClick={() =>
+                      setSelectedAction({ name: NodeActions.COMMISSION })
+                    }
+                  >
+                    Commission
+                  </Button>
+                )}
+              </div>
+            </Col>
+          </Row>
+        </Strip>
+      )}
+    </>
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
@@ -1,0 +1,60 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import MachineUSBDevices from "./MachineUSBDevices";
+
+import { NodeActions } from "app/store/types/node";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MachineUSBDevices", () => {
+  it(`prompts user to commission machine if no USB info available and machine
+    can be commissioned`, () => {
+    const setSelectedAction = jest.fn();
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            actions: [NodeActions.COMMISSION],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/usb-devices"
+            component={() => (
+              <MachineUSBDevices setSelectedAction={setSelectedAction} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='information-unavailable']").exists()).toBe(
+      true
+    );
+
+    wrapper.find("[data-test='commission-machine'] button").simulate("click");
+
+    expect(setSelectedAction).toHaveBeenCalledWith({
+      name: NodeActions.COMMISSION,
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
@@ -1,12 +1,18 @@
+import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
+
+import type { SetSelectedAction } from "../MachineSummary";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 
-const MachineUSBDevices = (): JSX.Element => {
+type Props = { setSelectedAction: SetSelectedAction };
+
+const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
   const machine = useSelector((state: RootState) =>
@@ -14,26 +20,58 @@ const MachineUSBDevices = (): JSX.Element => {
   );
 
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} USB devices`);
+  const informationAvailable = false; // TODO: Update when NodeDevice websocket api available
+  const canBeCommissioned = machine?.actions.includes(NodeActions.COMMISSION);
 
   return (
-    <table>
-      <thead>
-        <tr>
-          <th></th>
-          <th>
-            <div>Vendor</div>
-            <div>ID</div>
-          </th>
-          <th>Product</th>
-          <th>Product ID</th>
-          <th>Driver</th>
-          <th className="u-align--right">NUMA node</th>
-          <th className="u-align--right">Bus address</th>
-          <th className="u-align--right">Device address</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>
+              <div>Vendor</div>
+              <div>ID</div>
+            </th>
+            <th>Product</th>
+            <th>Product ID</th>
+            <th>Driver</th>
+            <th className="u-align--right">NUMA node</th>
+            <th className="u-align--right">Bus address</th>
+            <th className="u-align--right">Device address</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      {!informationAvailable && (
+        <Strip data-test="information-unavailable" shallow>
+          <Row>
+            <Col className="u-flex" emptyLarge={4} size={6}>
+              <h4>
+                <Icon name="warning" />
+              </h4>
+              <div className="u-flex--grow u-nudge-right">
+                <h4>USB information not available</h4>
+                <p className="u-sv1">
+                  Try commissioning this machine to load USB information.
+                </p>
+                {canBeCommissioned && (
+                  <Button
+                    appearance="positive"
+                    data-test="commission-machine"
+                    onClick={() =>
+                      setSelectedAction({ name: NodeActions.COMMISSION })
+                    }
+                  >
+                    Commission
+                  </Button>
+                )}
+              </div>
+            </Col>
+          </Row>
+        </Strip>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Done

- Added prompt for user to commission the machine if there is no PCI or USB device info. At the moment this is always the case because the websocket api has not been implemented yet.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the PCI devices tab of a machine
- Check that you are prompted to commission the machine
- Click "Commission" and check that the Commission form opens
- Commission the machine and check that the button disappears

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2297

## Screenshot
![Screenshot_2021-01-05 comic-toucan maas PCI devices bolla MAAS](https://user-images.githubusercontent.com/25733845/103609848-81ef3f80-4f6a-11eb-93e5-1eb2d6aa0c19.png)

