### PR TITLE
feat(shared): make MAAS and machine name bold in status bar

### DIFF
--- a/shared/src/components/StatusBar/StatusBar.tsx
+++ b/shared/src/components/StatusBar/StatusBar.tsx
@@ -16,7 +16,7 @@ export const StatusBar = ({
     <div className="p-status-bar">
       <div className="row">
         <div className="col-6">
-          <span data-test="status-bar-maas-name">{maasName} MAAS</span>:{" "}
+          <strong data-test="status-bar-maas-name">{maasName} MAAS</strong>:{" "}
           <span data-test="status-bar-version">{version}</span>
         </div>
         {status && (

--- a/ui/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/ui/src/app/base/components/StatusBar/StatusBar.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { StatusBar as SharedStatusBar } from "@maas-ui/maas-ui-shared";
 import { formatDistance, parse } from "date-fns";
 import { useSelector } from "react-redux";
@@ -8,11 +10,11 @@ import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
 import { NodeStatus } from "app/store/types/node";
 
-const getActiveMachineStatus = (machine: MachineDetails) => {
+const getLastCommissionedString = (machine: MachineDetails) => {
   if (machine.status === NodeStatus.COMMISSIONING) {
-    return `${machine.fqdn}: Commissioning in progress...`;
+    return "Commissioning in progress...";
   } else if (machine.commissioning_start_time === "") {
-    return `${machine.fqdn}: Not yet commissioned`;
+    return "Not yet commissioned";
   }
   try {
     const distance = formatDistance(
@@ -24,9 +26,9 @@ const getActiveMachineStatus = (machine: MachineDetails) => {
       new Date(),
       { addSuffix: true }
     );
-    return `${machine.fqdn}: Last commissioned ${distance}`;
+    return `Last commissioned ${distance}`;
   } catch (error) {
-    return `${machine.fqdn}: Unable to parse commissioning timestamp (${error.message})`;
+    return `Unable to parse commissioning timestamp (${error.message})`;
   }
 };
 
@@ -39,9 +41,14 @@ export const StatusBar = (): JSX.Element | null => {
     return null;
   }
 
-  let status = "";
+  let status: ReactNode = "";
   if (activeMachine && "commissioning_start_time" in activeMachine) {
-    status = getActiveMachineStatus(activeMachine);
+    const lastCommissioned = getLastCommissionedString(activeMachine);
+    status = (
+      <>
+        <strong>{activeMachine.fqdn}</strong>: <span>{lastCommissioned}</span>
+      </>
+    );
   }
 
   return (


### PR DESCRIPTION
## Done

- made MAAS and machine name bold in status bar

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a machine
- Check that the MAAS name and the machine's name are bolded in the status bar

## Screenshot
![Screenshot_2021-01-27 sure-cod maas PCI devices bolla MAAS](https://user-images.githubusercontent.com/25733845/105927778-66221980-6090-11eb-85af-4cf6292e8748.png)
