### PR TITLE
fix(integration): bump version and dependencies to 2.0.1

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@maas-ui/maas-ui-integration",
   "private": true,
-  "version": "1.3.1",
+  "version": "2.0.1",
   "scripts": {
     "clean": "rm -rf node_modules",
     "cypress-test": "yarn --cwd ../shared build && start-server-and-test serve-frontends '8401|8402' serve-base 'tcp:8400|8404' cypress-run",
@@ -11,7 +11,7 @@
     "cypress-open": "yarn cypress open -c baseUrl=http://0.0.0.0:8400"
   },
   "devDependencies": {
-    "@maas-ui/maas-ui-shared": "1.3.1",
+    "@maas-ui/maas-ui-shared": "2.0.1",
     "concurrently": "5.3.0",
     "cypress": "5.3.0",
     "dotenv-flow": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maas-ui-monorepo",
-  "version": "1.3.1-monorepo",
+  "version": "2.0.1-monorepo",
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {


### PR DESCRIPTION
----

## Done

- Bumped integration to 2.0.1
- Bumped dependency on shared to 2.0.1

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.