### PR TITLE
feat(ui): add filter links to workload annotations card

### DIFF
--- a/ui/src/app/machines/search.js
+++ b/ui/src/app/machines/search.js
@@ -20,7 +20,7 @@ export const getCurrentFilters = (search) => {
   // Match filters with parens e.g. 'status:(new,deployed)'.
   // Then: match filters without parens e.g. 'status:new,deployed' or 'status'
   const filterMatchingRegex = search.matchAll(
-    /(\b\w+:!*\([^)]+\))|(!*\w+\S*)/g
+    /(\b[\w-]+:!*\([^)]+\))|(!*\w+\S*)/g
   );
   [...filterMatchingRegex].forEach(([group]) => {
     // Get the filter name and values (if supplied).

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -202,6 +202,13 @@ describe("Search", () => {
         "workload-service": ["dvorak"],
       },
     },
+    {
+      input: "workload-type:(query with spaces)",
+      filters: {
+        q: [],
+        "workload-type": ["query with spaces"],
+      },
+    },
   ];
 
   scenarios.forEach((scenario) => {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.test.tsx
@@ -110,4 +110,33 @@ describe("WorkloadCard", () => {
       "value"
     );
   });
+
+  it("displays links to filter machine list by workload annotation", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+            workload_annotations: {
+              key: "value",
+            },
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <WorkloadCard id="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='workload-value'] Link").prop("to")).toBe(
+      "/machines?workload-key=value"
+    );
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
@@ -6,9 +6,11 @@ import {
   Tooltip,
 } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+import { Link as RouterLink } from "react-router-dom";
 
 import LabelledList from "app/base/components/LabelledList";
 import { useSendAnalytics } from "app/base/hooks";
+import { filtersToQueryString } from "app/machines/search";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -40,9 +42,16 @@ const WorkloadCard = ({ id }: Props): JSX.Element => {
               label: <div data-test="workload-key">{key}</div>,
               value: (
                 <div data-test="workload-value" key={key}>
-                  {separatedValue.map((val) => (
-                    <div key={`${key}-${val}`}>{val}</div>
-                  ))}
+                  {separatedValue.map((val) => {
+                    const filter = filtersToQueryString({
+                      [`workload-${key}`]: `${val}`,
+                    });
+                    return (
+                      <div key={`${key}-${val}`}>
+                        <RouterLink to={`/machines${filter}`}>{val}</RouterLink>
+                      </div>
+                    );
+                  })}
                 </div>
               ),
             };


### PR DESCRIPTION
## Done

- Added filter links to workload annotations card

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine summary of a machine that has workload annotations (on bolla `comic-toucan` and `sure-cod` have them, otherwise follow the steps in [this PR](https://github.com/canonical-web-and-design/maas-ui/pull/2014) to add some)
- Check that clicking one of the workload links takes you to the machine list and filters by that workload

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2318