### PR TITLE
ci: add build artifact upload workflow

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,37 @@
+name: Upload
+on:
+  push:
+    branches:
+      - master
+jobs:
+  upload-build:
+    if: github.event.pull_request.merged == true
+    name: Upload build artifacts
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Restore node_modules
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: CYPRESS_INSTALL_BINARY=0 yarn install
+      - name: Build
+        run: yarn build-all
+        env:
+          CI: true
+      - name: Upload build
+        uses: actions/upload-artifact@v2
+        with:
+          name: maas-ui-${GITHUB_SHA}
+          path: build/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "betterer": "yarn --cwd ui betterer",
     "build": "yarn build-shared",
-    "build-all": "yarn clean-all && yarn build-shared && yarn build-legacy && yarn build-ui && yarn build-root && yarn copy-build",
+    "cleanbuild": "yarn clean-all && yarn build-all",
+    "build-all": "yarn build-shared && yarn build-legacy && yarn build-ui && yarn build-root && yarn copy-build",
     "build-shared": "cd shared && yarn install && yarn build",
     "build-legacy": "cd legacy && yarn install && yarn build",
     "build-root": "cd root && yarn install && yarn build",


### PR DESCRIPTION
## Done

- Add build artifact upload workflow, stored by sha.
- Artifacts can be retrieved via the [artifact API](https://docs.github.com/en/rest/reference/actions#artifacts).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

n/a

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
