### PR TITLE
feat(ui): add ability to create RAID 1/5/6/10 devices

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -354,9 +354,9 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:1448020556": [
       [152, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.test.tsx:4211256433": [
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.test.tsx:4048186981": [
       [91, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [92, 6, 14, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; name: string; tags: string[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "554647951"]
+      [92, 6, 22, "Argument of type \'{ blockDeviceIds: number[]; fstype: string; level: string; mountOptions: string; mountPoint: string; name: string; partitionIds: number[]; spareBlockDeviceIds: number[]; sparePartitionIds: number[]; tags: string[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'blockDeviceIds\' does not exist in type \'FormEvent<{}>\'.", "2859435865"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.test.tsx:2826042312": [
       [126, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.test.tsx
@@ -61,7 +61,7 @@ describe("CreateRaid", () => {
     expect(wrapper.find("Input[name='name']").prop("value")).toBe("md2");
   });
 
-  it("correctly dispatches an action to create a RAID 0 device", () => {
+  it("correctly dispatches an action to create a RAID device", () => {
     const [selectedDisk, selectedPartition] = [
       diskFactory({ partitions: null, type: DiskTypes.PHYSICAL }),
       partitionFactory({ filesystem: null }),
@@ -90,10 +90,15 @@ describe("CreateRaid", () => {
     );
 
     wrapper.find("Formik").prop("onSubmit")({
+      blockDeviceIds: [1, 2],
       fstype: "ext4",
+      level: "raid-6",
       mountOptions: "option1,option2",
       mountPoint: "/mount-point",
       name: "md1",
+      partitionIds: [3, 4],
+      spareBlockDeviceIds: [5, 6],
+      sparePartitionIds: [7, 8],
       tags: ["tag1", "tag2"],
     });
 
@@ -106,13 +111,15 @@ describe("CreateRaid", () => {
       },
       payload: {
         params: {
-          block_devices: [selectedDisk.id],
+          block_devices: [1, 2],
           fstype: "ext4",
-          level: "raid-0",
+          level: "raid-6",
           mount_options: "option1,option2",
           mount_point: "/mount-point",
           name: "md1",
-          partitions: [selectedPartition.id],
+          partitions: [3, 4],
+          spare_devices: [5, 6],
+          spare_partitions: [7, 8],
           system_id: "abc123",
           tags: ["tag1", "tag2"],
         },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.test.tsx
@@ -1,0 +1,320 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CreateRaid from "../CreateRaid";
+
+import { DiskTypes } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machinePartition as partitionFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("CreateRaidFields", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+  });
+
+  it("can handle RAID 0 devices", async () => {
+    const disks = [
+      diskFactory({ available_size: 1000000000 }), // 1GB
+      diskFactory({ available_size: 1500000000 }), // 1.5GB
+    ];
+    state.machine.items[0] = machineDetailsFactory({
+      disks,
+      system_id: "abc123",
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+      </Provider>
+    );
+
+    // Select RAID 0
+    await act(async () => {
+      wrapper.find("FormikField[name='level'] select").simulate("change", {
+        target: { name: "level", value: DiskTypes.RAID_0 },
+      });
+    });
+    wrapper.update();
+
+    // RAID 0s should not allow spare devices
+    expect(wrapper.find("[data-test='max-spares']").exists()).toBe(false);
+    // RAID 0 size is calculated as (minSize * numActive) = 1GB * 2 disks
+    expect(wrapper.find("Input[data-test='raid-size']").prop("value")).toBe(
+      "2 GB"
+    );
+  });
+
+  it("can handle RAID 1 devices", async () => {
+    const disks = [
+      diskFactory({ available_size: 1000000000 }), // 1GB
+      diskFactory({ available_size: 1500000000 }), // 1.5GB
+      diskFactory({ available_size: 2000000000 }), // 2GB
+    ];
+    state.machine.items[0] = machineDetailsFactory({
+      disks,
+      system_id: "abc123",
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+      </Provider>
+    );
+
+    // Select RAID 1
+    await act(async () => {
+      wrapper.find("FormikField[name='level'] select").simulate("change", {
+        target: { name: "level", value: DiskTypes.RAID_1 },
+      });
+    });
+    wrapper.update();
+
+    // RAID 1s allow spare devices, with a minimum of 2 active
+    expect(wrapper.find("[data-test='max-spares']").text()).toBe(
+      "Spare (max 1)"
+    );
+    // RAID 1 size is calculated as (minSize) = 1GB
+    expect(wrapper.find("Input[data-test='raid-size']").prop("value")).toBe(
+      "1 GB"
+    );
+  });
+
+  it("can handle RAID 5 devices", async () => {
+    const disks = [
+      diskFactory({ available_size: 1000000000 }), // 1GB
+      diskFactory({ available_size: 1500000000 }), // 1.5GB
+      diskFactory({ available_size: 2000000000 }), // 2GB
+      diskFactory({ available_size: 2500000000 }), // 2.5GB
+    ];
+    state.machine.items[0] = machineDetailsFactory({
+      disks,
+      system_id: "abc123",
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+      </Provider>
+    );
+
+    // Select RAID 5
+    await act(async () => {
+      wrapper.find("FormikField[name='level'] select").simulate("change", {
+        target: { name: "level", value: DiskTypes.RAID_5 },
+      });
+    });
+    wrapper.update();
+
+    // RAID 5s allow spare devices, with a minimum of 3 active
+    expect(wrapper.find("[data-test='max-spares']").text()).toBe(
+      "Spare (max 1)"
+    );
+    // RAID 5 size is calculated as minSize * (numActive - 1) = 1GB * (4 - 1)
+    expect(wrapper.find("Input[data-test='raid-size']").prop("value")).toBe(
+      "3 GB"
+    );
+  });
+
+  it("can handle RAID 6 devices", async () => {
+    const disks = [
+      diskFactory({ available_size: 1000000000 }), // 1GB
+      diskFactory({ available_size: 1500000000 }), // 1.5GB
+      diskFactory({ available_size: 2000000000 }), // 2GB
+      diskFactory({ available_size: 2500000000 }), // 2.5GB
+      diskFactory({ available_size: 3000000000 }), // 3GB
+    ];
+    state.machine.items[0] = machineDetailsFactory({
+      disks,
+      system_id: "abc123",
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+      </Provider>
+    );
+
+    // Select RAID 6
+    await act(async () => {
+      wrapper.find("FormikField[name='level'] select").simulate("change", {
+        target: { name: "level", value: DiskTypes.RAID_6 },
+      });
+    });
+    wrapper.update();
+
+    // RAID 6s allow spare devices, with a minimum of 4 active
+    expect(wrapper.find("[data-test='max-spares']").text()).toBe(
+      "Spare (max 1)"
+    );
+    // RAID 6 size is calculated as minSize * (numActive - 2) = 1GB * (5 - 2)
+    expect(wrapper.find("Input[data-test='raid-size']").prop("value")).toBe(
+      "3 GB"
+    );
+  });
+
+  it("can handle RAID 10 devices", async () => {
+    const disks = [
+      diskFactory({ available_size: 1500000000 }), // 1.5GB
+      diskFactory({ available_size: 2000000000 }), // 2GB
+      diskFactory({ available_size: 2500000000 }), // 2.5GB
+      diskFactory({ available_size: 3000000000 }), // 3GB
+    ];
+    state.machine.items[0] = machineDetailsFactory({
+      disks,
+      system_id: "abc123",
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />
+      </Provider>
+    );
+
+    // Select RAID 10
+    await act(async () => {
+      wrapper.find("FormikField[name='level'] select").simulate("change", {
+        target: { name: "level", value: DiskTypes.RAID_10 },
+      });
+    });
+    wrapper.update();
+
+    // RAID 10s allow spare devices, with a minimum of 3 active
+    expect(wrapper.find("[data-test='max-spares']").text()).toBe(
+      "Spare (max 1)"
+    );
+    // RAID 10 size is calculated as (minSize * numActive) / 2 = (1.5GB * 4) / 2
+    expect(wrapper.find("Input[data-test='raid-size']").prop("value")).toBe(
+      "3 GB"
+    );
+  });
+
+  it("can handle setting spare disks and partitions", async () => {
+    const partitions = [
+      partitionFactory({ size: 1000000000 }), // 1GB
+      partitionFactory({ size: 1500000000 }), // 1.5GB
+    ];
+    const disks = [
+      diskFactory({ available_size: 2000000000 }), // 2GB
+      diskFactory({ available_size: 2500000000 }), // 2.5GB
+      diskFactory({ partitions }),
+    ];
+    state.machine.items[0] = machineDetailsFactory({
+      disks,
+      system_id: "abc123",
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateRaid
+          closeForm={jest.fn()}
+          selected={[disks[0], disks[1], ...partitions]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    // Select RAID 1
+    await act(async () => {
+      wrapper.find("FormikField[name='level'] select").simulate("change", {
+        target: { name: "level", value: DiskTypes.RAID_1 },
+      });
+    });
+    wrapper.update();
+
+    // RAID 1s allow spare devices, with a minimum of 2 active
+    expect(wrapper.find("[data-test='max-spares']").text()).toBe(
+      "Spare (max 2)"
+    );
+
+    // Check the spare checkboxes for the first disk and first partition
+    await act(async () => {
+      const diskId = `raid-${disks[0].type}-${disks[0].id}`;
+      const partitionId = `raid-${partitions[0].type}-${partitions[0].id}`;
+      wrapper.find(`Input[id='${diskId}'] input`).simulate("change", {
+        target: {
+          id: diskId,
+          value: "checked",
+        },
+      });
+      wrapper.find(`Input[id='${partitionId}'] input`).simulate("change", {
+        target: {
+          id: partitionId,
+          value: "checked",
+        },
+      });
+    });
+    wrapper.update();
+
+    // First disk and partition should be spare, second disk and partition
+    // should be active
+    expect(
+      wrapper
+        .find("[data-test='active-storage-device'] i")
+        .at(0)
+        .prop("className")
+    ).toBe("p-icon--close");
+    expect(
+      wrapper
+        .find("[data-test='active-storage-device'] i")
+        .at(1)
+        .prop("className")
+    ).toBe("p-icon--tick");
+    expect(
+      wrapper
+        .find("[data-test='active-storage-device'] i")
+        .at(2)
+        .prop("className")
+    ).toBe("p-icon--close");
+    expect(
+      wrapper
+        .find("[data-test='active-storage-device'] i")
+        .at(3)
+        .prop("className")
+    ).toBe("p-icon--tick");
+
+    // Should not be able to select any more spare devices
+    expect(
+      wrapper
+        .find("[data-test='spare-storage-device'] input")
+        .at(0)
+        .prop("disabled")
+    ).toBe(false);
+    expect(
+      wrapper
+        .find("[data-test='spare-storage-device'] input")
+        .at(1)
+        .prop("disabled")
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("[data-test='spare-storage-device'] input")
+        .at(2)
+        .prop("disabled")
+    ).toBe(false);
+    expect(
+      wrapper
+        .find("[data-test='spare-storage-device'] input")
+        .at(3)
+        .prop("disabled")
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
@@ -1,4 +1,4 @@
-import { Col, Input, Row } from "@canonical/react-components";
+import { Col, Input, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import FilesystemFields from "../../../FilesystemFields";
@@ -6,57 +6,227 @@ import type { CreateRaidValues } from "../CreateRaid";
 
 import FormikField from "app/base/components/FormikField";
 import TagSelector from "app/base/components/TagSelector";
+import { RAID_MODES } from "app/store/machine/constants";
+import type { RaidMode } from "app/store/machine/constants";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
-import { formatSize } from "app/store/machine/utils";
+import { formatSize, formatType, isDisk } from "app/store/machine/utils";
 
 type Props = {
   storageDevices: (Disk | Partition)[];
   systemId: Machine["system_id"];
 };
 
+/**
+ * Get the size of the RAID, given the RAID mode and number of active devices.
+ * @param storageDevices - the selected storage devices.
+ * @param raidMode - the selected RAID mode.
+ * @param numActive - the number of active (i.e not spare) devices.
+ * @returns the size of the RAID in bytes.
+ */
+const getRaidSize = (
+  storageDevices: (Disk | Partition)[],
+  raidMode: RaidMode,
+  numActive: number
+) => {
+  // Min size is disk.available_size for disks, partition.size for partitions
+  const minSize = Math.min(
+    ...storageDevices.map((storageDevice) =>
+      isDisk(storageDevice) ? storageDevice.available_size : storageDevice.size
+    )
+  );
+  return raidMode.calculateSize(minSize, numActive);
+};
+
+/**
+ * Determine whether a storage device is selected to be a spare device.
+ * @param storageDevice - the storage device to check.
+ * @param spareBlockDeviceIds - the ids of the block devices selected to be spare.
+ * @param sparePartitionIds - the ids of the partitions selected to be spare.
+ * @returns whether the storage device is selected to be a spare device.
+ */
+const isSpare = (
+  storageDevice: Disk | Partition,
+  spareBlockDeviceIds: CreateRaidValues["spareBlockDeviceIds"],
+  sparePartitionIds: CreateRaidValues["sparePartitionIds"]
+) =>
+  isDisk(storageDevice)
+    ? spareBlockDeviceIds.includes(storageDevice.id)
+    : sparePartitionIds.includes(storageDevice.id);
+
 export const CreateRaidFields = ({
   storageDevices,
   systemId,
 }: Props): JSX.Element => {
-  const { initialValues, setFieldValue } = useFormikContext<CreateRaidValues>();
+  const {
+    initialValues,
+    setFieldValue,
+    values,
+  } = useFormikContext<CreateRaidValues>();
+  const {
+    blockDeviceIds,
+    level,
+    partitionIds,
+    spareBlockDeviceIds,
+    sparePartitionIds,
+  } = values;
   const initialTags = initialValues.tags.map((tag) => ({ name: tag }));
-  const totalSize = storageDevices.reduce(
-    (sum, device) => (sum += device.size),
-    0
+  const availableRaidModes = RAID_MODES.filter(
+    (raidMode) => storageDevices.length >= raidMode.minDevices
   );
+  const selectedMode =
+    RAID_MODES.find((raidMode) => raidMode.level === level) || RAID_MODES[0];
+  const maxSpares = selectedMode.allowsSpares
+    ? storageDevices.length - selectedMode.minDevices
+    : 0;
+  const numActive = blockDeviceIds.length + partitionIds.length;
+  const numSpare = spareBlockDeviceIds.length + sparePartitionIds.length;
+  const raidSize = getRaidSize(storageDevices, selectedMode, numActive);
+
+  const handleSpareCheckbox = (
+    storageDevice: Disk | Partition,
+    isSpareDevice: boolean
+  ) => {
+    if (isDisk(storageDevice)) {
+      if (isSpareDevice) {
+        setFieldValue("blockDeviceIds", [...blockDeviceIds, storageDevice.id]);
+        setFieldValue(
+          "spareBlockDeviceIds",
+          spareBlockDeviceIds.filter((id) => id !== storageDevice.id)
+        );
+      } else {
+        setFieldValue(
+          "blockDeviceIds",
+          blockDeviceIds.filter((id) => id !== storageDevice.id)
+        );
+        setFieldValue("spareBlockDeviceIds", [
+          ...spareBlockDeviceIds,
+          storageDevice.id,
+        ]);
+      }
+    } else {
+      if (isSpareDevice) {
+        setFieldValue("partitionIds", [...partitionIds, storageDevice.id]);
+        setFieldValue(
+          "sparePartitionIds",
+          sparePartitionIds.filter((id) => id !== storageDevice.id)
+        );
+      } else {
+        setFieldValue(
+          "partitionIds",
+          partitionIds.filter((id) => id !== storageDevice.id)
+        );
+        setFieldValue("sparePartitionIds", [
+          ...sparePartitionIds,
+          storageDevice.id,
+        ]);
+      }
+    }
+  };
 
   return (
-    <Row>
-      <Col size="5">
-        <FormikField label="Name" name="name" required type="text" />
-        <Input
-          disabled
-          label="Size"
-          type="text"
-          value={formatSize(totalSize)}
-        />
-        {/* TODO: Replace hardcoded type value with select */}
-        <Input disabled label="RAID level" type="text" value="RAID 0" />
-        <FormikField
-          allowNewTags
-          component={TagSelector}
-          initialSelected={initialTags}
-          label="Tags"
-          name="tags"
-          onTagsUpdate={(selectedTags: { name: string }[]) => {
-            setFieldValue(
-              "tags",
-              selectedTags.map((tag) => tag.name)
-            );
-          }}
-          placeholder="Select or create tags"
-          tags={initialTags}
-        />
-      </Col>
-      <Col emptyLarge="7" size="5">
-        <FilesystemFields systemId={systemId} />
-      </Col>
-    </Row>
+    <>
+      <Row>
+        <Col size="5">
+          <FormikField label="Name" name="name" required type="text" />
+          <FormikField
+            component={Select}
+            label="RAID level"
+            name="level"
+            options={availableRaidModes.map((raidMode) => ({
+              label: raidMode.label,
+              key: raidMode.level,
+              value: raidMode.level,
+            }))}
+          />
+          <Input
+            data-test="raid-size"
+            disabled
+            label="Size"
+            type="text"
+            value={formatSize(raidSize)}
+          />
+          <FormikField
+            allowNewTags
+            component={TagSelector}
+            initialSelected={initialTags}
+            label="Tags"
+            name="tags"
+            onTagsUpdate={(selectedTags: { name: string }[]) => {
+              setFieldValue(
+                "tags",
+                selectedTags.map((tag) => tag.name)
+              );
+            }}
+            placeholder="Select or create tags"
+            tags={initialTags}
+          />
+        </Col>
+        <Col emptyLarge="7" size="5">
+          <FilesystemFields systemId={systemId} />
+        </Col>
+      </Row>
+      <Row>
+        <Col size="12">
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Size</th>
+                <th>Type</th>
+                {maxSpares > 0 && (
+                  <>
+                    <th>Active</th>
+                    <th data-test="max-spares">{`Spare (max ${maxSpares})`}</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {storageDevices.map((storageDevice) => {
+                const id = `raid-${storageDevice.type}-${storageDevice.id}`;
+                const isSpareDevice = isSpare(
+                  storageDevice,
+                  spareBlockDeviceIds,
+                  sparePartitionIds
+                );
+
+                return (
+                  <tr key={id}>
+                    <td>{storageDevice.name}</td>
+                    <td>{formatSize(storageDevice.size)}</td>
+                    <td>{formatType(storageDevice)}</td>
+                    {maxSpares > 0 && (
+                      <>
+                        <td data-test="active-storage-device">
+                          {isSpareDevice ? (
+                            <i className="p-icon--close"></i>
+                          ) : (
+                            <i className="p-icon--tick"></i>
+                          )}
+                        </td>
+                        <td data-test="spare-storage-device">
+                          <Input
+                            checked={isSpareDevice}
+                            className="has-inline-label"
+                            disabled={!isSpareDevice && numSpare >= maxSpares}
+                            id={id}
+                            label=" "
+                            onChange={() =>
+                              handleSpareCheckbox(storageDevice, isSpareDevice)
+                            }
+                            type="checkbox"
+                          />
+                        </td>
+                      </>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </Col>
+      </Row>
+    </>
   );
 };
 

--- a/ui/src/app/store/machine/constants.ts
+++ b/ui/src/app/store/machine/constants.ts
@@ -1,3 +1,61 @@
+import { DiskTypes } from "./types";
+
 // From models/partition.py. This should ideally be available over the websocket.
 // https://github.com/canonical-web-and-design/maas-ui/issues/1866
 export const MIN_PARTITION_SIZE = 4 * 1024 * 1024;
+
+export type RaidMode = {
+  allowsSpares: boolean;
+  calculateSize: (minSize: number, numActive: number) => number;
+  label: string;
+  level:
+    | DiskTypes.RAID_0
+    | DiskTypes.RAID_1
+    | DiskTypes.RAID_5
+    | DiskTypes.RAID_6
+    | DiskTypes.RAID_10;
+  minDevices: number;
+};
+// This should be made available over the websocket.
+// https://github.com/canonical-web-and-design/maas-ui/issues/1866
+export const RAID_MODES: RaidMode[] = [
+  {
+    allowsSpares: false,
+    calculateSize: (minSize: number, numActive: number): number =>
+      minSize * numActive,
+    label: "RAID 0",
+    level: DiskTypes.RAID_0,
+    minDevices: 2,
+  },
+  {
+    allowsSpares: true,
+    calculateSize: (minSize: number, _: number): number => minSize,
+    label: "RAID 1",
+    level: DiskTypes.RAID_1,
+    minDevices: 2,
+  },
+  {
+    allowsSpares: true,
+    calculateSize: (minSize: number, numActive: number): number =>
+      minSize * (numActive - 1),
+    label: "RAID 5",
+    level: DiskTypes.RAID_5,
+    minDevices: 3,
+  },
+  {
+    allowsSpares: true,
+    calculateSize: (minSize: number, numActive: number): number =>
+      minSize * (numActive - 2),
+    label: "RAID 6",
+    level: DiskTypes.RAID_6,
+    minDevices: 4,
+  },
+  {
+    allowsSpares: true,
+    calculateSize: (minSize: number, numActive: number): number =>
+      (minSize * numActive) / 2,
+    label: "RAID 10",
+    level: DiskTypes.RAID_10,
+    minDevices: 3,
+  },
+];


### PR DESCRIPTION
## Done

- Added storage devices table to Create RAID form
- Added ability to choose from RAID 0/1/5/6/10 devices when creating a RAID

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine in Ready or Allocated state.
- Create 2 partitions of different sizes.
- Select the partitions and click "Create RAID".
- RAID 0 should be selected by default. Note the RAID size, then submit the form.
- Check that the RAID is created with the correct size.
- Remove the RAID, add another partition with a different size, then select all 3 partitions and click "Create RAID".
- Select RAID 1 and check that the table adds 2 new columns for "Active" and "Spare".
- Tick one of the checkboxes and check that the other checkboxes become disabled. Note the RAID size then submit the form.
- Check that the RAID is created with the correct size, and the "Used disks and partitions" correctly shows which partitions are active and which are spare.
- Run the same tests for RAID 5 (min 3 devices), RAID 6 (min 4 devices) and RAID 10 (min 3 devices)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2320

## Screenshot

![Screenshot_2021-01-20 sure-cod maas storage bolla MAAS](https://user-images.githubusercontent.com/25733845/105107536-1679a600-5b04-11eb-942c-4001aa6252a6.png)

