### PR TITLE
refactor(ui): refactor some common form Select components

### DIFF
--- a/ui/src/app/base/components/ArchitectureSelect/ArchitectureSelect.test.tsx
+++ b/ui/src/app/base/components/ArchitectureSelect/ArchitectureSelect.test.tsx
@@ -1,0 +1,77 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import ArchitectureSelect from "./ArchitectureSelect";
+
+import {
+  architecturesState as architecturesStateFactory,
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ArchitectureSelect", () => {
+  it("renders a list of all architectures in state", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        architectures: architecturesStateFactory({
+          data: ["arch1", "arch2", "arch3"],
+          loaded: true,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ architecture: "" }} onSubmit={jest.fn()}>
+          <ArchitectureSelect name="architecture" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='architecture']")).toMatchSnapshot();
+  });
+
+  it("dispatches action to fetch architectures on load", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <Formik initialValues={{ architecture: "" }} onSubmit={jest.fn()}>
+          <ArchitectureSelect name="architecture" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "FETCH_GENERAL_ARCHITECTURES")
+    ).toBe(true);
+  });
+
+  it("disables select if architectures have not loaded", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        architectures: architecturesStateFactory({
+          loaded: false,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ architecture: "" }} onSubmit={jest.fn()}>
+          <ArchitectureSelect name="architecture" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='architecture']").prop("disabled")).toBe(
+      true
+    );
+  });
+});

--- a/ui/src/app/base/components/ArchitectureSelect/ArchitectureSelect.tsx
+++ b/ui/src/app/base/components/ArchitectureSelect/ArchitectureSelect.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import type { HTMLProps } from "react";
+
+import { Select } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import { general as generalActions } from "app/base/actions";
+import FormikField from "app/base/components/FormikField";
+import generalSelectors from "app/store/general/selectors";
+
+type Props = {
+  disabled?: boolean;
+  label?: string;
+  name: string;
+} & HTMLProps<HTMLSelectElement>;
+
+export const ArchitectureSelect = ({
+  disabled = false,
+  label = "Architecture",
+  name,
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const architectures = useSelector(generalSelectors.architectures.get);
+  const architecturesLoaded = useSelector(
+    generalSelectors.architectures.loaded
+  );
+
+  useEffect(() => {
+    dispatch(generalActions.fetchArchitectures());
+  }, [dispatch]);
+
+  return (
+    <FormikField
+      component={Select}
+      disabled={!architecturesLoaded || disabled}
+      label={label}
+      name={name}
+      options={[
+        {
+          label: "Select architecture",
+          value: "",
+          disabled: true,
+        },
+        ...architectures.map((architecture) => ({
+          key: architecture,
+          label: architecture,
+          value: architecture,
+        })),
+      ]}
+      {...props}
+    />
+  );
+};
+
+export default ArchitectureSelect;

--- a/ui/src/app/base/components/ArchitectureSelect/__snapshots__/ArchitectureSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ArchitectureSelect/__snapshots__/ArchitectureSelect.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ArchitectureSelect renders a list of all architectures in state 1`] = `
+<select
+  className="p-form-validation__input"
+  disabled={false}
+  name="architecture"
+  onBlur={[Function]}
+  onChange={[Function]}
+  value=""
+>
+  <option
+    disabled={true}
+    key="Select architecture"
+    value=""
+  >
+    Select architecture
+  </option>
+  <option
+    key="arch1"
+    value="arch1"
+  >
+    arch1
+  </option>
+  <option
+    key="arch2"
+    value="arch2"
+  >
+    arch2
+  </option>
+  <option
+    key="arch3"
+    value="arch3"
+  >
+    arch3
+  </option>
+</select>
+`;

--- a/ui/src/app/base/components/ArchitectureSelect/index.ts
+++ b/ui/src/app/base/components/ArchitectureSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ArchitectureSelect";

--- a/ui/src/app/base/components/DomainSelect/DomainSelect.test.tsx
+++ b/ui/src/app/base/components/DomainSelect/DomainSelect.test.tsx
@@ -1,0 +1,72 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DomainSelect from "./DomainSelect";
+
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DomainSelect", () => {
+  it("renders a list of all domains in state", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [
+          domainFactory({ id: 101, name: "Domain 1" }),
+          domainFactory({ id: 202, name: "Domain 2" }),
+        ],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ domain: "" }} onSubmit={jest.fn()}>
+          <DomainSelect name="domain" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='domain']")).toMatchSnapshot();
+  });
+
+  it("dispatches action to fetch domains on load", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <Formik initialValues={{ domain: "" }} onSubmit={jest.fn()}>
+          <DomainSelect name="domain" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "domain/fetch")
+    ).toBe(true);
+  });
+
+  it("disables select if domains have not loaded", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ domain: "" }} onSubmit={jest.fn()}>
+          <DomainSelect name="domain" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='domain']").prop("disabled")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/DomainSelect/DomainSelect.tsx
+++ b/ui/src/app/base/components/DomainSelect/DomainSelect.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import type { HTMLProps } from "react";
+
+import { Select } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import FormikField from "app/base/components/FormikField";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+import type { Domain } from "app/store/domain/types";
+
+type Props = {
+  disabled?: boolean;
+  label?: string;
+  name: string;
+  valueKey?: keyof Domain;
+} & HTMLProps<HTMLSelectElement>;
+
+export const DomainSelect = ({
+  disabled = false,
+  label = "Domain",
+  name,
+  valueKey = "name",
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const domains = useSelector(domainSelectors.all);
+  const domainsLoaded = useSelector(domainSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(domainActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <FormikField
+      component={Select}
+      disabled={!domainsLoaded || disabled}
+      label={label}
+      name={name}
+      options={[
+        { label: "Select domain", value: "", disabled: true },
+        ...domains.map((domain) => ({
+          key: `domain-${domain.id}`,
+          label: domain.name,
+          value: domain[valueKey],
+        })),
+      ]}
+      {...props}
+    />
+  );
+};
+
+export default DomainSelect;

--- a/ui/src/app/base/components/DomainSelect/__snapshots__/DomainSelect.test.tsx.snap
+++ b/ui/src/app/base/components/DomainSelect/__snapshots__/DomainSelect.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DomainSelect renders a list of all domains in state 1`] = `
+<select
+  className="p-form-validation__input"
+  disabled={false}
+  name="domain"
+  onBlur={[Function]}
+  onChange={[Function]}
+  value=""
+>
+  <option
+    disabled={true}
+    key="Select domain"
+    value=""
+  >
+    Select domain
+  </option>
+  <option
+    key="domain-101"
+    value="Domain 1"
+  >
+    Domain 1
+  </option>
+  <option
+    key="domain-202"
+    value="Domain 2"
+  >
+    Domain 2
+  </option>
+</select>
+`;

