### PR TITLE
feat(ui): add analytics to commissioning and testing tabs

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -392,6 +392,9 @@ exports[`stricter compilation`] = {
       [59, 30, 9, "Property \'system_id\' does not exist on type \'BaseMachine | MachineDetails | undefined\'.", "3292323602"],
       [68, 4, 16, "Type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to type \'Machine[]\'.\\n  Type \'BaseMachine | MachineDetails | undefined\' is not assignable to type \'Machine\'.\\n    Type \'undefined\' is not assignable to type \'Machine\'.", "2366246550"]
     ],
+    "src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioningTable/MachineCommissioningTable.test.tsx:2399127268": [
+      [42, 33, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    ],
     "src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx:4216798906": [
       [211, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [212, 6, 29, "Argument of type \'{ architecture: string; description: string; minHweKernel: string; pool: string; tags: string[]; zone: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'architecture\' does not exist in type \'FormEvent<{}>\'.", "3197827678"]
@@ -530,8 +533,11 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetailsLogs.tsx:2335753194": [
       [23, 18, 14, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'ScriptResultData\'.\\n  No index signature with a parameter of type \'string\' was found on type \'ScriptResultData\'.", "887297148"]
     ],
-    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:3341504211": [
-      [161, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx:2352214550": [
+      [44, 33, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx:3614398676": [
+      [177, 65, 1, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "177614"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:1782614757": [
       [106, 10, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'SelectedAction | null\' is not assignable to type \'MachineAction\'.\\n      Type \'null\' is not assignable to type \'MachineAction\'.", "167402512"],

--- a/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioningTable/MachineCommissioningTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioningTable/MachineCommissioningTable.tsx
@@ -8,7 +8,8 @@ import { getTestResultsIcon } from "../../utils";
 
 import TableMenu from "app/base/components/TableMenu";
 import { scriptStatus } from "app/base/enum";
-import { useTrackById } from "app/base/hooks";
+import type { SendAnalytics } from "app/base/hooks";
+import { useSendAnalytics, useTrackById } from "app/base/hooks";
 import type { TSFixMe } from "app/base/types";
 import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultSelectors from "app/store/scriptresult/selectors";
@@ -63,6 +64,7 @@ const renderExpandedContent = (
 const renderActions = (
   result: ScriptResult,
   toggleHistory: (id: ScriptResult["id"]) => void,
+  sendAnalytics: SendAnalytics,
   hasHistory: boolean,
   hasVisibleHistory: boolean
 ) => {
@@ -75,7 +77,14 @@ const renderActions = (
     if (!hasVisibleHistory) {
       links.push({
         children: "View previous tests",
-        onClick: () => toggleHistory(result.id),
+        onClick: () => {
+          toggleHistory(result.id);
+          sendAnalytics(
+            "Machine commissioning",
+            "View commissioning script history",
+            "View previous tests"
+          );
+        },
         "data-test": "action-menu-show-previous",
       });
     } else {
@@ -99,7 +108,7 @@ const renderActions = (
 
 const MachineCommissioningTable = ({ scriptResults }: Props): JSX.Element => {
   const dispatch = useDispatch();
-
+  const sendAnalytics = useSendAnalytics();
   const history = useSelector(scriptResultSelectors.history);
 
   const {
@@ -170,6 +179,7 @@ const MachineCommissioningTable = ({ scriptResults }: Props): JSX.Element => {
           content: renderActions(
             result,
             toggleHistory,
+            sendAnalytics,
             hasHistory,
             hasVisibleHistory
           ),


### PR DESCRIPTION
## Done

- Added analytics for:
  - Viewing previous tests
  - View metrics
  - Suppressing script results
  - Unsuppressing script results

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2194
