### PR TITLE
feat(ui): make the network table responsive

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
 import { Icon, MainTable, Spinner, Tooltip } from "@canonical/react-components";
+import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 
 import IPColumn from "./IPColumn";
@@ -134,7 +135,10 @@ const generateRow = (
       (!link && expanded.nicId === nic?.id));
   const showCheckbox = !isABondOrBridgeParent;
   return {
-    className: isExpanded ? "p-table__row is-active" : null,
+    className: classNames("p-table__row", {
+      "indented-border": isABondOrBridgeParent,
+      "is-active": isExpanded,
+    }),
     columns: [
       {
         content: (
@@ -534,7 +538,7 @@ const NetworkTable = ({
   );
   return (
     <MainTable
-      className="p-table-expanding--light"
+      className="p-table-expanding--light machine-network-table"
       defaultSort="name"
       defaultSortDirection="descending"
       expanding
@@ -548,14 +552,16 @@ const NetworkTable = ({
                 selectedItems={selected}
                 handleGroupCheckbox={handleGroupCheckbox}
               />
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => updateSort("name")}
-                sortKey="name"
-              >
-                Name
-              </TableHeader>
-              <TableHeader>MAC</TableHeader>
+              <div>
+                <TableHeader
+                  currentSort={currentSort}
+                  onClick={() => updateSort("name")}
+                  sortKey="name"
+                >
+                  Name
+                </TableHeader>
+                <TableHeader>MAC</TableHeader>
+              </div>
             </>
           ),
         },
@@ -587,7 +593,7 @@ const NetworkTable = ({
         },
         {
           content: (
-            <>
+            <div>
               <TableHeader
                 className="p-double-row__header-spacer"
                 currentSort={currentSort}
@@ -596,13 +602,15 @@ const NetworkTable = ({
               >
                 Type
               </TableHeader>
-              <TableHeader>NUMA node</TableHeader>
-            </>
+              <TableHeader className="p-double-row__header-spacer">
+                NUMA node
+              </TableHeader>
+            </div>
           ),
         },
         {
           content: (
-            <>
+            <div>
               <TableHeader
                 currentSort={currentSort}
                 onClick={() => updateSort("fabric")}
@@ -611,12 +619,12 @@ const NetworkTable = ({
                 Fabric
               </TableHeader>
               <TableHeader>VLAN</TableHeader>
-            </>
+            </div>
           ),
         },
         {
           content: (
-            <>
+            <div>
               <TableHeader
                 currentSort={currentSort}
                 onClick={() => updateSort("subnet")}
@@ -625,12 +633,12 @@ const NetworkTable = ({
                 Subnet
               </TableHeader>
               <TableHeader>Name</TableHeader>
-            </>
+            </div>
           ),
         },
         {
           content: (
-            <>
+            <div>
               <TableHeader
                 currentSort={currentSort}
                 onClick={() => updateSort("ip")}
@@ -639,7 +647,7 @@ const NetworkTable = ({
                 IP Address
               </TableHeader>
               <TableHeader>Status</TableHeader>
-            </>
+            </div>
           ),
         },
         {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/_index.scss
@@ -1,0 +1,34 @@
+@mixin MachineNetworkTable {
+  .machine-network-table {
+    th,
+    td {
+      &:nth-child(1) {
+        @include breakpoint-widths(0.45, 0.45, 0.26, 0.2, 0.16, true);
+      }
+      &:nth-child(2) {
+        @include breakpoint-widths(0, 0.06, 0.05, 0.05, 0.05, true);
+      }
+      &:nth-child(3) {
+        @include breakpoint-widths(0, 0, 0, 0.16, 0.14, true);
+      }
+      &:nth-child(4) {
+        @include breakpoint-widths(0.45, 0.45, 0.2, 0.15, 0.14, true);
+      }
+      &:nth-child(5) {
+        @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
+      }
+      &:nth-child(6) {
+        @include breakpoint-widths(0, 0, 0.17, 0.13, 0.12, true);
+      }
+      &:nth-child(7) {
+        @include breakpoint-widths(0, 0, 0, 0.12, 0.11, true);
+      }
+      &:nth-child(8) {
+        @include breakpoint-widths(0, 0, 0, 0, 0.12, true);
+      }
+      &:nth-child(9) {
+        @include breakpoint-widths(0, 0.1, 0.1, 0.06, 0.05, true);
+      }
+    }
+  }
+}

--- a/ui/src/scss/_breakpoint-widths.scss
+++ b/ui/src/scss/_breakpoint-widths.scss
@@ -3,7 +3,9 @@
   $width-two: $width-one,
   $width-three: $width-two,
   $width-four: $width-three,
-  $width-five: $width-four
+  $width-five: $width-four,
+  // Set the widths with flex e.g. for expanding tables.
+  $flex: false
 ) {
   $breakpoint-first: 600px;
   $breakpoint-second: 900px;
@@ -13,6 +15,8 @@
   @media (max-width: $breakpoint-first - 1px) {
     @if $width-one == 0 {
       display: none !important;
+    } @else if $flex == true {
+      flex-grow: $width-one;
     } @else {
       width: $width-one;
     }
@@ -21,6 +25,8 @@
   @media (min-width: $breakpoint-first) and (max-width: $breakpoint-second - 1px) {
     @if $width-two == 0 {
       display: none !important;
+    } @else if $flex == true {
+      flex-grow: $width-two;
     } @else {
       width: $width-two;
     }
@@ -29,6 +35,8 @@
   @media (min-width: $breakpoint-second) and (max-width: $breakpoint-third - 1px) {
     @if $width-three == 0 {
       display: none !important;
+    } @else if $flex == true {
+      flex-grow: $width-three;
     } @else {
       width: $width-three;
     }
@@ -37,6 +45,8 @@
   @media (min-width: $breakpoint-third) and (max-width: $breakpoint-fourth - 1px) {
     @if $width-four == 0 {
       display: none !important;
+    } @else if $flex == true {
+      flex-grow: $width-four;
     } @else {
       width: $width-four;
     }
@@ -45,6 +55,8 @@
   @media (min-width: $breakpoint-fourth) {
     @if $width-five == 0 {
       display: none !important;
+    } @else if $flex == true {
+      flex-grow: $width-five;
     } @else {
       width: $width-five;
     }

--- a/ui/src/scss/_patterns_tables.scss
+++ b/ui/src/scss/_patterns_tables.scss
@@ -41,4 +41,18 @@
     padding-top: $spv-inner--medium;
     text-transform: uppercase;
   }
+
+  tr:not(:first-child).indented-border {
+    border-color: transparent;
+    position: relative;
+
+    &::after {
+      background-color: $colors--light-theme--border-low-contrast;
+      content: "";
+      height: 1px;
+      left: #{2 * map-get($icon-sizes, default) + $sph-inner--small};
+      position: absolute;
+      right: 0;
+    }
+  }
 }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -115,6 +115,7 @@
 @import "~app/machines/views/MachineList";
 @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
 @import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
+@import "~app/machines/views/MachineDetails/MachineNetwork/NetworkTable";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
@@ -122,6 +123,7 @@
 @import "~app/machines/views/MachineDetails/NodeDevices";
 @include MachineList;
 @include MachineName;
+@include MachineNetworkTable;
 @include MachineSummary;
 @include MarkBrokenFormFields;
 @include NetworkCard;


### PR DESCRIPTION
## Done

- Set the breakpoints for the network table.
- Fix the double headers so they appear on two rows.
- Inset the parent interface borders.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the network tab in machine details.
- Resize your browser up and down. The table should look OK at all sizes.
- Check that the double headers appear on two rows.
- Find a machine with (or create) an interface with a bond or bridge relationship.
- The physical interface borders should be inset (the borders should stop before the checkbox).

## Fixes

Fixes: #2010.