--- a/ui/src/app/base/components/DomainSelect/index.ts
+++ b/ui/src/app/base/components/DomainSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DomainSelect";

--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -1,3 +1,4 @@
+import type { HTMLProps } from "react";
 import { useRef } from "react";
 
 import { Input } from "@canonical/react-components";
@@ -10,7 +11,7 @@ import type { TSFixMe } from "app/base/types";
 type Props = {
   Component?: JSX.Element;
   name: string;
-  value?: number | string;
+  value?: HTMLProps<HTMLElement>["value"];
   [x: string]: TSFixMe;
 };
 

--- a/ui/src/app/base/components/MinimumKernelSelect/MinimumKernelSelect.test.tsx
+++ b/ui/src/app/base/components/MinimumKernelSelect/MinimumKernelSelect.test.tsx
@@ -1,0 +1,80 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import MinimumKernelSelect from "./MinimumKernelSelect";
+
+import {
+  hweKernelsState as hweKernelsStateFactory,
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MinimumKernelSelect", () => {
+  it("renders a list of all hwe kernels in state", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        hweKernels: hweKernelsStateFactory({
+          data: [
+            ["kernel-1", "Kernel 1"],
+            ["kernel-2", "Kernel 2"],
+          ],
+          loaded: true,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ minKernel: "" }} onSubmit={jest.fn()}>
+          <MinimumKernelSelect name="minKernel" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='minKernel']")).toMatchSnapshot();
+  });
+
+  it("dispatches action to fetch hwe kernels on load", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <Formik initialValues={{ minKernel: "" }} onSubmit={jest.fn()}>
+          <MinimumKernelSelect name="minKernel" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "FETCH_GENERAL_HWE_KERNELS")
+    ).toBe(true);
+  });
+
+  it("disables select if hwe kernels have not loaded", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        hweKernels: hweKernelsStateFactory({
+          loaded: false,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ minKernel: "" }} onSubmit={jest.fn()}>
+          <MinimumKernelSelect name="minKernel" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='minKernel']").prop("disabled")).toBe(
+      true
+    );
+  });
+});

