### PR TITLE
refactor(ui): move group checkbox to shared component

### DIFF
--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
@@ -1,0 +1,40 @@
+import { shallow } from "enzyme";
+
+import GroupCheckbox from "./GroupCheckbox";
+
+describe("GroupCheckbox", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <GroupCheckbox
+        items={[]}
+        selectedItems={[]}
+        handleGroupCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("shows as mixed when some items are checked", () => {
+    const wrapper = shallow(
+      <GroupCheckbox
+        items={[1, 2, 3]}
+        selectedItems={[2]}
+        handleGroupCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper.prop("checked")).toBe(true);
+    expect(wrapper.hasClass("p-checkbox--mixed")).toBe(true);
+  });
+
+  it("can show a label", () => {
+    const wrapper = shallow(
+      <GroupCheckbox
+        items={[]}
+        label="Check all"
+        selectedItems={[]}
+        handleGroupCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper.prop("label")).toBe("Check all");
+  });
+});

--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
@@ -1,0 +1,42 @@
+import { useRef } from "react";
+import type { HTMLProps, ReactNode } from "react";
+
+import { Input } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
+import classNames from "classnames";
+
+import { someInArray, someNotAll } from "app/utils";
+
+type Props<R, S> = {
+  handleGroupCheckbox: (rows: R[], selected: S[]) => void;
+  items: R[];
+  label?: ReactNode;
+  selectedItems: S[];
+} & HTMLProps<HTMLInputElement>;
+
+const GroupCheckbox = <R, S>({
+  handleGroupCheckbox,
+  items,
+  label,
+  selectedItems,
+  ...props
+}: Props<R, S>): JSX.Element => {
+  const id = useRef(nanoid());
+  return (
+    <Input
+      checked={someInArray(items, selectedItems)}
+      className={classNames("has-inline-label", {
+        "p-checkbox--mixed": someNotAll(items, selectedItems),
+      })}
+      disabled={items.length === 0}
+      id={id.current}
+      label={label ? label : " "}
+      onChange={() => handleGroupCheckbox(items, selectedItems)}
+      type="checkbox"
+      wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
+      {...props}
+    />
+  );
+};
+
+export default GroupCheckbox;

