### PR TITLE
Backport changes to allow admins to update users' passwords.

### DIFF
--- a/ui/src/app/base/actions/auth/auth.js
+++ b/ui/src/app/base/actions/auth/auth.js
@@ -21,6 +21,18 @@ auth.changePassword = (params) => ({
   },
 });
 
+// Change a user's password as an admin
+auth.adminChangePassword = (params) => ({
+  type: "ADMIN_CHANGE_USER_PASSWORD",
+  meta: {
+    model: "user",
+    method: "admin_change_password",
+  },
+  payload: {
+    params,
+  },
+});
+
 auth.cleanup = () => ({
   type: "CLEANUP_AUTH_USER",
 });

--- a/ui/src/app/base/actions/auth/auth.test.js
+++ b/ui/src/app/base/actions/auth/auth.test.js
@@ -24,6 +24,19 @@ describe("base actions", () => {
     });
   });
 
+  it("creates an action for an admin changing a user's password", () => {
+    expect(auth.adminChangePassword({ password: "pass1" })).toEqual({
+      type: "ADMIN_CHANGE_USER_PASSWORD",
+      meta: {
+        model: "user",
+        method: "admin_change_password",
+      },
+      payload: {
+        params: { password: "pass1" },
+      },
+    });
+  });
+
   it("should handle cleaning up", () => {
     expect(auth.cleanup()).toEqual({
       type: "CLEANUP_AUTH_USER",

--- a/ui/src/app/base/components/UserForm/UserForm.js
+++ b/ui/src/app/base/components/UserForm/UserForm.js
@@ -129,6 +129,7 @@ export const UserForm = ({
       }
     >
       <FormikField
+        autoComplete="username"
         disabled={formDisabled}
         name="username"
         help="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."
@@ -171,6 +172,7 @@ export const UserForm = ({
         <>
           {includeCurrentPassword && (
             <FormikField
+              autoComplete="current-password"
               disabled={formDisabled}
               name="old_password"
               label="Current password"
@@ -179,6 +181,7 @@ export const UserForm = ({
             />
           )}
           <FormikField
+            autoComplete="new-password"
             disabled={formDisabled}
             name="password"
             label={includeCurrentPassword ? "New password" : "Password"}
@@ -186,6 +189,7 @@ export const UserForm = ({
             type="password"
           />
           <FormikField
+            autoComplete="new-password"
             disabled={formDisabled}
             name="passwordConfirm"
             help="Enter the same password as before, for verification"

--- a/ui/src/app/base/reducers/auth/auth.js
+++ b/ui/src/app/base/reducers/auth/auth.js
@@ -11,15 +11,18 @@ const auth = createNextState(
         draft.auth.loaded = true;
         draft.auth.user = action.payload;
         break;
+      case "ADMIN_CHANGE_USER_PASSWORD_START":
       case "CHANGE_AUTH_USER_PASSWORD_START":
         draft.auth.saved = false;
         draft.auth.saving = true;
         break;
+      case "ADMIN_CHANGE_USER_PASSWORD_ERROR":
       case "CHANGE_AUTH_USER_PASSWORD_ERROR":
         draft.auth.errors = action.error;
         draft.auth.saved = false;
         draft.auth.saving = false;
         break;
+      case "ADMIN_CHANGE_USER_PASSWORD_SUCCESS":
       case "CHANGE_AUTH_USER_PASSWORD_SUCCESS":
         draft.auth.errors = {};
         draft.auth.saved = true;

--- a/ui/src/app/base/reducers/auth/auth.test.js
+++ b/ui/src/app/base/reducers/auth/auth.test.js
@@ -125,6 +125,74 @@ describe("auth", () => {
     });
   });
 
+  it("should correctly reduce ADMIN_CHANGE_USER_PASSWORD_START", () => {
+    expect(
+      auth(
+        {
+          auth: {
+            saved: true,
+            saving: false,
+          },
+        },
+        {
+          payload: { password: "pass1" },
+          type: "ADMIN_CHANGE_USER_PASSWORD_START",
+        }
+      )
+    ).toStrictEqual({
+      auth: {
+        saved: false,
+        saving: true,
+      },
+    });
+  });
+
+  it("should correctly reduce ADMIN_CHANGE_USER_PASSWORD_ERROR", () => {
+    expect(
+      auth(
+        {
+          auth: {
+            saved: true,
+            saving: true,
+          },
+        },
+        {
+          error: { password: "Passwords don't match" },
+          type: "ADMIN_CHANGE_USER_PASSWORD_ERROR",
+        }
+      )
+    ).toStrictEqual({
+      auth: {
+        errors: { password: "Passwords don't match" },
+        saved: false,
+        saving: false,
+      },
+    });
+  });
+
+  it("should correctly reduce ADMIN_CHANGE_USER_PASSWORD_SUCCESS", () => {
+    expect(
+      auth(
+        {
+          auth: {
+            errors: { password: "Passwords don't match" },
+            saved: false,
+            saving: true,
+          },
+        },
+        {
+          type: "ADMIN_CHANGE_USER_PASSWORD_SUCCESS",
+        }
+      )
+    ).toStrictEqual({
+      auth: {
+        errors: {},
+        saved: true,
+        saving: false,
+      },
+    });
+  });
+
   it("should correctly reduce CREATE_USER_NOTIFY", () => {
     expect(
       auth(

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.js
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.js
@@ -69,6 +69,7 @@ describe("ScriptsList", () => {
 
   it("dispatches action to fetch scripts load", () => {
     const state = { ...initialState };
+    state.scripts.loaded = false;
     const store = mockStore(state);
 
     mount(
@@ -220,7 +221,7 @@ describe("ScriptsList", () => {
     wrapper.find("TableRow").at(1).find("Button").at(1).simulate("click");
     // Click on the delete confirm button
     wrapper.find("TableRow").at(1).find("Button").at(3).simulate("click");
-    expect(store.getActions()[1]).toEqual({
+    expect(store.getActions()[0]).toEqual({
       type: "DELETE_SCRIPT",
       payload: {
         id: 1,

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.js
@@ -1,6 +1,7 @@
 import { useDispatch, useSelector } from "react-redux";
 import React, { useState } from "react";
 
+import { auth as authActions } from "app/base/actions";
 import { user as userActions } from "app/base/actions";
 import { user as userSelectors } from "app/base/selectors";
 import { useAddMessage } from "app/base/hooks";
@@ -42,6 +43,9 @@ export const UserForm = ({ user }) => {
         onSave={(params, values, editing) => {
           if (editing) {
             dispatch(userActions.update(params));
+            if (values.password && values.passwordConfirm) {
+              dispatch(authActions.adminChangePassword(params));
+            }
           } else {
             dispatch(userActions.create(params));
           }

--- a/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
+++ b/ui/src/app/settings/views/Users/UserForm/UserForm.test.js
@@ -126,6 +126,77 @@ describe("UserForm", () => {
     ]);
   });
 
+  it("can change a user's password", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={["/"]}>
+          <UserForm
+            user={{
+              email: "old@example.com",
+              id: 808,
+              is_superuser: true,
+              last_name: "Miss Wallaby",
+              password1: "test1234",
+              password2: "test1234",
+              username: "admin",
+            }}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() =>
+      wrapper.find("UserForm").at(1).props().onSave(
+        {
+          isSuperuser: true,
+          email: "test@example.com",
+          fullName: "Miss Wallaby",
+          password: "test1234",
+          passwordConfirm: "test1234",
+          username: "admin",
+        },
+        { password: "test1234", passwordConfirm: "test1234" },
+        true
+      )
+    );
+    expect(store.getActions()).toEqual([
+      {
+        type: "UPDATE_USER",
+        payload: {
+          params: {
+            isSuperuser: true,
+            email: "test@example.com",
+            fullName: "Miss Wallaby",
+            password: "test1234",
+            passwordConfirm: "test1234",
+            username: "admin",
+          },
+        },
+        meta: {
+          model: "user",
+          method: "update",
+        },
+      },
+      {
+        type: "ADMIN_CHANGE_USER_PASSWORD",
+        payload: {
+          params: {
+            email: "test@example.com",
+            fullName: "Miss Wallaby",
+            isSuperuser: true,
+            password: "test1234",
+            passwordConfirm: "test1234",
+            username: "admin",
+          },
+        },
+        meta: {
+          method: "admin_change_password",
+          model: "user",
+        },
+      },
+    ]);
+  });
+
   it("can create a user", () => {
     const store = mockStore(state);
     const wrapper = mount(


### PR DESCRIPTION
## Done

- Backport changes to allow admins to update users' passwords (see: https://github.com/canonical-web-and-design/maas-ui/pull/1806).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- As an admin change a user's password from /settings/user.
- Confirm that the password has changed correctly by logging in as that user with the new password.

## Fixes

https://github.com/canonical-web-and-design/maas-ui/issues/1615.