### PR TITLE
refactor(ui): extract NodeDevice component from commonalities in PCI/USB components

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.test.tsx
@@ -5,22 +5,16 @@ import configureStore from "redux-mock-store";
 
 import MachinePCIDevices from "./MachinePCIDevices";
 
-import { HardwareType } from "app/base/enum";
-import { NodeDeviceBus } from "app/store/nodedevice/types";
-import { NodeActions } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
-  machineNumaNode as numaNodeFactory,
-  nodeDevice as nodeDeviceFactory,
-  nodeDeviceState as nodeDeviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("MachinePCIDevices", () => {
-  it("shows placeholder rows while PCI devices are loading", () => {
+  it("fetches the machine's node devices on load", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
@@ -29,100 +23,9 @@ describe("MachinePCIDevices", () => {
           }),
         ],
       }),
-      nodedevice: nodeDeviceStateFactory({ loading: true }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/pci-devices"
-            component={() => (
-              <MachinePCIDevices setSelectedAction={jest.fn()} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("Placeholder").exists()).toBe(true);
-  });
-
-  it(`prompts user to commission machine if no PCI info available and machine
-  can be commissioned`, () => {
-    const setSelectedAction = jest.fn();
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [
-          machineDetailsFactory({
-            actions: [NodeActions.COMMISSION],
-            system_id: "abc123",
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/pci-devices"
-            component={() => (
-              <MachinePCIDevices setSelectedAction={setSelectedAction} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='information-unavailable']").exists()).toBe(
-      true
-    );
-
-    wrapper.find("[data-test='commission-machine'] button").simulate("click");
-
-    expect(setSelectedAction).toHaveBeenCalledWith({
-      name: NodeActions.COMMISSION,
-    });
-  });
-
-  it("groups PCI devices by hardware type", () => {
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const networkDevices = [
-      nodeDeviceFactory({
-        bus: NodeDeviceBus.PCIE,
-        hardware_type: HardwareType.Network,
-        node_id: machine.id,
-      }),
-    ];
-    const storageDevices = Array.from(Array(3)).map(() =>
-      nodeDeviceFactory({
-        bus: NodeDeviceBus.PCIE,
-        hardware_type: HardwareType.Storage,
-        node_id: machine.id,
-      })
-    );
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machine],
-      }),
-      nodedevice: nodeDeviceStateFactory({
-        items: [...networkDevices, ...storageDevices],
-        loading: false,
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
+    mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[
@@ -141,122 +44,21 @@ describe("MachinePCIDevices", () => {
     );
 
     expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(0)
-        .find(".p-double-row__primary-row")
-        .text()
-    ).toBe("Network");
-    expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(0)
-        .find(".p-double-row__secondary-row")
-        .text()
-    ).toBe("1 device");
-    expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(1)
-        .find(".p-double-row__primary-row")
-        .text()
-    ).toBe("Storage");
-    expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(1)
-        .find(".p-double-row__secondary-row")
-        .text()
-    ).toBe("3 devices");
-  });
-
-  it("can link to the network and storage tabs", () => {
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const networkDevice = nodeDeviceFactory({
-      bus: NodeDeviceBus.PCIE,
-      hardware_type: HardwareType.Network,
-      node_id: machine.id,
+      store
+        .getActions()
+        .find((action) => action.type === "nodedevice/getByMachineId")
+    ).toStrictEqual({
+      type: "nodedevice/getByMachineId",
+      meta: {
+        method: "list",
+        model: "nodedevice",
+        nocache: true,
+      },
+      payload: {
+        params: {
+          system_id: "abc123",
+        },
+      },
     });
-    const storageDevice = nodeDeviceFactory({
-      bus: NodeDeviceBus.PCIE,
-      hardware_type: HardwareType.Storage,
-      node_id: machine.id,
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machine],
-      }),
-      nodedevice: nodeDeviceStateFactory({
-        items: [networkDevice, storageDevice],
-        loading: false,
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/pci-devices"
-            component={() => (
-              <MachinePCIDevices setSelectedAction={jest.fn()} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(
-      wrapper.find("[data-test='group-label']").at(0).find("Link").prop("to")
-    ).toBe("/machine/abc123/network");
-    expect(
-      wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
-    ).toBe("/machine/abc123/storage");
-  });
-
-  it("displays the NUMA node index of a node device", () => {
-    const numaNode = numaNodeFactory({ index: 128 });
-    const machine = machineDetailsFactory({
-      numa_nodes: [numaNode, numaNodeFactory()],
-      system_id: "abc123",
-    });
-    const pciDevice = nodeDeviceFactory({
-      bus: NodeDeviceBus.PCIE,
-      node_id: machine.id,
-      numa_node_id: numaNode.id,
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machine],
-      }),
-      nodedevice: nodeDeviceStateFactory({
-        items: [pciDevice],
-        loading: false,
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/pci-devices"
-            component={() => (
-              <MachinePCIDevices setSelectedAction={jest.fn()} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='pci-numa']").text()).toBe("128");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
@@ -1,230 +1,36 @@
-import { useEffect } from "react";
-
-import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
-import pluralize from "pluralize";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../MachineSummary";
+import NodeDevices from "../NodeDevices";
 
-import DoubleRow from "app/base/components/DoubleRow";
-import Placeholder from "app/base/components/Placeholder";
-import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
-import { actions as nodeDeviceActions } from "app/store/nodedevice";
-import nodeDeviceSelectors from "app/store/nodedevice/selectors";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
-import type { NodeDevice } from "app/store/nodedevice/types";
 import type { RootState } from "app/store/root/types";
-import { NodeActions } from "app/store/types/node";
-
-type NodeDeviceGroup = {
-  hardwareTypes: HardwareType[];
-  items: NodeDevice[];
-  label: string;
-  pathname?: string;
-};
 
 type Props = { setSelectedAction: SetSelectedAction };
 
-const generateGroup = (group: NodeDeviceGroup, machine: Machine) =>
-  group.items.map((nodeDevice, i) => {
-    const {
-      commissioning_driver,
-      id,
-      numa_node_id,
-      pci_address,
-      product_id,
-      product_name,
-      vendor_id,
-      vendor_name,
-    } = nodeDevice;
-    const numaNode =
-      "numa_nodes" in machine
-        ? machine.numa_nodes.find((numa) => numa.id === numa_node_id)
-        : null;
-
-    return (
-      <tr key={`pci-device-${id}`}>
-        <td>
-          {i === 0 && (
-            <DoubleRow
-              data-test="group-label"
-              primary={
-                <strong>
-                  {group.pathname ? (
-                    <Link to={`/machine/${machine.system_id}${group.pathname}`}>
-                      {group.label}
-                    </Link>
-                  ) : (
-                    group.label
-                  )}
-                </strong>
-              }
-              secondary={pluralize("device", group.items.length, true)}
-            />
-          )}
-        </td>
-        <td>
-          <DoubleRow primary={vendor_name} secondary={vendor_id} />
-        </td>
-        <td>{product_name}</td>
-        <td>{product_id}</td>
-        <td>{commissioning_driver}</td>
-        <td className="u-align--right" data-test="pci-numa">
-          {numaNode?.index}
-        </td>
-        <td className="u-align--right">{pci_address}</td>
-      </tr>
-    );
-  });
-
-const MachinePCIDevices = ({ setSelectedAction }: Props): JSX.Element => {
-  const dispatch = useDispatch();
-  const params = useParams<RouteParams>();
-  const { id } = params;
+const MachinePCIDevices = ({
+  setSelectedAction,
+}: Props): JSX.Element | null => {
+  const { id } = useParams<RouteParams>();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
-  const nodeDevices = useSelector((state: RootState) =>
-    nodeDeviceSelectors.getByMachineId(state, machine?.id || null)
-  );
-  const nodeDevicesLoading = useSelector(nodeDeviceSelectors.loading);
+  useWindowTitle(`${`${machine?.fqdn || "Machine"} `} PCI devices`);
 
-  useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} PCI devices`);
-  const canBeCommissioned = machine?.actions.includes(NodeActions.COMMISSION);
-
-  useEffect(() => {
-    dispatch(nodeDeviceActions.getByMachineId(id));
-  }, [dispatch, id]);
-
-  const groupedDevices = nodeDevices
-    .reduce<NodeDeviceGroup[]>(
-      (groups, nodeDevice) => {
-        const group = groups.find((group) =>
-          group.hardwareTypes.includes(nodeDevice.hardware_type)
-        );
-        if (group && nodeDevice.bus === NodeDeviceBus.PCIE) {
-          group.items.push(nodeDevice);
-        }
-        return groups;
-      },
-      [
-        {
-          hardwareTypes: [HardwareType.Network],
-          label: "Network",
-          pathname: "/network",
-          items: [],
-        },
-        {
-          hardwareTypes: [HardwareType.Storage],
-          label: "Storage",
-          pathname: "/storage",
-          items: [],
-        },
-        {
-          hardwareTypes: [HardwareType.GPU],
-          label: "GPU",
-          items: [],
-        },
-        {
-          hardwareTypes: [
-            HardwareType.CPU,
-            HardwareType.Memory,
-            HardwareType.Node,
-          ],
-          label: "Generic",
-          items: [],
-        },
-      ]
-    )
-    .filter((group) => group.items.length > 0);
-
-  return (
-    <>
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th>
-              <div>Vendor</div>
-              <div>ID</div>
-            </th>
-            <th>Product</th>
-            <th>Product ID</th>
-            <th>Driver</th>
-            <th className="u-align--right">NUMA node</th>
-            <th className="u-align--right">PCI address</th>
-          </tr>
-        </thead>
-        <tbody>
-          {nodeDevicesLoading || machine === null ? (
-            <>
-              {Array.from(Array(5)).map((_, i) => (
-                <tr key={`pci-placeholder-${i}`}>
-                  <td>
-                    <Placeholder>Group name</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>Example vendor description</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>Example product description</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>0000</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>Driver name</Placeholder>
-                  </td>
-                  <td className="u-align--right">
-                    <Placeholder>0000</Placeholder>
-                  </td>
-                  <td className="u-align--right">
-                    <Placeholder>0000:00:00.0</Placeholder>
-                  </td>
-                </tr>
-              ))}
-            </>
-          ) : (
-            groupedDevices.map((group) => generateGroup(group, machine))
-          )}
-        </tbody>
-      </table>
-      {!nodeDevicesLoading && nodeDevices.length === 0 && (
-        <Strip data-test="information-unavailable" shallow>
-          <Row>
-            <Col className="u-flex" emptyLarge={4} size={6}>
-              <h4>
-                <Icon name="warning" />
-              </h4>
-              <div className="u-flex--grow u-nudge-right">
-                <h4>PCI information not available</h4>
-                <p className="u-sv1">
-                  Try commissioning this machine to load PCI information.
-                </p>
-                {canBeCommissioned && (
-                  <Button
-                    appearance="positive"
-                    data-test="commission-machine"
-                    onClick={() =>
-                      setSelectedAction({ name: NodeActions.COMMISSION })
-                    }
-                  >
-                    Commission
-                  </Button>
-                )}
-              </div>
-            </Col>
-          </Row>
-        </Strip>
-      )}
-    </>
-  );
+  if (machine && "numa_nodes" in machine) {
+    return (
+      <NodeDevices
+        bus={NodeDeviceBus.PCIE}
+        machine={machine}
+        setSelectedAction={setSelectedAction}
+      />
+    );
+  }
+  return null;
 };
 
 export default MachinePCIDevices;

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.test.tsx
@@ -5,22 +5,16 @@ import configureStore from "redux-mock-store";
 
 import MachineUSBDevices from "./MachineUSBDevices";
 
-import { HardwareType } from "app/base/enum";
-import { NodeDeviceBus } from "app/store/nodedevice/types";
-import { NodeActions } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
-  machineNumaNode as numaNodeFactory,
   machineState as machineStateFactory,
-  nodeDevice as nodeDeviceFactory,
-  nodeDeviceState as nodeDeviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("MachineUSBDevices", () => {
-  it("shows placeholder rows while USB devices are loading", () => {
+  it("fetches the machine's node devices on load", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
@@ -29,137 +23,9 @@ describe("MachineUSBDevices", () => {
           }),
         ],
       }),
-      nodedevice: nodeDeviceStateFactory({ loading: true }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/usb-devices"
-            component={() => (
-              <MachineUSBDevices setSelectedAction={jest.fn()} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("Placeholder").exists()).toBe(true);
-  });
-
-  it(`prompts user to commission machine if no USB info available and machine
-    can be commissioned`, () => {
-    const setSelectedAction = jest.fn();
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [
-          machineDetailsFactory({
-            actions: [NodeActions.COMMISSION],
-            system_id: "abc123",
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/usb-devices"
-            component={() => (
-              <MachineUSBDevices setSelectedAction={setSelectedAction} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='information-unavailable']").exists()).toBe(
-      true
-    );
-
-    wrapper.find("[data-test='commission-machine'] button").simulate("click");
-
-    expect(setSelectedAction).toHaveBeenCalledWith({
-      name: NodeActions.COMMISSION,
-    });
-  });
-
-  it("shows a message if no USB devices have been detected", () => {
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machine],
-      }),
-      nodedevice: nodeDeviceStateFactory({
-        items: [
-          nodeDeviceFactory({
-            bus: NodeDeviceBus.PCIE,
-            node_id: machine.id,
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/usb-devices"
-            component={() => (
-              <MachineUSBDevices setSelectedAction={jest.fn()} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='no-usb']").exists()).toBe(true);
-  });
-
-  it("groups USB devices by hardware type", () => {
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const networkDevices = [
-      nodeDeviceFactory({
-        bus: NodeDeviceBus.USB,
-        hardware_type: HardwareType.Network,
-        node_id: machine.id,
-      }),
-    ];
-    const storageDevices = Array.from(Array(3)).map(() =>
-      nodeDeviceFactory({
-        bus: NodeDeviceBus.USB,
-        hardware_type: HardwareType.Storage,
-        node_id: machine.id,
-      })
-    );
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machine],
-      }),
-      nodedevice: nodeDeviceStateFactory({
-        items: [...networkDevices, ...storageDevices],
-        loading: false,
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
+    mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[
@@ -178,122 +44,21 @@ describe("MachineUSBDevices", () => {
     );
 
     expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(0)
-        .find(".p-double-row__primary-row")
-        .text()
-    ).toBe("Network");
-    expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(0)
-        .find(".p-double-row__secondary-row")
-        .text()
-    ).toBe("1 device");
-    expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(1)
-        .find(".p-double-row__primary-row")
-        .text()
-    ).toBe("Storage");
-    expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(1)
-        .find(".p-double-row__secondary-row")
-        .text()
-    ).toBe("3 devices");
-  });
-
-  it("can link to the network and storage tabs", () => {
-    const machine = machineDetailsFactory({ system_id: "abc123" });
-    const networkDevice = nodeDeviceFactory({
-      bus: NodeDeviceBus.USB,
-      hardware_type: HardwareType.Network,
-      node_id: machine.id,
+      store
+        .getActions()
+        .find((action) => action.type === "nodedevice/getByMachineId")
+    ).toStrictEqual({
+      type: "nodedevice/getByMachineId",
+      meta: {
+        method: "list",
+        model: "nodedevice",
+        nocache: true,
+      },
+      payload: {
+        params: {
+          system_id: "abc123",
+        },
+      },
     });
-    const storageDevice = nodeDeviceFactory({
-      bus: NodeDeviceBus.USB,
-      hardware_type: HardwareType.Storage,
-      node_id: machine.id,
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machine],
-      }),
-      nodedevice: nodeDeviceStateFactory({
-        items: [networkDevice, storageDevice],
-        loading: false,
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/usb-devices"
-            component={() => (
-              <MachineUSBDevices setSelectedAction={jest.fn()} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(
-      wrapper.find("[data-test='group-label']").at(0).find("Link").prop("to")
-    ).toBe("/machine/abc123/network");
-    expect(
-      wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
-    ).toBe("/machine/abc123/storage");
-  });
-
-  it("displays the NUMA node index of a USB device", () => {
-    const numaNode = numaNodeFactory({ index: 128 });
-    const machine = machineDetailsFactory({
-      numa_nodes: [numaNode, numaNodeFactory()],
-      system_id: "abc123",
-    });
-    const pciDevice = nodeDeviceFactory({
-      bus: NodeDeviceBus.USB,
-      node_id: machine.id,
-      numa_node_id: numaNode.id,
-    });
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machine],
-      }),
-      nodedevice: nodeDeviceStateFactory({
-        items: [pciDevice],
-        loading: false,
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/usb-devices", key: "testKey" },
-          ]}
-        >
-          <Route
-            exact
-            path="/machine/:id/usb-devices"
-            component={() => (
-              <MachineUSBDevices setSelectedAction={jest.fn()} />
-            )}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='usb-numa']").text()).toBe("128");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
@@ -1,251 +1,36 @@
-import { useEffect } from "react";
-
-import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
-import pluralize from "pluralize";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../MachineSummary";
+import NodeDevices from "../NodeDevices";
 
-import DoubleRow from "app/base/components/DoubleRow";
-import Placeholder from "app/base/components/Placeholder";
-import { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
-import { actions as nodeDeviceActions } from "app/store/nodedevice";
-import nodeDeviceSelectors from "app/store/nodedevice/selectors";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
-import type { NodeDevice } from "app/store/nodedevice/types";
 import type { RootState } from "app/store/root/types";
-import { NodeActions } from "app/store/types/node";
-
-type NodeDeviceGroup = {
-  hardwareTypes: HardwareType[];
-  items: NodeDevice[];
-  label: string;
-  pathname?: string;
-};
 
 type Props = { setSelectedAction: SetSelectedAction };
 
-const generateGroup = (group: NodeDeviceGroup, machine: Machine) =>
-  group.items.map((nodeDevice, i) => {
-    const {
-      bus_number,
-      commissioning_driver,
-      device_number,
-      id,
-      numa_node_id,
-      product_id,
-      product_name,
-      vendor_id,
-      vendor_name,
-    } = nodeDevice;
-    const numaNode =
-      "numa_nodes" in machine
-        ? machine.numa_nodes.find((numa) => numa.id === numa_node_id)
-        : null;
-
-    return (
-      <tr key={`usb-device-${id}`}>
-        <td>
-          {i === 0 && (
-            <DoubleRow
-              data-test="group-label"
-              primary={
-                <strong>
-                  {group.pathname ? (
-                    <Link to={`/machine/${machine.system_id}${group.pathname}`}>
-                      {group.label}
-                    </Link>
-                  ) : (
-                    group.label
-                  )}
-                </strong>
-              }
-              secondary={pluralize("device", group.items.length, true)}
-            />
-          )}
-        </td>
-        <td>
-          <DoubleRow primary={vendor_name} secondary={vendor_id} />
-        </td>
-        <td>{product_name}</td>
-        <td>{product_id}</td>
-        <td>{commissioning_driver}</td>
-        <td className="u-align--right" data-test="usb-numa">
-          {numaNode?.index}
-        </td>
-        <td className="u-align--right">{bus_number}</td>
-        <td className="u-align--right">{device_number}</td>
-      </tr>
-    );
-  });
-
-const MachineUSBDevices = ({ setSelectedAction }: Props): JSX.Element => {
-  const dispatch = useDispatch();
-  const params = useParams<RouteParams>();
-  const { id } = params;
+const MachineUSBDevices = ({
+  setSelectedAction,
+}: Props): JSX.Element | null => {
+  const { id } = useParams<RouteParams>();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
-  const nodeDevices = useSelector((state: RootState) =>
-    nodeDeviceSelectors.getByMachineId(state, machine?.id || null)
-  );
-  const nodeDevicesLoading = useSelector(nodeDeviceSelectors.loading);
+  useWindowTitle(`${`${machine?.fqdn || "Machine"} `} PCI devices`);
 
-  useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} USB devices`);
-  const canBeCommissioned = machine?.actions.includes(NodeActions.COMMISSION);
-
-  useEffect(() => {
-    dispatch(nodeDeviceActions.getByMachineId(id));
-  }, [dispatch, id]);
-
-  const usbDevices = nodeDevices.filter(
-    (nodeDevice) => nodeDevice.bus === NodeDeviceBus.USB
-  );
-  const groupedDevices = usbDevices
-    .reduce<NodeDeviceGroup[]>(
-      (groups, nodeDevice) => {
-        const group = groups.find((group) =>
-          group.hardwareTypes.includes(nodeDevice.hardware_type)
-        );
-        if (group) {
-          group.items.push(nodeDevice);
-        }
-        return groups;
-      },
-      [
-        {
-          hardwareTypes: [HardwareType.Network],
-          label: "Network",
-          pathname: "/network",
-          items: [],
-        },
-        {
-          hardwareTypes: [HardwareType.Storage],
-          label: "Storage",
-          pathname: "/storage",
-          items: [],
-        },
-        {
-          hardwareTypes: [HardwareType.GPU],
-          label: "GPU",
-          items: [],
-        },
-        {
-          hardwareTypes: [
-            HardwareType.CPU,
-            HardwareType.Memory,
-            HardwareType.Node,
-          ],
-          label: "Generic",
-          items: [],
-        },
-      ]
-    )
-    .filter((group) => group.items.length > 0);
-
-  const noDevices = nodeDevices.length === 0;
-  const noUsb = usbDevices.length === 0;
-
-  return (
-    <>
-      <table>
-        <thead>
-          <tr>
-            <th></th>
-            <th>
-              <div>Vendor</div>
-              <div>ID</div>
-            </th>
-            <th>Product</th>
-            <th>Product ID</th>
-            <th>Driver</th>
-            <th className="u-align--right">NUMA node</th>
-            <th className="u-align--right">Bus address</th>
-            <th className="u-align--right">Device address</th>
-          </tr>
-        </thead>
-        <tbody>
-          {nodeDevicesLoading || machine === null ? (
-            <>
-              {Array.from(Array(5)).map((_, i) => (
-                <tr key={`usb-placeholder-${i}`}>
-                  <td>
-                    <Placeholder>Group name</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>Example vendor description</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>Example product description</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>0000</Placeholder>
-                  </td>
-                  <td>
-                    <Placeholder>Driver name</Placeholder>
-                  </td>
-                  <td className="u-align--right">
-                    <Placeholder>0000</Placeholder>
-                  </td>
-                  <td className="u-align--right">
-                    <Placeholder>0000</Placeholder>
-                  </td>
-                  <td className="u-align--right">
-                    <Placeholder>0000</Placeholder>
-                  </td>
-                </tr>
-              ))}
-            </>
-          ) : (
-            groupedDevices.map((group) => generateGroup(group, machine))
-          )}
-        </tbody>
-      </table>
-      {!nodeDevicesLoading && (noDevices || noUsb) && (
-        <Strip shallow>
-          <Row>
-            <Col className="u-flex" emptyLarge={4} size={6}>
-              <h4>
-                <Icon name="warning" />
-              </h4>
-              <div className="u-flex--grow u-nudge-right">
-                <h4>USB information not available</h4>
-                {noDevices && (
-                  <>
-                    <p className="u-sv1" data-test="information-unavailable">
-                      Try commissioning this machine to load USB information.
-                    </p>
-                    {canBeCommissioned && (
-                      <Button
-                        appearance="positive"
-                        data-test="commission-machine"
-                        onClick={() =>
-                          setSelectedAction({ name: NodeActions.COMMISSION })
-                        }
-                      >
-                        Commission
-                      </Button>
-                    )}
-                  </>
-                )}
-                {noUsb && (
-                  <p className="u-sv1" data-test="no-usb">
-                    No USB devices discovered during commissioning.
-                  </p>
-                )}
-              </div>
-            </Col>
-          </Row>
-        </Strip>
-      )}
-    </>
-  );
+  if (machine && "numa_nodes" in machine) {
+    return (
+      <NodeDevices
+        bus={NodeDeviceBus.USB}
+        machine={machine}
+        setSelectedAction={setSelectedAction}
+      />
+    );
+  }
+  return null;
 };
 
 export default MachineUSBDevices;

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
@@ -1,0 +1,276 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import NodeDevices from "./NodeDevices";
+
+import { HardwareType } from "app/base/enum";
+import { NodeDeviceBus } from "app/store/nodedevice/types";
+import { NodeActions } from "app/store/types/node";
+import {
+  machineDetails as machineDetailsFactory,
+  machineNumaNode as numaNodeFactory,
+  nodeDevice as nodeDeviceFactory,
+  nodeDeviceState as nodeDeviceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NodeDevices", () => {
+  it("shows placeholder rows while node devices are loading", () => {
+    const machine = machineDetailsFactory();
+    const state = rootStateFactory({
+      nodedevice: nodeDeviceStateFactory({
+        loading: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NodeDevices
+          bus={NodeDeviceBus.PCIE}
+          machine={machine}
+          setSelectedAction={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("Placeholder").exists()).toBe(true);
+  });
+
+  it("shows a PCI address column if showing PCI devices", () => {
+    const machine = machineDetailsFactory();
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NodeDevices
+          bus={NodeDeviceBus.PCIE}
+          machine={machine}
+          setSelectedAction={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='pci-address-col']").exists()).toBe(true);
+  });
+
+  it("shows bus and device address columns if showing USB devices", () => {
+    const machine = machineDetailsFactory();
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NodeDevices
+          bus={NodeDeviceBus.USB}
+          machine={machine}
+          setSelectedAction={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='bus-address-col']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='device-address-col']").exists()).toBe(
+      true
+    );
+  });
+
+  it(`prompts user to commission machine if no devices found and machine can be
+    commissioned`, () => {
+    const setSelectedAction = jest.fn();
+    const machine = machineDetailsFactory({
+      actions: [NodeActions.COMMISSION],
+    });
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NodeDevices
+          bus={NodeDeviceBus.PCIE}
+          machine={machine}
+          setSelectedAction={setSelectedAction}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='no-devices']").exists()).toBe(true);
+
+    wrapper.find("[data-test='commission-machine'] button").simulate("click");
+
+    expect(setSelectedAction).toHaveBeenCalledWith({
+      name: NodeActions.COMMISSION,
+    });
+  });
+
+  it("shows a message if the machine has PCI devices but no USB devices", () => {
+    const machine = machineDetailsFactory();
+    const state = rootStateFactory({
+      nodedevice: nodeDeviceStateFactory({
+        items: [
+          nodeDeviceFactory({ bus: NodeDeviceBus.PCIE, node_id: machine.id }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NodeDevices
+          bus={NodeDeviceBus.USB}
+          machine={machine}
+          setSelectedAction={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='no-usb']").exists()).toBe(true);
+  });
+
+  it("groups node devices by hardware type", () => {
+    const machine = machineDetailsFactory({ system_id: "abc123" });
+    const networkDevices = [
+      nodeDeviceFactory({
+        bus: NodeDeviceBus.PCIE,
+        hardware_type: HardwareType.Network,
+        node_id: machine.id,
+      }),
+    ];
+    const storageDevices = Array.from(Array(3)).map(() =>
+      nodeDeviceFactory({
+        bus: NodeDeviceBus.PCIE,
+        hardware_type: HardwareType.Storage,
+        node_id: machine.id,
+      })
+    );
+    const state = rootStateFactory({
+      nodedevice: nodeDeviceStateFactory({
+        items: [...networkDevices, ...storageDevices],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <NodeDevices
+            bus={NodeDeviceBus.PCIE}
+            machine={machine}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(0)
+        .find(".p-double-row__primary-row")
+        .text()
+    ).toBe("Network");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(0)
+        .find(".p-double-row__secondary-row")
+        .text()
+    ).toBe("1 device");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(1)
+        .find(".p-double-row__primary-row")
+        .text()
+    ).toBe("Storage");
+    expect(
+      wrapper
+        .find("[data-test='group-label']")
+        .at(1)
+        .find(".p-double-row__secondary-row")
+        .text()
+    ).toBe("3 devices");
+  });
+
+  it("can link to the network and storage tabs", () => {
+    const machine = machineDetailsFactory({ system_id: "abc123" });
+    const networkDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.PCIE,
+      hardware_type: HardwareType.Network,
+      node_id: machine.id,
+    });
+    const storageDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.PCIE,
+      hardware_type: HardwareType.Storage,
+      node_id: machine.id,
+    });
+    const state = rootStateFactory({
+      nodedevice: nodeDeviceStateFactory({
+        items: [networkDevice, storageDevice],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <NodeDevices
+            bus={NodeDeviceBus.PCIE}
+            machine={machine}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='group-label']").at(0).find("Link").prop("to")
+    ).toBe("/machine/abc123/network");
+    expect(
+      wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
+    ).toBe("/machine/abc123/storage");
+  });
+
+  it("displays the NUMA node index of a node device", () => {
+    const numaNode = numaNodeFactory({ index: 128 });
+    const machine = machineDetailsFactory({
+      numa_nodes: [numaNode, numaNodeFactory()],
+      system_id: "abc123",
+    });
+    const pciDevice = nodeDeviceFactory({
+      bus: NodeDeviceBus.PCIE,
+      id: 1,
+      node_id: machine.id,
+      numa_node_id: numaNode.id,
+    });
+    const state = rootStateFactory({
+      nodedevice: nodeDeviceStateFactory({
+        items: [pciDevice],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/pci-devices", key: "testKey" },
+          ]}
+        >
+          <NodeDevices
+            bus={NodeDeviceBus.PCIE}
+            machine={machine}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='node-device-1-numa']").text()).toBe("128");
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -1,0 +1,289 @@
+import { useEffect } from "react";
+
+import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import type { SetSelectedAction } from "../MachineSummary";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import Placeholder from "app/base/components/Placeholder";
+import { HardwareType } from "app/base/enum";
+import type { MachineDetails } from "app/store/machine/types";
+import { actions as nodeDeviceActions } from "app/store/nodedevice";
+import nodeDeviceSelectors from "app/store/nodedevice/selectors";
+import { NodeDeviceBus } from "app/store/nodedevice/types";
+import type { NodeDevice } from "app/store/nodedevice/types";
+import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
+
+type Props = {
+  bus: NodeDeviceBus;
+  machine: MachineDetails;
+  setSelectedAction: SetSelectedAction;
+};
+type NodeDeviceGroup = {
+  hardwareTypes: HardwareType[];
+  items: NodeDevice[];
+  label: string;
+  pathname?: string;
+};
+
+const generateGroup = (
+  bus: NodeDeviceBus,
+  group: NodeDeviceGroup,
+  machine: MachineDetails
+) =>
+  group.items.map((nodeDevice, i) => {
+    const {
+      bus_number,
+      commissioning_driver,
+      device_number,
+      id,
+      numa_node_id,
+      pci_address,
+      product_id,
+      product_name,
+      vendor_id,
+      vendor_name,
+    } = nodeDevice;
+    const numaNode = machine.numa_nodes.find(
+      (numa) => numa.id === numa_node_id
+    );
+
+    return (
+      <tr key={`node-device-${id}`}>
+        <td>
+          {i === 0 && (
+            <DoubleRow
+              data-test="group-label"
+              primary={
+                <strong>
+                  {group.pathname ? (
+                    <Link to={`/machine/${machine.system_id}${group.pathname}`}>
+                      {group.label}
+                    </Link>
+                  ) : (
+                    group.label
+                  )}
+                </strong>
+              }
+              secondary={pluralize("device", group.items.length, true)}
+            />
+          )}
+        </td>
+        <td>
+          <DoubleRow primary={vendor_name} secondary={vendor_id} />
+        </td>
+        <td>{product_name}</td>
+        <td>{product_id}</td>
+        <td>{commissioning_driver}</td>
+        <td className="u-align--right" data-test={`node-device-${id}-numa`}>
+          {numaNode?.index || ""}
+        </td>
+        {bus === NodeDeviceBus.PCIE ? (
+          <td className="u-align--right">{pci_address}</td>
+        ) : (
+          <>
+            <td className="u-align--right">{bus_number}</td>
+            <td className="u-align--right">{device_number}</td>
+          </>
+        )}
+      </tr>
+    );
+  });
+
+const generateWarning = (
+  bus: NodeDeviceBus,
+  machine: MachineDetails,
+  nodeDevices: NodeDevice[],
+  setSelectedAction: SetSelectedAction
+) => {
+  const busDisplay = bus === NodeDeviceBus.PCIE ? "PCI" : "USB";
+  const canBeCommissioned = machine?.actions.includes(NodeActions.COMMISSION);
+  const noDevices = nodeDevices.length === 0;
+  const noUSB = !nodeDevices.some((device) => device.bus === NodeDeviceBus.USB);
+
+  let warning: React.ReactNode;
+  if (noDevices) {
+    warning = (
+      <>
+        <h4>{busDisplay} information not available</h4>
+        <p className="u-sv1" data-test="no-devices">
+          Try commissioning this machine to load {busDisplay} information.
+        </p>
+        {canBeCommissioned && (
+          <Button
+            appearance="positive"
+            data-test="commission-machine"
+            onClick={() => setSelectedAction({ name: NodeActions.COMMISSION })}
+          >
+            Commission
+          </Button>
+        )}
+      </>
+    );
+  } else if (bus === NodeDeviceBus.USB && noUSB) {
+    warning = (
+      <>
+        <h4>USB information not available</h4>
+        <p className="u-sv1" data-test="no-usb">
+          No USB devices discovered during commissioning.
+        </p>
+      </>
+    );
+  }
+  return warning ? (
+    <Strip data-test="node-devices-warning" shallow>
+      <Row>
+        <Col className="u-flex" emptyLarge={4} size={6}>
+          <h4>
+            <Icon name="warning" />
+          </h4>
+          <div className="u-flex--grow u-nudge-right">{warning}</div>
+        </Col>
+      </Row>
+    </Strip>
+  ) : null;
+};
+
+const NodeDevices = ({
+  bus,
+  machine,
+  setSelectedAction,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const nodeDevices = useSelector((state: RootState) =>
+    nodeDeviceSelectors.getByMachineId(state, machine.id)
+  );
+  const nodeDevicesLoading = useSelector(nodeDeviceSelectors.loading);
+
+  useEffect(() => {
+    dispatch(nodeDeviceActions.getByMachineId(machine.system_id));
+  }, [dispatch, machine.system_id]);
+
+  const groupedDevices = nodeDevices
+    .reduce<NodeDeviceGroup[]>(
+      (groups, nodeDevice) => {
+        const group = groups.find((group) =>
+          group.hardwareTypes.includes(nodeDevice.hardware_type)
+        );
+        if (group && nodeDevice.bus === bus) {
+          group.items.push(nodeDevice);
+        }
+        return groups;
+      },
+      [
+        {
+          hardwareTypes: [HardwareType.Network],
+          label: "Network",
+          pathname: "/network",
+          items: [],
+        },
+        {
+          hardwareTypes: [HardwareType.Storage],
+          label: "Storage",
+          pathname: "/storage",
+          items: [],
+        },
+        {
+          hardwareTypes: [HardwareType.GPU],
+          label: "GPU",
+          items: [],
+        },
+        {
+          hardwareTypes: [
+            HardwareType.CPU,
+            HardwareType.Memory,
+            HardwareType.Node,
+          ],
+          label: "Generic",
+          items: [],
+        },
+      ]
+    )
+    .filter((group) => group.items.length > 0);
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>
+              <div>Vendor</div>
+              <div>ID</div>
+            </th>
+            <th>Product</th>
+            <th>Product ID</th>
+            <th>Driver</th>
+            <th className="u-align--right">NUMA node</th>
+            {bus === NodeDeviceBus.PCIE ? (
+              <th className="u-align--right" data-test="pci-address-col">
+                PCI address
+              </th>
+            ) : (
+              <>
+                <th className="u-align--right" data-test="bus-address-col">
+                  Bus address
+                </th>
+                <th className="u-align--right" data-test="device-address-col">
+                  Device address
+                </th>
+              </>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {nodeDevicesLoading ? (
+            <>
+              {Array.from(Array(5)).map((_, i) => (
+                <tr key={`${bus}-placeholder-${i}`}>
+                  <td>
+                    <Placeholder>Group name</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Example vendor description</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Example product description</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>0000</Placeholder>
+                  </td>
+                  <td>
+                    <Placeholder>Driver name</Placeholder>
+                  </td>
+                  <td className="u-align--right">
+                    <Placeholder>0000</Placeholder>
+                  </td>
+                  {bus === NodeDeviceBus.PCIE ? (
+                    <td className="u-align--right">
+                      <Placeholder>0000:00:00.0</Placeholder>
+                    </td>
+                  ) : (
+                    <>
+                      <td className="u-align--right">
+                        <Placeholder>0000</Placeholder>
+                      </td>
+                      <td className="u-align--right">
+                        <Placeholder>0000</Placeholder>
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </>
+          ) : (
+            groupedDevices.map((group) => generateGroup(bus, group, machine))
+          )}
+        </tbody>
+      </table>
+      {!nodeDevicesLoading &&
+        generateWarning(bus, machine, nodeDevices, setSelectedAction)}
+    </>
+  );
+};
+
+export default NodeDevices;

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NodeDevices";


### PR DESCRIPTION
## Done

- Extracted the common elements in `MachinePCIDevices` and `MachineUSBDevices` and created a `NodeDevices` component.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that PCI and USB tabs still work as before
  - If a machine has been commissioned PCI devices should show up
  - Otherwise, a warning should prompt the user to commission their machine

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2311
