### PR TITLE
fix(ui): fix broken width interpolation in KVM compose form

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/_index.scss
@@ -2,7 +2,7 @@
 
 $ratio-total: $subnet-col-ratio + $fabric-col-ratio + $vlan-col-ratio;
 $ratio-multiplier: $ratio-total / $subnet-col-ratio;
-$padding-multiplier: 100% + #{2 * $sph-inner--small};
+$padding: 2 * $sph-inner--small;
 $pxe-col-compensation: $pxe-col-width - $sph-inner--small;
 
 @mixin KVMSubnetSelect {
@@ -14,7 +14,7 @@ $pxe-col-compensation: $pxe-col-width - $sph-inner--small;
       max-width: none;
       min-width: 0;
       width: calc(
-        #{$ratio-multiplier} * (#{$padding-multiplier}) + #{$pxe-col-compensation}
+        #{$ratio-multiplier} * (100% + #{$padding}) + #{$pxe-col-compensation}
       ) !important;
 
       @media only screen and (max-width: $breakpoint-medium) {
@@ -69,7 +69,7 @@ $pxe-col-compensation: $pxe-col-width - $sph-inner--small;
 
         // PXE
         &:nth-child(4) {
-          width: #{$pxe-col-width - #{3 * $sph-inner--small}};
+          width: #{$pxe-col-width - 3 * $sph-inner--small};
         }
 
         &:not(:last-child) {


### PR DESCRIPTION
## Done

- Fixed some broken width interpolation in KVM compose form. Turns out nesting `#{}`s doesn't work out too well.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a KVM that has available subnets (e.g. bolla)
- Open the Compose form from the action menu
- Define an interface
- Click the Subnet dropdown and check that the widths line up with the table columns
- Check there are no errors in the console

## Fixes

Fixes #2067 
