### PR TITLE
feat(ui): display script result logs

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -78,7 +78,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/Users/kit/src/work/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -412,6 +412,9 @@ exports[`stricter compilation`] = {
       [80, 9, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"],
       [94, 17, 36, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'MachineDetails\'.\\n  No index signature with a parameter of type \'string\' was found on type \'MachineDetails\'.", "830072625"]
     ],
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetailsLogs.tsx:2335753194": [
+      [23, 18, 14, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'ScriptResultData\'.\\n  No index signature with a parameter of type \'string\' was found on type \'ScriptResultData\'.", "887297148"]
+    ],
     "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:3077766076": [
       [186, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
     ],
@@ -513,8 +516,8 @@ exports[`stricter compilation`] = {
     "src/app/store/resourcepool/actions.test.ts:9201512": [
       [71, 52, 24, "Expected 1 arguments, but got 2.", "3295119724"]
     ],
-    "src/app/store/scriptresult/slice.ts:1276939673": [
-      [31, 2, 8, "Type \'SliceCaseReducers<ScriptResultState>\' does not satisfy the constraint \'SliceCaseReducers<GenericState<ScriptResult, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }> | CaseReducerWithPrepare<ScriptResultState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n      Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n        Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Property \'history\' is missing in type \'WritableDraft<GenericState<ScriptResult, any>>\' but required in type \'WritableDraft<ScriptResultState>\'.", "781891908"]
+    "src/app/store/scriptresult/slice.ts:817811787": [
+      [47, 2, 8, "Type \'Reducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<ScriptResult, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }> | CaseReducerWithPrepare<ScriptResultState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n      Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n        Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<ScriptResult, any>>\' is missing the following properties from type \'WritableDraft<ScriptResultState>\': history, logs", "781891908"]
     ],
     "src/app/store/user/reducers.test.ts:698541338": [
       [8, 6, 5, "Variable \'state\' implicitly has type \'any\' in some locations where its type cannot be determined.", "195031250"],
@@ -593,11 +596,11 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:2770740400": [
+    "src/testing/factories/state.ts:2187488226": [
       [269, 2, 4, "Type \'null\' is not assignable to type \'OSInfo | ArrayFactory<never> | AttributeFunction<OSInfo> | Factory<OSInfo> | DerivedFunction<OSInfoState, OSInfo>\'.", "2087377941"],
-      [356, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
-      [358, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
-      [363, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+      [357, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2158674347"],
+      [359, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Location<unknown>, string>\'.", "2087809207"],
+      [364, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | \\"PUSH\\" | \\"POP\\" | \\"REPLACE\\" | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -689,13 +692,13 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 58, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/selectors.ts:3809501328": [
-      [9, 13, 8, "RegExp match", "1152173309"],
-      [57, 34, 8, "RegExp match", "1152173309"]
+    "src/app/store/scriptresult/selectors.ts:1491879516": [
+      [13, 13, 8, "RegExp match", "1152173309"],
+      [71, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/types.ts:499587628": [
+    "src/app/store/scriptresult/types.ts:1361698920": [
       [7, 13, 8, "RegExp match", "1152173309"],
-      [108, 58, 8, "RegExp match", "1152173309"]
+      [115, 58, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scripts/types.ts:980490450": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -196,6 +196,7 @@ Object {
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "logs": null,
     "saved": false,
     "saving": false,
   },

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
@@ -117,4 +117,29 @@ describe("MachineTestDetails", () => {
         .text()
     ).toEqual("test-value");
   });
+
+  it("fetches script result logs", () => {
+    const scriptResults = [scriptResultFactory({ id: 1 })];
+
+    state.nodescriptresult.items = { abc123: [1] };
+    state.scriptresult.items = scriptResults;
+
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/machine/abc123/tests/1/details"]}>
+          <Route path="/machine/:id/tests/:scriptResultId/details">
+            <MachineTestsDetails />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(store.getActions()[0].type).toEqual("scriptresult/getLogs");
+    expect(store.getActions()[0].payload.params.data_type).toEqual("combined");
+    expect(store.getActions()[1].payload.params.data_type).toEqual("stdout");
+    expect(store.getActions()[2].payload.params.data_type).toEqual("stderr");
+    expect(store.getActions()[3].payload.params.data_type).toEqual("result");
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
@@ -5,6 +5,8 @@ import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useParams } from "react-router-dom";
 
+import MachineTestsDetailsLogs from "./MachineTestsDetailsLogs";
+
 import { scriptStatus } from "app/base/enum";
 import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
@@ -23,6 +25,10 @@ const MachineTestsDetails = (): JSX.Element | null => {
     scriptResultSelectors.getByMachineId(state, id)
   );
 
+  const logs = useSelector((state: RootState) =>
+    scriptResultSelectors.logs(state)
+  );
+
   const loading = useSelector((state: RootState) =>
     scriptResultSelectors.loading(state)
   );
@@ -36,6 +42,16 @@ const MachineTestsDetails = (): JSX.Element | null => {
       dispatch(scriptResultActions.getByMachineId(id));
     }
   }, [dispatch, scriptResults, loading, id]);
+
+  useEffect(() => {
+    if (!logs && result) {
+      ["combined", "stdout", "stderr", "result"].forEach((type) =>
+        dispatch(scriptResultActions.getLogs(result.id, type))
+      );
+    }
+  }, [dispatch, result, logs]);
+
+  const log = logs ? logs[parseInt(scriptResultId, 10)] : null;
 
   if (result) {
     const hasMetrics = result.results.length > 0;
@@ -107,6 +123,14 @@ const MachineTestsDetails = (): JSX.Element | null => {
                   ))}
                 </tbody>
               </table>
+            </Col>
+          </Row>
+        ) : null}
+        {log ? (
+          <Row>
+            <Col size="12">
+              <h4>Output</h4>
+              <MachineTestsDetailsLogs log={log} />
             </Col>
           </Row>
         ) : null}

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetailsLogs.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetailsLogs.test.tsx
@@ -1,0 +1,52 @@
+import { mount } from "enzyme";
+
+import MachineTestsDetailsLogs from "./MachineTestsDetailsLogs";
+
+describe("MachineTestsDetailsLogs", () => {
+  it("displays combined content by default", () => {
+    const log = {
+      combined: "combined content",
+      stdout: "stdout content",
+      stderr: "",
+      result: "yaml result",
+    };
+
+    const wrapper = mount(<MachineTestsDetailsLogs log={log} />);
+
+    expect(wrapper.find("[data-test='log-content'] code").text()).toEqual(
+      "combined content"
+    );
+  });
+
+  it("displays other content on click", () => {
+    const log = {
+      combined: "combined content",
+      stdout: "stdout content",
+      stderr: "",
+      result: "yaml result",
+    };
+
+    const wrapper = mount(<MachineTestsDetailsLogs log={log} />);
+    wrapper.find("a[data-test='tab-link-yaml']").simulate("click");
+
+    expect(wrapper.find("[data-test='log-content'] code").text()).toEqual(
+      "yaml result"
+    );
+  });
+
+  it("displays 'no data' for empty content", () => {
+    const log = {
+      combined: "combined content",
+      stdout: "stdout content",
+      stderr: "",
+      result: "yaml result",
+    };
+
+    const wrapper = mount(<MachineTestsDetailsLogs log={log} />);
+    wrapper.find("a[data-test='tab-link-stderr']").simulate("click");
+
+    expect(wrapper.find("[data-test='log-content'] code").text()).toEqual(
+      "No data"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetailsLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetailsLogs.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+import { Code, Tabs } from "@canonical/react-components";
+
+import type { ScriptResultData } from "app/store/scriptresult/types";
+
+type Props = {
+  log: ScriptResultData;
+};
+
+const MachineTestsDetailsLogs = ({ log }: Props): JSX.Element => {
+  const [activeTab, setActiveTab] = useState<string>("combined");
+
+  // Ideally should be buttons, see https://github.com/canonical-web-and-design/vanilla-framework/issues/3532
+  const links = ["combined", "stdout", "stderr", "result"].map((tab) => ({
+    active: activeTab === tab,
+    label: tab === "result" ? "yaml" : tab,
+    onClick: (e: React.MouseEvent) => {
+      e.preventDefault();
+      setActiveTab(tab);
+    },
+  }));
+
+  const tabText = log[activeTab] || "";
+
+  return (
+    <>
+      <Tabs links={links} />
+      <Code data-test="log-content" className="u-no-margin--bottom">
+        {tabText === "" ? "No data" : tabText}
+      </Code>
+    </>
+  );
+};
+
+export default MachineTestsDetailsLogs;

--- a/ui/src/app/store/scriptresult/reducers.test.ts
+++ b/ui/src/app/store/scriptresult/reducers.test.ts
@@ -16,6 +16,7 @@ describe("script result reducer", () => {
       saved: false,
       saving: false,
       history: {},
+      logs: null,
     });
   });
 
@@ -96,9 +97,9 @@ describe("script result reducer", () => {
       history: {},
     });
 
-    expect(
-      reducers(scriptResultState, actions.getByMachineIdStart(null))
-    ).toEqual(scriptResultStateFactory({ loading: true }));
+    expect(reducers(scriptResultState, actions.getHistoryStart(null))).toEqual(
+      scriptResultStateFactory({ loading: true })
+    );
   });
 
   it("reduces getHistorySuccess", () => {
@@ -124,6 +125,67 @@ describe("script result reducer", () => {
         loading: false,
         loaded: true,
         history: { 123: [partialScriptResult] },
+      })
+    );
+  });
+
+  it("reduces getLogsStart", () => {
+    const scriptResultState = scriptResultStateFactory({
+      items: [],
+      loading: false,
+      history: {},
+      logs: null,
+    });
+
+    expect(reducers(scriptResultState, actions.getLogsStart(null))).toEqual(
+      scriptResultStateFactory({ loading: true })
+    );
+  });
+
+  it("reduces getLogsSuccess", () => {
+    const scriptResult = scriptResultFactory({ id: 123 });
+
+    const scriptResultState = scriptResultStateFactory({
+      items: [scriptResult],
+      loading: true,
+      logs: null,
+    });
+
+    expect(
+      reducers(scriptResultState, {
+        meta: { item: { id: 123, data_type: "combined" } },
+        ...actions.getLogsSuccess("foo"),
+      })
+    ).toEqual(
+      scriptResultStateFactory({
+        items: [scriptResult],
+        loading: false,
+        loaded: true,
+        logs: { 123: { combined: "foo" } },
+      })
+    );
+  });
+
+  it("reduces getLogsSuccess with additional logs", () => {
+    const scriptResult = scriptResultFactory({ id: 123 });
+
+    const scriptResultState = scriptResultStateFactory({
+      items: [scriptResult],
+      loading: true,
+      logs: { 123: { combined: "foo" } },
+    });
+
+    expect(
+      reducers(scriptResultState, {
+        meta: { item: { id: 123, data_type: "result" } },
+        ...actions.getLogsSuccess("bar"),
+      })
+    ).toEqual(
+      scriptResultStateFactory({
+        items: [scriptResult],
+        loading: false,
+        loaded: true,
+        logs: { 123: { combined: "foo", result: "bar" } },
       })
     );
   });

--- a/ui/src/app/store/scriptresult/selectors.ts
+++ b/ui/src/app/store/scriptresult/selectors.ts
@@ -3,7 +3,11 @@ import { createSelector } from "@reduxjs/toolkit";
 import type { Machine } from "../machine/types";
 import nodeScriptResultSelectors from "../nodescriptresult/selectors";
 
-import type { PartialScriptResult, ScriptResult } from "./types";
+import type {
+  PartialScriptResult,
+  ScriptResult,
+  ScriptResultData,
+} from "./types";
 import { ResultStatusFailed } from "./types";
 
 import { HardwareType, ResultType } from "app/base/enum";
@@ -27,6 +31,16 @@ const history = (
   state: RootState
 ): Record<ScriptResult["id"], PartialScriptResult[]> =>
   state.scriptresult.history;
+
+/**
+ * Returns script result logs
+ * @param {RootState} state - Redux state
+ * @returns script logs
+ */
+const logs = (
+  state: RootState
+): Record<ScriptResult["id"], ScriptResultData> | null =>
+  state.scriptresult.logs;
 
 /**
  * Returns true if script results are loading
@@ -288,6 +302,7 @@ const getFailedTestingResultsByMachineIds = createSelector(
 const scriptResult = {
   all,
   history,
+  logs,
   errors,
   getByMachineId,
   getHardwareTestingByMachineId,

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -106,6 +106,14 @@ export type ScriptResultHistory = {
   [x: number]: PartialScriptResult[];
 };
 
+export type ScriptResultData = {
+  combined?: string;
+  stdout?: string;
+  stderr?: string;
+  result?: string;
+};
+
 export type ScriptResultState = GenericState<ScriptResult, TSFixMe> & {
   history: Record<ScriptResult["id"], PartialScriptResult[]>;
+  logs: Record<ScriptResult["id"], ScriptResultData> | null;
 };

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -328,6 +328,7 @@ export const resourcePoolState = define<ResourcePoolState>({
 export const scriptResultState = define<ScriptResultState>({
   ...defaultState,
   history: () => ({}),
+  logs: () => null,
 });
 
 export const serviceState = define<ServiceState>({


### PR DESCRIPTION
## Done

- add tabbed script result log output

![image](https://user-images.githubusercontent.com/130286/106695760-233be500-6640-11eb-8303-5eb6ed7df7f7.png)

Discovered that multiline support is currently [broken for `Code` in some states atm](https://github.com/canonical-web-and-design/react-components/issues/386) while working on this branch, which is why `copyable` is not set.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the testing tab for a machine with script result output (e.g. 4p3m6m on bolla)
- Ensure you see tabbed output for the script results

## Fixes

Fixes: canonical-web-and-design/MAAS-squad#2211

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
