### PR TITLE
feat(ui): add ability to create bcaches

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -351,7 +351,7 @@ exports[`stricter compilation`] = {
       [149, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [150, 6, 15, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "1103269280"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:3485561940": [
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:3446240187": [
       [152, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx:378591652": [
@@ -365,6 +365,10 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.test.tsx:2826042312": [
       [126, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [127, 6, 11, "Argument of type \'{ name: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "2802891064"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.test.tsx:2947973190": [
+      [100, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [101, 6, 33, "Argument of type \'{ cacheMode: BcacheModes; cacheSetId: number; fstype: string; mountOptions: string; mountPoint: string; name: string; tags: string[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'cacheMode\' does not exist in type \'FormEvent<{}>\'.", "3198063113"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditLogicalVolume/EditLogicalVolume.test.tsx:132455268": [
       [51, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -477,14 +481,14 @@ exports[`stricter compilation`] = {
     "src/app/store/general/selectors/machineActions.test.ts:638190955": [
       [91, 10, 4, "Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: NodeActions; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'NodeActions\' is not assignable to type \'NodeActions.ABORT | NodeActions.ACQUIRE | NodeActions.COMMISSION | NodeActions.DELETE | NodeActions.DEPLOY | NodeActions.EXIT_RESCUE_MODE | NodeActions.LOCK | ... 11 more ... | NodeActions.UNLOCK\'.", "2087377941"]
     ],
-    "src/app/store/machine/slice.ts:1904988182": [
+    "src/app/store/machine/slice.ts:3992141854": [
       [728, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
       [736, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
       [740, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
-    "src/app/store/machine/utils/storage.ts:2191389387": [
-      [104, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
-      [133, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
+    "src/app/store/machine/utils/storage.ts:2637304794": [
+      [134, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
+      [163, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
     ],
     "src/app/store/nodedevice/slice.ts:54310614": [
       [60, 4, 21, "Type \'(state: NodeDeviceState, action: PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<NodeDevice, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<NodeDevice, any>, PayloadAction<...>>\'.\\n  Type \'(state: NodeDeviceState, action: PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<NodeDevice, any>, { payload: any; type: string; }>\'.\\n    Types of parameters \'action\' and \'action\' are incompatible.\\n      Type \'{ payload: any; type: string; }\' is not assignable to type \'PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>, never>\'.\\n        Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.", "294608771"]
@@ -656,10 +660,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:2708521718": [
+    "src/app/store/machine/types.ts:1332432184": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [409, 34, 8, "RegExp match", "1152173309"],
-      [412, 25, 8, "RegExp match", "1152173309"]
+      [406, 34, 8, "RegExp match", "1152173309"],
+      [409, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/nodedevice/types.ts:2713937479": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -315,6 +315,35 @@ describe("AvailableStorageTable", () => {
     expect(wrapper.find("EditPhysicalDisk").exists()).toBe(true);
   });
 
+  it("can open the create bcache form if the machine has at least one cache set", () => {
+    const backingDevice = diskFactory({ type: DiskTypes.PHYSICAL });
+    const cacheSet = diskFactory({ type: DiskTypes.CACHE_SET });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [backingDevice, cacheSet],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AvailableStorageTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+
+    wrapper.find("TableMenu button").at(0).simulate("click");
+    wrapper.find("button[data-test='createBcache']").simulate("click");
+
+    expect(wrapper.find("CreateBcache").exists()).toBe(true);
+  });
+
   it("disables actions if a bulk action has been selected", () => {
     const partitions = [
       partitionFactory({ filesystem: null }),

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.test.tsx
@@ -1,0 +1,136 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CreateBcache from "./CreateBcache";
+
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { BcacheModes, DiskTypes } from "app/store/machine/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("CreateBcache", () => {
+  it("sets the initial name correctly", () => {
+    const cacheSet = diskFactory({ type: DiskTypes.CACHE_SET });
+    const bcaches = [
+      diskFactory({
+        name: "bcache0",
+        parent: {
+          id: 0,
+          type: DiskTypes.BCACHE,
+          uuid: "bcache0",
+        },
+        type: DiskTypes.VIRTUAL,
+      }),
+      diskFactory({
+        name: "bcache1",
+        parent: {
+          id: 1,
+          type: DiskTypes.BCACHE,
+          uuid: "bcache1",
+        },
+        type: DiskTypes.VIRTUAL,
+      }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [cacheSet, ...bcaches],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateBcache
+          closeExpanded={jest.fn()}
+          storageDevice={diskFactory()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    // Two bcaches already exist so the next one should be bcache2
+    expect(wrapper.find("Input[name='name']").prop("value")).toBe("bcache2");
+  });
+
+  it("correctly dispatches an action to create a bcache", () => {
+    const cacheSet = diskFactory({ type: DiskTypes.CACHE_SET });
+    const backingDevice = diskFactory({
+      available_size: MIN_PARTITION_SIZE + 1,
+      type: DiskTypes.PHYSICAL,
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [backingDevice, cacheSet],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateBcache
+          closeExpanded={jest.fn()}
+          storageDevice={backingDevice}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    wrapper.find("Formik").prop("onSubmit")({
+      cacheMode: BcacheModes.WRITE_BACK,
+      cacheSetId: cacheSet.id,
+      fstype: "fat32",
+      mountOptions: "noexec",
+      mountPoint: "/path",
+      name: "bcache0",
+      tags: ["tag1", "tag2"],
+    });
+
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/createBcache")
+    ).toStrictEqual({
+      meta: {
+        method: "create_bcache",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          block_id: backingDevice.id,
+          cache_mode: BcacheModes.WRITE_BACK,
+          cache_set: cacheSet.id,
+          fstype: "fat32",
+          mount_options: "noexec",
+          mount_point: "/path",
+          name: "bcache0",
+          system_id: "abc123",
+          tags: ["tag1", "tag2"],
+        },
+      },
+      type: "machine/createBcache",
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.tsx
@@ -1,0 +1,145 @@
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import CreateBcacheFields from "./CreateBcacheFields";
+
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { useMachineDetailsForm } from "app/machines/hooks";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { Disk, Machine, Partition } from "app/store/machine/types";
+import { BcacheModes } from "app/store/machine/types";
+import { isBcache, isCacheSet, isDisk } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+
+export type CreateBcacheValues = {
+  cacheMode: BcacheModes;
+  cacheSetId: string;
+  fstype?: string;
+  mountOptions?: string;
+  mountPoint?: string;
+  name: string;
+  tags: string[];
+};
+
+type Props = {
+  closeExpanded: () => void;
+  storageDevice: Disk | Partition;
+  systemId: Machine["system_id"];
+};
+
+const CreateBcacheSchema = Yup.object().shape({
+  cacheMode: Yup.string().required("Cache mode is required"),
+  cacheSetId: Yup.number().required("Cache set is required"),
+  fstype: Yup.string(),
+  mountOptions: Yup.string(),
+  mountPoint: Yup.string().when("fstype", {
+    is: (val: CreateBcacheValues["fstype"]) => Boolean(val),
+    then: Yup.string().matches(/^\//, "Mount point must start with /"),
+  }),
+  name: Yup.string().required("Name is required"),
+  tags: Yup.array().of(Yup.string()),
+});
+
+const getInitialName = (disks: Disk[]) => {
+  if (!disks || disks.length === 0) {
+    return "bcache0";
+  }
+  const bcacheCount = disks.reduce<number>(
+    (count, disk) => (isBcache(disk) ? count + 1 : count),
+    0
+  );
+  return `bcache${bcacheCount}`;
+};
+
+export const CreateBcache = ({
+  closeExpanded,
+  storageDevice,
+  systemId,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const { errors, saved, saving } = useMachineDetailsForm(
+    systemId,
+    "creatingBcache",
+    "createBcache",
+    () => closeExpanded()
+  );
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+
+  if (machine && "disks" in machine) {
+    const cacheSets = machine.disks.filter((disk) => isCacheSet(disk));
+
+    if (cacheSets.length === 0) {
+      // Close the form if the last remaining cache set was deleted after the
+      // form had already opened.
+      closeExpanded();
+      return null;
+    }
+
+    return (
+      <FormikForm
+        allowUnchanged
+        buttons={FormCardButtons}
+        cleanup={machineActions.cleanup}
+        errors={errors}
+        initialValues={{
+          cacheMode: BcacheModes.WRITE_BACK,
+          cacheSetId: cacheSets[0].id,
+          fstype: "",
+          mountOptions: "",
+          mountPoint: "",
+          name: getInitialName(machine.disks),
+          tags: [],
+        }}
+        onCancel={closeExpanded}
+        onSaveAnalytics={{
+          action: "Create bcache",
+          category: "Machine storage",
+          label: "Create bcache",
+        }}
+        onSubmit={(values: CreateBcacheValues) => {
+          const {
+            cacheMode,
+            cacheSetId,
+            fstype,
+            mountOptions,
+            mountPoint,
+            name,
+            tags,
+          } = values;
+
+          const params = {
+            cacheMode,
+            cacheSetId,
+            name,
+            systemId: machine.system_id,
+            ...(isDisk(storageDevice) && { blockId: storageDevice.id }),
+            ...(fstype && { fstype }),
+            ...(fstype && mountOptions && { mountOptions }),
+            ...(fstype && mountPoint && { mountPoint }),
+            ...(!isDisk(storageDevice) && { partitionId: storageDevice.id }),
+            ...(tags.length > 0 && { tags }),
+          };
+
+          dispatch(machineActions.createBcache(params));
+        }}
+        saved={saved}
+        saving={saving}
+        submitLabel="Create bcache"
+        validationSchema={CreateBcacheSchema}
+      >
+        <CreateBcacheFields
+          cacheSets={cacheSets}
+          storageDevice={storageDevice}
+          systemId={systemId}
+        />
+      </FormikForm>
+    );
+  }
+  return null;
+};
+
+export default CreateBcache;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/CreateBcacheFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/CreateBcacheFields.tsx
@@ -1,0 +1,89 @@
+import { Col, Input, Row, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import FilesystemFields from "../../FilesystemFields";
+import type { CreateBcacheValues } from "../CreateBcache";
+
+import FormikField from "app/base/components/FormikField";
+import TagSelector from "app/base/components/TagSelector";
+import type { Disk, Machine, Partition } from "app/store/machine/types";
+import { BcacheModes } from "app/store/machine/types";
+import { formatSize } from "app/store/machine/utils";
+
+type Props = {
+  cacheSets: Disk[];
+  storageDevice: Disk | Partition;
+  systemId: Machine["system_id"];
+};
+
+export const CreateBcacheFields = ({
+  cacheSets,
+  storageDevice,
+  systemId,
+}: Props): JSX.Element => {
+  const {
+    initialValues,
+    setFieldValue,
+  } = useFormikContext<CreateBcacheValues>();
+  const initialTags = initialValues.tags.map((tag) => ({ name: tag }));
+
+  return (
+    <Row>
+      <Col size="5">
+        <FormikField label="Name" name="name" required type="text" />
+        <Input
+          disabled
+          label="Size"
+          value={formatSize(storageDevice.size)}
+          type="text"
+        />
+        <FormikField
+          component={Select}
+          label="Cache set"
+          name="cacheSetId"
+          options={cacheSets.map((cacheSet) => ({
+            key: cacheSet.id,
+            label: cacheSet.name,
+            value: cacheSet.id,
+          }))}
+        />
+        <FormikField
+          component={Select}
+          label="Cache mode"
+          name="cacheMode"
+          options={[
+            { label: BcacheModes.WRITE_BACK, value: BcacheModes.WRITE_BACK },
+            {
+              label: BcacheModes.WRITE_THROUGH,
+              value: BcacheModes.WRITE_THROUGH,
+            },
+            {
+              label: BcacheModes.WRITE_AROUND,
+              value: BcacheModes.WRITE_AROUND,
+            },
+          ]}
+        />
+        <FormikField
+          allowNewTags
+          component={TagSelector}
+          initialSelected={initialTags}
+          label="Tags"
+          name="tags"
+          onTagsUpdate={(selectedTags: { name: string }[]) => {
+            setFieldValue(
+              "tags",
+              selectedTags.map((tag) => tag.name)
+            );
+          }}
+          placeholder="Select or create tags"
+          tags={[]}
+        />
+      </Col>
+      <Col emptyLarge="7" size="5">
+        <FilesystemFields systemId={systemId} />
+      </Col>
+    </Row>
+  );
+};
+
+export default CreateBcacheFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CreateBcacheFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./CreateBcache";
+export type { CreateBcacheValues } from "./CreateBcache";

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -392,27 +392,29 @@ const statusHandlers = generateStatusHandlers<
       case "create-bcache":
         handler.method = "create_bcache";
         handler.prepare = (params: {
-          blockId: number;
+          blockId?: number;
           cacheMode: string;
           cacheSetId: number;
-          fstype: string;
-          mountOptions: string;
-          mountPoint: string;
+          fstype?: string;
+          mountOptions?: string;
+          mountPoint?: string;
           name: string;
-          partitionId: number;
+          partitionId?: number;
           systemId: Machine["system_id"];
-          tags: string[];
+          tags?: string[];
         }) => ({
-          block_id: params.blockId,
           cache_mode: params.cacheMode,
           cache_set: params.cacheSetId,
-          fstype: params.fstype,
-          mount_options: params.mountOptions,
-          mount_point: params.mountPoint,
           name: params.name,
-          partition_id: params.partitionId,
           system_id: params.systemId,
-          tags: params.tags,
+          ...("blockId" in params && { block_id: params.blockId }),
+          ...("fstype" in params && { fstype: params.fstype }),
+          ...("mountOptions" in params && {
+            mount_options: params.mountOptions,
+          }),
+          ...("mountPoint" in params && { mount_point: params.mountPoint }),
+          ...("partitionId" in params && { partition_id: params.partitionId }),
+          ...("tags" in params && { tags: params.tags }),
         });
         break;
       case "create-cache-set":

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -137,6 +137,12 @@ export type Partition = Model & {
   used_for: string;
 };
 
+export enum BcacheModes {
+  WRITE_BACK = "writeback",
+  WRITE_THROUGH = "writethrough",
+  WRITE_AROUND = "writearound",
+}
+
 export enum DiskTypes {
   BCACHE = "bcache",
   CACHE_SET = "cache-set",

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -35,6 +35,7 @@ export {
   canBeDeleted,
   canBeFormatted,
   canBePartitioned,
+  canCreateBcache,
   canCreateCacheSet,
   canCreateLogicalVolume,
   canCreateRaid,

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -54,6 +54,36 @@ export const canBePartitioned = (disk: Disk | null): boolean => {
 };
 
 /**
+ * Returns whether a storage device can create a bcache.
+ * @param machineDisks - all of the machine's disks.
+ * @param storageDevice - the storage device to check.
+ * @returns whether the storage device can create a bcache.
+ */
+export const canCreateBcache = (
+  machineDisks: Disk[],
+  storageDevice: Disk | Partition | null
+): boolean => {
+  if (!storageDevice || !machineDisks.some((disk) => isCacheSet(disk))) {
+    return false;
+  }
+
+  if (
+    isDisk(storageDevice) &&
+    (storageDevice.partitions?.length ||
+      isVolumeGroup(storageDevice) ||
+      isBcache(storageDevice))
+  ) {
+    return false;
+  }
+
+  if (isFormatted(storageDevice.filesystem)) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
  * Returns whether a storage device can create a cache set.
  * @param storageDevice - the storage device to check.
  * @returns whether the storage device can create a cache set.


### PR DESCRIPTION
## Done

- Added ability to create bcaches. Like with cachesets, I've changed this from the angular client because you can only perform the action on a single storage device.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready or Allocated machine.
- Create 3 partitions.
- If there is a cache set already, delete it.
- Check that the action dropdowns for the partitions do not include "Create bcache".
- Create 2 cache sets from 2 of the partitions.
- Check that there is now a "Create bcache" action for the remaining partition.
- Check that you can select from the 2 created cache sets.
- Check that you can successfully create a bcache from the partition.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2168

## Screenshot

![Screenshot_2021-01-20 sure-cod maas storage bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/105138394-873eb380-5b40-11eb-9411-622815c89c4e.png)