--- a/ui/src/app/base/components/MinimumKernelSelect/MinimumKernelSelect.tsx
+++ b/ui/src/app/base/components/MinimumKernelSelect/MinimumKernelSelect.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+import type { HTMLProps } from "react";
+
+import { Select } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import { general as generalActions } from "app/base/actions";
+import FormikField from "app/base/components/FormikField";
+import generalSelectors from "app/store/general/selectors";
+
+type Props = {
+  disabled?: boolean;
+  label?: string;
+  name: string;
+} & HTMLProps<HTMLSelectElement>;
+
+export const MinimumKernelSelect = ({
+  disabled = false,
+  label = "Minimum kernel",
+  name,
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const hweKernels = useSelector(generalSelectors.hweKernels.get);
+  const hweKernelsLoaded = useSelector(generalSelectors.hweKernels.loaded);
+
+  useEffect(() => {
+    dispatch(generalActions.fetchHweKernels());
+  }, [dispatch]);
+
+  return (
+    <FormikField
+      component={Select}
+      disabled={!hweKernelsLoaded || disabled}
+      label={label}
+      name={name}
+      options={[
+        {
+          label: "Select minimum kernel",
+          value: null,
+          disabled: true,
+        },
+        { label: "No minimum kernel", value: "" },
+        ...hweKernels.map((kernel) => ({
+          key: `kernel-${kernel[1]}`,
+          label: kernel[1],
+          value: kernel[0],
+        })),
+      ]}
+      {...props}
+    />
+  );
+};
+
+export default MinimumKernelSelect;

--- a/ui/src/app/base/components/MinimumKernelSelect/__snapshots__/MinimumKernelSelect.test.tsx.snap
+++ b/ui/src/app/base/components/MinimumKernelSelect/__snapshots__/MinimumKernelSelect.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MinimumKernelSelect renders a list of all hwe kernels in state 1`] = `
+<select
+  className="p-form-validation__input"
+  disabled={false}
+  name="minKernel"
+  onBlur={[Function]}
+  onChange={[Function]}
+  value=""
+>
+  <option
+    disabled={true}
+    key="Select minimum kernel"
+    value={null}
+  >
+    Select minimum kernel
+  </option>
+  <option
+    key="No minimum kernel"
+    value=""
+  >
+    No minimum kernel
+  </option>
+  <option
+    key="kernel-Kernel 1"
+    value="kernel-1"
+  >
+    Kernel 1
+  </option>
+  <option
+    key="kernel-Kernel 2"
+    value="kernel-2"
+  >
+    Kernel 2
+  </option>
+</select>
+`;

--- a/ui/src/app/base/components/MinimumKernelSelect/index.ts
+++ b/ui/src/app/base/components/MinimumKernelSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MinimumKernelSelect";

--- a/ui/src/app/base/components/ResourcePoolSelect/ResourcePoolSelect.test.tsx
+++ b/ui/src/app/base/components/ResourcePoolSelect/ResourcePoolSelect.test.tsx
@@ -1,0 +1,72 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import ResourcePoolSelect from "./ResourcePoolSelect";
+
+import {
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ResourcePoolSelect", () => {
+  it("renders a list of all resource pools in state", () => {
+    const state = rootStateFactory({
+      resourcepool: resourcePoolStateFactory({
+        items: [
+          resourcePoolFactory({ id: 101, name: "Pool 1" }),
+          resourcePoolFactory({ id: 202, name: "Pool 2" }),
+        ],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ pool: "" }} onSubmit={jest.fn()}>
+          <ResourcePoolSelect name="pool" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='pool']")).toMatchSnapshot();
+  });
+
+  it("dispatches action to fetch resource pools on load", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <Formik initialValues={{ pool: "" }} onSubmit={jest.fn()}>
+          <ResourcePoolSelect name="pool" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "resourcepool/fetch")
+    ).toBe(true);
+  });
+
+  it("disables select if resource pools have not loaded", () => {
+    const state = rootStateFactory({
+      resourcepool: resourcePoolStateFactory({
+        loaded: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ pool: "" }} onSubmit={jest.fn()}>
+          <ResourcePoolSelect name="pool" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='pool']").prop("disabled")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/ResourcePoolSelect/ResourcePoolSelect.tsx
+++ b/ui/src/app/base/components/ResourcePoolSelect/ResourcePoolSelect.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import type { HTMLProps } from "react";
+
+import { Select } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import FormikField from "app/base/components/FormikField";
+import { actions as resourcePoolActions } from "app/store/resourcepool";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import type { ResourcePool } from "app/store/resourcepool/types";
+
+type Props = {
+  disabled?: boolean;
+  label?: string;
+  name: string;
+  valueKey?: keyof ResourcePool;
+} & HTMLProps<HTMLSelectElement>;
+
+export const DomainSelect = ({
+  disabled = false,
+  label = "Resource pool",
+  name,
+  valueKey = "name",
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const resourcePoolsLoaded = useSelector(resourcePoolSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(resourcePoolActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <FormikField
+      component={Select}
+      disabled={!resourcePoolsLoaded || disabled}
+      label={label}
+      name={name}
+      options={[
+        { label: "Select resource pool", value: "", disabled: true },
+        ...resourcePools.map((resourcePool) => ({
+          key: `resource-pool-${resourcePool.id}`,
+          label: resourcePool.name,
+          value: resourcePool[valueKey],
+        })),
+      ]}
+      {...props}
+    />
+  );
+};
+
+export default DomainSelect;

--- a/ui/src/app/base/components/ResourcePoolSelect/__snapshots__/ResourcePoolSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ResourcePoolSelect/__snapshots__/ResourcePoolSelect.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResourcePoolSelect renders a list of all resource pools in state 1`] = `
+<select
+  className="p-form-validation__input"
+  disabled={false}
+  name="pool"
+  onBlur={[Function]}
+  onChange={[Function]}
+  value=""
+>
+  <option
+    disabled={true}
+    key="Select resource pool"
+    value=""
+  >
+    Select resource pool
+  </option>
+  <option
+    key="resource-pool-101"
+    value="Pool 1"
+  >
+    Pool 1
+  </option>
+  <option
+    key="resource-pool-202"
+    value="Pool 2"
+  >
+    Pool 2
+  </option>
+</select>
+`;

