### PR TITLE
refactor(ui): create shared tag component

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -92,6 +92,9 @@ exports[`stricter compilation`] = {
       [32, 4, 11, "Type \'number\' is not assignable to type \'null\'.", "1179509236"],
       [34, 4, 12, "Type \'number\' is not assignable to type \'null\'.", "304100367"]
     ],
+    "src/app/base/components/TagField/TagField.tsx:4277498646": [
+      [17, 18, 13, "Object is of type \'unknown\'.", "4056394851"]
+    ],
     "src/app/base/components/TagSelector/TagSelector.test.tsx:3224389514": [
       [5, 6, 4, "Variable \'tags\' implicitly has type \'any\' in some locations where its type cannot be determined.", "2087952548"],
       [20, 14, 4, "Variable \'tags\' implicitly has an \'any\' type.", "2087952548"],
@@ -111,8 +114,8 @@ exports[`stricter compilation`] = {
       [185, 10, 39, "Property \'id\' is missing in type \'{ displayName: string; name: string; }\' but required in type \'Tag\'.", "3084210389"],
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
-    "src/app/base/components/TagSelector/TagSelector.tsx:2324825209": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+    "src/app/base/components/TagSelector/TagSelector.tsx:4083206781": [
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -200,9 +203,10 @@ exports[`stricter compilation`] = {
       [235, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "107957199"],
       [246, 6, 87, "Cannot invoke an object which is possibly \'undefined\'.", "2561676462"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx:543913811": [
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx:1065312531": [
       [137, 24, 10, "Type \'(poolName: string) => void\' is not assignable to type \'SelectPool\'.\\n  Types of parameters \'poolName\' and \'poolName\' are incompatible.\\n    Type \'string | undefined\' is not assignable to type \'string\'.\\n      Type \'undefined\' is not assignable to type \'string\'.", "1972538641"],
-      [191, 10, 7, "Type \'false | \\"For the Beta version of LXD VM hosts each VM can only be assigned a single block device.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"]
+      [145, 22, 5, "Type \'null\' is not assignable to type \'string | undefined\'.", "173467459"],
+      [184, 10, 7, "Type \'false | \\"For the Beta version of LXD VM hosts each VM can only be assigned a single block device.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"]
     ],
     "src/app/kvm/components/PodConfiguration/PodConfiguration.test.tsx:122950996": [
       [99, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],

--- a/ui/src/app/base/components/FormikField/FormikField.tsx
+++ b/ui/src/app/base/components/FormikField/FormikField.tsx
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 
 import type { TSFixMe } from "app/base/types";
 
-type Props = {
+export type Props = {
   Component?: JSX.Element;
   name: string;
   value?: HTMLProps<HTMLElement>["value"];

--- a/ui/src/app/base/components/TagField/TagField.test.tsx
+++ b/ui/src/app/base/components/TagField/TagField.test.tsx
@@ -1,0 +1,58 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import TagField from "./TagField";
+
+describe("FormikField", () => {
+  it("maps the initial value to the tag format", () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{ tags: ["koala", "wallaby"] }}
+        onSubmit={jest.fn()}
+      >
+        <TagField />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("initialSelected")).toStrictEqual([
+      {
+        name: "koala",
+      },
+      {
+        name: "wallaby",
+      },
+    ]);
+    expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([
+      {
+        name: "koala",
+      },
+      {
+        name: "wallaby",
+      },
+    ]);
+  });
+
+  it("can override the field name", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
+        <TagField name="wombatTags" />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("name")).toBe("wombatTags");
+  });
+
+  it("can populate the list of tags", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ tags: null }} onSubmit={jest.fn()}>
+        <TagField tagList={["koala", "wallaby"]} />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField").prop("tags")).toStrictEqual([
+      {
+        name: "koala",
+      },
+      {
+        name: "wallaby",
+      },
+    ]);
+  });
+});

