### PR TITLE
fix(ui): only fetch scripts if they have not been fetched before

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -72,8 +72,9 @@ describe("CommissionForm", () => {
     });
   });
 
-  it("fetches the necessary data on load", () => {
+  it("fetches scripts if they haven't been loaded yet", () => {
     const state = { ...initialState };
+    state.scripts.loaded = false;
     const store = mockStore(state);
     mount(
       <Provider store={store}>
@@ -88,6 +89,25 @@ describe("CommissionForm", () => {
     expect(
       store.getActions().some((action) => action.type === "FETCH_SCRIPTS")
     ).toBe(true);
+  });
+
+  it("does not fetch scripts if they've already been loaded", () => {
+    const state = { ...initialState };
+    state.scripts.loaded = true;
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CommissionForm setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "FETCH_SCRIPTS")
+    ).toBe(false);
   });
 
   it("correctly dispatches actions to commission selected machines in machine list", () => {

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -97,8 +97,12 @@ export const CommissionForm = ({ setSelectedAction }: Props): JSX.Element => {
   );
 
   useEffect(() => {
-    dispatch(scriptActions.fetch());
-  }, [dispatch]);
+    if (!scriptsLoaded) {
+      // scripts are fetched via http, so we explicitly check if they're already
+      // loaded here.
+      dispatch(scriptActions.fetch());
+    }
+  }, [dispatch, scriptsLoaded]);
 
   return (
     <ActionForm

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -96,8 +96,12 @@ export const TestForm = ({
   }, {});
 
   useEffect(() => {
-    dispatch(scriptActions.fetch());
-  }, [dispatch]);
+    if (!scriptsLoaded) {
+      // scripts are fetched via http, so we explicitly check if they're already
+      // loaded here.
+      dispatch(scriptActions.fetch());
+    }
+  }, [dispatch, scriptsLoaded]);
 
   return (
     <ActionForm

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -20,10 +20,7 @@ import StatusColumn from "./StatusColumn";
 import StorageColumn from "./StorageColumn";
 import ZoneColumn from "./ZoneColumn";
 import { actions as machineActions } from "app/store/machine";
-import {
-  general as generalActions,
-  scripts as scriptActions,
-} from "app/base/actions";
+import { general as generalActions } from "app/base/actions";
 import TableHeader from "app/base/components/TableHeader";
 import { nodeStatus } from "app/base/enum";
 import { useTableSort } from "app/base/hooks";
@@ -485,7 +482,6 @@ export const MachineListTable = ({
     dispatch(generalActions.fetchPowerTypes());
     dispatch(generalActions.fetchVersion());
     dispatch(resourcePoolActions.fetch());
-    dispatch(scriptActions.fetch());
     dispatch(tagActions.fetch());
     dispatch(userActions.fetch());
     dispatch(zoneActions.fetch());

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -68,8 +68,9 @@ describe("ScriptsList", () => {
     });
   });
 
-  it("dispatches action to fetch scripts load", () => {
+  it("fetches scripts if they haven't been loaded yet", () => {
     const state = { ...initialState };
+    state.scripts.loaded = false;
     const store = mockStore(state);
 
     mount(
@@ -80,11 +81,27 @@ describe("ScriptsList", () => {
       </Provider>
     );
 
-    expect(store.getActions()).toEqual([
-      {
-        type: "FETCH_SCRIPTS",
-      },
-    ]);
+    expect(
+      store.getActions().some((action) => action.type === "FETCH_SCRIPTS")
+    ).toBe(true);
+  });
+
+  it("does not fetch scripts if they've already been loaded", () => {
+    const state = { ...initialState };
+    state.scripts.loaded = true;
+    const store = mockStore(state);
+
+    mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <ScriptsList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "FETCH_SCRIPTS")
+    ).toBe(false);
   });
 
   it("Displays commissioning scripts by default", () => {
@@ -194,7 +211,9 @@ describe("ScriptsList", () => {
     wrapper.find("TableRow").at(1).find("Button").at(1).simulate("click");
     // Click on the delete confirm button
     wrapper.find("TableRow").at(1).find("Button").at(3).simulate("click");
-    expect(store.getActions()[1]).toEqual({
+    expect(
+      store.getActions().find((action) => action.type === "DELETE_SCRIPT")
+    ).toEqual({
       type: "DELETE_SCRIPT",
       payload: {
         id: 1,

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -171,8 +171,12 @@ const ScriptsList = ({ type = "commissioning" }: Props): JSX.Element => {
   };
 
   useEffect(() => {
-    dispatch(scriptActions.fetch());
-  }, [dispatch, type]);
+    if (!scriptsLoaded) {
+      // scripts are fetched via http, so we explicitly check if they're already
+      // loaded here.
+      dispatch(scriptActions.fetch());
+    }
+  }, [dispatch, scriptsLoaded, type]);
 
   return (
     <SettingsTable


### PR DESCRIPTION
## Done

- Remove script fetch from machine list table because it already gets fetched from the components that need them 
- Only fetch scripts if they have not been fetched before

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open your browser's network tab
- Select some machines and open the test or commissioning action form
- Check that an http request is made to /MAAS/api/2.0/scripts/?include_script=true
- Close the form and reopen it
- Go to Settings > Commissioning scripts
- Go to Settings > Testing scripts
- Check that the http request is not made again

## Fixes

Fixes #2209 

## Launchpad issue

[lp#1916317](https://bugs.launchpad.net/bugs/1916317)
