### PR TITLE
feat(ui) machine details instances table

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -5,6 +5,7 @@ import { useParams } from "react-router";
 import { Redirect, Route, Switch } from "react-router-dom";
 
 import MachineHeader from "./MachineHeader";
+import MachineInstances from "./MachineInstances";
 import MachineNetwork from "./MachineNetwork";
 import NetworkNotifications from "./MachineNetwork/NetworkNotifications";
 import MachinePCIDevices from "./MachinePCIDevices";
@@ -67,6 +68,9 @@ const MachineDetails = (): JSX.Element => {
           <Route exact path="/machine/:id/summary">
             <SummaryNotifications id={id} />
             <MachineSummary setSelectedAction={setSelectedAction} />
+          </Route>
+          <Route exact path="/machine/:id/instances">
+            <MachineInstances />
           </Route>
           <Route exact path="/machine/:id/network">
             <NetworkNotifications id={id} />

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -139,9 +139,9 @@ const MachineHeader = ({
           ? [
               {
                 active: pathname.startsWith(`${urlBase}/instances`),
-                component: LegacyLink,
+                component: Link,
                 label: "Instances",
-                route: `${urlBase}?area=instances`,
+                route: `${urlBase}/instances`,
               },
             ]
           : []),

--- a/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.test.tsx
@@ -1,0 +1,333 @@
+import React from "react";
+
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import MachineInstances from "./MachineInstances";
+
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineDevice as machineDeviceFactory,
+  machineInterface as machineInterfaceFactory,
+  networkLink as networkLinkFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MachineInstances", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+            devices: [
+              machineDeviceFactory({
+                fqdn: "instance1",
+                interfaces: [
+                  machineInterfaceFactory({
+                    mac_address: "f5:f6:9b:7c:1b:85",
+                    links: [
+                      networkLinkFactory({
+                        ip_address: "1.2.3.99",
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("displays the spinner on load", () => {
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/fake123/instances", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/instances"
+            component={() => <MachineInstances />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays the table when data is available", () => {
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/instances", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/instances"
+            component={() => <MachineInstances />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+
+  it("displays instance with mac address and ip address correctly", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        devices: [
+          machineDeviceFactory({
+            fqdn: "foo",
+            interfaces: [
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:85",
+                links: [
+                  networkLinkFactory({
+                    ip_address: "100.100.3.99",
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/instances", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/instances"
+            component={() => <MachineInstances />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='name']").text()).toBe("foo");
+    expect(wrapper.find("[data-test='mac']").text()).toBe("00:00:9b:7c:1b:85");
+    expect(wrapper.find("[data-test='ip']").text()).toBe("100.100.3.99");
+  });
+
+  it("displays instance with mac address correctly", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        devices: [
+          machineDeviceFactory({
+            fqdn: "foo",
+            interfaces: [
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:85",
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/instances", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/instances"
+            component={() => <MachineInstances />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='name']").text()).toBe("foo");
+    expect(wrapper.find("[data-test='mac']").text()).toBe("00:00:9b:7c:1b:85");
+    expect(wrapper.find("[data-test='ip']").text()).toBe("");
+  });
+
+  it("displays multiple instances", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        devices: [
+          machineDeviceFactory({
+            fqdn: "foo",
+            interfaces: [
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:85",
+              }),
+            ],
+          }),
+          machineDeviceFactory({
+            fqdn: "bar",
+            interfaces: [
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:85",
+              }),
+            ],
+          }),
+          machineDeviceFactory({
+            fqdn: "baz",
+            interfaces: [
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:85",
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/instances", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/instances"
+            component={() => <MachineInstances />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='name']").length).toBe(3);
+  });
+
+  it("displays instances with multiple mac addresses", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        devices: [
+          machineDeviceFactory({
+            fqdn: "foo",
+            interfaces: [
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:85",
+              }),
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:01",
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/instances", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/instances"
+            component={() => <MachineInstances />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='mac']").length).toBe(2);
+    expect(wrapper.find("[data-test='name']").at(0).text()).toBe("foo");
+    expect(wrapper.find("[data-test='mac']").at(0).text()).toBe(
+      "00:00:9b:7c:1b:85"
+    );
+    expect(wrapper.find("[data-test='ip']").at(0).text()).toBe("");
+    expect(wrapper.find("[data-test='name']").at(1).text()).toBe("");
+    expect(wrapper.find("[data-test='mac']").at(1).text()).toBe(
+      "00:00:9b:7c:1b:01"
+    );
+    expect(wrapper.find("[data-test='ip']").at(1).text()).toBe("");
+  });
+
+  it("displays instances with multiple ip addresses", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        devices: [
+          machineDeviceFactory({
+            fqdn: "foo",
+            interfaces: [
+              machineInterfaceFactory({
+                mac_address: "00:00:9b:7c:1b:85",
+                links: [
+                  networkLinkFactory({
+                    ip_address: "1.2.3.4",
+                  }),
+                  networkLinkFactory({
+                    ip_address: "1.2.3.5",
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ];
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/instances", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/instances"
+            component={() => <MachineInstances />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='mac']").length).toBe(2);
+    expect(wrapper.find("[data-test='name']").at(0).text()).toBe("foo");
+    expect(wrapper.find("[data-test='mac']").at(0).text()).toBe(
+      "00:00:9b:7c:1b:85"
+    );
+    expect(wrapper.find("[data-test='ip']").at(0).text()).toBe("1.2.3.4");
+    expect(wrapper.find("[data-test='name']").at(1).text()).toBe("");
+    expect(wrapper.find("[data-test='mac']").at(1).text()).toBe("");
+    expect(wrapper.find("[data-test='ip']").at(1).text()).toBe("1.2.3.5");
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+
+import { Spinner, Row, Col, MainTable } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Redirect, useParams } from "react-router";
+
+import { useWindowTitle } from "app/base/hooks";
+import type { RouteParams } from "app/base/types";
+import machineSelectors from "app/store/machine/selectors";
+import type {
+  MachineDevice,
+  NetworkInterface,
+  NetworkLink,
+} from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type InterfaceRow = {
+  key: string;
+  columns: { content: JSX.Element }[];
+};
+
+const formatRowData = (
+  name: MachineDevice["fqdn"],
+  macAddress: NetworkInterface["mac_address"],
+  ipAddress: NetworkLink["ip_address"]
+): InterfaceRow => {
+  return {
+    key: name + macAddress + ipAddress,
+    columns: [
+      { content: <span data-test="name">{name}</span> },
+      { content: <span data-test="mac">{macAddress}</span> },
+      { content: <span data-test="ip">{ipAddress}</span> },
+    ],
+  };
+};
+
+const generateRows = (devices: MachineDevice[]) => {
+  const formattedDevices: InterfaceRow[] = [];
+
+  devices.forEach((device) => {
+    let deviceName = device.fqdn;
+    if (device.interfaces && device.interfaces.length > 0) {
+      device.interfaces.forEach((deviceInterface, deviceIndex) => {
+        // Remove device name so it is not duplicated in the table since this
+        // is another MAC address on this device.
+        if (deviceIndex > 0) {
+          deviceName = "";
+        }
+
+        let interfaceMacAddress = deviceInterface.mac_address;
+
+        if (deviceInterface.links && deviceInterface.links.length > 0) {
+          deviceInterface.links.forEach((interfaceLink, interfaceIndex) => {
+            // Remove the MAC address so it is not duplicated in the table
+            // since this is another link on this interface.
+            if (interfaceIndex > 0) {
+              interfaceMacAddress = "";
+              deviceName = "";
+            }
+
+            formattedDevices.push(
+              formatRowData(
+                deviceName,
+                interfaceMacAddress,
+                interfaceLink.ip_address
+              )
+            );
+          });
+        } else {
+          formattedDevices.push(
+            formatRowData(deviceName, interfaceMacAddress, "")
+          );
+        }
+      });
+    } else {
+      formattedDevices.push(formatRowData(deviceName, "", ""));
+    }
+  });
+
+  return formattedDevices;
+};
+
+const MachineInstances = (): JSX.Element => {
+  const params = useParams<RouteParams>();
+  const { id } = params;
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
+
+  useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} instances`);
+
+  if (!machine) {
+    return <Spinner text="Loading..." />;
+  }
+
+  if (!("devices" in machine) || machine.devices.length === 0) {
+    return <Redirect to={`/machine/${machine.system_id}/summary`} />;
+  }
+
+  return (
+    <Row>
+      <Col size={12}>
+        <MainTable
+          headers={[
+            {
+              content: "Name",
+            },
+            {
+              content: "MAC",
+            },
+            {
+              content: "IP Address",
+            },
+          ]}
+          paginate={50}
+          rows={generateRows(machine.devices)}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default MachineInstances;

--- a/ui/src/app/machines/views/MachineDetails/MachineInstances/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineInstances/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineInstances";


### PR DESCRIPTION
## Done
- Build the machine details instances table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch
You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Point your this branch as Karura
- Go to the machine "grand-amoeba"
- Switch to Instances tab
- Check it matches http://karura.internal:5240/MAAS/l/machine/qt7e3e?area=instances

## Fixes
Fixes: https://github.com/canonical-web-and-design/MAAS-squad/issues/2214