### PR TITLE
docs(shared): link to docs root instead of named file

### DIFF
--- a/integration/cypress/integration/base/footer.spec.ts
+++ b/integration/cypress/integration/base/footer.spec.ts
@@ -22,10 +22,7 @@ context("Footer", () => {
 
   it("navigates to the local documentation", () => {
     cy.get(".p-footer__link:contains(Local documentation)").click();
-    cy.location("pathname").should(
-      "eq",
-      "/MAAS/docs/maas-documentation-25.html"
-    );
+    cy.location("pathname").should("eq", "/MAAS/docs/");
   });
 
   it("has a link to legal", () => {

--- a/shared/src/components/Footer/Footer.tsx
+++ b/shared/src/components/Footer/Footer.tsx
@@ -45,10 +45,7 @@ export const Footer = ({
         <div className="col-10 p-footer__nav">
           <ul className="p-inline-list--middot">
             <li className="p-inline-list__item">
-              <a
-                href={`${BASENAME}/docs/maas-documentation-25.html`}
-                className="p-footer__link"
-              >
+              <a href={`${BASENAME}/docs/`} className="p-footer__link">
                 Local documentation
               </a>
             </li>

--- a/shared/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/shared/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Footer renders 1`] = `
         >
           <a
             className="p-footer__link"
-            href="/MAAS/docs/maas-documentation-25.html"
+            href="/MAAS/docs/"
           >
             Local documentation
           </a>


### PR DESCRIPTION
lp#1913323
-------

## Done

- Link to /docs/ instead of a named HTML file therein

## QA

- Click local documentation and ensure you get to the index page of the local docs

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

## Fixes

## Launchpad issue

lp#1913323