### PR TITLE
feat(ui): add metrics to script results view

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -98,13 +98,13 @@ exports[`stricter compilation`] = {
       [227, 21, 1, "Parameter \'e\' implicitly has an \'any\' type.", "177600"],
       [229, 23, 1, "Parameter \'e\' implicitly has an \'any\' type.", "177600"]
     ],
-    "src/app/base/hooks.ts:1665091113": [
-      [439, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
-      [440, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
-      [445, 31, 5, "Object is of type \'unknown\'.", "195909086"],
-      [445, 39, 5, "Object is of type \'unknown\'.", "195909085"],
-      [448, 31, 5, "Object is of type \'unknown\'.", "195909086"],
-      [448, 39, 5, "Object is of type \'unknown\'.", "195909085"]
+    "src/app/base/hooks.ts:4078034521": [
+      [459, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
+      [460, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
+      [465, 31, 5, "Object is of type \'unknown\'.", "195909086"],
+      [465, 39, 5, "Object is of type \'unknown\'.", "195909085"],
+      [468, 31, 5, "Object is of type \'unknown\'.", "195909086"],
+      [468, 39, 5, "Object is of type \'unknown\'.", "195909085"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:2641018437": [
       [140, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -326,9 +326,6 @@ exports[`stricter compilation`] = {
       [59, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
       [68, 4, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx:1577403034": [
-      [115, 18, 5, "Type \'MenuLink<null>[]\' is not assignable to type \'(string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined)[]\'.\\n  Type \'MenuLink<null>\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n    Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'string | InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<...>; ... 4 more ...; onClick: Requireable<...>; }> | (InferProps<...> | ... 1 more ... | undefined)[] | null | undefined\'.\\n      Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'InferProps<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }>\'.\\n        Type \'{ appearance?: string | undefined; children?: ReactNode; className?: string | undefined; dense?: boolean | undefined; disabled?: boolean | undefined; element?: \\"symbol\\" | ... 178 more ... | undefined; hasIcon?: boolean | undefined; inline?: boolean | undefined; onClick?: ((evt: MouseEvent<...>) => void) | undefined;...\' is not assignable to type \'Partial<InferPropsInner<Pick<{ appearance: Requireable<string>; children: Requireable<ReactNodeLike>; className: Requireable<string>; dense: Requireable<boolean>; ... 4 more ...; onClick: Requireable<...>; }, \\"children\\" | ... 7 more ... | \\"inline\\">>>\'.\\n          Types of property \'element\' are incompatible.\\n            Type \'\\"symbol\\" | \\"object\\" | \\"metadata\\" | \\"map\\" | \\"filter\\" | \\"path\\" | \\"label\\" | \\"data\\" | \\"a\\" | \\"abbr\\" | \\"address\\" | \\"area\\" | \\"article\\" | \\"aside\\" | \\"audio\\" | \\"b\\" | \\"base\\" | \\"bdi\\" | \\"bdo\\" | ... 160 more ... | undefined\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n              Type \'FunctionComponent<null>\' is not assignable to type \'string | ((props: any, context?: any) => any) | (new (props: any, context?: any) => any) | null | undefined\'.\\n                Type \'FunctionComponent<null>\' is not assignable to type \'(props: any, context?: any) => any\'.\\n                  Types of parameters \'props\' and \'props\' are incompatible.\\n                    Type \'any\' is not assignable to type \'never\'.", "173192470"]
-    ],
     "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:463222167": [
       [406, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
       [410, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
@@ -351,7 +348,7 @@ exports[`stricter compilation`] = {
       [149, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [150, 6, 15, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "1103269280"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:3446240187": [
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:4260149689": [
       [152, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx:1790086047": [
@@ -416,17 +413,16 @@ exports[`stricter compilation`] = {
       [80, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
       [94, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"]
     ],
-    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:1977710823": [
-      [68, 22, 37, "Argument of type \'number[]\' is not assignable to parameter of type \'SetStateAction<never[]>\'.\\n  Type \'number[]\' is not assignable to type \'never[]\'.\\n    Type \'number\' is not assignable to type \'never\'.", "3211590551"],
-      [78, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:3965116768": [
+      [159, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:1209352711": [
       [106, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
       [127, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.", "167402512"],
       [132, 42, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
-    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:727620712": [
-      [92, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
+    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:830492471": [
+      [93, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
     ],
     "src/app/rsd/components/RSDActionFormWrapper/DeleteForm/DeleteForm.test.tsx:1760843255": [
       [40, 14, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -490,25 +486,14 @@ exports[`stricter compilation`] = {
     "src/app/store/general/selectors/machineActions.test.ts:638190955": [
       [91, 10, 4, "Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: NodeActions; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'NodeActions\' is not assignable to type \'NodeActions.ABORT | NodeActions.ACQUIRE | NodeActions.COMMISSION | NodeActions.DELETE | NodeActions.DEPLOY | NodeActions.EXIT_RESCUE_MODE | NodeActions.LOCK | ... 11 more ... | NodeActions.UNLOCK\'.", "2087377941"]
     ],
-<<<<<<< HEAD
     "src/app/store/machine/slice.ts:3998145734": [
       [773, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
       [781, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
       [785, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
-    "src/app/store/machine/utils/storage.ts:3270313282": [
+    "src/app/store/machine/utils/storage.ts:2131529770": [
       [164, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
       [193, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
-=======
-    "src/app/store/machine/slice.ts:2803904352": [
-      [769, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
-      [777, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
-      [781, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
-    ],
-    "src/app/store/machine/utils/storage.ts:4105327027": [
-      [134, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
-      [163, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
->>>>>>> 1ca30540 (feat(ui): display block device title)
     ],
     "src/app/store/nodedevice/slice.ts:54310614": [
       [60, 4, 21, "Type \'(state: NodeDeviceState, action: PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<NodeDevice, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<NodeDevice, any>, PayloadAction<...>>\'.\\n  Type \'(state: NodeDeviceState, action: PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to type \'CaseReducer<GenericState<NodeDevice, any>, { payload: any; type: string; }>\'.\\n    Types of parameters \'action\' and \'action\' are incompatible.\\n      Type \'{ payload: any; type: string; }\' is not assignable to type \'PayloadAction<NodeDevice[], string, GenericItemMeta<ItemMeta>, never>\'.\\n        Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.", "294608771"]
@@ -620,12 +605,12 @@ exports[`stricter compilation`] = {
 
 exports[`no TSFixMe types`] = {
   value: `{
-    "src/app/base/hooks.ts:1665091113": [
+    "src/app/base/hooks.ts:4078034521": [
       [11, 13, 8, "RegExp match", "1152173309"],
       [27, 39, 8, "RegExp match", "1152173309"],
       [65, 61, 7, "RegExp match", "1425257597"],
-      [268, 56, 8, "RegExp match", "1152173309"],
-      [270, 2, 8, "RegExp match", "1152173309"]
+      [288, 56, 8, "RegExp match", "1152173309"],
+      [290, 2, 8, "RegExp match", "1152173309"]
     ],
     "src/app/base/types.ts:1483624430": [
       [0, 11, 8, "RegExp match", "1152173309"]
@@ -709,9 +694,9 @@ exports[`no TSFixMe types`] = {
       [9, 13, 8, "RegExp match", "1152173309"],
       [57, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/types.ts:882436801": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [99, 58, 8, "RegExp match", "1152173309"]
+    "src/app/store/scriptresult/types.ts:499587628": [
+      [7, 13, 8, "RegExp match", "1152173309"],
+      [108, 58, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scripts/types.ts:980490450": [
       [0, 13, 8, "RegExp match", "1152173309"],
@@ -777,5 +762,5 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `413`
+  value: `407`
 };

--- a/ui/src/app/base/hooks.ts
+++ b/ui/src/app/base/hooks.ts
@@ -258,6 +258,26 @@ export const useVisible = (
 };
 
 /**
+ * Track and untrack ids.
+ */
+export const useTrackById = <T>(): {
+  tracked: T[];
+  toggleTracked: (id: T) => void;
+} => {
+  const [tracked, setTracked] = useState<T[]>([]);
+
+  const toggleTracked = (id: T) => {
+    if (tracked.find((trackedId) => trackedId === id)) {
+      setTracked(tracked.filter((trackedId) => trackedId !== id));
+    } else {
+      setTracked([...tracked, id]);
+    }
+  };
+
+  return { tracked, toggleTracked };
+};
+
+/**
  * Returns a Yup validation schema with dynamically generated power parameters
  * schema, depending on the selected power type in the form.
  * @param powerType - Power type selected in the form.

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
@@ -15,6 +15,7 @@ import {
   partialScriptResult as partialScriptResultFactory,
   rootState as rootStateFactory,
   scriptResult as scriptResultFactory,
+  scriptResultResult as scriptResultResultFactory,
   scriptResultState as scriptResultStateFactory,
 } from "testing/factories";
 
@@ -182,6 +183,9 @@ describe("MachineTestsTable", () => {
       </Provider>
     );
     wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper
+      .find("Button[data-test='action-menu-show-previous']")
+      .simulate("click");
 
     expect(
       wrapper.find("tr[data-test='script-result-history']").exists()
@@ -207,8 +211,70 @@ describe("MachineTestsTable", () => {
       </Provider>
     );
 
-    expect(wrapper.find("Button.p-contextual-menu__toggle").exists()).toEqual(
-      false
+    expect(
+      wrapper.find("Button[data-test='action-menu-show-previous']").exists()
+    ).toEqual(false);
+  });
+
+  it("displays metrics when clicking the show metrics action button", () => {
+    const metrics = scriptResultResultFactory({
+      title: "test-title",
+      value: "test-value",
+    });
+    const scriptResults = [scriptResultFactory({ id: 1, results: [metrics] })];
+
+    state.nodescriptresult.items = { abc123: [1] };
+    state.scriptresult.items = scriptResults;
+
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineTestsTable machineId="abc123" scriptResults={scriptResults} />
+        </MemoryRouter>
+      </Provider>
     );
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper
+      .find("Button[data-test='action-menu-show-metrics']")
+      .simulate("click");
+
+    expect(
+      wrapper.find("tr[data-test='script-result-metrics']").exists()
+    ).toEqual(true);
+    expect(
+      wrapper.find("tr[data-test='script-result-metrics'] td").at(0).text()
+    ).toEqual("test-title");
+    expect(
+      wrapper.find("tr[data-test='script-result-metrics'] td").at(1).text()
+    ).toEqual("test-value");
+  });
+
+  it("does not display an action item to view metrics for script results without metrics", () => {
+    const scriptResults = [scriptResultFactory({ id: 1 })];
+    const scriptResultState = scriptResultStateFactory({
+      items: scriptResults,
+    });
+    state.nodescriptresult.items = { abc123: [1] };
+    state.scriptresult = scriptResultState;
+
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineTestsTable machineId="abc123" scriptResults={scriptResults} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("Button[data-test='action-menu-show-metrics']").exists()
+    ).toEqual(false);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
@@ -183,6 +183,7 @@ exports[`MachineTestsTable renders 1`] = `
         }
       >
         <MainTable
+          className="p-table-expanding--light"
           defaultSort="name"
           defaultSortDirection="ascending"
           expanding={true}
@@ -217,6 +218,7 @@ exports[`MachineTestsTable renders 1`] = `
           rows={
             Array [
               Object {
+                "className": null,
                 "columns": Array [
                   Object {
                     "content": <React.Fragment />,
@@ -261,16 +263,24 @@ exports[`MachineTestsTable renders 1`] = `
                   },
                   Object {
                     "className": "u-align--right",
-                    "content": null,
+                    "content": <TableMenu
+                      data-test="action-menu"
+                      links={
+                        Array [
+                          Object {
+                            "children": "View metrics",
+                            "data-test": "action-menu-show-metrics",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      position="right"
+                      title="Take action:"
+                    />,
                   },
                 ],
                 "expanded": false,
-                "expandedContent": <table
-                  className="p-table-expanding--light"
-                  role="grid"
-                >
-                  <tbody />
-                </table>,
+                "expandedContent": <div />,
                 "key": 27,
                 "sortData": Object {
                   "date": "Fri, 13 Nov. 2020 04:50:27",
@@ -278,6 +288,7 @@ exports[`MachineTestsTable renders 1`] = `
                 },
               },
               Object {
+                "className": null,
                 "columns": Array [
                   Object {
                     "content": <React.Fragment />,
@@ -322,16 +333,24 @@ exports[`MachineTestsTable renders 1`] = `
                   },
                   Object {
                     "className": "u-align--right",
-                    "content": null,
+                    "content": <TableMenu
+                      data-test="action-menu"
+                      links={
+                        Array [
+                          Object {
+                            "children": "View metrics",
+                            "data-test": "action-menu-show-metrics",
+                            "onClick": [Function],
+                          },
+                        ]
+                      }
+                      position="right"
+                      title="Take action:"
+                    />,
                   },
                 ],
                 "expanded": false,
-                "expandedContent": <table
-                  className="p-table-expanding--light"
-                  role="grid"
-                >
-                  <tbody />
-                </table>,
+                "expandedContent": <div />,
                 "key": 28,
                 "sortData": Object {
                   "date": "Fri, 13 Nov. 2020 04:50:27",
@@ -343,12 +362,12 @@ exports[`MachineTestsTable renders 1`] = `
           sortable={true}
         >
           <Table
-            className="p-main-table"
+            className="p-table-expanding--light"
             expanding={true}
             sortable={true}
           >
             <table
-              className="p-main-table p-table--sortable p-table-expanding"
+              className="p-table-expanding--light p-table--sortable p-table-expanding"
               role="grid"
             >
               <thead>
@@ -458,9 +477,11 @@ exports[`MachineTestsTable renders 1`] = `
               </thead>
               <tbody>
                 <TableRow
+                  className={null}
                   key="27"
                 >
                   <tr
+                    className={null}
                     role="row"
                   >
                     <TableCell
@@ -558,7 +579,74 @@ exports[`MachineTestsTable renders 1`] = `
                         aria-hidden={false}
                         className="u-align--right"
                         role="gridcell"
-                      />
+                      >
+                        <TableMenu
+                          data-test="action-menu"
+                          links={
+                            Array [
+                              Object {
+                                "children": "View metrics",
+                                "data-test": "action-menu-show-metrics",
+                                "onClick": [Function],
+                              },
+                            ]
+                          }
+                          position="right"
+                          title="Take action:"
+                        >
+                          <ContextualMenu
+                            className="p-table-menu"
+                            hasToggleIcon={true}
+                            links={
+                              Array [
+                                "Take action:",
+                                Object {
+                                  "children": "View metrics",
+                                  "data-test": "action-menu-show-metrics",
+                                  "onClick": [Function],
+                                },
+                              ]
+                            }
+                            position="right"
+                            toggleAppearance="base"
+                            toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+                            toggleDisabled={false}
+                          >
+                            <span
+                              className="p-table-menu p-contextual-menu"
+                              style={
+                                Object {
+                                  "position": "relative",
+                                }
+                              }
+                            >
+                              <Button
+                                appearance="base"
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                disabled={false}
+                                hasIcon={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="true"
+                                  className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <i
+                                    className="p-icon--contextual-menu p-contextual-menu__indicator"
+                                  />
+                                </button>
+                              </Button>
+                            </span>
+                          </ContextualMenu>
+                        </TableMenu>
+                      </td>
                     </TableCell>
                     <TableCell
                       expanding={true}
@@ -569,20 +657,17 @@ exports[`MachineTestsTable renders 1`] = `
                         className="p-table-expanding__panel"
                         role="gridcell"
                       >
-                        <table
-                          className="p-table-expanding--light"
-                          role="grid"
-                        >
-                          <tbody />
-                        </table>
+                        <div />
                       </td>
                     </TableCell>
                   </tr>
                 </TableRow>
                 <TableRow
+                  className={null}
                   key="28"
                 >
                   <tr
+                    className={null}
                     role="row"
                   >
                     <TableCell
@@ -680,7 +765,74 @@ exports[`MachineTestsTable renders 1`] = `
                         aria-hidden={false}
                         className="u-align--right"
                         role="gridcell"
-                      />
+                      >
+                        <TableMenu
+                          data-test="action-menu"
+                          links={
+                            Array [
+                              Object {
+                                "children": "View metrics",
+                                "data-test": "action-menu-show-metrics",
+                                "onClick": [Function],
+                              },
+                            ]
+                          }
+                          position="right"
+                          title="Take action:"
+                        >
+                          <ContextualMenu
+                            className="p-table-menu"
+                            hasToggleIcon={true}
+                            links={
+                              Array [
+                                "Take action:",
+                                Object {
+                                  "children": "View metrics",
+                                  "data-test": "action-menu-show-metrics",
+                                  "onClick": [Function],
+                                },
+                              ]
+                            }
+                            position="right"
+                            toggleAppearance="base"
+                            toggleClassName="u-no-margin--bottom p-table-menu__toggle"
+                            toggleDisabled={false}
+                          >
+                            <span
+                              className="p-table-menu p-contextual-menu"
+                              style={
+                                Object {
+                                  "position": "relative",
+                                }
+                              }
+                            >
+                              <Button
+                                appearance="base"
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                className="p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                disabled={false}
+                                hasIcon={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <button
+                                  aria-expanded="false"
+                                  aria-haspopup="true"
+                                  className="p-button--base has-icon p-contextual-menu__toggle u-no-margin--bottom p-table-menu__toggle"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <i
+                                    className="p-icon--contextual-menu p-contextual-menu__indicator"
+                                  />
+                                </button>
+                              </Button>
+                            </span>
+                          </ContextualMenu>
+                        </TableMenu>
+                      </td>
                     </TableCell>
                     <TableCell
                       expanding={true}
@@ -691,12 +843,7 @@ exports[`MachineTestsTable renders 1`] = `
                         className="p-table-expanding__panel"
                         role="gridcell"
                       >
-                        <table
-                          className="p-table-expanding--light"
-                          role="grid"
-                        >
-                          <tbody />
-                        </table>
+                        <div />
                       </td>
                     </TableCell>
                   </tr>

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -102,6 +102,10 @@ export type ScriptResult = PartialScriptResult & {
   tags: string;
 };
 
+export type ScriptResultHistory = {
+  [x: number]: PartialScriptResult[];
+};
+
 export type ScriptResultState = GenericState<ScriptResult, TSFixMe> & {
   history: Record<ScriptResult["id"], PartialScriptResult[]>;
 };


### PR DESCRIPTION
## Done

- Add metrics to script results (testing) tab

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Find a machine with script result *results* (😞) e.g. [7z result for fun-mammal](/MAAS/r/machine/feeaq4/tests) on bolla.

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2208

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
