### PR TITLE
feat(ui): add ability to create datastores

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/work/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -354,6 +354,10 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:3485561940": [
       [152, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx:378591652": [
+      [178, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [179, 6, 18, "Argument of type \'{ name: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "219600198"]
+    ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.test.tsx:4048186981": [
       [91, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [92, 6, 22, "Argument of type \'{ blockDeviceIds: number[]; fstype: string; level: string; mountOptions: string; mountPoint: string; name: string; partitionIds: number[]; spareBlockDeviceIds: number[]; sparePartitionIds: number[]; tags: string[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'blockDeviceIds\' does not exist in type \'FormEvent<{}>\'.", "2859435865"]
@@ -382,8 +386,8 @@ exports[`stricter compilation`] = {
       [62, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [63, 6, 15, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "556729358"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2261070022": [
-      [168, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    "src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx:2240768967": [
+      [169, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
     "src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx:3437058613": [
       [33, 27, 10, "Property \'numa_nodes\' does not exist on type \'Machine\'.\\n  Property \'numa_nodes\' does not exist on type \'BaseMachine\'.", "3857696382"]
@@ -399,9 +403,9 @@ exports[`stricter compilation`] = {
       [80, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
       [94, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"]
     ],
-    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:1176053753": [
-      [67, 22, 37, "Argument of type \'number[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.\\n  Type \'number[]\' is not assignable to type \'never[]\'.\\n    Type \'number\' is not assignable to type \'never\'.", "3211590551"],
-      [77, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:1977710823": [
+      [68, 22, 37, "Argument of type \'number[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.\\n  Type \'number[]\' is not assignable to type \'never[]\'.\\n    Type \'number\' is not assignable to type \'never\'.", "3211590551"],
+      [78, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:1209352711": [
       [106, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
@@ -473,10 +477,10 @@ exports[`stricter compilation`] = {
     "src/app/store/general/selectors/machineActions.test.ts:638190955": [
       [91, 10, 4, "Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: NodeActions; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'NodeActions\' is not assignable to type \'NodeActions.ABORT | NodeActions.ACQUIRE | NodeActions.COMMISSION | NodeActions.DELETE | NodeActions.DEPLOY | NodeActions.EXIT_RESCUE_MODE | NodeActions.LOCK | ... 11 more ... | NodeActions.UNLOCK\'.", "2087377941"]
     ],
-    "src/app/store/machine/slice.ts:1577821033": [
-      [726, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
-      [734, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
-      [738, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
+    "src/app/store/machine/slice.ts:1904988182": [
+      [728, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
+      [736, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
+      [740, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
     "src/app/store/machine/utils/storage.ts:2191389387": [
       [104, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
@@ -652,10 +656,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:2346712921": [
+    "src/app/store/machine/types.ts:2708521718": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [400, 34, 8, "RegExp match", "1152173309"],
-      [403, 25, 8, "RegExp match", "1152173309"]
+      [409, 34, 8, "RegExp match", "1152173309"],
+      [412, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/nodedevice/types.ts:2713937479": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -44,7 +44,7 @@ import {
 import type { RootState } from "app/store/root/types";
 
 // Actions that are performed on multiple devices at once
-export type BulkAction = "createRaid" | "createVolumeGroup";
+export type BulkAction = "createDatastore" | "createRaid" | "createVolumeGroup";
 
 // Actions that are performed on a single device
 type Expanded = {
@@ -649,13 +649,14 @@ const AvailableStorageTable = ({
           rows={rows}
         />
         {rows.length === 0 && (
-          <div className="u-nudge-right--small" data-test="no-available">
+          <div className="u-nudge-right--small u-sv2" data-test="no-available">
             No available disks or partitions.
           </div>
         )}
         {canEditStorage && (
           <BulkActions
             bulkAction={bulkAction}
+            storageLayout={machine.detected_storage_layout}
             selected={selected}
             setBulkAction={setBulkAction}
             systemId={systemId}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.test.tsx
@@ -4,7 +4,7 @@ import configureStore from "redux-mock-store";
 
 import BulkActions from "./BulkActions";
 
-import { DiskTypes } from "app/store/machine/types";
+import { DiskTypes, StorageLayout } from "app/store/machine/types";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
@@ -30,6 +30,7 @@ describe("BulkActions", () => {
         bulkAction={null}
         selected={selected}
         setBulkAction={jest.fn()}
+        storageLayout={StorageLayout.BLANK}
         systemId="abc123"
       />
     );
@@ -50,6 +51,7 @@ describe("BulkActions", () => {
         bulkAction={null}
         selected={selected}
         setBulkAction={jest.fn()}
+        storageLayout={StorageLayout.BLANK}
         systemId="abc123"
       />
     );
@@ -57,6 +59,126 @@ describe("BulkActions", () => {
     expect(wrapper.find("button[data-test='create-vg']").prop("disabled")).toBe(
       false
     );
+  });
+
+  it("renders VMFS6 bulk actions if the detected layout is VMFS6", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <BulkActions
+          bulkAction={null}
+          selected={[]}
+          setBulkAction={jest.fn()}
+          storageLayout={StorageLayout.VMFS6}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='vmfs6-bulk-actions']").exists()).toBe(
+      true
+    );
+  });
+
+  it("enables the create datastore button if at least one device is selected", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <BulkActions
+          bulkAction={null}
+          selected={[diskFactory()]}
+          setBulkAction={jest.fn()}
+          storageLayout={StorageLayout.VMFS6}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("button[data-test='create-datastore']").prop("disabled")
+    ).toBe(false);
+  });
+
+  it("can render the create datastore form", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <BulkActions
+          bulkAction="createDatastore"
+          selected={[]}
+          setBulkAction={jest.fn()}
+          storageLayout={StorageLayout.VMFS6}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("CreateDatastore").exists()).toBe(true);
+  });
+
+  it("can render the create RAID form", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <BulkActions
+          bulkAction="createRaid"
+          selected={[]}
+          setBulkAction={jest.fn()}
+          storageLayout={StorageLayout.BLANK}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("CreateRaid").exists()).toBe(true);
   });
 
   it("can render the create volume group form", () => {
@@ -79,6 +201,7 @@ describe("BulkActions", () => {
           bulkAction="createVolumeGroup"
           selected={[]}
           setBulkAction={jest.fn()}
+          storageLayout={StorageLayout.BLANK}
           systemId="abc123"
         />
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.tsx
@@ -1,17 +1,20 @@
-import { Button, Tooltip } from "@canonical/react-components";
+import { Button, List, Tooltip } from "@canonical/react-components";
 
 import type { BulkAction } from "../AvailableStorageTable";
 
+import CreateDatastore from "./CreateDatastore";
 import CreateRaid from "./CreateRaid";
 import CreateVolumeGroup from "./CreateVolumeGroup";
 
 import type { Disk, Machine, Partition } from "app/store/machine/types";
+import { StorageLayout } from "app/store/machine/types";
 import { canCreateRaid, canCreateVolumeGroup } from "app/store/machine/utils";
 
 type Props = {
   bulkAction: BulkAction | null;
   selected: (Disk | Partition)[];
   setBulkAction: (bulkAction: BulkAction | null) => void;
+  storageLayout: StorageLayout;
   systemId: Machine["system_id"];
 };
 
@@ -19,10 +22,18 @@ const BulkActions = ({
   bulkAction,
   selected,
   setBulkAction,
+  storageLayout,
   systemId,
 }: Props): JSX.Element | null => {
-  const createRaidEnabled = canCreateRaid(selected);
-  const createVgEnabled = canCreateVolumeGroup(selected);
+  if (bulkAction === "createDatastore") {
+    return (
+      <CreateDatastore
+        closeForm={() => setBulkAction(null)}
+        selected={selected}
+        systemId={systemId}
+      />
+    );
+  }
 
   if (bulkAction === "createRaid") {
     return (
@@ -33,6 +44,7 @@ const BulkActions = ({
       />
     );
   }
+
   if (bulkAction === "createVolumeGroup") {
     return (
       <CreateVolumeGroup
@@ -42,9 +54,48 @@ const BulkActions = ({
       />
     );
   }
+
+  if (storageLayout === StorageLayout.VMFS6) {
+    const createDatastoreEnabled = selected.length >= 1;
+
+    return (
+      <List
+        className="u-no-margin--bottom"
+        data-test="vmfs6-bulk-actions"
+        inline
+        items={[
+          <Tooltip
+            data-test="create-datastore-tooltip"
+            message={
+              !createDatastoreEnabled
+                ? "Select one or more storage devices to create a datastore"
+                : null
+            }
+            position="top-left"
+          >
+            <Button
+              appearance="neutral"
+              data-test="create-datastore"
+              disabled={!createDatastoreEnabled}
+              onClick={() => setBulkAction("createDatastore")}
+            >
+              Create datastore
+            </Button>
+          </Tooltip>,
+        ]}
+      />
+    );
+  }
+
+  const createRaidEnabled = canCreateRaid(selected);
+  const createVgEnabled = canCreateVolumeGroup(selected);
+
   return (
-    <ul className="p-inline-list u-no-margin--bottom">
-      <li className="p-inline-list__item">
+    <List
+      className="u-no-margin--bottom"
+      data-test="vmfs6-bulk-actions"
+      inline
+      items={[
         <Tooltip
           data-test="create-vg-tooltip"
           message={
@@ -62,9 +113,7 @@ const BulkActions = ({
           >
             Create volume group
           </Button>
-        </Tooltip>
-      </li>
-      <li className="p-inline-list__item">
+        </Tooltip>,
         <Tooltip
           data-test="create-raid-tooltip"
           message={
@@ -82,9 +131,9 @@ const BulkActions = ({
           >
             Create RAID
           </Button>
-        </Tooltip>
-      </li>
-    </ul>
+        </Tooltip>,
+      ]}
+    />
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
@@ -1,0 +1,203 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CreateDatastore from "./CreateDatastore";
+
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { DiskTypes } from "app/store/machine/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+  machinePartition as partitionFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("CreateDatastore", () => {
+  it("sets the initial name correctly", () => {
+    const datastores = [
+      diskFactory({
+        filesystem: fsFactory({ fstype: "vmfs6" }),
+        type: DiskTypes.PHYSICAL,
+      }),
+      diskFactory({
+        filesystem: fsFactory({ fstype: "vmfs6" }),
+        type: DiskTypes.PHYSICAL,
+      }),
+    ];
+    const newDatastore = diskFactory({
+      available_size: MIN_PARTITION_SIZE + 1,
+      type: DiskTypes.PHYSICAL,
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [...datastores, newDatastore],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateDatastore
+          closeForm={jest.fn()}
+          selected={[newDatastore]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    // Two datastores already exist so the next one should be datastore2
+    expect(wrapper.find("Input[name='name']").prop("value")).toBe("datastore2");
+  });
+
+  it("calculates the sum of the selected storage devices", () => {
+    const [selectedDisk, selectedPartition] = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        name: "floppy",
+        partitions: null,
+        size: 1000000000, // 1GB
+        type: DiskTypes.PHYSICAL,
+      }),
+      partitionFactory({
+        filesystem: null,
+        name: "flippy",
+        size: 500000000, // 500MB
+      }),
+    ];
+    const disks = [
+      selectedDisk,
+      diskFactory({ partitions: [selectedPartition] }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: disks, system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateDatastore
+          closeForm={jest.fn()}
+          selected={[selectedDisk, selectedPartition]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("Input[data-test='datastore-size']").prop("value")
+    ).toBe("1.5 GB");
+  });
+
+  it("shows the details of the selected storage devices", () => {
+    const [selectedDisk, selectedPartition] = [
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        name: "floppy",
+        partitions: null,
+        type: DiskTypes.PHYSICAL,
+      }),
+      partitionFactory({ filesystem: null, name: "flippy" }),
+    ];
+    const disks = [
+      selectedDisk,
+      diskFactory({ partitions: [selectedPartition] }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: disks, system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateDatastore
+          closeForm={jest.fn()}
+          selected={[selectedDisk, selectedPartition]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("tbody TableRow").length).toBe(2);
+    expect(
+      wrapper.find("tbody TableRow").at(0).find("TableCell").at(0).text()
+    ).toBe(selectedDisk.name);
+    expect(
+      wrapper.find("tbody TableRow").at(1).find("TableCell").at(0).text()
+    ).toBe(selectedPartition.name);
+  });
+
+  it("correctly dispatches an action to create a datastore", () => {
+    const [selectedDisk, selectedPartition] = [
+      diskFactory({ partitions: null, type: DiskTypes.PHYSICAL }),
+      partitionFactory({ filesystem: null }),
+    ];
+    const disks = [
+      selectedDisk,
+      diskFactory({ partitions: [selectedPartition] }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: disks, system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CreateDatastore
+          closeForm={jest.fn()}
+          selected={[selectedDisk, selectedPartition]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    wrapper.find("Formik").prop("onSubmit")({
+      name: "datastore1",
+    });
+
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/createVmfsDatastore")
+    ).toStrictEqual({
+      meta: {
+        method: "create_vmfs_datastore",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          block_devices: [selectedDisk.id],
+          name: "datastore1",
+          partitions: [selectedPartition.id],
+          system_id: "abc123",
+        },
+      },
+      type: "machine/createVmfsDatastore",
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CreateDatastore";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.tsx
@@ -11,7 +11,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
 import { DiskTypes } from "app/store/machine/types";
-import { isDisk, isRaid } from "app/store/machine/utils";
+import { isRaid, splitDiskPartitionIds } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 export type CreateRaidValues = {
@@ -80,16 +80,8 @@ export const CreateRaid = ({
     "createRaid",
     () => closeForm()
   );
-  const [initialBlockDevices, initialPartitions] = selected.reduce<number[][]>(
-    ([diskIds, partitionIds], storageDevice: Disk | Partition) => {
-      if (isDisk(storageDevice)) {
-        diskIds.push(storageDevice.id);
-      } else {
-        partitionIds.push(storageDevice.id);
-      }
-      return [diskIds, partitionIds];
-    },
-    [[], []]
+  const [initialBlockDevices, initialPartitions] = splitDiskPartitionIds(
+    selected
   );
 
   if (machine && "disks" in machine) {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.test.tsx
@@ -17,6 +17,31 @@ import {
 const mockStore = configureStore();
 
 describe("DatastoresTable", () => {
+  it("shows a message if no datastores are detected", () => {
+    const notDatastore = fsFactory({ fstype: "fat32" });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [
+              diskFactory({ name: "not-datastore", filesystem: notDatastore }),
+            ],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DatastoresTable canEditStorage systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='no-datastores']").text()).toBe(
+      "No datastores detected."
+    );
+  });
+
   it("only shows filesystems that are VMFS6 datastores", () => {
     const [datastore, notDatastore] = [
       fsFactory({ fstype: "vmfs6" }),

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -118,6 +118,11 @@ const DatastoresTable = ({
           ]}
           rows={rows}
         />
+        {rows.length === 0 && (
+          <div className="u-nudge-right--small" data-test="no-datastores">
+            No datastores detected.
+          </div>
+        )}
       </>
     );
   }

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -7,7 +7,7 @@ import configureStore from "redux-mock-store";
 import MachineStorage from "./MachineStorage";
 
 import * as hooks from "app/base/hooks";
-import { DiskTypes } from "app/store/machine/types";
+import { DiskTypes, StorageLayout } from "app/store/machine/types";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -77,12 +77,13 @@ describe("MachineStorage", () => {
     expect(wrapper.find("CacheSetsTable").exists()).toBe(true);
   });
 
-  it("renders a list of datastores if any exist", () => {
+  it("renders a list of datastores if the detected layout is VMFS6", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
           machineDetailsFactory({
             system_id: "abc123",
+            detected_storage_layout: StorageLayout.VMFS6,
             disks: [
               diskFactory({
                 filesystem: fsFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -13,11 +13,8 @@ import UsedStorageTable from "./UsedStorageTable";
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
-import {
-  isCacheSet,
-  isDatastore,
-  useCanEditStorage,
-} from "app/store/machine/utils";
+import { StorageLayout } from "app/store/machine/types";
+import { isCacheSet, useCanEditStorage } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 const MachineStorage = (): JSX.Element => {
@@ -32,9 +29,8 @@ const MachineStorage = (): JSX.Element => {
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} storage`);
 
   if (machine && "disks" in machine && "special_filesystems" in machine) {
-    const showDatastores = machine.disks.some((disk) =>
-      isDatastore(disk.filesystem)
-    );
+    const showDatastores =
+      machine.detected_storage_layout === StorageLayout.VMFS6;
     const showCacheSets = machine.disks.some((disk) => isCacheSet(disk));
 
     return (

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -650,9 +650,9 @@ describe("machine actions", () => {
   it("can handle creating a VMFS datastore", () => {
     expect(
       actions.createVmfsDatastore({
-        blockDeviceIDs: [1, 2],
+        blockDeviceIds: [1, 2],
         name: "datastore1",
-        partitionIDs: [3, 4],
+        partitionIds: [3, 4],
         systemId: "abc123",
       })
     ).toEqual({

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -491,15 +491,17 @@ const statusHandlers = generateStatusHandlers<
       case "create-vmfs-datastore":
         handler.method = "create_vmfs_datastore";
         handler.prepare = (params: {
-          blockDeviceIDs: number[];
+          blockDeviceIds?: number[];
           name: string;
-          partitionIDs: number[];
+          partitionIds?: number[];
           systemId: Machine["system_id"];
         }) => ({
-          block_devices: params.blockDeviceIDs,
           name: params.name,
-          partitions: params.partitionIDs,
           system_id: params.systemId,
+          ...("blockDeviceIds" in params && {
+            block_devices: params.blockDeviceIds,
+          }),
+          ...("partitionIds" in params && { partitions: params.partitionIds }),
         });
         break;
       case "create-volume-group":

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -108,6 +108,15 @@ export type NetworkInterface = Model & {
   vlan_id: number;
 };
 
+export enum StorageLayout {
+  BCACHE = "bcache",
+  BLANK = "blank",
+  FLAT = "flat",
+  LVM = "lvm",
+  UNKNOWN = "unknown",
+  VMFS6 = "vmfs6",
+}
+
 export type Filesystem = Model & {
   fstype: string;
   is_format_fstype: boolean;
@@ -304,7 +313,7 @@ export type MachineDetails = BaseMachine & {
   current_commissioning_script_set: number;
   current_installation_script_set: number;
   current_testing_script_set: number;
-  detected_storage_layout: "bcache" | "blank" | "flat" | "lvm" | "vmfs6";
+  detected_storage_layout: StorageLayout;
   devices: MachineDevice[];
   dhcp_on: boolean;
   disks: Disk[];

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -58,5 +58,6 @@ export {
   isVirtual,
   isVolumeGroup,
   partitionAvailable,
+  splitDiskPartitionIds,
   usesStorage,
 } from "./storage";

--- a/ui/src/app/store/machine/utils/storage.test.ts
+++ b/ui/src/app/store/machine/utils/storage.test.ts
@@ -27,6 +27,7 @@ import {
   isVirtual,
   isVolumeGroup,
   partitionAvailable,
+  splitDiskPartitionIds,
   usesStorage,
 } from "./storage";
 
@@ -693,6 +694,22 @@ describe("machine storage utils", () => {
         filesystem: fsFactory({ is_format_fstype: true, mount_point: "" }),
       });
       expect(partitionAvailable(partition)).toBe(true);
+    });
+  });
+
+  describe("splitDiskPartitionIds", () => {
+    it("handles empty array case", () => {
+      expect(splitDiskPartitionIds([])).toStrictEqual([[], []]);
+    });
+
+    it("can split a list of storage devices into disk ids and partition ids", () => {
+      const disks = [diskFactory(), diskFactory()];
+      const partitions = [partitionFactory(), partitionFactory()];
+      const combined = [...disks, ...partitions];
+      expect(splitDiskPartitionIds(combined)).toStrictEqual([
+        [disks[0].id, disks[1].id],
+        [partitions[0].id, partitions[1].id],
+      ]);
     });
   });
 

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -397,6 +397,26 @@ export const partitionAvailable = (partition: Partition | null): boolean => {
 };
 
 /**
+ * Converts a list of storage devices into separated disk ids and partition ids
+ * @param storageDevices - the storage devices whose ids are to be separated
+ * @returns an array of disk ids and an array of partition ids
+ */
+export const splitDiskPartitionIds = (
+  storageDevices: (Disk | Partition)[]
+): [Disk["id"][], Partition["id"][]] =>
+  storageDevices.reduce<[Disk["id"][], Partition["id"][]]>(
+    ([diskIds, partitionIds], storageDevice: Disk | Partition) => {
+      if (isDisk(storageDevice)) {
+        diskIds.push(storageDevice.id);
+      } else {
+        partitionIds.push(storageDevice.id);
+      }
+      return [diskIds, partitionIds];
+    },
+    [[], []]
+  );
+
+/**
  * Returns whether a filesystem uses storage.
  * @param fs - the filesystem to check.
  * @returns whether the filesystem uses storage

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -22,6 +22,7 @@ import {
   DiskTypes,
   NetworkLinkMode,
   NetworkInterfaceTypes,
+  StorageLayout,
 } from "app/store/machine/types";
 import type {
   Pod,
@@ -252,7 +253,7 @@ export const machineDetails = extend<Machine, MachineDetails>(machine, {
   current_commissioning_script_set: 6188,
   current_installation_script_set: 6174,
   current_testing_script_set: 6192,
-  detected_storage_layout: "flat",
+  detected_storage_layout: StorageLayout.FLAT,
   devices: () => [],
   dhcp_on: false,
   disks: () => [],


### PR DESCRIPTION
## Done

- Added the ability to create datastores
- Made the datastores table dependent on the storage layout, since it's possible to be in VMFS6 storage layout without any datastores

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready or Allocated machine
- Change the storage layout to VMFS6
- If the machine only has one disk, remove the datastore that has been created
- Tick the checkbox for the released partition and check that the "Create datastore" button is enabled
- Click "Create datastore" and change the name
- Submit the form and check that the datastore is successfully created and shows in the datastores table 

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2169

## Screenshot

![Screenshot_2021-01-21 sure-cod maas storage bolla MAAS](https://user-images.githubusercontent.com/25733845/105287658-6723f880-5c03-11eb-94bf-7525969b1229.png)

