### PR TITLE
feat(all): route between clients for machine detail tabs

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -572,8 +572,7 @@
               role="tab"
               class="p-tabs__link"
               data-ng-if="!isController && !isDevice"
-              data-ng-class="{ 'is-active': section.area === 'summary'}"
-              data-ng-click="openSection('summary')"
+              data-ng-click="navigateToNew('/machine/' + node.system_id + '/summary')"
               >Machine summary</a
             >
           </li>
@@ -634,6 +633,24 @@
               data-ng-class="{ 'is-active': section.area === 'storage'}"
               data-ng-click="openSection('storage')"
               >Storage</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="!isController && !isDevice"
+              data-ng-click="navigateToNew('/machine/' + node.system_id + '/pci-devices')"
+              >PCI devices</a
+            >
+          </li>
+          <li class="p-tabs__item" role="presentation">
+            <a
+              role="tab"
+              class="p-tabs__link"
+              data-ng-if="!isController && !isDevice"
+              data-ng-click="navigateToNew('/machine/' + node.system_id + '/usb-devices')"
+              >USB</a
             >
           </li>
           <li class="p-tabs__item" role="presentation">

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -573,7 +573,7 @@
               class="p-tabs__link"
               data-ng-if="!isController && !isDevice"
               data-ng-click="navigateToNew('/machine/' + node.system_id + '/summary')"
-              >Machine summary</a
+              >Summary</a
             >
           </li>
           <li class="p-tabs__item" role="presentation">

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -9,6 +9,7 @@ import type { SelectedAction, SetSelectedAction } from "../MachineSummary";
 
 import MachineName from "./MachineName";
 
+import LegacyLink from "app/base/components/LegacyLink";
 import SectionHeader from "app/base/components/SectionHeader";
 import TableMenu from "app/base/components/TableMenu";
 import { useMachineActions } from "app/base/hooks";
@@ -138,23 +139,23 @@ const MachineHeader = ({
           ? [
               {
                 active: pathname.startsWith(`${urlBase}/instances`),
-                component: Link,
+                component: LegacyLink,
                 label: "Instances",
-                to: `${urlBase}/instances`,
+                route: `${urlBase}?area=instances`,
               },
             ]
           : []),
         {
           active: pathname.startsWith(`${urlBase}/network`),
-          component: Link,
+          component: LegacyLink,
           label: "Network",
-          to: `${urlBase}/network`,
+          route: `${urlBase}?area=network`,
         },
         {
           active: pathname.startsWith(`${urlBase}/storage`),
-          component: Link,
+          component: LegacyLink,
           label: "Storage",
-          to: `${urlBase}/storage`,
+          route: `${urlBase}?area=storage`,
         },
         {
           active: pathname.startsWith(`${urlBase}/pci-devices`),
@@ -170,33 +171,33 @@ const MachineHeader = ({
         },
         {
           active: pathname.startsWith(`${urlBase}/commissioning`),
-          component: Link,
+          component: LegacyLink,
           label: "Commissioning",
-          to: `${urlBase}/commissioning`,
+          route: `${urlBase}?area=commissioning`,
         },
         {
           active: pathname.startsWith(`${urlBase}/tests`),
-          component: Link,
+          component: LegacyLink,
           label: "Tests",
-          to: `${urlBase}/tests`,
+          route: `${urlBase}?area=testing`,
         },
         {
           active: pathname.startsWith(`${urlBase}/logs`),
-          component: Link,
+          component: LegacyLink,
           label: "Logs",
-          to: `${urlBase}/logs`,
+          route: `${urlBase}?area=logs`,
         },
         {
           active: pathname.startsWith(`${urlBase}/events`),
-          component: Link,
+          component: LegacyLink,
           label: "Events",
-          to: `${urlBase}/events`,
+          route: `${urlBase}?area=events`,
         },
         {
           active: pathname.startsWith(`${urlBase}/configuration`),
-          component: Link,
+          component: LegacyLink,
           label: "Configuration",
-          to: `${urlBase}/configuration`,
+          route: `${urlBase}?area=configuration`,
         },
       ]}
       title={

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -2,13 +2,13 @@ import { Fragment, useEffect } from "react";
 
 import { Card, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../MachineSummary";
 import TestResults from "../TestResults";
 
 import NetworkCardTable from "./NetworkCardTable";
 
+import LegacyLink from "app/base/components/LegacyLink";
 import { HardwareType } from "app/base/enum";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
@@ -113,6 +113,7 @@ const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
   }, [dispatch]);
 
   let content: JSX.Element;
+  const networkRoute = `/machine/${id}?area=network`;
 
   // Confirm that the full machine details have been fetched. This also allows
   // TypeScript know we're using the right union type (otherwise it will
@@ -149,7 +150,7 @@ const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
         ))}
         <p>
           Information about tagged traffic can be seen in the{" "}
