### PR TITLE
fix(ui): only load node devices once when navigating to PCI/USB tabs

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
@@ -19,6 +19,68 @@ import {
 const mockStore = configureStore();
 
 describe("NodeDevices", () => {
+  it("fetches node devices by machine id if not already loaded", () => {
+    const machine = machineDetailsFactory();
+    const state = rootStateFactory({
+      nodedevice: nodeDeviceStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <NodeDevices
+          bus={NodeDeviceBus.PCIE}
+          machine={machine}
+          setSelectedAction={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "nodedevice/getByMachineId")
+    ).toStrictEqual({
+      meta: {
+        model: "nodedevice",
+        method: "list",
+        nocache: true,
+      },
+      payload: {
+        params: {
+          system_id: machine.system_id,
+        },
+      },
+      type: "nodedevice/getByMachineId",
+    });
+  });
+
+  it("does not fetch node devices if already loaded", () => {
+    const machine = machineDetailsFactory();
+    const state = rootStateFactory({
+      nodedevice: nodeDeviceStateFactory({
+        items: [nodeDeviceFactory({ node_id: machine.id })],
+      }),
+    });
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <NodeDevices
+          bus={NodeDeviceBus.PCIE}
+          machine={machine}
+          setSelectedAction={jest.fn()}
+        />
+      </Provider>
+    );
+
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "nodedevice/getByMachineId")
+    ).toEqual(undefined);
+  });
+
   it("shows placeholder rows while node devices are loading", () => {
     const machine = machineDetailsFactory();
     const state = rootStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -171,10 +171,15 @@ const NodeDevices = ({
     nodeDeviceSelectors.getByMachineId(state, machine.id)
   );
   const nodeDevicesLoading = useSelector(nodeDeviceSelectors.loading);
+  const loaded = nodeDevices.some(
+    (nodeDevice) => nodeDevice.node_id === machine.id
+  );
 
   useEffect(() => {
-    dispatch(nodeDeviceActions.getByMachineId(machine.system_id));
-  }, [dispatch, machine.system_id]);
+    if (!loaded) {
+      dispatch(nodeDeviceActions.getByMachineId(machine.system_id));
+    }
+  }, [dispatch, loaded, machine.system_id]);
 
   const groupedDevices = nodeDevices
     .reduce<NodeDeviceGroup[]>(


### PR DESCRIPTION
## Done

- Only load node devices once when navigating to PCI/USB tabs

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the PCI tab of a machine and check that the loading placeholder rows show up
- Navigate away and then back
- The data should load instantly, i.e. the placeholder rows should not show

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2317

