### PR TITLE
feat(ui): add menu item for adding an alias or VLAN

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -436,8 +436,8 @@ exports[`stricter compilation`] = {
       [357, 35, 9, "Object is possibly \'null\'.", "1794230341"],
       [357, 47, 9, "Object is possibly \'null\'.", "1612642726"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx:136171821": [
-      [79, 8, 5, "Object is possibly \'null\'.", "179721187"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx:2132094581": [
+      [82, 8, 5, "Object is possibly \'null\'.", "179721187"]
     ],
     "src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx:1067981421": [
       [102, 6, 78, "Cannot invoke an object which is possibly \'undefined\'.", "1912336017"],

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -238,7 +238,7 @@ describe("NetworkTableActions", () => {
           (n) =>
             n.type() === "button" &&
             n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Add alias or VLAN"
+            n.text() === "Add alias"
         )
         .exists()
     ).toBe(true);
@@ -270,7 +270,7 @@ describe("NetworkTableActions", () => {
           (n) =>
             n.type() === "button" &&
             n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Add alias or VLAN"
+            n.text() === "Add VLAN"
         )
         .exists()
     ).toBe(true);
@@ -298,7 +298,17 @@ describe("NetworkTableActions", () => {
           (n) =>
             n.type() === "button" &&
             n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Add alias or VLAN"
+            n.text() === "Add alias"
+        )
+        .exists()
+    ).toBe(false);
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.type() === "button" &&
+            n.hasClass("p-contextual-menu__link") &&
+            n.text() === "Add VLAN"
         )
         .exists()
     ).toBe(false);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -43,9 +43,9 @@ const NetworkTableActions = ({
   }
   const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
   const isLimitedEditingAllowed = useIsLimitedEditingAllowed(nic, machine);
-  const canAddVLAN = useCanAddVLAN(machine, nic);
+  const canAddVLAN = useCanAddVLAN(machine, nic, link);
   const canAddAliasOrVLAN =
-    !isAllNetworkingDisabled && (canAddAlias(nic) || canAddVLAN);
+    !isAllNetworkingDisabled && (canAddAlias(machine, nic, link) || canAddVLAN);
   const isPhysical = nic?.type === NetworkInterfaceTypes.PHYSICAL;
   let actions: TableMenuProps["links"] = [];
   if (machine && nic) {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -44,8 +44,6 @@ const NetworkTableActions = ({
   const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
   const isLimitedEditingAllowed = useIsLimitedEditingAllowed(nic, machine);
   const canAddVLAN = useCanAddVLAN(machine, nic, link);
-  const canAddAliasOrVLAN =
-    !isAllNetworkingDisabled && (canAddAlias(machine, nic, link) || canAddVLAN);
   const isPhysical = nic?.type === NetworkInterfaceTypes.PHYSICAL;
   let actions: TableMenuProps["links"] = [];
   if (machine && nic) {
@@ -61,9 +59,14 @@ const NetworkTableActions = ({
         label: "Mark as disconnected",
       },
       {
-        inMenu: canAddAliasOrVLAN,
-        state: ExpandedState.ADD_ALIAS_OR_VLAN,
-        label: "Add alias or VLAN",
+        inMenu: !isAllNetworkingDisabled && canAddAlias(machine, nic, link),
+        state: ExpandedState.ADD_ALIAS,
+        label: "Add alias",
+      },
+      {
+        inMenu: !isAllNetworkingDisabled && canAddVLAN,
+        state: ExpandedState.ADD_VLAN,
+        label: "Add VLAN",
       },
       {
         inMenu: true,

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -13,8 +13,10 @@ import type {
 } from "app/store/machine/types";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import {
+  canAddAlias,
   getInterfaceTypeText,
   getLinkInterface,
+  useCanAddVLAN,
   useIsAllNetworkingDisabled,
   useIsLimitedEditingAllowed,
 } from "app/store/machine/utils";
@@ -41,8 +43,9 @@ const NetworkTableActions = ({
   }
   const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
   const isLimitedEditingAllowed = useIsLimitedEditingAllowed(nic, machine);
-  // Placeholders for hook results that are not yet implemented.
-  const canAddAliasOrVLAN = true;
+  const canAddVLAN = useCanAddVLAN(machine, nic);
+  const canAddAliasOrVLAN =
+    !isAllNetworkingDisabled && (canAddAlias(nic) || canAddVLAN);
   const isPhysical = nic?.type === NetworkInterfaceTypes.PHYSICAL;
   let actions: TableMenuProps["links"] = [];
   if (machine && nic) {
@@ -59,7 +62,7 @@ const NetworkTableActions = ({
       },
       {
         inMenu: canAddAliasOrVLAN,
-        state: ExpandedState.MARK_DISCONNECTED,
+        state: ExpandedState.ADD_ALIAS_OR_VLAN,
         label: "Add alias or VLAN",
       },
       {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
@@ -147,6 +147,8 @@ const NetworkTableConfirmation = ({
         systemId={machine.system_id}
       />
     );
+  } else if (expanded?.content === ExpandedState.ADD_ALIAS_OR_VLAN) {
+    content = "Add alias or VLAN.";
   }
   return <div className="u-flex--grow">{content}</div>;
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
@@ -147,8 +147,10 @@ const NetworkTableConfirmation = ({
         systemId={machine.system_id}
       />
     );
-  } else if (expanded?.content === ExpandedState.ADD_ALIAS_OR_VLAN) {
-    content = "Add alias or VLAN.";
+  } else if (expanded?.content === ExpandedState.ADD_ALIAS) {
+    content = "Add alias.";
+  } else if (expanded?.content === ExpandedState.ADD_VLAN) {
+    content = "Add VLAN.";
   }
   return <div className="u-flex--grow">{content}</div>;
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
@@ -1,6 +1,7 @@
 import type { NetworkInterface, NetworkLink } from "app/store/machine/types";
 
 export enum ExpandedState {
+  ADD_ALIAS_OR_VLAN = "addAliasOrVlan",
   ADD_PHYSICAL = "addPhysical",
   DISCONNECTED_WARNING = "disconnectedWarning",
   EDIT = "edit",

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
@@ -1,8 +1,9 @@
 import type { NetworkInterface, NetworkLink } from "app/store/machine/types";
 
 export enum ExpandedState {
-  ADD_ALIAS_OR_VLAN = "addAliasOrVlan",
+  ADD_ALIAS = "addAlias",
   ADD_PHYSICAL = "addPhysical",
+  ADD_VLAN = "addVlan",
   DISCONNECTED_WARNING = "disconnectedWarning",
   EDIT = "edit",
   MARK_CONNECTED = "markConnected",

--- a/ui/src/app/store/machine/utils/hooks.ts
+++ b/ui/src/app/store/machine/utils/hooks.ts
@@ -178,14 +178,21 @@ export const useIsLimitedEditingAllowed = (
  */
 export const useCanAddVLAN = (
   machine?: Machine | null,
-  nic?: NetworkInterface | null
+  nic?: NetworkInterface | null,
+  link?: NetworkLink | null
 ): boolean => {
   const unusedVLANs = useSelector((state: RootState) =>
     vlanSelectors.getUnusedForInterface(state, machine, nic)
   );
   if (
+    !machine ||
     !nic ||
-    [NetworkInterfaceTypes.ALIAS, NetworkInterfaceTypes.VLAN].includes(nic.type)
+    hasInterfaceType(
+      [NetworkInterfaceTypes.ALIAS, NetworkInterfaceTypes.VLAN],
+      machine,
+      nic,
+      link
+    )
   ) {
     return false;
   }

--- a/ui/src/app/store/machine/utils/hooks.ts
+++ b/ui/src/app/store/machine/utils/hooks.ts
@@ -16,6 +16,7 @@ import { getLinkInterface, hasInterfaceType } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import type { Host } from "app/store/types/host";
 import { NodeStatus } from "app/store/types/node";
+import vlanSelectors from "app/store/vlan/selectors";
 
 /**
  * Check if a machine can be edited.
@@ -167,4 +168,27 @@ export const useIsLimitedEditingAllowed = (
     machine?.status === NodeStatus.DEPLOYED &&
     !hasInterfaceType(NetworkInterfaceTypes.VLAN, machine, nic, link)
   );
+};
+
+/**
+ * Check if a VLAN can be added to the interface.
+ * @param machine - A machine.
+ * @param nic - A network interface.
+ * @return Whether limited editing is allowed.
+ */
+export const useCanAddVLAN = (
+  machine?: Machine | null,
+  nic?: NetworkInterface | null
+): boolean => {
+  const unusedVLANs = useSelector((state: RootState) =>
+    vlanSelectors.getUnusedForInterface(state, machine, nic)
+  );
+  if (
+    !nic ||
+    [NetworkInterfaceTypes.ALIAS, NetworkInterfaceTypes.VLAN].includes(nic.type)
+  ) {
+    return false;
+  }
+  // Check that there are unused VLANS available.
+  return unusedVLANs.length > 0;
 };

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -1,4 +1,5 @@
 export {
+  useCanAddVLAN,
   useCanEdit,
   useCanEditStorage,
   useFormattedOS,
@@ -9,6 +10,7 @@ export {
 } from "./hooks";
 
 export {
+  canAddAlias,
   getBondOrBridgeChild,
   getBondOrBridgeParents,
   getInterfaceDiscovered,

--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -1,4 +1,5 @@
 import {
+  canAddAlias,
   getBondOrBridgeChild,
   getBondOrBridgeParents,
   getInterfaceDiscovered,
@@ -917,6 +918,39 @@ describe("machine networking utils", () => {
       expect(
         getNextNicName(machine, NetworkInterfaceTypes.PHYSICAL)
       ).toStrictEqual("eth2");
+    });
+  });
+
+  describe("canAddAlias", () => {
+    it("can not add an alias if the nic is an alias", () => {
+      const nic = machineInterfaceFactory({
+        type: NetworkInterfaceTypes.ALIAS,
+      });
+      expect(canAddAlias(nic)).toBe(false);
+    });
+
+    it("can not add an alias if there are no links", () => {
+      const nic = machineInterfaceFactory({
+        links: [],
+        type: NetworkInterfaceTypes.ALIAS,
+      });
+      expect(canAddAlias(nic)).toBe(false);
+    });
+
+    it("can not add an alias if the first link is LINK_UP", () => {
+      const nic = machineInterfaceFactory({
+        links: [networkLinkFactory({ mode: NetworkLinkMode.LINK_UP })],
+        type: NetworkInterfaceTypes.ALIAS,
+      });
+      expect(canAddAlias(nic)).toBe(false);
+    });
+
+    it("can add an alias", () => {
+      const nic = machineInterfaceFactory({
+        links: [networkLinkFactory({ mode: NetworkLinkMode.AUTO })],
+        type: NetworkInterfaceTypes.PHYSICAL,
+      });
+      expect(canAddAlias(nic)).toBe(true);
     });
   });
 });

--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -923,10 +923,15 @@ describe("machine networking utils", () => {
 
   describe("canAddAlias", () => {
     it("can not add an alias if the nic is an alias", () => {
+      const link = networkLinkFactory();
       const nic = machineInterfaceFactory({
-        type: NetworkInterfaceTypes.ALIAS,
+        links: [networkLinkFactory(), link],
+        type: NetworkInterfaceTypes.PHYSICAL,
       });
-      expect(canAddAlias(nic)).toBe(false);
+      const machine = machineDetailsFactory({
+        interfaces: [nic],
+      });
+      expect(canAddAlias(machine, nic, link)).toBe(false);
     });
 
     it("can not add an alias if there are no links", () => {
@@ -934,7 +939,10 @@ describe("machine networking utils", () => {
         links: [],
         type: NetworkInterfaceTypes.ALIAS,
       });
-      expect(canAddAlias(nic)).toBe(false);
+      const machine = machineDetailsFactory({
+        interfaces: [nic],
+      });
+      expect(canAddAlias(machine, nic)).toBe(false);
     });
 
     it("can not add an alias if the first link is LINK_UP", () => {
@@ -942,7 +950,10 @@ describe("machine networking utils", () => {
         links: [networkLinkFactory({ mode: NetworkLinkMode.LINK_UP })],
         type: NetworkInterfaceTypes.ALIAS,
       });
-      expect(canAddAlias(nic)).toBe(false);
+      const machine = machineDetailsFactory({
+        interfaces: [nic],
+      });
+      expect(canAddAlias(machine, nic)).toBe(false);
     });
 
     it("can add an alias", () => {
@@ -950,7 +961,10 @@ describe("machine networking utils", () => {
         links: [networkLinkFactory({ mode: NetworkLinkMode.AUTO })],
         type: NetworkInterfaceTypes.PHYSICAL,
       });
-      expect(canAddAlias(nic)).toBe(true);
+      const machine = machineDetailsFactory({
+        interfaces: [nic],
+      });
+      expect(canAddAlias(machine, nic)).toBe(true);
     });
   });
 });

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -661,11 +661,18 @@ export const getNextNicName = (
 
 /**
  * Check if an alias can be added to the interface.
+ * @param machine - A machine.
  * @param nic - A network interface.
+ * @param link - A link to an interface.
  * @return An available name.
  */
-export const canAddAlias = (nic?: NetworkInterface | null): boolean =>
+export const canAddAlias = (
+  machine?: Machine | null,
+  nic?: NetworkInterface | null,
+  link?: NetworkLink | null
+): boolean =>
+  !!machine &&
   !!nic &&
-  nic.type !== NetworkInterfaceTypes.ALIAS &&
-  (nic.links.length > 0 ||
-    getLinkMode(nic.links[0]) !== NetworkLinkMode.LINK_UP);
+  !hasInterfaceType(NetworkInterfaceTypes.ALIAS, machine, nic, link) &&
+  nic.links.length > 0 &&
+  getLinkMode(nic.links[0]) !== NetworkLinkMode.LINK_UP;

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -658,3 +658,14 @@ export const getNextNicName = (
   });
   return prefix ? `${prefix}${idx}` : null;
 };
+
+/**
+ * Check if an alias can be added to the interface.
+ * @param nic - A network interface.
+ * @return An available name.
+ */
+export const canAddAlias = (nic?: NetworkInterface | null): boolean =>
+  !!nic &&
+  nic.type !== NetworkInterfaceTypes.ALIAS &&
+  (nic.links.length > 0 ||
+    getLinkMode(nic.links[0]) !== NetworkLinkMode.LINK_UP);

--- a/ui/src/app/store/vlan/selectors.ts
+++ b/ui/src/app/store/vlan/selectors.ts
@@ -1,12 +1,67 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { Machine, NetworkInterface } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 import { generateBaseSelectors } from "app/store/utils";
 import type { VLAN, VLANState } from "app/store/vlan/types";
 
 const searchFunction = (vlan: VLAN, term: string) => vlan.name.includes(term);
 
-const selectors = generateBaseSelectors<VLANState, VLAN, "id">(
+const defaultSelectors = generateBaseSelectors<VLANState, VLAN, "id">(
   "vlan",
   "id",
   searchFunction
 );
+
+/**
+ * Get a list of unused VLANs for an interface.
+ * @param machine - The nic's machine.
+ * @param nic - A network interface.
+ * @return Unused VLANs for an interface.
+ */
+const getUnusedForInterface = createSelector(
+  [
+    defaultSelectors.all,
+    (
+      _state: RootState,
+      // Accept `undefined` instead of making these optional params otherwise
+      // `createSelector` returns the wrong type for this selector.
+      machine: Machine | null | undefined,
+      nic: NetworkInterface | null | undefined
+    ) => ({
+      machine,
+      nic,
+    }),
+  ],
+  (vlans, { machine, nic }) => {
+    if (!nic || !machine || !("interfaces" in machine)) {
+      return [];
+    }
+    const currentVLAN = vlans.find(({ id }) => id === nic.vlan_id);
+    // Remove the default VLAN.
+    const allButDefault = vlans.filter(({ vid }) => vid !== 0);
+    // Get the VLANS in the current fabric.
+    const vlansInFabric = allButDefault.filter(
+      (vlan) => vlan.fabric === currentVLAN?.fabric
+    );
+    const usedVLANs: VLAN["id"][] = [];
+    // Find VLANS that are used by children of this nic.
+    machine.interfaces.forEach((networkInterface: NetworkInterface) => {
+      if (
+        networkInterface.type === NetworkInterfaceTypes.VLAN &&
+        networkInterface.parents[0] === nic.id
+      ) {
+        usedVLANs.push(networkInterface.vlan_id);
+      }
+    });
+    return vlansInFabric.filter(({ id }) => !usedVLANs.includes(id));
+  }
+);
+
+const selectors = {
+  ...defaultSelectors,
+  getUnusedForInterface,
+};
 
 export default selectors;


### PR DESCRIPTION
## Done

- Add an item to the row menu in the network table to add an alias or VLAN.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View both the react and legacy network details for a machine.
- Open the menu for different rows and you should see an item for adding an alias or a vlan in the same cases as the legacy page.

## Fixes

Fixes: #2215.