### PR TITLE
feat(ui): add ability to set boot disk from machine storage tab

### DIFF
--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -43,6 +43,7 @@ export {
   canCreateVolumeGroup,
   canOsSupportBcacheZFS,
   canOsSupportStorageConfig,
+  canSetBootDisk,
   diskAvailable,
   formatSize,
   formatType,

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -1,6 +1,6 @@
 import { nodeStatus } from "app/base/enum";
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
-import { DiskTypes } from "app/store/machine/types";
+import { DiskTypes, StorageLayout } from "app/store/machine/types";
 import type {
   Disk,
   Filesystem,
@@ -214,6 +214,18 @@ export const canOsSupportBcacheZFS = (machine?: Machine | null): boolean =>
  */
 export const canOsSupportStorageConfig = (machine?: Machine | null): boolean =>
   !!machine && ["centos", "rhel", "ubuntu"].includes(machine.osystem);
+
+/**
+ * Returns whether a disk can be set as the machine's boot disk.
+ * @param storageLayout - the machine's detected storage layout.
+ * @param disk - the disk to check.
+ * @returns whether the disk can be set as the machine's boot disk.
+ */
+export const canSetBootDisk = (
+  storageLayout: StorageLayout,
+  disk: Disk
+): boolean =>
+  storageLayout !== StorageLayout.VMFS6 && isPhysical(disk) && !disk.is_boot;
 
 /**
  * Returns whether a disk is available to use.


### PR DESCRIPTION
## Done

- Added "Set boot disk" to the list of actions a disk can do

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine with at least 2 disks, and is in Ready or Allocated state. (If you set the MAAS to karura you can find one at http://0.0.0.0:8400/MAAS/r/machine/8qcbef/storage).
- Check that the boot disk does not have the "Set boot disk" action.
- Check that the non-boot disk has the "Set boot disk" action.
- Click "Set boot disk". There's a bug on the backend where the machine update is not broadcast to the browser, so you will need to refresh the page to confirm that the boot disk was successfully set.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2322

## Launchpad issue

[lp#1912722](https://bugs.launchpad.net/maas/+bug/1912722)
