### PR TITLE
fix(all): fix machine details tab links in legacy and react

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -573,6 +573,7 @@
               class="p-tabs__link"
               data-ng-if="!isController && !isDevice"
               data-ng-click="navigateToNew('/machine/' + node.system_id + '/summary')"
+              href="{$ newURLBase + '/machine/' + node.system_id + '/summary' $}"
               >Summary</a
             >
           </li>
@@ -602,7 +603,8 @@
               class="p-tabs__link"
               data-ng-if="!isController && devices.length"
               data-ng-class="{ 'is-active': section.area === 'instances'}"
-              data-ng-click="openSection('instances')"
+              data-ng-click="isDevice ? openSection('instances') : navigateToNew('/machine/' + node.system_id + '/instances')"
+              href="{$ isDevice ? undefined : newURLBase + '/machine/' + node.system_id + '/instances' $}"
               >Instances</a
             >
           </li>
@@ -631,7 +633,8 @@
               class="p-tabs__link"
               data-ng-if="!isDevice"
               data-ng-class="{ 'is-active': section.area === 'storage'}"
-              data-ng-click="openSection('storage')"
+              data-ng-click="isController ? openSection('storage') : navigateToNew('/machine/' + node.system_id + '/storage')"
+              href="{$ isController ? undefined : newURLBase + '/machine/' + node.system_id + '/storage' $}"
               >Storage</a
             >
           </li>
@@ -641,6 +644,7 @@
               class="p-tabs__link"
               data-ng-if="!isController && !isDevice"
               data-ng-click="navigateToNew('/machine/' + node.system_id + '/pci-devices')"
+              href="{$ newURLBase + '/machine/' + node.system_id + '/pci-devices' $}"
               >PCI devices</a
             >
           </li>
@@ -650,6 +654,7 @@
               class="p-tabs__link"
               data-ng-if="!isController && !isDevice"
               data-ng-click="navigateToNew('/machine/' + node.system_id + '/usb-devices')"
+              href="{$ newURLBase + '/machine/' + node.system_id + '/usb-devices' $}"
               >USB</a
             >
           </li>
@@ -673,7 +678,8 @@
               class="p-tabs__link"
               data-ng-if="node.testing_status.pending > 0 || node.testing_status.running > 0 || node.testing_status.passed > 0 || node.testing_status.failed > 0"
               data-ng-class="{ 'is-active': section.area === 'testing'}"
