### PR TITLE
feat(ui): build PCI devices table

### DIFF
--- a/ui/src/app/base/enum.ts
+++ b/ui/src/app/base/enum.ts
@@ -72,6 +72,7 @@ export enum HardwareType {
   Memory = 2,
   Storage = 3,
   Network = 4,
+  GPU = 5,
 }
 
 export enum ResultType {

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
@@ -5,10 +5,14 @@ import configureStore from "redux-mock-store";
 
 import MachinePCIDevices from "./MachinePCIDevices";
 
+import { HardwareType } from "app/base/enum";
+import { NodeDeviceBus } from "app/store/nodedevice/types";
 import { NodeActions } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
+  machineNumaNode as numaNodeFactory,
+  nodeDevice as nodeDeviceFactory,
   nodeDeviceState as nodeDeviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -90,5 +94,169 @@ describe("MachinePCIDevices", () => {
     expect(setSelectedAction).toHaveBeenCalledWith({
       name: NodeActions.COMMISSION,
     });
+  });
+
+  it("groups PCI devices by hardware type", () => {
+    const machine = machineDetailsFactory({ system_id: "abc123" });
+    const networkDevices = [
+      nodeDeviceFactory({
+        bus: NodeDeviceBus.PCIE,
+        hardware_type: HardwareType.Network,
+        node_id: machine.id,
+      }),
+    ];
+    const storageDevices = Array.from(Array(3)).map(() =>
+      nodeDeviceFactory({
+        bus: NodeDeviceBus.PCIE,
+        hardware_type: HardwareType.Storage,
+        node_id: machine.id,
+      })
+    );
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      nodedevice: nodeDeviceStateFactory({
+        items: [...networkDevices, ...storageDevices],
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/pci-devices"
+            component={() => (
+              <MachinePCIDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(0)
+        .find(".p-double-row__primary-row")
+        .text()
+    ).toBe("Network");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(0)
+        .find(".p-double-row__secondary-row")
+        .text()
+    ).toBe("1 device");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(1)
+        .find(".p-double-row__primary-row")
+        .text()
+    ).toBe("Storage");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(1)
+        .find(".p-double-row__secondary-row")
+        .text()
+    ).toBe("3 devices");
+  });
+
+  it("can link to the network and storage tabs", () => {
+    const machine = machineDetailsFactory({ system_id: "abc123" });
+    const networkDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.PCIE,
+      hardware_type: HardwareType.Network,
+      node_id: machine.id,
+    });
+    const storageDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.PCIE,
+      hardware_type: HardwareType.Storage,
+      node_id: machine.id,
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      nodedevice: nodeDeviceStateFactory({
+        items: [networkDevice, storageDevice],
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/pci-devices"
+            component={() => (
+              <MachinePCIDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='group-label']").at(0).find("Link").prop("to")
+    ).toBe("/machine/abc123/network");
+    expect(
+      wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
+    ).toBe("/machine/abc123/storage");
+  });
+
+  it("displays the NUMA node index of a node device", () => {
+    const numaNode = numaNodeFactory({ index: 128 });
+    const machine = machineDetailsFactory({
+      numa_nodes: [numaNode, numaNodeFactory()],
+      system_id: "abc123",
+    });
+    const pciDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.PCIE,
+      node_id: machine.id,
+      numa_node_id: numaNode.id,
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      nodedevice: nodeDeviceStateFactory({
+        items: [pciDevice],
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/pci-devices"
+            component={() => (
+              <MachinePCIDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='pci-numa']").text()).toBe("128");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
@@ -1,21 +1,87 @@
 import { useEffect } from "react";
 
 import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
+import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
+import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../MachineSummary";
 
+import DoubleRow from "app/base/components/DoubleRow";
 import Placeholder from "app/base/components/Placeholder";
+import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
 import { actions as nodeDeviceActions } from "app/store/nodedevice";
 import nodeDeviceSelectors from "app/store/nodedevice/selectors";
+import { NodeDeviceBus } from "app/store/nodedevice/types";
+import type { NodeDevice } from "app/store/nodedevice/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 
+type NodeDeviceGroup = {
+  hardwareTypes: HardwareType[];
+  items: NodeDevice[];
+  label: string;
+  pathname?: string;
+};
+
 type Props = { setSelectedAction: SetSelectedAction };
+
+const generateGroup = (group: NodeDeviceGroup, machine: Machine) =>
+  group.items.map((nodeDevice, i) => {
+    const {
+      commissioning_driver,
+      id,
+      numa_node_id,
+      pci_address,
+      product_id,
+      product_name,
+      vendor_id,
+      vendor_name,
+    } = nodeDevice;
+    const numaNode =
+      "numa_nodes" in machine
+        ? machine.numa_nodes.find((numa) => numa.id === numa_node_id)
+        : null;
+
+    return (
+      <tr key={`pci-device-${id}`}>
+        <td>
+          {i === 0 && (
+            <DoubleRow
+              data-test="group-label"
+              primary={
+                <strong>
+                  {group.pathname ? (
+                    <Link to={`/machine/${machine.system_id}${group.pathname}`}>
+                      {group.label}
+                    </Link>
+                  ) : (
+                    group.label
+                  )}
+                </strong>
+              }
+              secondary={pluralize("device", group.items.length, true)}
+            />
+          )}
+        </td>
+        <td>
+          <DoubleRow primary={vendor_name} secondary={vendor_id} />
+        </td>
+        <td>{product_name}</td>
+        <td>{product_id}</td>
+        <td>{commissioning_driver}</td>
+        <td className="u-align--right" data-test="pci-numa">
+          {numaNode?.index}
+        </td>
+        <td className="u-align--right">{pci_address}</td>
+      </tr>
+    );
+  });
 
 const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -23,6 +89,9 @@ const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
   const { id } = params;
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
+  );
+  const nodeDevices = useSelector((state: RootState) =>
+    nodeDeviceSelectors.getByMachineId(state, machine?.id || null)
   );
   const nodeDevicesLoading = useSelector(nodeDeviceSelectors.loading);
 
@@ -32,6 +101,48 @@ const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
   useEffect(() => {
     dispatch(nodeDeviceActions.getByMachineId(id));
   }, [dispatch, id]);
+
+  const groupedDevices = nodeDevices
+    .reduce<NodeDeviceGroup[]>(
+      (groups, nodeDevice) => {
+        const group = groups.find((group) =>
+          group.hardwareTypes.includes(nodeDevice.hardware_type)
+        );
+        if (group && nodeDevice.bus === NodeDeviceBus.PCIE) {
+          group.items.push(nodeDevice);
+        }
+        return groups;
+      },
+      [
+        {
+          hardwareTypes: [HardwareType.Network],
+          label: "Network",
+          pathname: "/network",
+          items: [],
+        },
+        {
+          hardwareTypes: [HardwareType.Storage],
+          label: "Storage",
+          pathname: "/storage",
+          items: [],
+        },
+        {
+          hardwareTypes: [HardwareType.GPU],
+          label: "GPU",
+          items: [],
+        },
+        {
+          hardwareTypes: [
+            HardwareType.CPU,
+            HardwareType.Memory,
+            HardwareType.Node,
+          ],
+          label: "Generic",
+          items: [],
+        },
+      ]
+    )
+    .filter((group) => group.items.length > 0);
 
   return (
     <>
@@ -51,7 +162,7 @@ const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
           </tr>
         </thead>
         <tbody>
-          {nodeDevicesLoading ? (
+          {nodeDevicesLoading || machine === null ? (
             <>
               {Array.from(Array(5)).map((_, i) => (
                 <tr key={`pci-placeholder-${i}`}>
@@ -79,10 +190,12 @@ const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
                 </tr>
               ))}
             </>
-          ) : null}
+          ) : (
+            groupedDevices.map((group) => generateGroup(group, machine))
+          )}
         </tbody>
       </table>
-      {!nodeDevicesLoading && (
+      {!nodeDevicesLoading && nodeDevices.length === 0 && (
         <Strip data-test="information-unavailable" shallow>
           <Row>
             <Col className="u-flex" emptyLarge={4} size={6}>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/__snapshots__/NumaCard.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/__snapshots__/NumaCard.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`NumaCard renders with numa nodes 1`] = `
                       Object {
                         "cores": Array [],
                         "hugepages_set": Array [],
+                        "id": 28,
                         "index": 2,
                         "memory": 256,
                       }
@@ -57,6 +58,7 @@ exports[`NumaCard renders with numa nodes 1`] = `
                     Object {
                       "cores": Array [],
                       "hugepages_set": Array [],
+                      "id": 28,
                       "index": 2,
                       "memory": 256,
                     }

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -212,7 +212,7 @@ export type MachineMetadata = {
   system_version?: string;
 };
 
-export type MachineNumaNode = {
+export type MachineNumaNode = Model & {
   cores: number[];
   hugepages_set: {
     page_size: number;

--- a/ui/src/app/store/nodedevice/selectors.ts
+++ b/ui/src/app/store/nodedevice/selectors.ts
@@ -23,7 +23,7 @@ const getByMachineId = createSelector(
     defaultSelectors.all,
     (_: RootState, machineId: Machine["id"] | null) => machineId,
   ],
-  (nodeDevices, machineId): NodeDevice[] | null =>
+  (nodeDevices, machineId): NodeDevice[] =>
     nodeDevices.filter((nodeDevice) => nodeDevice.node_id === machineId)
 );
 

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -141,7 +141,7 @@ export const machine = extend<BaseNode, Machine>(node, {
   zone: modelRef,
 });
 
-export const machineNumaNode = define<MachineNumaNode>({
+export const machineNumaNode = extend<Model, MachineNumaNode>(model, {
   cores: () => [],
   hugepages_set: () => [],
   index: sequence,


### PR DESCRIPTION
## Done

- Built PCI devices table as per [design](https://app.zeplin.io/project/5f9af2ae43654ab5edbcfd29/screen/5fd0a9eee9fc0650e2ecbf94) (there are some minor details like the group title borders and cell widths that I'll address later)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Commission a machine if it hasn't been commissioned in the last week or so in order to gather info about the PCI devices
- Go to the PCI devices tab of a machine and check that the data loads in correctly
- Check that you can navigate to the storage and network tabs via the group headers

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2299

## Screenshot

![Screenshot_2021-01-11 comic-toucan maas PCI devices bolla MAAS](https://user-images.githubusercontent.com/25733845/104155283-9469ed00-5432-11eb-978c-66fb128f7ecc.png)

