### PR TITLE
feat(ui): add ability to filter machines by workload annotation

### DIFF
--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -180,6 +180,28 @@ describe("Search", () => {
         status: ["=new", "!failed disk erasing", "=!pending", "!=deploying"],
       },
     },
+    {
+      input: "workload-type:()",
+      filters: {
+        q: [],
+        "workload-type": [""],
+      },
+    },
+    {
+      input: "workload-type:(qwerty)",
+      filters: {
+        q: [],
+        "workload-type": ["qwerty"],
+      },
+    },
+    {
+      input: "free-text workload-type:(qwerty) workload-service:(dvorak)",
+      filters: {
+        q: ["free-text"],
+        "workload-type": ["qwerty"],
+        "workload-service": ["dvorak"],
+      },
+    },
   ];
 
   scenarios.forEach((scenario) => {
@@ -269,6 +291,18 @@ describe("Search", () => {
           "type",
           "valid",
           true
+        )
+      ).toBe(true);
+    });
+
+    it("returns true if workload annotation key exists in filter list", () => {
+      expect(
+        isFilterActive(
+          {
+            "workload-type": ["production"],
+          },
+          "workload_annotations",
+          "type"
         )
       ).toBe(true);
     });

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -8,6 +8,7 @@ import MachineList from "./MachineList";
 import { nodeStatus, scriptStatus } from "app/base/enum";
 import {
   generalState as generalStateFactory,
+  machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -38,7 +39,7 @@ describe("MachineList", () => {
       machine: machineStateFactory({
         loaded: true,
         items: [
-          {
+          machineFactory({
             actions: [],
             architecture: "amd64/generic",
             cpu_count: 4,
@@ -79,8 +80,8 @@ describe("MachineList", () => {
             },
             system_id: "abc123",
             zone: {},
-          },
-          {
+          }),
+          machineFactory({
             actions: [],
             architecture: "amd64/generic",
             cpu_count: 2,
@@ -121,8 +122,8 @@ describe("MachineList", () => {
             },
             system_id: "def456",
             zone: {},
-          },
-          {
+          }),
+          machineFactory({
             actions: [],
             architecture: "amd64/generic",
             cpu_count: 2,
@@ -163,7 +164,7 @@ describe("MachineList", () => {
             },
             system_id: "ghi789",
             zone: {},
-          },
+          }),
         ],
       }),
     });

--- a/ui/src/app/machines/views/MachineList/MachineListControls/FilterAccordion/FilterAccordion.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/FilterAccordion/FilterAccordion.test.js
@@ -25,6 +25,9 @@ describe("FilterAccordion", () => {
               id: 1,
               name: "pool1",
             },
+            workload_annotations: {
+              type: "production",
+            },
             zone: {
               id: 1,
               name: "zone1",
@@ -108,7 +111,7 @@ describe("FilterAccordion", () => {
     );
   });
 
-  it("can set a new filter", () => {
+  it("can set a non-workload filter", () => {
     const setSearchText = jest.fn();
     const store = mockStore(state);
     const wrapper = mount(
@@ -124,6 +127,45 @@ describe("FilterAccordion", () => {
     wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
     wrapper.find(".filter-accordion__item").at(0).simulate("click");
     expect(setSearchText).toHaveBeenCalledWith("pool:(=pool1)");
+  });
+
+  it("can set a workload filter", () => {
+    const setSearchText = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion setSearchText={setSearchText} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.find(".filter-accordion__item").at(2).simulate("click");
+    expect(setSearchText).toHaveBeenCalledWith("workload-type:()");
+  });
+
+  it("can remove a workload filter", () => {
+    const setSearchText = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <FilterAccordion
+            searchText="workload-type:(production)"
+            setSearchText={setSearchText}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.find(".filter-accordion__item").at(2).simulate("click");
+    expect(setSearchText).toHaveBeenCalledWith("");
   });
 
   it("hides filters if there are no values", () => {

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -9,7 +9,9 @@ import { NodeActions } from "app/store/types/node";
 import { nodeStatus, scriptStatus } from "app/base/enum";
 import {
   generalState as generalStateFactory,
+  machine as machineFactory,
   machineState as machineStateFactory,
+  resourcePool as resourcePoolFactory,
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
   routerState as routerStateFactory,
@@ -41,7 +43,7 @@ describe("Machines", () => {
       machine: machineStateFactory({
         loaded: true,
         items: [
-          {
+          machineFactory({
             actions: [],
             architecture: "amd64/generic",
             cpu_count: 4,
@@ -77,14 +79,13 @@ describe("Machines", () => {
             storage_test_status: {
               status: scriptStatus.PASSED,
             },
-
             testing_status: {
               status: scriptStatus.PASSED,
             },
             system_id: "abc123",
             zone: {},
-          },
-          {
+          }),
+          machineFactory({
             actions: [],
             architecture: "amd64/generic",
             cpu_count: 2,
@@ -125,7 +126,7 @@ describe("Machines", () => {
             },
             system_id: "def456",
             zone: {},
-          },
+          }),
         ],
         statuses: {
           abc123: {},
@@ -135,20 +136,20 @@ describe("Machines", () => {
       resourcepool: resourcePoolStateFactory({
         loaded: true,
         items: [
-          {
+          resourcePoolFactory({
             id: 0,
             name: "default",
             description: "default",
             is_default: true,
             permissions: [],
-          },
-          {
+          }),
+          resourcePoolFactory({
             id: 1,
             name: "Backup",
             description: "A backup pool",
             is_default: false,
             permissions: [],
-          },
+          }),
         ],
       }),
       router: routerStateFactory(),

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -287,6 +287,7 @@ export type BaseMachine = BaseNode & {
   subnets: string[];
   testing_status: TestStatus;
   vlan: Vlan | null;
+  workload_annotations: { [x: string]: string };
   zone: ModelRef;
 };
 
@@ -343,7 +344,6 @@ export type MachineDetails = BaseMachine & {
   swap_size: number | null;
   testing_start_time: string;
   updated: string;
-  workload_annotations: { [x: string]: string };
 };
 
 // Depending on where the user has navigated in the app, machines in state can

--- a/ui/src/app/utils/search.js
+++ b/ui/src/app/utils/search.js
@@ -1,3 +1,5 @@
+import { WORKLOAD_FILTER_PREFIX } from "app/machines/search";
+
 // Helpers that convert the pseudo field on node to an actual
 // value from the node.
 const searchMappings = {
@@ -28,12 +30,20 @@ const searchMappings = {
     (interfaces && interfaces.some((iface) => iface.sriov_max_vf >= 1))
       ? "Supported"
       : "Not supported",
+  workload_annotations: ({ workload_annotations }) =>
+    Object.keys(workload_annotations),
 };
 
 export const getMachineValue = (machine, filter) => {
   const mapFunc = searchMappings[filter];
   let value;
-  if (typeof mapFunc === "function") {
+  if (filter.startsWith(WORKLOAD_FILTER_PREFIX)) {
+    // Workload annotation filters are treated differently, as filtering is done
+    // based on arbitrary object keys rather than simple, defined machine values.
+    const [, ...splitWorkload] = filter.split(WORKLOAD_FILTER_PREFIX);
+    const workloadKey = splitWorkload.join("");
+    value = machine.workload_annotations[workloadKey];
+  } else if (typeof mapFunc === "function") {
     value = mapFunc(machine);
   } else if (machine.hasOwnProperty(filter)) {
     value = machine[filter];

--- a/ui/src/app/utils/search.test.js
+++ b/ui/src/app/utils/search.test.js
@@ -10,4 +10,13 @@ describe("getMachineValue", () => {
   it("can get an attribute directly from the machine", () => {
     expect(getMachineValue({ id: 808 }, "id")).toBe(808);
   });
+
+  it("can get a workload annotation value", () => {
+    expect(
+      getMachineValue(
+        { workload_annotations: { type: "production" } },
+        "workload-type"
+      )
+    ).toBe("production");
+  });
 });

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -137,6 +137,7 @@ export const machine = extend<BaseNode, Machine>(node, {
   storage: 8,
   subnets,
   testing_status: testStatus,
+  workload_annotations: () => ({}),
   vlan: null,
   zone: modelRef,
 });
@@ -297,7 +298,6 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   swap_size: null,
   testing_start_time: "Thu, 15 Oct. 2020 07:25:10",
   updated: "Fri, 23 Oct. 2020 05:24:41",
-  workload_annotations: () => ({}),
 });
 
 export const controller = extend<BaseNode, Controller>(node, {


### PR DESCRIPTION
## Done

- Added ability to filter machines by workload annotation. It works differently to the rest of the filters so it introduces a bit of bespoke code. I think this is ok for now - at some point the search/filter functionality is going to be replaced with the new Vanilla pattern at which point the whole thing is going to have a major rewrite anyway.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Add workload annotations to some machines if you haven't already. On bolla I've added some random ones to `comic-toucan` and `sure-cod` but if you wanted to add your own to your own MAAS you can follow the steps in [this old PR](https://github.com/canonical-web-and-design/maas-ui/pull/2014).
- Check that you can filter by "Workload" and that clicking a filter will populate the search text with `workload-${filter}:()`
- Check that the machine list is filtered by machines that contain that workload annotation key, regardless of the value
- Check that you can filter by the workload annotation value with some of the DSL for exact, negation, etc. e.g.`workload-created:(dec)`, `workload-type:(=development)`, `workload-service:() workload-type:(!prod)`

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2291
