### PR TITLE
fix machine searches that start with a number

### DIFF
--- a/ui/src/app/machines/filter-nodes.js
+++ b/ui/src/app/machines/filter-nodes.js
@@ -5,6 +5,12 @@ import { getMachineValue } from "app/utils";
 // lowercased lowerTerm.
 const _matches = (value, lowerTerm, exact) => {
   if (typeof value === "number") {
+    // Check that term is a valid number before comparing it to the value.
+    // This is to prevent issues when parsing strings to numbers
+    // e.g. parseInt("1thing") returns the number 1.
+    if (isNaN(lowerTerm)) {
+      return false;
+    }
     if (exact) {
       if (Number.isInteger(value)) {
         return value === parseInt(lowerTerm, 10);

--- a/ui/src/app/machines/filter-nodes.test.js
+++ b/ui/src/app/machines/filter-nodes.test.js
@@ -25,6 +25,19 @@ describe("filterNodes", () => {
       filter: "nam",
     },
     {
+      description: "matches free search that starts with a number",
+      filter: "1nam",
+      nodes: [
+        { hostname: "1name" },
+        {
+          hostname: "name2",
+          // It shouldn't match this node by turning "1nam" in an integer of 1.
+          vlan_id: 1,
+        },
+      ],
+      result: [0],
+    },
+    {
       description: "doesn't return duplicates using free search",
       filter: "nam am",
       nodes: [
@@ -94,6 +107,18 @@ describe("filterNodes", () => {
     {
       description: "matches on attribute",
       filter: "hostname:name",
+    },
+    {
+      description: "matches on attribute that starts with a number",
+      filter: "hostname:1nam",
+      nodes: [
+        { hostname: "1name" },
+        {
+          // It shouldn't match this node by turning "1nam" in an integer of 1.
+          hostname: 1,
+        },
+      ],
+      result: [0],
     },
     {
       description: "matches with contains on attribute",

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -25,6 +25,12 @@ describe("Search", () => {
       },
     },
     {
+      input: "1moon",
+      filters: {
+        q: ["1moon"],
+      },
+    },
+    {
       input: "m",
       filters: {
         q: ["m"],
@@ -47,6 +53,13 @@ describe("Search", () => {
       filters: {
         q: ["moon"],
         status: ["new"],
+      },
+    },
+    {
+      input: "moon status:(1new)",
+      filters: {
+        q: ["moon"],
+        status: ["1new"],
       },
     },
     {

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -192,4 +192,24 @@ describe("machine selectors", () => {
       bar: scriptResults.bar,
     });
   });
+
+  it("can search items", () => {
+    const items = [machineFactory({ hostname: "abc" }), machineFactory()];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items,
+      }),
+    });
+    expect(machine.search(state, "abc")).toStrictEqual([items[0]]);
+  });
+
+  it("can search items starting with a number", () => {
+    const items = [machineFactory({ hostname: "1abc" }), machineFactory()];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items,
+      }),
+    });
+    expect(machine.search(state, "1abc")).toStrictEqual([items[0]]);
+  });
 });

--- a/ui/src/testing/factories/model.ts
+++ b/ui/src/testing/factories/model.ts
@@ -7,5 +7,5 @@ export const model = define<Model>({
 });
 
 export const modelRef = extend<Model, ModelRef>(model, {
-  name: `modelref-${random}`,
+  name: `modelref-${random()}`,
 });

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -47,7 +47,7 @@ const hints = () => ({ ...podHint(), ...podHintExtras() });
 const simpleNode = extend<Model, SimpleNode>(model, {
   actions,
   domain: modelRef,
-  hostname: `test-machine-${random}`,
+  hostname: (i: number) => `test-machine-${i}`,
   fqdn: "test.maas",
   link_type: "",
   node_type_display: "",


### PR DESCRIPTION
## Done

- Fix free searches that start with a number that were erroneously being converted to numbers.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Add (or edit) some machines with names that start with a number.
- On the machine list type in the start of the name, it should filter the machines.

## Fixes

Fixes: #2152.