### PR TITLE
refactor(ui): create generic TableActionsDropdown component and use in storage

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -386,10 +386,10 @@ exports[`stricter compilation`] = {
       [116, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [116, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx:3035156036": [
-      [41, 25, 2, "Object is possibly \'null\'.", "5860944"],
-      [41, 38, 2, "Object is possibly \'null\'.", "5860944"],
-      [55, 23, 2, "Object is possibly \'null\'.", "5860944"]
+    "src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx:530744010": [
+      [45, 25, 2, "Object is possibly \'null\'.", "5860944"],
+      [45, 38, 2, "Object is possibly \'null\'.", "5860944"],
+      [53, 23, 2, "Object is possibly \'null\'.", "5860944"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx:829149380": [
       [62, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],

--- a/ui/src/app/base/components/TableActionsDropdown/TableActionsDropdown.test.tsx
+++ b/ui/src/app/base/components/TableActionsDropdown/TableActionsDropdown.test.tsx
@@ -1,0 +1,61 @@
+import { mount, shallow } from "enzyme";
+
+import TableActionsDropdown from "./TableActionsDropdown";
+
+describe("TableActionsDropdown", () => {
+  it("can be explicitly disabled", () => {
+    const wrapper = shallow(
+      <TableActionsDropdown
+        actions={[
+          { label: "Action 1", type: "action-1" },
+          { label: "Action 2", type: "action-2" },
+          { label: "Action 3", type: "action-3" },
+        ]}
+        disabled
+        onActionClick={jest.fn()}
+      />
+    );
+    expect(wrapper.find("TableMenu").prop("disabled")).toBe(true);
+  });
+
+  it("is disabled if no actions are provided", () => {
+    const wrapper = shallow(
+      <TableActionsDropdown actions={[]} onActionClick={jest.fn()} />
+    );
+    expect(wrapper.find("TableMenu").prop("disabled")).toBe(true);
+  });
+
+  it("can conditionally show actions", () => {
+    const wrapper = mount(
+      <TableActionsDropdown
+        actions={[
+          { label: "Action 1", show: true, type: "action-1" },
+          { label: "Action 2", type: "action-2" },
+          { label: "Action 3", show: false, type: "action-3" },
+        ]}
+        onActionClick={jest.fn()}
+      />
+    );
+    // Open menu
+    wrapper.find("button").simulate("click");
+
+    expect(wrapper.find("button[data-test='action-1']").exists()).toBe(true);
+    expect(wrapper.find("button[data-test='action-2']").exists()).toBe(true);
+    expect(wrapper.find("button[data-test='action-3']").exists()).toBe(false);
+  });
+
+  it("runs click function with action type as argument", () => {
+    const onActionClick = jest.fn();
+    const wrapper = mount(
+      <TableActionsDropdown
+        actions={[{ label: "Action 1", type: "action-1" }]}
+        onActionClick={onActionClick}
+      />
+    );
+    // Open menu and click the actions
+    wrapper.find("button").simulate("click");
+    wrapper.find("button[data-test='action-1']").simulate("click");
+
+    expect(onActionClick).toHaveBeenCalledWith("action-1");
+  });
+});

--- a/ui/src/app/base/components/TableActionsDropdown/TableActionsDropdown.tsx
+++ b/ui/src/app/base/components/TableActionsDropdown/TableActionsDropdown.tsx
@@ -1,0 +1,48 @@
+import type { Props as ButtonProps } from "@canonical/react-components/dist/components/Button";
+
+import TableMenu from "app/base/components/TableMenu";
+
+export type TableAction<A> = {
+  label: string;
+  show?: boolean;
+  type: A;
+};
+
+// This allows the "data-test" attribute to be used for the action links, which
+// is technically not a valid HTML prop, but we use it throughout maas-ui.
+type TableActionsLink = ButtonProps & { "data-test": string };
+
+type Props<A> = {
+  actions: TableAction<A>[];
+  disabled?: boolean;
+  onActionClick: (action: A) => void;
+};
+
+const TableActionsDropdown = <A extends string>({
+  actions,
+  disabled = false,
+  onActionClick,
+}: Props<A>): JSX.Element => {
+  const actionLinks = actions.reduce<TableActionsLink[]>((links, action) => {
+    if (!(action.show === false)) {
+      // Show actions that do not explicitly set show to false.
+      links.push({
+        children: action.label,
+        "data-test": action.type,
+        onClick: () => onActionClick(action.type),
+      });
+    }
+    return links;
+  }, []);
+
+  return (
+    <TableMenu
+      disabled={disabled || actions.length === 0}
+      links={actionLinks}
+      position="right"
+      title="Take action:"
+    />
+  );
+};
+
+export default TableActionsDropdown;

--- a/ui/src/app/base/components/TableActionsDropdown/index.ts
+++ b/ui/src/app/base/components/TableActionsDropdown/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./TableActionsDropdown";
+export type { TableAction } from "./TableActionsDropdown";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.test.tsx
@@ -2,6 +2,8 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import { BulkAction } from "../AvailableStorageTable";
+
 import BulkActions from "./BulkActions";
 
 import { DiskTypes, StorageLayout } from "app/store/machine/types";
@@ -209,7 +211,7 @@ describe("BulkActions", () => {
     const wrapper = mount(
       <Provider store={store}>
         <BulkActions
-          bulkAction="createDatastore"
+          bulkAction={BulkAction.CREATE_DATASTORE}
           selected={[]}
           setBulkAction={jest.fn()}
           systemId="abc123"
@@ -237,7 +239,7 @@ describe("BulkActions", () => {
     const wrapper = mount(
       <Provider store={store}>
         <BulkActions
-          bulkAction="createRaid"
+          bulkAction={BulkAction.CREATE_RAID}
           selected={[]}
           setBulkAction={jest.fn()}
           systemId="abc123"
@@ -265,7 +267,7 @@ describe("BulkActions", () => {
     const wrapper = mount(
       <Provider store={store}>
         <BulkActions
-          bulkAction="createVolumeGroup"
+          bulkAction={BulkAction.CREATE_VOLUME_GROUP}
           selected={[]}
           setBulkAction={jest.fn()}
           systemId="abc123"
@@ -293,7 +295,7 @@ describe("BulkActions", () => {
     const wrapper = mount(
       <Provider store={store}>
         <BulkActions
-          bulkAction="updateDatastore"
+          bulkAction={BulkAction.UPDATE_DATASTORE}
           selected={[]}
           setBulkAction={jest.fn()}
           systemId="abc123"

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/BulkActions.tsx
@@ -1,7 +1,7 @@
 import { Button, List, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import type { BulkAction } from "../AvailableStorageTable";
+import { BulkAction } from "../AvailableStorageTable";
 
 import CreateDatastore from "./CreateDatastore";
 import CreateRaid from "./CreateRaid";
@@ -40,7 +40,7 @@ const BulkActions = ({
     return null;
   }
 
-  if (bulkAction === "createDatastore") {
+  if (bulkAction === BulkAction.CREATE_DATASTORE) {
     return (
       <CreateDatastore
         closeForm={() => setBulkAction(null)}
@@ -50,7 +50,7 @@ const BulkActions = ({
     );
   }
 
-  if (bulkAction === "createRaid") {
+  if (bulkAction === BulkAction.CREATE_RAID) {
     return (
       <CreateRaid
         closeForm={() => setBulkAction(null)}
@@ -60,7 +60,7 @@ const BulkActions = ({
     );
   }
 
-  if (bulkAction === "createVolumeGroup") {
+  if (bulkAction === BulkAction.CREATE_VOLUME_GROUP) {
     return (
       <CreateVolumeGroup
         closeForm={() => setBulkAction(null)}
@@ -70,7 +70,7 @@ const BulkActions = ({
     );
   }
 
-  if (bulkAction === "updateDatastore") {
+  if (bulkAction === BulkAction.UPDATE_DATASTORE) {
     return (
       <UpdateDatastore
         closeForm={() => setBulkAction(null)}
@@ -114,7 +114,7 @@ const BulkActions = ({
               appearance="neutral"
               data-test="create-datastore"
               disabled={!createDatastoreEnabled}
-              onClick={() => setBulkAction("createDatastore")}
+              onClick={() => setBulkAction(BulkAction.CREATE_DATASTORE)}
             >
               Create datastore
             </Button>
@@ -128,7 +128,7 @@ const BulkActions = ({
               appearance="neutral"
               data-test="add-to-datastore"
               disabled={!updateDatastoreEnabled}
-              onClick={() => setBulkAction("updateDatastore")}
+              onClick={() => setBulkAction(BulkAction.UPDATE_DATASTORE)}
             >
               Add to existing datastore
             </Button>
@@ -160,7 +160,7 @@ const BulkActions = ({
             appearance="neutral"
             data-test="create-vg"
             disabled={!createVgEnabled}
-            onClick={() => setBulkAction("createVolumeGroup")}
+            onClick={() => setBulkAction(BulkAction.CREATE_VOLUME_GROUP)}
           >
             Create volume group
           </Button>
@@ -178,7 +178,7 @@ const BulkActions = ({
             appearance="neutral"
             data-test="create-raid"
             disabled={!createRaidEnabled}
-            onClick={() => setBulkAction("createRaid")}
+            onClick={() => setBulkAction(BulkAction.CREATE_RAID)}
           >
             Create RAID
           </Button>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/StorageDeviceActions/StorageDeviceActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/StorageDeviceActions/StorageDeviceActions.tsx
@@ -1,0 +1,120 @@
+import { useSelector } from "react-redux";
+
+import { StorageDeviceAction } from "../AvailableStorageTable";
+
+import TableActionsDropdown from "app/base/components/TableActionsDropdown";
+import type { TableAction } from "app/base/components/TableActionsDropdown";
+import machineSelectors from "app/store/machine/selectors";
+import type { Disk, MachineDetails, Partition } from "app/store/machine/types";
+import {
+  canBeDeleted,
+  canBePartitioned,
+  canCreateBcache,
+  canCreateCacheSet,
+  canCreateLogicalVolume,
+  canSetBootDisk,
+  formatType,
+  isDisk,
+  isPartition,
+  isVolumeGroup,
+} from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  disabled: boolean;
+  storageDevice: Disk | Partition;
+  onActionClick: (rowAction: StorageDeviceAction) => void;
+  systemId: MachineDetails["system_id"];
+};
+
+const StorageDeviceActions = ({
+  disabled,
+  storageDevice,
+  onActionClick,
+  systemId,
+}: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  let actions: TableAction<StorageDeviceAction>[] = [];
+
+  if (machine && "disks" in machine) {
+    if (isDisk(storageDevice)) {
+      actions = [
+        {
+          label: "Add logical volume...",
+          show: canCreateLogicalVolume(storageDevice),
+          type: StorageDeviceAction.CREATE_LOGICAL_VOLUME,
+        },
+        {
+          label: "Add partition...",
+          show: canBePartitioned(storageDevice),
+          type: StorageDeviceAction.CREATE_PARTITION,
+        },
+        {
+          label: "Create bcache...",
+          show: canCreateBcache(machine.disks, storageDevice),
+          type: StorageDeviceAction.CREATE_BCACHE,
+        },
+        {
+          label: "Create cache set...",
+          show: canCreateCacheSet(storageDevice),
+          type: StorageDeviceAction.CREATE_CACHE_SET,
+        },
+        {
+          label: "Set boot disk...",
+          show: canSetBootDisk(machine.detected_storage_layout, storageDevice),
+          type: StorageDeviceAction.SET_BOOT_DISK,
+        },
+        {
+          label: `Edit ${formatType(storageDevice, true)}...`,
+          show: !isVolumeGroup(storageDevice),
+          type: StorageDeviceAction.EDIT_DISK,
+        },
+        {
+          label: "Remove volume group...",
+          show: canBeDeleted(storageDevice) && isVolumeGroup(storageDevice),
+          type: StorageDeviceAction.DELETE_VOLUME_GROUP,
+        },
+        {
+          label: `Remove ${formatType(storageDevice, true)}...`,
+          show: canBeDeleted(storageDevice) && !isVolumeGroup(storageDevice),
+          type: StorageDeviceAction.DELETE_DISK,
+        },
+      ];
+    }
+    if (isPartition(storageDevice)) {
+      actions = [
+        {
+          label: "Edit partition...",
+          type: StorageDeviceAction.EDIT_PARTITION,
+        },
+        {
+          label: "Create bcache...",
+          show: canCreateBcache(machine.disks, storageDevice),
+          type: StorageDeviceAction.CREATE_BCACHE,
+        },
+        {
+          label: "Create cache set...",
+          show: canCreateCacheSet(storageDevice),
+          type: StorageDeviceAction.CREATE_CACHE_SET,
+        },
+        {
+          label: "Remove partition...",
+          type: StorageDeviceAction.DELETE_PARTITION,
+        },
+      ];
+    }
+
+    return (
+      <TableActionsDropdown
+        actions={actions}
+        disabled={disabled}
+        onActionClick={onActionClick}
+      />
+    );
+  }
+  return null;
+};
+
+export default StorageDeviceActions;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/StorageDeviceActions/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/StorageDeviceActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StorageDeviceActions";

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/CacheSetsTable/CacheSetsTable.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import ActionConfirm from "../../ActionConfirm";
 
-import TableMenu from "app/base/components/TableMenu";
+import TableActionsDropdown from "app/base/components/TableActionsDropdown";
 import type { TSFixMe } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -13,8 +13,12 @@ import type { Machine } from "app/store/machine/types";
 import { formatSize, isCacheSet } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
+export enum CacheSetAction {
+  DELETE = "deleteCacheSet",
+}
+
 type Expanded = {
-  content: "deleteCacheSet";
+  content: CacheSetAction;
   id: string;
 };
 
@@ -39,13 +43,6 @@ const CacheSetsTable = ({
       if (isCacheSet(disk)) {
         const rowId = `${disk.type}-${disk.id}`;
         const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
-        const cacheSetActions = [
-          {
-            children: "Remove cache set...",
-            onClick: () =>
-              setExpanded({ content: "deleteCacheSet", id: rowId }),
-          },
-        ];
 
         rows.push({
           className: isExpanded ? "p-table__row is-active" : null,
@@ -56,11 +53,17 @@ const CacheSetsTable = ({
             {
               className: "u-align--right",
               content: (
-                <TableMenu
+                <TableActionsDropdown
+                  actions={[
+                    {
+                      label: "Remove cache set...",
+                      type: CacheSetAction.DELETE,
+                    },
+                  ]}
                   disabled={!canEditStorage}
-                  links={cacheSetActions}
-                  position="right"
-                  title="Take action:"
+                  onActionClick={(action: CacheSetAction) =>
+                    setExpanded({ content: action, id: rowId })
+                  }
                 />
               ),
             },
@@ -68,7 +71,7 @@ const CacheSetsTable = ({
           expanded: isExpanded,
           expandedContent: (
             <div className="u-flex--grow">
-              {expanded?.content === "deleteCacheSet" && (
+              {expanded?.content === CacheSetAction.DELETE && (
                 <ActionConfirm
                   closeExpanded={closeExpanded}
                   confirmLabel="Remove cache set"

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import ActionConfirm from "../../ActionConfirm";
 
-import TableMenu from "app/base/components/TableMenu";
+import TableActionsDropdown from "app/base/components/TableActionsDropdown";
 import type { TSFixMe } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
@@ -13,8 +13,12 @@ import type { Machine } from "app/store/machine/types";
 import { formatSize, isDatastore } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
+export enum DatastoreAction {
+  DELETE = "deleteDisk",
+}
+
 type Expanded = {
-  content: "deleteDisk";
+  content: DatastoreAction;
   id: string;
 };
 
@@ -41,12 +45,6 @@ const DatastoresTable = ({
         const fs = disk.filesystem;
         const rowId = `${fs.fstype}-${fs.id}`;
         const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
-        const datastoreActions = [
-          {
-            children: "Remove datastore...",
-            onClick: () => setExpanded({ content: "deleteDisk", id: rowId }),
-          },
-        ];
         rows.push({
           className: isExpanded ? "p-table__row is-active" : null,
           columns: [
@@ -56,11 +54,17 @@ const DatastoresTable = ({
             { content: fs.mount_point },
             {
               content: (
-                <TableMenu
+                <TableActionsDropdown
+                  actions={[
+                    {
+                      label: "Remove datastore...",
+                      type: DatastoreAction.DELETE,
+                    },
+                  ]}
                   disabled={!canEditStorage}
-                  links={datastoreActions}
-                  position="right"
-                  title="Take action:"
+                  onActionClick={(action: DatastoreAction) =>
+                    setExpanded({ content: action, id: rowId })
+                  }
                 />
               ),
               className: "u-align--right",


### PR DESCRIPTION
## Done

- Created `TableActionsDropdown` component, which is an extension of `TableMenu` but used specifically for the actions cell.
- Moved storage action code out of `AvailableStorageTable` and into new `StorageDeviceActions` component.
- Converted storage action strings into enums. 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click around the storage tab of a Ready or Allocated machine and check that the actions still work.

## Fixes

Fixes #2072 
