### PR TITLE
feat(ui): build USB devices table

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
@@ -5,10 +5,14 @@ import configureStore from "redux-mock-store";
 
 import MachineUSBDevices from "./MachineUSBDevices";
 
+import { HardwareType } from "app/base/enum";
+import { NodeDeviceBus } from "app/store/nodedevice/types";
 import { NodeActions } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
+  machineNumaNode as numaNodeFactory,
   machineState as machineStateFactory,
+  nodeDevice as nodeDeviceFactory,
   nodeDeviceState as nodeDeviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -90,5 +94,206 @@ describe("MachineUSBDevices", () => {
     expect(setSelectedAction).toHaveBeenCalledWith({
       name: NodeActions.COMMISSION,
     });
+  });
+
+  it("shows a message if no USB devices have been detected", () => {
+    const machine = machineDetailsFactory({ system_id: "abc123" });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      nodedevice: nodeDeviceStateFactory({
+        items: [
+          nodeDeviceFactory({
+            bus: NodeDeviceBus.PCIE,
+            node_id: machine.id,
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/usb-devices"
+            component={() => (
+              <MachineUSBDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='no-usb']").exists()).toBe(true);
+  });
+
+  it("groups USB devices by hardware type", () => {
+    const machine = machineDetailsFactory({ system_id: "abc123" });
+    const networkDevices = [
+      nodeDeviceFactory({
+        bus: NodeDeviceBus.USB,
+        hardware_type: HardwareType.Network,
+        node_id: machine.id,
+      }),
+    ];
+    const storageDevices = Array.from(Array(3)).map(() =>
+      nodeDeviceFactory({
+        bus: NodeDeviceBus.USB,
+        hardware_type: HardwareType.Storage,
+        node_id: machine.id,
+      })
+    );
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      nodedevice: nodeDeviceStateFactory({
+        items: [...networkDevices, ...storageDevices],
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/usb-devices"
+            component={() => (
+              <MachineUSBDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(0)
+        .find(".p-double-row__primary-row")
+        .text()
+    ).toBe("Network");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(0)
+        .find(".p-double-row__secondary-row")
+        .text()
+    ).toBe("1 device");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(1)
+        .find(".p-double-row__primary-row")
+        .text()
+    ).toBe("Storage");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(1)
+        .find(".p-double-row__secondary-row")
+        .text()
+    ).toBe("3 devices");
+  });
+
+  it("can link to the network and storage tabs", () => {
+    const machine = machineDetailsFactory({ system_id: "abc123" });
+    const networkDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.USB,
+      hardware_type: HardwareType.Network,
+      node_id: machine.id,
+    });
+    const storageDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.USB,
+      hardware_type: HardwareType.Storage,
+      node_id: machine.id,
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      nodedevice: nodeDeviceStateFactory({
+        items: [networkDevice, storageDevice],
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/usb-devices"
+            component={() => (
+              <MachineUSBDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='group-label']").at(0).find("Link").prop("to")
+    ).toBe("/machine/abc123/network");
+    expect(
+      wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
+    ).toBe("/machine/abc123/storage");
+  });
+
+  it("displays the NUMA node index of a USB device", () => {
+    const numaNode = numaNodeFactory({ index: 128 });
+    const machine = machineDetailsFactory({
+      numa_nodes: [numaNode, numaNodeFactory()],
+      system_id: "abc123",
+    });
+    const pciDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.USB,
+      node_id: machine.id,
+      numa_node_id: numaNode.id,
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+      }),
+      nodedevice: nodeDeviceStateFactory({
+        items: [pciDevice],
+        loading: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/usb-devices"
+            component={() => (
+              <MachineUSBDevices setSelectedAction={jest.fn()} />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='usb-numa']").text()).toBe("128");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
@@ -1,21 +1,89 @@
 import { useEffect } from "react";
 
 import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
+import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
+import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../MachineSummary";
 
+import DoubleRow from "app/base/components/DoubleRow";
 import Placeholder from "app/base/components/Placeholder";
+import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
 import { actions as nodeDeviceActions } from "app/store/nodedevice";
 import nodeDeviceSelectors from "app/store/nodedevice/selectors";
+import { NodeDeviceBus } from "app/store/nodedevice/types";
+import type { NodeDevice } from "app/store/nodedevice/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 
+type NodeDeviceGroup = {
+  hardwareTypes: HardwareType[];
+  items: NodeDevice[];
+  label: string;
+  pathname?: string;
+};
+
 type Props = { setSelectedAction: SetSelectedAction };
+
+const generateGroup = (group: NodeDeviceGroup, machine: Machine) =>
+  group.items.map((nodeDevice, i) => {
+    const {
+      bus_number,
+      commissioning_driver,
+      device_number,
+      id,
+      numa_node_id,
+      product_id,
+      product_name,
+      vendor_id,
+      vendor_name,
+    } = nodeDevice;
+    const numaNode =
+      "numa_nodes" in machine
+        ? machine.numa_nodes.find((numa) => numa.id === numa_node_id)
+        : null;
+
+    return (
+      <tr key={`usb-device-${id}`}>
+        <td>
+          {i === 0 && (
+            <DoubleRow
+              data-test="group-label"
+              primary={
+                <strong>
+                  {group.pathname ? (
+                    <Link to={`/machine/${machine.system_id}${group.pathname}`}>
+                      {group.label}
+                    </Link>
+                  ) : (
+                    group.label
+                  )}
+                </strong>
+              }
+              secondary={pluralize("device", group.items.length, true)}
+            />
+          )}
+        </td>
+        <td>
+          <DoubleRow primary={vendor_name} secondary={vendor_id} />
+        </td>
+        <td>{product_name}</td>
+        <td>{product_id}</td>
+        <td>{commissioning_driver}</td>
+        <td className="u-align--right" data-test="usb-numa">
+          {numaNode?.index}
+        </td>
+        <td className="u-align--right">{bus_number}</td>
+        <td className="u-align--right">{device_number}</td>
+      </tr>
+    );
+  });
 
 const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -23,6 +91,9 @@ const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
   const { id } = params;
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
+  );
+  const nodeDevices = useSelector((state: RootState) =>
+    nodeDeviceSelectors.getByMachineId(state, machine?.id || null)
   );
   const nodeDevicesLoading = useSelector(nodeDeviceSelectors.loading);
 
@@ -32,6 +103,54 @@ const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
   useEffect(() => {
     dispatch(nodeDeviceActions.getByMachineId(id));
   }, [dispatch, id]);
+
+  const usbDevices = nodeDevices.filter(
+    (nodeDevice) => nodeDevice.bus === NodeDeviceBus.USB
+  );
+  const groupedDevices = usbDevices
+    .reduce<NodeDeviceGroup[]>(
+      (groups, nodeDevice) => {
+        const group = groups.find((group) =>
+          group.hardwareTypes.includes(nodeDevice.hardware_type)
+        );
+        if (group) {
+          group.items.push(nodeDevice);
+        }
+        return groups;
+      },
+      [
+        {
+          hardwareTypes: [HardwareType.Network],
+          label: "Network",
+          pathname: "/network",
+          items: [],
+        },
+        {
+          hardwareTypes: [HardwareType.Storage],
+          label: "Storage",
+          pathname: "/storage",
+          items: [],
+        },
+        {
+          hardwareTypes: [HardwareType.GPU],
+          label: "GPU",
+          items: [],
+        },
+        {
+          hardwareTypes: [
+            HardwareType.CPU,
+            HardwareType.Memory,
+            HardwareType.Node,
+          ],
+          label: "Generic",
+          items: [],
+        },
+      ]
+    )
+    .filter((group) => group.items.length > 0);
+
+  const noDevices = nodeDevices.length === 0;
+  const noUsb = usbDevices.length === 0;
 
   return (
     <>
@@ -52,7 +171,7 @@ const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
           </tr>
         </thead>
         <tbody>
-          {nodeDevicesLoading ? (
+          {nodeDevicesLoading || machine === null ? (
             <>
               {Array.from(Array(5)).map((_, i) => (
                 <tr key={`usb-placeholder-${i}`}>
@@ -78,16 +197,18 @@ const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
                     <Placeholder>0000</Placeholder>
                   </td>
                   <td className="u-align--right">
-                    <Placeholder>0000:00:00.0</Placeholder>
+                    <Placeholder>0000</Placeholder>
                   </td>
                 </tr>
               ))}
             </>
-          ) : null}
+          ) : (
+            groupedDevices.map((group) => generateGroup(group, machine))
+          )}
         </tbody>
       </table>
-      {!nodeDevicesLoading && (
-        <Strip data-test="information-unavailable" shallow>
+      {!nodeDevicesLoading && (noDevices || noUsb) && (
+        <Strip shallow>
           <Row>
             <Col className="u-flex" emptyLarge={4} size={6}>
               <h4>
@@ -95,19 +216,28 @@ const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
               </h4>
               <div className="u-flex--grow u-nudge-right">
                 <h4>USB information not available</h4>
-                <p className="u-sv1">
-                  Try commissioning this machine to load USB information.
-                </p>
-                {canBeCommissioned && (
-                  <Button
-                    appearance="positive"
-                    data-test="commission-machine"
-                    onClick={() =>
-                      setSelectedAction({ name: NodeActions.COMMISSION })
-                    }
-                  >
-                    Commission
-                  </Button>
+                {noDevices && (
+                  <>
+                    <p className="u-sv1" data-test="information-unavailable">
+                      Try commissioning this machine to load USB information.
+                    </p>
+                    {canBeCommissioned && (
+                      <Button
+                        appearance="positive"
+                        data-test="commission-machine"
+                        onClick={() =>
+                          setSelectedAction({ name: NodeActions.COMMISSION })
+                        }
+                      >
+                        Commission
+                      </Button>
+                    )}
+                  </>
+                )}
+                {noUsb && (
+                  <p className="u-sv1" data-test="no-usb">
+                    No USB devices discovered during commissioning.
+                  </p>
                 )}
               </div>
             </Col>


### PR DESCRIPTION
## Done

- Built USB devices table, which is largely a copy+paste job from the [PCI devices table PR](https://github.com/canonical-web-and-design/maas-ui/pull/2046). I'll extract the common elements in [this issue](https://github.com/canonical-web-and-design/maas-squad/issues/2311) - for now I'm just getting everything working.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- This is hard to QA for real because bolla only has VMs, and I'm not entirely sure how you connect a USB device to a VM. So for these steps I've just fudged in some fake USB devices in the UI code, which I think is good enough because the only thing that differentiates a PCI from a USB device is the bus (and only PCI devices have a pci_address).
- First, go to the USB tab of a machine that has been commissioned recently (so it has PCI devices) but it does not have any USB devices.
- Check there is a message that says no USB devices were detected.
- Open `MachineUSBDevices.tsx` and change lines 95-97 to:
``` typescript
const originalNodeDevices = useSelector((state: RootState) =>
  nodeDeviceSelectors.getByMachineId(state, machine?.id || null)
);
const nodeDevices = [...originalNodeDevices].map((nodeDevice, i) =>
  i % 2 === 0
    ? { ...nodeDevice, bus: NodeDeviceBus.USB, pci_address: undefined }
    : nodeDevice
);
```
- Reload the USB devices tab and check that it populates with the fudged data.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2300