-          <Link to={`/machine/${id}/network`}>Network tab</Link>.
+          <LegacyLink route={networkRoute}>Network tab</LegacyLink>.
         </p>
         <TestResults
           machine={machine}
@@ -166,7 +167,7 @@ const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
     <div className="machine-summary__network-card">
       <Card>
         <h4 className="p-muted-heading u-sv1">
-          <Link to={`/machine/${id}/network`}>Network&nbsp;&rsaquo;</Link>
+          <LegacyLink route={networkRoute}>Network&nbsp;&rsaquo;</LegacyLink>
         </h4>
         {content}
       </Card>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import { general as generalActions } from "app/base/actions";
+import LegacyLink from "app/base/components/LegacyLink";
 import { useSendAnalytics } from "app/base/hooks";
 import generalSelectors from "app/store/general/selectors";
 import type { MachineDetails } from "app/store/machine/types";
@@ -28,7 +29,7 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
   );
   const powerTypes = useSelector(generalSelectors.powerTypes.get);
 
-  const configTabUrl = `/machine/${machine.system_id}/configuration`;
+  const configTabUrl = `/machine/${machine.system_id}?area=configuration`;
   const podNumaID = pod ? getPodNumaID(machine, pod) : null;
 
   const powerTypeDescription = powerTypes.find(
@@ -75,8 +76,8 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
       <div data-test="zone">
         <div>
           {canEdit ? (
-            <Link
-              to={configTabUrl}
+            <LegacyLink
+              route={configTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -86,7 +87,7 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
               }
             >
               Zone ›
-            </Link>
+            </LegacyLink>
           ) : (
             <span className="u-text--muted">Zone</span>
           )}
@@ -97,8 +98,8 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
       <div data-test="resource-pool">
         <div>
           {canEdit ? (
-            <Link
-              to={configTabUrl}
+            <LegacyLink
+              route={configTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -108,7 +109,7 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
               }
             >
               Resource pool ›
-            </Link>
+            </LegacyLink>
           ) : (
             <span className="u-text--muted">Resource pool</span>
           )}
@@ -119,8 +120,8 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
       <div>
         <div>
           {canEdit ? (
-            <Link
-              to={configTabUrl}
+            <LegacyLink
+              route={configTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -130,7 +131,7 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
               }
             >
               Power type ›
-            </Link>
+            </LegacyLink>
           ) : (
             <span className="u-text--muted">Power type</span>
           )}
@@ -142,8 +143,8 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
       <div className="u-text-overflow">
         <div>
           {canEdit ? (
-            <Link
-              to={configTabUrl}
+            <LegacyLink
+              route={configTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -153,7 +154,7 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
               }
             >
               Tags ›
-            </Link>
+            </LegacyLink>
           ) : (
             <span className="u-text--muted">Tags</span>
           )}

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
 
 import { general as generalActions } from "app/base/actions";
 import LegacyLink from "app/base/components/LegacyLink";
@@ -67,12 +66,12 @@ const SummaryNotifications = ({ id }: Props): JSX.Element | null => {
           content: (
             <>
               {formatEventText(machine.events[0])}.{" "}
-              <Link
-                to={`/machine/${machine.system_id}/logs`}
+              <LegacyLink
+                route={`/machine/${machine.system_id}?area=logs`}
                 className="p-notification__action"
               >
                 See logs
-              </Link>
+              </LegacyLink>
             </>
           ),
           status: "Error:",

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,8 +1,8 @@
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
-import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "..";
 
+import LegacyLink from "app/base/components/LegacyLink";
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
 import type { MachineDetails } from "app/store/machine/types";
@@ -29,7 +29,7 @@ const TestResults = ({
 }: Props): JSX.Element => {
   const sendAnalytics = useSendAnalytics();
 
-  const testsTabUrl = `/machine/${machine.system_id}/tests`;
+  const testsTabUrl = `/machine/${machine.system_id}?area=testing`;
   const scriptType = HardwareType[hardwareType]?.toLowerCase();
 
   return (
@@ -37,8 +37,8 @@ const TestResults = ({
       <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
         {machine[`${scriptType}_test_status`].passed ? (
           <li className="p-inline-list__item">
-            <Link
-              to={testsTabUrl}
+            <LegacyLink
+              route={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -51,7 +51,7 @@ const TestResults = ({
               <span className="u-nudge-right--x-small">
                 {machine[`${scriptType}_test_status`].passed}
               </span>
-            </Link>
+            </LegacyLink>
           </li>
         ) : null}
 
@@ -59,8 +59,8 @@ const TestResults = ({
           machine[`${scriptType}_test_status`].running >
         0 ? (
           <li className="p-inline-list__item">
-            <Link
-              to={testsTabUrl}
+            <LegacyLink
+              route={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -74,14 +74,14 @@ const TestResults = ({
                 {machine[`${scriptType}_test_status`].pending +
                   machine[`${scriptType}_test_status`].running}
               </span>
-            </Link>
+            </LegacyLink>
           </li>
         ) : null}
 
         {machine[`${scriptType}_test_status`].failed > 0 ? (
           <li className="p-inline-list__item">
-            <Link
-              to={testsTabUrl}
+            <LegacyLink
+              route={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -94,14 +94,14 @@ const TestResults = ({
               <span className="u-nudge-right--x-small">
                 {machine[`${scriptType}_test_status`].failed}
               </span>
-            </Link>
+            </LegacyLink>
           </li>
         ) : null}
 
         {hasTestsRun(machine, scriptType) ? (
           <li className="p-inline-list__item">
-            <Link
-              to={testsTabUrl}
+            <LegacyLink
+              route={testsTabUrl}
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -111,7 +111,7 @@ const TestResults = ({
               }
             >
               View results&nbsp;&rsaquo;
-            </Link>
+            </LegacyLink>
           </li>
         ) : (
           <li className="p-inline-list__item">

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
@@ -230,11 +230,19 @@ describe("NodeDevices", () => {
     );
 
     expect(
-      wrapper.find("[data-test='group-label']").at(0).find("Link").prop("to")
-    ).toBe("/machine/abc123/network");
+      wrapper
+        .find("[data-test='group-label']")
+        .at(0)
+        .find("LegacyLink")
+        .prop("route")
+    ).toBe("/machine/abc123?area=network");
     expect(
-      wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
-    ).toBe("/machine/abc123/storage");
+      wrapper
+        .find("[data-test='group-label']")
+        .at(1)
+        .find("LegacyLink")
+        .prop("route")
+    ).toBe("/machine/abc123?area=storage");
   });
 
   it("displays the NUMA node index of a node device", () => {

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -3,11 +3,11 @@ import { useEffect } from "react";
 import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../MachineSummary";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import LegacyLink from "app/base/components/LegacyLink";
 import Placeholder from "app/base/components/Placeholder";
 import { HardwareType } from "app/base/enum";
 import type { MachineDetails } from "app/store/machine/types";
@@ -67,9 +67,11 @@ const generateGroup = (
               primary={
                 <strong>
                   {group.pathname ? (
-                    <Link to={`/machine/${machine.system_id}${group.pathname}`}>
+                    <LegacyLink
+                      route={`/machine/${machine.system_id}?area=${group.pathname}`}
+                    >
                       {group.label}
-                    </Link>
+                    </LegacyLink>
                   ) : (
                     group.label
                   )}
@@ -189,13 +191,13 @@ const NodeDevices = ({
         {
           hardwareTypes: [HardwareType.Network],
           label: "Network",
-          pathname: "/network",
+          pathname: "network",
           items: [],
         },
         {
           hardwareTypes: [HardwareType.Storage],
           label: "Storage",
-          pathname: "/storage",
+          pathname: "storage",
           items: [],
         },
         {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -1,16 +1,16 @@
 import { Tooltip } from "@canonical/react-components";
 import { Input } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import { memo } from "react";
 import { useSelector } from "react-redux";
 
 import machineSelectors from "app/store/machine/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
-import LegacyLink from "app/base/components/LegacyLink";
 
 const generateFQDN = (machine, machineURL) => {
   return (
-    <LegacyLink route={machineURL} title={machine.fqdn}>
+    <Link to={machineURL} title={machine.fqdn}>
       <strong data-test="hostname">
         {machine.locked ? (
           <span title="This machine is locked. You have to unlock it to perform any actions.">
@@ -20,7 +20,7 @@ const generateFQDN = (machine, machineURL) => {
         {machine.hostname}
       </strong>
       <small>.{machine.domain.name}</small>
-    </LegacyLink>
+    </Link>
   );
 };
 
@@ -78,14 +78,11 @@ const generateIPAddresses = (machine) => {
 const generateMAC = (machine, machineURL) => {
   return (
     <>
-      <LegacyLink route={machineURL} title={machine.pxe_mac_vendor}>
+      <Link to={machineURL} title={machine.pxe_mac_vendor}>
         {machine.pxe_mac}
-      </LegacyLink>
+      </Link>
       {machine.extra_macs && machine.extra_macs.length > 0 ? (
-        <LegacyLink route={machineURL}>
-          {" "}
-          (+{machine.extra_macs.length})
-        </LegacyLink>
+        <Link to={machineURL}> (+{machine.extra_macs.length})</Link>
       ) : null}
     </>
   );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -12,8 +12,8 @@ exports[`NameColumn renders 1`] = `
         className="has-inline-label keep-label-opacity"
         id="abc123"
         label={
-          <LegacyLink
-            route="/undefined/abc123"
+          <Link
+            to="/undefined/abc123"
           >
             <strong
               data-test="hostname"
@@ -24,7 +24,7 @@ exports[`NameColumn renders 1`] = `
               .
               example
             </small>
-          </LegacyLink>
+          </Link>
         }
         onChange={[MockFunction]}
         type="checkbox"
@@ -51,8 +51,8 @@ exports[`NameColumn renders 1`] = `
               className="has-inline-label keep-label-opacity"
               id="abc123"
               label={
-                <LegacyLink
-                  route="/undefined/abc123"
+                <Link
+                  to="/undefined/abc123"
                 >
                   <strong
                     data-test="hostname"
@@ -63,7 +63,7 @@ exports[`NameColumn renders 1`] = `
                     .
                     example
                   </small>
-                </LegacyLink>
+                </Link>
               }
               onChange={[MockFunction]}
               type="checkbox"
@@ -73,8 +73,8 @@ exports[`NameColumn renders 1`] = `
                 className="u-no-margin--bottom machine-list--inline-input"
                 forId="abc123"
                 label={
-                  <LegacyLink
-                    route="/undefined/abc123"
+                  <Link
+                    to="/undefined/abc123"
                   >
                     <strong
                       data-test="hostname"
@@ -85,7 +85,7 @@ exports[`NameColumn renders 1`] = `
                       .
                       example
                     </small>
-                  </LegacyLink>
+                  </Link>
                 }
                 labelFirst={false}
               >
@@ -108,16 +108,15 @@ exports[`NameColumn renders 1`] = `
                         className="p-form__label"
                         htmlFor="abc123"
                       >
-                        <LegacyLink
-                          route="/undefined/abc123"
+                        <Link
+                          to="/undefined/abc123"
                         >
-                          <Link
-                            href="/MAAS/l/undefined/abc123"
-                            onClick={[Function]}
+                          <LinkAnchor
+                            href="/undefined/abc123"
+                            navigate={[Function]}
                           >
                             <a
-                              className=""
-                              href="/MAAS/l/undefined/abc123"
+                              href="/undefined/abc123"
                               onClick={[Function]}
                             >
                               <strong
@@ -130,8 +129,8 @@ exports[`NameColumn renders 1`] = `
                                 example
                               </small>
                             </a>
-                          </Link>
-                        </LegacyLink>
+                          </LinkAnchor>
+                        </Link>
                       </label>
                     </Label>
                   </div>

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.js
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Spinner } from "@canonical/react-components";
 import PropTypes from "prop-types";
 
@@ -19,6 +20,9 @@ const DhcpTarget = ({ nodeId, subnetId }) => {
       <small>.{target.domain.name}</small>
     </>
   );
+  if (type === "machine") {
+    return <Link to={`/${type}/${nodeId || subnetId}`}>{name}</Link>;
+  }
 
   return (
     <LegacyLink route={`/${type}/${nodeId || subnetId}`}>{name}</LegacyLink>

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.js
@@ -89,8 +89,8 @@ describe("DhcpTarget", () => {
         </MemoryRouter>
       </Provider>
     );
-    const link = wrapper.find("LegacyLink");
-    expect(link.prop("route")).toBe("/machine/xyz");
+    const link = wrapper.find("Link");
+    expect(link.prop("to")).toBe("/machine/xyz");
     expect(link).toMatchSnapshot();
   });
 });

--- a/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.js.snap
+++ b/ui/src/app/settings/views/Dhcp/DhcpTarget/__snapshots__/DhcpTarget.test.js.snap
@@ -1,16 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DhcpTarget can display a node link 1`] = `
-<LegacyLink
-  route="/machine/xyz"
+<Link
+  to="/machine/xyz"
 >
-  <Link
-    href="/MAAS/l/machine/xyz"
-    onClick={[Function]}
+  <LinkAnchor
+    href="/machine/xyz"
+    navigate={[Function]}
   >
     <a
-      className=""
-      href="/MAAS/l/machine/xyz"
+      href="/machine/xyz"
       onClick={[Function]}
     >
       machine1
@@ -19,6 +18,6 @@ exports[`DhcpTarget can display a node link 1`] = `
         test
       </small>
     </a>
-  </Link>
-</LegacyLink>
+  </LinkAnchor>
+</Link>
 `;


### PR DESCRIPTION
## Done

- Update the machine details tabs to route between the legacy/react clients as needed.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to the machine list.
- Click on a machine, you should be taken to the react summary.
- click on on the different tabs: you should end up on the react client for summary, pci and usb devices and you should end up on the legacy page for all other tabs.
- Note: you'll get some prop errors which I've fixed in: https://github.com/canonical-web-and-design/react-components/pull/370.

## Fixes

Fixes: #2059.

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
