### PR TITLE
feat(ui): allow LXD pods to compose machines with multiple disks

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -88,21 +88,6 @@ describe("StorageTable", () => {
     });
   });
 
-  it("disables add disk button with tooltip if KVM type is LXD", () => {
-    const pod = podDetailsFactory({ id: 1, type: "lxd" });
-    const state = { ...initialState };
-    state.pod.items = [pod];
-    const store = mockStore(state);
-    const wrapper = generateWrapper(store, pod);
-
-    expect(wrapper.find("[data-test='add-disk'] button").prop("disabled")).toBe(
-      true
-    );
-    expect(wrapper.find("[data-test='add-disk']").prop("message")).toBe(
-      "For the Beta version of LXD VM hosts each VM can only be assigned a single block device."
-    );
-  });
-
   it("disables add disk button if pod is composing a machine", () => {
     const pod = podDetailsFactory({ id: 1 });
     const state = { ...initialState };
@@ -116,7 +101,7 @@ describe("StorageTable", () => {
     );
   });
 
-  it("can add disks and remove all but last disk if KVM type is not LXD", async () => {
+  it("can add disks and remove all but last disk", async () => {
     const pod = podDetailsFactory({
       default_storage_pool: "pool-1",
       id: 1,

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -8,7 +8,6 @@ import {
   TableCell,
   TableHeader,
   TableRow,
-  Tooltip,
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
@@ -62,9 +61,7 @@ export const StorageTable = ({ defaultDisk }: Props): JSX.Element => {
   };
 
   if (!!pod) {
-    // For the Beta version of LXD VM hosts each VM can only be assigned a single block device.
-    const cannotHaveMultipleDisks = pod.type === "lxd";
-    const disabled = cannotHaveMultipleDisks || !!composingPods.length;
+    const disabled = !!composingPods.length;
 
     // RSD VM hosts can only choose "Local" storage, or "iSCSI" (if they have the capability).
     const isRSD = pod.type === "rsd";
@@ -180,25 +177,17 @@ export const StorageTable = ({ defaultDisk }: Props): JSX.Element => {
             })}
           </tbody>
         </Table>
-        <Tooltip
+        <Button
+          className="u-hide--small"
           data-test="add-disk"
-          message={
-            cannotHaveMultipleDisks &&
-            "For the Beta version of LXD VM hosts each VM can only be assigned a single block device."
-          }
-          position="right"
+          disabled={disabled}
+          hasIcon
+          onClick={addDisk}
+          type="button"
         >
-          <Button
-            className="u-hide--small"
-            disabled={disabled}
-            hasIcon
-            onClick={addDisk}
-            type="button"
-          >
-            <i className="p-icon--plus"></i>
-            <span>Add disk</span>
-          </Button>
-        </Tooltip>
+          <i className="p-icon--plus"></i>
+          <span>Add disk</span>
+        </Button>
       </>
     );
   }


### PR DESCRIPTION
## Done

- Removed the conditional that prevented LXD pods from composing machines with multiple disks

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM details page of a LXD KVM.
- Choose "Compose" from the "Take action" menu and check that the "Add disk" button is not disabled
- Add one or more disks then click compose
- Check that the machine is created with the correct number of disks. Note that there is currently a bug in the backend where the storage sizes are wrong while the machine is commissioning, and the boot disk + tags do not persists properly through commissioning.
- Check that after commissioning is finished the disks all have the correct sizes.

## Fixes

Fixes #2135 

## Launchpad issue

[lp#1915715](https://bugs.launchpad.net/maas/+bug/1915715)