### PR TITLE
feat(ui): add the create physical interface form

### DIFF
--- a/root/report.20210218.124724.4180.0.001.json
+++ b/root/report.20210218.124724.4180.0.001.json
@@ -1,0 +1,453 @@
+
+{
+  "header": {
+    "event": "Allocation failed - JavaScript heap out of memory",
+    "trigger": "FatalError",
+    "filename": "report.20210218.124724.4180.0.001.json",
+    "dumpEventTime": "2021-02-18T12:47:24Z",
+    "dumpEventTimeStamp": "1613612844777",
+    "processId": 4180,
+    "cwd": "/home/ubuntu/code/maas-ui/root",
+    "commandLine": [
+      "/snap/dotrun/35/usr/bin/node",
+      "/home/ubuntu/code/maas-ui/root/node_modules/.bin/webpack",
+      "serve",
+      "--host",
+      "0.0.0.0",
+      "--port",
+      "8404",
+      "--config",
+      "webpack.dev.js"
+    ],
+    "nodejsVersion": "v12.4.0",
+    "glibcVersionRuntime": "2.27",
+    "glibcVersionCompiler": "2.17",
+    "wordSize": 64,
+    "arch": "x64",
+    "platform": "linux",
+    "componentVersions": {
+      "node": "12.4.0",
+      "v8": "7.4.288.27-node.18",
+      "uv": "1.29.1",
+      "zlib": "1.2.11",
+      "brotli": "1.0.7",
+      "ares": "1.15.0",
+      "modules": "72",
+      "nghttp2": "1.38.0",
+      "napi": "4",
+      "llhttp": "1.1.3",
+      "http_parser": "2.8.0",
+      "openssl": "1.1.1b",
+      "cldr": "35.1",
+      "icu": "64.2",
+      "tz": "2019a",
+      "unicode": "12.1"
+    },
+    "release": {
+      "name": "node",
+      "headersUrl": "https://nodejs.org/download/release/v12.4.0/node-v12.4.0-headers.tar.gz",
+      "sourceUrl": "https://nodejs.org/download/release/v12.4.0/node-v12.4.0.tar.gz"
+    },
+    "osName": "Linux",
+    "osRelease": "5.4.0-65-generic",
+    "osVersion": "#73-Ubuntu SMP Mon Jan 18 17:25:17 UTC 2021",
+    "osMachine": "x86_64",
+    "host": "projects"
+  },
+  "javascriptStack": {
+    "message": "No stack.",
+    "stack": [
+      "Unavailable."
+    ]
+  },
+  "nativeStack": [
+    {
+      "pc": "0x0000000000aadaf5",
+      "symbol": "report::TriggerNodeReport(v8::Isolate*, node::Environment*, char const*, char const*, std::string const&, v8::Local<v8::String>) [webpack]"
+    },
+    {
+      "pc": "0x000000000098fec3",
+      "symbol": "node::OnFatalError(char const*, char const*) [webpack]"
+    },
+    {
+      "pc": "0x0000000000b1552e",
+      "symbol": "v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [webpack]"
+    },
+    {
+      "pc": "0x0000000000b158a9",
+      "symbol": "v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [webpack]"
+    },
+    {
+      "pc": "0x0000000000f20105",
+      "symbol": " [webpack]"
+    },
+    {
+      "pc": "0x0000000000f2aa6b",
+      "symbol": "v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::GCCallbackFlags) [webpack]"
+    },
+    {
+      "pc": "0x0000000000f2b787",
+      "symbol": "v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [webpack]"
+    },
+    {
+      "pc": "0x0000000000f2e225",
+      "symbol": "v8::internal::Heap::AllocateRawWithRetryOrFail(int, v8::internal::AllocationType, v8::internal::AllocationAlignment) [webpack]"
+    },
+    {
+      "pc": "0x0000000000ef9250",
+      "symbol": "v8::internal::Factory::NewFillerObject(int, bool, v8::internal::AllocationSpace) [webpack]"
+    },
+    {
+      "pc": "0x00000000011cb0ce",
+      "symbol": "v8::internal::Runtime_AllocateInNewSpace(int, unsigned long*, v8::internal::Isolate*) [webpack]"
+    },
+    {
+      "pc": "0x0000000001a93942",
+      "symbol": " [webpack]"
+    }
+  ],
+  "javascriptHeap": {
+    "totalMemory": 2188615680,
+    "totalCommittedMemory": 2187502280,
+    "usedMemory": 2130673656,
+    "availableMemory": 61927656,
+    "memoryLimit": 2197815296,
+    "heapSpaces": {
+      "read_only_space": {
+        "memorySize": 524288,
+        "committedMemory": 32024,
+        "capacity": 523976,
+        "used": 31712,
+        "available": 492264
+      },
+      "new_space": {
+        "memorySize": 33554432,
+        "committedMemory": 33554072,
+        "capacity": 16767232,
+        "used": 4570984,
+        "available": 12196248
+      },
+      "old_space": {
+        "memorySize": 1312415744,
+        "committedMemory": 1312291216,
+        "capacity": 1309363280,
+        "used": 1286090984,
+        "available": 23272296
+      },
+      "code_space": {
+        "memorySize": 1736704,
+        "committedMemory": 1399168,
+        "capacity": 1362656,
+        "used": 1362656,
+        "available": 0
+      },
+      "map_space": {
+        "memorySize": 4198400,
+        "committedMemory": 4039688,
+        "capacity": 2687600,
+        "used": 2687600,
+        "available": 0
+      },
+      "large_object_space": {
+        "memorySize": 835563520,
+        "committedMemory": 835563520,
+        "capacity": 835379160,
+        "used": 835379160,
+        "available": 0
+      },
+      "code_large_object_space": {
+        "memorySize": 622592,
+        "committedMemory": 622592,
+        "capacity": 550560,
+        "used": 550560,
+        "available": 0
+      },
+      "new_large_object_space": {
+        "memorySize": 0,
+        "committedMemory": 0,
+        "capacity": 16767232,
+        "used": 0,
+        "available": 16767232
+      }
+    }
+  },
+  "resourceUsage": {
+    "userCpuSeconds": 446.195,
+    "kernelCpuSeconds": 40.2232,
+    "cpuConsumptionPercent": 78.7084,
+    "maxRss": 2691104768,
+    "pageFaults": {
+      "IORequired": 5,
+      "IONotRequired": 3767022
+    },
+    "fsActivity": {
+      "reads": 530,
+      "writes": 223064
+    }
+  },
+  "uvthreadResourceUsage": {
+    "userCpuSeconds": 253.027,
+    "kernelCpuSeconds": 19.28,
+    "cpuConsumptionPercent": 44.0626,
+    "fsActivity": {
+      "reads": 530,
+      "writes": 0
+    }
+  },
+  "libuv": [
+  ],
+  "environmentVariables": {
+    "LESSOPEN": "| /usr/bin/lesspipe %s",
+    "npm_package_scripts_lint_legacy": "cd legacy && yarn run lint",
+    "npm_package_scripts_clean_shared": "cd shared && yarn run clean",
+    "npm_package_devDependencies__maas_ui_maas_ui_shared": "1.3.1",
+    "npm_package_scripts_lint_package_json": "npmPkgJsonLint .",
+    "npm_package_scripts_test_cypress": "yarn --cwd integration run cypress-test",
+    "npm_package_devDependencies_http_proxy_middleware": "1.0.6",
+    "npm_package_dependencies__maas_ui_maas_ui": "1.3.1",
+    "SNAP_COMMON": "/var/snap/dotrun/common",
+    "SNAP_INSTANCE_KEY": "",
+    "SSH_CLIENT": "fe80::10a3:1813:6946:9f80%enp0s2 49625 22",
+    "USER": "ubuntu",
+    "npm_package_scripts_lint_shared": "cd shared && yarn run lint",
+    "npm_config_version_commit_hooks": "true",
+    "npm_config_user_agent": "yarn/1.22.0 npm/? node/v12.4.0 linux x64",
+    "npm_package_devDependencies_webpack_cli": "4.5.0",
+    "GIT_SHA": "ba842244",
+    "npm_package_scripts_release": "cd ui && yarn run release",
+    "npm_config_bin_links": "true",
+    "npm_config_wrap_output": "",
+    "npm_package_bugs_url": "https://github.com/canonical-web-and-design/maas-ui.git",
+    "XDG_SESSION_TYPE": "tty",
+    "npm_node_execpath": "/snap/dotrun/35/usr/bin/node",
+    "npm_config_init_version": "1.0.0",
+    "SHLVL": "1",
+    "TEMPDIR": "/tmp",
+    "LD_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void:/snap/dotrun/35/lib/x86_64-linux-gnu:/snap/dotrun/35/usr/lib/x86_64-linux-gnu::/snap/dotrun/35/lib:/snap/dotrun/35/usr/lib:/snap/dotrun/35/lib/x86_64-linux-gnu:/snap/dotrun/35/usr/lib/x86_64-linux-gnu",
+    "npm_package_devDependencies_wait_on": "5.2.1",
+    "npm_package_scripts_serve_ui_standalone": "yarn build-root-css && cd ../ui && BROWSER=none PORT=8401 yarn run standalone",
+    "HOME": "/home/ubuntu/snap/dotrun/35",
+    "MOTD_SHOWN": "pam",
+    "OLDPWD": "/home/ubuntu/code/maas-ui/proxy",
+    "SNAP_LIBRARY_PATH": "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32:/var/lib/snapd/void",
+    "npm_package_npmpackagejsonlint_rules_prefer_alphabetical_devDependencies": "error",
+    "npm_package_devDependencies_sass": "1.32.7",
+    "npm_package_browserslist_production_0": "last 1 chrome version",
+    "SNAP_USER_DATA": "/home/ubuntu/snap/dotrun/35",
+    "SSH_TTY": "/dev/pts/0",
+    "npm_package_scripts_build_all": "yarn build-shared && yarn build-legacy && yarn build-ui && yarn build-root && yarn copy-build",
+    "npm_package_browserslist_production_1": "last 1 firefox version",
+    "npm_package_workspaces_packages_0": "integration",
+    "npm_config_init_license": "MIT",
+    "npm_package_browserslist_production_2": "last 1 safari version",
+    "SKIP_PREFLIGHT_CHECK": "true",
+    "YARN_WRAP_OUTPUT": "false",
+    "npm_package_workspaces_packages_1": "legacy",
+    "npm_package_scripts_test_legacy": "cd legacy && yarn run test",
+    "npm_config_version_tag_prefix": "v",
+    "npm_package_scripts_serve_base": "concurrently \"yarn serve-root\" \"yarn serve-proxy\"",
+    "LC_CTYPE": "C.UTF-8",
+    "npm_package_workspaces_packages_2": "proxy",
+    "npm_package_scripts_serve": "yarn start",
+    "npm_package_scripts_betterer": "yarn --cwd ui betterer",
+    "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
+    "npm_package_workspaces_packages_3": "shared",
+    "npm_package_scripts_test_shared": "cd shared && yarn run test",
+    "npm_package_scripts_cypress_run": "yarn --cwd integration cypress-run",
+    "npm_package_scripts_build_legacy": "cd legacy && yarn install && yarn build",
+    "npm_package_scripts_serve_root": "cd ../root && yarn start",
+    "npm_package_devDependencies_css_minimizer_webpack_plugin": "1.2.0",
+    "LC_TERMINAL_VERSION": "3.4.4",
+    "SNAP_REVISION": "35",
+    "npm_package_description": "SingleSPA app which registers maas-ui-legacy and maas-ui apps.",
+    "npm_package_workspaces_packages_4": "ui",
+    "npm_package_devDependencies_babel_loader": "8.2.2",
+    "npm_package_readmeFilename": "README.md",
+    "npm_package_workspaces_packages_5": "root",
+    "npm_package_scripts_build_shared": "cd ../shared && yarn build",
+    "TMPDIR": "/tmp",
+    "npm_package_scripts_clean_monorepo": "rm -rf node_modules",
+    "npm_package_npmpackagejsonlint_rules_prefer_absolute_version_dependencies": "error",
+    "npm_package_devDependencies_dotenv_flow": "3.2.0",
+    "FORCE_COLOR": "2",
+    "LOGNAME": "ubuntu",
+    "npm_package_scripts_clean": "rm -rf dist node_modules",
+    "npm_package_scripts_serve_ui": "cd ../ui && BROWSER=none PORT=8401 yarn run start",
+    "SNAP_CONTEXT": "VmAjUd2mXa5queZWODktzclvniHCZGlVuN_RoJAdm-Gcjrn74Gdg",
+    "_": "/snap/bin/dotrun",
+    "npm_package_scripts_clean_root": "cd root && yarn run clean",
+    "npm_package_private": "true",
+    "npm_package_devDependencies_autoprefixer": "10.2.4",
+    "SNAP_VERSION": "1.1.9",
+    "XDG_SESSION_CLASS": "user",
+    "npm_package_scripts_lint": "yarn lint-package-json && yarn lint-js",
+    "npm_package_scripts_copy_legacy_assets": "cp -R legacy/dist/assets build/",
+    "npm_config_registry": "https://registry.yarnpkg.com",
+    "TERM": "xterm-256color",
+    "XDG_SESSION_ID": "1",
+    "npm_package_scripts_lint_root": "cd root && yarn run lint",
+    "SNAP_INSTANCE_NAME": "dotrun",
+    "npm_package_scripts_start": "GIT_SHA=`git rev-parse --short HEAD` webpack serve --host 0.0.0.0 --port 8404 --config webpack.dev.js",
+    "npm_config_ignore_scripts": "",
+    "npm_package_devDependencies_process": "0.11.10",
+    "npm_package_devDependencies_html_webpack_plugin": "5.1.0",
+    "npm_package_devDependencies_clean_webpack_plugin": "3.0.0",
+    "npm_package_scripts_unlink_components": "yarn unlink react && yarn unlink \"@canonical/react-components\"",
+    "npm_package_scripts_clean_ui": "cd ui && yarn run clean",
+    "npm_package_scripts_copy_build": "mkdir -p build && yarn copy-root && yarn copy-legacy-assets && yarn copy-ui-css",
+    "npm_package_scripts_watch_shared": "cd ../shared && concurrently \"yarn watch\" \"yarn watch-declaration\"",
+    "npm_package_scripts_serve_proxy": "node ./index.js",
+    "npm_package_browserslist_development_0": "last 1 chrome version",
+    "npm_package_devDependencies_postcss_loader": "5.0.0",
+    "PATH": "/tmp/yarn--1613612226074-0.8158082123225734:/home/ubuntu/code/maas-ui/root/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.config/yarn/link/node_modules/.bin:/home/ubuntu/code/maas-ui/node_modules/.bin:/snap/dotrun/35/usr/libexec/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/bin/node_modules/npm/bin/node-gyp-bin:/tmp/yarn--1613612225379-0.5591919544187403:/home/ubuntu/code/maas-ui/proxy/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.config/yarn/link/node_modules/.bin:/home/ubuntu/code/maas-ui/node_modules/.bin:/snap/dotrun/35/usr/libexec/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/bin/node_modules/npm/bin/node-gyp-bin:/tmp/yarn--1613612224134-0.1570263448819913:/home/ubuntu/code/maas-ui/proxy/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.config/yarn/link/node_modules/.bin:/home/ubuntu/code/maas-ui/node_modules/.bin:/snap/dotrun/35/usr/libexec/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/bin/node_modules/npm/bin/node-gyp-bin:/tmp/yarn--1613612146637-0.9922276994589538:/home/ubuntu/code/maas-ui/proxy/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.config/yarn/link/node_modules/.bin:/home/ubuntu/code/maas-ui/node_modules/.bin:/snap/dotrun/35/usr/libexec/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/bin/node_modules/npm/bin/node-gyp-bin:/tmp/yarn--1613612138542-0.21850769039346685:/home/ubuntu/code/maas-ui/proxy/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.config/yarn/link/node_modules/.bin:/home/ubuntu/code/maas-ui/node_modules/.bin:/snap/dotrun/35/usr/libexec/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/bin/node_modules/npm/bin/node-gyp-bin:/tmp/yarn--1613612138245-0.015798258927231634:/home/ubuntu/code/maas-ui/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.config/yarn/link/node_modules/.bin:/home/ubuntu/code/maas-ui/node_modules/.bin:/snap/dotrun/35/usr/libexec/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/bin/node_modules/npm/bin/node-gyp-bin:/tmp/yarn--1613612137939-0.27541827916195305:/home/ubuntu/code/maas-ui/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.config/yarn/link/node_modules/.bin:/home/ubuntu/code/maas-ui/node_modules/.bin:/home/ubuntu/snap/dotrun/35/.yarn/bin:/snap/dotrun/35/usr/libexec/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/lib/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/bin/node_modules/npm/bin/node-gyp-bin:/snap/dotrun/35/usr/sbin:/snap/dotrun/35/usr/bin:/snap/dotrun/35/sbin:/snap/dotrun/35/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games",
+    "NODE": "/snap/dotrun/35/usr/bin/node",
+    "npm_package_scripts_copy_ui_css": "cp ui/dist/static/css/* build/assets/css/",
+    "npm_package_name": "@maas-ui/maas-ui-root",
+    "npm_package_browserslist_development_1": "last 1 firefox version",
+    "npm_package_repository_type": "git",
+    "npm_package_scripts_lint_js": "eslint src",
+    "SNAP_DATA": "/var/snap/dotrun/35",
+    "XDG_RUNTIME_DIR": "/run/user/1000/snap.dotrun",
+    "npm_package_scripts_lint_ui": "cd ui && yarn run lint",
+    "npm_package_scripts_copy_root": "cp -R root/dist/* build/",
+    "npm_package_devDependencies_npm_package_json_lint": "5.1.0",
+    "npm_package_browserslist_development_2": "last 1 safari version",
+    "npm_package_devDependencies_cz_conventional_changelog": "3.3.0",
+    "npm_package_dependencies__maas_ui_maas_ui_legacy": "1.3.1",
+    "npm_package_devDependencies_webpack_merge": "5.7.3",
+    "npm_package_devDependencies_dotenv_flow_webpack": "1.1.0",
+    "LANG": "C.UTF-8",
+    "LD_PRELOAD": "/snap/dotrun/35/lib/semwraplib.so",
+    "npm_package_scripts_start_ui": "concurrently \"yarn serve-ui-standalone\" \"yarn watch-shared\" \"yarn serve-ui-proxy\"",
+    "npm_package_scripts_build_root_css": "cd ../root && [ -f dist/assets/css/root-application.css ] || { yarn install; sass --load-path=../node_modules src/scss/base.scss dist/assets/css/root-application.css; }",
+    "npm_package_devDependencies_webpack": "5.22.0",
+    "npm_package_devDependencies_eslint": "7.20.0",
+    "LS_COLORS": "rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:",
+    "npm_lifecycle_script": "GIT_SHA=`git rev-parse --short HEAD` webpack serve --host 0.0.0.0 --port 8404 --config webpack.dev.js",
+    "npm_package_scripts_clean_proxy": "cd proxy && yarn run clean",
+    "npm_package_scripts_serve_ui_proxy": "node ./ui.js",
+    "npm_package_dependencies__maas_ui_maas_ui_shared": "1.3.1",
+    "npm_package_devDependencies_copy_webpack_plugin": "7.0.0",
+    "npm_package_main": "src/root-application.js",
+    "SNAP_ARCH": "amd64",
+    "SNAP_COOKIE": "VmAjUd2mXa5queZWODktzclvniHCZGlVuN_RoJAdm-Gcjrn74Gdg",
+    "SNAP_USER_COMMON": "/home/ubuntu/snap/dotrun/common",
+    "SSH_AUTH_SOCK": "/tmp/ssh-E2tMyavkfn/agent.1079",
+    "npm_package_scripts_test": "yarn build-shared && yarn test-legacy && yarn test-ui && yarn test-shared",
+    "npm_package_scripts_cypress_open": "yarn --cwd integration cypress-open",
+    "npm_config_version_git_message": "v%s",
+    "npm_package_devDependencies_concurrently": "5.3.0",
+    "npm_package_dependencies_single_spa": "5.9.1",
+    "npm_package_devDependencies_webpack_dev_server": "3.11.2",
+    "SHELL": "/bin/bash",
+    "npm_lifecycle_event": "start",
+    "npm_package_workspaces_nohoist_0": "**/babel**",
+    "npm_package_scripts_link_components": "yarn link \"@canonical/react-components\" && yarn link \"react\" && yarn install",
+    "npm_package_version": "1.3.1",
+    "npm_package_repository_url": "git+https://github.com/canonical-web-and-design/maas-ui.git",
+    "SNAP_REEXEC": "",
+    "npm_config_argv": "{\"remain\":[],\"cooked\":[\"run\",\"start\"],\"original\":[\"run\",\"start\"]}",
+    "npm_package_workspaces_nohoist_1": "**/eslint**",
+    "npm_package_scripts_build": "GIT_SHA=`git rev-parse --short HEAD` webpack --config webpack.prod.js --progress",
+    "npm_package_npmpackagejsonlint_rules_prefer_absolute_version_devDependencies": "error",
+    "LESSCLOSE": "/usr/bin/lesspipe %s %s",
+    "SNAP_NAME": "dotrun",
+    "npm_package_config_commitizen_path": "./node_modules/cz-conventional-changelog",
+    "npm_package_workspaces_nohoist_2": "**/mini-css-extract-plugin**",
+    "npm_package_scripts_build_root": "cd root && yarn install && yarn build",
+    "LC_TERMINAL": "iTerm2",
+    "npm_package_workspaces_nohoist_3": "**/react-scripts**",
+    "npm_config_version_git_tag": "true",
+    "npm_config_version_git_sign": "",
+    "npm_package_devDependencies_sass_loader": "11.0.1",
+    "npm_package_workspaces_nohoist_4": "**/react-app-rewired**",
+    "npm_package_scripts_test_ui": "cd ui && yarn run test --watchAll=false",
+    "npm_package_license": "AGPL-3.0",
+    "npm_config_strict_ssl": "true",
+    "npm_package_npmpackagejsonlint_rules_prefer_alphabetical_dependencies": "error",
+    "npm_package_scripts_serve_frontends": "concurrently \"yarn serve-ui\" \"yarn serve-legacy\"",
+    "npm_package_workspaces_nohoist_5": "**/jest",
+    "npm_package_scripts_commit": "git-cz",
+    "npm_package_scripts_serve_legacy": "cd ../legacy && yarn run start",
+    "LC_ALL": "C.UTF-8",
+    "PWD": "/home/ubuntu/code/maas-ui/root",
+    "npm_execpath": "/snap/dotrun/35/usr/share/yarn/bin/yarn.js",
+    "npm_package_workspaces_nohoist_6": "**/webpack**",
+    "npm_package_scripts_clean_all": "rm -rf build && yarn clean-monorepo && yarn clean-proxy && yarn clean-shared && yarn clean-legacy && yarn clean-ui && yarn clean-root",
+    "npm_package_scripts_build_ui": "cd ui && yarn install && yarn build",
+    "SNAP_REAL_HOME": "/home/ubuntu",
+    "SSH_CONNECTION": "fe80::10a3:1813:6946:9f80%enp0s2 49625 fe80::1082:78ff:fe9e:d0b2%enp0s2 22",
+    "XDG_DATA_DIRS": "/usr/local/share:/usr/share:/var/lib/snapd/desktop",
+    "CYPRESS_INSTALL_BINARY": "0",
+    "npm_package_scripts_ui": "cd proxy && yarn start-ui",
+    "npm_package_scripts_serve_base_wait": "wait-on http://0.0.0.0:8401 && wait-on http://0.0.0.0:8402 && yarn serve-base",
+    "npm_package_scripts_serve_apps": "concurrently \"yarn serve-frontends\" \"yarn watch-shared\"",
+    "npm_package_devDependencies_css_loader": "5.0.2",
+    "npm_package_author_name": "Canonical Webteam",
+    "SNAP": "/snap/dotrun/35",
+    "npm_config_save_prefix": "^",
+    "npm_config_ignore_optional": "",
+    "npm_package_devDependencies_postcss": "8.2.6",
+    "npm_package_scripts_cleanbuild": "yarn clean-all && yarn build-all",
+    "npm_package_dependencies_vanilla_framework": "2.24.0",
+    "npm_package_devDependencies_mini_css_extract_plugin": "1.3.7",
+    "npm_package_devDependencies_babel_eslint": "10.1.0",
+    "npm_package_scripts_clean_legacy": "cd legacy && yarn run clean",
+    "INIT_CWD": "/home/ubuntu/code/maas-ui",
+    "WEBPACK_DEV_SERVER": "true"
+  },
+  "userLimits": {
+    "core_file_size_blocks": {
+      "soft": 0,
+      "hard": "unlimited"
+    },
+    "data_seg_size_kbytes": {
+      "soft": "unlimited",
+      "hard": "unlimited"
+    },
+    "file_size_blocks": {
+      "soft": "unlimited",
+      "hard": "unlimited"
+    },
+    "max_locked_memory_bytes": {
+      "soft": 67108864,
+      "hard": 67108864
+    },
+    "max_memory_size_kbytes": {
+      "soft": "unlimited",
+      "hard": "unlimited"
+    },
+    "open_files": {
+      "soft": 1048576,
+      "hard": 1048576
+    },
+    "stack_size_bytes": {
+      "soft": 8388608,
+      "hard": "unlimited"
+    },
+    "cpu_time_seconds": {
+      "soft": "unlimited",
+      "hard": "unlimited"
+    },
+    "max_user_processes": {
+      "soft": 63921,
+      "hard": 63921
+    },
+    "virtual_memory_kbytes": {
+      "soft": "unlimited",
+      "hard": "unlimited"
+    }
+  },
+  "sharedObjects": [
+    "linux-vdso.so.1",
+    "/snap/dotrun/35/lib/semwraplib.so",
+    "/lib/x86_64-linux-gnu/libdl.so.2",
+    "/lib/x86_64-linux-gnu/librt.so.1",
+    "/usr/lib/x86_64-linux-gnu/libstdc++.so.6",
+    "/lib/x86_64-linux-gnu/libm.so.6",
+    "/snap/dotrun/35/lib/x86_64-linux-gnu/libgcc_s.so.1",
+    "/lib/x86_64-linux-gnu/libpthread.so.0",
+    "/lib/x86_64-linux-gnu/libc.so.6",
+    "/lib64/ld-linux-x86-64.so.2"
+  ]
+}

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -128,7 +128,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:4083206781": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -414,7 +414,17 @@ exports[`stricter compilation`] = {
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:1649694459": [
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx:3088897502": [
+      [104, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [108, 10, 9, "Argument of type \'{ fabric: number; ip_address: string; mac_address: string; mode: NetworkLinkMode; name: string; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'fabric\' does not exist in type \'FormEvent<{}>\'.", "3240912851"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx:612974810": [
+      [106, 8, 8, "Type \'(values: AddInterfaceValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'AddInterfaceValues\'.", "1301647696"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterfaceFormFields/AddInterfaceFormFields.tsx:287316851": [
+      [65, 33, 23, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "3266610074"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:1686781195": [
       [430, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"bondOrBridge\\" | \\"dhcp\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | \\"speed\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"bondOrBridge\\" | \\"dhcp\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | \\"speed\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"bondOrBridge\\" | \\"dhcp\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | \\"speed\\"\'.", "193424690"],
       [434, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"bondOrBridge\\" | \\"dhcp\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | \\"speed\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"bondOrBridge\\" | \\"dhcp\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | \\"speed\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"bondOrBridge\\" | \\"dhcp\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | \\"speed\\"\'.", "193424690"],
       [459, 35, 9, "Object is possibly \'null\'.", "1794230341"],

--- a/ui/src/app/base/components/VLANSelect/VLANSelect.test.tsx
+++ b/ui/src/app/base/components/VLANSelect/VLANSelect.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import VLANSelect from "./VLANSelect";
 
 import type { RootState } from "app/store/root/types";
+import type { VLAN } from "app/store/vlan/types";
 import {
   rootState as rootStateFactory,
   vlan as vlanFactory,
@@ -19,7 +20,10 @@ describe("VLANSelect", () => {
   beforeEach(() => {
     state = rootStateFactory({
       vlan: vlanStateFactory({
-        items: [],
+        items: [
+          vlanFactory({ id: 1, name: "vlan1", vid: 1 }),
+          vlanFactory({ id: 2, name: "vlan2", vid: 2 }),
+        ],
         loaded: true,
       }),
     });
@@ -39,11 +43,6 @@ describe("VLANSelect", () => {
   });
 
   it("displays the vlan options", () => {
-    const items = [
-      vlanFactory({ id: 1, name: "vlan1", vid: 1 }),
-      vlanFactory({ id: 2, name: "vlan2", vid: 2 }),
-    ];
-    state.vlan.items = items;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -94,5 +93,26 @@ describe("VLANSelect", () => {
       </Provider>
     );
     expect(wrapper.find("FormikField").prop("options").length).toBe(0);
+  });
+
+  it("filter the vlan options", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ subnet: "" }} onSubmit={jest.fn()}>
+          <VLANSelect
+            name="vlan"
+            filterFunction={(vlan: VLAN) => vlan.name === "vlan1"}
+          />
+        </Formik>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField").prop("options")).toStrictEqual([
+      { label: "Select VLAN", value: "" },
+      {
+        label: "1 (vlan1)",
+        value: "1",
+      },
+    ]);
   });
 });

--- a/ui/src/app/base/components/VLANSelect/VLANSelect.tsx
+++ b/ui/src/app/base/components/VLANSelect/VLANSelect.tsx
@@ -12,15 +12,17 @@ import { getVLANDisplay } from "app/store/vlan/utils";
 
 type Props = {
   defaultOption?: { label: string; value: string } | null;
+  filterFunction?: (vlan: VLAN) => boolean;
 } & FormikFieldProps;
 
 export const VLANSelect = ({
   defaultOption = { label: "Select VLAN", value: "" },
+  filterFunction,
   name,
   ...props
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const vlans: VLAN[] = useSelector(vlanSelectors.all);
+  let vlans: VLAN[] = useSelector(vlanSelectors.all);
   const vlansLoaded = useSelector(vlanSelectors.loaded);
 
   useEffect(() => {
@@ -29,6 +31,10 @@ export const VLANSelect = ({
 
   if (!vlansLoaded) {
     return <Spinner />;
+  }
+
+  if (vlans && filterFunction) {
+    vlans = vlans.filter(filterFunction);
   }
 
   const vlanOptions = vlans.map((vlan) => ({

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -1,0 +1,144 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddInterface from "./AddInterface";
+
+import { NetworkLinkMode } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AddInterface", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        items: [fabricFactory({}), fabricFactory()],
+        loaded: true,
+      }),
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+      subnet: subnetStateFactory({
+        items: [subnetFactory(), subnetFactory()],
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        items: [vlanFactory(), vlanFactory()],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("fetches the necessary data on load", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const expectedActions = ["fabric/fetch", "vlan/fetch"];
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        store.getActions().some((action) => action.type === expectedAction)
+      );
+    });
+  });
+
+  it("displays a spinner when data is loading", () => {
+    state.vlan.loaded = false;
+    state.fabric.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("correctly dispatches actions to add a physical interface", () => {
+    state.machine.selected = ["abc123", "def456"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          fabric: 1,
+          ip_address: "1.2.3.4",
+          mac_address: "28:21:c6:b9:1b:22",
+          mode: NetworkLinkMode.LINK_UP,
+          name: "eth1",
+          subnet: 1,
+          tags: ["a", "tag"],
+          vlan: 1,
+        })
+    );
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "machine/createPhysical")
+    ).toStrictEqual({
+      type: "machine/createPhysical",
+      meta: {
+        model: "machine",
+        method: "create_physical",
+      },
+      payload: {
+        params: {
+          fabric: 1,
+          ip_address: "1.2.3.4",
+          mac_address: "28:21:c6:b9:1b:22",
+          mode: NetworkLinkMode.LINK_UP,
+          name: "eth1",
+          subnet: 1,
+          system_id: "abc123",
+          tags: ["a", "tag"],
+          vlan: 1,
+        },
+      },
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import AddInterfaceFormFields from "./AddInterfaceFormFields";
+import type { AddInterfaceValues } from "./types";
+
+import FormCard from "app/base/components/FormCard";
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { MAC_ADDRESS_REGEX } from "app/base/validation";
+import { useMachineDetailsForm } from "app/machines/hooks";
+import { actions as fabricActions } from "app/store/fabric";
+import fabricSelectors from "app/store/fabric/selectors";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine, MachineDetails } from "app/store/machine/types";
+import {
+  NetworkInterfaceTypes,
+  NetworkLinkMode,
+} from "app/store/machine/types";
+import { getNextNicName } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+
+type Props = {
+  close: () => void;
+  systemId: MachineDetails["system_id"];
+};
+
+const InterfaceSchema = Yup.object().shape({
+  ip_address: Yup.string(),
+  mac_address: Yup.string()
+    .matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
+    .required("MAC address is required"),
+  mode: Yup.mixed().oneOf(Object.values(NetworkLinkMode)),
+  name: Yup.string(),
+  fabric: Yup.number().required("Fabric is required"),
+  subnet: Yup.number(),
+  tags: Yup.array().of(Yup.string()),
+  vlan: Yup.number().required("VLAN is required"),
+});
+
+const AddInterface = ({ close, systemId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const cleanup = useCallback(() => machineActions.cleanup(), []);
+  const fabrics = useSelector(fabricSelectors.all);
+  const fabricsLoaded = useSelector(fabricSelectors.loaded);
+  const vlans = useSelector(vlanSelectors.all);
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+  const nextName = getNextNicName(machine, NetworkInterfaceTypes.PHYSICAL);
+  const { errors, saved, saving } = useMachineDetailsForm(
+    systemId,
+    "creatingPhysical",
+    "createPhysical",
+    () => close()
+  );
+
+  useEffect(() => {
+    dispatch(fabricActions.fetch());
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  if (
+    !machine ||
+    !("interfaces" in machine) ||
+    !vlansLoaded ||
+    !fabricsLoaded
+  ) {
+    return <Spinner text="Loading..." />;
+  }
+  return (
+    <FormCard sidebar={false}>
+      <FormikForm
+        buttons={FormCardButtons}
+        cleanup={cleanup}
+        errors={errors}
+        initialValues={{
+          ip_address: "",
+          mac_address: "",
+          mode: NetworkLinkMode.LINK_UP,
+          name: nextName,
+          fabric: fabrics[0]?.id,
+          subnet: "",
+          tags: [],
+          vlan: vlans[0]?.id,
+        }}
+        onSaveAnalytics={{
+          action: "Add interface",
+          category: "Machine details networking",
+          label: "Add interface form",
+        }}
+        onCancel={close}
+        onSubmit={(values: AddInterfaceValues) => {
+          // Clear the errors from the previous submission.
+          dispatch(cleanup());
+          type Payload = AddInterfaceValues & {
+            system_id: Machine["system_id"];
+          };
+          const payload: Payload = {
+            ...values,
+            system_id: systemId,
+          };
+          // Remove all empty values.
+          Object.entries(payload).forEach(([key, value]) => {
+            if (value === "") {
+              delete payload[key as keyof Payload];
+            }
+          });
+          dispatch(machineActions.createPhysical(payload));
+        }}
+        resetOnSave
+        saved={saved}
+        saving={saving}
+        submitLabel="Save interface"
+        validationSchema={InterfaceSchema}
+      >
+        <AddInterfaceFormFields />
+      </FormikForm>
+    </FormCard>
+  );
+};
+
+export default AddInterface;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterfaceFormFields/AddInterfaceFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterfaceFormFields/AddInterfaceFormFields.test.tsx
@@ -1,0 +1,324 @@
+import { mount } from "enzyme";
+import type { ReactWrapper } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddInterface from "../AddInterface";
+
+import { NetworkLinkMode } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+  subnetStatistics as subnetStatisticsFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+const changeField = async (
+  wrapper: ReactWrapper,
+  selector: string,
+  name: string,
+  value: unknown
+) => {
+  return act(async () => {
+    wrapper.find(selector).simulate("change", {
+      target: {
+        name,
+        value,
+      },
+    });
+  });
+};
+
+describe("AddInterfaceFormFields", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        items: [
+          fabricFactory({ default_vlan_id: 1 }),
+          fabricFactory({ default_vlan_id: 1 }),
+        ],
+        loaded: true,
+      }),
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+      subnet: subnetStateFactory({
+        items: [subnetFactory(), subnetFactory()],
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        items: [vlanFactory({ id: 1 }), vlanFactory()],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("changes the vlan to the default for a fabric", async () => {
+    state.fabric.items = [fabricFactory({ id: 2, default_vlan_id: 3 })];
+    state.vlan.items = [vlanFactory({ id: 1 }), vlanFactory({ id: 3 })];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("VLANSelect select").prop("value")).toBe(1);
+    await changeField(wrapper, "FabricSelect select", "fabric", 2);
+    wrapper.update();
+    expect(wrapper.find("VLANSelect select").prop("value")).toBe(3);
+  });
+
+  it("resets all fields after vlan when the fabric is changed", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Set the values of the fields so they're all visible and have values.
+    await changeField(wrapper, "SubnetSelect select", "subnet", 2);
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "LinkModeSelect select",
+      "mode",
+      NetworkLinkMode.STATIC
+    );
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "FormikField[name='ip_address'] input",
+      "ip_address",
+      "1.2.3.4"
+    );
+    // Change the fabric and the other fields should reset.
+    await changeField(wrapper, "FabricSelect select", "fabric", 2);
+    wrapper.update();
+    expect(wrapper.find("SubnetSelect select").prop("value")).toBe("");
+    expect(wrapper.find("LinkModeSelect").exists()).toBe(false);
+    expect(wrapper.find("FormikField[name='ip_address']").exists()).toBe(false);
+  });
+
+  it("resets all fields after vlan when it is changed", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Set the values of the fields so they're all visible and have values.
+    await changeField(wrapper, "SubnetSelect select", "subnet", 2);
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "LinkModeSelect select",
+      "mode",
+      NetworkLinkMode.STATIC
+    );
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "FormikField[name='ip_address'] input",
+      "ip_address",
+      "1.2.3.4"
+    );
+    // Change the VLAN and the other fields should reset.
+    await changeField(wrapper, "VLANSelect select", "vlan", 2);
+    wrapper.update();
+    expect(wrapper.find("SubnetSelect select").prop("value")).toBe("");
+    expect(wrapper.find("LinkModeSelect").exists()).toBe(false);
+    expect(wrapper.find("FormikField[name='ip_address']").exists()).toBe(false);
+  });
+
+  it("resets all fields after subnet when it is changed", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Set the values of the fields so they're all visible and have values.
+    await changeField(wrapper, "SubnetSelect select", "subnet", 2);
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "LinkModeSelect select",
+      "mode",
+      NetworkLinkMode.STATIC
+    );
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "FormikField[name='ip_address'] input",
+      "ip_address",
+      "1.2.3.4"
+    );
+    // Change the subnet and the other fields should reset.
+    await changeField(wrapper, "SubnetSelect select", "subnet", "");
+    wrapper.update();
+    expect(wrapper.find("LinkModeSelect").exists()).toBe(false);
+    expect(wrapper.find("FormikField[name='ip_address']").exists()).toBe(false);
+  });
+
+  it("sets the ip address to the first address from the subnet when the mode is static", async () => {
+    state.subnet.items.push(
+      subnetFactory({
+        id: 3,
+        statistics: subnetStatisticsFactory({
+          first_address: "1.2.3.4",
+        }),
+      })
+    );
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Set the values of the fields so they're all visible and have values.
+    await changeField(wrapper, "SubnetSelect select", "subnet", 3);
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "LinkModeSelect select",
+      "mode",
+      NetworkLinkMode.STATIC
+    );
+    wrapper.update();
+    expect(
+      wrapper.find("FormikField[name='ip_address'] input").prop("value")
+    ).toBe("1.2.3.4");
+  });
+
+  it("does not display the mode field if a subnet has not been chosen", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("LinkModeSelect").exists()).toBe(false);
+    expect(wrapper.find("FormikField[name='ip_address']").exists()).toBe(false);
+  });
+
+  it("displays the mode field if a subnet has been chosen", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    await changeField(wrapper, "SubnetSelect select", "subnet", 2);
+    wrapper.update();
+    expect(wrapper.find("LinkModeSelect").exists()).toBe(true);
+  });
+
+  it("does not display the ip address field if the mode has not been chosen", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikField[name='ip_address']").exists()).toBe(false);
+  });
+
+  it("does not display the ip address field if the chosen mode is not static", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    await changeField(wrapper, "SubnetSelect select", "subnet", 2);
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "LinkModeSelect select",
+      "mode",
+      NetworkLinkMode.AUTO
+    );
+    wrapper.update();
+    expect(wrapper.find("FormikField[name='ip_address']").exists()).toBe(false);
+  });
+
+  it("displays the ip address field if the mode is static", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <AddInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    await changeField(wrapper, "SubnetSelect select", "subnet", 2);
+    wrapper.update();
+    await changeField(
+      wrapper,
+      "LinkModeSelect select",
+      "mode",
+      NetworkLinkMode.STATIC
+    );
+    wrapper.update();
+    expect(wrapper.find("FormikField[name='ip_address']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterfaceFormFields/AddInterfaceFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterfaceFormFields/AddInterfaceFormFields.tsx
@@ -1,0 +1,126 @@
+import { Col, Input, Row } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+
+import type { AddInterfaceValues } from "../types";
+
+import FabricSelect from "app/base/components/FabricSelect";
+import FormikField from "app/base/components/FormikField";
+import LinkModeSelect from "app/base/components/LinkModeSelect";
+import MacAddressField from "app/base/components/MacAddressField";
+import SubnetSelect from "app/base/components/SubnetSelect";
+import TagField from "app/base/components/TagField";
+import VLANSelect from "app/base/components/VLANSelect";
+import fabricSelectors from "app/store/fabric/selectors";
+import { NetworkLinkMode } from "app/store/machine/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import type { Subnet } from "app/store/subnet/types";
+import type { VLAN } from "app/store/vlan/types";
+
+const fieldOrder = ["fabric", "vlan", "subnet", "mode", "ip_address"];
+
+const AddInterfaceFormFields = (): JSX.Element | null => {
+  const fabrics = useSelector(fabricSelectors.all);
+  const subnets = useSelector(subnetSelectors.all);
+  const { setFieldValue, values } = useFormikContext<AddInterfaceValues>();
+  const resetFollowingFields = (name: keyof AddInterfaceValues) => {
+    // Reset all fields after this one.
+    const position = fieldOrder.indexOf(name);
+    for (let i = position + 1; i < fieldOrder.length; i++) {
+      setFieldValue(fieldOrder[i], "");
+    }
+  };
+  return (
+    <>
+      <Row>
+        <Col size="6">
+          <FormikField label="Name" type="text" name="name" />
+        </Col>
+      </Row>
+      <hr />
+      <Row>
+        <Col size="6">
+          <Input
+            disabled
+            label="Type"
+            value="Physical"
+            type="text"
+            name="type"
+          />
+          <MacAddressField label="MAC address" name="mac_address" />
+          <TagField />
+        </Col>
+        <Col size="6">
+          <FabricSelect
+            name="fabric"
+            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+              const { value } = evt.target;
+              // Manually set the value because we've overwritten the onChange.
+              setFieldValue("fabric", Number(value));
+              if (value || typeof value === "number") {
+                const fabric = fabrics.find(({ id }) => id === Number(value));
+                // Update the VLAN on the node to be the default VLAN for that
+                // fabric.
+                setFieldValue("vlan", fabric?.default_vlan_id);
+                resetFollowingFields("vlan");
+              }
+            }}
+          />
+          <VLANSelect
+            filterFunction={(vlan: VLAN) => vlan.fabric === values.fabric}
+            name="vlan"
+            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+              const { value } = evt.target;
+              // Manually set the value because we've overwritten the onChange.
+              setFieldValue("vlan", Number(value));
+              resetFollowingFields("vlan");
+            }}
+          />
+          <SubnetSelect
+            defaultOption={{
+              label: "Unconfigured",
+              value: "",
+            }}
+            filterFunction={(subnet: Subnet) => subnet.vlan === values.vlan}
+            name="subnet"
+            onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+              const { value } = evt.target;
+              // Manually set the value so that the next fields get reset.
+              setFieldValue("subnet", Number(value));
+              resetFollowingFields("subnet");
+            }}
+          />
+          {values.subnet ? (
+            <LinkModeSelect
+              name="mode"
+              onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                const { value } = evt.target;
+                // Manually set the value because we've overwritten the onChange.
+                setFieldValue("mode", value as NetworkLinkMode);
+                if (value === NetworkLinkMode.STATIC) {
+                  const subnet = subnets.find(
+                    // Formik values eventually resolve to the correct types,
+                    // meanwile we need to force the subnet value to be a number
+                    // to compare against the ids in the store.
+                    ({ id }) => id === Number(values.subnet)
+                  );
+                  setFieldValue(
+                    "ip_address",
+                    subnet?.statistics.first_address || ""
+                  );
+                } else {
+                  setFieldValue("ip_address", "");
+                }
+              }}
+            />
+          ) : null}
+          {values.mode === NetworkLinkMode.STATIC ? (
+            <FormikField label="IP address" type="text" name="ip_address" />
+          ) : null}
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default AddInterfaceFormFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterfaceFormFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterfaceFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddInterfaceFormFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddInterface";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/types.ts
@@ -1,0 +1,17 @@
+import type {
+  NetworkInterface,
+  NetworkLink,
+  NetworkLinkMode,
+  Vlan,
+} from "app/store/machine/types";
+
+export type AddInterfaceValues = {
+  ip_address?: NetworkLink["ip_address"];
+  mac_address: NetworkInterface["mac_address"];
+  mode?: NetworkLinkMode;
+  name?: NetworkInterface["name"];
+  fabric: Vlan["fabric_id"];
+  subnet?: NetworkLink["subnet_id"];
+  tags?: NetworkInterface["tags"];
+  vlan: NetworkInterface["vlan_id"];
+};

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -2,13 +2,16 @@ import React from "react";
 
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachineNetwork from "./MachineNetwork";
 
 import {
+  machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -32,5 +35,34 @@ describe("MachineNetwork", () => {
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays the add interface form when expanded", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/network", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/network"
+            component={() => <MachineNetwork setSelectedAction={jest.fn()} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button[children='Add interface']").simulate("click");
+    expect(wrapper.find("AddInterface").exists()).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -6,9 +6,12 @@ import { useParams } from "react-router";
 
 import type { SetSelectedAction } from "../types";
 
+import AddInterface from "./AddInterface";
 import DHCPTable from "./DHCPTable";
 import NetworkActions from "./NetworkActions";
 import NetworkTable from "./NetworkTable";
+import type { Expanded } from "./NetworkTable/types";
+import { ExpandedState } from "./NetworkTable/types";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
@@ -22,6 +25,9 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
   const [selected, setSelected] = useState<NetworkInterface["id"][]>([]);
+  const [interfaceExpanded, setInterfaceExpanded] = useState<Expanded | null>(
+    null
+  );
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
@@ -34,13 +40,26 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <>
-      <NetworkActions setSelectedAction={setSelectedAction} systemId={id} />
+      <NetworkActions
+        expanded={interfaceExpanded}
+        setExpanded={setInterfaceExpanded}
+        setSelectedAction={setSelectedAction}
+        systemId={id}
+      />
       <Strip>
         <NetworkTable
-          systemId={id}
+          expanded={interfaceExpanded}
           selected={selected}
+          setExpanded={setInterfaceExpanded}
           setSelected={setSelected}
+          systemId={id}
         />
+        {interfaceExpanded?.content === ExpandedState.ADD_PHYSICAL ? (
+          <AddInterface
+            close={() => setInterfaceExpanded(null)}
+            systemId={id}
+          />
+        ) : null}
       </Strip>
       <DHCPTable systemId={id} />
     </>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
@@ -3,6 +3,8 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
+import { ExpandedState } from "../NetworkTable/types";
+
 import NetworkActions from "./NetworkActions";
 
 import type { RootState } from "app/store/root/types";
@@ -36,7 +38,12 @@ describe("NetworkActions", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NetworkActions setSelectedAction={jest.fn()} systemId="abc123" />
+          <NetworkActions
+            expanded={null}
+            setExpanded={jest.fn()}
+            setSelectedAction={jest.fn()}
+            systemId="abc123"
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -51,7 +58,12 @@ describe("NetworkActions", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <NetworkActions setSelectedAction={jest.fn()} systemId="abc123" />
+          <NetworkActions
+            expanded={null}
+            setExpanded={jest.fn()}
+            setSelectedAction={jest.fn()}
+            systemId="abc123"
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -67,6 +79,8 @@ describe("NetworkActions", () => {
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
           <NetworkActions
+            expanded={null}
+            setExpanded={jest.fn()}
             setSelectedAction={setSelectedAction}
             systemId="abc123"
           />
@@ -78,5 +92,72 @@ describe("NetworkActions", () => {
       name: NodeActions.TEST,
       formProps: { applyConfiguredNetworking: true },
     });
+  });
+
+  it("sets the state to show the add interface form when clicking the button", () => {
+    const store = mockStore(state);
+    const setExpanded = jest.fn();
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NetworkActions
+            expanded={null}
+            setExpanded={setExpanded}
+            setSelectedAction={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button[children='Add interface']").simulate("click");
+    expect(setExpanded).toHaveBeenCalledWith({
+      content: ExpandedState.ADD_PHYSICAL,
+    });
+  });
+
+  it("disables the add interface button when networking is disabled", () => {
+    state.machine.items[0].status = NodeStatus.DEPLOYED;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NetworkActions
+            expanded={null}
+            setExpanded={jest.fn()}
+            setSelectedAction={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("Button[children='Add interface']").prop("disabled")
+    ).toBe(true);
+  });
+
+  it("disables the add interface button when the form is expanded", () => {
+    state.machine.items[0].status = NodeStatus.DEPLOYED;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <NetworkActions
+            expanded={{ content: ExpandedState.ADD_PHYSICAL }}
+            setExpanded={jest.fn()}
+            setSelectedAction={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("Button[children='Add interface']").prop("disabled")
+    ).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
@@ -2,6 +2,8 @@ import { Button, Col, Row } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import type { SetSelectedAction } from "../../types";
+import { ExpandedState } from "../NetworkTable/types";
+import type { Expanded, SetExpanded } from "../NetworkTable/types";
 
 import { useSendAnalytics } from "app/base/hooks";
 import machineSelectors from "app/store/machine/selectors";
@@ -11,11 +13,15 @@ import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 
 type Props = {
+  expanded: Expanded | null;
+  setExpanded: SetExpanded;
   systemId: Machine["system_id"];
   setSelectedAction: SetSelectedAction;
 };
 
 const NetworkActions = ({
+  expanded,
+  setExpanded,
   setSelectedAction,
   systemId,
 }: Props): JSX.Element | null => {
@@ -31,7 +37,19 @@ const NetworkActions = ({
 
   return (
     <Row>
-      <Col size="8"></Col>
+      <Col size="8">
+        <Button
+          disabled={
+            isAllNetworkingDisabled ||
+            expanded?.content === ExpandedState.ADD_PHYSICAL
+          }
+          onClick={() => {
+            setExpanded({ content: ExpandedState.ADD_PHYSICAL });
+          }}
+        >
+          Add interface
+        </Button>
+      </Col>
       <Col className="u-align--right" size="4">
         <Button
           disabled={isAllNetworkingDisabled}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/__snapshots__/NetworkActions.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/__snapshots__/NetworkActions.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`NetworkActions renders 1`] = `
 <NetworkActions
+  expanded={null}
+  setExpanded={[MockFunction]}
   setSelectedAction={[MockFunction]}
   systemId="abc123"
 >
@@ -14,7 +16,20 @@ exports[`NetworkActions renders 1`] = `
       >
         <div
           className="col-8"
-        />
+        >
+          <Button
+            disabled={false}
+            onClick={[Function]}
+          >
+            <button
+              className="p-button--neutral"
+              disabled={false}
+              onClick={[Function]}
+            >
+              Add interface
+            </button>
+          </Button>
+        </div>
       </Col>
       <Col
         className="u-align--right"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import NetworkTable from "./NetworkTable";
+import { ExpandedState } from "./types";
 
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -52,7 +53,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -62,7 +69,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
@@ -83,7 +96,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("[data-test='speed'] Icon").prop("name")).toBe(
@@ -108,7 +127,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("[data-test='speed'] Icon").prop("name")).toBe(
@@ -131,7 +156,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='speed']").exists()).toBe(true);
@@ -156,7 +187,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='type']").exists()).toBe(true);
@@ -179,7 +216,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='type']").exists()).toBe(true);
@@ -206,7 +249,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     const links = wrapper.find("DoubleRow[data-test='fabric'] LegacyLink");
@@ -220,7 +269,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='dhcp']").exists()).toBe(false);
@@ -250,7 +305,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='dhcp']").prop("primary")).toBe(
@@ -281,7 +342,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("DoubleRow[data-test='dhcp'] Icon").exists()).toBe(
@@ -304,7 +371,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("Icon[name='success']").exists()).toBe(true);
@@ -336,7 +409,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("SubnetColumn DoubleRow").prop("primary")).toBe(
@@ -375,7 +454,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("SubnetColumn LegacyLink").at(0).text()).toBe(
@@ -420,7 +505,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     const alias = wrapper.findWhere(
@@ -439,7 +530,7 @@ describe("NetworkTable", () => {
         interfaces: [
           machineInterfaceFactory({
             discovered: null,
-            links: [networkLinkFactory(), networkLinkFactory()],
+            links: [networkLinkFactory(), networkLinkFactory({ id: 2 })],
             name: "alias",
             type: NetworkInterfaceTypes.ALIAS,
           }),
@@ -450,28 +541,16 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={{ content: ExpandedState.REMOVE, linkId: 2 }}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
-    let row = wrapper.findWhere(
-      (n) => n.name() === "TableRow" && n.key() === "alias:1"
-    );
-    // Open the action menu on the row:
-    row.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    row = wrapper.findWhere(
-      (n) => n.name() === "TableRow" && n.key() === "alias:1"
-    );
-    row
-      .findWhere(
-        (n) =>
-          n.type() === "button" &&
-          n.hasClass("p-contextual-menu__link") &&
-          n.text() === "Remove Alias..."
-      )
-      .simulate("click");
-    wrapper.update();
-    row = wrapper.findWhere(
+    const row = wrapper.findWhere(
       (n) => n.name() === "TableRow" && n.key() === "alias:1"
     );
     expect(row.prop("className").includes("is-active")).toBe(true);
@@ -482,6 +561,7 @@ describe("NetworkTable", () => {
       machineDetailsFactory({
         interfaces: [
           machineInterfaceFactory({
+            id: 2,
             discovered: null,
             links: [],
             name: "eth0",
@@ -494,28 +574,16 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={{ content: ExpandedState.REMOVE, nicId: 2 }}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
-    let row = wrapper.findWhere(
-      (n) => n.name() === "TableRow" && n.key() === "eth0"
-    );
-    // Open the action menu on the row:
-    row.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    row = wrapper.findWhere(
-      (n) => n.name() === "TableRow" && n.key() === "eth0"
-    );
-    row
-      .findWhere(
-        (n) =>
-          n.type() === "button" &&
-          n.hasClass("p-contextual-menu__link") &&
-          n.text() === "Remove Physical..."
-      )
-      .simulate("click");
-    wrapper.update();
-    row = wrapper.findWhere(
+    const row = wrapper.findWhere(
       (n) => n.name() === "TableRow" && n.key() === "eth0"
     );
     expect(row.prop("className").includes("is-active")).toBe(true);
@@ -536,7 +604,13 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable selected={[]} setSelected={jest.fn()} systemId="abc123" />
+        <NetworkTable
+          expanded={null}
+          setExpanded={jest.fn()}
+          selected={[]}
+          setSelected={jest.fn()}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("RowCheckbox").last().prop("disabled")).toBe(true);
@@ -570,6 +644,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -585,6 +661,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -599,6 +677,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -613,6 +693,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -629,6 +711,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -643,6 +727,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -657,6 +743,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -671,6 +759,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -685,6 +775,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -748,6 +840,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"
@@ -777,6 +871,8 @@ describe("NetworkTable", () => {
       const wrapper = mount(
         <Provider store={store}>
           <NetworkTable
+            expanded={null}
+            setExpanded={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
             systemId="abc123"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { Icon, MainTable, Spinner, Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
@@ -467,18 +467,21 @@ const rowSort = (
 };
 
 type Props = {
+  expanded: Expanded | null;
   selected: NetworkInterface["id"][];
+  setExpanded: SetExpanded;
   setSelected: (selected: NetworkInterface["id"][]) => void;
   systemId: Machine["system_id"];
 };
 
 const NetworkTable = ({
+  expanded,
   selected,
+  setExpanded,
   setSelected,
   systemId,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const [expanded, setExpanded] = useState<Expanded | null>(null);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
@@ -1,6 +1,7 @@
 import type { NetworkInterface, NetworkLink } from "app/store/machine/types";
 
 export enum ExpandedState {
+  ADD_PHYSICAL = "addPhysical",
   DISCONNECTED_WARNING = "disconnectedWarning",
   EDIT = "edit",
   MARK_CONNECTED = "markConnected",


### PR DESCRIPTION
## Done

- Add a form to create physical interfaces to the networking tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Find a machine with editable network.
- Click "Add interface" above the table.
- Fill out the details and submit. The interface should be created.

## Fixes

Fixes: #2151.