### PR TITLE
feat(ui): add the DHCP snippets table to machine details

### DIFF
--- a/ui/src/app/base/components/TableActions/TableActions.js
+++ b/ui/src/app/base/components/TableActions/TableActions.js
@@ -12,17 +12,19 @@ const TableActions = ({
   editPath,
   editTooltip,
   onDelete,
+  onEdit,
 }) => (
   <div>
     {copyValue && <CopyButton value={copyValue} />}
-    {editPath && (
+    {(editPath || onEdit) && (
       <Tooltip message={editTooltip} position="left">
         <Button
           appearance="base"
           className="is-dense u-table-cell-padding-overlap"
           disabled={editDisabled}
-          element={Link}
+          element={editPath ? Link : undefined}
           hasIcon
+          onClick={onEdit ? () => onEdit() : null}
           to={editPath}
         >
           <i className="p-icon--edit">Edit</i>
@@ -54,6 +56,7 @@ TableActions.propTypes = {
   editPath: PropTypes.string,
   editTooltip: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   onDelete: PropTypes.func,
+  onEdit: PropTypes.func,
 };
 
 export default TableActions;

--- a/ui/src/app/base/components/TableActions/TableActions.test.js
+++ b/ui/src/app/base/components/TableActions/TableActions.test.js
@@ -13,6 +13,14 @@ describe("TableActions ", () => {
     expect(wrapper.find("Button").props().to).toBe("/bar");
   });
 
+  it("renders an edit button if edit on-click provided", () => {
+    const onEdit = jest.fn();
+    const wrapper = shallow(<TableActions onEdit={onEdit} />);
+    wrapper.find("Button").props().onClick();
+    expect(onEdit).toHaveBeenCalled();
+    expect(wrapper.find("Button").prop("element")).toBe(undefined);
+  });
+
   it("renders a delete button if delete function provided", () => {
     const onDelete = jest.fn();
     const wrapper = shallow(<TableActions onDelete={onDelete} />);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.test.tsx
@@ -1,0 +1,69 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DHCPTable from "./DHCPTable";
+
+import type { RootState } from "app/store/root/types";
+import { NodeStatus } from "app/store/types/node";
+import {
+  dhcpSnippet as dhcpSnippetFactory,
+  dhcpSnippetState as dhcpSnippetStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineEvent as machineEventFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DHCPTable", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      dhcpsnippet: dhcpSnippetStateFactory({
+        loaded: true,
+        loading: false,
+        items: [
+          dhcpSnippetFactory({ node: "abc123" }),
+          dhcpSnippetFactory({ node: "abc123" }),
+          dhcpSnippetFactory(),
+        ],
+      }),
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            architecture: "amd64",
+            events: [machineEventFactory()],
+            system_id: "abc123",
+          }),
+        ],
+        loaded: true,
+        loading: false,
+      }),
+    });
+  });
+
+  it("shows snippets for a machine", () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        on_network: true,
+        osystem: "ubuntu",
+        status: NodeStatus.NEW,
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <DHCPTable systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("TableRow").length).toBe(3);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+
+import { List, MainTable, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import TableActions from "app/base/components/TableActions";
+import { actions as dhcpsnippetActions } from "app/store/dhcpsnippet";
+import dhcpsnippetSelectors from "app/store/dhcpsnippet/selectors";
+import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+const generateRows = (
+  dhcpsnippets: DHCPSnippet[],
+  expanded: DHCPSnippet["id"] | null,
+  machine: Machine,
+  setExpanded: (id: DHCPSnippet["id"] | null) => void
+) =>
+  dhcpsnippets.map((dhcpsnippet: DHCPSnippet) => {
+    const isExpanded = expanded === dhcpsnippet.id;
+    const enabled = dhcpsnippet.enabled ? "Yes" : "No";
+    const type =
+      (dhcpsnippet.node && "Node") ||
+      (dhcpsnippet.subnet && "Subnet") ||
+      "Global";
+    return {
+      className: isExpanded ? "p-table__row is-active" : null,
+      columns: [
+        {
+          content: dhcpsnippet.name,
+          role: "rowheader",
+        },
+        {
+          content: type,
+        },
+        {
+          content: machine.fqdn,
+        },
+        { content: enabled },
+        { content: dhcpsnippet.description },
+        {
+          content: (
+            <TableActions
+              onEdit={() => {
+                setExpanded(expanded ? null : dhcpsnippet.id);
+              }}
+            />
+          ),
+          className: "u-align--right",
+        },
+      ],
+      expanded: isExpanded,
+      expandedContent: isExpanded && <>Edit {dhcpsnippet.name}</>,
+      key: dhcpsnippet.id,
+      sortData: {
+        name: dhcpsnippet.name,
+        description: dhcpsnippet.description,
+        enabled,
+        target: machine.fqdn,
+        type,
+      },
+    };
+  });
+
+type Props = {
+  systemId: Machine["system_id"];
+};
+
+const DHCPTable = ({ systemId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const [expanded, setExpanded] = useState<DHCPSnippet["id"] | null>(null);
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const dhcpsnippetLoading = useSelector(dhcpsnippetSelectors.loading);
+  const dhcpsnippets = useSelector((state: RootState) =>
+    dhcpsnippetSelectors.getByNode(state, systemId)
+  );
+
+  useEffect(() => {
+    dispatch(dhcpsnippetActions.fetch());
+  }, [dispatch]);
+
+  if (!machine) {
+    return null;
+  }
+
+  if (dhcpsnippetLoading) {
+    return <Spinner />;
+  }
+
+  return (
+    <>
+      <h2 className="p-heading--four">DHCP snippets</h2>
+      <MainTable
+        className="dhcp-snippets-table p-table-expanding--light"
+        defaultSort="name"
+        defaultSortDirection="descending"
+        expanding
+        headers={[
+          {
+            content: "Name",
+            sortKey: "name",
+          },
+          {
+            content: "Type",
+            sortKey: "type",
+          },
+          {
+            content: "Applies to",
+            sortKey: "target",
+          },
+          {
+            content: "Enabled",
+            sortKey: "enabled",
+          },
+          {
+            content: "Description",
+            sortKey: "description",
+          },
+          {
+            content: "Actions",
+            className: "u-align--right",
+          },
+        ]}
+        rows={generateRows(dhcpsnippets, expanded, machine, setExpanded)}
+        sortable
+      />
+      <List
+        items={[
+          <Link to="/settings/dhcp">
+            All snippets: Settings &gt; DHCP snippets
+          </Link>,
+          <a
+            className="p-link--external"
+            href="https://maas.io/docs/dhcp"
+            rel="noreferrer"
+            target="_blank"
+          >
+            About DHCP snippets
+          </a>,
+        ]}
+        middot
+      />
+    </>
+  );
+};
+
+export default DHCPTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/_index.scss
@@ -1,0 +1,25 @@
+@mixin MachineDHCPTable {
+  .dhcp-snippets-table {
+    th,
+    td {
+      &:nth-child(1) {
+        @include breakpoint-widths(0.45, 0.45, 0.26, 0.2, 0.15, true);
+      }
+      &:nth-child(2) {
+        @include breakpoint-widths(0, 0, 0.1, 0.1, 0.1, true);
+      }
+      &:nth-child(3) {
+        @include breakpoint-widths(0, 0, 0, 0.2, 0.2, true);
+      }
+      &:nth-child(4) {
+        @include breakpoint-widths(0, 0.1, 0.1, 0.1, 0.1, true);
+      }
+      &:nth-child(5) {
+        @include breakpoint-widths(0.35, 0.35, 0.35, 0.35, 0.35, true);
+      }
+      &:nth-child(6) {
+        @include breakpoint-widths(0, 0.1, 0.1, 0.06, 0.05, true);
+      }
+    }
+  }
+}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/_index.scss
@@ -3,7 +3,7 @@
     th,
     td {
       &:nth-child(1) {
-        @include breakpoint-widths(0.45, 0.45, 0.26, 0.2, 0.15, true);
+        @include breakpoint-widths(0.45, 0.45, 0.35, 0.2, 0.2, true);
       }
       &:nth-child(2) {
         @include breakpoint-widths(0, 0, 0.1, 0.1, 0.1, true);
@@ -15,10 +15,10 @@
         @include breakpoint-widths(0, 0.1, 0.1, 0.1, 0.1, true);
       }
       &:nth-child(5) {
-        @include breakpoint-widths(0.35, 0.35, 0.35, 0.35, 0.35, true);
+        @include breakpoint-widths(0.55, 0.35, 0.35, 0.35, 0.35, true);
       }
       &:nth-child(6) {
-        @include breakpoint-widths(0, 0.1, 0.1, 0.06, 0.05, true);
+        @include breakpoint-widths(0, 0.1, 0.1, 0.05, 0.05, true);
       }
     }
   }

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DHCPTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 
-import { Spinner } from "@canonical/react-components";
+import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import type { SetSelectedAction } from "../types";
 
+import DHCPTable from "./DHCPTable";
 import NetworkActions from "./NetworkActions";
 import NetworkTable from "./NetworkTable";
 
@@ -34,11 +35,14 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
   return (
     <>
       <NetworkActions setSelectedAction={setSelectedAction} systemId={id} />
-      <NetworkTable
-        systemId={id}
-        selected={selected}
-        setSelected={setSelected}
-      />
+      <Strip>
+        <NetworkTable
+          systemId={id}
+          selected={selected}
+          setSelected={setSelected}
+        />
+      </Strip>
+      <DHCPTable systemId={id} />
     </>
   );
 };

