### PR TITLE
feat(ui): add tests details view

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -218,8 +218,8 @@ exports[`stricter compilation`] = {
       [331, 6, 98, "Object is possibly \'undefined\'.", "1041189900"],
       [353, 6, 98, "Object is possibly \'undefined\'.", "1041189900"]
     ],
-    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:1343696512": [
-      [117, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, kvmHosts: (Controller | Machine)[], pools: ResourcePool[], osReleases: TSFixMe) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'kvmHosts\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Host[]\'.", "3312061634"]
+    "src/app/kvm/views/KVMList/KVMListTable/KVMListTable.tsx:3214710366": [
+      [113, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, kvmHosts: (Controller | Machine)[], pools: ResourcePool[], osReleases: TSFixMe) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'kvmHosts\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'Host[]\'.", "3312061634"]
     ],
     "src/app/kvm/views/KVMList/KVMListTable/OSColumn/OSColumn.tsx:2466040368": [
       [17, 32, 3, "Argument of type \'BasePod | PodDetails | null\' is not assignable to parameter of type \'Pod\'.\\n  Type \'null\' is not assignable to type \'Pod\'.", "193426238"]
@@ -413,8 +413,8 @@ exports[`stricter compilation`] = {
       [80, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
       [94, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"]
     ],
-    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:3965116768": [
-      [159, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:2526985709": [
+      [160, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:1209352711": [
       [106, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],
@@ -440,7 +440,7 @@ exports[`stricter compilation`] = {
       [70, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [71, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; power_pass: string; power_user: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "244873512"]
     ],
-    "src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx:612654686": [
+    "src/app/rsd/views/RSDList/RSDListTable/RSDListTable.tsx:1138227193": [
       [77, 4, 12, "Argument of type \'(sortKey: SortKey, rsd: Pod, pools: ResourcePool[]) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
     ],
     "src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx:3661263440": [
@@ -585,8 +585,8 @@ exports[`stricter compilation`] = {
     "src/app/utils/getCookie.ts:940992619": [
       [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
     ],
-    "src/app/utils/someInArray.ts:1012121545": [
-      [8, 4, 68, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "3447795550"]
+    "src/app/utils/someInArray.ts:1833644967": [
+      [11, 4, 68, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "3447795550"]
     ],
     "src/app/utils/someNotAll.ts:3892711037": [
       [7, 2, 71, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "1467649629"]

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -15,6 +15,7 @@ import type { SelectedAction } from "./MachineSummary";
 import MachineSummary from "./MachineSummary";
 import SummaryNotifications from "./MachineSummary/SummaryNotifications";
 import MachineTests from "./MachineTests";
+import MachineTestsDetails from "./MachineTests/MachineTestsDetails/MachineTestsDetails";
 import MachineUSBDevices from "./MachineUSBDevices";
 
 import Section from "app/base/components/Section";
@@ -88,6 +89,9 @@ const MachineDetails = (): JSX.Element => {
           </Route>
           <Route exact path="/machine/:id/tests">
             <MachineTests />
+          </Route>
+          <Route exact path="/machine/:id/tests/:scriptResultId/details">
+            <MachineTestsDetails />
           </Route>
           <Route exact path="/machine/:id">
             <Redirect to={`/machine/${id}/summary`} />

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
@@ -1,0 +1,76 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router";
+import configureStore from "redux-mock-store";
+
+import MachineTestsDetails from ".";
+
+import type { RootState } from "app/store/root/types";
+import {
+  machineState as machineStateFactory,
+  machineDetails as machineDetailsFactory,
+  rootState as rootStateFactory,
+  scriptResult as scriptResultFactory,
+  scriptResultState as scriptResultStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MachineTestDetails", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        loaded: true,
+        items: [
+          machineDetailsFactory({
+            locked: false,
+            permissions: ["edit"],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+      scriptresult: scriptResultStateFactory({
+        loaded: true,
+        items: [scriptResultFactory()],
+      }),
+    });
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineTestsDetails />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("displays script result details", () => {
+    const scriptResult = scriptResultFactory({ id: 1 });
+    const scriptResults = [scriptResult];
+    state.nodescriptresult.items = { abc123: [1] };
+    state.scriptresult.items = scriptResults;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/machine/abc123/tests/1/details"]}>
+          <Route path="/machine/:id/tests/:scriptResultId/details">
+            <MachineTestsDetails />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("span[data-test='status-name']").text()).toEqual(
+      scriptResult.status_name
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect } from "react";
+
+import { Col, Row } from "@canonical/react-components";
+import classNames from "classnames";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useParams } from "react-router-dom";
+
+import { scriptStatus } from "app/base/enum";
+import type { RouteParams } from "app/base/types";
+import type { RootState } from "app/store/root/types";
+import { actions as scriptResultActions } from "app/store/scriptresult";
+import scriptResultSelectors from "app/store/scriptresult/selectors";
+
+type DetailsRouteParams = RouteParams & { scriptResultId: string };
+
+const MachineTestsDetails = (): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const params = useParams<DetailsRouteParams>();
+  const { id, scriptResultId } = params;
+
+  const scriptResults = useSelector((state: RootState) =>
+    scriptResultSelectors.getByMachineId(state, id)
+  );
+
+  const loading = useSelector((state: RootState) =>
+    scriptResultSelectors.loading(state)
+  );
+
+  const result = scriptResults?.find(
+    (result) => result.id === parseInt(scriptResultId, 10)
+  );
+
+  useEffect(() => {
+    if (!scriptResults?.length && !loading) {
+      dispatch(scriptResultActions.getByMachineId(id));
+    }
+  }, [dispatch, scriptResults, loading, id]);
+
+  if (result) {
+    return (
+      <>
+        <Row className="u-sv2">
+          <Col size="8">
+            <h2 className="p-heading--four">{result.name} details</h2>
+          </Col>
+          <Col size="4">
+            <Link to={`/machine/${id}/tests`}>
+              &lsaquo; Back to test results
+            </Link>
+          </Col>
+        </Row>
+        <Row>
+          <Col size="6">
+            <Row>
+              <Col size="2">Status</Col>
+              <Col size="4">
+                <i
+                  className={classNames("is-inline", {
+                    "p-icon--success": result.status === scriptStatus.PASSED,
+                    "p-icon--error": result.status !== scriptStatus.PASSED,
+                  })}
+                />
+                <span data-test="status-name">{result.status_name}</span>
+              </Col>
+            </Row>
+            <Row>
+              <Col size="2">Exit status</Col>
+              <Col size="4">{result.exit_status}</Col>
+            </Row>
+            <Row>
+              <Col size="2">Tags</Col>
+              <Col size="4">{result.tags}</Col>
+            </Row>
+          </Col>
+          <Col size="6">
+            <Row>
+              <Col size="2">Start time</Col>
+              <Col size="4">{result.started}</Col>
+            </Row>
+            <Row>
+              <Col size="2">End time</Col>
+              <Col size="4">{result.ended}</Col>
+            </Row>
+            <Row>
+              <Col size="2">Runtime</Col>
+              <Col size="4">{result.runtime}</Col>
+            </Row>
+          </Col>
+        </Row>
+      </>
+    );
+  }
+  return null;
+};
+
+export default MachineTestsDetails;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/__snapshots__/MachineTestsDetails.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/__snapshots__/MachineTestsDetails.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MachineTestDetails renders 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <MemoryRouter
+    initialEntries={
+      Array [
+        Object {
+          "key": "testKey",
+          "pathname": "/machine/abc123",
+        },
+      ]
+    }
+  >
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/machine/abc123",
+              "search": "",
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": "testKey",
+            "pathname": "/machine/abc123",
+            "search": "",
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+    >
+      <MachineTestsDetails />
+    </Router>
+  </MemoryRouter>
+</Provider>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineTestsDetails";

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import { Input, MainTable } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import TableMenu from "app/base/components/TableMenu";
 import { scriptStatus } from "app/base/enum";
@@ -232,7 +233,20 @@ const MachineTestsTable = ({
           content: <span data-test="date">{result.updated}</span>,
         },
         {
-          content: <span data-test="status">{result.status_name}</span>,
+          content: (
+            <span data-test="status">
+              {result.status_name}{" "}
+              {result.status === scriptStatus.PASSED ||
+              result.status === scriptStatus.FAILED ||
+              result.status === scriptStatus.TIMEDOUT ||
+              result.status === scriptStatus.DEGRADED ||
+              result.status === scriptStatus.FAILED_INSTALLING ||
+              result.status === scriptStatus.SKIPPED ||
+              result.status === scriptStatus.FAILED_APPLYING_NETCONF ? (
+                <Link to={`tests/${result.id}/details`}>View details</Link>
+              ) : null}
+            </span>
+          ),
         },
         {
           content: renderActions(

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/__snapshots__/MachineTestsTable.test.tsx.snap
@@ -259,6 +259,12 @@ exports[`MachineTestsTable renders 1`] = `
                       data-test="status"
                     >
                       test status
+                       
+                      <Link
+                        to="tests/27/details"
+                      >
+                        View details
+                      </Link>
                     </span>,
                   },
                   Object {
@@ -329,6 +335,12 @@ exports[`MachineTestsTable renders 1`] = `
                       data-test="status"
                     >
                       test status
+                       
+                      <Link
+                        to="tests/28/details"
+                      >
+                        View details
+                      </Link>
                     </span>,
                   },
                   Object {
@@ -568,6 +580,22 @@ exports[`MachineTestsTable renders 1`] = `
                           data-test="status"
                         >
                           test status
+                           
+                          <Link
+                            to="tests/27/details"
+                          >
+                            <LinkAnchor
+                              href="/machine/tests/27/details"
+                              navigate={[Function]}
+                            >
+                              <a
+                                href="/machine/tests/27/details"
+                                onClick={[Function]}
+                              >
+                                View details
+                              </a>
+                            </LinkAnchor>
+                          </Link>
                         </span>
                       </td>
                     </TableCell>
@@ -754,6 +782,22 @@ exports[`MachineTestsTable renders 1`] = `
                           data-test="status"
                         >
                           test status
+                           
+                          <Link
+                            to="tests/28/details"
+                          >
+                            <LinkAnchor
+                              href="/machine/tests/28/details"
+                              navigate={[Function]}
+                            >
+                              <a
+                                href="/machine/tests/28/details"
+                                onClick={[Function]}
+                              >
+                                View details
+                              </a>
+                            </LinkAnchor>
+                          </Link>
                         </span>
                       </td>
                     </TableCell>


### PR DESCRIPTION
## Done

- Add view for script result details
- Display script result details

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the tests tab for a machine with script results
- Follow the "view details" link, you should be taken to /machine/:id/tests/:scriptResultId/details and see script results rendered

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
