### PR TITLE
feat(ui): make the network table sortable

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.test.tsx
@@ -8,41 +8,48 @@ import { HardwareType, ResultType } from "app/base/enum";
 import { NetworkLinkMode } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { ResultStatus } from "app/store/scriptresult/types";
-import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
 import {
-  networkDiscoveredIP as networkDiscoveredIPFactory,
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
+  networkDiscoveredIP as networkDiscoveredIPFactory,
   networkLink as networkLinkFactory,
   nodeScriptResultState as nodeScriptResultStateFactory,
   rootState as rootStateFactory,
   scriptResult as scriptResultFactory,
   scriptResultState as scriptResultStateFactory,
-  subnetState as subnetStateFactory,
-  subnet as subnetFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("IPColumn", () => {
   let state: RootState;
-  let subnet: Subnet;
+  let vlan: VLAN;
 
   beforeEach(() => {
-    subnet = subnetFactory();
+    const fabric = fabricFactory({ name: "fabric-name" });
+    vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
     state = rootStateFactory({
-      subnet: subnetStateFactory({
-        items: [subnet],
+      fabric: fabricStateFactory({
+        items: [fabric],
+      }),
+      vlan: vlanStateFactory({
+        items: [vlan],
       }),
     });
   });
 
   it("can display a discovered ip address", () => {
     const discovered = networkDiscoveredIPFactory({ ip_address: "1.2.3.99" });
-    const links = [networkLinkFactory({ subnet_id: subnet.id })];
+    const links = [networkLinkFactory()];
     const nic = machineInterfaceFactory({
       discovered: [discovered],
       links,
+      vlan_id: vlan.id,
     });
     state.machine.items = [
       machineDetailsFactory({
@@ -63,12 +70,12 @@ describe("IPColumn", () => {
 
   it("can display an ip address from a link", () => {
     const link = networkLinkFactory({
-      subnet_id: subnet.id,
       ip_address: "1.2.3.99",
     });
     const nic = machineInterfaceFactory({
       discovered: [],
       links: [link],
+      vlan_id: vlan.id,
     });
     state.machine.items = [
       machineDetailsFactory({
@@ -89,6 +96,7 @@ describe("IPColumn", () => {
     const nic = machineInterfaceFactory({
       discovered: [],
       links: [],
+      vlan_id: vlan.id,
     });
     state.machine.items = [
       machineDetailsFactory({
@@ -109,12 +117,12 @@ describe("IPColumn", () => {
     const links = [
       networkLinkFactory({
         mode: NetworkLinkMode.AUTO,
-        subnet_id: subnet.id,
       }),
     ];
     const nic = machineInterfaceFactory({
       discovered: [],
       links,
+      vlan_id: vlan.id,
     });
     state.machine.items = [
       machineDetailsFactory({
@@ -132,14 +140,11 @@ describe("IPColumn", () => {
   });
 
   it("can display the failed network status for multiple tests", () => {
-    const links = [
-      networkLinkFactory({
-        subnet_id: subnet.id,
-      }),
-    ];
+    const links = [networkLinkFactory()];
     const nic = machineInterfaceFactory({
       discovered: [],
       links,
+      vlan_id: vlan.id,
     });
     state.machine.items = [
       machineDetailsFactory({
@@ -178,14 +183,11 @@ describe("IPColumn", () => {
   });
 
   it("can display the failed network status for one test", () => {
-    const links = [
-      networkLinkFactory({
-        subnet_id: subnet.id,
-      }),
-    ];
+    const links = [networkLinkFactory()];
     const nic = machineInterfaceFactory({
       discovered: [],
       links,
+      vlan_id: vlan.id,
     });
     state.machine.items = [
       machineDetailsFactory({
@@ -221,6 +223,7 @@ describe("IPColumn", () => {
     const nic = machineInterfaceFactory({
       discovered: [],
       links: [networkLinkFactory()],
+      vlan_id: vlan.id,
     });
     state.machine.items = [
       machineDetailsFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -15,6 +15,7 @@ import {
   networkLink as networkLinkFactory,
   rootState as rootStateFactory,
   subnet as subnetFactory,
+  subnetState as subnetStateFactory,
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
@@ -30,6 +31,9 @@ describe("NetworkTable", () => {
       }),
       machine: machineStateFactory({
         items: [machineDetailsFactory({ system_id: "abc123" })],
+        loaded: true,
+      }),
+      subnet: subnetStateFactory({
         loaded: true,
       }),
       vlan: vlanStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SubnetColumn/SubnetColumn.test.tsx
@@ -7,14 +7,15 @@ import SubnetColumn from "./SubnetColumn";
 import type { RootState } from "app/store/root/types";
 import { NodeStatus } from "app/store/types/node";
 import {
-  networkDiscoveredIP as networkDiscoveredIPFactory,
   fabric as fabricFactory,
-  vlan as vlanFactory,
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
+  networkDiscoveredIP as networkDiscoveredIPFactory,
   networkLink as networkLinkFactory,
   rootState as rootStateFactory,
   subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -22,7 +23,11 @@ const mockStore = configureStore();
 describe("SubnetColumn", () => {
   let state: RootState;
   beforeEach(() => {
-    state = rootStateFactory();
+    state = rootStateFactory({
+      subnet: subnetStateFactory({
+        loaded: true,
+      }),
+    });
   });
 
   it("can display subnet links", () => {
@@ -59,10 +64,8 @@ describe("SubnetColumn", () => {
     const fabric = fabricFactory({ name: "fabric-name" });
     state.fabric.items = [fabric];
     const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
-    const subnet = subnetFactory({ cidr: "" });
     state.vlan.items = [vlan];
-    state.subnet.items = [subnet];
-    const link = networkLinkFactory({ subnet_id: subnet.id });
+    const link = networkLinkFactory();
     const nic = machineInterfaceFactory({
       discovered: null,
       links: [link],

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -11,8 +11,13 @@ export {
 export {
   getBondOrBridgeChild,
   getBondOrBridgeParents,
+  getInterfaceDiscovered,
+  getInterfaceFabric,
+  getInterfaceIPAddress,
+  getInterfaceIPAddressOrMode,
   getInterfaceName,
   getInterfaceNumaNodes,
+  getInterfaceSubnet,
   getInterfaceType,
   getInterfaceTypeText,
   getLinkInterface,

--- a/ui/src/app/store/subnet/utils.test.ts
+++ b/ui/src/app/store/subnet/utils.test.ts
@@ -17,5 +17,10 @@ describe("subnet utils", () => {
       const subnet = subnetFactory({ cidr: "cidr-name", name: "subnet-name" });
       expect(getSubnetDisplay(subnet)).toBe("cidr-name (subnet-name)");
     });
+
+    it("can return the short name instead of cidr + name", function () {
+      const subnet = subnetFactory({ cidr: "cidr-name", name: "subnet-name" });
+      expect(getSubnetDisplay(subnet, true)).toBe("cidr-name");
+    });
   });
 });

--- a/ui/src/app/store/subnet/utils.ts
+++ b/ui/src/app/store/subnet/utils.ts
@@ -5,10 +5,13 @@ import type { Subnet } from "app/store/subnet/types";
  * @param subnet - A subnet.
  * @return The subnet display text.
  */
-export const getSubnetDisplay = (subnet: Subnet | null | undefined): string => {
+export const getSubnetDisplay = (
+  subnet: Subnet | null | undefined,
+  short?: boolean
+): string => {
   if (!subnet) {
     return "Unconfigured";
-  } else if (subnet.cidr !== subnet.name) {
+  } else if (!short && subnet.cidr !== subnet.name) {
     return `${subnet.cidr} (${subnet.name})`;
   } else {
     return subnet.cidr;


### PR DESCRIPTION
## Done

- Move the data manipulation to utils and use it in the table to set the sortable data.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the react network tab for a few machines.
- You should be able to sort the table by all the headers (the node/bridge interfaces will be made to keep their order in #1946.

## Fixes

Fixes: #2011.