### PR TITLE
feat(ui): add network validation to network tab

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -21,7 +21,7 @@ import { useMachineActionForm } from "app/machines/hooks";
 import type {
   SelectedAction,
   SetSelectedAction,
-} from "app/machines/views/MachineDetails/MachineSummary";
+} from "app/machines/views/MachineDetails/types";
 import { actions as machineActions } from "app/store/machine";
 import { NodeActions } from "app/store/types/node";
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx
@@ -196,6 +196,47 @@ describe("TestForm", () => {
     expect(preselected.length).toEqual(1);
   });
 
+  it("prepopulates scripts with apply_configured_networking", () => {
+    const state = { ...initialState };
+    const scripts = [
+      scriptsFactory({
+        apply_configured_networking: true,
+        type: ScriptType.Testing,
+      }),
+      scriptsFactory({
+        apply_configured_networking: false,
+        type: ScriptType.Testing,
+      }),
+      scriptsFactory({
+        apply_configured_networking: true,
+        type: ScriptType.Testing,
+      }),
+    ];
+    state.scripts.items = scripts;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TestForm
+            setSelectedAction={jest.fn()}
+            applyConfiguredNetworking={true}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // An equality assertion can't be made here as preselected scripts have
+    // a 'displayName' added
+    const preselected: Scripts[] = wrapper
+      .find("TestFormFields")
+      .prop("preselected");
+    expect(preselected[0].id).toEqual(scripts[0].id);
+    expect(preselected[1].id).toEqual(scripts[2].id);
+    expect(preselected.length).toEqual(2);
+  });
+
   it("dispatches an action to test machine from details view", () => {
     const state = { ...initialState };
     state.machine.active = "abc123";

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -43,11 +43,13 @@ export type FormValues = {
 type Props = {
   setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
   hardwareType?: HardwareType;
+  applyConfiguredNetworking?: Scripts["apply_configured_networking"];
 };
 
 export const TestForm = ({
   setSelectedAction,
   hardwareType,
+  applyConfiguredNetworking,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
@@ -58,19 +60,30 @@ export const TestForm = ({
     NodeActions.TEST
   );
 
-  const formattedScripts = scripts.map((script) => ({
+  type FormattedScript = Scripts & {
+    displayName: string;
+  };
+
+  const formattedScripts = scripts.map<FormattedScript>((script) => ({
     ...script,
     displayName: `${script.name} (${script.tags.join(", ")})`,
   }));
 
-  const preselected = hardwareType
-    ? formattedScripts.filter(
-        (script) => script?.hardware_type === hardwareType
-      )
-    : [
-        formattedScripts.find((script) => script.name === "smartctl-validate"),
-      ].filter(Boolean);
-
+  let preselected: FormattedScript[];
+  if (hardwareType) {
+    preselected = formattedScripts.filter(
+      (script) => script?.hardware_type === hardwareType
+    );
+  } else if (applyConfiguredNetworking) {
+    preselected = formattedScripts.filter(
+      (script) =>
+        script?.apply_configured_networking === applyConfiguredNetworking
+    );
+  } else {
+    preselected = [
+      formattedScripts.find((script) => script.name === "smartctl-validate"),
+    ].filter(Boolean);
+  }
   const initialScriptInputs = urlScripts.reduce((scriptInputs, script) => {
     if (
       !(script.name in scriptInputs) &&

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -7,7 +7,7 @@ import { useParams } from "react-router";
 
 import { general as generalActions } from "app/base/actions";
 import type { RouteParams } from "app/base/types";
-import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
+import type { SetSelectedAction } from "app/machines/views/MachineDetails/types";
 import generalSelectors from "app/store/general/selectors";
 import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -11,12 +11,12 @@ import NetworkNotifications from "./MachineNetwork/NetworkNotifications";
 import MachinePCIDevices from "./MachinePCIDevices";
 import MachineStorage from "./MachineStorage";
 import StorageNotifications from "./MachineStorage/StorageNotifications";
-import type { SelectedAction } from "./MachineSummary";
 import MachineSummary from "./MachineSummary";
 import SummaryNotifications from "./MachineSummary/SummaryNotifications";
 import MachineTests from "./MachineTests";
 import MachineTestsDetails from "./MachineTests/MachineTestsDetails/MachineTestsDetails";
 import MachineUSBDevices from "./MachineUSBDevices";
+import type { SelectedAction } from "./types";
 
 import Section from "app/base/components/Section";
 import type { RouteParams } from "app/base/types";
@@ -75,7 +75,7 @@ const MachineDetails = (): JSX.Element => {
           </Route>
           <Route exact path="/machine/:id/network">
             <NetworkNotifications id={id} />
-            <MachineNetwork />
+            <MachineNetwork setSelectedAction={setSelectedAction} />
           </Route>
           <Route exact path="/machine/:id/storage">
             <StorageNotifications id={id} />

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";
 
-import type { SelectedAction, SetSelectedAction } from "../MachineSummary";
+import type { SelectedAction, SetSelectedAction } from "../types";
 
 import MachineName from "./MachineName";
 

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -27,7 +27,7 @@ describe("MachineNetwork", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineNetwork />
+          <MachineNetwork setSelectedAction={jest.fn()} />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -4,6 +4,9 @@ import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import type { SetSelectedAction } from "../types";
+
+import NetworkActions from "./NetworkActions";
 import NetworkTable from "./NetworkTable";
 
 import { useWindowTitle } from "app/base/hooks";
@@ -12,7 +15,9 @@ import machineSelectors from "app/store/machine/selectors";
 import type { NetworkInterface } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
-const MachineNetwork = (): JSX.Element => {
+type Props = { setSelectedAction: SetSelectedAction };
+
+const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
   const [selected, setSelected] = useState<NetworkInterface["id"][]>([]);
@@ -27,7 +32,14 @@ const MachineNetwork = (): JSX.Element => {
   }
 
   return (
-    <NetworkTable systemId={id} selected={selected} setSelected={setSelected} />
+    <>
+      <NetworkActions setSelectedAction={setSelectedAction} systemId={id} />
+      <NetworkTable
+        systemId={id}
+        selected={selected}
+        setSelected={setSelected}
+      />
+    </>
   );
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
@@ -1,0 +1,82 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import NetworkActions from "./NetworkActions";
+
+import type { RootState } from "app/store/root/types";
+import { NodeActions, NodeStatus } from "app/store/types/node";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NetworkActions", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("renders", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NetworkActions setSelectedAction={jest.fn()} systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("NetworkActions")).toMatchSnapshot();
+  });
+
+  it("disables the validate network button when networking is disabled", () => {
+    state.machine.items[0].status = NodeStatus.DEPLOYED;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NetworkActions setSelectedAction={jest.fn()} systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
+  });
+
+  it("shows the test form when clicking the validate network button", () => {
+    const store = mockStore(state);
+    const setSelectedAction = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NetworkActions
+            setSelectedAction={setSelectedAction}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button").last().simulate("click");
+    expect(setSelectedAction).toHaveBeenCalledWith({
+      name: NodeActions.TEST,
+      formProps: { applyConfiguredNetworking: true },
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
@@ -1,0 +1,57 @@
+import { Button, Col, Row } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import type { SetSelectedAction } from "../../types";
+
+import { useSendAnalytics } from "app/base/hooks";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import { useIsAllNetworkingDisabled } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
+
+type Props = {
+  systemId: Machine["system_id"];
+  setSelectedAction: SetSelectedAction;
+};
+
+const NetworkActions = ({
+  setSelectedAction,
+  systemId,
+}: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
+  const sendAnalytics = useSendAnalytics();
+
+  if (!machine) {
+    return null;
+  }
+
+  return (
+    <Row className="is-shallow">
+      <Col size="8"></Col>
+      <Col className="u-align--right" size="4">
+        <Button
+          disabled={isAllNetworkingDisabled}
+          onClick={() => {
+            setSelectedAction({
+              name: NodeActions.TEST,
+              formProps: { applyConfiguredNetworking: true },
+            });
+            sendAnalytics(
+              "Machine details",
+              "Validate network configuration",
+              "Network tab"
+            );
+          }}
+        >
+          Validate network configuration
+        </Button>
+      </Col>
+    </Row>
+  );
+};
+
+export default NetworkActions;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
@@ -30,7 +30,7 @@ const NetworkActions = ({
   }
 
   return (
-    <Row className="is-shallow">
+    <Row>
       <Col size="8"></Col>
       <Col className="u-align--right" size="4">
         <Button

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/__snapshots__/NetworkActions.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/__snapshots__/NetworkActions.test.tsx.snap
@@ -5,11 +5,9 @@ exports[`NetworkActions renders 1`] = `
   setSelectedAction={[MockFunction]}
   systemId="abc123"
 >
-  <Row
-    className="is-shallow"
-  >
+  <Row>
     <div
-      className="is-shallow row"
+      className="row"
     >
       <Col
         size="8"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/__snapshots__/NetworkActions.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/__snapshots__/NetworkActions.test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NetworkActions renders 1`] = `
+<NetworkActions
+  setSelectedAction={[MockFunction]}
+  systemId="abc123"
+>
+  <Row
+    className="is-shallow"
+  >
+    <div
+      className="is-shallow row"
+    >
+      <Col
+        size="8"
+      >
+        <div
+          className="col-8"
+        />
+      </Col>
+      <Col
+        className="u-align--right"
+        size="4"
+      >
+        <div
+          className="u-align--right col-4"
+        >
+          <Button
+            disabled={false}
+            onClick={[Function]}
+          >
+            <button
+              className="p-button--neutral"
+              disabled={false}
+              onClick={[Function]}
+            >
+              Validate network configuration
+            </button>
+          </Button>
+        </div>
+      </Col>
+    </div>
+  </Row>
+</NetworkActions>
+`;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NetworkActions";

--- a/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachinePCIDevices/MachinePCIDevices.tsx
@@ -1,8 +1,8 @@
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { SetSelectedAction } from "../MachineSummary";
 import NodeDevices from "../NodeDevices";
+import type { SetSelectedAction } from "../types";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -4,30 +4,19 @@ import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import type { SetSelectedAction } from "../types";
+
 import NetworkCard from "./NetworkCard";
 import NumaCard from "./NumaCard";
 import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
 import WorkloadCard from "./WorkloadCard";
 
-import type { HardwareType } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
-import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
-
-export type SelectedAction = {
-  name: MachineAction["name"];
-  sentence?: MachineAction["sentence"];
-  formProps?: { hardwareType: HardwareType };
-};
-
-export type SetSelectedAction = (
-  action: SelectedAction | null,
-  deselect?: boolean
-) => void;
 
 type Props = {
   setSelectedAction: SetSelectedAction;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -3,7 +3,7 @@ import { Fragment, useEffect } from "react";
 import { Card, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
-import type { SetSelectedAction } from "../MachineSummary";
+import type { SetSelectedAction } from "../../types";
 import TestResults from "../TestResults";
 
 import NetworkCardTable from "./NetworkCardTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/CpuCard/CpuCard.tsx
@@ -1,6 +1,6 @@
 import pluralize from "pluralize";
 
-import type { SetSelectedAction } from "../../MachineSummary";
+import type { SetSelectedAction } from "../../../types";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/MemoryCard/MemoryCard.tsx
@@ -1,4 +1,4 @@
-import type { SetSelectedAction } from "../../MachineSummary";
+import type { SetSelectedAction } from "../../../types";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/OverviewCard.tsx
@@ -1,7 +1,7 @@
 import { Card, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import type { SetSelectedAction } from "../MachineSummary";
+import type { SetSelectedAction } from "../../types";
 
 import CpuCard from "./CpuCard";
 import DetailsCard from "./DetailsCard";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StorageCard/StorageCard.tsx
@@ -1,6 +1,6 @@
 import pluralize from "pluralize";
 
-import type { SetSelectedAction } from "../../MachineSummary";
+import type { SetSelectedAction } from "../../../types";
 import TestResults from "../../TestResults";
 
 import { HardwareType } from "app/base/enum";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,6 +1,6 @@
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
 
-import type { SetSelectedAction } from "..";
+import type { SetSelectedAction } from "../../types";
 
 import LegacyLink from "app/base/components/LegacyLink";
 import { HardwareType } from "app/base/enum";

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./MachineSummary";
-export type { SelectedAction, SetSelectedAction } from "./MachineSummary";

--- a/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineUSBDevices/MachineUSBDevices.tsx
@@ -1,8 +1,8 @@
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
-import type { SetSelectedAction } from "../MachineSummary";
 import NodeDevices from "../NodeDevices";
+import type { SetSelectedAction } from "../types";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
-import type { SetSelectedAction } from "../MachineSummary";
+import type { SetSelectedAction } from "../types";
 
 import NodeDevicesWarning from "./NodeDevicesWarning";
 

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
@@ -1,6 +1,6 @@
 import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 
-import type { SetSelectedAction } from "../../MachineSummary";
+import type { SetSelectedAction } from "../../types";
 
 import { nodeStatus } from "app/base/enum";
 import type { MachineDetails } from "app/store/machine/types";

--- a/ui/src/app/machines/views/MachineDetails/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/types.ts
@@ -1,0 +1,17 @@
+import type { HardwareType } from "app/base/enum";
+import type { MachineAction } from "app/store/general/types";
+import type { Scripts } from "app/store/scripts/types";
+
+export type SelectedAction = {
+  name: MachineAction["name"];
+  sentence?: MachineAction["sentence"];
+  formProps?: {
+    hardwareType?: HardwareType;
+    applyConfiguredNetworking?: Scripts["apply_configured_networking"];
+  };
+};
+
+export type SetSelectedAction = (
+  action: SelectedAction | null,
+  deselect?: boolean
+) => void;

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -16,7 +16,7 @@ import {
   getCurrentFilters,
   toggleFilter,
 } from "app/machines/search";
-import type { SetSelectedAction } from "app/machines/views/MachineDetails/MachineSummary";
+import type { SetSelectedAction } from "app/machines/views/MachineDetails/types";
 import type { MachineAction } from "app/store/general/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";


### PR DESCRIPTION
## Done

- Add a button to validate the network in the machine details network tab.
- As a drive-by the types for the selected action were moved to a types file instead of living in the summary component.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit a machine where you can edit the network (NOT new, ready, failed testing, allocated or broken).
- Click the "Validate network configuration" button.
- The test form should open and have some connectivity scripts preselected.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2150.