### PR TITLE
feat(ui): display a warning when trying to edit a disconnected interface

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.tsx
@@ -22,7 +22,7 @@ type Props = {
   onConfirm: () => void;
   onSaveAnalytics: AnalyticsEvent;
   statusKey: keyof MachineStatus;
-  submitAppearance?: "negative" | "positive";
+  submitAppearance?: "negative" | "neutral" | "positive";
   systemId: Machine["system_id"];
 };
 

--- a/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/ActionConfirm/ActionConfirm.tsx
@@ -7,6 +7,7 @@ import {
   Notification,
   Row,
 } from "@canonical/react-components";
+import type { Props as ButtonProps } from "@canonical/react-components/dist/components/Button/Button";
 
 import { useSendAnalyticsWhen } from "app/base/hooks";
 import type { AnalyticsEvent } from "app/base/types";
@@ -22,7 +23,7 @@ type Props = {
   onConfirm: () => void;
   onSaveAnalytics: AnalyticsEvent;
   statusKey: keyof MachineStatus;
-  submitAppearance?: "negative" | "neutral" | "positive";
+  submitAppearance?: ButtonProps["appearance"];
   systemId: Machine["system_id"];
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -44,7 +44,6 @@ const NetworkTableActions = ({
   // Placeholders for hook results that are not yet implemented.
   const canAddAliasOrVLAN = true;
   const isPhysical = nic?.type === NetworkInterfaceTypes.PHYSICAL;
-  const cannotEditInterface = false;
   let actions: TableMenuProps["links"] = [];
   if (machine && nic) {
     actions = [
@@ -64,9 +63,11 @@ const NetworkTableActions = ({
         label: "Add alias or VLAN",
       },
       {
-        // This menu item is not yet implemented.
-        inMenu: !cannotEditInterface,
-        state: null,
+        inMenu: true,
+        state:
+          isPhysical && !nic?.link_connected
+            ? ExpandedState.DISCONNECTED_WARNING
+            : ExpandedState.EDIT,
         label: `Edit ${getInterfaceTypeText(machine, nic, link)}`,
       },
       {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
@@ -244,6 +244,27 @@ describe("NetworkTableConfirmation", () => {
       expect(confirmation.prop("submitAppearance")).toBe("negative");
     });
 
+    it("can display a disconnected warning", () => {
+      const store = mockStore(state);
+      const wrapper = mount(
+        <Provider store={store}>
+          <NetworkTableConfirmation
+            expanded={{
+              content: ExpandedState.DISCONNECTED_WARNING,
+            }}
+            nic={nic}
+            setExpanded={jest.fn()}
+            systemId="abc123"
+          />
+        </Provider>
+      );
+      const confirmation = wrapper.find("ActionConfirm");
+      expect(confirmation.prop("eventName")).toBe("updateInterface");
+      expect(confirmation.prop("confirmLabel")).toBe("Mark as connected");
+      expect(confirmation.prop("statusKey")).toBe("updatingInterface");
+      expect(confirmation.prop("submitAppearance")).toBe("neutral");
+    });
+
     it("can confirm marking connected", () => {
       const store = mockStore(state);
       const wrapper = mount(

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
@@ -262,7 +262,7 @@ describe("NetworkTableConfirmation", () => {
       expect(confirmation.prop("eventName")).toBe("updateInterface");
       expect(confirmation.prop("confirmLabel")).toBe("Mark as connected");
       expect(confirmation.prop("statusKey")).toBe("updatingInterface");
-      expect(confirmation.prop("submitAppearance")).toBe("neutral");
+      expect(confirmation.prop("submitAppearance")).toBe("positive");
     });
 
     it("can confirm marking connected", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { Button } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionConfirm from "../../../ActionConfirm";
@@ -113,11 +112,7 @@ const NetworkTableConfirmation = ({
           This interface is <strong>disconnected</strong>, it cannot be
           configured unless a cable is connected.
           <br />
-          If this is no longer true,
-          <Button className="p-button--link" onClick={updateConnection}>
-            mark cable as connected
-          </Button>
-          .
+          If this is no longer true, mark cable as connected.
         </>
       );
     } else {
@@ -148,13 +143,7 @@ const NetworkTableConfirmation = ({
           label: "Update",
         }}
         statusKey="updatingInterface"
-        submitAppearance={
-          markConnected
-            ? showDisconnectedWarning
-              ? "neutral"
-              : "positive"
-            : "negative"
-        }
+        submitAppearance={markConnected ? "positive" : "negative"}
         systemId={machine.system_id}
       />
     );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
@@ -1,9 +1,11 @@
 import type { NetworkInterface, NetworkLink } from "app/store/machine/types";
 
 export enum ExpandedState {
-  REMOVE = "remove",
-  MARK_DISCONNECTED = "markDisconnected",
+  DISCONNECTED_WARNING = "disconnectedWarning",
+  EDIT = "edit",
   MARK_CONNECTED = "markConnected",
+  MARK_DISCONNECTED = "markDisconnected",
+  REMOVE = "remove",
 }
 
 export type Expanded = {


### PR DESCRIPTION
## Done

- Display a warning when trying to edit a physical interface that is disconnected.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Find a physical interface that is disconnected (or use the action menu to mark it as disconnected).
- Using the action menu click edit.
- It should show a warning.
- Click the button and it should mark it as connected.

## Fixes

Fixes: #2330.