### PR TITLE
fix(ui): fix node device table borders in Chrome

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
@@ -50,6 +50,9 @@
   .node-devices-table__row:not(:first-child) {
     @extend %vf-pseudo-border--top;
     border: 0;
+    // position: relative for <tr>s only works in Firefox, unless the element
+    // is coerced into a fixed position container.
+    transform: scale(1);
 
     &.truncated-border::after {
       @media only screen and (min-width: 900px) {


### PR DESCRIPTION
## Done

- Fixed a bug where pseudo-element borders were not showing up in the node devices table in Chrome

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using Chrome, open up the PCI devices tab of a machine with PCI devices
- Check that the table borders show up correctly
