### PR TITLE
feat(ui): improve styling of PCI/USB device tables

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -48,14 +48,20 @@ const generateGroup = (
       vendor_id,
       vendor_name,
     } = nodeDevice;
+    const groupLabel = i === 0;
     const numaNode = machine.numa_nodes.find(
       (numa) => numa.id === numa_node_id
     );
 
     return (
-      <tr key={`node-device-${id}`}>
-        <td>
-          {i === 0 && (
+      <tr
+        className={`node-devices-table__row${
+          groupLabel ? "" : " truncated-border"
+        }`}
+        key={`node-device-${id}`}
+      >
+        <td className="group-col">
+          {groupLabel && (
             <DoubleRow
               data-test="group-label"
               primary={
@@ -73,21 +79,26 @@ const generateGroup = (
             />
           )}
         </td>
-        <td>
+        <td className="vendor-col">
           <DoubleRow primary={vendor_name} secondary={vendor_id} />
         </td>
-        <td>{product_name}</td>
-        <td>{product_id}</td>
-        <td>{commissioning_driver}</td>
-        <td className="u-align--right" data-test={`node-device-${id}-numa`}>
-          {numaNode?.index || ""}
+        <td className="product-col">{product_name}</td>
+        <td className="product-id-col">{product_id}</td>
+        <td className="driver-col">{commissioning_driver}</td>
+        <td
+          className="numa-node-col u-align--right"
+          data-test={`node-device-${id}-numa`}
+        >
+          {numaNode?.index ?? ""}
         </td>
         {bus === NodeDeviceBus.PCIE ? (
-          <td className="u-align--right">{pci_address}</td>
+          <td className="pci-address-col u-align--right">{pci_address}</td>
         ) : (
           <>
-            <td className="u-align--right">{bus_number}</td>
-            <td className="u-align--right">{device_number}</td>
+            <td className="bus-address-col u-align--right">{bus_number}</td>
+            <td className="device-address-col u-align--right">
+              {device_number}
+            </td>
           </>
         )}
       </tr>
@@ -207,28 +218,41 @@ const NodeDevices = ({
 
   return (
     <>
-      <table>
+      <table
+        className={`node-devices-table--${
+          bus === NodeDeviceBus.PCIE ? "pci" : "usb"
+        }`}
+      >
         <thead>
           <tr>
-            <th></th>
-            <th>
+            <th className="group-col"></th>
+            <th className="vendor-col">
               <div>Vendor</div>
               <div>ID</div>
             </th>
-            <th>Product</th>
-            <th>Product ID</th>
-            <th>Driver</th>
-            <th className="u-align--right">NUMA node</th>
+            <th className="product-col">Product</th>
+            <th className="product-id-col">Product ID</th>
+            <th className="driver-col">Driver</th>
+            <th className="numa-node-col u-align--right">NUMA node</th>
             {bus === NodeDeviceBus.PCIE ? (
-              <th className="u-align--right" data-test="pci-address-col">
+              <th
+                className="pci-address-col u-align--right"
+                data-test="pci-address-col"
+              >
                 PCI address
               </th>
             ) : (
               <>
-                <th className="u-align--right" data-test="bus-address-col">
+                <th
+                  className="bus-address-col u-align--right"
+                  data-test="bus-address-col"
+                >
                   Bus address
                 </th>
-                <th className="u-align--right" data-test="device-address-col">
+                <th
+                  className="device-address-col u-align--right"
+                  data-test="device-address-col"
+                >
                   Device address
                 </th>
               </>
@@ -240,34 +264,40 @@ const NodeDevices = ({
             <>
               {Array.from(Array(5)).map((_, i) => (
                 <tr key={`${bus}-placeholder-${i}`}>
-                  <td>
-                    <Placeholder>Group name</Placeholder>
+                  <td className="group-col">
+                    <DoubleRow
+                      primary={<Placeholder>Group name</Placeholder>}
+                      secondary={<Placeholder>X devices</Placeholder>}
+                    />
                   </td>
-                  <td>
-                    <Placeholder>Example vendor description</Placeholder>
+                  <td className="vendor-col">
+                    <DoubleRow
+                      primary={<Placeholder>Example vendor</Placeholder>}
+                      secondary={<Placeholder>0000</Placeholder>}
+                    />
                   </td>
-                  <td>
+                  <td className="product-col">
                     <Placeholder>Example product description</Placeholder>
                   </td>
-                  <td>
+                  <td className="product-id-col">
                     <Placeholder>0000</Placeholder>
                   </td>
-                  <td>
+                  <td className="driver-col">
                     <Placeholder>Driver name</Placeholder>
                   </td>
-                  <td className="u-align--right">
+                  <td className="numa-node-col u-align--right">
                     <Placeholder>0000</Placeholder>
                   </td>
                   {bus === NodeDeviceBus.PCIE ? (
-                    <td className="u-align--right">
+                    <td className="pci-address-col u-align--right">
                       <Placeholder>0000:00:00.0</Placeholder>
                     </td>
                   ) : (
                     <>
-                      <td className="u-align--right">
+                      <td className="bus-address-col u-align--right">
                         <Placeholder>0000</Placeholder>
                       </td>
-                      <td className="u-align--right">
+                      <td className="device-address-col u-align--right">
                         <Placeholder>0000</Placeholder>
                       </td>
                     </>

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
@@ -1,0 +1,60 @@
+@mixin NodeDevices {
+  $group-label-width: 10rem;
+
+  %node-devices-table {
+    .group-col {
+      @include breakpoint-widths(0, 0, $group-label-width);
+    }
+
+    .vendor-col {
+      @include breakpoint-widths(50%, 40%);
+    }
+
+    .product-col {
+      @include breakpoint-widths(50%, 40%);
+    }
+
+    .product-id-col {
+      @include breakpoint-widths(0, 6rem, 8rem);
+    }
+
+    .driver-col {
+      @include breakpoint-widths(0, 20%);
+    }
+
+    .numa-node-col {
+      @include breakpoint-widths(0, 0, 6rem);
+    }
+  }
+
+  .node-devices-table--pci {
+    @extend %node-devices-table;
+
+    .pci-address-col {
+      @include breakpoint-widths(0, 8rem);
+    }
+  }
+
+  .node-devices-table--usb {
+    @extend %node-devices-table;
+
+    .bus-address-col {
+      @include breakpoint-widths(0, 6rem, 8rem);
+    }
+
+    .device-address-col {
+      @include breakpoint-widths(0, 6rem, 8rem);
+    }
+  }
+
+  .node-devices-table__row:not(:first-child) {
+    @extend %vf-pseudo-border--top;
+    border: 0;
+
+    &.truncated-border::after {
+      @media only screen and (min-width: 900px) {
+        left: $group-label-width;
+      }
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -119,6 +119,7 @@
 @import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/OverviewCard";
+@import "~app/machines/views/MachineDetails/NodeDevices";
 @include MachineList;
 @include MachineName;
 @include MachineSummary;
@@ -127,6 +128,7 @@
 @include NumaCard;
 @include OverviewCard;
 @include FilterAccordion;
+@include NodeDevices;
 
 // preferences
 @import "~app/preferences/views/APIKeys/APIKeyList";


### PR DESCRIPTION
## Done

- Made table a bit more responsive with better cell widths at different breakpoints
- Table rows are now grouped properly

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the PCI tab of a machine
- Check that the table looks ok at all viewport sizes
- Check that the table rows are grouped correctly

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2312

## Screenshot
![Screenshot_2021-01-15 sure-cod maas PCI devices bolla MAAS](https://user-images.githubusercontent.com/25733845/104675587-84ebec00-5731-11eb-8cda-73ed18906fe2.png)
