### PR TITLE
feat(ui): display interface table on edit form

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.test.tsx
@@ -1,0 +1,64 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import EditInterface from "./EditInterface";
+
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("EditInterface", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+  });
+
+  it("displays a spinner when data is loading", () => {
+    state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <EditInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a form when loaded", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <EditInterface systemId="abc123" close={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormCard").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
@@ -1,0 +1,43 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import InterfaceFormTable from "../InterfaceFormTable";
+
+import FormCard from "app/base/components/FormCard";
+import machineSelectors from "app/store/machine/selectors";
+import type {
+  MachineDetails,
+  NetworkInterface,
+  NetworkLink,
+} from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  close: () => void;
+  linkId?: NetworkLink["id"] | null;
+  nicId?: NetworkInterface["id"] | null;
+  systemId: MachineDetails["system_id"];
+};
+
+const EditInterface = ({
+  close,
+  linkId,
+  nicId,
+  systemId,
+}: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+
+  if (!machine || !("interfaces" in machine)) {
+    return <Spinner text="Loading..." />;
+  }
+  return (
+    <FormCard sidebar={false} stacked title="Edit physical">
+      <InterfaceFormTable linkId={linkId} nicId={nicId} systemId={systemId} />
+      <button onClick={close}>Close</button>
+    </FormCard>
+  );
+};
+
+export default EditInterface;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditInterface";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
@@ -1,0 +1,59 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import NetworkTable from "./InterfaceFormTable";
+
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NetworkTable", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+        loaded: true,
+        statuses: {
+          abc123: machineStatusFactory(),
+        },
+      }),
+    });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a table when loaded", () => {
+    const nic = machineInterfaceFactory();
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTable nicId={nic.id} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("MainTable").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
@@ -2,7 +2,7 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import NetworkTable from "./InterfaceFormTable";
+import InterfaceFormTable from "./InterfaceFormTable";
 
 import type { RootState } from "app/store/root/types";
 import {
@@ -15,7 +15,7 @@ import {
 
 const mockStore = configureStore();
 
-describe("NetworkTable", () => {
+describe("InterfaceFormTable", () => {
   let state: RootState;
   beforeEach(() => {
     state = rootStateFactory({
@@ -34,7 +34,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable systemId="abc123" />
+        <InterfaceFormTable systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -51,7 +51,7 @@ describe("NetworkTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <NetworkTable nicId={nic.id} systemId="abc123" />
+        <InterfaceFormTable nicId={nic.id} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
@@ -38,6 +38,7 @@ const generateRow = (machine: Machine, nic: NetworkInterface): NetworkRow => {
       },
       {
         content: <PXEColumn nic={nic} systemId={machine.system_id} />,
+        className: "u-align--center",
       },
       {
         content: <SpeedColumn nic={nic} systemId={machine.system_id} />,
@@ -68,7 +69,11 @@ type Props = {
   systemId: Machine["system_id"];
 };
 
-const NetworkTable = ({ linkId, nicId, systemId }: Props): JSX.Element => {
+const InterfaceFormTable = ({
+  linkId,
+  nicId,
+  systemId,
+}: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
@@ -155,4 +160,4 @@ const NetworkTable = ({ linkId, nicId, systemId }: Props): JSX.Element => {
   );
 };
 
-export default NetworkTable;
+export default InterfaceFormTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
@@ -1,0 +1,158 @@
+import type { ReactNode } from "react";
+
+import { MainTable, Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import DHCPColumn from "../NetworkTable/DHCPColumn";
+import FabricColumn from "../NetworkTable/FabricColumn";
+import IPColumn from "../NetworkTable/IPColumn";
+import NameColumn from "../NetworkTable/NameColumn";
+import PXEColumn from "../NetworkTable/PXEColumn";
+import SpeedColumn from "../NetworkTable/SpeedColumn";
+import SubnetColumn from "../NetworkTable/SubnetColumn";
+import TypeColumn from "../NetworkTable/TypeColumn";
+
+import TableHeader from "app/base/components/TableHeader";
+import machineSelectors from "app/store/machine/selectors";
+import type {
+  NetworkInterface,
+  NetworkLink,
+  Machine,
+} from "app/store/machine/types";
+import { getInterfaceName } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+
+// TODO: This should eventually extend the react-components table row type
+// when it has been migrated to TypeScript.
+type NetworkRow = {
+  columns: { className?: string; content: ReactNode }[];
+  key: NetworkInterface["name"];
+};
+
+const generateRow = (machine: Machine, nic: NetworkInterface): NetworkRow => {
+  const name = getInterfaceName(machine, nic);
+  return {
+    columns: [
+      {
+        content: <NameColumn nic={nic} systemId={machine.system_id} />,
+      },
+      {
+        content: <PXEColumn nic={nic} systemId={machine.system_id} />,
+      },
+      {
+        content: <SpeedColumn nic={nic} systemId={machine.system_id} />,
+      },
+      {
+        content: <TypeColumn nic={nic} systemId={machine.system_id} />,
+      },
+      {
+        content: <FabricColumn nic={nic} systemId={machine.system_id} />,
+      },
+      {
+        content: <SubnetColumn nic={nic} systemId={machine.system_id} />,
+      },
+      {
+        content: <IPColumn nic={nic} systemId={machine.system_id} />,
+      },
+      {
+        content: <DHCPColumn nic={nic} systemId={machine.system_id} />,
+      },
+    ],
+    key: name,
+  };
+};
+
+type Props = {
+  linkId?: NetworkLink["id"] | null;
+  nicId?: NetworkInterface["id"] | null;
+  systemId: Machine["system_id"];
+};
+
+const NetworkTable = ({ linkId, nicId, systemId }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const nic = useSelector((state: RootState) =>
+    machineSelectors.getInterfaceById(state, systemId, nicId, linkId)
+  );
+
+  if (!machine || !("interfaces" in machine) || !nic) {
+    return <Spinner />;
+  }
+
+  const row = generateRow(machine, nic);
+  return (
+    <MainTable
+      headers={[
+        {
+          content: (
+            <>
+              <TableHeader>Name</TableHeader>
+              <TableHeader>MAC</TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <>
+              <TableHeader className="u-align--center">PXE</TableHeader>
+            </>
+          ),
+        },
+        {
+          content: (
+            <TableHeader className="p-double-row__header-spacer">
+              Link/interface speed
+            </TableHeader>
+          ),
+        },
+        {
+          content: (
+            <div>
+              <TableHeader className="p-double-row__header-spacer">
+                Type
+              </TableHeader>
+              <TableHeader className="p-double-row__header-spacer">
+                NUMA node
+              </TableHeader>
+            </div>
+          ),
+        },
+        {
+          content: (
+            <div>
+              <TableHeader>Fabric</TableHeader>
+              <TableHeader>VLAN</TableHeader>
+            </div>
+          ),
+        },
+        {
+          content: (
+            <div>
+              <TableHeader>Subnet</TableHeader>
+              <TableHeader>Name</TableHeader>
+            </div>
+          ),
+        },
+        {
+          content: (
+            <div>
+              <TableHeader>IP Address</TableHeader>
+              <TableHeader>Status</TableHeader>
+            </div>
+          ),
+        },
+        {
+          content: (
+            <TableHeader className="p-double-row__header-spacer">
+              DHCP
+            </TableHeader>
+          ),
+        },
+      ]}
+      rows={[row]}
+    />
+  );
+};
+
+export default NetworkTable;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InterfaceFormTable";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -7,8 +7,10 @@ import configureStore from "redux-mock-store";
 
 import MachineNetwork from "./MachineNetwork";
 
+import { NetworkInterfaceTypes } from "app/store/machine/types";
 import {
   machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
   machineStatuses as machineStatusesFactory,
@@ -64,5 +66,57 @@ describe("MachineNetwork", () => {
     );
     wrapper.find("Button[children='Add interface']").simulate("click");
     expect(wrapper.find("AddInterface").exists()).toBe(true);
+  });
+
+  it("can display the edit interface form", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            interfaces: [
+              machineInterfaceFactory({
+                type: NetworkInterfaceTypes.PHYSICAL,
+              }),
+            ],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            { pathname: "/machine/abc123/network", key: "testKey" },
+          ]}
+        >
+          <Route
+            exact
+            path="/machine/:id/network"
+            component={() => <MachineNetwork setSelectedAction={jest.fn()} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open an interface row menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.update();
+    wrapper
+      .findWhere(
+        (n) =>
+          n.type() === "button" &&
+          n.hasClass("p-contextual-menu__link") &&
+          n.text() === "Edit Physical"
+      )
+      .simulate("click");
+    wrapper.update();
+    expect(wrapper.find("EditInterface").exists()).toBe(true);
+    expect(wrapper.find("NetworkActions").exists()).toBe(false);
+    expect(wrapper.find("AddInterface").exists()).toBe(false);
+    expect(wrapper.find("DHCPTable").exists()).toBe(false);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -8,6 +8,7 @@ import type { SetSelectedAction } from "../types";
 
 import AddInterface from "./AddInterface";
 import DHCPTable from "./DHCPTable";
+import EditInterface from "./EditInterface";
 import NetworkActions from "./NetworkActions";
 import NetworkTable from "./NetworkTable";
 import type { Expanded } from "./NetworkTable/types";
@@ -38,7 +39,14 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
     return <Spinner text="Loading..." />;
   }
 
-  return (
+  return interfaceExpanded?.content === ExpandedState.EDIT ? (
+    <EditInterface
+      close={() => setInterfaceExpanded(null)}
+      linkId={interfaceExpanded?.linkId}
+      nicId={interfaceExpanded?.nicId}
+      systemId={id}
+    />
+  ) : (
     <>
       <NetworkActions
         expanded={interfaceExpanded}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NameColumn/NameColumn.tsx
@@ -16,18 +16,20 @@ import {
 import type { RootState } from "app/store/root/types";
 
 type Props = {
-  handleRowCheckbox: (
+  checkboxSpace?: boolean;
+  handleRowCheckbox?: (
     item: NetworkInterface["id"],
     rows: NetworkInterface["id"][]
-  ) => void;
+  ) => void | null;
   link?: NetworkLink | null;
   nic?: NetworkInterface | null;
-  selected: NetworkInterface["id"][];
-  showCheckbox: boolean;
+  selected?: NetworkInterface["id"][] | null;
+  showCheckbox?: boolean;
   systemId: Machine["system_id"];
 };
 
 const NameColumn = ({
+  checkboxSpace,
   handleRowCheckbox,
   link,
   nic,
@@ -53,7 +55,7 @@ const NameColumn = ({
   return (
     <DoubleRow
       primary={
-        showCheckbox ? (
+        showCheckbox && handleRowCheckbox && selected ? (
           <RowCheckbox
             disabled={isAllNetworkingDisabled}
             handleRowCheckbox={handleRowCheckbox}
@@ -66,8 +68,8 @@ const NameColumn = ({
         )
       }
       secondary={nic.mac_address}
-      primaryClassName={showCheckbox ? null : "u-nudge--primary-row"}
-      secondaryClassName="u-nudge--secondary-row"
+      primaryClassName={checkboxSpace ? "u-nudge--primary-row" : null}
+      secondaryClassName={checkboxSpace ? "u-nudge--secondary-row" : null}
     />
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -64,7 +64,7 @@ describe("NetworkTable", () => {
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
-  it("displays a table when loading", () => {
+  it("displays a table when loaded", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -78,33 +78,6 @@ describe("NetworkTable", () => {
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
-  });
-
-  it("can display a boot icon", () => {
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [
-          machineInterfaceFactory({
-            is_boot: true,
-            type: NetworkInterfaceTypes.PHYSICAL,
-          }),
-        ],
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTable
-          expanded={null}
-          setExpanded={jest.fn()}
-          selected={[]}
-          setSelected={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
-    );
-    expect(wrapper.find("Icon[name='success']").exists()).toBe(true);
   });
 
   it("can display an interface that has no links", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -355,7 +355,7 @@ describe("NetworkTable", () => {
           />
         </Provider>
       );
-      expect(wrapper.find("Icon[name='success']").length).toBe(1);
+      expect(wrapper.find("Icon[name='tick']").length).toBe(1);
     });
 
     it("does not display a fabric column for parent interfaces", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-import { Icon, MainTable, Spinner } from "@canonical/react-components";
+import { MainTable, Spinner } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -11,6 +11,7 @@ import IPColumn from "./IPColumn";
 import NameColumn from "./NameColumn";
 import NetworkTableActions from "./NetworkTableActions";
 import NetworkTableConfirmation from "./NetworkTableConfirmation";
+import PXEColumn from "./PXEColumn";
 import SpeedColumn from "./SpeedColumn";
 import SubnetColumn from "./SubnetColumn";
 import TypeColumn from "./TypeColumn";
@@ -140,6 +141,7 @@ const generateRow = (
       {
         content: (
           <NameColumn
+            checkboxSpace={!showCheckbox}
             handleRowCheckbox={handleRowCheckbox}
             link={link}
             nic={nic}
@@ -150,12 +152,10 @@ const generateRow = (
         ),
       },
       {
-        content:
-          !isABondOrBridgeParent && isBoot ? (
-            <span className="u-align--center">
-              <Icon name="success" />
-            </span>
-          ) : null,
+        content: !isABondOrBridgeParent && (
+          <PXEColumn link={link} nic={nic} systemId={machine.system_id} />
+        ),
+        className: "u-align--center",
       },
       {
         content: (

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/PXEColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/PXEColumn.test.tsx
@@ -1,0 +1,72 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import PXEColumn from "./PXEColumn";
+
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("PXEColumn", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        loaded: true,
+        statuses: {
+          abc123: machineStatusFactory(),
+        },
+      }),
+    });
+  });
+
+  it("can display a boot icon", () => {
+    const nic = machineInterfaceFactory({
+      is_boot: true,
+      type: NetworkInterfaceTypes.PHYSICAL,
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <PXEColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("Icon").exists()).toBe(true);
+  });
+
+  it("does not display an icon if it is not a boot interface", () => {
+    const nic = machineInterfaceFactory({
+      is_boot: false,
+      type: NetworkInterfaceTypes.PHYSICAL,
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <PXEColumn nic={nic} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("Icon").exists()).toBe(false);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/PXEColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/PXEColumn.tsx
@@ -1,0 +1,35 @@
+import { Icon } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import machineSelectors from "app/store/machine/selectors";
+import type {
+  Machine,
+  NetworkInterface,
+  NetworkLink,
+} from "app/store/machine/types";
+import { isBootInterface } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  link?: NetworkLink | null;
+  nic?: NetworkInterface | null;
+  systemId: Machine["system_id"];
+};
+
+const PXEColumn = ({ link, nic, systemId }: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  if (!machine) {
+    return null;
+  }
+  const isBoot = isBootInterface(machine, nic, link);
+
+  return isBoot ? (
+    <span className="u-align--center">
+      <Icon name="success" />
+    </span>
+  ) : null;
+};
+
+export default PXEColumn;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/PXEColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/PXEColumn.tsx
@@ -27,7 +27,7 @@ const PXEColumn = ({ link, nic, systemId }: Props): JSX.Element | null => {
 
   return isBoot ? (
     <span className="u-align--center">
-      <Icon name="success" />
+      <Icon name="tick" />
     </span>
   ) : null;
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/PXEColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PXEColumn";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SpeedColumn/SpeedColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/SpeedColumn/SpeedColumn.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { Icon, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
@@ -36,6 +38,23 @@ const SpeedColumn = ({ link, nic, systemId }: Props): JSX.Element | null => {
   if (!nic) {
     return null;
   }
+  const isConnected = isInterfaceConnected(machine, nic, link);
+  let icon: ReactNode = null;
+
+  if (!isConnected) {
+    icon = (
+      <Tooltip position="top-left" message="This interface is disconnected.">
+        <Icon name="disconnected" />
+      </Tooltip>
+    );
+  }
+  if (isConnected && nic.link_speed < nic.interface_speed) {
+    icon = (
+      <Tooltip position="top-left" message="Link connected to slow interface.">
+        <Icon name="warning" />
+      </Tooltip>
+    );
+  }
 
   return hasInterfaceType(
     [
@@ -49,27 +68,7 @@ const SpeedColumn = ({ link, nic, systemId }: Props): JSX.Element | null => {
   ) ? null : (
     <DoubleRow
       data-test="speed"
-      icon={
-        <>
-          {isInterfaceConnected(machine, nic, link) ? null : (
-            <Tooltip
-              position="top-left"
-              message="This interface is disconnected."
-            >
-              <Icon name="disconnected" />
-            </Tooltip>
-          )}
-          {isInterfaceConnected(machine, nic, link) &&
-          nic.link_speed < nic.interface_speed ? (
-            <Tooltip
-              position="top-left"
-              message="Link connected to slow interface."
-            >
-              <Icon name="warning" />
-            </Tooltip>
-          ) : null}
-        </>
-      }
+      icon={icon}
       iconSpace={true}
       primary={
         <>

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -1,8 +1,12 @@
 import machine from "./selectors";
 
+import { NetworkInterfaceTypes } from "app/store/machine/types";
 import { NodeActions } from "app/store/types/node";
 import {
   machine as machineFactory,
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  networkLink as networkLinkFactory,
   machineEventError as machineEventErrorFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
@@ -445,5 +449,41 @@ describe("machine selectors", () => {
       }),
     });
     expect(machine.search(state, "1abc")).toStrictEqual([items[0]]);
+  });
+
+  it("can get an interface by id", () => {
+    const nic = machineInterfaceFactory({
+      type: NetworkInterfaceTypes.PHYSICAL,
+    });
+    const node = machineDetailsFactory({
+      interfaces: [nic],
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [node],
+      }),
+    });
+    expect(
+      machine.getInterfaceById(state, node.system_id, nic.id)
+    ).toStrictEqual(nic);
+  });
+
+  it("can get an interface by link id", () => {
+    const link = networkLinkFactory();
+    const nic = machineInterfaceFactory({
+      links: [link],
+      type: NetworkInterfaceTypes.PHYSICAL,
+    });
+    const node = machineDetailsFactory({
+      interfaces: [nic],
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [node],
+      }),
+    });
+    expect(
+      machine.getInterfaceById(state, node.system_id, null, link.id)
+    ).toStrictEqual(nic);
   });
 });

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -21,6 +21,7 @@ export {
   getInterfaceType,
   getInterfaceTypeText,
   getLinkInterface,
+  getLinkInterfaceById,
   getLinkModeDisplay,
   getNextNicName,
   getRemoveTypeText,

--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -11,6 +11,7 @@ import {
   getInterfaceType,
   getInterfaceTypeText,
   getLinkInterface,
+  getLinkInterfaceById,
   getLinkMode,
   getLinkModeDisplay,
   getNextNicName,
@@ -56,6 +57,26 @@ describe("machine networking utils", () => {
       });
       const machine = machineDetailsFactory({ interfaces: [nic] });
       expect(getLinkInterface(machine, null)).toStrictEqual([null, null]);
+    });
+  });
+
+  describe("getLinkInterfaceById", () => {
+    it("can get the interface a link belongs to", () => {
+      const link = networkLinkFactory();
+      const nic = machineInterfaceFactory({
+        links: [link, networkLinkFactory()],
+      });
+      const machine = machineDetailsFactory({ interfaces: [nic] });
+      expect(getLinkInterfaceById(machine, link.id)).toStrictEqual([nic, 0]);
+    });
+
+    it("does not get an interface if a link is not provided", () => {
+      const link = networkLinkFactory();
+      const nic = machineInterfaceFactory({
+        links: [link, networkLinkFactory()],
+      });
+      const machine = machineDetailsFactory({ interfaces: [nic] });
+      expect(getLinkInterfaceById(machine, null)).toStrictEqual([null, null]);
     });
   });
 

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -23,6 +23,30 @@ const INTERFACE_TYPE_DISPLAY = {
 };
 
 /**
+ * Get the link's interface and position by a link's ID.
+ * @param machine - The nic's machine.
+ * @param linkId - A link's ID.
+ * @return The link's interface and position.
+ */
+export const getLinkInterfaceById = (
+  machine: Machine,
+  linkId?: NetworkLink["id"] | null
+): [NetworkInterface | null, number | null] => {
+  if (!linkId || !("interfaces" in machine)) {
+    return [null, null];
+  }
+  for (let i = 0; i < machine.interfaces.length; i++) {
+    const links = machine.interfaces[i].links;
+    for (let j = 0; j < links.length; j++) {
+      if (links[j].id === linkId) {
+        return [machine.interfaces[i], j];
+      }
+    }
+  }
+  return [null, null];
+};
+
+/**
  * Get the link's interface and position.
  * @param machine - The nic's machine.
  * @param link - A link to an interface.
@@ -32,18 +56,7 @@ export const getLinkInterface = (
   machine: Machine,
   link?: NetworkLink | null
 ): [NetworkInterface | null, number | null] => {
-  if (!link || !("interfaces" in machine)) {
-    return [null, null];
-  }
-  for (let i = 0; i < machine.interfaces.length; i++) {
-    const links = machine.interfaces[i].links;
-    for (let j = 0; j < links.length; j++) {
-      if (links[j].id === link.id) {
-        return [machine.interfaces[i], j];
-      }
-    }
-  }
-  return [null, null];
+  return getLinkInterfaceById(machine, link?.id);
 };
 
 /**
@@ -367,7 +380,7 @@ export const getInterfaceTypeText = (
  */
 export const isBootInterface = (
   machine: Machine,
-  nic: NetworkInterface | null,
+  nic?: NetworkInterface | null,
   link?: NetworkLink | null
 ): boolean => {
   if (link && !nic) {


### PR DESCRIPTION
## Done

- Display a table of the interfaces being edited on the edit form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab for a machine.
- On a physical interface row open the action menu and click "Edit physical".
- you should see a form card and a table showing the interface.

## Fixes

Fixes: #2200.