### PR TITLE
feat(ui): add disabled prop to GroupCheckbox

### DIFF
--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
@@ -37,4 +37,17 @@ describe("GroupCheckbox", () => {
     );
     expect(wrapper.prop("label")).toBe("Check all");
   });
+
+  it("can be disabled even if items exist", () => {
+    const wrapper = shallow(
+      <GroupCheckbox
+        disabled
+        items={[1, 2, 3]}
+        inputLabel="Check all"
+        selectedItems={[2]}
+        handleGroupCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper.prop("disabled")).toBe(true);
+  });
 });

--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import { someInArray, someNotAll } from "app/utils";
 
 type Props<R, S> = {
+  disabled?: boolean;
   handleGroupCheckbox: (rows: R[], selected: S[]) => void;
   inRow?: boolean;
   items: R[];
@@ -18,6 +19,7 @@ type Props<R, S> = {
 } & HTMLProps<HTMLInputElement>;
 
 const GroupCheckbox = <R, S>({
+  disabled,
   handleGroupCheckbox,
   inRow,
   items,
@@ -32,7 +34,7 @@ const GroupCheckbox = <R, S>({
       className={classNames("has-inline-label", {
         "p-checkbox--mixed": someNotAll(items, selectedItems),
       })}
-      disabled={items.length === 0}
+      disabled={items.length === 0 || disabled}
       id={id.current}
       label={inputLabel ? inputLabel : " "}
       onChange={() => handleGroupCheckbox(items, selectedItems)}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -113,7 +113,7 @@ describe("AvailableStorageTable", () => {
     expect(wrapper.find("TableCell Input").prop("checked")).toBe(true);
   });
 
-  it("can select all disks", () => {
+  it("can select all storage devices", () => {
     const disks = [
       diskFactory({
         available_size: MIN_PARTITION_SIZE + 1,
@@ -143,8 +143,8 @@ describe("AvailableStorageTable", () => {
       </Provider>
     );
 
-    wrapper.find("input[data-test='all-disks-checkbox']").simulate("change", {
-      target: { name: "all-disks-checkbox" },
+    wrapper.find("input[data-test='all-storage-checkbox']").simulate("change", {
+      target: { name: "all-storage-checkbox" },
     });
 
     expect(
@@ -154,12 +154,16 @@ describe("AvailableStorageTable", () => {
     ).toBe(true);
   });
 
-  it("disables action dropdown if storage cannot be edited", () => {
+  it("disables action dropdown and checkboxes if storage cannot be edited", () => {
+    const disk = diskFactory({
+      available_size: MIN_PARTITION_SIZE + 1,
+      type: DiskTypes.PHYSICAL,
+    });
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [
           machineDetailsFactory({
-            disks: [diskFactory({ available_size: MIN_PARTITION_SIZE + 1 })],
+            disks: [disk],
             system_id: "abc123",
           }),
         ],
@@ -173,6 +177,14 @@ describe("AvailableStorageTable", () => {
     );
 
     expect(wrapper.find("TableMenu").at(0).prop("disabled")).toBe(true);
+    expect(
+      wrapper
+        .find(`Input[data-test='checkbox-${disk.type}-${disk.id}']`)
+        .prop("disabled")
+    ).toBe(true);
+    expect(
+      wrapper.find("Input[data-test='all-storage-checkbox']").prop("disabled")
+    ).toBe(true);
   });
 
   it("can open the add partition form if disk can be partitioned", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -667,10 +667,11 @@ const AvailableStorageTable = ({
               content: (
                 <div className="u-flex">
                   <GroupCheckbox
+                    data-test="all-storage-checkbox"
+                    disabled={actionsDisabled}
+                    handleGroupCheckbox={handleAllCheckbox}
                     items={rows.map(({ key }) => key)}
                     selectedItems={selected.map((item) => uniqueId(item))}
-                    handleGroupCheckbox={handleAllCheckbox}
-                    data-test="all-disks-checkbox"
                   />
                   <div>
                     <div>Name</div>


### PR DESCRIPTION
## Done

- Added `disabled` prop to GroupCheckbox so you can disable it in more ways than just there being no items in the group

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine that is neither Ready nor Allocated, i.e. it's storage can't be edited
- Check that the checkbox in the available storage table header is disabled