--- a/ui/src/app/store/dhcpsnippet/selectors.test.ts
+++ b/ui/src/app/store/dhcpsnippet/selectors.test.ts
@@ -105,4 +105,21 @@ describe("dhcpsnippet selectors", () => {
     });
     expect(dhcpsnippet.getById(state, 909)).toStrictEqual(items[1]);
   });
+
+  it("can get dhcp snippets for a node", () => {
+    const items = [
+      dhcpSnippetFactory({ id: 707, node: "abc123" }),
+      dhcpSnippetFactory({ id: 808 }),
+      dhcpSnippetFactory({ id: 909, node: "abc123" }),
+    ];
+    const state = rootStateFactory({
+      dhcpsnippet: dhcpSnippetStateFactory({
+        items,
+      }),
+    });
+    expect(dhcpsnippet.getByNode(state, "abc123")).toStrictEqual([
+      items[0],
+      items[2],
+    ]);
+  });
 });

--- a/ui/src/app/store/dhcpsnippet/selectors.ts
+++ b/ui/src/app/store/dhcpsnippet/selectors.ts
@@ -1,16 +1,43 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 import type {
   DHCPSnippet,
   DHCPSnippetState,
 } from "app/store/dhcpsnippet/types";
+import type { RootState } from "app/store/root/types";
 import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (snippet: DHCPSnippet, term: string) =>
   snippet.name.includes(term) || snippet.description.includes(term);
 
