### PR TITLE
refactor(ui): row checkboxes shared component

### DIFF
--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
@@ -30,7 +30,7 @@ describe("GroupCheckbox", () => {
     const wrapper = shallow(
       <GroupCheckbox
         items={[]}
-        label="Check all"
+        inputLabel="Check all"
         selectedItems={[]}
         handleGroupCheckbox={jest.fn()}
       />

--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
@@ -11,7 +11,9 @@ type Props<R, S> = {
   handleGroupCheckbox: (rows: R[], selected: S[]) => void;
   inRow?: boolean;
   items: R[];
-  label?: ReactNode;
+  // This needs to be something other than `label` to prevent conflicts with the
+  // HTMLInputElement type.
+  inputLabel?: ReactNode;
   selectedItems: S[];
 } & HTMLProps<HTMLInputElement>;
 
@@ -19,7 +21,7 @@ const GroupCheckbox = <R, S>({
   handleGroupCheckbox,
   inRow,
   items,
-  label,
+  inputLabel,
   selectedItems,
   ...props
 }: Props<R, S>): JSX.Element => {
@@ -32,7 +34,7 @@ const GroupCheckbox = <R, S>({
       })}
       disabled={items.length === 0}
       id={id.current}
-      label={label ? label : " "}
+      label={inputLabel ? inputLabel : " "}
       onChange={() => handleGroupCheckbox(items, selectedItems)}
       type="checkbox"
       wrapperClassName={classNames("u-no-margin--bottom u-nudge--checkbox", {

--- a/ui/src/app/base/components/RowCheckbox/RowCheckbox.test.tsx
+++ b/ui/src/app/base/components/RowCheckbox/RowCheckbox.test.tsx
@@ -1,0 +1,24 @@
+import { shallow } from "enzyme";
+
+import RowCheckbox from "./RowCheckbox";
+
+describe("RowCheckbox", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <RowCheckbox items={[]} item={null} handleRowCheckbox={jest.fn()} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can show a label", () => {
+    const wrapper = shallow(
+      <RowCheckbox
+        items={[]}
+        label="Check row"
+        item={null}
+        handleRowCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper.prop("label")).toBe("Check row");
+  });
+});

--- a/ui/src/app/base/components/RowCheckbox/RowCheckbox.tsx
+++ b/ui/src/app/base/components/RowCheckbox/RowCheckbox.tsx
@@ -1,0 +1,44 @@
+import { useRef } from "react";
+import type { HTMLProps, ReactNode } from "react";
+
+import { Input } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
+
+import { someInArray } from "app/utils";
+
+type Props<I> = {
+  handleRowCheckbox: (item: I, rows: I[]) => void;
+  checkSelected?: ((item: I, rows: I[]) => boolean) | null;
+  items: I[];
+  // This needs to be something other than `label` to prevent conflicts with the
+  // HTMLInputElement type.
+  inputLabel?: ReactNode;
+  item: I;
+} & HTMLProps<HTMLInputElement>;
+
+const RowCheckbox = <I,>({
+  handleRowCheckbox,
+  checkSelected,
+  item,
+  items,
+  inputLabel,
+  ...props
+}: Props<I>): JSX.Element => {
+  const id = useRef(nanoid());
+  return (
+    <Input
+      checked={
+        checkSelected ? checkSelected(item, items) : someInArray(item, items)
+      }
+      className="has-inline-label keep-label-opacity"
+      id={id.current}
+      onChange={() => handleRowCheckbox(item, items)}
+      type="checkbox"
+      label={inputLabel}
+      wrapperClassName="u-no-margin--bottom u-nudge--checkbox"
+      {...props}
+    />
+  );
+};
+
+export default RowCheckbox;

--- a/ui/src/app/base/components/RowCheckbox/__snapshots__/RowCheckbox.test.tsx.snap
+++ b/ui/src/app/base/components/RowCheckbox/__snapshots__/RowCheckbox.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RowCheckbox renders 1`] = `
+<Input
+  checked={false}
+  className="has-inline-label keep-label-opacity"
+  onChange={[Function]}
+  type="checkbox"
+  wrapperClassName="u-no-margin--bottom u-nudge--checkbox"
+/>
+`;

--- a/ui/src/app/base/components/RowCheckbox/index.ts
+++ b/ui/src/app/base/components/RowCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RowCheckbox";

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx
@@ -30,11 +30,7 @@ import { actions as poolActions } from "app/store/resourcepool";
 import poolSelectors from "app/store/resourcepool/selectors";
 import type { ResourcePool } from "app/store/resourcepool/types";
 import { actions as zoneActions } from "app/store/zone";
-import {
-  generateCheckboxHandlers,
-  getStatusText,
-  someInArray,
-} from "app/utils";
+import { generateCheckboxHandlers, getStatusText } from "app/utils";
 
 type SortKey = keyof Pod | "cpu" | "os" | "pool" | "power" | "ram" | "storage";
 
@@ -88,7 +84,7 @@ const generateRows = (
           <NameColumn
             handleCheckbox={() => handleRowCheckbox(kvm.id, selectedKVMIDs)}
             id={kvm.id}
-            selected={someInArray(kvm.id, selectedKVMIDs)}
+            selected={selectedKVMIDs}
           />
         ),
       },

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.test.tsx
@@ -28,7 +28,7 @@ describe("NameColumn", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <NameColumn handleCheckbox={jest.fn()} id={1} selected={false} />
+          <NameColumn handleCheckbox={jest.fn()} id={1} selected={[]} />
         </MemoryRouter>
       </Provider>
     );
@@ -48,7 +48,11 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn handleCheckbox={jest.fn()} id={1} selected />
+          <NameColumn
+            handleCheckbox={jest.fn()}
+            id={1}
+            selected={state.pod.selected}
+          />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/NameColumn/NameColumn.tsx
@@ -1,16 +1,16 @@
-import { Input } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import RowCheckbox from "app/base/components/RowCheckbox";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
   handleCheckbox: (podID: Pod["id"]) => void;
-  id: number;
-  selected: boolean;
+  id: Pod["id"];
+  selected: Pod["id"][];
 };
 
 const NameColumn = ({
@@ -26,19 +26,16 @@ const NameColumn = ({
     return (
       <DoubleRow
         primary={
-          <Input
-            checked={selected}
-            className="has-inline-label keep-label-opacity"
+          <RowCheckbox
             data-test="pod-checkbox"
-            id={`${id}`}
-            label={
+            handleRowCheckbox={handleCheckbox}
+            item={id}
+            items={selected}
+            inputLabel={
               <Link to={`/kvm/${id}`}>
                 <strong>{pod.name}</strong>
               </Link>
             }
-            onChange={handleCheckbox}
-            type="checkbox"
-            wrapperClassName="u-no-margin--bottom u-nudge--checkbox"
           />
         }
       />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Input, MainTable } from "@canonical/react-components";
+import { MainTable } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionConfirm from "../../ActionConfirm";
@@ -19,6 +19,7 @@ import EditPhysicalDisk from "./EditPhysicalDisk";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import GroupCheckbox from "app/base/components/GroupCheckbox";
+import RowCheckbox from "app/base/components/RowCheckbox";
 import TableMenu from "app/base/components/TableMenu";
 import type { TSFixMe } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
@@ -245,16 +246,14 @@ const normaliseRowData = (
         content: (
           <DoubleRow
             primary={
-              <Input
-                checked={isSelected(storageDevice, selected)}
-                className="has-inline-label keep-label-opacity"
+              <RowCheckbox
+                checkSelected={isSelected}
                 data-test={`checkbox-${rowId}`}
                 disabled={actionsDisabled}
-                id={rowId}
-                label={storageDevice.name}
-                onChange={() => handleRowCheckbox(storageDevice)}
-                type="checkbox"
-                wrapperClassName="u-no-margin--bottom u-nudge--checkbox"
+                handleRowCheckbox={handleRowCheckbox}
+                item={storageDevice}
+                items={selected}
+                inputLabel={storageDevice.name}
               />
             }
             secondary={"serial" in storageDevice && storageDevice.serial}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -39,7 +39,6 @@ import {
   generateCheckboxHandlers,
   groupAsMap,
   simpleSortByKey,
-  someInArray,
 } from "app/utils";
 
 const getSortValue = (sortKey, machine) => {
@@ -122,7 +121,7 @@ const generateRows = ({
                 ? () => handleRowCheckbox(row.system_id, selectedIDs)
                 : undefined
             }
-            selected={someInArray(row.system_id, selectedIDs)}
+            selected={selectedIDs}
             showMAC={showMAC}
             systemId={row.system_id}
           />
@@ -384,7 +383,7 @@ const generateGroupRows = ({
                       items={machineIDs}
                       selectedItems={selectedIDs}
                       handleGroupCheckbox={handleGroupCheckbox}
-                      label={<strong>{label}</strong>}
+                      inputLabel={<strong>{label}</strong>}
                     />
                   ) : (
                     <strong>{label}</strong>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.js
@@ -1,5 +1,4 @@
 import { Tooltip } from "@canonical/react-components";
-import { Input } from "@canonical/react-components";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import { memo } from "react";
@@ -7,6 +6,7 @@ import { useSelector } from "react-redux";
 
 import machineSelectors from "app/store/machine/selectors";
 import DoubleRow from "app/base/components/DoubleRow";
+import RowCheckbox from "app/base/components/RowCheckbox";
 
 const generateFQDN = (machine, machineURL) => {
   return (
@@ -103,20 +103,16 @@ export const NameColumn = ({ handleCheckbox, selected, showMAC, systemId }) => {
       data-test="name-column"
       primary={
         handleCheckbox ? (
-          <Input
-            checked={selected}
-            className="has-inline-label keep-label-opacity"
-            id={systemId}
-            label={primaryRow}
-            onChange={handleCheckbox}
-            type="checkbox"
-            wrapperClassName="u-no-margin--bottom machine-list--inline-input"
+          <RowCheckbox
+            handleRowCheckbox={handleCheckbox}
+            item={systemId}
+            items={selected}
+            inputLabel={primaryRow}
           />
         ) : (
           primaryRow
         )
       }
-      primaryTextClassName={handleCheckbox && "u-nudge--checkbox"}
       secondary={secondaryRow}
       secondaryClassName={handleCheckbox && "u-nudge--secondary-row"}
     />
@@ -125,7 +121,7 @@ export const NameColumn = ({ handleCheckbox, selected, showMAC, systemId }) => {
 
 NameColumn.propTypes = {
   handleCheckbox: PropTypes.func,
-  selected: PropTypes.bool,
+  selected: PropTypes.arrayOf(PropTypes.string),
   showMAC: PropTypes.bool,
   systemId: PropTypes.string.isRequired,
 };

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.js
@@ -240,7 +240,7 @@ describe("NameColumn", () => {
         >
           <NameColumn
             handleCheckbox={jest.fn()}
-            selected
+            selected={["abc123"]}
             showMAC={true}
             systemId="abc123"
           />
@@ -257,7 +257,7 @@ describe("NameColumn", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <NameColumn handleCheckbox={undefined} systemId="abc123" />
+          <NameColumn systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.js.snap
@@ -8,10 +8,9 @@ exports[`NameColumn renders 1`] = `
   <DoubleRow
     data-test="name-column"
     primary={
-      <Input
-        className="has-inline-label keep-label-opacity"
-        id="abc123"
-        label={
+      <RowCheckbox
+        handleRowCheckbox={[MockFunction]}
+        inputLabel={
           <Link
             to="/undefined/abc123"
           >
@@ -26,12 +25,9 @@ exports[`NameColumn renders 1`] = `
             </small>
           </Link>
         }
-        onChange={[MockFunction]}
-        type="checkbox"
-        wrapperClassName="u-no-margin--bottom machine-list--inline-input"
+        item="abc123"
       />
     }
-    primaryTextClassName="u-nudge--checkbox"
     secondary=""
     secondaryClassName="u-nudge--secondary-row"
   >
@@ -45,12 +41,11 @@ exports[`NameColumn renders 1`] = `
           className="p-double-row__primary-row"
         >
           <div
-            className="p-double-row__primary-row-text u-truncate u-nudge--checkbox"
+            className="p-double-row__primary-row-text u-truncate"
           >
-            <Input
-              className="has-inline-label keep-label-opacity"
-              id="abc123"
-              label={
+            <RowCheckbox
+              handleRowCheckbox={[MockFunction]}
+              inputLabel={
                 <Link
                   to="/undefined/abc123"
                 >
@@ -65,13 +60,11 @@ exports[`NameColumn renders 1`] = `
                   </small>
                 </Link>
               }
-              onChange={[MockFunction]}
-              type="checkbox"
-              wrapperClassName="u-no-margin--bottom machine-list--inline-input"
+              item="abc123"
             >
-              <Field
-                className="u-no-margin--bottom machine-list--inline-input"
-                forId="abc123"
+              <Input
+                checked={false}
+                className="has-inline-label keep-label-opacity"
                 label={
                   <Link
                     to="/undefined/abc123"
@@ -87,56 +80,75 @@ exports[`NameColumn renders 1`] = `
                     </small>
                   </Link>
                 }
-                labelFirst={false}
+                onChange={[Function]}
+                type="checkbox"
+                wrapperClassName="u-no-margin--bottom u-nudge--checkbox"
               >
-                <div
-                  className="p-form__group p-form-validation u-no-margin--bottom machine-list--inline-input"
+                <Field
+                  className="u-no-margin--bottom u-nudge--checkbox"
+                  label={
+                    <Link
+                      to="/undefined/abc123"
+                    >
+                      <strong
+                        data-test="hostname"
+                      >
+                        koala
+                      </strong>
+                      <small>
+                        .
+                        example
+                      </small>
+                    </Link>
+                  }
+                  labelFirst={false}
                 >
                   <div
-                    className="p-form__control u-clearfix"
+                    className="p-form__group p-form-validation u-no-margin--bottom u-nudge--checkbox"
                   >
-                    <input
-                      className="p-form-validation__input has-inline-label keep-label-opacity"
-                      id="abc123"
-                      onChange={[MockFunction]}
-                      type="checkbox"
-                    />
-                    <Label
-                      forId="abc123"
+                    <div
+                      className="p-form__control u-clearfix"
                     >
-                      <label
-                        className="p-form__label"
-                        htmlFor="abc123"
-                      >
-                        <Link
-                          to="/undefined/abc123"
+                      <input
+                        checked={false}
+                        className="p-form-validation__input has-inline-label keep-label-opacity"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <Label>
+                        <label
+                          className="p-form__label"
                         >
-                          <LinkAnchor
-                            href="/undefined/abc123"
-                            navigate={[Function]}
+                          <Link
+                            to="/undefined/abc123"
                           >
-                            <a
+                            <LinkAnchor
                               href="/undefined/abc123"
-                              onClick={[Function]}
+                              navigate={[Function]}
                             >
-                              <strong
-                                data-test="hostname"
+                              <a
+                                href="/undefined/abc123"
+                                onClick={[Function]}
                               >
-                                koala
-                              </strong>
-                              <small>
-                                .
-                                example
-                              </small>
-                            </a>
-                          </LinkAnchor>
-                        </Link>
-                      </label>
-                    </Label>
+                                <strong
+                                  data-test="hostname"
+                                >
+                                  koala
+                                </strong>
+                                <small>
+                                  .
+                                  example
+                                </small>
+                              </a>
+                            </LinkAnchor>
+                          </Link>
+                        </label>
+                      </Label>
+                    </div>
                   </div>
-                </div>
-              </Field>
-            </Input>
+                </Field>
+              </Input>
+            </RowCheckbox>
           </div>
         </div>
       </div>

--- a/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
+++ b/ui/src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx
@@ -19,7 +19,7 @@ import { actions as poolActions } from "app/store/resourcepool";
 import poolSelectors from "app/store/resourcepool/selectors";
 import type { ResourcePool } from "app/store/resourcepool/types";
 import { actions as zoneActions } from "app/store/zone";
-import { generateCheckboxHandlers, someInArray } from "app/utils";
+import { generateCheckboxHandlers } from "app/utils";
 
 type SortKey = keyof Pod | "cpu" | "pool" | "ram" | "storage";
 
@@ -53,7 +53,7 @@ const generateRows = (
           <NameColumn
             handleCheckbox={() => handleRowCheckbox(rsd.id, selectedRSDIDs)}
             id={rsd.id}
-            selected={someInArray(rsd.id, selectedRSDIDs)}
+            selected={selectedRSDIDs}
           />
         ),
       },

--- a/ui/src/app/utils/generateCheckboxHandlers.ts
+++ b/ui/src/app/utils/generateCheckboxHandlers.ts
@@ -1,6 +1,6 @@
 import { someInArray } from "./someInArray";
 
-type CheckboxHandlers<ID> = {
+export type CheckboxHandlers<ID> = {
   handleGroupCheckbox: (ids: ID[], selectedIDs: ID[]) => void;
   handleRowCheckbox: (rowID: ID, selectedIDs: ID[]) => void;
 };

--- a/ui/src/app/utils/someInArray.ts
+++ b/ui/src/app/utils/someInArray.ts
@@ -5,6 +5,9 @@
  * @returns {boolean} `toCheck` or an item in `toCheck` is inside `arr`
  */
 export const someInArray = (toCheck: unknown, arr: unknown[]): boolean => {
+  if (!arr) {
+    return false;
+  }
   if (Array.isArray(toCheck)) {
     return toCheck.length && toCheck.some((item) => arr.includes(item));
   }


### PR DESCRIPTION
## Done

- Move the row checkboxes to a shared component.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the machine, rsd and kvm lists. The checkboxes should work as before.
- Navigate to the storage tab for a machine with available storage. The checkboxes should work in that table too.

## Fixes

Working towards: canonical-web-and-design/maas-squad#2284