### PR TITLE
feat(ui): add network table checkboxes

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/work/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/multipass/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -218,8 +218,8 @@ exports[`stricter compilation`] = {
       [331, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
       [353, 6, 98, "Object is possibly \'undefined\'.", "1041189900"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:1343696512": [
-      [117, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, kvmHosts: (Controller | Machine)[], pools: ResourcePool[], osReleases: TSFixMe) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'kvmHosts\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Host[]\'.", "3312061634"]
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:3214710366": [
+      [113, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, kvmHosts: (Controller | Machine)[], pools: ResourcePool[], osReleases: TSFixMe) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'kvmHosts\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Host[]\'.", "3312061634"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:2466040368": [
       [17, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
@@ -326,13 +326,16 @@ exports[`stricter compilation`] = {
       [59, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
       [68, 4, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:463222167": [
-      [406, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
-      [410, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
-      [435, 35, 9, "Object is possibly \'null\'.", "1794230341"],
-      [435, 47, 9, "Object is possibly \'null\'.", "1612642726"],
-      [438, 35, 9, "Object is possibly \'null\'.", "1794230341"],
-      [438, 47, 9, "Object is possibly \'null\'.", "1612642726"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:418524379": [
+      [426, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
+      [430, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"ip\\" | \\"type\\" | \\"speed\\" | \\"dhcp\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
+      [455, 35, 9, "Object is possibly \'null\'.", "1794230341"],
+      [455, 47, 9, "Object is possibly \'null\'.", "1612642726"],
+      [458, 35, 9, "Object is possibly \'null\'.", "1794230341"],
+      [458, 47, 9, "Object is possibly \'null\'.", "1612642726"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx:3609566884": [
+      [78, 8, 5, "Object is possibly \'null\'.", "179721187"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx:1067981421": [
       [102, 6, 78, "Cannot invoke an object which is possibly \'undefined\'.", "1912336017"],
@@ -348,7 +351,7 @@ exports[`stricter compilation`] = {
       [149, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [150, 6, 15, "Argument of type \'{ fstype: string; mountOptions: string; mountPoint: string; partitionSize: number; unit: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, but \'fstype\' does not exist in type \'FormEvent<{}>\'. Did you mean to write \'type\'?", "1103269280"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:4260149689": [
+    "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx:2799316202": [
       [152, 31, 21, "Type \'boolean | undefined\' is not assignable to type \'boolean\'.\\n  Type \'undefined\' is not assignable to type \'boolean\'.", "2249082150"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.test.tsx:1790086047": [
@@ -440,7 +443,7 @@ exports[`stricter compilation`] = {
       [70, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [71, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; power_pass: string; power_user: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "244873512"]
     ],
-    "src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx:612654686": [
+    "src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx:1138227193": [
       [77, 4, 12, "Argument of type \'(sortKey: SortKey, rsd: Pod, pools: ResourcePool[]) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
     ],
     "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:3661263440": [
@@ -486,10 +489,10 @@ exports[`stricter compilation`] = {
     "src/app/store/general/selectors/machineActions.test.ts:638190955": [
       [91, 10, 4, "Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[] | AttributeFunction<MachineAction[]> | Factory<MachineAction[]> | DerivedFunction<MachineActionsState, MachineAction[]> | ArrayFactory<...> | undefined\'.\\n  Type \'{ name: NodeActions; title: string; sentence: string; type: string; }[]\' is not assignable to type \'MachineAction[]\'.\\n    Type \'{ name: NodeActions; title: string; sentence: string; type: string; }\' is not assignable to type \'MachineAction\'.\\n      Types of property \'name\' are incompatible.\\n        Type \'NodeActions\' is not assignable to type \'NodeActions.ABORT | NodeActions.ACQUIRE | NodeActions.COMMISSION | NodeActions.DELETE | NodeActions.DEPLOY | NodeActions.EXIT_RESCUE_MODE | NodeActions.LOCK | ... 11 more ... | NodeActions.UNLOCK\'.", "2087377941"]
     ],
-    "src/app/store/machine/slice.ts:3998145734": [
-      [773, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
-      [781, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
-      [785, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
+    "src/app/store/machine/slice.ts:3830645401": [
+      [811, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
+      [819, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
+      [823, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
     "src/app/store/machine/utils/storage.ts:2131529770": [
       [164, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
@@ -585,8 +588,8 @@ exports[`stricter compilation`] = {
     "src/app/utils/getCookie.ts:940992619": [
       [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
     ],
-    "src/app/utils/someInArray.ts:1012121545": [
-      [8, 4, 68, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "3447795550"]
+    "src/app/utils/someInArray.ts:1833644967": [
+      [11, 4, 68, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "3447795550"]
     ],
     "src/app/utils/someNotAll.ts:3892711037": [
       [7, 2, 71, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "1467649629"]
@@ -594,11 +597,11 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:136596448": [
-      [268, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
-      [355, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
-      [357, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
-      [362, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:2770740400": [
+      [269, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
+      [356, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
+      [358, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
+      [363, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -665,10 +668,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:2231288590": [
+    "src/app/store/machine/types.ts:3114079984": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [417, 34, 8, "RegExp match", "1152173309"],
-      [420, 25, 8, "RegExp match", "1152173309"]
+      [418, 34, 8, "RegExp match", "1152173309"],
+      [421, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/nodedevice/types.ts:2713937479": [
       [1, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/base/components/DoubleRow/DoubleRow.tsx
+++ b/ui/src/app/base/components/DoubleRow/DoubleRow.tsx
@@ -8,22 +8,22 @@ import TableMenu from "app/base/components/TableMenu";
 import type { Props as TableMenuProps } from "app/base/components/TableMenu/TableMenu";
 
 type Props<L> = {
-  className?: string;
-  icon?: ReactNode;
-  iconSpace?: boolean;
-  menuClassName?: string;
-  menuLinks?: TableMenuProps<L>["links"];
-  menuTitle?: string;
-  onToggleMenu?: TableMenuProps<L>["onToggleMenu"];
-  primary?: ReactNode;
-  primaryAriaLabel?: string;
-  primaryClassName?: string;
-  primaryTextClassName?: string;
-  primaryTitle?: string;
-  secondary?: ReactNode;
-  secondaryAriaLabel?: string;
-  secondaryClassName?: string;
-  secondaryTitle?: string;
+  className?: string | null;
+  icon?: ReactNode | null;
+  iconSpace?: boolean | null;
+  menuClassName?: string | null;
+  menuLinks?: TableMenuProps<L>["links"] | null;
+  menuTitle?: string | null;
+  onToggleMenu?: TableMenuProps<L>["onToggleMenu"] | null;
+  primary?: ReactNode | null;
+  primaryAriaLabel?: string | null;
+  primaryClassName?: string | null;
+  primaryTextClassName?: string | null;
+  primaryTitle?: string | null;
+  secondary?: ReactNode | null;
+  secondaryAriaLabel?: string | null;
+  secondaryClassName?: string | null;
+  secondaryTitle?: string | null;
 };
 
 const DoubleRow = <L,>({
@@ -65,7 +65,7 @@ const DoubleRow = <L,>({
       <div className="p-double-row__rows-container">
         <div
           className={classNames("p-double-row__primary-row", primaryClassName)}
-          aria-label={primaryAriaLabel}
+          aria-label={primaryAriaLabel || undefined}
           ref={parent}
         >
           <div
@@ -73,7 +73,7 @@ const DoubleRow = <L,>({
               "p-double-row__primary-row-text u-truncate",
               primaryTextClassName
             )}
-            title={primaryTitle}
+            title={primaryTitle || undefined}
           >
             {primary}
           </div>
@@ -94,8 +94,8 @@ const DoubleRow = <L,>({
               "u-truncate",
               secondaryClassName
             )}
-            aria-label={secondaryAriaLabel}
-            title={secondaryTitle}
+            aria-label={secondaryAriaLabel || undefined}
+            title={secondaryTitle || undefined}
           >
             {secondary}
           </div>

--- a/ui/src/app/base/components/TableMenu/TableMenu.tsx
+++ b/ui/src/app/base/components/TableMenu/TableMenu.tsx
@@ -4,13 +4,13 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 
 export type Props<L = null> = {
-  className?: ContextualMenuProps<L>["className"];
-  disabled?: ContextualMenuProps<L>["toggleDisabled"];
-  links?: ContextualMenuProps<L>["links"];
-  onToggleMenu?: ContextualMenuProps<L>["onToggleMenu"];
+  className?: ContextualMenuProps<L>["className"] | null;
+  disabled?: ContextualMenuProps<L>["toggleDisabled"] | null;
+  links?: ContextualMenuProps<L>["links"] | null;
+  onToggleMenu?: ContextualMenuProps<L>["onToggleMenu"] | null;
   position?: ContextualMenuProps<L>["position"];
   positionNode?: ContextualMenuProps<L>["positionNode"] | null;
-  title?: string;
+  title?: string | null;
 };
 
 const TableMenu = <L extends null>({
@@ -32,14 +32,14 @@ const TableMenu = <L extends null>({
         ...(title ? [title] : []),
         ...(Array.isArray(links) ? links : [links]),
       ]}
-      onToggleMenu={onToggleMenu}
+      onToggleMenu={onToggleMenu || undefined}
       position={position}
       // This shouldn't need to pass `undefined` once ContextualMenu supports null
       // See: https://github.com/canonical-web-and-design/react-components/issues/377
       positionNode={positionNode || undefined}
       toggleAppearance="base"
       toggleClassName="u-no-margin--bottom p-table-menu__toggle"
-      toggleDisabled={disabled}
+      toggleDisabled={disabled || false}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
@@ -9,11 +9,13 @@ import NetworkTable from "./NetworkTable";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
+import type { NetworkInterface } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 const MachineNetwork = (): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
+  const [selected, setSelected] = useState<NetworkInterface["id"][]>([]);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
@@ -24,7 +26,9 @@ const MachineNetwork = (): JSX.Element => {
     return <Spinner text="Loading..." />;
   }
 
-  return <NetworkTable systemId={id} />;
+  return (
+    <NetworkTable systemId={id} selected={selected} setSelected={setSelected} />
+  );
 };
 
 export default MachineNetwork;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -6,6 +6,7 @@ import NetworkTable from "./NetworkTable";
 
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { NodeStatus } from "app/store/types/node";
 import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
@@ -51,7 +52,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -61,7 +62,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
@@ -82,7 +83,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("[data-test='speed'] Icon").prop("name")).toBe(
@@ -107,7 +108,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("[data-test='speed'] Icon").prop("name")).toBe(
@@ -130,7 +131,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='speed']").exists()).toBe(true);
@@ -155,7 +156,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='type']").exists()).toBe(true);
@@ -178,7 +179,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='type']").exists()).toBe(true);
@@ -205,7 +206,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     const links = wrapper.find("DoubleRow[data-test='fabric'] LegacyLink");
@@ -219,7 +220,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='dhcp']").exists()).toBe(false);
@@ -249,7 +250,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='dhcp']").prop("primary")).toBe(
@@ -280,7 +281,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='dhcp'] Icon").exists()).toBe(
@@ -303,7 +304,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("Icon[name='success']").exists()).toBe(true);
@@ -335,7 +336,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
@@ -374,7 +375,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("SubnetColumn LegacyLink").at(0).text()).toBe(
@@ -419,7 +420,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     const alias = wrapper.findWhere(
@@ -449,7 +450,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     let row = wrapper.findWhere(
@@ -493,7 +494,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
       </Provider>
     );
     let row = wrapper.findWhere(
@@ -520,7 +521,28 @@ describe("NetworkTable", () => {
     expect(row.prop("className").includes("is-active")).toBe(true);
   });
 
-  describe("member interfaces", () => {
+  it("disables the checkboxes when networking is disabled", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            type: NetworkInterfaceTypes.PHYSICAL,
+          }),
+        ],
+        status: NodeStatus.COMMISSIONING,
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("RowCheckbox").last().prop("disabled")).toBe(true);
+  });
+
+  describe("bond and bridge interfaces", () => {
     beforeEach(() => {
       state.machine.items = [
         machineDetailsFactory({
@@ -543,21 +565,44 @@ describe("NetworkTable", () => {
       ];
     });
 
-    it("does not display a boot icon for member interfaces", () => {
+    it("does not display a checkbox for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      // There should be one checkbox for the child interface.
+      expect(wrapper.find("RowCheckbox").length).toBe(1);
+    });
+
+    it("does not display a boot icon for parent interfaces", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       expect(wrapper.find("Icon[name='success']").length).toBe(1);
     });
 
-    it("displays the full type for member interfaces", () => {
+    it("displays the full type for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       expect(
@@ -565,51 +610,71 @@ describe("NetworkTable", () => {
       ).toBe("Bonded physical");
     });
 
-    it("does not display a fabric column for member interfaces", () => {
+    it("does not display a fabric column for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       expect(wrapper.find("DoubleRow[data-test='fabric']").length).toBe(1);
     });
 
-    it("does not display a DHCP column for member interfaces", () => {
+    it("does not display a DHCP column for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       expect(wrapper.find("DoubleRow[data-test='dhcp']").length).toBe(1);
     });
 
-    it("does not display a subnet column for member interfaces", () => {
+    it("does not display a subnet column for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       expect(wrapper.find("SubnetColumn").length).toBe(1);
     });
 
-    it("does not display an IP column for member interfaces", () => {
+    it("does not display an IP column for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       expect(wrapper.find("IPColumn").length).toBe(1);
     });
 
-    it("does not display an actions menu for member interfaces", () => {
+    it("does not display an actions menu for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       expect(wrapper.find("NetworkTableActions").length).toBe(1);
@@ -668,12 +733,16 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       const names = wrapper
         .find("[data-test='name']")
-        .map((name) => name.prop("primary"));
+        .map((name) => name.text());
       expect(names).toStrictEqual([
         // Bond group:
         "bond0",
@@ -693,13 +762,17 @@ describe("NetworkTable", () => {
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
-          <NetworkTable systemId="abc123" />
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
         </Provider>
       );
       wrapper.find("TableHeader").first().find("button").simulate("click");
       const names = wrapper
         .find("[data-test='name']")
-        .map((name) => name.prop("primary"));
+        .map((name) => name.text());
       expect(names).toStrictEqual([
         // Physical:
         "eth2",

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -580,6 +580,20 @@ describe("NetworkTable", () => {
       expect(wrapper.find("RowCheckbox").length).toBe(1);
     });
 
+    it("does not include parent interfaces in the GroupCheckbox", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTable
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      expect(wrapper.find("GroupCheckbox").prop("items")).toStrictEqual([100]);
+    });
+
     it("does not display a boot icon for parent interfaces", () => {
       const store = mockStore(state);
       const wrapper = mount(

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -523,6 +523,15 @@ const NetworkTable = ({
     vlansLoaded
   );
   const sortedRows = sortRows(rows);
+  const nicIds = machine.interfaces.reduce<NetworkInterface["id"][]>(
+    (nics = [], nic) => {
+      if (!isBondOrBridgeParent(machine, nic)) {
+        nics.push(nic.id);
+      }
+      return nics;
+    },
+    []
+  );
   return (
     <MainTable
       className="p-table-expanding--light"
@@ -534,7 +543,8 @@ const NetworkTable = ({
           content: (
             <>
               <GroupCheckbox
-                items={machine.interfaces.map(({ id }) => id)}
+                disabled={isAllNetworkingDisabled}
+                items={nicIds}
                 selectedItems={selected}
                 handleGroupCheckbox={handleGroupCheckbox}
               />

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -11,7 +11,9 @@ import SubnetColumn from "./SubnetColumn";
 import type { Expanded, SetExpanded } from "./types";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import GroupCheckbox from "app/base/components/GroupCheckbox";
 import LegacyLink from "app/base/components/LegacyLink";
+import RowCheckbox from "app/base/components/RowCheckbox";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
 import type { Sort } from "app/base/hooks";
@@ -49,7 +51,8 @@ import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import type { VLAN } from "app/store/vlan/types";
 import { getDHCPStatus, getVLANDisplay } from "app/store/vlan/utils";
-import { formatSpeedUnits } from "app/utils";
+import { formatSpeedUnits, generateCheckboxHandlers } from "app/utils";
+import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
 type NetworkRowSortData = {
   bondOrBridge: NetworkInterface["id"] | null;
@@ -85,10 +88,14 @@ const generateRow = (
   expanded: Expanded | null,
   fabrics: Fabric[],
   fabricsLoaded: boolean,
+  handleRowCheckbox: CheckboxHandlers<
+    NetworkInterface["id"]
+  >["handleRowCheckbox"],
   isAllNetworkingDisabled: boolean,
   link: NetworkLink | null,
   machine: Machine,
   nic: NetworkInterface | null,
+  selected: Props["selected"],
   setExpanded: SetExpanded,
   subnets: Subnet[],
   vlans: VLAN[],
@@ -125,15 +132,29 @@ const generateRow = (
     !!expanded &&
     ((link && expanded.linkId === link.id) ||
       (!link && expanded.nicId === nic?.id));
+  const showCheckbox = !isABondOrBridgeParent;
   return {
     className: isExpanded ? "p-table__row is-active" : null,
     columns: [
       {
         content: (
           <DoubleRow
-            data-test="name"
-            primary={name}
+            primary={
+              showCheckbox ? (
+                <RowCheckbox
+                  disabled={isAllNetworkingDisabled}
+                  handleRowCheckbox={handleRowCheckbox}
+                  item={nic.id}
+                  items={selected}
+                  inputLabel={<span data-test="name">{name}</span>}
+                />
+              ) : (
+                <span data-test="name">{name}</span>
+              )
+            }
             secondary={nic.mac_address}
+            primaryClassName={showCheckbox ? null : "u-nudge--primary-row"}
+            secondaryClassName="u-nudge--secondary-row"
           />
         ),
       },
@@ -314,8 +335,12 @@ const generateRows = (
   expanded: Expanded | null,
   fabrics: Fabric[],
   fabricsLoaded: boolean,
+  handleRowCheckbox: CheckboxHandlers<
+    NetworkInterface["id"]
+  >["handleRowCheckbox"],
   isAllNetworkingDisabled: boolean,
   machine: Machine,
+  selected: Props["selected"],
   setExpanded: (expanded: Expanded | null) => void,
   subnets: Subnet[],
   vlans: VLAN[],
@@ -327,38 +352,33 @@ const generateRows = (
   const rows: NetworkRow[] = [];
   // Create a list of interfaces and aliases to use to generate the table rows.
   machine.interfaces.forEach((nic: NetworkInterface) => {
-    if (nic.links.length === 0) {
-      const row = generateRow(
+    const createRow = (
+      link: NetworkLink | null,
+      nic: NetworkInterface | null
+    ) =>
+      generateRow(
         expanded,
         fabrics,
         fabricsLoaded,
+        handleRowCheckbox,
         isAllNetworkingDisabled,
-        null,
+        link,
         machine,
         nic,
+        selected,
         setExpanded,
         subnets,
         vlans,
         vlansLoaded
       );
+    if (nic.links.length === 0) {
+      const row = createRow(null, nic);
       if (row) {
         rows.push(row);
       }
     } else {
       nic.links.forEach((link: NetworkLink) => {
-        const row = generateRow(
-          expanded,
-          fabrics,
-          fabricsLoaded,
-          isAllNetworkingDisabled,
-          link,
-          machine,
-          null,
-          setExpanded,
-          subnets,
-          vlans,
-          vlansLoaded
-        );
+        const row = createRow(link, null);
         if (row) {
           rows.push(row);
         }
@@ -442,9 +462,17 @@ const rowSort = (
   return 0;
 };
 
-type Props = { systemId: Machine["system_id"] };
+type Props = {
+  selected: NetworkInterface["id"][];
+  setSelected: (selected: NetworkInterface["id"][]) => void;
+  systemId: Machine["system_id"];
+};
 
-const NetworkTable = ({ systemId }: Props): JSX.Element => {
+const NetworkTable = ({
+  selected,
+  setSelected,
+  systemId,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [expanded, setExpanded] = useState<Expanded | null>(null);
   const machine = useSelector((state: RootState) =>
@@ -467,6 +495,9 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
     },
     rowSort
   );
+  const { handleGroupCheckbox, handleRowCheckbox } = generateCheckboxHandlers<
+    NetworkInterface["id"]
+  >(setSelected);
 
   useEffect(() => {
     dispatch(fabricActions.fetch());
@@ -482,8 +513,10 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
     expanded,
     fabrics,
     fabricsLoaded,
+    handleRowCheckbox,
     isAllNetworkingDisabled,
     machine,
+    selected,
     setExpanded,
     subnets,
     vlans,
@@ -500,6 +533,11 @@ const NetworkTable = ({ systemId }: Props): JSX.Element => {
         {
           content: (
             <>
+              <GroupCheckbox
+                items={machine.interfaces.map(({ id }) => id)}
+                selectedItems={selected}
+                handleGroupCheckbox={handleGroupCheckbox}
+              />
               <TableHeader
                 currentSort={currentSort}
                 onClick={() => updateSort("name")}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/__snapshots__/OwnerColumn.test.js.snap
@@ -123,7 +123,6 @@ exports[`OwnerColumn renders 1`] = `
         </div>
         <div
           className="p-double-row__secondary-row u-truncate"
-          title=""
         >
           <span
             data-test="tags"

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -111,6 +111,10 @@
     padding-left: $checkbox-offset;
   }
 
+  .u-nudge--primary-row {
+    padding-left: $box-size + $sph-inner + $checkbox-offset;
+  }
+
   .u-nudge--secondary-row {
     padding-left: $box-size + $sph-inner + $checkbox-offset;
   }


### PR DESCRIPTION
## Done

- Add checkboxes to the network table in machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the network tab in machine details for a new or ready machine.
- Check that there are checkboxes and that they work as expected.
- Visit a deployed machine and check that the checkboxes are disabled.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2284.