-const selectors = generateBaseSelectors<DHCPSnippetState, DHCPSnippet, "id">(
-  "dhcpsnippet",
-  "id",
-  searchFunction
+const defaultSelectors = generateBaseSelectors<
+  DHCPSnippetState,
+  DHCPSnippet,
+  "id"
+>("dhcpsnippet", "id", searchFunction);
+
+/**
+ * Finds snippets for a node.
+ * @param state - The redux state.
+ * @param systemId - A node's system id.
+ * @returns Snippets for a node.
+ */
+const getByNode = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, node: DHCPSnippet["node"] | null) => node,
+  ],
+  (snippets: DHCPSnippet[], node) => {
+    if (!node) {
+      return [];
+    }
+    return snippets.filter((snippet) => snippet.node === node);
+  }
 );
+
+const selectors = {
+  ...defaultSelectors,
+  getByNode,
+};
 
 export default selectors;

--- a/ui/src/app/store/dhcpsnippet/types.ts
+++ b/ui/src/app/store/dhcpsnippet/types.ts
@@ -16,7 +16,7 @@ export type DHCPSnippet = Model & {
   enabled: boolean;
   history: DHCPSnippetHistory[];
   name: string;
-  node: Host | Device | null;
+  node: Host["system_id"] | Device["system_id"] | null;
   subnet: Subnet["id"] | null;
   updated: string;
   value: string;

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -115,6 +115,7 @@
 @import "~app/machines/views/MachineList";
 @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
 @import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
+@import "~app/machines/views/MachineDetails/MachineNetwork/DHCPTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/NetworkTable";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
@@ -122,6 +123,7 @@
 @import "~app/machines/views/MachineDetails/MachineSummary/OverviewCard";
 @import "~app/machines/views/MachineDetails/NodeDevices";
 @include MachineList;
+@include MachineDHCPTable;
 @include MachineName;
 @include MachineNetworkTable;
 @include MachineSummary;


### PR DESCRIPTION
## Done

- Display the DHCP snippets in the machine network tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the DHCP settings (/MAAS/r/settings/dhcp).
- Add a snippet and set the type to a machine.
- Go to the new network tab for the machine you added the DHCP snippet to.
- You should see a DHCP table that includes your new DHCP snippet.

## Fixes

Fixes: #1888.