### PR TITLE
feat(ui): add mark as connected/disconnected menu items

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.test.tsx
@@ -38,7 +38,7 @@ describe("ActionConfirm", () => {
           closeExpanded={jest.fn()}
           confirmLabel="Confirm"
           eventName="deleteFilesystem"
-          message="Are you sure you want to do that?"
+          message={<span>Are you sure you want to do that?</span>}
           onConfirm={jest.fn()}
           onSaveAnalytics={{
             action: "Action",

--- a/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import {
   ActionButton,
   Button,
@@ -15,7 +17,7 @@ import { formatErrors } from "app/utils";
 type Props = {
   confirmLabel: string;
   eventName?: string;
-  message?: string;
+  message?: ReactNode;
   closeExpanded: () => void;
   onConfirm: () => void;
   onSaveAnalytics: AnalyticsEvent;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -67,6 +67,62 @@ describe("NetworkTableActions", () => {
     expect(wrapper.find("TableMenu").prop("disabled")).toBe(true);
   });
 
+  it("can display an item to mark an interface as connected", () => {
+    nic.type = NetworkInterfaceTypes.PHYSICAL;
+    nic.link_connected = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.update();
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.type() === "button" &&
+            n.hasClass("p-contextual-menu__link") &&
+            n.text() === "Mark as connected"
+        )
+        .exists()
+    ).toBe(true);
+  });
+
+  it("can display an item to mark an interface as disconnected", () => {
+    nic.type = NetworkInterfaceTypes.PHYSICAL;
+    nic.link_connected = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.update();
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.type() === "button" &&
+            n.hasClass("p-contextual-menu__link") &&
+            n.text() === "Mark as disconnected"
+        )
+        .exists()
+    ).toBe(true);
+  });
+
   it("can display an item to remove the interface", () => {
     nic.type = NetworkInterfaceTypes.BOND;
     const store = mockStore(state);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
@@ -56,146 +56,262 @@ describe("NetworkTableConfirmation", () => {
     expect(wrapper.find("ActionConfirm").exists()).toBe(false);
   });
 
-  it("can display a delete confirmation for an interface", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableConfirmation
-          expanded={{
-            content: ExpandedState.REMOVE,
-          }}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
-    );
-    const confirmation = wrapper.find("ActionConfirm");
-    expect(confirmation.prop("eventName")).toBe("deleteInterface");
-    expect(confirmation.prop("message")).toBe(
-      "Are you sure you want to remove this interface?"
-    );
-    expect(confirmation.prop("statusKey")).toBe("deletingInterface");
-  });
+  describe("delete confirmation", () => {
+    it("can display a delete confirmation for an interface", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.REMOVE,
+            }}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      const confirmation = wrapper.find("ActionConfirm");
+      expect(confirmation.prop("eventName")).toBe("deleteInterface");
+      expect(confirmation.prop("message")).toBe(
+        "Are you sure you want to remove this interface?"
+      );
+      expect(confirmation.prop("statusKey")).toBe("deletingInterface");
+    });
 
-  it("can confirm deleting an interface", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableConfirmation
-          expanded={{
-            content: ExpandedState.REMOVE,
-          }}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
-    );
-    wrapper.find("ActionConfirm ActionButton").simulate("click");
-    expect(
-      store
-        .getActions()
-        .find((action) => action.type === "machine/deleteInterface")
-    ).toStrictEqual({
-      type: "machine/deleteInterface",
-      meta: {
-        method: "delete_interface",
-        model: "machine",
-      },
-      payload: {
-        params: {
-          interface_id: nic.id,
-          system_id: "abc123",
+    it("can confirm deleting an interface", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.REMOVE,
+            }}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      wrapper.find("ActionConfirm ActionButton").simulate("click");
+      expect(
+        store
+          .getActions()
+          .find((action) => action.type === "machine/deleteInterface")
+      ).toStrictEqual({
+        type: "machine/deleteInterface",
+        meta: {
+          method: "delete_interface",
+          model: "machine",
         },
-      },
+        payload: {
+          params: {
+            interface_id: nic.id,
+            system_id: "abc123",
+          },
+        },
+      });
+    });
+
+    it("can display a delete confirmation for an alias", () => {
+      const link = networkLinkFactory();
+      state.machine.items = [
+        machineDetailsFactory({
+          interfaces: [
+            machineInterfaceFactory({
+              discovered: null,
+              links: [networkLinkFactory(), link],
+              name: "alias",
+              type: NetworkInterfaceTypes.PHYSICAL,
+            }),
+          ],
+          system_id: "abc123",
+        }),
+      ];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.REMOVE,
+            }}
+            link={link}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      const confirmation = wrapper.find("ActionConfirm");
+      expect(confirmation.prop("eventName")).toBe("unlinkSubnet");
+      expect(confirmation.prop("message")).toBe(
+        "Are you sure you want to remove this alias?"
+      );
+      expect(confirmation.prop("statusKey")).toBe("unlinkingSubnet");
+    });
+
+    it("can confirm deleting an alias", () => {
+      const link = networkLinkFactory();
+      state.machine.items = [
+        machineDetailsFactory({
+          interfaces: [
+            machineInterfaceFactory({
+              discovered: null,
+              links: [networkLinkFactory(), link],
+              name: "alias",
+              type: NetworkInterfaceTypes.PHYSICAL,
+            }),
+          ],
+          system_id: "abc123",
+        }),
+      ];
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.REMOVE,
+            }}
+            link={link}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      wrapper.find("ActionConfirm ActionButton").simulate("click");
+      expect(
+        store
+          .getActions()
+          .find((action) => action.type === "machine/unlinkSubnet")
+      ).toStrictEqual({
+        type: "machine/unlinkSubnet",
+        meta: {
+          method: "unlink_subnet",
+          model: "machine",
+        },
+        payload: {
+          params: {
+            interface_id: nic.id,
+            link_id: link.id,
+            system_id: "abc123",
+          },
+        },
+      });
     });
   });
 