--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
@@ -9,6 +9,7 @@ import { someInArray, someNotAll } from "app/utils";
 
 type Props<R, S> = {
   handleGroupCheckbox: (rows: R[], selected: S[]) => void;
+  inRow?: boolean;
   items: R[];
   label?: ReactNode;
   selectedItems: S[];
@@ -16,6 +17,7 @@ type Props<R, S> = {
 
 const GroupCheckbox = <R, S>({
   handleGroupCheckbox,
+  inRow,
   items,
   label,
   selectedItems,
@@ -33,7 +35,9 @@ const GroupCheckbox = <R, S>({
       label={label ? label : " "}
       onChange={() => handleGroupCheckbox(items, selectedItems)}
       type="checkbox"
-      wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
+      wrapperClassName={classNames("u-no-margin--bottom u-nudge--checkbox", {
+        "u-align-header-checkbox": !inRow,
+      })}
       {...props}
     />
   );

--- a/ui/src/app/base/components/GroupCheckbox/__snapshots__/GroupCheckbox.test.tsx.snap
+++ b/ui/src/app/base/components/GroupCheckbox/__snapshots__/GroupCheckbox.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GroupCheckbox renders 1`] = `
+<Input
+  checked={0}
+  className="has-inline-label"
+  disabled={true}
+  label=" "
+  onChange={[Function]}
+  type="checkbox"
+  wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
+/>
+`;

--- a/ui/src/app/base/components/GroupCheckbox/__snapshots__/GroupCheckbox.test.tsx.snap
+++ b/ui/src/app/base/components/GroupCheckbox/__snapshots__/GroupCheckbox.test.tsx.snap
@@ -8,6 +8,6 @@ exports[`GroupCheckbox renders 1`] = `
   label=" "
   onChange={[Function]}
   type="checkbox"
-  wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
+  wrapperClassName="u-no-margin--bottom u-nudge--checkbox u-align-header-checkbox"
 />
 `;

--- a/ui/src/app/base/components/GroupCheckbox/index.ts
+++ b/ui/src/app/base/components/GroupCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GroupCheckbox";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 
-import { Col, Input, MainTable, Row } from "@canonical/react-components";
-import classNames from "classnames";
+import { Col, MainTable, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import CPUColumn from "./CPUColumn";
@@ -15,6 +14,7 @@ import TypeColumn from "./TypeColumn";
 import VMsColumn from "./VMsColumn";
 
 import { general as generalActions } from "app/base/actions";
+import GroupCheckbox from "app/base/components/GroupCheckbox";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
 import type { TSFixMe } from "app/base/types";
@@ -34,7 +34,6 @@ import {
   generateCheckboxHandlers,
   getStatusText,
   someInArray,
-  someNotAll,
 } from "app/utils";
 
 type SortKey = keyof Pod | "cpu" | "os" | "pool" | "power" | "ram" | "storage";
@@ -146,18 +145,11 @@ const KVMListTable = (): JSX.Element => {
             {
               content: (
                 <div className="u-flex">
-                  <Input
-                    checked={someInArray(kvmIDs, selectedKVMIDs)}
-                    className={classNames("has-inline-label", {
-                      "p-checkbox--mixed": someNotAll(kvmIDs, selectedKVMIDs),
-                    })}
+                  <GroupCheckbox
+                    items={kvmIDs}
+                    selectedItems={selectedKVMIDs}
+                    handleGroupCheckbox={handleGroupCheckbox}
                     data-test="all-pods-checkbox"
-                    disabled={kvms.length === 0}
-                    id="all-pods-checkbox"
-                    label={" "}
-                    onChange={() => handleGroupCheckbox(kvmIDs, selectedKVMIDs)}
-                    type="checkbox"
-                    wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
                   />
                   <TableHeader
                     currentSort={currentSort}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 
 import { Input, MainTable } from "@canonical/react-components";
-import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionConfirm from "../../ActionConfirm";
@@ -19,6 +18,7 @@ import EditPartition from "./EditPartition";
 import EditPhysicalDisk from "./EditPhysicalDisk";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import GroupCheckbox from "app/base/components/GroupCheckbox";
 import TableMenu from "app/base/components/TableMenu";
 import type { TSFixMe } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
@@ -620,18 +620,11 @@ const AvailableStorageTable = ({
             {
               content: (
                 <div className="u-flex">
-                  <Input
-                    checked={selected.length > 0}
-                    className={classNames("has-inline-label", {
-                      "p-checkbox--mixed": selected.length !== rows.length,
-                    })}
+                  <GroupCheckbox
+                    items={rows.map(({ key }) => key)}
+                    selectedItems={selected.map((item) => uniqueId(item))}
+                    handleGroupCheckbox={handleAllCheckbox}
                     data-test="all-disks-checkbox"
-                    disabled={actionsDisabled || rows.length === 0}
-                    id="all-disks-checkbox"
-                    label={" "}
-                    onChange={handleAllCheckbox}
-                    type="checkbox"
-                    wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
                   />
                   <div>
                     <div>Name</div>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -380,6 +380,7 @@ const generateGroupRows = ({
                 primary={
                   showActions ? (
                     <GroupCheckbox
+                      inRow
                       items={machineIDs}
                       selectedItems={selectedIDs}
                       handleGroupCheckbox={handleGroupCheckbox}
@@ -389,7 +390,6 @@ const generateGroupRows = ({
                     <strong>{label}</strong>
                   )
                 }
-                primaryTextClassName={showActions && "u-nudge--checkbox"}
                 secondary={getGroupSecondaryString(machineIDs, selectedIDs)}
                 secondaryClassName={showActions && "u-nudge--secondary-row"}
               />
@@ -526,11 +526,7 @@ export const MachineListTable = ({
       key: "fqdn",
       className: "fqdn-col",
       content: (
-        <div
-          className={classNames("u-flex", {
-            "u-nudge--checkbox": showActions,
-          })}
-        >
+        <div className="u-flex">
           {showActions && (
             <GroupCheckbox
               items={machineIDs}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -1,10 +1,11 @@
-import { Button, Input, MainTable, Strip } from "@canonical/react-components";
+import { Button, MainTable, Strip } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
 import classNames from "classnames";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import pluralize from "pluralize";
 
+import GroupCheckbox from "app/base/components/GroupCheckbox";
 import { actions as userActions } from "app/store/user";
 import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
@@ -39,7 +40,6 @@ import {
   groupAsMap,
   simpleSortByKey,
   someInArray,
-  someNotAll,
 } from "app/utils";
 
 const getSortValue = (sortKey, machine) => {
@@ -379,22 +379,11 @@ const generateGroupRows = ({
                 data-test="group-cell"
                 primary={
                   showActions ? (
-                    <Input
-                      checked={someInArray(machineIDs, selectedIDs)}
-                      className={classNames("has-inline-label", {
-                        "p-checkbox--mixed": someNotAll(
-                          machineIDs,
-                          selectedIDs
-                        ),
-                      })}
-                      disabled={false}
-                      id={label}
+                    <GroupCheckbox
+                      items={machineIDs}
+                      selectedItems={selectedIDs}
+                      handleGroupCheckbox={handleGroupCheckbox}
                       label={<strong>{label}</strong>}
-                      onChange={() =>
-                        handleGroupCheckbox(machineIDs, selectedIDs)
-                      }
-                      type="checkbox"
-                      wrapperClassName="u-no-margin--bottom"
                     />
                   ) : (
                     <strong>{label}</strong>
@@ -543,18 +532,11 @@ export const MachineListTable = ({
           })}
         >
           {showActions && (
-            <Input
-              checked={someInArray(machineIDs, selectedIDs)}
-              className={classNames("has-inline-label", {
-                "p-checkbox--mixed": someNotAll(machineIDs, selectedIDs),
-              })}
+            <GroupCheckbox
+              items={machineIDs}
+              selectedItems={selectedIDs}
+              handleGroupCheckbox={handleGroupCheckbox}
               data-test="all-machines-checkbox"
-              disabled={machines.length === 0}
-              id="all-machines-checkbox"
-              label={" "}
-              onChange={() => handleGroupCheckbox(machineIDs, selectedIDs)}
-              type="checkbox"
-              wrapperClassName="u-no-margin--bottom"
             />
           )}
           <div>

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from "react";
 
-import { Col, Input, MainTable, Row } from "@canonical/react-components";
-import classNames from "classnames";
+import { Col, MainTable, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
+import GroupCheckbox from "app/base/components/GroupCheckbox";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
 import CPUColumn from "app/kvm/views/KVMList/KVMListTable/CPUColumn";
@@ -19,7 +19,7 @@ import { actions as poolActions } from "app/store/resourcepool";
 import poolSelectors from "app/store/resourcepool/selectors";
 import type { ResourcePool } from "app/store/resourcepool/types";
 import { actions as zoneActions } from "app/store/zone";
-import { generateCheckboxHandlers, someInArray, someNotAll } from "app/utils";
+import { generateCheckboxHandlers, someInArray } from "app/utils";
 
 type SortKey = keyof Pod | "cpu" | "pool" | "ram" | "storage";
 
@@ -102,18 +102,11 @@ const RSDListTable = (): JSX.Element => {
             {
               content: (
                 <div className="u-flex">
-                  <Input
-                    checked={someInArray(rsdIDs, selectedRSDIDs)}
-                    className={classNames("has-inline-label", {
-                      "p-checkbox--mixed": someNotAll(rsdIDs, selectedRSDIDs),
-                    })}
+                  <GroupCheckbox
+                    items={rsdIDs}
+                    selectedItems={selectedRSDIDs}
+                    handleGroupCheckbox={handleGroupCheckbox}
                     data-test="all-rsds-checkbox"
-                    disabled={rsds.length === 0}
-                    id="all-rsds-checkbox"
-                    label={" "}
-                    onChange={() => handleGroupCheckbox(rsdIDs, selectedRSDIDs)}
-                    type="checkbox"
-                    wrapperClassName="u-no-margin--bottom u-align-header-checkbox u-nudge--checkbox"
                   />
                   <TableHeader
                     currentSort={currentSort}


### PR DESCRIPTION
## Done

- Dedupe the checkbox for selecting everything in a table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Make sure you can use the group checkbox and top/all checkbox to select/deselect the rows.
- Make sure selecting some rows makes the top checkboxe turn into a dash.
- Do the same for the RSD and KVM lists.
- Navigate to the storage tab for a machine and make sure the checkboxes work in the available storage table.

## Fixes

First step for: canonical-web-and-design/maas-squad#2284.