### PR TITLE
feat(ui): add ability to create cache sets

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.test.tsx
@@ -93,6 +93,39 @@ describe("ActionConfirm", () => {
     expect(wrapper.find("[data-test='error-message']").text()).toBe("uh oh");
   });
 
+  it("can change the submit appearance", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory({ creatingCacheSet: false }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const closeExpanded = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActionConfirm
+          closeExpanded={closeExpanded}
+          confirmLabel="Confirm"
+          message="Are you sure you want to do that?"
+          onConfirm={jest.fn()}
+          onSaveAnalytics={{
+            action: "Action",
+            category: "Category",
+            label: "Label",
+          }}
+          statusKey="creatingCacheSet"
+          submitAppearance="positive"
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("ActionButton").prop("appearance")).toBe("positive");
+  });
+
   it("sends an analytics event when saved", () => {
     const analyticsEvent = {
       action: "Action",

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ActionConfirm/ActionConfirm.tsx
@@ -15,11 +15,12 @@ import { formatErrors } from "app/utils";
 type Props = {
   confirmLabel: string;
   eventName?: string;
-  message: string;
+  message?: string;
   closeExpanded: () => void;
   onConfirm: () => void;
   onSaveAnalytics: AnalyticsEvent;
   statusKey: keyof MachineStatus;
+  submitAppearance?: "negative" | "positive";
   systemId: Machine["system_id"];
 };
 
@@ -31,6 +32,7 @@ const ActionConfirm = ({
   onConfirm,
   onSaveAnalytics,
   statusKey,
+  submitAppearance = "negative",
   systemId,
 }: Props): JSX.Element => {
   const { errors, saved, saving } = useMachineDetailsForm(
@@ -56,17 +58,19 @@ const ActionConfirm = ({
         </Notification>
       ) : null}
       <Col size={8}>
-        <p className="u-no-margin--bottom u-no-max-width">
-          <i className="p-icon--warning is-inline">Warning</i>
-          {message}
-        </p>
+        {message && (
+          <p className="u-no-margin--bottom u-no-max-width">
+            <i className="p-icon--warning is-inline">Warning</i>
+            {message}
+          </p>
+        )}
       </Col>
       <Col size={4} className="u-align--right">
         <Button className="u-no-margin--bottom" onClick={closeExpanded}>
           Cancel
         </Button>
         <ActionButton
-          appearance="negative"
+          appearance={submitAppearance}
           className="u-no-margin--bottom"
           loading={saving}
           onClick={onConfirm}

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -401,13 +401,13 @@ const statusHandlers = generateStatusHandlers<
       case "create-cache-set":
         handler.method = "create_cache_set";
         handler.prepare = (params: {
-          blockId: number;
-          partitionId: number;
+          blockId?: number;
+          partitionId?: number;
           systemId: Machine["system_id"];
         }) => ({
-          block_id: params.blockId,
-          partition_id: params.partitionId,
           system_id: params.systemId,
+          ...("blockId" in params && { block_id: params.blockId }),
+          ...("partitionId" in params && { partition_id: params.partitionId }),
         });
         break;
       case "create-logical-volume":

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -34,6 +34,7 @@ export {
   canBeDeleted,
   canBeFormatted,
   canBePartitioned,
+  canCreateCacheSet,
   canCreateLogicalVolume,
   canCreateRaid,
   canCreateVolumeGroup,

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -54,6 +54,32 @@ export const canBePartitioned = (disk: Disk | null): boolean => {
 };
 
 /**
+ * Returns whether a storage device can create a cache set.
+ * @param storageDevice - the storage device to check.
+ * @returns whether the storage device can create a cache set.
+ */
+export const canCreateCacheSet = (
+  storageDevice: Disk | Partition | null
+): boolean => {
+  if (!storageDevice) {
+    return false;
+  }
+
+  if (
+    isDisk(storageDevice) &&
+    (storageDevice.partitions?.length || isVolumeGroup(storageDevice))
+  ) {
+    return false;
+  }
+
+  if (isFormatted(storageDevice.filesystem)) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
  * Returns whether a disk can create a logical volume.
  * @param disk - the disk to check.
  * @returns whether the disk can create a logical volume.


### PR DESCRIPTION
## Done

- Added ability to create cache sets. I've decided not to follow the same design as the legacy storage tab, in which creating cache sets is handled as a bulk action despite the fact that you can only perform it on a single storage device.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready or Allocated machine that has an unpartitioned disk.
- Open the action dropdown for the unpartitioned disk and check that you can create a cache set.
- Check that the cache set now shows up in the cache sets table
- Remove the cache set
- Create a single partition and check that you can no longer create a cache set from the disk
- Open the action dropdown for the partition and check that you can create a cache set

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2321