-  it("can display a delete confirmation for an alias", () => {
-    const link = networkLinkFactory();
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [
-          machineInterfaceFactory({
-            discovered: null,
-            links: [networkLinkFactory(), link],
-            name: "alias",
-            type: NetworkInterfaceTypes.PHYSICAL,
-          }),
-        ],
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableConfirmation
-          expanded={{
-            content: ExpandedState.REMOVE,
-          }}
-          link={link}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
-    );
-    const confirmation = wrapper.find("ActionConfirm");
-    expect(confirmation.prop("eventName")).toBe("unlinkSubnet");
-    expect(confirmation.prop("message")).toBe(
-      "Are you sure you want to remove this alias?"
-    );
-    expect(confirmation.prop("statusKey")).toBe("unlinkingSubnet");
-  });
+  describe("connect/disconnect confirmations", () => {
+    it("can display a mark connected confirmation", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.MARK_CONNECTED,
+            }}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      const confirmation = wrapper.find("ActionConfirm");
+      expect(confirmation.prop("eventName")).toBe("updateInterface");
+      expect(confirmation.prop("confirmLabel")).toBe("Mark as connected");
+      expect(confirmation.prop("statusKey")).toBe("updatingInterface");
+      expect(confirmation.prop("submitAppearance")).toBe("positive");
+    });
 
-  it("can confirm deleting an alias", () => {
-    const link = networkLinkFactory();
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [
-          machineInterfaceFactory({
-            discovered: null,
-            links: [networkLinkFactory(), link],
-            name: "alias",
-            type: NetworkInterfaceTypes.PHYSICAL,
-          }),
-        ],
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableConfirmation
-          expanded={{
-            content: ExpandedState.REMOVE,
-          }}
-          link={link}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
-    );
-    wrapper.find("ActionConfirm ActionButton").simulate("click");
-    expect(
-      store
-        .getActions()
-        .find((action) => action.type === "machine/unlinkSubnet")
-    ).toStrictEqual({
-      type: "machine/unlinkSubnet",
-      meta: {
-        method: "unlink_subnet",
-        model: "machine",
-      },
-      payload: {
-        params: {
-          interface_id: nic.id,
-          link_id: link.id,
-          system_id: "abc123",
+    it("can display a mark disconnected confirmation", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.MARK_DISCONNECTED,
+            }}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      const confirmation = wrapper.find("ActionConfirm");
+      expect(confirmation.prop("eventName")).toBe("updateInterface");
+      expect(confirmation.prop("confirmLabel")).toBe("Mark as disconnected");
+      expect(confirmation.prop("statusKey")).toBe("updatingInterface");
+      expect(confirmation.prop("submitAppearance")).toBe("negative");
+    });
+
+    it("can confirm marking connected", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.MARK_CONNECTED,
+            }}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      wrapper.find("ActionConfirm ActionButton").simulate("click");
+      expect(
+        store
+          .getActions()
+          .find((action) => action.type === "machine/updateInterface")
+      ).toStrictEqual({
+        type: "machine/updateInterface",
+        meta: {
+          method: "update_interface",
+          model: "machine",
         },
-      },
+        payload: {
+          params: {
+            interface_id: nic.id,
+            link_connected: true,
+            system_id: "abc123",
+          },
+        },
+      });
+    });
+
+    it("can confirm marking disconnected", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.MARK_DISCONNECTED,
+            }}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      wrapper.find("ActionConfirm ActionButton").simulate("click");
+      expect(
+        store
+          .getActions()
+          .find((action) => action.type === "machine/updateInterface")
+      ).toStrictEqual({
+        type: "machine/updateInterface",
+        meta: {
+          method: "update_interface",
+          model: "machine",
+        },
+        payload: {
+          params: {
+            interface_id: nic.id,
+            link_connected: false,
+            system_id: "abc123",
+          },
+        },
+      });
     });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