--- a/ui/src/app/base/components/TagField/TagField.tsx
+++ b/ui/src/app/base/components/TagField/TagField.tsx
@@ -1,0 +1,45 @@
+import { useFormikContext } from "formik";
+
+import FormikField from "app/base/components/FormikField";
+import type { Props as FormikFieldProps } from "app/base/components/FormikField/FormikField";
+import TagSelector from "app/base/components/TagSelector";
+import type {
+  Props as TagSelectorProps,
+  Tag,
+} from "app/base/components/TagSelector/TagSelector";
+
+type Props = {
+  tagList?: string[] | null;
+} & Partial<FormikFieldProps> &
+  Partial<TagSelectorProps>;
+
+const TagField = ({ name = "tags", tagList, ...props }: Props): JSX.Element => {
+  const { initialValues, setFieldValue } = useFormikContext();
+  const initial = initialValues[name] || [];
+  return (
+    <FormikField
+      allowNewTags
+      component={TagSelector}
+      initialSelected={initial.map((tag: string) => ({
+        name: tag,
+      }))}
+      label="Tags"
+      name={name}
+      onTagsUpdate={(tags: Tag[]) =>
+        setFieldValue(
+          name,
+          tags.map(({ name }) => name)
+        )
+      }
+      placeholder="Select or create tags"
+      // Populate the list of tags with the provided list or with the initial values list.
+      // The initial values array uses spread to make it writable by `sort()`.
+      tags={(tagList || [...initial] || [])
+        .sort()
+        .map((tag: string) => ({ name: tag }))}
+      {...props}
+    />
+  );
+};
+
+export default TagField;

--- a/ui/src/app/base/components/TagField/index.ts
+++ b/ui/src/app/base/components/TagField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TagField";

--- a/ui/src/app/base/components/TagSelector/TagSelector.tsx
+++ b/ui/src/app/base/components/TagSelector/TagSelector.tsx
@@ -135,7 +135,7 @@ const generateSelectedItems = (
     );
   });
 