-              data-ng-click="openSection('testing')"
+              data-ng-click="isController || isDevice ? openSection('testing') : navigateToNew('/machine/' + node.system_id + '/testing')"
+              href="{$ isController || isDevice ? undefined : newURLBase + '/machine/' + node.system_id + '/testing' $}"
               ><span
                 data-maas-script-status="script-status"
                 data-script-status="node.testing_status.status"

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -87,10 +87,10 @@ const MachineDetails = (): JSX.Element => {
           <Route exact path="/machine/:id/usb-devices">
             <MachineUSBDevices setSelectedAction={setSelectedAction} />
           </Route>
-          <Route exact path="/machine/:id/tests">
+          <Route exact path="/machine/:id/testing">
             <MachineTests />
           </Route>
-          <Route exact path="/machine/:id/tests/:scriptResultId/details">
+          <Route exact path="/machine/:id/testing/:scriptResultId/details">
             <MachineTestsDetails />
           </Route>
           <Route exact path="/machine/:id">

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -178,10 +178,10 @@ const MachineHeader = ({
           route: `${urlBase}?area=commissioning`,
         },
         {
-          active: pathname.startsWith(`${urlBase}/tests`),
-          component: LegacyLink,
+          active: pathname.startsWith(`${urlBase}/testing`),
+          component: Link,
           label: "Tests",
-          route: `${urlBase}?area=testing`,
+          to: `${urlBase}/testing`,
         },
         {
           active: pathname.startsWith(`${urlBase}/logs`),

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,8 +1,8 @@
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../../types";
 
-import LegacyLink from "app/base/components/LegacyLink";
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
 import type { MachineDetails } from "app/store/machine/types";
@@ -29,7 +29,7 @@ const TestResults = ({
 }: Props): JSX.Element => {
   const sendAnalytics = useSendAnalytics();
 
-  const testsTabUrl = `/machine/${machine.system_id}?area=testing`;
+  const testsTabUrl = `/machine/${machine.system_id}/testing`;
   const scriptType = HardwareType[hardwareType]?.toLowerCase();
 
   return (
@@ -37,8 +37,7 @@ const TestResults = ({
       <ul className="p-inline-list u-no-margin--bottom" data-test="tests">
         {machine[`${scriptType}_test_status`].passed ? (
           <li className="p-inline-list__item">
-            <LegacyLink
-              route={testsTabUrl}
+            <Link
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -46,12 +45,13 @@ const TestResults = ({
                   "Machine summary tab"
                 )
               }
+              to={testsTabUrl}
             >
               <Icon name={ICONS.success} />
               <span className="u-nudge-right--x-small">
                 {machine[`${scriptType}_test_status`].passed}
               </span>
-            </LegacyLink>
+            </Link>
           </li>
         ) : null}
 
@@ -59,8 +59,7 @@ const TestResults = ({
           machine[`${scriptType}_test_status`].running >
         0 ? (
           <li className="p-inline-list__item">
-            <LegacyLink
-              route={testsTabUrl}
+            <Link
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -68,20 +67,20 @@ const TestResults = ({
                   "Machine summary tab"
                 )
               }
+              to={testsTabUrl}
             >
               <Icon name={"pending"} />
               <span className="u-nudge-right--x-small">
                 {machine[`${scriptType}_test_status`].pending +
                   machine[`${scriptType}_test_status`].running}
               </span>
-            </LegacyLink>
+            </Link>
           </li>
         ) : null}
 
         {machine[`${scriptType}_test_status`].failed > 0 ? (
           <li className="p-inline-list__item">
-            <LegacyLink
-              route={testsTabUrl}
+            <Link
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -89,19 +88,19 @@ const TestResults = ({
                   "Machine summary tab"
                 )
               }
+              to={testsTabUrl}
             >
               <Icon name={ICONS.error} />
               <span className="u-nudge-right--x-small">
                 {machine[`${scriptType}_test_status`].failed}
               </span>
-            </LegacyLink>
+            </Link>
           </li>
         ) : null}
 
         {hasTestsRun(machine, scriptType) ? (
           <li className="p-inline-list__item">
-            <LegacyLink
-              route={testsTabUrl}
+            <Link
               onClick={() =>
                 sendAnalytics(
                   "Machine details",
@@ -109,9 +108,10 @@ const TestResults = ({
                   "Machine summary tab"
                 )
               }
+              to={testsTabUrl}
             >
               View results&nbsp;&rsaquo;
-            </LegacyLink>
+            </Link>
           </li>
         ) : (
           <li className="p-inline-list__item">

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.test.tsx
@@ -62,8 +62,8 @@ describe("MachineTestDetails", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={["/machine/abc123/tests/1/details"]}>
-          <Route path="/machine/:id/tests/:scriptResultId/details">
+        <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
+          <Route path="/machine/:id/testing/:scriptResultId/details">
             <MachineTestsDetails />
           </Route>
         </MemoryRouter>
@@ -89,8 +89,8 @@ describe("MachineTestDetails", () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={["/machine/abc123/tests/1/details"]}>
-          <Route path="/machine/:id/tests/:scriptResultId/details">
+        <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
+          <Route path="/machine/:id/testing/:scriptResultId/details">
             <MachineTestsDetails />
           </Route>
         </MemoryRouter>
@@ -128,8 +128,8 @@ describe("MachineTestDetails", () => {
 
     mount(
       <Provider store={store}>
-        <MemoryRouter initialEntries={["/machine/abc123/tests/1/details"]}>
-          <Route path="/machine/:id/tests/:scriptResultId/details">
+        <MemoryRouter initialEntries={["/machine/abc123/testing/1/details"]}>
+          <Route path="/machine/:id/testing/:scriptResultId/details">
             <MachineTestsDetails />
           </Route>
         </MemoryRouter>

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetails.tsx
@@ -62,7 +62,7 @@ const MachineTestsDetails = (): JSX.Element | null => {
             <h2 className="p-heading--four">{result.name} details</h2>
           </Col>
           <Col size="4">
-            <Link to={`/machine/${id}/tests`}>
+            <Link to={`/machine/${id}/testing`}>
               &lsaquo; Back to test results
             </Link>
           </Col>


### PR DESCRIPTION
## Done

- Changed tests tab over to React link
- Fixed links to React tabs from the angular tabs

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine summary of a machine that has run at least one test
- Click the "View results" link for a test type and check that it takes you to the React version of the Tests tab
- Check that the machine details tabs take you to the right place whether clicking from a React tab or an Angular tab

## Fixes

Fixes #2137 