@@ -83,6 +83,49 @@ const NetworkTableConfirmation = ({
         systemId={machine.system_id}
       />
     );
+  } else if (
+    expanded?.content === ExpandedState.MARK_CONNECTED ||
+    expanded?.content === ExpandedState.MARK_DISCONNECTED
+  ) {
+    const markConnected = expanded?.content === ExpandedState.MARK_CONNECTED;
+    const event = markConnected ? "connected" : "disconnected";
+    content = (
+      <ActionConfirm
+        closeExpanded={() => setExpanded(null)}
+        confirmLabel={`Mark as ${event}`}
+        eventName="updateInterface"
+        message={
+          <>
+            This interface was detected as{" "}
+            <strong>{nic.link_connected ? "connected" : "disconnected"}</strong>
+            . Are you sure you want to mark it as {event}?
+            {markConnected ? null : (
+              <>
+                <br />
+                When the interface is disconnected, it cannot be configured.
+              </>
+            )}
+          </>
+        }
+        onConfirm={() => {
+          dispatch(
+            machineActions.updateInterface({
+              interfaceId: nic?.id,
+              linkConnected: !!markConnected,
+              systemId: machine.system_id,
+            })
+          );
+        }}
+        onSaveAnalytics={{
+          action: `Mark interface as ${event}`,
+          category: "Machine network",
+          label: "Update",
+        }}
+        statusKey="updatingInterface"
+        submitAppearance={markConnected ? "positive" : "negative"}
+        systemId={machine.system_id}
+      />
+    );
   }
   return <div className="u-flex--grow">{content}</div>;
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
@@ -2,6 +2,8 @@ import type { NetworkInterface, NetworkLink } from "app/store/machine/types";
 
 export enum ExpandedState {
   REMOVE = "remove",
+  MARK_DISCONNECTED = "markDisconnected",
+  MARK_CONNECTED = "markConnected",
 }
 
 export type Expanded = {

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -979,6 +979,45 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle updating an interface", () => {
+    expect(
+      actions.updateInterface({
+        interfaceId: 1,
+        enabled: true,
+        interfaceSpeed: 10,
+        linkConnected: true,
+        linkSpeed: 100,
+        macAddress: "2a:67:d7:a7:0f:f9",
+        name: "ech0",
+        numaNode: 1,
+        tags: ["tag"],
+        vlan: 9,
+        systemId: "abc123",
+      })
+    ).toEqual({
+      type: "machine/updateInterface",
+      meta: {
+        model: "machine",
+        method: "update_interface",
+      },
+      payload: {
+        params: {
+          interface_id: 1,
+          enabled: true,
+          interface_speed: 10,
+          link_connected: true,
+          link_speed: 100,
+          mac_address: "2a:67:d7:a7:0f:f9",
+          name: "ech0",
+          numa_node: 1,
+          tags: ["tag"],
+          vlan: 9,
+          system_id: "abc123",
+        },
+      },
+    });
+  });
+
   it("can handle updating a VMFS datastore", () => {
     expect(
       actions.updateVmfsDatastore({

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -190,6 +190,10 @@ export const ACTIONS = [
     status: "updatingFilesystem",
   },
   {
+    name: "update-interface",
+    status: "updatingInterface",
+  },
+  {
     name: "update-vmfs-datastore",
     status: "updatingVmfsDatastore",
   },
@@ -236,6 +240,7 @@ const DEFAULT_STATUSES = {
   unmountingSpecial: false,
   updatingDisk: false,
   updatingFilesystem: false,
+  updatingInterface: false,
   updatingVmfsDatastore: false,
 };
 
@@ -290,6 +295,7 @@ type MachineReducers = SliceCaseReducers<MachineState> & {
   unmountSpecial: WithPrepare;
   updateDisk: WithPrepare;
   updateFilesystem: WithPrepare;
+  updateInterface: WithPrepare;
   updateVmfsDatastore: WithPrepare;
 };
 
@@ -748,6 +754,38 @@ const statusHandlers = generateStatusHandlers<
           ...("tags" in params && { tags: params.tags }),
         });
         break;
+      case "update-interface":
+        handler.method = "update_interface";
+        handler.prepare = (params: {
+          enabled?: NetworkInterface["enabled"];
+          interfaceId: NetworkInterface["id"];
+          interfaceSpeed?: NetworkInterface["interface_speed"];
+          linkConnected?: NetworkInterface["link_connected"];
+          linkSpeed?: NetworkInterface["link_speed"];
+          macAddress?: NetworkInterface["mac_address"];
+          name?: NetworkInterface["name"];
+          numaNode?: NetworkInterface["numa_node"];
+          systemId: Machine["system_id"];
+          tags?: NetworkInterface["tags"];
+          vlan?: NetworkInterface["vlan_id"];
+        }) => ({
+          interface_id: params.interfaceId,
+          system_id: params.systemId,
+          ...("enabled" in params && { enabled: params.enabled }),
+          ...("interfaceSpeed" in params && {
+            interface_speed: params.interfaceSpeed,
+          }),
+          ...("linkConnected" in params && {
+            link_connected: params.linkConnected,
+          }),
+          ...("linkSpeed" in params && { link_speed: params.linkSpeed }),
+          ...("macAddress" in params && { mac_address: params.macAddress }),
+          ...("name" in params && { name: params.name }),
+          ...("numaNode" in params && { numa_node: params.numaNode }),
+          ...("tags" in params && { tags: params.tags }),
+          ...("vlan" in params && { vlan: params.vlan }),
+        });
+        break;
       case "update-vmfs-datastore":
         handler.method = "update_vmfs_datastore";
         handler.prepare = (params: {
@@ -952,6 +990,10 @@ const machineSlice = generateSlice<
     updateFilesystemStart: statusHandlers.updateFilesystemStart,
     updateFilesystemSuccess: statusHandlers.updateFilesystemSuccess,
     updateFilesystemError: statusHandlers.updateFilesystemError,
+    updateInterface: statusHandlers.updateInterface,
+    updateInterfaceStart: statusHandlers.updateInterfaceStart,
+    updateInterfaceSuccess: statusHandlers.updateInterfaceSuccess,
+    updateInterfaceError: statusHandlers.updateInterfaceError,
     updateVmfsDatastore: statusHandlers.updateVmfsDatastore,
     updateVmfsDatastoreStart: statusHandlers.updateVmfsDatastoreStart,
     updateVmfsDatastoreSuccess: statusHandlers.updateVmfsDatastoreSuccess,

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -406,6 +406,7 @@ export type MachineStatus = {
   unmountingSpecial: boolean;
   updatingDisk: boolean;
   updatingFilesystem: boolean;
+  updatingInterface: boolean;
   updatingVmfsDatastore: boolean;
 };
 

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -146,6 +146,7 @@ export const machineStatus = define<MachineStatus>({
   unmountingSpecial: false,
   updatingDisk: false,
   updatingFilesystem: false,
+  updatingInterface: false,
   updatingVmfsDatastore: false,
 });
 


### PR DESCRIPTION
## Done

- Add the ability to mark an interface as connected or disconnected.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View a machine that can have the network edited (eg a new machine).
- The menus for non-physical interfaces should not have the mark connected/disconnected options.
- On a physical interface use the menu to mark the interface as connected/disconnected.
- The interface should update with the new status.

## Fixes

Fixes: #2146.