--- a/ui/src/app/base/components/ResourcePoolSelect/index.ts
+++ b/ui/src/app/base/components/ResourcePoolSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ResourcePoolSelect";

--- a/ui/src/app/base/components/ZoneSelect/ZoneSelect.test.tsx
+++ b/ui/src/app/base/components/ZoneSelect/ZoneSelect.test.tsx
@@ -1,0 +1,72 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import ZoneSelect from "./ZoneSelect";
+
+import {
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ZoneSelect", () => {
+  it("renders a list of all zones in state", () => {
+    const state = rootStateFactory({
+      zone: zoneStateFactory({
+        items: [
+          zoneFactory({ id: 101, name: "Pool 1" }),
+          zoneFactory({ id: 202, name: "Pool 2" }),
+        ],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ zone: "" }} onSubmit={jest.fn()}>
+          <ZoneSelect name="zone" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='zone']")).toMatchSnapshot();
+  });
+
+  it("dispatches action to fetch zones on load", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <Formik initialValues={{ zone: "" }} onSubmit={jest.fn()}>
+          <ZoneSelect name="zone" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "zone/fetch")
+    ).toBe(true);
+  });
+
+  it("disables select if zones have not loaded", () => {
+    const state = rootStateFactory({
+      zone: zoneStateFactory({
+        loaded: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ zone: "" }} onSubmit={jest.fn()}>
+          <ZoneSelect name="zone" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(wrapper.find("select[name='zone']").prop("disabled")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/ZoneSelect/ZoneSelect.tsx
+++ b/ui/src/app/base/components/ZoneSelect/ZoneSelect.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import type { HTMLProps } from "react";
+
+import { Select } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import FormikField from "app/base/components/FormikField";
+import { actions as zoneActions } from "app/store/zone";
+import zoneSelectors from "app/store/zone/selectors";
+import type { Zone } from "app/store/zone/types";
+
+type Props = {
+  disabled?: boolean;
+  label?: string;
+  name: string;
+  valueKey?: keyof Zone;
+} & HTMLProps<HTMLSelectElement>;
+
+export const DomainSelect = ({
+  disabled = false,
+  label = "Zone",
+  name,
+  valueKey = "name",
+  ...props
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const zones = useSelector(zoneSelectors.all);
+  const zonesLoaded = useSelector(zoneSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(zoneActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <FormikField
+      component={Select}
+      disabled={!zonesLoaded || disabled}
+      label={label}
+      name={name}
+      options={[
+        { label: "Select zone", value: "", disabled: true },
+        ...zones.map((zone) => ({
+          key: `zone-${zone.id}`,
+          label: zone.name,
+          value: zone[valueKey],
+        })),
+      ]}
+      {...props}
+    />
+  );
+};
+
+export default DomainSelect;

--- a/ui/src/app/base/components/ZoneSelect/__snapshots__/ZoneSelect.test.tsx.snap
+++ b/ui/src/app/base/components/ZoneSelect/__snapshots__/ZoneSelect.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ZoneSelect renders a list of all zones in state 1`] = `
+<select
+  className="p-form-validation__input"
+  disabled={false}
+  name="zone"
+  onBlur={[Function]}
+  onChange={[Function]}
+  value=""
+>
+  <option
+    disabled={true}
+    key="Select zone"
+    value=""
+  >
+    Select zone
+  </option>
+  <option
+    key="zone-101"
+    value="Pool 1"
+  >
+    Pool 1
+  </option>
+  <option
+    key="zone-202"
+    value="Pool 2"
+  >
+    Pool 2
+  </option>
+</select>
+`;

--- a/ui/src/app/base/components/ZoneSelect/index.ts
+++ b/ui/src/app/base/components/ZoneSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ZoneSelect";

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -1,13 +1,12 @@
 import { Col, Row, Select } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 
 import type { ComposeFormDefaults } from "../ComposeForm";
 
+import DomainSelect from "app/base/components/DomainSelect";
 import FormikField from "app/base/components/FormikField";
-import domainSelectors from "app/store/domain/selectors";
+import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
+import ZoneSelect from "app/base/components/ZoneSelect";
 import type { Pod } from "app/store/pod/types";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
-import zoneSelectors from "app/store/zone/selectors";
 
 type Props = {
   architectures: Pod["architectures"];
@@ -23,10 +22,6 @@ export const ComposeFormFields = ({
   available,
   defaults,
 }: Props): JSX.Element => {
-  const domains = useSelector(domainSelectors.all);
-  const resourcePools = useSelector(resourcePoolSelectors.all);
-  const zones = useSelector(zoneSelectors.all);
-
   const coresCaution = available.cores < defaults.cores;
   const memoryCaution = available.memory < defaults.memory;
 
@@ -39,45 +34,9 @@ export const ComposeFormFields = ({
           placeholder="Optional"
           type="text"
         />
-        <FormikField
-          component={Select}
-          label="Domain"
-          name="domain"
-          options={[
-            { label: "Select your domain", value: "", disabled: true },
-            ...domains.map((domain) => ({
-              key: `domain-${domain.id}`,
-              label: domain.name,
-              value: domain.id,
-            })),
-          ]}
-        />
-        <FormikField
-          component={Select}
-          label="Zone"
-          name="zone"
-          options={[
-            { label: "Select your zone", value: "", disabled: true },
-            ...zones.map((zone) => ({
-              key: `zone-${zone.id}`,
-              label: zone.name,
-              value: zone.id,
-            })),
-          ]}
-        />
-        <FormikField
-          component={Select}
-          label="Pool"
-          name="pool"
-          options={[
-            { label: "Select your pool", value: "", disabled: true },
-            ...resourcePools.map((pool) => ({
-              key: `pool-${pool.id}`,
-              label: pool.name,
-              value: pool.id,
-            })),
-          ]}
-        />
+        <DomainSelect name="domain" required valueKey="id" />
+        <ZoneSelect name="zone" required valueKey="id" />
+        <ResourcePoolSelect name="pool" required valueKey="id" />
       </Col>
       <Col size="5" emptyLarge="7">
         <FormikField
@@ -85,7 +44,7 @@ export const ComposeFormFields = ({
           label="Architecture"
           name="architecture"
           options={[
-            { label: "Select your architecture", value: "", disabled: true },
+            { label: "Select architecture", value: "", disabled: true },
             ...architectures.map((architecture) => ({
               key: architecture,
               label: architecture,

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
@@ -1,26 +1,24 @@
 import * as React from "react";
 
-import { Col, Input, Row, Select, Slider } from "@canonical/react-components";
+import { Col, Input, Row, Slider } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import type { PodConfigurationValues } from "../PodConfiguration";
 
 import FormikField from "app/base/components/FormikField";
+import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
 import TagSelector from "app/base/components/TagSelector";
+import ZoneSelect from "app/base/components/ZoneSelect";
 import { formatHostType } from "app/store/pod/utils";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import tagSelectors from "app/store/tag/selectors";
-import zoneSelectors from "app/store/zone/selectors";
 
 type Props = { showHostType?: boolean };
 
 const PodConfigurationFields = ({
   showHostType = true,
 }: Props): JSX.Element => {
-  const resourcePools = useSelector(resourcePoolSelectors.all);
   const allTags = useSelector(tagSelectors.all);
-  const zones = useSelector(zoneSelectors.all);
   const {
     initialValues,
     setFieldValue,
@@ -47,36 +45,8 @@ const PodConfigurationFields = ({
             type="text"
           />
         )}
-        <FormikField
-          component={Select}
-          label="Zone"
-          name="zone"
-          options={[
-            { label: "Select your zone", value: "", disabled: true },
-            ...zones.map((zone) => ({
-              key: `zone-${zone.id}`,
-              label: zone.name,
-              value: zone.id,
-            })),
-          ]}
-        />
-        <FormikField
-          component={Select}
-          label="Resource pool"
-          name="pool"
-          options={[
-            {
-              label: "Select your resource pool",
-              value: "",
-              disabled: true,
-            },
-            ...resourcePools.map((pool) => ({
-              key: `pool-${pool.id}`,
-              label: pool.name,
-              value: pool.id,
-            })),
-          ]}
-        />
+        <ZoneSelect name="zone" required valueKey="id" />
+        <ResourcePoolSelect name="pool" required valueKey="id" />
         <FormikField
           allowNewTags
           component={TagSelector}

--- a/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVMForm/AddKVMFormFields/AddKVMFormFields.tsx
@@ -1,19 +1,17 @@
-import { Col, Row, Select } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import type { AddKVMFormValues } from "../AddKVMForm";
 
 import FormikField from "app/base/components/FormikField";
+import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
+import ZoneSelect from "app/base/components/ZoneSelect";
 import PowerTypeFields from "app/machines/components/PowerTypeFields";
 import generalSelectors from "app/store/general/selectors";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
-import zoneSelectors from "app/store/zone/selectors";
 
 export const AddKVMFormFields = (): JSX.Element => {
   const powerTypes = useSelector(generalSelectors.powerTypes.get);
-  const resourcePools = useSelector(resourcePoolSelectors.all);
-  const zones = useSelector(zoneSelectors.all);
 
   const formikProps = useFormikContext();
   const { values }: AddKVMFormValues = formikProps;
@@ -51,34 +49,8 @@ export const AddKVMFormFields = (): JSX.Element => {
       </Col>
       <Col size="5">
         <FormikField label="Name" name="name" type="text" />
-        <FormikField
-          component={Select}
-          label="Zone"
-          name="zone"
-          options={[
-            { label: "Select your zone", value: "", disabled: true },
-            ...zones.map((zone) => ({
-              key: `zone-${zone.id}`,
-              label: zone.name,
-              value: zone.id,
-            })),
-          ]}
-          required
-        />
-        <FormikField
-          component={Select}
-          label="Resource pool"
-          name="pool"
-          options={[
-            { label: "Select your resource pool", value: "", disabled: true },
-            ...resourcePools.map((pool) => ({
-              key: `pool-${pool.id}`,
-              label: pool.name,
-              value: pool.id,
-            })),
-          ]}
-          required
-        />
+        <ZoneSelect name="zone" required valueKey="id" />
+        <ResourcePoolSelect name="pool" required valueKey="id" />
         <PowerTypeFields
           driverType="pod"
           formikProps={formikProps}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.js
@@ -1,28 +1,16 @@
-import { Col, Row, Select } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import { useSelector } from "react-redux";
-
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
 
 import FormikField from "app/base/components/FormikField";
+import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
 
 export const SetPoolFormFields = () => {
-  const resourcePools = useSelector(resourcePoolSelectors.all);
   const {
     handleChange,
     values,
     setFieldValue,
     setFieldTouched,
   } = useFormikContext();
-
-  const resourcePoolOptions = [
-    { label: "Select resource pool", value: "", disabled: true },
-    ...resourcePools.map((pool) => ({
-      key: `pool-${pool.id}`,
-      label: pool.name,
-      value: pool.name,
-    })),
-  ];
 
   const handleRadioChange = (evt) => {
     handleChange(evt);
@@ -58,13 +46,7 @@ export const SetPoolFormFields = () => {
           </li>
         </ul>
         {values.poolSelection === "select" ? (
-          <FormikField
-            component={Select}
-            label="Pool"
-            name="name"
-            options={resourcePoolOptions}
-            required
-          />
+          <ResourcePoolSelect name="name" required />
         ) : (
           <>
             <FormikField label="Name" name="name" required type="text" />

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -1,4 +1,4 @@
-import { Col, Row, Select } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import PropTypes from "prop-types";
@@ -11,7 +11,7 @@ import { NodeActions } from "app/store/types/node";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 import ActionForm from "app/base/components/ActionForm";
-import FormikField from "app/base/components/FormikField";
+import ZoneSelect from "app/base/components/ZoneSelect";
 
 const SetZoneSchema = Yup.object().shape({
   zone: Yup.string().required("Zone is required"),
@@ -29,15 +29,6 @@ export const SetZoneForm = ({ setSelectedAction }) => {
   useEffect(() => {
     dispatch(zoneActions.fetch());
   }, [dispatch]);
-
-  const zoneOptions = [
-    { label: "Select your zone", value: "", disabled: true },
-    ...zones.map((zone) => ({
-      key: `zone-${zone.id}`,
-      label: zone.name,
-      value: zone.name,
-    })),
-  ];
 
   return (
     <ActionForm
@@ -65,13 +56,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
     >
       <Row>
         <Col size="6">
-          <FormikField
-            component={Select}
-            label="Zone"
-            name="zone"
-            options={zoneOptions}
-            required
-          />
+          <ZoneSelect name="zone" required />
         </Col>
       </Row>
     </ActionForm>

--- a/ui/src/app/machines/views/AddChassis/AddChassisFormFields/AddChassisFormFields.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisFormFields/AddChassisFormFields.js
@@ -1,36 +1,17 @@
-import { Col, Row, Select } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import { useSelector } from "react-redux";
 
-import domainSelectors from "app/store/domain/selectors";
-import FormikField from "app/base/components/FormikField";
+import DomainSelect from "app/base/components/DomainSelect";
 import PowerTypeFields from "app/machines/components/PowerTypeFields";
 
 export const AddChassisFormFields = ({ chassisPowerTypes }) => {
-  const domains = useSelector(domainSelectors.all);
-
   const formikProps = useFormikContext();
   const { values } = formikProps;
-
-  const domainOptions = [
-    { label: "Select your domain", value: "", disabled: true },
-    ...domains.map((domain) => ({
-      key: `domain-${domain.id}`,
-      label: domain.name,
-      value: domain.name,
-    })),
-  ];
 
   return (
     <Row>
       <Col size="5">
-        <FormikField
-          component={Select}
-          label="Domain"
-          name="domain"
-          options={domainOptions}
-          required
-        />
+        <DomainSelect name="domain" required />
       </Col>
       <Col size="5">
         <PowerTypeFields

--- a/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineFormFields/AddMachineFormFields.js
@@ -1,23 +1,20 @@
-import { Button, Col, Input, Row, Select } from "@canonical/react-components";
+import { Button, Col, Input, Row } from "@canonical/react-components";
 import { useEffect, useState } from "react";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import { formatMacAddress } from "app/utils";
-import domainSelectors from "app/store/domain/selectors";
+import ArchitectureSelect from "app/base/components/ArchitectureSelect";
+import DomainSelect from "app/base/components/DomainSelect";
 import FormikField from "app/base/components/FormikField";
+import MinimumKernelSelect from "app/base/components/MinimumKernelSelect";
 import generalSelectors from "app/store/general/selectors";
 import PowerTypeFields from "app/machines/components/PowerTypeFields";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
-import zoneSelectors from "app/store/zone/selectors";
+import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
+import ZoneSelect from "app/base/components/ZoneSelect";
 
 export const AddMachineFormFields = ({ saved }) => {
-  const architectures = useSelector(generalSelectors.architectures.get);
-  const domains = useSelector(domainSelectors.all);
-  const hweKernels = useSelector(generalSelectors.hweKernels.get);
   const powerTypes = useSelector(generalSelectors.powerTypes.get);
-  const resourcePools = useSelector(resourcePoolSelectors.all);
-  const zones = useSelector(zoneSelectors.all);
 
   const [extraMACs, setExtraMACs] = useState([]);
 
@@ -30,56 +27,6 @@ export const AddMachineFormFields = ({ saved }) => {
     }
   }, [saved]);
 
-  const architectureOptions = [
-    {
-      label: "Select your architecture",
-      value: "",
-      disabled: true,
-    },
-    ...architectures.map((arch) => ({
-      key: arch,
-      label: arch,
-      value: arch,
-    })),
-  ];
-  const domainOptions = [
-    { label: "Select your domain", value: "", disabled: true },
-    ...domains.map((domain) => ({
-      key: `domain-${domain.id}`,
-      label: domain.name,
-      value: domain.name,
-    })),
-  ];
-  const hweKernelOptions = [
-    {
-      label: "Select your minimum kernel",
-      value: null,
-      disabled: true,
-    },
-    { label: "No minimum kernel", value: "" },
-    ...hweKernels.map((kernel) => ({
-      key: `kernel-${kernel[1]}`,
-      label: kernel[1],
-      value: kernel[0],
-    })),
-  ];
-  const resourcePoolOptions = [
-    { label: "Select your resource pool", value: "", disabled: true },
-    ...resourcePools.map((pool) => ({
-      key: `pool-${pool.id}`,
-      label: pool.name,
-      value: pool.name,
-    })),
-  ];
-  const zoneOptions = [
-    { label: "Select your zone", value: "", disabled: true },
-    ...zones.map((zone) => ({
-      key: `zone-${zone.id}`,
-      label: zone.name,
-      value: zone.name,
-    })),
-  ];
-
   const macAddressRequired = values.power_type !== "ipmi";
 
   return (
@@ -91,40 +38,11 @@ export const AddMachineFormFields = ({ saved }) => {
           placeholder="Machine name (optional)"
           type="text"
         />
-        <FormikField
-          component={Select}
-          label="Domain"
-          name="domain"
-          options={domainOptions}
-          required
-        />
-        <FormikField
-          component={Select}
-          label="Architecture"
-          name="architecture"
-          options={architectureOptions}
-          required
-        />
-        <FormikField
-          component={Select}
-          label="Minimum kernel"
-          name="min_hwe_kernel"
-          options={hweKernelOptions}
-        />
-        <FormikField
-          component={Select}
-          label="Zone"
-          name="zone"
-          options={zoneOptions}
-          required
-        />
-        <FormikField
-          component={Select}
-          label="Resource pool"
-          name="pool"
-          options={resourcePoolOptions}
-          required
-        />
+        <DomainSelect name="domain" required />
+        <ArchitectureSelect name="architecture" required />
+        <MinimumKernelSelect name="min_hwe_kernel" />
+        <ZoneSelect name="zone" required />
+        <ResourcePoolSelect name="pool" required />
         <FormikField
           label="MAC address"
           maxLength="17"


### PR DESCRIPTION
## Done

- Created common form Select components that are used in a few places. Each of them do the same thing - load the relevant items into state and turn them into a select. These will also be used in the machine configuration tab (and likely devices and controllers)
  - `ArchitectureSelect`
  - `DomainSelect`
  - `MinimumKernelSelect`
  - `ResourcePoolSelect`
  - `ZoneSelect` 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/machines/add and check that the selects still work correctly (i.e. is populated and can select option), and the form submits correctly

## Fixes

Fixes #2126 
