### PR TITLE
feat(ui): add Placeholder component and use in PCI/USB tables

### DIFF
--- a/ui/src/app/base/components/Placeholder/Placeholder.test.tsx
+++ b/ui/src/app/base/components/Placeholder/Placeholder.test.tsx
@@ -1,0 +1,18 @@
+import { shallow } from "enzyme";
+
+import Placeholder from "./Placeholder";
+
+describe("Placeholder", () => {
+  beforeEach(() => {
+    jest.spyOn(Math, "floor").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders", () => {
+    const wrapper = shallow(<Placeholder>Placeholder text</Placeholder>);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/base/components/Placeholder/Placeholder.tsx
+++ b/ui/src/app/base/components/Placeholder/Placeholder.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import classNames from "classnames";
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+const Placeholder = ({ children, className }: Props): JSX.Element => {
+  const delay = Math.floor(Math.random() * 750);
+  return (
+    <span
+      className={classNames("p-placeholder", className)}
+      style={{ animationDelay: `${delay}ms` }}
+    >
+      {children}
+    </span>
+  );
+};
+
+export default Placeholder;

--- a/ui/src/app/base/components/Placeholder/__snapshots__/Placeholder.test.tsx.snap
+++ b/ui/src/app/base/components/Placeholder/__snapshots__/Placeholder.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Placeholder renders 1`] = `
+<span
+  className="p-placeholder"
+  style={
+    Object {
+      "animationDelay": "0ms",
+    }
+  }
+>
+  Placeholder text
+</span>
+`;

--- a/ui/src/app/base/components/Placeholder/_index.scss
+++ b/ui/src/app/base/components/Placeholder/_index.scss
@@ -1,0 +1,27 @@
+@mixin Placeholder {
+  .p-placeholder {
+    animation: shine 1.5s infinite ease-out;
+    background-color: $color-mid-x-light;
+    background-image: linear-gradient(
+      to right,
+      $color-mid-x-light calc(50% - 2rem),
+      $color-light 50%,
+      $color-mid-x-light calc(50% + 2rem)
+    );
+    background-size: 300% 100%;
+    color: transparent;
+    overflow: hidden;
+    pointer-events: none;
+    text-indent: -100%;
+  }
+
+  @keyframes shine {
+    0% {
+      background-position: right;
+    }
+
+    100% {
+      background-position: left;
+    }
+  }
+}

--- a/ui/src/app/base/components/Placeholder/index.ts
+++ b/ui/src/app/base/components/Placeholder/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Placeholder";

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
@@ -9,12 +9,46 @@ import { NodeActions } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
+  nodeDeviceState as nodeDeviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("MachinePCIDevices", () => {
+  it("shows placeholder rows while PCI devices are loading", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+      }),
+      nodedevice: nodeDeviceStateFactory({ loading: true }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/pci-devices"
+            component={() => (
+              <MachinePCIDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Placeholder").exists()).toBe(true);
+  });
+
   it(`prompts user to commission machine if no PCI info available and machine
   can be commissioned`, () => {
     const setSelectedAction = jest.fn();

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
@@ -1,18 +1,12 @@
 import { useEffect } from "react";
 
-import {
-  Button,
-  Col,
-  Icon,
-  Row,
-  Spinner,
-  Strip,
-} from "@canonical/react-components";
+import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import type { SetSelectedAction } from "../MachineSummary";
 
+import Placeholder from "app/base/components/Placeholder";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
@@ -56,11 +50,39 @@ const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
             <th className="u-align--right">PCI address</th>
           </tr>
         </thead>
-        <tbody></tbody>
+        <tbody>
+          {nodeDevicesLoading ? (
+            <>
+              {Array.from(Array(5)).map((_, i) => (
+                <tr key={`pci-placeholder-${i}`}>
+                  <td>
+                    <Placeholder>Group name</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Example vendor description</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Example product description</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>0000</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Driver name</Placeholder>
+                  </td>
+                  <td className="u-align--right">
+                    <Placeholder>0000</Placeholder>
+                  </td>
+                  <td className="u-align--right">
+                    <Placeholder>0000:00:00.0</Placeholder>
+                  </td>
+                </tr>
+              ))}
+            </>
+          ) : null}
+        </tbody>
       </table>
-      {nodeDevicesLoading ? (
-        <Spinner text="Loading..." />
-      ) : (
+      {!nodeDevicesLoading && (
         <Strip data-test="information-unavailable" shallow>
           <Row>
             <Col className="u-flex" emptyLarge={4} size={6}>

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
@@ -9,12 +9,46 @@ import { NodeActions } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
+  nodeDeviceState as nodeDeviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("MachineUSBDevices", () => {
+  it("shows placeholder rows while USB devices are loading", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+      }),
+      nodedevice: nodeDeviceStateFactory({ loading: true }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/usb-devices"
+            component={() => (
+              <MachineUSBDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Placeholder").exists()).toBe(true);
+  });
+
   it(`prompts user to commission machine if no USB info available and machine
     can be commissioned`, () => {
     const setSelectedAction = jest.fn();

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
@@ -1,18 +1,12 @@
 import { useEffect } from "react";
 
-import {
-  Button,
-  Col,
-  Icon,
-  Row,
-  Spinner,
-  Strip,
-} from "@canonical/react-components";
+import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import type { SetSelectedAction } from "../MachineSummary";
 
+import Placeholder from "app/base/components/Placeholder";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
@@ -57,11 +51,42 @@ const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
             <th className="u-align--right">Device address</th>
           </tr>
         </thead>
-        <tbody></tbody>
+        <tbody>
+          {nodeDevicesLoading ? (
+            <>
+              {Array.from(Array(5)).map((_, i) => (
+                <tr key={`usb-placeholder-${i}`}>
+                  <td>
+                    <Placeholder>Group name</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Example vendor description</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Example product description</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>0000</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Driver name</Placeholder>
+                  </td>
+                  <td className="u-align--right">
+                    <Placeholder>0000</Placeholder>
+                  </td>
+                  <td className="u-align--right">
+                    <Placeholder>0000</Placeholder>
+                  </td>
+                  <td className="u-align--right">
+                    <Placeholder>0000:00:00.0</Placeholder>
+                  </td>
+                </tr>
+              ))}
+            </>
+          ) : null}
+        </tbody>
       </table>
-      {nodeDevicesLoading ? (
-        <Spinner text="Loading..." />
-      ) : (
+      {!nodeDevicesLoading && (
         <Strip data-test="information-unavailable" shallow>
           <Row>
             <Col className="u-flex" emptyLarge={4} size={6}>

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -67,6 +67,7 @@
 @import "~app/base/components/LabelledList";
 @import "~app/base/components/Login";
 @import "~app/base/components/Meter";
+@import "~app/base/components/Placeholder";
 @import "~app/base/components/Popover";
 @import "~app/base/components/Section";
 @import "~app/base/components/TableMenu";
@@ -77,6 +78,7 @@
 @include LabelledList;
 @include Login;
 @include Meter;
+@include Placeholder;
 @include Popover;
 @include Section;
 @include TableMenu;


### PR DESCRIPTION
## Done

- Added Placeholder component, which replaces any given text with a grey bar that has a "shine" animation.
- Implemented the Placeholder component in the PCI and USB tables

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to the PCI or USB tab of a machine
- Check that grey placeholder blocks show briefly while the data is loading

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2298

## Screenshot

![Screenshot_2021-01-08 comic-toucan maas PCI devices bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/103983498-122ebe00-51d1-11eb-9e9d-de07069ede31.png)


