### PR TITLE
feat(ui): add link to workload annotations discourse page

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/WorkloadCard/WorkloadCard.tsx
@@ -86,7 +86,7 @@ const WorkloadCard = ({ id }: Props): JSX.Element => {
           </div>
           <Link
             external
-            href="https://maas.io/docs" // TODO: Replace with real link
+            href="https://discourse.maas.io/t/machine-workload-annotations/4237"
             onClick={() =>
               sendAnalytics(
                 "Machine summary",


### PR DESCRIPTION
## Done

- Replaced placeholder docs link for workload annotations

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine details page of an Allocated or Deployed machine
- Click the "Read more" link in the Workloads card
- Check that it takes you to a discourse page (which is currently empty, but will have content by 2.10 release)

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2304