-type Props = {
+export type Props = {
   allowNewTags?: boolean;
   disabled?: boolean;
   error?: string;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -20,7 +20,7 @@ import PoolSelect from "./PoolSelect";
 
 import FormikField from "app/base/components/FormikField";
 import TableActions from "app/base/components/TableActions";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 import type { RouteParams } from "app/base/types";
 import podSelectors from "app/store/pod/selectors";
 import type { RootState } from "app/store/root/types";
@@ -142,16 +142,9 @@ export const StorageTable = ({ defaultDisk }: Props): JSX.Element => {
                     )}
                   </TableCell>
                   <TableCell aria-label="Tags">
-                    <FormikField
-                      allowNewTags
-                      component={TagSelector}
+                    <TagField
+                      label={null}
                       name={`disks[${i}].tags`}
-                      onTagsUpdate={(selectedTags: { name: string }[]) => {
-                        setFieldValue(
-                          `disks[${i}].tags`,
-                          selectedTags.map((tag) => tag.name)
-                        );
-                      }}
                       placeholder="Add tags"
                     />
                   </TableCell>

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.tsx
@@ -8,7 +8,7 @@ import type { PodConfigurationValues } from "../PodConfiguration";
 
 import FormikField from "app/base/components/FormikField";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 import ZoneSelect from "app/base/components/ZoneSelect";
 import { formatHostType } from "app/store/pod/utils";
 import tagSelectors from "app/store/tag/selectors";
@@ -18,20 +18,8 @@ type Props = { showHostType?: boolean };
 const PodConfigurationFields = ({
   showHostType = true,
 }: Props): JSX.Element => {
-  const allTags = useSelector(tagSelectors.all);
-  const {
-    initialValues,
-    setFieldValue,
-    values,
-  } = useFormikContext<PodConfigurationValues>();
-  // Tags in state is an array of objects
-  const allTagsSorted = [...allTags].sort((a, b) =>
-    a.name.localeCompare(b.name)
-  );
-  // pod.tags is an array of strings, so needs to be converted into objects
-  const initialTags = [...initialValues.tags]
-    .sort()
-    .map((tag) => ({ name: tag }));
+  const tags = useSelector(tagSelectors.all);
+  const { setFieldValue, values } = useFormikContext<PodConfigurationValues>();
 
   return (
     <Row>
@@ -47,22 +35,7 @@ const PodConfigurationFields = ({
         )}
         <ZoneSelect name="zone" required valueKey="id" />
         <ResourcePoolSelect name="pool" required valueKey="id" />
-        <FormikField
-          allowNewTags
-          component={TagSelector}
-          initialSelected={initialTags}
-          label="Tags"
-          name="tags"
-          onTagsUpdate={(selectedTags: { name: string }[]) => {
-            setFieldValue(
-              "tags",
-              // Convert back to array of strings
-              selectedTags.map((tag) => tag.name)
-            );
-          }}
-          placeholder="Select or create tags"
-          tags={allTagsSorted}
-        />
+        <TagField tagList={tags.map(({ name }) => name)} />
       </Col>
       <Col size="5">
         <FormikField label="Address" name="power_address" type="text" />

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.js
@@ -14,12 +14,7 @@ import { NodeActions } from "app/store/types/node";
 
 const TagFormSchema = Yup.object().shape({
   tags: Yup.array()
-    .of(
-      Yup.object().shape({
-        name: Yup.string().required(),
-        displayName: Yup.string(),
-      })
-    )
+    .of(Yup.string())
     .min(1)
     .required("You must select at least one tag."),
 });
@@ -60,12 +55,7 @@ export const TagForm = ({ setSelectedAction }) => {
       onSubmit={(values) => {
         if (values.tags && values.tags.length) {
           machinesToAction.forEach((machine) => {
-            dispatch(
-              machineActions.tag(
-                machine.system_id,
-                values.tags.map((tag) => tag.name)
-              )
-            );
+            dispatch(machineActions.tag(machine.system_id, values.tags));
           });
         }
         setInitialValues(values);

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.test.js
@@ -82,7 +82,7 @@ describe("TagForm", () => {
         .find("Formik")
         .props()
         .onSubmit({
-          tags: [{ name: "tag1" }, { name: "tag2" }],
+          tags: ["tag1", "tag2"],
         })
     );
     expect(
@@ -147,7 +147,7 @@ describe("TagForm", () => {
         .find("Formik")
         .props()
         .onSubmit({
-          tags: [{ name: "tag1" }, { name: "tag2" }],
+          tags: ["tag1", "tag2"],
         })
     );
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.js
@@ -1,32 +1,15 @@
 import { Col, Row } from "@canonical/react-components";
-import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
 import tagSelectors from "app/store/tag/selectors";
-import FormikField from "app/base/components/FormikField";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 
 export const TagFormFields = () => {
-  const { initialValues, setFieldValue } = useFormikContext();
   const tags = useSelector(tagSelectors.all);
-  const sortedTags = tags
-    .map((tag) => ({ displayName: tag.name, name: tag.name }))
-    .sort((a, b) => a.name.localeCompare(b.name));
-
   return (
     <Row>
       <Col size="6">
-        <FormikField
-          allowNewTags
-          component={TagSelector}
-          initialSelected={initialValues.tags}
-          label="Tags"
-          name="tags"
-          onTagsUpdate={(selectedTags) => setFieldValue("tags", selectedTags)}
-          placeholder="Select or create tags"
-          required
-          tags={sortedTags}
-        />
+        <TagField required tagList={tags.map(({ name }) => name)} />
       </Col>
     </Row>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
@@ -10,7 +10,7 @@ import ArchitectureSelect from "app/base/components/ArchitectureSelect";
 import FormikField from "app/base/components/FormikField";
 import MinimumKernelSelect from "app/base/components/MinimumKernelSelect";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 import ZoneSelect from "app/base/components/ZoneSelect";
 import TagLinks from "app/machines/components/TagLinks";
 import tagSelectors from "app/store/tag/selectors";
@@ -18,14 +18,8 @@ import tagSelectors from "app/store/tag/selectors";
 type Props = { editing: boolean };
 
 const MachineFormFields = ({ editing }: Props): JSX.Element => {
-  const allTags = useSelector(tagSelectors.all);
-  const {
-    initialValues,
-    setFieldValue,
-  } = useFormikContext<MachineFormValues>();
-  const allTagsSorted = [...allTags].sort((a, b) =>
-    a.name.localeCompare(b.name)
-  );
+  const tags = useSelector(tagSelectors.all);
+  const { initialValues } = useFormikContext<MachineFormValues>();
   const sortedInitialTags = [...initialValues.tags].sort();
 
   return (
@@ -42,22 +36,7 @@ const MachineFormFields = ({ editing }: Props): JSX.Element => {
           type="text"
         />
         {editing ? (
-          <FormikField
-            allowNewTags
-            component={TagSelector}
-            initialSelected={sortedInitialTags.map((tag) => ({ name: tag }))}
-            label="Tags"
-            name="tags"
-            onTagsUpdate={(selectedTags: { name: string }[]) => {
-              setFieldValue(
-                "tags",
-                // Convert back to array of strings
-                selectedTags.map((tag) => tag.name)
-              );
-            }}
-            placeholder="Select or create tags"
-            tags={allTagsSorted}
-          />
+          <TagField tagList={tags.map(({ name }) => name)} />
         ) : (
           <>
             <p>Tags</p>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolumeFields/AddLogicalVolumeFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolumeFields/AddLogicalVolumeFields.tsx
@@ -5,7 +5,7 @@ import FilesystemFields from "../../FilesystemFields";
 import type { AddLogicalVolumeValues } from "../AddLogicalVolume";
 
 import FormikField from "app/base/components/FormikField";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 import type { Machine } from "app/store/machine/types";
 
 type Props = {
@@ -15,11 +15,9 @@ type Props = {
 export const AddLogicalVolumeFields = ({ systemId }: Props): JSX.Element => {
   const {
     handleChange,
-    initialValues,
     setFieldTouched,
     setFieldValue,
   } = useFormikContext<AddLogicalVolumeValues>();
-  const initialTags = initialValues.tags.map((tag) => ({ name: tag }));
 
   return (
     <Row>
@@ -56,21 +54,7 @@ export const AddLogicalVolumeFields = ({ systemId }: Props): JSX.Element => {
             { label: "TB", value: "TB" },
           ]}
         />
-        <FormikField
-          allowNewTags
-          component={TagSelector}
-          initialSelected={initialTags}
-          label="Tags"
-          name="tags"
-          onTagsUpdate={(selectedTags: { name: string }[]) => {
-            setFieldValue(
-              "tags",
-              selectedTags.map((tag) => tag.name)
-            );
-          }}
-          placeholder="Select or create tags"
-          tags={[]}
-        />
+        <TagField />
       </Col>
       <Col emptyLarge="7" size="5">
         <FilesystemFields systemId={systemId} />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
@@ -5,7 +5,7 @@ import FilesystemFields from "../../../FilesystemFields";
 import type { CreateRaidValues } from "../CreateRaid";
 
 import FormikField from "app/base/components/FormikField";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 import { RAID_MODES } from "app/store/machine/constants";
 import type { RaidMode } from "app/store/machine/constants";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
@@ -57,11 +57,7 @@ export const CreateRaidFields = ({
   storageDevices,
   systemId,
 }: Props): JSX.Element => {
-  const {
-    initialValues,
-    setFieldValue,
-    values,
-  } = useFormikContext<CreateRaidValues>();
+  const { setFieldValue, values } = useFormikContext<CreateRaidValues>();
   const {
     blockDeviceIds,
     level,
@@ -69,7 +65,6 @@ export const CreateRaidFields = ({
     spareBlockDeviceIds,
     sparePartitionIds,
   } = values;
-  const initialTags = initialValues.tags.map((tag) => ({ name: tag }));
   const availableRaidModes = RAID_MODES.filter(
     (raidMode) => storageDevices.length >= raidMode.minDevices
   );
@@ -145,21 +140,7 @@ export const CreateRaidFields = ({
             type="text"
             value={formatSize(raidSize)}
           />
-          <FormikField
-            allowNewTags
-            component={TagSelector}
-            initialSelected={initialTags}
-            label="Tags"
-            name="tags"
-            onTagsUpdate={(selectedTags: { name: string }[]) => {
-              setFieldValue(
-                "tags",
-                selectedTags.map((tag) => tag.name)
-              );
-            }}
-            placeholder="Select or create tags"
-            tags={initialTags}
-          />
+          <TagField />
         </Col>
         <Col emptyLarge="7" size="5">
           <FilesystemFields systemId={systemId} />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/CreateBcacheFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcacheFields/CreateBcacheFields.tsx
@@ -1,11 +1,9 @@
 import { Col, Input, Row, Select } from "@canonical/react-components";
-import { useFormikContext } from "formik";
 
 import FilesystemFields from "../../FilesystemFields";
-import type { CreateBcacheValues } from "../CreateBcache";
 
 import FormikField from "app/base/components/FormikField";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
 import { BcacheModes } from "app/store/machine/types";
 import { formatSize } from "app/store/machine/utils";
@@ -21,12 +19,6 @@ export const CreateBcacheFields = ({
   storageDevice,
   systemId,
 }: Props): JSX.Element => {
-  const {
-    initialValues,
-    setFieldValue,
-  } = useFormikContext<CreateBcacheValues>();
-  const initialTags = initialValues.tags.map((tag) => ({ name: tag }));
-
   return (
     <Row>
       <Col size="5">
@@ -63,21 +55,7 @@ export const CreateBcacheFields = ({
             },
           ]}
         />
-        <FormikField
-          allowNewTags
-          component={TagSelector}
-          initialSelected={initialTags}
-          label="Tags"
-          name="tags"
-          onTagsUpdate={(selectedTags: { name: string }[]) => {
-            setFieldValue(
-              "tags",
-              selectedTags.map((tag) => tag.name)
-            );
-          }}
-          placeholder="Select or create tags"
-          tags={[]}
-        />
+        <TagField />
       </Col>
       <Col emptyLarge="7" size="5">
         <FilesystemFields systemId={systemId} />

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDiskFields/EditDiskFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDiskFields/EditDiskFields.tsx
@@ -1,11 +1,8 @@
 import { Col, Input, Row } from "@canonical/react-components";
-import { useFormikContext } from "formik";
 
 import FilesystemFields from "../../FilesystemFields";
-import type { EditDiskValues } from "../EditDisk";
 
-import FormikField from "app/base/components/FormikField";
-import TagSelector from "app/base/components/TagSelector";
+import TagField from "app/base/components/TagField";
 import type { Disk, Machine } from "app/store/machine/types";
 import { formatSize, formatType } from "app/store/machine/utils";
 
@@ -15,9 +12,6 @@ type Props = {
 };
 
 export const EditDiskFields = ({ disk, systemId }: Props): JSX.Element => {
-  const { initialValues, setFieldValue } = useFormikContext<EditDiskValues>();
-  const initialTags = initialValues.tags.map((tag) => ({ name: tag }));
-
   return (
     <Row>
       <Col size="5">
@@ -32,21 +26,7 @@ export const EditDiskFields = ({ disk, systemId }: Props): JSX.Element => {
       </Col>
       <Col emptyLarge="7" size="5">
         {disk.is_boot === false && <FilesystemFields systemId={systemId} />}
-        <FormikField
-          allowNewTags
-          component={TagSelector}
-          initialSelected={initialTags}
-          label="Tags"
-          name="tags"
-          onTagsUpdate={(selectedTags: { name: string }[]) => {
-            setFieldValue(
-              "tags",
-              selectedTags.map((tag) => tag.name)
-            );
-          }}
-          placeholder="Select or create tags"
-          tags={initialTags}
-        />
+        <TagField />
       </Col>
     </Row>
   );


### PR DESCRIPTION
## Done

- Dedupe all the tag field components.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Make sure the existing tag fields work as before e.g. in the machine tag form, storage form, pod config etc.

## Fixes

Fixes: #2165.