### PR TITLE
fix(ui): add message to PCI/USB tab if machine is commissioning

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
@@ -89,6 +89,25 @@ describe("NodeDevicesWarning", () => {
     );
   });
 
+  it("shows a message if the machine has no node devices and is commissioning", () => {
+    const machine = machineDetailsFactory({
+      locked: false,
+      status_code: nodeStatus.COMMISSIONING,
+    });
+    const wrapper = mount(
+      <NodeDevicesWarning
+        bus={NodeDeviceBus.PCIE}
+        machine={machine}
+        nodeDevices={[]}
+        setSelectedAction={jest.fn()}
+      />
+    );
+
+    expect(wrapper.find("[data-test='no-devices']").text()).toBe(
+      "Commissioning is currently in progress..."
+    );
+  });
+
   it("shows a generic message if the machine has no node devices and cannot be commissioned", () => {
     const machine = machineDetailsFactory({
       actions: [],

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
@@ -42,6 +42,8 @@ const NodeDevicesWarning = ({
       } else if (machine.status_code === nodeStatus.DEPLOYED) {
         warningMessage =
           "Release this machine before commissioning to load PCI and USB device information.";
+      } else if (machine.status_code === nodeStatus.COMMISSIONING) {
+        warningMessage = "Commissioning is currently in progress...";
       } else {
         warningMessage = "Commissioning cannot be run at this time.";
       }


### PR DESCRIPTION
## Done

- Add a message to the PCI/USB tab if the machine is commissioning and no node devices have been discovered yet

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go the PCI tab of a machine that has not been commissioned recently (so it has no PCI/USB devices). Alternatively, you can add a machine with manual power type.
- Commission the machine from the action menu and check that the warning in the table says "Commissioning is currently in progress..."

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2303
