### PR TITLE
feat(ui): group bonds and bridges in the network table

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -98,13 +98,13 @@ exports[`stricter compilation`] = {
       [227, 21, 1, "Parameter \'e\' implicitly has an \'any\' type.", "177600"],
       [229, 23, 1, "Parameter \'e\' implicitly has an \'any\' type.", "177600"]
     ],
-    "src/app/base/hooks.ts:846402160": [
-      [427, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
-      [428, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
-      [433, 31, 5, "Object is of type \'unknown\'.", "195909086"],
-      [433, 39, 5, "Object is of type \'unknown\'.", "195909085"],
-      [436, 31, 5, "Object is of type \'unknown\'.", "195909086"],
-      [436, 39, 5, "Object is of type \'unknown\'.", "195909085"]
+    "src/app/base/hooks.ts:1665091113": [
+      [439, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
+      [440, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
+      [445, 31, 5, "Object is of type \'unknown\'.", "195909086"],
+      [445, 39, 5, "Object is of type \'unknown\'.", "195909085"],
+      [448, 31, 5, "Object is of type \'unknown\'.", "195909086"],
+      [448, 39, 5, "Object is of type \'unknown\'.", "195909085"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:2641018437": [
       [140, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -329,6 +329,14 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:1232551003": [
       [114, 18, 5, "Type \'MenuLink<null>[]\' is not assignable to type \'(string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined)[]\'.\\n  Type \'MenuLink<null>\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n    Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n      Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }>\'.\\n        Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'Partial<InferPropsInner<Pick<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }, \\"children\\" | ... 7 more ... | \\"inline\\">>>\'.\\n          Types of property \'element\' are incompatible.\\n            Type \'\\"symbol\\" | \\"object\\" | \\"metadata\\" | \\"map\\" | \\"filter\\" | \\"path\\" | \\"label\\" | \\"data\\" | \\"a\\" | \\"abbr\\" | \\"address\\" | \\"area\\" | \\"article\\" | \\"aside\\" | \\"audio\\" | \\"b\\" | \\"base\\" | \\"bdi\\" | \\"bdo\\" | ... 160 more ... | undefined\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n              Type \'FunctionComponent<null>\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n                Type \'FunctionComponent<null>\' is not assignable to type \'(props: any, context?: any) => any\'.\\n                  Types of parameters \'props\' and \'props\' are incompatible.\\n                    Type \'any\' is not assignable to type \'never\'.", "173192470"]
     ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:3956707169": [
+      [377, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
+      [381, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
+      [406, 35, 9, "Object is possibly \'null\'.", "1794230341"],
+      [406, 47, 9, "Object is possibly \'null\'.", "1612642726"],
+      [409, 35, 9, "Object is possibly \'null\'.", "1794230341"],
+      [409, 47, 9, "Object is possibly \'null\'.", "1612642726"]
+    ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx:1067981421": [
       [102, 6, 78, "Cannot invoke an object which is possibly \'undefined\'.", "1912336017"],
       [111, 6, 79, "Cannot invoke an object which is possibly \'undefined\'.", "2346482156"],
@@ -466,7 +474,7 @@ exports[`stricter compilation`] = {
       [734, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
       [738, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
-    "src/app/store/machine/utils/storage.ts:3179004120": [
+    "src/app/store/machine/utils/storage.ts:3837730053": [
       [78, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
       [107, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
     ],
@@ -580,7 +588,7 @@ exports[`stricter compilation`] = {
 
 exports[`no TSFixMe types`] = {
   value: `{
-    "src/app/base/hooks.ts:846402160": [
+    "src/app/base/hooks.ts:1665091113": [
       [11, 13, 8, "RegExp match", "1152173309"],
       [27, 39, 8, "RegExp match", "1152173309"],
       [65, 61, 7, "RegExp match", "1425257597"],
@@ -640,7 +648,7 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:4050302297": [
+    "src/app/store/machine/types.ts:2346712921": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [400, 34, 8, "RegExp match", "1152173309"],
       [403, 25, 8, "RegExp match", "1152173309"]

--- a/ui/src/app/base/hooks.ts
+++ b/ui/src/app/base/hooks.ts
@@ -381,7 +381,7 @@ type SortValueGetter<I, K extends string | null> = (
   ...args: unknown[]
 ) => unknown;
 
-type Sort<K extends string | null> = {
+export type Sort<K extends string | null> = {
   key: K | null;
   direction: "ascending" | "descending" | "none";
 };
@@ -396,11 +396,20 @@ type TableSort<I, K extends string | null> = {
  * Handle sorting in tables.
  * @param sortValueGetter - The function that determines what value to use when comparing row objects.
  * @param initialSort - The initial sort key and direction on table render.
+ * @param sortFunction - A function to be used to sort the items.
  * @returns The properties and helper functions to use in table sorting.
  */
 export const useTableSort = <I, K extends string | null>(
   sortValueGetter: SortValueGetter<I, K>,
-  initialSort: Sort<K>
+  initialSort: Sort<K>,
+  sortFunction?: (
+    itemA: I,
+    itemB: I,
+    key: Sort<K>["key"],
+    args: unknown[],
+    direction: Sort<K>["direction"],
+    items: I[]
+  ) => -1 | 0 | 1
 ): TableSort<I, K> => {
   const [currentSort, setCurrentSort] = useState(initialSort);
 
@@ -425,6 +434,9 @@ export const useTableSort = <I, K extends string | null>(
     const { key, direction } = currentSort;
 
     const sortFunctionGenerator = (itemA: I, itemB: I) => {
+      if (sortFunction) {
+        return sortFunction(itemA, itemB, key, args, direction, items);
+      }
       const sortA = sortValueGetter(key, itemA, ...args);
       const sortB = sortValueGetter(key, itemB, ...args);
 

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -24,6 +24,7 @@ export {
   getLinkModeDisplay,
   hasInterfaceType,
   isAlias,
+  isBondOrBridgeChild,
   isBondOrBridgeParent,
   isBootInterface,
   isInterfaceConnected,

--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -15,6 +15,7 @@ import {
   getLinkModeDisplay,
   hasInterfaceType,
   isAlias,
+  isBondOrBridgeChild,
   isBondOrBridgeParent,
   isBootInterface,
   isInterfaceConnected,
@@ -332,6 +333,61 @@ describe("machine networking utils", () => {
       });
       const machine = machineDetailsFactory({ interfaces: [nic, parent] });
       expect(isBondOrBridgeParent(machine, null, link)).toBe(false);
+    });
+  });
+
+  describe("isBondOrBridgeChild", () => {
+    it("can be an interface child", () => {
+      const nic = machineInterfaceFactory({
+        parents: [99],
+        type: NetworkInterfaceTypes.BOND,
+      });
+      const parent = machineInterfaceFactory({
+        children: [nic.id],
+        id: 99,
+        type: NetworkInterfaceTypes.PHYSICAL,
+      });
+      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      expect(isBondOrBridgeChild(machine, nic)).toBe(true);
+    });
+
+    it("is not an interface child when there are no parents", () => {
+      const nic = machineInterfaceFactory({
+        parents: [],
+        type: NetworkInterfaceTypes.BOND,
+      });
+      const machine = machineDetailsFactory({ interfaces: [nic] });
+      expect(isBondOrBridgeChild(machine, nic)).toBe(false);
+    });
+
+    it("is not an interface child if it is not a bond or bridge", () => {
+      const nic = machineInterfaceFactory({
+        parents: [99],
+        type: NetworkInterfaceTypes.ALIAS,
+      });
+      const parent = machineInterfaceFactory({
+        children: [nic.id, 101],
+        id: 99,
+        type: NetworkInterfaceTypes.PHYSICAL,
+      });
+      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      expect(isBondOrBridgeChild(machine, nic)).toBe(false);
+    });
+
+    it("is not an interface child when providing an alias", () => {
+      const link = networkLinkFactory();
+      const nic = machineInterfaceFactory({
+        links: [link],
+        parents: [99],
+        type: NetworkInterfaceTypes.ALIAS,
+      });
+      const parent = machineInterfaceFactory({
+        children: [nic.id, 101],
+        id: 99,
+        type: NetworkInterfaceTypes.PHYSICAL,
+      });
+      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      expect(isBondOrBridgeChild(machine, null, link)).toBe(false);
     });
   });
 

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -226,7 +226,7 @@ export const isBondOrBridgeParent = (
   link?: NetworkLink | null
 ): boolean => {
   if (link && isAlias(machine, link)) {
-    // Links can't be bond or bridge parents.
+    // Aliases can't be bond or bridge parents.
     return false;
   }
   if (link && !nic) {
@@ -246,6 +246,36 @@ export const isBondOrBridgeParent = (
     );
   }
   return false;
+};
+
+/**
+ * Check if an interface is a bond or bridge child.
+ * @param machine - The nic's machine.
+ * @param nic - A network interface.
+ * @param link - A link to an interface.
+ * @return Whether an interface is a bond or bridge child.
+ */
+export const isBondOrBridgeChild = (
+  machine: Machine,
+  nic: NetworkInterface | null,
+  link?: NetworkLink | null
+): boolean => {
+  if (link && isAlias(machine, link)) {
+    // Aliases can't be bond or bridge children.
+    return false;
+  }
+  if (link && !nic) {
+    [nic] = getLinkInterface(machine, link);
+  }
+  // A bond or bridge child must have at least one parent.
+  if (!nic || nic.parents.length === 0) {
+    return false;
+  }
+  return hasInterfaceType(
+    [NetworkInterfaceTypes.BOND, NetworkInterfaceTypes.BRIDGE],
+    machine,
+    nic
+  );
 };
 
 /**


### PR DESCRIPTION
## Done

- Keep bond and bridge rows in groups when sorting the network table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the network tab for a machine with bond and bridges (sampledata has these).
- the bond and bridge rows should have the parents/children next to each other.
- Sort the table by a different column, the groups should stay together.

## Fixes

Fixes: #1946.