### PR TITLE
feat(ui): add last commissioning timestamp to status bar of active machine

### DIFF
--- a/shared/src/components/StatusBar/StatusBar.test.tsx
+++ b/shared/src/components/StatusBar/StatusBar.test.tsx
@@ -17,4 +17,13 @@ describe("StatusBar", () => {
       "2.7.5"
     );
   });
+
+  it("can show a status", () => {
+    const wrapper = shallow(
+      <StatusBar maasName="foo" status="Activating charcoal" version="2.7.5" />
+    );
+    expect(wrapper.find("[data-test='status-bar-status']").text()).toBe(
+      "Activating charcoal"
+    );
+  });
 });

--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -3,17 +3,27 @@ import React from "react";
 
 type Props = {
   maasName: string;
+  status?: React.ReactNode;
   version: string;
 };
 
-export const StatusBar = ({ maasName, version }: Props): JSX.Element => {
+export const StatusBar = ({
+  maasName,
+  status,
+  version,
+}: Props): JSX.Element => {
   return (
     <div className="p-status-bar">
       <div className="row">
-        <div className="col-12">
+        <div className="col-6">
           <span data-test="status-bar-maas-name">{maasName} MAAS</span>:{" "}
           <span data-test="status-bar-version">{version}</span>
         </div>
+        {status && (
+          <div className="col-6 u-align--right" data-test="status-bar-status">
+            {status}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -21,6 +31,7 @@ export const StatusBar = ({ maasName, version }: Props): JSX.Element => {
 
 StatusBar.propTypes = {
   maasName: PropTypes.string.isRequired,
+  status: PropTypes.node,
   version: PropTypes.string.isRequired,
 };
 

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -7,7 +7,6 @@ import {
   generateLegacyURL,
   Header,
   navigateToLegacy,
-  StatusBar,
 } from "@maas-ui/maas-ui-shared";
 import * as Sentry from "@sentry/browser";
 import { useDispatch, useSelector } from "react-redux";
@@ -24,6 +23,7 @@ import {
 } from "app/base/actions";
 import Login from "app/base/components/Login";
 import Section from "app/base/components/Section";
+import StatusBar from "app/base/components/StatusBar";
 import { config as configActions } from "app/settings/actions";
 import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
@@ -56,7 +56,6 @@ export const App = (): JSX.Element => {
   const authLoading = useSelector(authSelectors.loading);
   const navigationOptions = useSelector(generalSelectors.navigationOptions.get);
   const version = useSelector(generalSelectors.version.get);
-  const maasName = useSelector(configSelectors.maasName);
   const uuid = useSelector(configSelectors.uuid);
   const completedIntro = useSelector(configSelectors.completedIntro);
   const dispatch = useDispatch();
@@ -201,9 +200,7 @@ export const App = (): JSX.Element => {
           version={version}
         />
       )}
-      {maasName && version && (
-        <StatusBar maasName={maasName as string} version={version} />
-      )}
+      <StatusBar />
     </div>
   );
 };

--- a/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -1,0 +1,133 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import StatusBar from "./StatusBar";
+
+import type { RootState } from "app/store/root/types";
+import { NodeStatus } from "app/store/types/node";
+import {
+  machineDetails as machineDetailsFactory,
+  config as configFactory,
+  configState as configStateFactory,
+  generalState as generalStateFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  versionState as versionStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("StatusBar", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    jest.useFakeTimers("modern");
+    // Thu, 31 Dec. 2020 23:00:00 UTC
+    jest.setSystemTime(new Date(Date.UTC(2020, 11, 31, 23, 0, 0)));
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [configFactory({ name: "maas_name", value: "bolla" })],
+      }),
+      general: generalStateFactory({
+        version: versionStateFactory({ data: "2.10.0" }),
+      }),
+      machine: machineStateFactory({
+        active: "abc123",
+        items: [],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("active machine status", () => {
+    it("can show if a machine is currently commissioning", () => {
+      state.machine.items = [
+        machineDetailsFactory({
+          fqdn: "test.maas",
+          status: NodeStatus.COMMISSIONING,
+          system_id: "abc123",
+        }),
+      ];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <StatusBar />
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-bar-status']").text()).toBe(
+        "test.maas: Commissioning in progress..."
+      );
+    });
+
+    it("can show if a machine has not been commissioned yet", () => {
+      state.machine.items = [
+        machineDetailsFactory({
+          commissioning_start_time: "",
+          fqdn: "test.maas",
+          system_id: "abc123",
+        }),
+      ];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <StatusBar />
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-bar-status']").text()).toBe(
+        "test.maas: Not yet commissioned"
+      );
+    });
+
+    it("can show the last time a machine was commissioned", () => {
+      state.machine.items = [
+        machineDetailsFactory({
+          commissioning_start_time: "Thu, 31 Dec. 2020 22:59:00",
+          fqdn: "test.maas",
+          status: NodeStatus.DEPLOYED,
+          system_id: "abc123",
+        }),
+      ];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <StatusBar />
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-bar-status']").text()).toBe(
+        "test.maas: Last commissioned 1 minute ago"
+      );
+    });
+
+    it("can handle an incorrectly formatted commissioning timestamp", () => {
+      state.machine.items = [
+        machineDetailsFactory({
+          commissioning_start_time: "2020-03-01 09:12:43",
+          fqdn: "test.maas",
+          status: NodeStatus.DEPLOYED,
+          system_id: "abc123",
+        }),
+      ];
+
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <StatusBar />
+        </Provider>
+      );
+
+      expect(wrapper.find("[data-test='status-bar-status']").text()).toBe(
+        "test.maas: Unable to parse commissioning timestamp (Invalid time value)"
+      );
+    });
+  });
+});

