### PR TITLE
feat(ui): link to React version of machine storage tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -155,9 +155,9 @@ const MachineHeader = ({
         },
         {
           active: pathname.startsWith(`${urlBase}/storage`),
-          component: LegacyLink,
+          component: Link,
           label: "Storage",
-          route: `${urlBase}?area=storage`,
+          to: `${urlBase}/storage`,
         },
         {
           active: pathname.startsWith(`${urlBase}/pci-devices`),

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
@@ -248,12 +248,8 @@ describe("NodeDevices", () => {
         .prop("route")
     ).toBe("/machine/abc123?area=network");
     expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(1)
-        .find("LegacyLink")
-        .prop("route")
-    ).toBe("/machine/abc123?area=storage");
+      wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
+    ).toBe("/machine/abc123/storage");
   });
 
   it("displays the NUMA node index of a node device", () => {

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from "react";
 import { useEffect } from "react";
 
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../MachineSummary";
 
@@ -48,35 +50,42 @@ const generateGroup = (
       vendor_id,
       vendor_name,
     } = nodeDevice;
-    const groupLabel = i === 0;
     const numaNode = machine.numa_nodes.find(
       (numa) => numa.id === numa_node_id
     );
 
+    const showGroupLabel = i === 0;
+    let groupLabel: ReactNode;
+    if (showGroupLabel) {
+      if (group.pathname === "storage") {
+        groupLabel = (
+          <Link to={`/machine/${machine.system_id}/storage`}>
+            {group.label}
+          </Link>
+        );
+      } else if (group.pathname === "network") {
+        groupLabel = (
+          <LegacyLink route={`/machine/${machine.system_id}?area=network`}>
+            {group.label}
+          </LegacyLink>
+        );
+      } else {
+        groupLabel = group.label;
+      }
+    }
+
     return (
       <tr
         className={`node-devices-table__row${
-          groupLabel ? "" : " truncated-border"
+          showGroupLabel ? "" : " truncated-border"
         }`}
         key={`node-device-${id}`}
       >
         <td className="group-col">
-          {groupLabel && (
+          {showGroupLabel && (
             <DoubleRow
               data-test="group-label"
-              primary={
-                <strong>
-                  {group.pathname ? (
-                    <LegacyLink
-                      route={`/machine/${machine.system_id}?area=${group.pathname}`}
-                    >
-                      {group.label}
-                    </LegacyLink>
-                  ) : (
-                    group.label
-                  )}
-                </strong>
-              }
+              primary={<strong>{groupLabel}</strong>}
               secondary={pluralize("device", group.items.length, true)}
             />
           )}


### PR DESCRIPTION
## Done

- Update storage links to point to React version

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine's details page
- Click "Storage" in the tab strip and check that it takes you to the React version (with `/r/` in the url)
