### PR TITLE
fix(ui): only show workloads card for allocated/deployed machines

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -1,10 +1,11 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachineSummary from "./MachineSummary";
 
+import { nodeStatus } from "app/base/enum";
 import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
@@ -51,5 +52,77 @@ describe("MachineSummary", () => {
       </Provider>
     );
     expect(wrapper.find("MachineSummary")).toMatchSnapshot();
+  });
+
+  it("shows workload annotations for deployed machines", () => {
+    state.machine.items = [
+      machineFactory({ status_code: nodeStatus.DEPLOYED, system_id: "abc123" }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/summary"
+            component={() => <MachineSummary setSelectedAction={jest.fn()} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("WorkloadCard").exists()).toBe(true);
+  });
+
+  it("shows workload annotations for allocated machines", () => {
+    state.machine.items = [
+      machineFactory({
+        status_code: nodeStatus.ALLOCATED,
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/summary"
+            component={() => <MachineSummary setSelectedAction={jest.fn()} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("WorkloadCard").exists()).toBe(true);
+  });
+
+  it("does not show workload annotations for machines that are neither deployed nor allocated", () => {
+    state.machine.items = [
+      machineFactory({ status_code: nodeStatus.NEW, system_id: "abc123" }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/summary", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/summary"
+            component={() => <MachineSummary setSelectedAction={jest.fn()} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("WorkloadCard").exists()).toBe(false);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -12,6 +12,7 @@ import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
 import WorkloadCard from "./WorkloadCard";
 
+import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
@@ -39,13 +40,17 @@ const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
     return <Spinner text="Loading" />;
   }
 
+  const showWorkloadCard =
+    "workload_annotations" in machine &&
+    [nodeStatus.ALLOCATED, nodeStatus.DEPLOYED].includes(machine.status_code);
+
   return (
     <div className="machine-summary__cards">
       <OverviewCard id={id} setSelectedAction={setSelectedAction} />
       <SystemCard id={id} />
       <NumaCard id={id} />
       <NetworkCard id={id} setSelectedAction={setSelectedAction} />
-      {"workload_annotations" in machine ? <WorkloadCard id={id} /> : null}
+      {showWorkloadCard ? <WorkloadCard id={id} /> : null}
     </div>
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
@@ -62,26 +62,6 @@ const WorkloadCard = ({ id }: Props): JSX.Element => {
       content = (
         <div data-test="no-workload-annotations">
           <h4>Workload information not available</h4>
-          <p>
-            Workload annotations are available when a machine is allocated.
-            Learn how to{" "}
-            <Link
-              external
-              href="https://maas.io/docs" // TODO: Replace with real link
-              onClick={() =>
-                sendAnalytics(
-                  "Machine summary",
-                  "Click link to workload annotation docs",
-                  "create machine workload annotations"
-                )
-              }
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              create machine workload annotations
-            </Link>
-            .
-          </p>
         </div>
       );
     }


### PR DESCRIPTION
## Done

- Removed paragraph text from workload card
- Made workload card only show for deployed or allocated machines

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine that is deployed/allocated and has workload annotations and check that they display fine.
- Go to a machine that is deployed/allocated and does not have workload annotations. Check that there is simply the message "Workload information not available".
- Go to a machine that is neither deployed nor allocated and check that there is no workload annotations card.

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2305
