### PR TITLE
fix(ui): handle pods with undefined storage pools

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -31,9 +31,10 @@ const generateDropdownContent = (
   requests: RequestMap,
   selectPool: SelectPool
 ): JSX.Element => {
+  const pools = pod.storage_pools || [];
   const sortedPools = [
-    pod.storage_pools.find((pool) => pool.id === pod.default_storage_pool),
-    ...pod.storage_pools.filter((pool) => pool.id !== pod.default_storage_pool),
+    pools.find((pool) => pool.id === pod.default_storage_pool),
+    ...pools.filter((pool) => pool.id !== pod.default_storage_pool),
   ].filter(Boolean);
 
   return (

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -117,7 +117,12 @@ describe("StorageTable", () => {
   });
 
   it("can add disks and remove all but last disk if KVM type is not LXD", async () => {
-    const pod = podDetailsFactory({ id: 1, type: "virsh" });
+    const pod = podDetailsFactory({
+      default_storage_pool: "pool-1",
+      id: 1,
+      storage_pools: [podStoragePoolFactory({ id: "pool-1" })],
+      type: "virsh",
+    });
     const state = { ...initialState };
     state.pod.items = [pod];
     const store = mockStore(state);
@@ -151,7 +156,11 @@ describe("StorageTable", () => {
   });
 
   it("displays a caution message if disk size is less than 8GB", async () => {
-    const pod = podDetailsFactory({ id: 1 });
+    const pod = podDetailsFactory({
+      default_storage_pool: "pool-1",
+      id: 1,
+      storage_pools: [podStoragePoolFactory({ id: "pool-1" })],
+    });
     const state = { ...initialState };
     state.pod.items = [pod];
     const store = mockStore(state);

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
@@ -23,7 +23,8 @@ const PodStorage = ({ id }: Props): JSX.Element | null => {
   const sendAnalytics = useSendAnalytics();
 
   if (!!pod) {
-    const sortedPools = [...pod.storage_pools].sort((a, b) => {
+    const pools = pod.storage_pools || [];
+    const sortedPools = [...pools].sort((a, b) => {
       if (a.id === pod.default_storage_pool || b.id > a.id) {
         return -1;
       }

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/StorageColumn/StoragePopover/StoragePopover.tsx
@@ -15,7 +15,7 @@ type Props = {
 const StoragePopover = ({
   children,
   defaultPoolID,
-  pools,
+  pools = [],
 }: Props): JSX.Element => {
   const sortedPools = [
     pools.find((pool) => pool.id === defaultPoolID),

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -70,7 +70,8 @@ export type BasePod = Model & {
   cpu_speed: number;
   created: string;
   default_macvlan_mode: string;
-  default_storage_pool: string;
+  // The websocket does not include this value if the pod has no storage pools
+  default_storage_pool?: string;
   hints: PodHint & PodHintExtras;
   host: string | null;
   ip_address: number | string;
@@ -83,7 +84,8 @@ export type BasePod = Model & {
   power_address: string;
   power_pass?: string;
   owners_count: number;
-  storage_pools: PodStoragePool[];
+  // The websocket does not include this value if the pod has no storage pools
+  storage_pools?: PodStoragePool[];
   tags: string[];
   total: PodHint;
   type: string;


### PR DESCRIPTION
## Done

- Updated `BasePod` type so that `storage_pools` and `default_storage_pool` are optional, to match the api
- Handle cases where `pod.storage_pools` is undefined

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the KVM list still loads and you can still compose machines
- betterer should pass without needing to update

## Fixes

Related: #2081 

## Launchpad issue

[lp#1912727](https://bugs.launchpad.net/maas/+bug/1912727)