### PR TITLE
Backport loading machine details fixes to 2.8

### DIFF
--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -339,7 +339,6 @@ describe("NodeDetailsController", function () {
       ResourcePoolsManager,
       FabricsManager,
       VLANsManager,
-      MachinesManager,
       PodsManager,
       ScriptsManager,
     ]);
@@ -382,11 +381,15 @@ describe("NodeDetailsController", function () {
   });
 
   it("doesnt call setActiveItem if node is loaded", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     spyOn(MachinesManager, "setActiveItem").and.returnValue($q.defer().promise);
     var defer = $q.defer();
     makeController(defer);
     MachinesManager._activeItem = node;
 
+    getItemDefer.resolve(node);
     defer.resolve();
     $rootScope.$digest();
 
@@ -396,10 +399,13 @@ describe("NodeDetailsController", function () {
   });
 
   it("calls setActiveItem if node is not active", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
     spyOn(MachinesManager, "setActiveItem").and.returnValue($q.defer().promise);
     var defer = $q.defer();
     makeController(defer);
 
+    getItemDefer.resolve(node);
     defer.resolve();
     $rootScope.$digest();
 
@@ -407,7 +413,12 @@ describe("NodeDetailsController", function () {
   });
 
   it("sets node and loaded once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     makeControllerResolveSetActiveItem();
+
     expect($scope.node).toBe(node);
     expect($scope.loaded).toBe(true);
   });
@@ -426,15 +437,19 @@ describe("NodeDetailsController", function () {
     expect($scope.type_name_title).toBe("Machine");
   });
 
-  it("fetches pod details if node has a pod", function() {
+  it("fetches pod details if node has a pod", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
     node.pod = { id: 1 };
     MachinesManager._activeItem = node;
     spyOn(PodsManager, "getItem").and.returnValue($q.defer().promise);
     var defer = $q.defer();
     makeController(defer);
 
+    getItemDefer.resolve(node);
     defer.resolve();
     $rootScope.$digest();
+
     expect(PodsManager.getItem).toHaveBeenCalledWith(node.pod.id);
   });
 
@@ -457,6 +472,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("updateServices sets $scope.services when node is loaded", function () {
+    const getItemDefer = $q.defer();
+    spyOn(ControllersManager, "getItem").and.returnValue(getItemDefer.promise);
+
     spyOn(ControllersManager, "getServices").and.returnValue([
       { status: "running", name: "rackd" },
     ]);
@@ -470,6 +488,7 @@ describe("NodeDetailsController", function () {
     ControllersManager._activeItem = node;
 
     defer.resolve();
+    getItemDefer.resolve(node);
     $rootScope.$digest();
 
     expect($scope.node).toBe(node);
@@ -482,6 +501,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("loads node actions", function () {
+    const getItemDefer = $q.defer();
+    spyOn(ControllersManager, "getItem").and.returnValue(getItemDefer.promise);
+
     spyOn(ControllersManager, "setActiveItem").and.returnValue(
       $q.defer().promise
     );
@@ -501,7 +523,9 @@ describe("NodeDetailsController", function () {
     ControllersManager._activeItem = myNode;
     loadManagersDefer.resolve();
     loadItemsDefer.resolve();
+    getItemDefer.resolve(myNode);
     $rootScope.$digest();
+
     expect(GeneralManager.isDataLoaded.calls.count()).toBe(2);
     expect(GeneralManager.isDataLoaded).toHaveBeenCalledWith(
       "rack_controller_actions"
@@ -512,11 +536,20 @@ describe("NodeDetailsController", function () {
   });
 
   it("title is updated once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     makeControllerResolveSetActiveItem();
+
     expect($rootScope.title).toBe(node.fqdn);
   });
 
   it("summary section placed in edit mode if architecture blank", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     node.architecture = "";
     node.permissions = ["edit"];
     GeneralManager._data.power_types.data = [{}];
@@ -544,7 +577,12 @@ describe("NodeDetailsController", function () {
   });
 
   it("summary section is updated once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     makeControllerResolveSetActiveItem();
+
     expect($scope.summary.zone.selected).toBe(
       ZonesManager.getItemFromList(node.zone.id)
     );
@@ -560,9 +598,14 @@ describe("NodeDetailsController", function () {
   });
 
   it("power section edit mode if power_type blank for a machine", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
+    getItemDefer.resolve(node);
     GeneralManager._data.power_types.data = [{}];
     node.permissions = ["edit"];
     makeControllerResolveSetActiveItem();
+
     expect($scope.power.editing).toBe(true);
   });
 
@@ -580,6 +623,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("starts watching once setActiveItem resolves", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     var setActiveDefer = $q.defer();
     spyOn(MachinesManager, "setActiveItem").and.returnValue(
       setActiveDefer.promise
@@ -592,6 +638,7 @@ describe("NodeDetailsController", function () {
 
     defer.resolve();
     $rootScope.$digest();
+    getItemDefer.resolve(node);
     setActiveDefer.resolve(node);
     $rootScope.$digest();
 
@@ -631,6 +678,9 @@ describe("NodeDetailsController", function () {
   });
 
   it("updates $scope.devices", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     var setActiveDefer = $q.defer();
     spyOn(MachinesManager, "setActiveItem").and.returnValue(
       setActiveDefer.promise
@@ -679,6 +729,7 @@ describe("NodeDetailsController", function () {
 
     defer.resolve();
     $rootScope.$digest();
+    getItemDefer.resolve(node);
     setActiveDefer.resolve(node);
     $rootScope.$digest();
 
@@ -719,10 +770,14 @@ describe("NodeDetailsController", function () {
   });
 
   it("updates $scope.actions", function () {
+    const getItemDefer = $q.defer();
+    spyOn(MachinesManager, "getItem").and.returnValue(getItemDefer.promise);
+
     var setActiveDefer = $q.defer();
     spyOn(MachinesManager, "setActiveItem").and.returnValue(
       setActiveDefer.promise
     );
+
     var loadManagersDefer = $q.defer();
     var loadItemsDefer = $q.defer();
     makeController(loadManagersDefer, loadItemsDefer);
@@ -737,6 +792,7 @@ describe("NodeDetailsController", function () {
     ];
     loadManagersDefer.resolve();
     $rootScope.$digest();
+    getItemDefer.resolve(node);
     setActiveDefer.resolve(node);
     $rootScope.$digest();
     // loadItems normally sets loaded to true and sets data to the items

--- a/legacy/src/app/services/manager.js
+++ b/legacy/src/app/services/manager.js
@@ -391,8 +391,13 @@ function Manager($q, $rootScope, $timeout, RegionConnection) {
     var method = this._handler + ".get";
     var params = {};
     params[this._pk] = pk_value;
-    return RegionConnection.callMethod(method, params).then(function(item) {
-      self._replaceItem(item);
+    return RegionConnection.callMethod(method, params).then(function (item) {
+      self._loaded = true;
+      if (self._items.length === 0) {
+        self._items.push(item);
+      } else {
+        self._replaceItem(item);
+      }
       return item;
     });
   };

--- a/legacy/src/app/services/manager.js
+++ b/legacy/src/app/services/manager.js
@@ -393,7 +393,8 @@ function Manager($q, $rootScope, $timeout, RegionConnection) {
     params[this._pk] = pk_value;
     return RegionConnection.callMethod(method, params).then(function (item) {
       self._loaded = true;
-      if (self._items.length === 0) {
+      var idx = self._getIndexOfItem(self._items, pk_value);
+      if (idx === -1) {
         self._items.push(item);
       } else {
         self._replaceItem(item);

--- a/legacy/src/app/services/tests/test_manager.js
+++ b/legacy/src/app/services/tests/test_manager.js
@@ -619,7 +619,31 @@ describe("Manager", function() {
       });
     });
 
-    it("updates node in items and selectedItems list", function(done) {
+    it("adds a new node to an empty items list", function (done) {
+      var fakeNode = makeNode();
+      fakeNode.name = makeName("name");
+
+      webSocket.returnData.push(makeFakeResponse(fakeNode));
+      NodesManager.getItem(fakeNode.system_id).then(function () {
+        expect(NodesManager._items[0].name).toBe(fakeNode.name);
+        done();
+      });
+    });
+
+    it("adds a new node to the items list when it already contains nodes", function (done) {
+      var existingFakeNode = makeNode();
+      var fakeNode = makeNode();
+      fakeNode.name = makeName("name");
+      NodesManager._items.push(existingFakeNode);
+
+      webSocket.returnData.push(makeFakeResponse(fakeNode));
+      NodesManager.getItem(fakeNode.system_id).then(function () {
+        expect(NodesManager._items[1].name).toBe(fakeNode.name);
+        done();
+      });
+    });
+
+    it("updates node in items and selectedItems list", function (done) {
       var fakeNode = makeNode();
       var updatedNode = angular.copy(fakeNode);
       updatedNode.name = makeName("name");

--- a/ui/src/app/machines/filter-nodes.js
+++ b/ui/src/app/machines/filter-nodes.js
@@ -5,6 +5,12 @@ import { getMachineValue } from "app/utils";
 // lowercased lowerTerm.
 const _matches = (value, lowerTerm, exact) => {
   if (typeof value === "number") {
+    // Check that term is a valid number before comparing it to the value.
+    // This is to prevent issues when parsing strings to numbers
+    // e.g. parseInt("1thing") returns the number 1.
+    if (isNaN(lowerTerm)) {
+      return false;
+    }
     if (exact) {
       if (Number.isInteger(value)) {
         return value === parseInt(lowerTerm, 10);

--- a/ui/src/app/machines/filter-nodes.test.js
+++ b/ui/src/app/machines/filter-nodes.test.js
@@ -25,6 +25,19 @@ describe("filterNodes", () => {
       filter: "nam",
     },
     {
+      description: "matches free search that starts with a number",
+      filter: "1nam",
+      nodes: [
+        { hostname: "1name" },
+        {
+          hostname: "name2",
+          // It shouldn't match this node by turning "1nam" in an integer of 1.
+          vlan_id: 1,
+        },
+      ],
+      result: [0],
+    },
+    {
       description: "doesn't return duplicates using free search",
       filter: "nam am",
       nodes: [
@@ -94,6 +107,18 @@ describe("filterNodes", () => {
     {
       description: "matches on attribute",
       filter: "hostname:name",
+    },
+    {
+      description: "matches on attribute that starts with a number",
+      filter: "hostname:1nam",
+      nodes: [
+        { hostname: "1name" },
+        {
+          // It shouldn't match this node by turning "1nam" in an integer of 1.
+          hostname: 1,
+        },
+      ],
+      result: [0],
     },
     {
       description: "matches with contains on attribute",

--- a/ui/src/app/machines/search.test.js
+++ b/ui/src/app/machines/search.test.js
@@ -25,6 +25,12 @@ describe("Search", () => {
       },
     },
     {
+      input: "1moon",
+      filters: {
+        q: ["1moon"],
+      },
+    },
+    {
       input: "m",
       filters: {
         q: ["m"],
@@ -47,6 +53,13 @@ describe("Search", () => {
       filters: {
         q: ["moon"],
         status: ["new"],
+      },
+    },
+    {
+      input: "moon status:(1new)",
+      filters: {
+        q: ["moon"],
+        status: ["1new"],
       },
     },
     {


### PR DESCRIPTION
## Done

- Only fetch a single machine on machine details, rather than every machine.
- Always add the loaded machine to the store when fetching a single machine for machine details.
- Fix free searches that start with a number that were erroneously being converted to numbers.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Use a dev maas to create a heap of machines:
```
make harness
from maasserver.testing.factory import factory
from maasserver.models import Zone
zone = Zone.objects.get(id=1)
for i in range(0, 2000): factory.make_Node(zone=zone)
```
- Load the machine details and click on a machine.
- The machine details should load relatively quickly.
- Refresh the page a few times, it should load every time.

## Fixes

Fixes: #2189.

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
