### PR TITLE
Correctly preselect commissioning scripts that don't have 'noauto' tag

### DIFF
--- a/legacy/src/app/directives/script_select.js
+++ b/legacy/src/app/directives/script_select.js
@@ -124,7 +124,7 @@ export function maasScriptSelect(ScriptsManager, ManagerHelperService) {
             script.script_type === $scope.scriptType &&
             script.for_hardware.length === 0
           ) {
-            if ($scope.scriptType === 0) {
+            if ($scope.scriptType === 0 && !script.tags.includes("noauto")) {
               // By default MAAS runs all custom
               // commissioning scripts in addition to all
               // builtin commissioning scripts.

--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -164,7 +164,6 @@
             </div>
           </form>
         </div>
-      </div>
       <div
         class="row ng-hide"
         data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || action.option.name !== 'commission'"

--- a/ui/src/app/base/components/TagSelector/TagSelector.js
+++ b/ui/src/app/base/components/TagSelector/TagSelector.js
@@ -92,31 +92,39 @@ const generateDropdownItems = ({
   return dropdownItems;
 };
 
-const generateSelectedItems = ({ selectedTags, updateTags }) =>
-  selectedTags.map((tag) => (
-    <li className="tag-selector__selected-item" key={tag.name}>
-      <Button
-        appearance="base"
-        className="tag-selector__selected-button"
-        data-test="selected-tag"
-        dense
-        hasIcon
-        onClick={() =>
-          updateTags(
-            selectedTags.filter((item) => item !== tag),
-            false
-          )
-        }
-      >
-        <span>{tag.name}</span>
-        <i className="p-icon--close" />
-      </Button>
-    </li>
-  ));
+const generateSelectedItems = (selectedTags, updateTags, disabledTags) =>
+  selectedTags.map((tag) => {
+    const isDisabled = disabledTags.some(
+      (disabledTag) => disabledTag.id === tag.id
+    );
+    return (
+      <li className="tag-selector__selected-item" key={tag.name}>
+        <Button
+          appearance="base"
+          className="tag-selector__selected-button"
+          data-test="selected-tag"
+          disabled={isDisabled}
+          dense
+          hasIcon
+          onClick={() =>
+            updateTags(
+              selectedTags.filter((item) => item !== tag),
+              false
+            )
+          }
+          type="button"
+        >
+          <span>{tag.name}</span>
+          {!isDisabled && <i className="p-icon--close" />}
+        </Button>
+      </li>
+    );
+  });
 
 export const TagSelector = ({
   allowNewTags = false,
   disabled,
+  disabledTags = [],
   error,
   help,
   initialSelected = [],
@@ -167,7 +175,7 @@ export const TagSelector = ({
       >
         {selectedTags.length > 0 && (
           <ul className="tag-selector__selected-list">
-            {generateSelectedItems({ selectedTags, updateTags })}
+            {generateSelectedItems(selectedTags, updateTags, disabledTags)}
           </ul>
         )}
         <Input
@@ -185,7 +193,7 @@ export const TagSelector = ({
               }
             }
           }}
-          placeholder={placeholder}
+          placeholder={selectedTags.length !== tags.length ? placeholder : ""}
           required={required}
           type="text"
           value={filter}

--- a/ui/src/app/base/components/TagSelector/TagSelector.test.js
+++ b/ui/src/app/base/components/TagSelector/TagSelector.test.js
@@ -205,4 +205,25 @@ describe("TagSelector", () => {
       component.find('[data-test="existing-tag"] > span em').at(1).text()
     ).toBe("the");
   });
+
+  it("can disable tags", () => {
+    const tags = [
+      { id: 1, name: "enabledTag" },
+      { id: 2, name: "disabledTag" },
+    ];
+    const component = shallow(
+      <TagSelector
+        disabledTags={[{ id: 2, name: "disabledTag" }]}
+        initialSelected={tags}
+        tags={tags}
+      />
+    );
+
+    expect(
+      component.find('[data-test="selected-tag"]').at(0).prop("disabled")
+    ).toBe(false);
+    expect(
+      component.find('[data-test="selected-tag"]').at(1).prop("disabled")
+    ).toBe(true);
+  });
 });

--- a/ui/src/app/base/selectors/scripts/scripts.js
+++ b/ui/src/app/base/selectors/scripts/scripts.js
@@ -73,6 +73,17 @@ scripts.commissioning = createSelector([scripts.all], (scriptItems) =>
 );
 
 /**
+ * Returns all preselected commissioning scripts
+ * @param {Object} state - Redux state
+ * @returns {Array} Preselected commissioning scripts
+ */
+scripts.preselectedCommissioning = createSelector(
+  [scripts.commissioning],
+  (commissioningScripts) =>
+    commissioningScripts.filter((script) => !script.tags.includes("noauto"))
+);
+
+/**
  * Returns all testing scripts
  * @param {Object} state - Redux state
  * @returns {Array} Testing scripts

--- a/ui/src/app/base/selectors/scripts/scripts.test.js
+++ b/ui/src/app/base/selectors/scripts/scripts.test.js
@@ -95,6 +95,29 @@ describe("scripts selectors", () => {
     });
   });
 
+  describe("preselectedCommissioning", () => {
+    it("returns all preselected commissioning scripts", () => {
+      const preselectedItems = [
+        { type: 0, default: true, tags: [] },
+        { type: 0, default: false, tags: [] },
+      ];
+      const nonPreselectedItems = [
+        {
+          default: true,
+          type: 0,
+          tags: ["noauto"],
+        },
+      ];
+      const state = {
+        scripts: {
+          items: [...preselectedItems, ...nonPreselectedItems],
+        },
+      };
+
+      expect(scripts.preselectedCommissioning(state)).toEqual(preselectedItems);
+    });
+  });
+
   describe("testing", () => {
     it("returns all testing scripts", () => {
       const items = [

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionForm.js
@@ -1,3 +1,4 @@
+import { Spinner, Strip } from "@canonical/react-components";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
@@ -46,11 +47,15 @@ export const CommissionForm = ({
   const saved = useSelector(machineSelectors.saved);
   const errors = useSelector(machineSelectors.errors);
   const commissioningScripts = useSelector(scriptSelectors.commissioning);
+  const preselectedCommissioningScripts = useSelector(
+    scriptSelectors.preselectedCommissioning
+  );
   const urlScripts = useSelector(scriptSelectors.testingWithUrl);
   const testingScripts = useSelector(scriptSelectors.testing);
   const commissioningSelected = useSelector(
     machineSelectors.commissioningSelected
   );
+  const loading = useSelector(scriptSelectors.loading);
 
   const formatScripts = (scripts) =>
     scripts.map((script) => ({
@@ -88,6 +93,13 @@ export const CommissionForm = ({
     Object.keys(errors).length > 0
   );
 
+  if (loading) {
+    return (
+      <Strip shallow>
+        <Spinner text="Loading..." />
+      </Strip>
+    );
+  }
   return (
     <FormikForm
       allowUnchanged
@@ -102,8 +114,7 @@ export const CommissionForm = ({
         skipStorage: false,
         updateFirmware: false,
         configureHBA: false,
-        commissioningScripts:
-          commissioningScripts.length > 0 ? formattedCommissioningScripts : [],
+        commissioningScripts: preselectedCommissioningScripts,
         testingScripts: preselectedTestingScripts,
         scriptInputs: initialScriptInputs,
       }}
@@ -158,7 +169,7 @@ export const CommissionForm = ({
     >
       <CommissionFormFields
         preselectedTesting={preselectedTestingScripts}
-        preselectedCommissioning={commissioningScripts}
+        preselectedCommissioning={preselectedCommissioningScripts}
         commissioningScripts={formattedCommissioningScripts}
         testingScripts={formattedTestingScripts}
       />

--- a/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
+++ b/ui/src/app/machines/components/HeaderStrip/ActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.js
@@ -40,13 +40,16 @@ export const CommissionFormFields = ({
           disabled={
             values.commissioningScripts.length === commissioningScripts.length
           }
+          disabledTags={commissioningScripts.filter(
+            (script) => script.default === true
+          )}
           initialSelected={preselectedCommissioning}
-          label="Additional commissioning scripts"
+          label="Commissioning scripts"
           name="commissioningScripts"
           onTagsUpdate={(selectedScripts) =>
             setFieldValue("commissioningScripts", selectedScripts)
           }
-          placeholder="Select commissioning scripts"
+          placeholder="Select additional scripts"
           required
           tags={commissioningScripts}
         />
@@ -55,12 +58,12 @@ export const CommissionFormFields = ({
           data-test="testing-scripts-selector"
           disabled={values.testingScripts.length === testingScripts.length}
           initialSelected={preselectedTesting}
-          label="Tests"
+          label="Testing scripts"
           name="tests"
           onTagsUpdate={(selectedScripts) =>
             setFieldValue("testingScripts", selectedScripts)
           }
-          placeholder="Select testing scripts"
+          placeholder="Select additional scripts"
           required
           tags={testingScripts}
         />


### PR DESCRIPTION
## Done

- In the legacy and react commissioning forms, the preselected scripts are now all the scripts that do not explicitly have the `noauto` tag.
- In the react commissioning form `default` scripts are now disabled. It's not possible to do this in the angular form without a major rewrite of the script selector code, which relies on `ng-tags-input`. Anyway, the api runs the default scripts regardless of whether they're included in the form submission.
- Added a loading spinner to the react form, otherwise it looked kinda jarring having the preselected scripts pop in suddenly.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Add a commissioning script with the `noauto` tag. I've added one on karura for reference.
- Open the commissioning form from the machine list.
- Check that the default scripts are disabled.
- Check that all the commissioning scripts are already selected except for the noauto script.
- Open the commissioning form from a machine details page.
- Check that all the commissioning scripts are already selected except for the noauto script.

## Fixes

Fixes #1498 

## Launchpad issue

[lp#1884827](https://bugs.launchpad.net/bugs/1884827)