--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,56 @@
+import { StatusBar as SharedStatusBar } from "@maas-ui/maas-ui-shared";
+import { formatDistance, parse } from "date-fns";
+import { useSelector } from "react-redux";
+
+import configSelectors from "app/store/config/selectors";
+import generalSelectors from "app/store/general/selectors";
+import machineSelectors from "app/store/machine/selectors";
+import type { MachineDetails } from "app/store/machine/types";
+import { NodeStatus } from "app/store/types/node";
+
+const getActiveMachineStatus = (machine: MachineDetails) => {
+  if (machine.status === NodeStatus.COMMISSIONING) {
+    return `${machine.fqdn}: Commissioning in progress...`;
+  } else if (machine.commissioning_start_time === "") {
+    return `${machine.fqdn}: Not yet commissioned`;
+  }
+  try {
+    const distance = formatDistance(
+      parse(
+        `${machine.commissioning_start_time} +00`, // let parse fn know it's UTC
+        "E, dd LLL. yyyy HH:mm:ss x",
+        new Date()
+      ),
+      new Date(),
+      { addSuffix: true }
+    );
+    return `${machine.fqdn}: Last commissioned ${distance}`;
+  } catch (error) {
+    return `${machine.fqdn}: Unable to parse commissioning timestamp (${error.message})`;
+  }
+};
+
+export const StatusBar = (): JSX.Element | null => {
+  const activeMachine = useSelector(machineSelectors.active);
+  const version = useSelector(generalSelectors.version.get);
+  const maasName = useSelector(configSelectors.maasName);
+
+  if (!(maasName && version)) {
+    return null;
+  }
+
+  let status = "";
+  if (activeMachine && "commissioning_start_time" in activeMachine) {
+    status = getActiveMachineStatus(activeMachine);
+  }
+
+  return (
+    <SharedStatusBar
+      maasName={maasName as string}
+      status={status}
+      version={version}
+    />
+  );
+};
+
+export default StatusBar;

--- a/ui/src/app/base/components/StatusBar/index.ts
+++ b/ui/src/app/base/components/StatusBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StatusBar";

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -297,6 +297,7 @@ export type MachineDetails = BaseMachine & {
   bios_boot_method: string;
   bmc: number;
   boot_disk: Disk | null;
+  commissioning_start_time: string;
   cpu_test_status: TestStatus;
   created: string;
   current_commissioning_script_set: number;
@@ -316,6 +317,7 @@ export type MachineDetails = BaseMachine & {
   }[];
   hardware_uuid: string;
   hwe_kernel: string;
+  installation_start_time: string;
   installation_status: number;
   interface_test_status: TestStatus;
   interfaces: NetworkInterface[];
@@ -339,6 +341,7 @@ export type MachineDetails = BaseMachine & {
     ui: string;
   }[];
   swap_size: number | null;
+  testing_start_time: string;
   updated: string;
   workload_annotations: { [x: string]: string };
 };

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -246,6 +246,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   bios_boot_method: "uefi",
   bmc: 190,
   boot_disk: null,
+  commissioning_start_time: "Thu, 15 Oct. 2020 07:25:10",
   created: "Thu, 15 Oct. 2020 07:25:10",
   current_commissioning_script_set: 6188,
   current_installation_script_set: 6174,
@@ -260,6 +261,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   grouped_storages: () => [],
   hardware_uuid: "F5BB1CC9-45B2-46EA-B96A-7D528A902F4B",
   hwe_kernel: "groovy (ga-20.10)",
+  installation_start_time: "Thu, 15 Oct. 2020 07:25:10",
   installation_status: 3,
   interfaces: () => [],
   license_key: "",
@@ -293,6 +295,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   storage_layout_issues: () => [],
   supported_filesystems: () => [],
   swap_size: null,
+  testing_start_time: "Thu, 15 Oct. 2020 07:25:10",
   updated: "Fri, 23 Oct. 2020 05:24:41",
   workload_annotations: () => ({}),
 });


### PR DESCRIPTION
## Done

- Added last commissioning timestamp to the status bar if viewing machine details

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a new machine (can be fake, just add one with manual power type) and go to its details page
- The machine should start commissioning by default. Check that the status bar says that commissioning is in progress.
- Abort the action and check that the status bar now says "Not yet commissioned"
- Go to the machine details page of a machine that has been successfully commissioned in the past
- Check that the status bar now says how long it's been since the machine has been commissioned. Note that the timestamps from the api are in UTC

## Fixes

Fixes #2029 

## Screenshot

![Screenshot_2021-01-08 fun-mammal maas PCI devices bolla MAAS](https://user-images.githubusercontent.com/25733845/103963523-3b395980-51a5-11eb-9265-9ab84f1ced0b.png)

