### PR TITLE
feat(ui): add script result history reducer

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -484,8 +484,8 @@ exports[`stricter compilation`] = {
     "src/app/store/resourcepool/actions.test.ts:9201512": [
       [71, 52, 24, "Expected 1 arguments, but got 2.", "3295119724"]
     ],
-    "src/app/store/scriptresult/slice.ts:2688136994": [
-      [60, 4, 21, "Type \'(state: ScriptResultState, action: PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n  Type \'(state: ScriptResultState, action: PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }>\'.\\n    Types of parameters \'action\' and \'action\' are incompatible.\\n      Type \'{ payload: any; type: string; }\' is not assignable to type \'PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>, never>\'.\\n        Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.", "294608771"]
+    "src/app/store/scriptresult/slice.ts:58699384": [
+      [31, 2, 8, "Type \'SliceCaseReducers<ScriptResultState>\' does not satisfy the constraint \'SliceCaseReducers<GenericState<ScriptResult, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }> | CaseReducerWithPrepare<ScriptResultState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n      Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n        Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Property \'history\' is missing in type \'WritableDraft<GenericState<ScriptResult, any>>\' but required in type \'WritableDraft<ScriptResultState>\'.", "781891908"]
     ],
     "src/app/store/user/reducers.test.ts:698541338": [
       [8, 6, 5, "Variable \'state\' implicitly has type \'any\' in some locations where its type cannot be determined.", "195031250"],
@@ -564,11 +564,11 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:2676414242": [
+    "src/testing/factories/state.ts:3790991929": [
       [266, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
-      [352, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
-      [354, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
-      [359, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+      [353, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
+      [355, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
+      [360, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -635,7 +635,7 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:4035557104": [
+    "src/app/store/machine/types.ts:4050302297": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [400, 34, 8, "RegExp match", "1152173309"],
       [403, 25, 8, "RegExp match", "1152173309"]
@@ -664,9 +664,9 @@ exports[`no TSFixMe types`] = {
       [9, 13, 8, "RegExp match", "1152173309"],
       [47, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/types.ts:1927624346": [
+    "src/app/store/scriptresult/types.ts:3791165396": [
       [3, 13, 8, "RegExp match", "1152173309"],
-      [65, 58, 8, "RegExp match", "1152173309"]
+      [70, 30, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scripts/types.ts:980490450": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -192,6 +192,7 @@ Object {
   },
   "scriptresult": Object {
     "errors": null,
+    "history": Object {},
     "items": Array [],
     "loaded": false,
     "loading": false,

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
@@ -1,9 +1,11 @@
 import { Input, MainTable } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
 
+import TableMenu from "app/base/components/TableMenu";
 import { scriptStatus } from "app/base/enum";
 import { actions as machineActions } from "app/store/machine";
 import type { Machine } from "app/store/machine/types";
+import { actions as scriptResultActions } from "app/store/scriptresult";
 import type { ScriptResult } from "app/store/scriptresult/types";
 
 type Props = { machineId: Machine["system_id"]; scriptResults: ScriptResult[] };
@@ -19,6 +21,11 @@ const MachineTestsTable = ({
   scriptResults,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+
+  const showPreviousTests = (id: ScriptResult["id"]) => {
+    dispatch(scriptResultActions.getHistory(id));
+  };
+
   return (
     <>
       <MainTable
@@ -101,7 +108,18 @@ const MachineTestsTable = ({
                 content: <span data-test="status">{result.status_name}</span>,
               },
               {
-                content: "",
+                content: (
+                  <TableMenu
+                    links={[
+                      {
+                        children: "View previous tests",
+                        onClick: () => showPreviousTests(result.id),
+                      },
+                    ]}
+                    position="right"
+                    title="Take action:"
+                  />
+                ),
                 className: "u-align--right",
               },
             ],

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
@@ -257,7 +257,18 @@ exports[`MachineTestsTable renders 1`] = `
                   },
                   Object {
                     "className": "u-align--right",
-                    "content": "",
+                    "content": <TableMenu
+                      links={
+                        Array [
+                          Object {
+                            "children": "View previous tests",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      position="right"
+                      title="Take action:"
+                    />,
                   },
                 ],
                 "key": 27,
@@ -308,7 +319,18 @@ exports[`MachineTestsTable renders 1`] = `
                   },
                   Object {
                     "className": "u-align--right",
-                    "content": "",
+                    "content": <TableMenu
+                      links={
+                        Array [
+                          Object {
+                            "children": "View previous tests",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      position="right"
+                      title="Take action:"
+                    />,
                   },
                 ],
                 "key": 28,
@@ -524,7 +546,71 @@ exports[`MachineTestsTable renders 1`] = `
                         aria-hidden={false}
                         className="u-align--right"
                         role="gridcell"
-                      />
+                      >
+                        <TableMenu
+                          links={
+                            Array [
+                              Object {
+                                "children": "View previous tests",
+                                "onClick": [Function],
+                              },
+                            ]
+                          }
+                          position="right"
+                          title="Take action:"
+                        >
+                          <ContextualMenu
+                            className="p-table-menu"
+                            hasToggleIcon={true}
+                            links={
+                              Array [
+                                "Take action:",
+                                Object {
+                                  "children": "View previous tests",
+                                  "onClick": [Function],
+                                },
+                              ]
+                            }
+                            position="right"
+                            toggleAppearance="base"
+                            toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+                            toggleDisabled={false}
+                          >
+                            <span
+                              className="p-table-menu p-contextual-menu"
+                              style={
+                                Object {
+                                  "position": "relative",
+                                }
+                              }
+                            >
+                              <Button
+                                appearance="base"
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                disabled={false}
+                                hasIcon={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="true"
+                                  className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <i
+                                    className="p-icon--contextual-menu p-contextual-menu__indicator"
+                                  />
+                                </button>
+                              </Button>
+                            </span>
+                          </ContextualMenu>
+                        </TableMenu>
+                      </td>
                     </TableCell>
                   </tr>
                 </TableRow>
@@ -626,7 +712,71 @@ exports[`MachineTestsTable renders 1`] = `
                         aria-hidden={false}
                         className="u-align--right"
                         role="gridcell"
-                      />
+                      >
+                        <TableMenu
+                          links={
+                            Array [
+                              Object {
+                                "children": "View previous tests",
+                                "onClick": [Function],
+                              },
+                            ]
+                          }
+                          position="right"
+                          title="Take action:"
+                        >
+                          <ContextualMenu
+                            className="p-table-menu"
+                            hasToggleIcon={true}
+                            links={
+                              Array [
+                                "Take action:",
+                                Object {
+                                  "children": "View previous tests",
+                                  "onClick": [Function],
+                                },
+                              ]
+                            }
+                            position="right"
+                            toggleAppearance="base"
+                            toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+                            toggleDisabled={false}
+                          >
+                            <span
+                              className="p-table-menu p-contextual-menu"
+                              style={
+                                Object {
+                                  "position": "relative",
+                                }
+                              }
+                            >
+                              <Button
+                                appearance="base"
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                disabled={false}
+                                hasIcon={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="true"
+                                  className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <i
+                                    className="p-icon--contextual-menu p-contextual-menu__indicator"
+                                  />
+                                </button>
+                              </Button>
+                            </span>
+                          </ContextualMenu>
+                        </TableMenu>
+                      </td>
                     </TableCell>
                   </tr>
                 </TableRow>

--- a/ui/src/app/store/scriptresult/reducers.test.ts
+++ b/ui/src/app/store/scriptresult/reducers.test.ts
@@ -1,6 +1,7 @@
 import reducers, { actions } from "./slice";
 
 import {
+  partialScriptResult as partialScriptResultFactory,
   scriptResult as scriptResultFactory,
   scriptResultState as scriptResultStateFactory,
 } from "testing/factories";
@@ -14,6 +15,7 @@ describe("script result reducer", () => {
       loading: false,
       saved: false,
       saving: false,
+      history: {},
     });
   });
 
@@ -30,8 +32,8 @@ describe("script result reducer", () => {
 
   it("reduces getByMachineIdSuccess", () => {
     const existingScriptResult = scriptResultFactory();
-    const newScriptResult = scriptResultFactory();
-    const newScriptResult2 = scriptResultFactory();
+    const newScriptResult = scriptResultFactory({ id: 2 });
+    const newScriptResult2 = scriptResultFactory({ id: 3 });
 
     const scriptResultState = scriptResultStateFactory({
       items: [existingScriptResult],
@@ -48,6 +50,7 @@ describe("script result reducer", () => {
         items: [existingScriptResult, newScriptResult, newScriptResult2],
         loading: false,
         loaded: true,
+        history: { 2: [], 3: [] },
       })
     );
   });
@@ -82,6 +85,45 @@ describe("script result reducer", () => {
     ).toEqual(
       scriptResultStateFactory({
         items: [updatedScriptResult],
+      })
+    );
+  });
+
+  it("reduces getHistoryStart", () => {
+    const scriptResultState = scriptResultStateFactory({
+      items: [],
+      loading: false,
+      history: {},
+    });
+
+    expect(
+      reducers(scriptResultState, actions.getByMachineIdStart(null))
+    ).toEqual(scriptResultStateFactory({ loading: true }));
+  });
+
+  it("reduces getHistorySuccess", () => {
+    const scriptResult = scriptResultFactory({ id: 123 });
+    const partialScriptResult = partialScriptResultFactory({
+      id: scriptResult.id,
+    });
+
+    const scriptResultState = scriptResultStateFactory({
+      items: [scriptResult],
+      loading: true,
+      history: { 123: [] },
+    });
+
+    expect(
+      reducers(scriptResultState, {
+        meta: { item: { id: 123 } },
+        ...actions.getHistorySuccess([partialScriptResult]),
+      })
+    ).toEqual(
+      scriptResultStateFactory({
+        items: [scriptResult],
+        loading: false,
+        loaded: true,
+        history: { 123: [partialScriptResult] },
       })
     );
   });

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -39,10 +39,19 @@ export type ScriptResultResult = {
   surfaced: boolean;
 };
 
-export type ScriptResult = Model & {
-  ended?: string;
+export type PartialScriptResult = Model & {
   endtime: number;
   estimated_runtime: string;
+  runtime: string;
+  starttime: number;
+  status: ResultStatus;
+  status_name: string;
+  suppressed: boolean;
+  updated?: string;
+};
+
+export type ScriptResult = PartialScriptResult & {
+  ended?: string;
   exit_status?: ExitStatus | number | null;
   hardware_type: HardwareType;
   interface?: NetworkInterface | null;
@@ -51,16 +60,12 @@ export type ScriptResult = Model & {
   physical_blockdevice?: number | null;
   result_type: ResultType;
   results: ScriptResultResult[];
-  runtime: string;
   script?: number;
   script_version?: number | null;
   started?: string;
-  starttime: number;
-  status: ResultStatus;
-  status_name: string;
-  suppressed: boolean;
   tags: string;
-  updated?: string;
 };
 
-export type ScriptResultState = GenericState<ScriptResult, TSFixMe>;
+export type ScriptResultState = GenericState<ScriptResult, TSFixMe> & {
+  history: Record<ScriptResult["id"], PartialScriptResult[]>;
+};

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -98,7 +98,11 @@ export { nodeDevice } from "./nodedevice";
 export { notification } from "./notification";
 export { packageRepository } from "./packagerepository";
 export { resourcePool } from "./resourcepool";
-export { scriptResult, scriptResultResult } from "./scriptResult";
+export {
+  partialScriptResult,
+  scriptResult,
+  scriptResultResult,
+} from "./scriptResult";
 export { scripts } from "./scripts";
 export { service } from "./service";
 export { space } from "./space";

--- a/ui/src/testing/factories/scriptResult.ts
+++ b/ui/src/testing/factories/scriptResult.ts
@@ -3,6 +3,7 @@ import { array, define, extend } from "cooky-cutter";
 import { model } from "./model";
 
 import type {
+  PartialScriptResult,
   ScriptResult,
   ScriptResultResult,
 } from "app/store/scriptresult/types";
@@ -14,6 +15,17 @@ export const scriptResultResult = define<ScriptResultResult>({
   description: "test description",
   value: "test value",
   surfaced: false,
+});
+
+export const partialScriptResult = extend<Model, PartialScriptResult>(model, {
+  endtime: 1605243027.158285,
+  estimated_runtime: "test runtime",
+  runtime: "0:00:00",
+  starttime: 605243026.966467,
+  status: 2,
+  status_name: "test status",
+  suppressed: false,
+  updated: "Fri, 13 Nov. 2020 04:50:27",
 });
 
 export const scriptResult = extend<Model, ScriptResult>(model, {

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -324,6 +324,7 @@ export const resourcePoolState = define<ResourcePoolState>({
 
 export const scriptResultState = define<ScriptResultState>({
   ...defaultState,
+  history: () => ({}),
 });
 
 export const serviceState = define<ServiceState>({


### PR DESCRIPTION
## Done

- Add 'show previous tests' take action item
- Add script result history reducer to root of scriptresult store

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit testing details for a machine with test results.
- Select 'show previous tests' from the take action menu
- Check the redux store and ensure the script result history is reduced correctly

## Fixes

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
