### PR TITLE
fix(legacy): fix race condition when loading machine details

### DIFF
--- a/legacy/src/app/services/manager.js
+++ b/legacy/src/app/services/manager.js
@@ -397,7 +397,8 @@ function Manager($q, $rootScope, $timeout, RegionConnection) {
     params[this._pk] = pk_value;
     return RegionConnection.callMethod(method, params).then(function (item) {
       self._loaded = true;
-      if (self._items.length === 0) {
+      var idx = self._getIndexOfItem(self._items, pk_value);
+      if (idx === -1) {
         self._items.push(item);
       } else {
         self._replaceItem(item);

--- a/legacy/src/app/services/tests/test_manager.js
+++ b/legacy/src/app/services/tests/test_manager.js
@@ -619,6 +619,30 @@ describe("Manager", function () {
       });
     });
 
+    it("adds a new node to an empty items list", function (done) {
+      var fakeNode = makeNode();
+      fakeNode.name = makeName("name");
+
+      webSocket.returnData.push(makeFakeResponse(fakeNode));
+      NodesManager.getItem(fakeNode.system_id).then(function () {
+        expect(NodesManager._items[0].name).toBe(fakeNode.name);
+        done();
+      });
+    });
+
+    it("adds a new node to the items list when it already contains nodes", function (done) {
+      var existingFakeNode = makeNode();
+      var fakeNode = makeNode();
+      fakeNode.name = makeName("name");
+      NodesManager._items.push(existingFakeNode);
+
+      webSocket.returnData.push(makeFakeResponse(fakeNode));
+      NodesManager.getItem(fakeNode.system_id).then(function () {
+        expect(NodesManager._items[1].name).toBe(fakeNode.name);
+        done();
+      });
+    });
+
     it("updates node in items and selectedItems list", function (done) {
       var fakeNode = makeNode();
       var updatedNode = angular.copy(fakeNode);


### PR DESCRIPTION
## Done

- Always add the loaded machine to the store when fetching a single machine for machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit a machine details page.
- Click on DNS in the header and navigate to one of the domains.
- From the list of resources click a machine (if there is no machine you might need to add one or look in another domain).
- The machine details should load.
- Do this a few more times and you should see the machine every time.

## Fixes

Fixes: #2161.