### PR TITLE
feat(ui): allow adding storage to existing datastores

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -218,8 +218,8 @@ exports[`stricter compilation`] = {
       [331, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
       [353, 6, 98, "Object is possibly \'undefined\'.", "1041189900"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:3530346002": [
-      [118, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, kvmHosts: (Controller | Machine)[], pools: ResourcePool[], osReleases: TSFixMe) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'kvmHosts\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Host[]\'.", "3312061634"]
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:1343696512": [
+      [117, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, kvmHosts: (Controller | Machine)[], pools: ResourcePool[], osReleases: TSFixMe) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'kvmHosts\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Host[]\'.", "3312061634"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:2466040368": [
       [17, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
@@ -320,7 +320,7 @@ exports[`stricter compilation`] = {
       [98, 10, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
     "src/app/machines/hooks.tsx:4039767025": [
-      [53, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 55 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 55 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
+      [53, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 59 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 59 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
       [53, 37, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [53, 56, 6, "Object is possibly \'undefined\'.", "1314712411"],
       [59, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
@@ -329,13 +329,13 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:1152214997": [
       [115, 18, 5, "Type \'MenuLink<null>[]\' is not assignable to type \'(string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined)[]\'.\\n  Type \'MenuLink<null>\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n    Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n      Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }>\'.\\n        Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'Partial<InferPropsInner<Pick<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }, \\"children\\" | ... 7 more ... | \\"inline\\">>>\'.\\n          Types of property \'element\' are incompatible.\\n            Type \'\\"symbol\\" | \\"object\\" | \\"metadata\\" | \\"map\\" | \\"filter\\" | \\"path\\" | \\"label\\" | \\"data\\" | \\"a\\" | \\"abbr\\" | \\"address\\" | \\"area\\" | \\"article\\" | \\"aside\\" | \\"audio\\" | \\"b\\" | \\"base\\" | \\"bdi\\" | \\"bdo\\" | ... 160 more ... | undefined\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n              Type \'FunctionComponent<null>\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n                Type \'FunctionComponent<null>\' is not assignable to type \'(props: any, context?: any) => any\'.\\n                  Types of parameters \'props\' and \'props\' are incompatible.\\n                    Type \'any\' is not assignable to type \'never\'.", "173192470"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:3956707169": [
-      [377, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
-      [381, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
-      [406, 35, 9, "Object is possibly \'null\'.", "1794230341"],
-      [406, 47, 9, "Object is possibly \'null\'.", "1612642726"],
-      [409, 35, 9, "Object is possibly \'null\'.", "1794230341"],
-      [409, 47, 9, "Object is possibly \'null\'.", "1612642726"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:463222167": [
+      [406, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
+      [410, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
+      [435, 35, 9, "Object is possibly \'null\'.", "1794230341"],
+      [435, 47, 9, "Object is possibly \'null\'.", "1612642726"],
+      [438, 35, 9, "Object is possibly \'null\'.", "1794230341"],
+      [438, 47, 9, "Object is possibly \'null\'.", "1612642726"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx:1067981421": [
       [102, 6, 78, "Cannot invoke an object which is possibly \'undefined\'.", "1912336017"],
@@ -354,7 +354,7 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:3446240187": [
       [152, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx:378591652": [
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx:1790086047": [
       [178, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [179, 6, 18, "Argument of type \'{ name: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "219600198"]
     ],
@@ -365,6 +365,10 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.test.tsx:2826042312": [
       [126, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [127, 6, 11, "Argument of type \'{ name: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "2802891064"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.test.tsx:2021068327": [
+      [99, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [100, 6, 23, "Argument of type \'{ datastore: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'datastore\' does not exist in type \'FormEvent<{}>\'.", "3324044956"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.test.tsx:2947973190": [
       [100, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -385,6 +389,11 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx:2970206867": [
       [116, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [116, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx:3035156036": [
+      [41, 25, 2, "Object is possibly \'null\'.", "5860944"],
+      [41, 38, 2, "Object is possibly \'null\'.", "5860944"],
+      [55, 23, 2, "Object is possibly \'null\'.", "5860944"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx:829149380": [
       [62, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -435,7 +444,7 @@ exports[`stricter compilation`] = {
       [70, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [71, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; power_pass: string; power_user: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "244873512"]
     ],
-    "src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx:1047585709": [
+    "src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx:612654686": [
       [77, 4, 12, "Argument of type \'(sortKey: SortKey, rsd: Pod, pools: ResourcePool[]) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
     ],
     "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:3661263440": [
@@ -481,14 +490,14 @@ exports[`stricter compilation`] = {
     "src/app/store/general/selectors/machineActions.test.ts:638190955": [
       [91, 10, 4, "Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: NodeActions; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'NodeActions\' is not assignable to type \'NodeActions.ABORT | NodeActions.ACQUIRE | NodeActions.COMMISSION | NodeActions.DELETE | NodeActions.DEPLOY | NodeActions.EXIT_RESCUE_MODE | NodeActions.LOCK | ... 11 more ... | NodeActions.UNLOCK\'.", "2087377941"]
     ],
-    "src/app/store/machine/slice.ts:3992141854": [
-      [728, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
-      [736, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
-      [740, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
+    "src/app/store/machine/slice.ts:3998145734": [
+      [773, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
+      [781, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
+      [785, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
-    "src/app/store/machine/utils/storage.ts:2637304794": [
-      [134, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
-      [163, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
+    "src/app/store/machine/utils/storage.ts:3270313282": [
+      [164, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
+      [193, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
     ],
     "src/app/store/nodedevice/slice.ts:54310614": [
       [60, 4, 21, "Type \'(state: NodeDeviceState, action: PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<NodeDevice, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<NodeDevice, any>, PayloadAction<...>>\'.\\n  Type \'(state: NodeDeviceState, action: PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<NodeDevice, any>, { payload: any; type: string; }>\'.\\n    Types of parameters \'action\' and \'action\' are incompatible.\\n      Type \'{ payload: any; type: string; }\' is not assignable to type \'PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>, never>\'.\\n        Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.", "294608771"]
@@ -589,11 +598,11 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:3790991929": [
-      [266, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
-      [353, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
-      [355, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
-      [360, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:136596448": [
+      [268, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
+      [355, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
+      [357, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
+      [362, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -660,10 +669,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:1332432184": [
+    "src/app/store/machine/types.ts:2231288590": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [406, 34, 8, "RegExp match", "1152173309"],
-      [409, 25, 8, "RegExp match", "1152173309"]
+      [417, 34, 8, "RegExp match", "1152173309"],
+      [420, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/nodedevice/types.ts:2713937479": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -46,7 +46,11 @@ import {
 import type { RootState } from "app/store/root/types";
 
 // Actions that are performed on multiple devices at once
-export type BulkAction = "createDatastore" | "createRaid" | "createVolumeGroup";
+export type BulkAction =
+  | "createDatastore"
+  | "createRaid"
+  | "createVolumeGroup"
+  | "updateDatastore";
 
 // Actions that are performed on a single device
 type Expanded = {
@@ -687,7 +691,6 @@ const AvailableStorageTable = ({
         {canEditStorage && (
           <BulkActions
             bulkAction={bulkAction}
-            storageLayout={machine.detected_storage_layout}
             selected={selected}
             setBulkAction={setBulkAction}
             systemId={systemId}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx
@@ -59,8 +59,8 @@ describe("CreateDatastore", () => {
       </Provider>
     );
 
-    // Two datastores already exist so the next one should be datastore2
-    expect(wrapper.find("Input[name='name']").prop("value")).toBe("datastore2");
+    // Two datastores already exist, indexed at 1, so the next one should be datastore3
+    expect(wrapper.find("Input[name='name']").prop("value")).toBe("datastore3");
   });
 
   it("calculates the sum of the selected storage devices", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.tsx
@@ -36,23 +36,20 @@ type Props = {
   systemId: Machine["system_id"];
 };
 
+/**
+ * Get the initial name of the datastore for the form, which is a simple count
+ * of the number of existing datastores, indexed at 1 to match the api.
+ * @param disks - the disks to search for datastores.
+ * @returns initial name of the datastore for the form
+ */
 const getInitialName = (disks: Disk[]) => {
   if (!disks || disks.length === 0) {
-    return "datastore0";
+    return "datastore1";
   }
-  const datastoresCount = disks.reduce<number>((count, disk) => {
-    if (isDatastore(disk.filesystem)) {
-      count += 1;
-    }
-    if (disk.partitions?.length) {
-      disk.partitions.forEach((partition) => {
-        if (isDatastore(partition.filesystem)) {
-          count += 1;
-        }
-      });
-    }
-    return count;
-  }, 0);
+  const datastoresCount = disks.reduce<number>(
+    (count, disk) => (isDatastore(disk.filesystem) ? count + 1 : count),
+    1
+  );
   return `datastore${datastoresCount}`;
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.test.tsx
@@ -1,0 +1,124 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import UpdateDatastore from "./UpdateDatastore";
+
+import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
+import { DiskTypes } from "app/store/machine/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+  machinePartition as partitionFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("UpdateDatastore", () => {
+  it("calculates the total size of the selected storage devices", () => {
+    const [datastore, selectedDisk, selectedPartition] = [
+      diskFactory({
+        filesystem: fsFactory({ fstype: "vmfs6" }),
+      }),
+      diskFactory({
+        available_size: MIN_PARTITION_SIZE + 1,
+        name: "floppy",
+        partitions: null,
+        size: 1000000000, // 1GB
+        type: DiskTypes.PHYSICAL,
+      }),
+      partitionFactory({
+        filesystem: null,
+        name: "flippy",
+        size: 500000000, // 500MB
+      }),
+    ];
+    const disks = [
+      datastore,
+      selectedDisk,
+      diskFactory({ partitions: [selectedPartition] }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: disks, system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UpdateDatastore
+          closeForm={jest.fn()}
+          selected={[selectedDisk, selectedPartition]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("Input[data-test='size-to-add']").prop("value")).toBe(
+      "1.5 GB"
+    );
+  });
+
+  it("correctly dispatches an action to update a datastore", () => {
+    const [datastore, selectedDisk, selectedPartition] = [
+      diskFactory({ filesystem: fsFactory({ fstype: "vmfs6" }) }),
+      diskFactory({ partitions: null, type: DiskTypes.PHYSICAL }),
+      partitionFactory({ filesystem: null }),
+    ];
+    const disks = [
+      datastore,
+      selectedDisk,
+      diskFactory({ partitions: [selectedPartition] }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: disks, system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UpdateDatastore
+          closeForm={jest.fn()}
+          selected={[selectedDisk, selectedPartition]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    wrapper.find("Formik").prop("onSubmit")({
+      datastore: datastore.id,
+    });
+
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/updateVmfsDatastore")
+    ).toStrictEqual({
+      meta: {
+        method: "update_vmfs_datastore",
+        model: "machine",
+      },
+      payload: {
+        params: {
+          add_block_devices: [selectedDisk.id],
+          add_partitions: [selectedPartition.id],
+          system_id: "abc123",
+          vmfs_datastore_id: datastore.id,
+        },
+      },
+      type: "machine/updateVmfsDatastore",
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.tsx
@@ -1,0 +1,102 @@
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import UpdateDatastoreFields from "./UpdateDatastoreFields";
+
+import FormCard from "app/base/components/FormCard";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { useMachineDetailsForm } from "app/machines/hooks";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { Disk, Machine, Partition } from "app/store/machine/types";
+import { isDatastore, splitDiskPartitionIds } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+
+export type UpdateDatastoreValues = {
+  datastore: number;
+};
+
+type Props = {
+  closeForm: () => void;
+  selected: (Disk | Partition)[];
+  systemId: Machine["system_id"];
+};
+
+const UpdateDatastoreSchema = Yup.object().shape({
+  datastore: Yup.number().required("Datastore is required"),
+});
+
+export const UpdateDatastore = ({
+  closeForm,
+  selected,
+  systemId,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const { errors, saved, saving } = useMachineDetailsForm(
+    systemId,
+    "updatingVmfsDatastore",
+    "updateVmfsDatastore",
+    () => closeForm()
+  );
+
+  if (machine && "disks" in machine) {
+    const datastores = machine.disks.filter((disk) =>
+      isDatastore(disk.filesystem)
+    );
+
+    if (datastores.length === 0) {
+      // Close the form if the last remaining datastore was deleted after the
+      // form had already been opened.
+      closeForm();
+      return null;
+    }
+
+    return (
+      <FormCard sidebar={false}>
+        <FormikForm
+          allowUnchanged
+          buttons={FormCardButtons}
+          cleanup={machineActions.cleanup}
+          errors={errors}
+          initialValues={{
+            datastore: datastores[0].id,
+          }}
+          onCancel={closeForm}
+          onSaveAnalytics={{
+            action: "Update datastore",
+            category: "Machine storage",
+            label: "Add to datastore",
+          }}
+          onSubmit={(values: UpdateDatastoreValues) => {
+            const [blockDeviceIds, partitionIds] = splitDiskPartitionIds(
+              selected
+            );
+            const params = {
+              systemId,
+              vmfsDatastoreId: values.datastore,
+              ...(blockDeviceIds.length > 0 && { blockDeviceIds }),
+              ...(partitionIds.length > 0 && { partitionIds }),
+            };
+            dispatch(machineActions.updateVmfsDatastore(params));
+          }}
+          saved={saved}
+          saving={saving}
+          submitLabel="Add to datastore"
+          validationSchema={UpdateDatastoreSchema}
+        >
+          <UpdateDatastoreFields
+            datastores={datastores}
+            storageDevices={selected}
+          />
+        </FormikForm>
+      </FormCard>
+    );
+  }
+  return null;
+};
+
+export default UpdateDatastore;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastoreFields/UpdateDatastoreFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastoreFields/UpdateDatastoreFields.tsx
@@ -1,0 +1,89 @@
+import {
+  Col,
+  Input,
+  Row,
+  Select,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { UpdateDatastoreValues } from "../UpdateDatastore";
+
+import FormikField from "app/base/components/FormikField";
+import type { Disk, Partition } from "app/store/machine/types";
+import { formatSize, formatType } from "app/store/machine/utils";
+
+type Props = {
+  datastores: Disk[];
+  storageDevices: (Disk | Partition)[];
+};
+
+export const UpdateDatastoreFields = ({
+  datastores,
+  storageDevices,
+}: Props): JSX.Element => {
+  const { values } = useFormikContext<UpdateDatastoreValues>();
+  const selectedDatastore = datastores.find(
+    (datastore) => datastore.id === Number(values.datastore)
+  );
+  const totalSize = storageDevices.reduce(
+    (sum, device) => (sum += device.size),
+    0
+  );
+
+  return (
+    <Row>
+      <Col small="4" medium="6" size="6">
+        <Table>
+          <thead>
+            <TableRow>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>Size</TableHeader>
+              <TableHeader>Device type</TableHeader>
+            </TableRow>
+          </thead>
+          <tbody>
+            {storageDevices.map((device) => (
+              <TableRow key={`${device.type}-${device.id}`}>
+                <TableCell>{device.name}</TableCell>
+                <TableCell>{formatSize(device.size)}</TableCell>
+                <TableCell>{formatType(device)}</TableCell>
+              </TableRow>
+            ))}
+          </tbody>
+        </Table>
+      </Col>
+      <Col small="4" medium="6" size="6">
+        <FormikField
+          component={Select}
+          label="Datastore"
+          name="datastore"
+          options={datastores.map((datastore) => ({
+            label: datastore.name,
+            key: datastore.id,
+            value: datastore.id,
+          }))}
+        />
+        <Input
+          data-test="datastore-mount-point"
+          disabled
+          label="Mount point"
+          value={selectedDatastore?.filesystem?.mount_point || ""}
+          type="text"
+        />
+        <Input
+          data-test="size-to-add"
+          disabled
+          label="Size to add"
+          value={`${formatSize(totalSize)}`}
+          type="text"
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default UpdateDatastoreFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastoreFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastoreFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UpdateDatastoreFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./UpdateDatastore";
+export type { UpdateDatastoreValues } from "./UpdateDatastore";

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -982,9 +982,9 @@ describe("machine actions", () => {
   it("can handle updating a VMFS datastore", () => {
     expect(
       actions.updateVmfsDatastore({
-        addBlockDeviceIDs: [1, 2],
-        addPartitionIDs: [3, 4],
+        blockDeviceIds: [1, 2],
         name: "datastore1",
+        partitionIds: [3, 4],
         systemId: "abc123",
         vmfsDatastoreId: 5,
       })

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -191,7 +191,7 @@ export const ACTIONS = [
   },
   {
     name: "update-vmfs-datastore",
-    status: "updatingVMFSDatastore",
+    status: "updatingVmfsDatastore",
   },
 ];
 
@@ -751,17 +751,21 @@ const statusHandlers = generateStatusHandlers<
       case "update-vmfs-datastore":
         handler.method = "update_vmfs_datastore";
         handler.prepare = (params: {
-          addBlockDeviceIDs: number[];
-          addPartitionIDs: number[];
+          blockDeviceIds: number[];
           name: string;
+          partitionIds: number[];
           systemId: Machine["system_id"];
           vmfsDatastoreId: number;
         }) => ({
-          add_block_devices: params.addBlockDeviceIDs,
-          add_partitions: params.addPartitionIDs,
-          name: params.name,
           system_id: params.systemId,
           vmfs_datastore_id: params.vmfsDatastoreId,
+          ...("blockDeviceIds" in params && {
+            add_block_devices: params.blockDeviceIds,
+          }),
+          ...("partitionIds" in params && {
+            add_partitions: params.partitionIds,
+          }),
+          ...("name" in params && { name: params.name }),
         });
         break;
     }

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -38,6 +38,7 @@ export {
   canCreateBcache,
   canCreateCacheSet,
   canCreateLogicalVolume,
+  canCreateOrUpdateDatastore,
   canCreateRaid,
   canCreateVolumeGroup,
   canOsSupportBcacheZFS,

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -118,6 +118,36 @@ export const canCreateLogicalVolume = (disk: Disk | null): boolean =>
   isVolumeGroup(disk) && diskAvailable(disk);
 
 /**
+ * Returns whether a list of storage devices can create or update a datastore.
+ * @param storageDevices - the list of disks and partitions to check.
+ * @returns whether the list of storage devices can create or update a datastore.
+ */
+export const canCreateOrUpdateDatastore = (
+  storageDevices: (Disk | Partition)[]
+): boolean => {
+  if (
+    storageDevices.length === 0 ||
+    storageDevices.some((device) => isFormatted(device.filesystem))
+  ) {
+    return false;
+  }
+
+  for (const device of storageDevices) {
+    if (isDisk(device)) {
+      if (
+        device.partitions?.length ||
+        isBcache(device) ||
+        isLogicalVolume(device) ||
+        isVolumeGroup(device)
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+/**
  * Returns whether a list of storage devices can create a RAID.
  * @param storageDevices - the list of disks and partitions to check.
  * @returns whether the list of storage devices can create a RAID.
@@ -317,7 +347,7 @@ export const isCacheSet = (disk: Disk | null): boolean =>
  * @param fs - the filesystem to check.
  * @returns whether the filesystem is a VMFS6 datastore
  */
-export const isDatastore = (fs: Filesystem | null): fs is Filesystem =>
+export const isDatastore = (fs: Filesystem | null): boolean =>
   fs?.fstype === "vmfs6";
 
 /**


### PR DESCRIPTION
## Done

- Added "Add to existing datastore" to VMFS6 bulk actions

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine with at least 2 disks, and is in Ready or Allocated state. (If you set the MAAS to karura you can find one at http://0.0.0.0:8400/MAAS/r/machine/8qcbef/storage).
- Change the storage layout to VMFS6, which will automatically partition and use one of the disks
- Partition the other disk into 3 unformatted partitions
- Select one of the partitions and create a datastore from it
- Select both of the remaining partitions and click "Add to existing datastore"
- Check that the total size is correct
- Check that you can choose from the 2 newly created datastores, and the mount point updates correctly
- Check that you can successfully add storage to a datastore

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2172
