### PR TITLE
fix(ui): show form fields for mounting non-boot physical disks

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPhysicalDisk/EditPhysicalDisk.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPhysicalDisk/EditPhysicalDisk.test.tsx
@@ -17,6 +17,35 @@ import {
 const mockStore = configureStore();
 
 describe("EditPhysicalDisk", () => {
+  it("shows filesystem fields if the disk is not the boot disk", () => {
+    const disk = diskFactory({ is_boot: false, type: DiskTypes.PHYSICAL });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <EditPhysicalDisk
+          closeExpanded={jest.fn()}
+          disk={disk}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find("FilesystemFields").exists()).toBe(true);
+  });
+
   it("correctly dispatches an action to edit a disk", () => {
     const disk = diskFactory({ type: DiskTypes.PHYSICAL });
     const state = rootStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPhysicalDisk/EditPhysicalDiskFields/EditPhysicalDiskFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPhysicalDisk/EditPhysicalDiskFields/EditPhysicalDiskFields.tsx
@@ -1,18 +1,23 @@
 import { Col, Input, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
+import FilesystemFields from "../../FilesystemFields";
 import type { EditPhysicalDiskValues } from "../EditPhysicalDisk";
 
 import FormikField from "app/base/components/FormikField";
 import TagSelector from "app/base/components/TagSelector";
-import type { Disk } from "app/store/machine/types";
+import type { Disk, Machine } from "app/store/machine/types";
 import { formatSize, formatType } from "app/store/machine/utils";
 
 type Props = {
   disk: Disk;
+  systemId: Machine["system_id"];
 };
 
-export const EditPhysicalDiskFields = ({ disk }: Props): JSX.Element => {
+export const EditPhysicalDiskFields = ({
+  disk,
+  systemId,
+}: Props): JSX.Element => {
   const {
     initialValues,
     setFieldValue,
@@ -32,6 +37,7 @@ export const EditPhysicalDiskFields = ({ disk }: Props): JSX.Element => {
         />
       </Col>
       <Col emptyLarge="7" size="5">
+        {disk.is_boot === false && <FilesystemFields systemId={systemId} />}
         <FormikField
           allowNewTags
           component={TagSelector}


### PR DESCRIPTION
## Done

- Added FilesystemFields to the EditPhysicalDisk form for non-boot disks

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine with at least 2 disks, and is in Ready or Allocated state. (If you set the MAAS to karura you can find one at http://0.0.0.0:8400/MAAS/r/machine/8qcbef/storage).
- Open the "Edit physical disk" form for the boot disk and check that there are no form fields for mounting the disk
- Open the "Edit physical disk" form for the non-boot disk and check that the form fields exist

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2324

