### PR TITLE
feat(ui): add selectors for grouping/getting pods by LXD address

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 import ComposeForm from "../ComposeForm";
 
 import { DriverType } from "app/store/general/types";
+import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
@@ -120,6 +121,7 @@ describe("ComposeFormFields", () => {
     const powerType = powerTypeFactory({
       defaults: { cores: 2, memory: 2, storage: 2 },
       driver_type: DriverType.POD,
+      name: "virsh",
     });
     state.general.powerTypes.data = [powerType];
     state.pod.items = [
@@ -128,7 +130,7 @@ describe("ComposeFormFields", () => {
         id: 1,
         memory_over_commit_ratio: 1,
         total: podHintFactory({ cores: 2, memory: 2 }),
-        type: powerType.name,
+        type: PodType.VIRSH,
         used: podHintFactory({ cores: 1, memory: 1 }),
       }),
     ];

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -10,6 +10,7 @@ import configureStore from "redux-mock-store";
 import ComposeForm from "../ComposeForm";
 
 import type { Pod } from "app/store/pod/types";
+import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
@@ -106,7 +107,7 @@ describe("StorageTable", () => {
       default_storage_pool: "pool-1",
       id: 1,
       storage_pools: [podStoragePoolFactory({ id: "pool-1" })],
-      type: "virsh",
+      type: PodType.VIRSH,
     });
     const state = { ...initialState };
     state.pod.items = [pod];
@@ -203,7 +204,7 @@ describe("StorageTable", () => {
       id: 1,
       default_storage_pool: pool.id,
       storage_pools: [pool],
-      type: "virsh",
+      type: PodType.VIRSH,
     });
     const state = { ...initialState };
     state.pod.items = [pod];

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import KVMActionFormWrapper from "./KVMActionFormWrapper";
 
+import { PodType } from "app/store/pod/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -21,8 +22,8 @@ describe("KVMActionFormWrapper", () => {
     initialState = rootStateFactory({
       pod: podStateFactory({
         items: [
-          podFactory({ id: 1, name: "pod-1", type: "lxd" }),
-          podFactory({ id: 2, name: "pod-2", type: "virsh" }),
+          podFactory({ id: 1, name: "pod-1", type: PodType.LXD }),
+          podFactory({ id: 2, name: "pod-2", type: PodType.VIRSH }),
         ],
         statuses: {
           1: podStatusFactory(),

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfiguration.tsx
@@ -15,6 +15,7 @@ import type { RouteParams } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
+import { PodType } from "app/store/pod/types";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import type { RootState } from "app/store/root/types";
@@ -77,7 +78,8 @@ const PodConfiguration = (): JSX.Element => {
   const loaded = resourcePoolsLoaded && tagsLoaded && zonesLoaded;
 
   if (!!pod && loaded) {
-    const podPassword = pod.type === "lxd" ? pod.password : pod.power_pass;
+    const podPassword =
+      pod.type === PodType.LXD ? pod.password : pod.power_pass;
 
     return (
       <FormCard sidebar={false} title={`${podType} configuration`}>

--- a/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
+++ b/ui/src/app/kvm/components/PodConfiguration/PodConfigurationFields/PodConfigurationFields.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import PodConfiguration from "../PodConfiguration";
 
+import { PodType } from "app/store/pod/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -36,7 +37,11 @@ describe("PodConfigurationFields", () => {
 
   it("correctly sets initial values for virsh pods", () => {
     const state = { ...initialState };
-    const pod = podFactory({ id: 1, type: "virsh", power_pass: "maxpower" });
+    const pod = podFactory({
+      id: 1,
+      type: PodType.VIRSH,
+      power_pass: "maxpower",
+    });
     state.pod.items = [pod];
     const store = mockStore(state);
     const wrapper = mount(
@@ -79,7 +84,11 @@ describe("PodConfigurationFields", () => {
 
   it("correctly sets initial values for lxd pods", () => {
     const state = { ...initialState };
-    const pod = podFactory({ id: 1, type: "lxd", password: "powerranger" });
+    const pod = podFactory({
+      id: 1,
+      type: PodType.LXD,
+      password: "powerranger",
+    });
     state.pod.items = [pod];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMSummary/KVMSummary.tsx
@@ -15,6 +15,7 @@ import PodAggregateResources from "app/kvm/components/PodAggregateResources";
 import PodStorage from "app/kvm/components/PodStorage";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
+import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 
 const KVMSummary = (): JSX.Element => {
@@ -42,7 +43,7 @@ const KVMSummary = (): JSX.Element => {
       <>
         <div className="u-flex">
           <p className="u-nudge-left">
-            {pod.type === "virsh" ? "Virsh:" : "LXD URL:"}
+            {pod.type === PodType.VIRSH ? "Virsh:" : "LXD URL:"}
           </p>
           <Code copyable className="u-flex--grow">
             {pod.power_address}

--- a/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/KVMListTable/TypeColumn/TypeColumn.test.tsx
@@ -4,6 +4,7 @@ import configureStore from "redux-mock-store";
 
 import TypeColumn from "./TypeColumn";
 
+import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
@@ -21,7 +22,7 @@ describe("TypeColumn", () => {
       pod: podStateFactory({
         items: [
           podFactory({
-            type: "virsh",
+            type: PodType.VIRSH,
           }),
         ],
       }),

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import DetailsCard from "./DetailsCard";
 
+import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
@@ -76,7 +77,7 @@ describe("DetailsCard", () => {
     const pod = podFactory({
       id: 1,
       name: "pod-1",
-      type: "lxd",
+      type: PodType.LXD,
       numa_pinning: [podNumaNodeFactory({ node_id: 10 })],
     });
 
@@ -104,7 +105,7 @@ describe("DetailsCard", () => {
     const pod = podFactory({
       id: 1,
       name: "pod-1",
-      type: "lxd",
+      type: PodType.LXD,
       numa_pinning: [],
     });
 

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -2,6 +2,11 @@ import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
+export enum PodType {
+  LXD = "lxd",
+  VIRSH = "virsh",
+}
+
 export type PodHint = {
   cores: number;
   local_storage: number;
@@ -70,8 +75,7 @@ export type BasePod = Model & {
   cpu_speed: number;
   created: string;
   default_macvlan_mode: string;
-  // The websocket does not include this value if the pod has no storage pools
-  default_storage_pool?: string;
+  default_storage_pool: string | null;
   hints: PodHint & PodHintExtras;
   host: string | null;
   ip_address: number | string;
@@ -83,12 +87,13 @@ export type BasePod = Model & {
   pool: number;
   power_address: string;
   power_pass?: string;
+  // Only LXD pods have the project parameter.
+  project?: string;
   owners_count: number;
-  // The websocket does not include this value if the pod has no storage pools
-  storage_pools?: PodStoragePool[];
+  storage_pools: PodStoragePool[];
   tags: string[];
   total: PodHint;
-  type: string;
+  type: PodType;
   updated: string;
   used: PodHint;
   zone: number;

--- a/ui/src/app/store/pod/utils.ts
+++ b/ui/src/app/store/pod/utils.ts
@@ -1,11 +1,12 @@
 import type { Machine } from "app/store/machine/types";
 import type { Pod } from "app/store/pod/types";
+import { PodType } from "app/store/pod/types";
 
-export const formatHostType = (type: string): string => {
+export const formatHostType = (type: PodType): string => {
   switch (type) {
-    case "lxd":
+    case PodType.LXD:
       return "LXD";
-    case "virsh":
+    case PodType.VIRSH:
       return "Virsh";
     default:
       return type;

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -32,6 +32,7 @@ import type {
   PodNumaNode,
   PodStoragePool,
 } from "app/store/pod/types";
+import { PodType } from "app/store/pod/types";
 import type { Model } from "app/store/types/model";
 import type { BaseNode, SimpleNode, TestStatus } from "app/store/types/node";
 import { NodeStatus } from "app/store/types/node";
@@ -379,7 +380,7 @@ export const pod = extend<Model, Pod>(model, {
   storage_pools,
   tags,
   total: podHint,
-  type: "virsh",
+  type: PodType.VIRSH,
   updated: "Fri, 03 Jul. 2020 02:44:12",
   used: podHint,
   zone: 1,


### PR DESCRIPTION
## Done

- Added selectors for:
  - getting all virsh pods (will have its own table)
  - getting all LXD pods
  - grouping LXD pods by LXD server (for the KVM list)
  - getting all LXD pods in a given LXD server (for calculating the overall resource usage of a LXD server)
- Added pod type enum since behaviour for LXD and virsh pods is becoming increasingly divergent

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A

## Fixes

Fixes #2256 
