### PR TITLE
fix(ui): fix infinite redirect of death when switching user

### DIFF
--- a/ui/src/app/base/sagas/http.js
+++ b/ui/src/app/base/sagas/http.js
@@ -93,7 +93,10 @@ export const api = {
       return fetch(LOGOUT_API, {
         headers: { "X-CSRFToken": csrftoken },
         method: "POST",
-      }).then(handleErrors);
+      }).then((res) => {
+        handleErrors(res);
+        window.location.reload();
+      });
     },
   },
   licenseKeys: {


### PR DESCRIPTION
## Done

- Fixed a bug where stale state was being stored in the legacy app (`window.CONFIG`), causing an infinite redirect loop if the legacy and react apps had different values for `user.completed_intro`. The fix is pretty rudimentary (trigger a refresh on logout) but at least it's consistent - feel like messing with the legacy websocket code might backfire.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- To reproduce the fix on master/bolla:
- Log in as an admin and create a new user
- Navigate to a legacy page, which will bootstrap the legacy app and set `window.CONFIG`
- Navigate *back* to a react page and logout
- Log in as the new user and check that the app redirects between `/l/intro/user` and `/r/machines` infinitely
- Pull this code, follow the same steps and check that the new user lands on `/l/intro/user` correctly

## Fixes

Fixes #2174
