### PR TITLE
fix(ui): aliases shouldn't have mark connection action

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -128,6 +128,68 @@ describe("NetworkTableActions", () => {
     ).toBe(true);
   });
 
+  it("does not display an item to mark an alias as connected", () => {
+    nic.type = NetworkInterfaceTypes.PHYSICAL;
+    nic.link_connected = false;
+    const link = networkLinkFactory();
+    nic.links = [networkLinkFactory(), link];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions
+          link={link}
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.update();
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.type() === "button" &&
+            n.hasClass("p-contextual-menu__link") &&
+            n.text() === "Mark as connected"
+        )
+        .exists()
+    ).toBe(false);
+  });
+
+  it("does not display an item to mark an alias as disconnected", () => {
+    nic.type = NetworkInterfaceTypes.PHYSICAL;
+    nic.link_connected = true;
+    const link = networkLinkFactory();
+    nic.links = [networkLinkFactory(), link];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions
+          link={link}
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.update();
+    expect(
+      wrapper
+        .findWhere(
+          (n) =>
+            n.type() === "button" &&
+            n.hasClass("p-contextual-menu__link") &&
+            n.text() === "Mark as disconnected"
+        )
+        .exists()
+    ).toBe(false);
+  });
+
   it("can display an item to remove the interface", () => {
     nic.type = NetworkInterfaceTypes.BOND;
     const store = mockStore(state);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.tsx
@@ -14,6 +14,7 @@ import type {
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import {
   canAddAlias,
+  hasInterfaceType,
   getInterfaceTypeText,
   getLinkInterface,
   useCanAddVLAN,
@@ -44,7 +45,15 @@ const NetworkTableActions = ({
   const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
   const isLimitedEditingAllowed = useIsLimitedEditingAllowed(nic, machine);
   const canAddVLAN = useCanAddVLAN(machine, nic, link);
-  const isPhysical = nic?.type === NetworkInterfaceTypes.PHYSICAL;
+  if (!machine || !("interfaces" in machine)) {
+    return null;
+  }
+  const isPhysical = hasInterfaceType(
+    NetworkInterfaceTypes.PHYSICAL,
+    machine,
+    nic,
+    link
+  );
   let actions: TableMenuProps["links"] = [];
   if (machine && nic) {
     actions = [


### PR DESCRIPTION
## Done

- Correctly check the interface type so that alises can't mark a connection as connected/disconnected.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the network tab for a machine.
- Open the action menu on an alias row. There should be no mark connected/disconnected action.

## Fixes

Fixes: #2255.