### PR TITLE
refactor(ui): move script+node base enums to their store directories

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -128,7 +128,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:4083206781": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -283,11 +283,8 @@ exports[`stricter compilation`] = {
       [62, 23, 4, "Object is possibly \'undefined\'.", "2088098233"],
       [66, 48, 4, "Object is possibly \'undefined\'.", "2088098233"]
     ],
-    "src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx:957388686": [
-      [59, 6, 88, "Object is possibly \'undefined\'.", "465871270"]
-    ],
-    "src/app/kvm/views/KVMList/VirshTable/VirshTable.tsx:3253574565": [
-      [53, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, pools: ResourcePool[]) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
+    "src/app/kvm/views/KVMList/VirshTable/VirshTable.tsx:254800136": [
+      [78, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, pools: ResourcePool[]) => string | number | string[] | PodHint | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
     ],
     "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:1056284611": [
       [69, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
@@ -540,10 +537,10 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/MachineTestsDetailsLogs.tsx:2335753194": [
       [23, 18, 14, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'ScriptResultData\'.\\n  No index signature with a parameter of type \'string\' was found on type \'ScriptResultData\'.", "887297148"]
     ],
-    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx:3805373909": [
-      [42, 33, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx:1996481352": [
+      [45, 33, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
-    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx:3833156813": [
+    "src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx:4259727775": [
       [23, 33, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
     "src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx:1782614757": [
@@ -551,8 +548,8 @@ exports[`stricter compilation`] = {
       [127, 12, 17, "Type \'(action: MachineAction, deselect?: boolean | undefined) => void\' is not assignable to type \'SetSelectedAction\'.", "167402512"],
       [132, 42, 16, "Argument of type \'(BaseMachine | MachineDetails | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
     ],
-    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:1068995972": [
-      [87, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
+    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:1357884494": [
+      [81, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
     ],
     "src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx:1934760491": [
       [63, 6, 8, "Type \'(values: any, { resetForm }: { resetForm: any; }) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'__1\' and \'formikHelpers\' are incompatible.\\n    Type \'FormikHelpers<unknown> | undefined\' is not assignable to type \'{ resetForm: any; }\'.\\n      Type \'undefined\' is not assignable to type \'{ resetForm: any; }\'.", "1301647696"],
@@ -612,7 +609,7 @@ exports[`stricter compilation`] = {
       [903, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
       [907, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
-    "src/app/store/machine/utils/storage.ts:2131529770": [
+    "src/app/store/machine/utils/storage.ts:2193730426": [
       [164, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
       [193, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
     ],
@@ -808,13 +805,13 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 58, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/selectors.ts:858659080": [
-      [13, 13, 8, "RegExp match", "1152173309"],
-      [71, 34, 8, "RegExp match", "1152173309"]
+    "src/app/store/scriptresult/selectors.ts:1811886847": [
+      [14, 13, 8, "RegExp match", "1152173309"],
+      [72, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/types.ts:1361698920": [
-      [7, 13, 8, "RegExp match", "1152173309"],
-      [115, 58, 8, "RegExp match", "1152173309"]
+    "src/app/store/scriptresult/types.ts:532063327": [
+      [3, 13, 8, "RegExp match", "1152173309"],
+      [114, 58, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scripts/types.ts:980490450": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/base/components/ScriptResultStatus/ScriptResultStatus.test.tsx
+++ b/ui/src/app/base/components/ScriptResultStatus/ScriptResultStatus.test.tsx
@@ -2,13 +2,13 @@ import { shallow } from "enzyme";
 
 import ScriptResultStatus from "./ScriptResultStatus";
 
-import { scriptStatus } from "app/base/enum";
+import { ScriptResultStatus as ScriptStatus } from "app/store/scriptresult/types";
 import { scriptResult as scriptResultFactory } from "testing/factories";
 
 describe("ScriptResultStatus", () => {
   it("renders", () => {
     const scriptResult = scriptResultFactory({
-      status: scriptStatus.PASSED,
+      status: ScriptStatus.PASSED,
       status_name: "Passed",
     });
     const wrapper = shallow(<ScriptResultStatus scriptResult={scriptResult} />);

--- a/ui/src/app/base/components/ScriptResultStatus/ScriptResultStatus.tsx
+++ b/ui/src/app/base/components/ScriptResultStatus/ScriptResultStatus.tsx
@@ -1,8 +1,8 @@
-import { scriptStatus } from "app/base/enum";
 import type {
   PartialScriptResult,
   ScriptResult,
 } from "app/store/scriptresult/types";
+import { ScriptResultStatus as ScriptStatus } from "app/store/scriptresult/types";
 
 type Props = { scriptResult: ScriptResult | PartialScriptResult };
 
@@ -10,25 +10,25 @@ const getTestResultsIcon = (
   result: ScriptResult | PartialScriptResult
 ): string => {
   switch (result.status) {
-    case scriptStatus.PENDING:
+    case ScriptStatus.PENDING:
       return "p-icon--pending";
-    case scriptStatus.RUNNING:
-    case scriptStatus.APPLYING_NETCONF:
-    case scriptStatus.INSTALLING:
+    case ScriptStatus.RUNNING:
+    case ScriptStatus.APPLYING_NETCONF:
+    case ScriptStatus.INSTALLING:
       return "p-icon--running";
-    case scriptStatus.PASSED:
+    case ScriptStatus.PASSED:
       return "p-icon--success";
-    case scriptStatus.FAILED:
-    case scriptStatus.ABORTED:
-    case scriptStatus.DEGRADED:
-    case scriptStatus.FAILED_APPLYING_NETCONF:
-    case scriptStatus.FAILED_INSTALLING:
+    case ScriptStatus.FAILED:
+    case ScriptStatus.ABORTED:
+    case ScriptStatus.DEGRADED:
+    case ScriptStatus.FAILED_APPLYING_NETCONF:
+    case ScriptStatus.FAILED_INSTALLING:
       return "p-icon--error";
-    case scriptStatus.TIMEDOUT:
+    case ScriptStatus.TIMEDOUT:
       return "p-icon--timed-out";
-    case scriptStatus.SKIPPED:
+    case ScriptStatus.SKIPPED:
       return "p-icon--warning";
-    case scriptStatus.NONE:
+    case ScriptStatus.NONE:
       return "";
     default:
       return "p-icon--help";

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.js
@@ -1,7 +1,7 @@
 import { Tooltip } from "@canonical/react-components";
 import PropTypes from "prop-types";
 
-import { scriptStatus } from "app/base/enum";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 
 const ScriptStatus = ({
   children,
@@ -10,7 +10,7 @@ const ScriptStatus = ({
   tooltipPosition,
 }) => {
   switch (scriptType.status) {
-    case scriptStatus.PASSED: {
+    case ScriptResultStatus.PASSED: {
       return hidePassedIcon ? (
         children
       ) : (
@@ -21,10 +21,10 @@ const ScriptStatus = ({
       );
     }
 
-    case scriptStatus.DEGRADED:
-    case scriptStatus.FAILED:
-    case scriptStatus.FAILED_APPLYING_NETCONF:
-    case scriptStatus.FAILED_INSTALLING: {
+    case ScriptResultStatus.DEGRADED:
+    case ScriptResultStatus.FAILED:
+    case ScriptResultStatus.FAILED_APPLYING_NETCONF:
+    case ScriptResultStatus.FAILED_INSTALLING: {
       return (
         <Tooltip
           message="Machine has failed tests."
@@ -37,7 +37,7 @@ const ScriptStatus = ({
       );
     }
 
-    case scriptStatus.TIMEDOUT: {
+    case ScriptResultStatus.TIMEDOUT: {
       return (
         <Tooltip
           message="Machine has tests that have timed out."
@@ -50,9 +50,9 @@ const ScriptStatus = ({
       );
     }
 
-    case scriptStatus.APPLYING_NETCONF:
-    case scriptStatus.INSTALLING:
-    case scriptStatus.RUNNING: {
+    case ScriptResultStatus.APPLYING_NETCONF:
+    case ScriptResultStatus.INSTALLING:
+    case ScriptResultStatus.RUNNING: {
       return (
         <>
           <i className="p-icon--running is-inline" />
@@ -61,7 +61,7 @@ const ScriptStatus = ({
       );
     }
 
-    case scriptStatus.PENDING: {
+    case ScriptResultStatus.PENDING: {
       return (
         <>
           <i className="p-icon--pending is-inline" />

--- a/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.js
+++ b/ui/src/app/base/components/ScriptStatus/ScriptStatus.test.js
@@ -1,12 +1,12 @@
 import { shallow } from "enzyme";
 
-import { scriptStatus } from "app/base/enum";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 import ScriptStatus from "./ScriptStatus";
 
 describe("ScriptStatus ", () => {
   it("renders", () => {
     const wrapper = shallow(
-      <ScriptStatus scriptType={{ status: scriptStatus.PASSED }}>
+      <ScriptStatus scriptType={{ status: ScriptResultStatus.PASSED }}>
         All tests have passed
       </ScriptStatus>
     );
@@ -15,7 +15,7 @@ describe("ScriptStatus ", () => {
 
   it("displays a success icon if scripts passed", () => {
     const wrapper = shallow(
-      <ScriptStatus scriptType={{ status: scriptStatus.PASSED }}>
+      <ScriptStatus scriptType={{ status: ScriptResultStatus.PASSED }}>
         All tests have passed
       </ScriptStatus>
     );
@@ -25,7 +25,10 @@ describe("ScriptStatus ", () => {
   it(`does not display a success icon if scripts passed
     and hidePassedIcon is false`, () => {
     const wrapper = shallow(
-      <ScriptStatus hidePassedIcon scriptType={{ status: scriptStatus.PASSED }}>
+      <ScriptStatus
+        hidePassedIcon
+        scriptType={{ status: ScriptResultStatus.PASSED }}
+      >
         All tests have passed
       </ScriptStatus>
     );
@@ -34,7 +37,7 @@ describe("ScriptStatus ", () => {
 
   it("displays an error icon and tooltip if scripts have failed", () => {
     const wrapper = shallow(
-      <ScriptStatus scriptType={{ status: scriptStatus.FAILED }}>
+      <ScriptStatus scriptType={{ status: ScriptResultStatus.FAILED }}>
         Some or all tests have failed
       </ScriptStatus>
     );
@@ -44,7 +47,7 @@ describe("ScriptStatus ", () => {
 
   it("displays a timed out icon and tooltip if scripts have timed out", () => {
     const wrapper = shallow(
-      <ScriptStatus scriptType={{ status: scriptStatus.TIMEDOUT }}>
+      <ScriptStatus scriptType={{ status: ScriptResultStatus.TIMEDOUT }}>
         Some or all tests have timed out
       </ScriptStatus>
     );
@@ -54,7 +57,7 @@ describe("ScriptStatus ", () => {
 
   it("displays a pending icon if scripts are pending", () => {
     const wrapper = shallow(
-      <ScriptStatus scriptType={{ status: scriptStatus.PENDING }}>
+      <ScriptStatus scriptType={{ status: ScriptResultStatus.PENDING }}>
         Some or all tests are pending
       </ScriptStatus>
     );
@@ -63,7 +66,7 @@ describe("ScriptStatus ", () => {
 
   it("displays a running icon if scripts are running", () => {
     const wrapper = shallow(
-      <ScriptStatus scriptType={{ status: scriptStatus.RUNNING }}>
+      <ScriptStatus scriptType={{ status: ScriptResultStatus.RUNNING }}>
         Some or all tests are running
       </ScriptStatus>
     );

--- a/ui/src/app/base/enum.ts
+++ b/ui/src/app/base/enum.ts
@@ -1,78 +1,3 @@
-export const nodeStatus = {
-  // The node has been created and has a system ID assigned to it.
-  NEW: 0,
-  // Testing and other commissioning steps are taking place.
-  COMMISSIONING: 1,
-  // The commissioning step failed.
-  FAILED_COMMISSIONING: 2,
-  // The node can't be contacted.
-  MISSING: 3,
-  // The node is in the general pool ready to be deployed.
-  READY: 4,
-  // The node is ready for named deployment.
-  RESERVED: 5,
-  // The node has booted into the operating system of its owner's choice
-  // and is ready for use.
-  DEPLOYED: 6,
-  // The node has been removed from service manually until an admin
-  // overrides the retirement.
-  RETIRED: 7,
-  // The node is broken: a step in the node lifecycle failed.
-  // More details can be found in the node's event log.
-  BROKEN: 8,
-  // The node is being installed.
-  DEPLOYING: 9,
-  // The node has been allocated to a user and is ready for deployment.
-  ALLOCATED: 10,
-  // The deployment of the node failed.
-  FAILED_DEPLOYMENT: 11,
-  // The node is powering down after a release request.
-  RELEASING: 12,
-  // The releasing of the node failed.
-  FAILED_RELEASING: 13,
-  // The node is erasing its disks.
-  DISK_ERASING: 14,
-  // The node failed to erase its disks.
-  FAILED_DISK_ERASING: 15,
-  // The node is in rescue mode.
-  RESCUE_MODE: 16,
-  // The node is entering rescue mode.
-  ENTERING_RESCUE_MODE: 17,
-  // The node failed to enter rescue mode.
-  FAILED_ENTERING_RESCUE_MODE: 18,
-  // The node is exiting rescue mode.
-  EXITING_RESCUE_MODE: 19,
-  // The node failed to exit rescue mode.
-  FAILED_EXITING_RESCUE_MODE: 20,
-  // Running tests on Node
-  TESTING: 21,
-  // Testing has failed
-  FAILED_TESTING: 22,
-};
-
-export const scriptStatus = {
-  NONE: -1,
-  PENDING: 0,
-  RUNNING: 1,
-  PASSED: 2,
-  FAILED: 3,
-  TIMEDOUT: 4,
-  ABORTED: 5,
-  DEGRADED: 6,
-  INSTALLING: 7,
-  FAILED_INSTALLING: 8,
-  SKIPPED: 9,
-  APPLYING_NETCONF: 10,
-  FAILED_APPLYING_NETCONF: 11,
-};
-
-export enum ScriptResultParamType {
-  Interface = "interface",
-  Runtime = "runtime",
-  Storage = "storage",
-  Url = "url",
-}
-
 export enum HardwareType {
   Node = 0,
   CPU = 1,
@@ -80,10 +5,4 @@ export enum HardwareType {
   Storage = 3,
   Network = 4,
   GPU = 5,
-}
-
-export enum ResultType {
-  Commissioning = 0,
-  Installation = 1,
-  Testing = 2,
 }

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.test.js
@@ -5,8 +5,10 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import OverrideTestForm from "./OverrideTestForm";
-import { ResultType } from "app/base/enum";
-import { ResultStatus } from "app/store/scriptresult/types";
+import {
+  ScriptResultStatus,
+  ScriptResultType,
+} from "app/store/scriptresult/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -58,9 +60,9 @@ describe("OverrideTestForm", () => {
         loading: false,
         items: [
           scriptResultFactory({
-            status: ResultStatus.FAILED,
+            status: ScriptResultStatus.FAILED,
             id: 1,
-            result_type: ResultType.Testing,
+            result_type: ScriptResultType.TESTING,
             results: [
               scriptResultResultFactory({
                 id: 1,
@@ -73,9 +75,9 @@ describe("OverrideTestForm", () => {
             ],
           }),
           scriptResultFactory({
-            status: ResultStatus.FAILED,
+            status: ScriptResultStatus.FAILED,
             id: 2,
-            result_type: ResultType.Testing,
+            result_type: ScriptResultType.TESTING,
             results: [scriptResultResultFactory()],
           }),
         ],

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/IPColumn/IPColumn.test.tsx
@@ -4,10 +4,13 @@ import configureStore from "redux-mock-store";
 
 import IPColumn from "./IPColumn";
 
-import { HardwareType, ResultType } from "app/base/enum";
+import { HardwareType } from "app/base/enum";
 import { NetworkLinkMode } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-import { ResultStatus } from "app/store/scriptresult/types";
+import {
+  ScriptResultStatus,
+  ScriptResultType,
+} from "app/store/scriptresult/types";
 import type { VLAN } from "app/store/vlan/types";
 import {
   fabric as fabricFactory,
@@ -158,15 +161,15 @@ describe("IPColumn", () => {
           id: 1,
           hardware_type: HardwareType.Network,
           interface: nic,
-          result_type: ResultType.Testing,
-          status: ResultStatus.FAILED,
+          result_type: ScriptResultType.TESTING,
+          status: ScriptResultStatus.FAILED,
         }),
         scriptResultFactory({
           id: 2,
           hardware_type: HardwareType.Network,
           interface: nic,
-          result_type: ResultType.Testing,
-          status: ResultStatus.FAILED,
+          result_type: ScriptResultType.TESTING,
+          status: ScriptResultStatus.FAILED,
         }),
       ],
     });
@@ -202,8 +205,8 @@ describe("IPColumn", () => {
           hardware_type: HardwareType.Network,
           interface: nic,
           name: "nic test",
-          result_type: ResultType.Testing,
-          status: ResultStatus.FAILED,
+          result_type: ScriptResultType.TESTING,
+          status: ScriptResultStatus.FAILED,
         }),
       ],
     });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
@@ -5,9 +5,9 @@ import configureStore from "redux-mock-store";
 
 import StorageNotifications from "./StorageNotifications";
 
-import { nodeStatus } from "app/base/enum";
 import type { MachineDetails } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { NodeStatusCode } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
   machineDisk as diskFactory,
@@ -27,7 +27,7 @@ describe("StorageNotifications", () => {
       locked: false,
       osystem: "ubuntu",
       permissions: ["edit"],
-      status_code: nodeStatus.READY,
+      status_code: NodeStatusCode.READY,
       storage_layout_issues: [],
       system_id: "abc123",
     });
@@ -72,7 +72,7 @@ describe("StorageNotifications", () => {
   });
 
   it("can display a machine state error", () => {
-    machine.status_code = nodeStatus.NEW;
+    machine.status_code = NodeStatusCode.NEW;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.test.tsx
@@ -2,47 +2,59 @@ import { mount } from "enzyme";
 
 import TestStatus from "./TestStatus";
 
-import { scriptStatus } from "app/base/enum";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 
 describe("TestStatus", () => {
   it("can show passed test status", () => {
-    const wrapper = mount(<TestStatus testStatus={scriptStatus.PASSED} />);
+    const wrapper = mount(
+      <TestStatus testStatus={ScriptResultStatus.PASSED} />
+    );
 
     expect(wrapper.find(".p-icon--success").exists()).toBe(true);
   });
 
   it("can show running test status", () => {
-    const wrapper = mount(<TestStatus testStatus={scriptStatus.RUNNING} />);
+    const wrapper = mount(
+      <TestStatus testStatus={ScriptResultStatus.RUNNING} />
+    );
 
     expect(wrapper.find(".p-icon--running").exists()).toBe(true);
   });
 
   it("can show pending test status", () => {
-    const wrapper = mount(<TestStatus testStatus={scriptStatus.PENDING} />);
+    const wrapper = mount(
+      <TestStatus testStatus={ScriptResultStatus.PENDING} />
+    );
 
     expect(wrapper.find(".p-icon--pending").exists()).toBe(true);
   });
 
   it("can show error test status", () => {
-    const wrapper = mount(<TestStatus testStatus={scriptStatus.FAILED} />);
+    const wrapper = mount(
+      <TestStatus testStatus={ScriptResultStatus.FAILED} />
+    );
 
     expect(wrapper.find(".p-icon--error").exists()).toBe(true);
   });
 
   it("can show timed out test status", () => {
-    const wrapper = mount(<TestStatus testStatus={scriptStatus.TIMEDOUT} />);
+    const wrapper = mount(
+      <TestStatus testStatus={ScriptResultStatus.TIMEDOUT} />
+    );
 
     expect(wrapper.find(".p-icon--timed-out").exists()).toBe(true);
   });
 
   it("can show warning test status", () => {
-    const wrapper = mount(<TestStatus testStatus={scriptStatus.SKIPPED} />);
+    const wrapper = mount(
+      <TestStatus testStatus={ScriptResultStatus.SKIPPED} />
+    );
 
     expect(wrapper.find(".p-icon--warning").exists()).toBe(true);
   });
 
   it("can show unknown test status", () => {
-    const wrapper = mount(<TestStatus testStatus={scriptStatus.NONE} />);
+    const wrapper = mount(<TestStatus testStatus={ScriptResultStatus.NONE} />);
 
     expect(wrapper.find(".p-icon--power-unknown").exists()).toBe(true);
   });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/TestStatus/TestStatus.tsx
@@ -1,42 +1,42 @@
-import { scriptStatus } from "app/base/enum";
 import type { Disk } from "app/store/machine/types";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 
 type Props = { testStatus: Disk["test_status"] };
 
 const TestStatus = ({ testStatus }: Props): JSX.Element => {
   switch (testStatus) {
-    case scriptStatus.PENDING:
+    case ScriptResultStatus.PENDING:
       return <i className="p-icon--pending"></i>;
-    case scriptStatus.RUNNING:
-    case scriptStatus.APPLYING_NETCONF:
-    case scriptStatus.INSTALLING:
+    case ScriptResultStatus.RUNNING:
+    case ScriptResultStatus.APPLYING_NETCONF:
+    case ScriptResultStatus.INSTALLING:
       return <i className="p-icon--running"></i>;
-    case scriptStatus.PASSED:
+    case ScriptResultStatus.PASSED:
       return (
         <>
           <i className="p-icon--success is-inline"></i>
           <span>OK</span>
         </>
       );
-    case scriptStatus.FAILED:
-    case scriptStatus.ABORTED:
-    case scriptStatus.DEGRADED:
-    case scriptStatus.FAILED_APPLYING_NETCONF:
-    case scriptStatus.FAILED_INSTALLING:
+    case ScriptResultStatus.FAILED:
+    case ScriptResultStatus.ABORTED:
+    case ScriptResultStatus.DEGRADED:
+    case ScriptResultStatus.FAILED_APPLYING_NETCONF:
+    case ScriptResultStatus.FAILED_INSTALLING:
       return (
         <>
           <i className="p-icon--error is-inline"></i>
           <span>Error</span>
         </>
       );
-    case scriptStatus.TIMEDOUT:
+    case ScriptResultStatus.TIMEDOUT:
       return (
         <>
           <i className="p-icon--timed-out is-inline"></i>
           <span>Timed out</span>
         </>
       );
-    case scriptStatus.SKIPPED:
+    case ScriptResultStatus.SKIPPED:
       return (
         <>
           <i className="p-icon--warning is-inline"></i>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.test.tsx
@@ -5,8 +5,8 @@ import configureStore from "redux-mock-store";
 
 import MachineSummary from "./MachineSummary";
 
-import { nodeStatus } from "app/base/enum";
 import type { RootState } from "app/store/root/types";
+import { NodeStatusCode } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -56,7 +56,10 @@ describe("MachineSummary", () => {
 
   it("shows workload annotations for deployed machines", () => {
     state.machine.items = [
-      machineFactory({ status_code: nodeStatus.DEPLOYED, system_id: "abc123" }),
+      machineFactory({
+        status_code: NodeStatusCode.DEPLOYED,
+        system_id: "abc123",
+      }),
     ];
     const store = mockStore(state);
     const wrapper = mount(
@@ -80,7 +83,7 @@ describe("MachineSummary", () => {
   it("shows workload annotations for allocated machines", () => {
     state.machine.items = [
       machineFactory({
-        status_code: nodeStatus.ALLOCATED,
+        status_code: NodeStatusCode.ALLOCATED,
         system_id: "abc123",
       }),
     ];
@@ -105,7 +108,7 @@ describe("MachineSummary", () => {
 
   it("does not show workload annotations for machines that are neither deployed nor allocated", () => {
     state.machine.items = [
-      machineFactory({ status_code: nodeStatus.NEW, system_id: "abc123" }),
+      machineFactory({ status_code: NodeStatusCode.NEW, system_id: "abc123" }),
     ];
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -12,12 +12,12 @@ import OverviewCard from "./OverviewCard";
 import SystemCard from "./SystemCard";
 import WorkloadCard from "./WorkloadCard";
 
-import { nodeStatus } from "app/base/enum";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
+import { NodeStatusCode } from "app/store/types/node";
 
 type Props = {
   setSelectedAction: SetSelectedAction;
@@ -42,7 +42,9 @@ const MachineSummary = ({ setSelectedAction }: Props): JSX.Element => {
 
   const showWorkloadCard =
     "workload_annotations" in machine &&
-    [nodeStatus.ALLOCATED, nodeStatus.DEPLOYED].includes(machine.status_code);
+    [NodeStatusCode.ALLOCATED, NodeStatusCode.DEPLOYED].includes(
+      machine.status_code
+    );
 
   return (
     <div className="machine-summary__cards">

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,6 +1,6 @@
-import { nodeStatus, scriptStatus } from "app/base/enum";
 import type { MachineDetails } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
+import { NodeStatusCode, TestStatusStatus } from "app/store/types/node";
 
 type Props = {
   machine: MachineDetails;
@@ -16,17 +16,12 @@ const isVM = (machine: MachineDetails) => {
 
 const showFailedTestsWarning = (machine: MachineDetails) => {
   switch (machine.status_code) {
-    case nodeStatus.COMMISSIONING:
-    case nodeStatus.TESTING:
+    case NodeStatusCode.COMMISSIONING:
+    case NodeStatusCode.TESTING:
       return false;
   }
 
-  return (
-    machine.testing_status.status === scriptStatus.FAILED ||
-    machine.testing_status.status === scriptStatus.FAILED_INSTALLING ||
-    machine.testing_status.status === scriptStatus.DEGRADED ||
-    machine.testing_status.status === scriptStatus.TIMEDOUT
-  );
+  return machine.testing_status.status === TestStatusStatus.FAILED;
 };
 
 const StatusCard = ({ machine }: Props): JSX.Element => {

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -5,8 +5,12 @@ import configureStore from "redux-mock-store";
 
 import MachineTests from ".";
 
-import { HardwareType, ResultType, ScriptResultParamType } from "app/base/enum";
+import { HardwareType } from "app/base/enum";
 import type { RootState } from "app/store/root/types";
+import {
+  ScriptResultType,
+  ScriptResultParamType,
+} from "app/store/scriptresult/types";
 import {
   machineState as machineStateFactory,
   machineDetails as machineDetailsFactory,
@@ -42,17 +46,17 @@ describe("MachineTests", () => {
     state.scriptresult.items = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
         hardware_type: HardwareType.CPU,
       }),
       scriptResultFactory({
         id: 2,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
         hardware_type: HardwareType.Network,
       }),
       scriptResultFactory({
         id: 3,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
         hardware_type: HardwareType.Node,
       }),
     ];
@@ -86,18 +90,18 @@ describe("MachineTests", () => {
     state.scriptresult.items = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
         hardware_type: HardwareType.Storage,
         physical_blockdevice: 1,
       }),
       scriptResultFactory({
         id: 2,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
         hardware_type: HardwareType.Storage,
         physical_blockdevice: 2,
         parameters: {
           storage: {
-            type: ScriptResultParamType.Storage,
+            type: ScriptResultParamType.STORAGE,
             value: {
               model: "QEMU HARDDISK",
               name: "sda",

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.test.tsx
@@ -5,9 +5,12 @@ import configureStore from "redux-mock-store";
 
 import MachineTestsTable from ".";
 
-import { ResultType, scriptStatus } from "app/base/enum";
 import * as hooks from "app/base/hooks";
 import type { RootState } from "app/store/root/types";
+import {
+  ScriptResultStatus,
+  ScriptResultType,
+} from "app/store/scriptresult/types";
 import {
   machineState as machineStateFactory,
   machineDetails as machineDetailsFactory,
@@ -55,8 +58,8 @@ describe("MachineTestsTable", () => {
     const scriptResults = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
-        status: scriptStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
         suppressed: false,
       }),
     ];
@@ -82,8 +85,8 @@ describe("MachineTestsTable", () => {
     const scriptResults = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Commissioning,
-        status: scriptStatus.FAILED,
+        result_type: ScriptResultType.COMMISSIONING,
+        status: ScriptResultStatus.FAILED,
         suppressed: false,
       }),
     ];
@@ -109,8 +112,8 @@ describe("MachineTestsTable", () => {
     const scriptResults = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
-        status: scriptStatus.PASSED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.PASSED,
         suppressed: false,
       }),
     ];
@@ -141,8 +144,8 @@ describe("MachineTestsTable", () => {
     const scriptResults = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
-        status: scriptStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
         suppressed: false,
       }),
     ];
@@ -175,8 +178,8 @@ describe("MachineTestsTable", () => {
     const scriptResults = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
-        status: scriptStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
         suppressed: true,
       }),
     ];
@@ -209,8 +212,8 @@ describe("MachineTestsTable", () => {
     const scriptResults = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
-        status: scriptStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
         suppressed: false,
       }),
     ];
@@ -242,8 +245,8 @@ describe("MachineTestsTable", () => {
     const scriptResults = [
       scriptResultFactory({
         id: 1,
-        result_type: ResultType.Testing,
-        status: scriptStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
         suppressed: true,
       }),
     ];

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
@@ -9,12 +9,13 @@ import TestMetrics from "./TestMetrics";
 
 import ScriptResultStatus from "app/base/components/ScriptResultStatus";
 import TableHeader from "app/base/components/TableHeader";
-import { ResultType, scriptStatus } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
 import type { TSFixMe } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import type { Machine } from "app/store/machine/types";
 import type { ScriptResult } from "app/store/scriptresult/types";
+import { ScriptResultType } from "app/store/scriptresult/types";
+import { canBeSuppressed } from "app/store/scriptresult/utils";
 
 export enum ScriptResultAction {
   VIEW_METRICS = "viewMetrics",
@@ -33,15 +34,6 @@ type Props = {
   scriptResults: ScriptResult[];
 };
 
-const canBeSuppressed = (result: ScriptResult) =>
-  result.result_type === ResultType.Testing &&
-  [
-    scriptStatus.FAILED_APPLYING_NETCONF,
-    scriptStatus.FAILED_INSTALLING,
-    scriptStatus.FAILED,
-    scriptStatus.TIMEDOUT,
-  ].includes(result.status);
-
 const MachineTestsTable = ({
   machineId,
   scriptResults,
@@ -51,7 +43,7 @@ const MachineTestsTable = ({
   const [expanded, setExpanded] = useState<Expanded | null>(null);
   const closeExpanded = () => setExpanded(null);
   const containsTesting = scriptResults.some(
-    (result) => result.result_type === ResultType.Testing
+    (result) => result.result_type === ScriptResultType.TESTING
   );
   const rows: TSFixMe = [];
 

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.test.tsx
@@ -4,8 +4,8 @@ import { MemoryRouter } from "react-router";
 
 import TestActions from "./TestActions";
 
-import { scriptStatus } from "app/base/enum";
 import * as hooks from "app/base/hooks";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 import {
   scriptResult as scriptResultFactory,
   scriptResultResult as scriptResultResultFactory,
@@ -34,7 +34,7 @@ describe("TestActions", () => {
   it("can display an action to view commissioning script details", () => {
     const scriptResult = scriptResultFactory({
       id: 1,
-      status: scriptStatus.PASSED,
+      status: ScriptResultStatus.PASSED,
     });
     const wrapper = mount(
       <MemoryRouter
@@ -54,7 +54,7 @@ describe("TestActions", () => {
   it("can display an action to view testing script details", () => {
     const scriptResult = scriptResultFactory({
       id: 1,
-      status: scriptStatus.PASSED,
+      status: ScriptResultStatus.PASSED,
     });
     const wrapper = mount(
       <MemoryRouter initialEntries={[{ pathname: "/machine/abc123/testing" }]}>

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestActions/TestActions.tsx
@@ -4,10 +4,10 @@ import type { SetExpanded } from "../MachineTestsTable";
 import { ScriptResultAction } from "../MachineTestsTable";
 
 import TableMenu from "app/base/components/TableMenu";
-import { scriptStatus } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
 import type { TSFixMe } from "app/base/types";
 import type { ScriptResult } from "app/store/scriptresult/types";
+import { scriptResultInProgress } from "app/store/scriptresult/utils";
 
 type Props = {
   scriptResult: ScriptResult;
@@ -17,15 +17,7 @@ type Props = {
 const TestActions = ({ scriptResult, setExpanded }: Props): JSX.Element => {
   const sendAnalytics = useSendAnalytics();
   const location = useLocation();
-  const canViewDetails = [
-    scriptStatus.DEGRADED,
-    scriptStatus.FAILED_APPLYING_NETCONF,
-    scriptStatus.FAILED_INSTALLING,
-    scriptStatus.FAILED,
-    scriptStatus.PASSED,
-    scriptStatus.SKIPPED,
-    scriptStatus.TIMEDOUT,
-  ].includes(scriptResult.status);
+  const canViewDetails = !scriptResultInProgress(scriptResult.status);
   const hasMetrics = scriptResult.results.length > 0;
   // TODO - Update ContextualMenu props to be able to accept non Button props
   const links: TSFixMe = [];

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.tsx
@@ -5,11 +5,11 @@ import { Button, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import ScriptResultStatus from "app/base/components/ScriptResultStatus";
-import { ResultType } from "app/base/enum";
 import type { RootState } from "app/store/root/types";
 import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultSelectors from "app/store/scriptresult/selectors";
 import type { ScriptResult } from "app/store/scriptresult/types";
+import { ScriptResultType } from "app/store/scriptresult/types";
 
 type Props = {
   close: () => void;
@@ -21,7 +21,7 @@ const TestHistory = ({ close, scriptResult }: Props): JSX.Element => {
   const history = useSelector((state: RootState) =>
     scriptResultSelectors.getHistoryById(state, scriptResult.id)
   );
-  const isTesting = scriptResult.result_type === ResultType.Testing;
+  const isTesting = scriptResult.result_type === ScriptResultType.TESTING;
 
   useEffect(() => {
     dispatch(scriptResultActions.getHistory(scriptResult.id));

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
@@ -2,9 +2,8 @@ import { mount } from "enzyme";
 
 import NodeDevicesWarning from "./NodeDevicesWarning";
 
-import { nodeStatus } from "app/base/enum";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
-import { NodeActions } from "app/store/types/node";
+import { NodeActions, NodeStatusCode } from "app/store/types/node";
 import {
   machineDetails as machineDetailsFactory,
   nodeDevice as nodeDeviceFactory,
@@ -55,7 +54,7 @@ describe("NodeDevicesWarning", () => {
 
   it("shows a message if the machine has no node devices and is in failed testing state", () => {
     const machine = machineDetailsFactory({
-      status_code: nodeStatus.FAILED_TESTING,
+      status_code: NodeStatusCode.FAILED_TESTING,
     });
     const wrapper = mount(
       <NodeDevicesWarning
@@ -73,7 +72,7 @@ describe("NodeDevicesWarning", () => {
 
   it("shows a message if the machine has no node devices and is deployed", () => {
     const machine = machineDetailsFactory({
-      status_code: nodeStatus.DEPLOYED,
+      status_code: NodeStatusCode.DEPLOYED,
     });
     const wrapper = mount(
       <NodeDevicesWarning
@@ -92,7 +91,7 @@ describe("NodeDevicesWarning", () => {
   it("shows a message if the machine has no node devices and is commissioning", () => {
     const machine = machineDetailsFactory({
       locked: false,
-      status_code: nodeStatus.COMMISSIONING,
+      status_code: NodeStatusCode.COMMISSIONING,
     });
     const wrapper = mount(
       <NodeDevicesWarning
@@ -112,7 +111,7 @@ describe("NodeDevicesWarning", () => {
     const machine = machineDetailsFactory({
       actions: [],
       locked: false,
-      status_code: nodeStatus.NEW,
+      status_code: NodeStatusCode.NEW,
     });
     const wrapper = mount(
       <NodeDevicesWarning

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
@@ -2,11 +2,10 @@ import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 
 import type { SetSelectedAction } from "../../types";
 
-import { nodeStatus } from "app/base/enum";
 import type { MachineDetails } from "app/store/machine/types";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
 import type { NodeDevice } from "app/store/nodedevice/types";
-import { NodeActions } from "app/store/types/node";
+import { NodeActions, NodeStatusCode } from "app/store/types/node";
 
 type Props = {
   bus: NodeDeviceBus;
@@ -36,13 +35,13 @@ const NodeDevicesWarning = ({
       if (machine.locked) {
         warningMessage =
           "The machine is locked. Unlock and release this machine before commissioning to load PCI and USB device information.";
-      } else if (machine.status_code === nodeStatus.FAILED_TESTING) {
+      } else if (machine.status_code === NodeStatusCode.FAILED_TESTING) {
         warningMessage =
           "Override failed testing before commissioning to load PCI and USB device information.";
-      } else if (machine.status_code === nodeStatus.DEPLOYED) {
+      } else if (machine.status_code === NodeStatusCode.DEPLOYED) {
         warningMessage =
           "Release this machine before commissioning to load PCI and USB device information.";
-      } else if (machine.status_code === nodeStatus.COMMISSIONING) {
+      } else if (machine.status_code === NodeStatusCode.COMMISSIONING) {
         warningMessage = "Commissioning is currently in progress...";
       } else {
         warningMessage = "Commissioning cannot be run at this time.";

--- a/ui/src/app/machines/views/MachineList/MachineList.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineList.test.js
@@ -5,7 +5,8 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import MachineList from "./MachineList";
-import { nodeStatus, scriptStatus } from "app/base/enum";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
+import { NodeStatusCode } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -44,7 +45,7 @@ describe("MachineList", () => {
             architecture: "amd64/generic",
             cpu_count: 4,
             cpu_test_status: {
-              status: scriptStatus.RUNNING,
+              status: ScriptResultStatus.RUNNING,
             },
             distro_series: "bionic",
             domain: {
@@ -56,10 +57,10 @@ describe("MachineList", () => {
             ip_addresses: [],
             memory: 8,
             memory_test_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             network_test_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             osystem: "ubuntu",
             owner: "admin",
@@ -69,14 +70,14 @@ describe("MachineList", () => {
             pxe_mac: "00:11:22:33:44:55",
             spaces: [],
             status: "Deployed",
-            status_code: nodeStatus.DEPLOYED,
+            status_code: NodeStatusCode.DEPLOYED,
             status_message: "",
             storage: 8,
             storage_test_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             testing_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             system_id: "abc123",
             zone: {},
@@ -86,7 +87,7 @@ describe("MachineList", () => {
             architecture: "amd64/generic",
             cpu_count: 2,
             cpu_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             distro_series: "xenial",
             domain: {
@@ -98,10 +99,10 @@ describe("MachineList", () => {
             ip_addresses: [],
             memory: 6,
             memory_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             network_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             osystem: "ubuntu",
             owner: "user",
@@ -111,14 +112,14 @@ describe("MachineList", () => {
             pxe_mac: "66:77:88:99:00:11",
             spaces: [],
             status: "Releasing",
-            status_code: nodeStatus.RELEASING,
+            status_code: NodeStatusCode.RELEASING,
             status_message: "",
             storage: 16,
             storage_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             testing_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             system_id: "def456",
             zone: {},
@@ -128,7 +129,7 @@ describe("MachineList", () => {
             architecture: "amd64/generic",
             cpu_count: 2,
             cpu_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             distro_series: "xenial",
             domain: {
@@ -140,10 +141,10 @@ describe("MachineList", () => {
             ip_addresses: [],
             memory: 6,
             memory_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             network_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             osystem: "ubuntu",
             owner: "user",
@@ -153,14 +154,14 @@ describe("MachineList", () => {
             pxe_mac: "66:77:88:99:00:11",
             spaces: [],
             status: "Releasing",
-            status_code: nodeStatus.DEPLOYED,
+            status_code: NodeStatusCode.DEPLOYED,
             status_message: "",
             storage: 16,
             storage_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             testing_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             system_id: "ghi789",
             zone: {},

--- a/ui/src/app/machines/views/MachineList/MachineListTable/DisksColumn/DisksColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/DisksColumn/DisksColumn.test.js
@@ -3,8 +3,9 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import { scriptStatus } from "app/base/enum";
 import { DisksColumn } from "./DisksColumn";
+
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 
 const mockStore = configureStore();
 
@@ -65,7 +66,7 @@ describe("DisksColumn", () => {
 
   it("correctly shows error icon and tooltip if storage tests failed", () => {
     state.machine.items[0].storage_test_status = {
-      status: scriptStatus.FAILED,
+      status: ScriptResultStatus.FAILED,
     };
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -22,7 +22,6 @@ import ZoneColumn from "./ZoneColumn";
 import { actions as machineActions } from "app/store/machine";
 import { general as generalActions } from "app/base/actions";
 import TableHeader from "app/base/components/TableHeader";
-import { nodeStatus } from "app/base/enum";
 import { useTableSort } from "app/base/hooks";
 import {
   filtersToString,
@@ -31,6 +30,7 @@ import {
 } from "app/machines/search";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import { actions as tagActions } from "app/store/tag";
+import { NodeStatusCode } from "app/store/types/node";
 import { actions as zoneActions } from "app/store/zone";
 import {
   generateCheckboxHandlers,
@@ -269,68 +269,68 @@ const generateGroups = (grouping, machines) => {
       {
         label: "Failed",
         machines: [
-          ...(groupMap.get(nodeStatus.FAILED_COMMISSIONING) || []),
-          ...(groupMap.get(nodeStatus.FAILED_DEPLOYMENT) || []),
-          ...(groupMap.get(nodeStatus.FAILED_DISK_ERASING) || []),
-          ...(groupMap.get(nodeStatus.FAILED_ENTERING_RESCUE_MODE) || []),
-          ...(groupMap.get(nodeStatus.FAILED_EXITING_RESCUE_MODE) || []),
-          ...(groupMap.get(nodeStatus.FAILED_RELEASING) || []),
-          ...(groupMap.get(nodeStatus.FAILED_TESTING) || []),
+          ...(groupMap.get(NodeStatusCode.FAILED_COMMISSIONING) || []),
+          ...(groupMap.get(NodeStatusCode.FAILED_DEPLOYMENT) || []),
+          ...(groupMap.get(NodeStatusCode.FAILED_DISK_ERASING) || []),
+          ...(groupMap.get(NodeStatusCode.FAILED_ENTERING_RESCUE_MODE) || []),
+          ...(groupMap.get(NodeStatusCode.FAILED_EXITING_RESCUE_MODE) || []),
+          ...(groupMap.get(NodeStatusCode.FAILED_RELEASING) || []),
+          ...(groupMap.get(NodeStatusCode.FAILED_TESTING) || []),
         ],
       },
       {
         label: "New",
-        machines: groupMap.get(nodeStatus.NEW) || [],
+        machines: groupMap.get(NodeStatusCode.NEW) || [],
       },
       {
         label: "Commissioning",
-        machines: groupMap.get(nodeStatus.COMMISSIONING) || [],
+        machines: groupMap.get(NodeStatusCode.COMMISSIONING) || [],
       },
       {
         label: "Testing",
-        machines: groupMap.get(nodeStatus.TESTING) || [],
+        machines: groupMap.get(NodeStatusCode.TESTING) || [],
       },
       {
         label: "Ready",
-        machines: groupMap.get(nodeStatus.READY) || [],
+        machines: groupMap.get(NodeStatusCode.READY) || [],
       },
       {
         label: "Allocated",
-        machines: groupMap.get(nodeStatus.ALLOCATED) || [],
+        machines: groupMap.get(NodeStatusCode.ALLOCATED) || [],
       },
       {
         label: "Deploying",
-        machines: groupMap.get(nodeStatus.DEPLOYING) || [],
+        machines: groupMap.get(NodeStatusCode.DEPLOYING) || [],
       },
       {
         label: "Deployed",
-        machines: groupMap.get(nodeStatus.DEPLOYED) || [],
+        machines: groupMap.get(NodeStatusCode.DEPLOYED) || [],
       },
       {
         label: "Rescue mode",
         machines: [
-          ...(groupMap.get(nodeStatus.ENTERING_RESCUE_MODE) || []),
-          ...(groupMap.get(nodeStatus.EXITING_RESCUE_MODE) || []),
-          ...(groupMap.get(nodeStatus.RESCUE_MODE) || []),
+          ...(groupMap.get(NodeStatusCode.ENTERING_RESCUE_MODE) || []),
+          ...(groupMap.get(NodeStatusCode.EXITING_RESCUE_MODE) || []),
+          ...(groupMap.get(NodeStatusCode.RESCUE_MODE) || []),
         ],
       },
       {
         label: "Releasing",
         machines: [
-          ...(groupMap.get(nodeStatus.DISK_ERASING) || []),
-          ...(groupMap.get(nodeStatus.RELEASING) || []),
+          ...(groupMap.get(NodeStatusCode.DISK_ERASING) || []),
+          ...(groupMap.get(NodeStatusCode.RELEASING) || []),
         ],
       },
       {
         label: "Broken",
-        machines: groupMap.get(nodeStatus.BROKEN) || [],
+        machines: groupMap.get(NodeStatusCode.BROKEN) || [],
       },
       {
         label: "Other",
         machines: [
-          ...(groupMap.get(nodeStatus.MISSING) || []),
-          ...(groupMap.get(nodeStatus.RESERVED) || []),
-          ...(groupMap.get(nodeStatus.RETIRED) || []),
+          ...(groupMap.get(NodeStatusCode.MISSING) || []),
+          ...(groupMap.get(NodeStatusCode.RESERVED) || []),
+          ...(groupMap.get(NodeStatusCode.RETIRED) || []),
         ],
       },
     ].filter((group) => group.machines.length);

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.js
@@ -3,14 +3,16 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
+import { MachineListTable } from "./MachineListTable";
+
+import { ScriptResultStatus } from "app/store/scriptresult/types";
+import { NodeStatusCode } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { MachineListTable } from "./MachineListTable";
-import { nodeStatus, scriptStatus } from "app/base/enum";
 
 const mockStore = configureStore();
 
@@ -25,7 +27,7 @@ describe("MachineListTable", () => {
         architecture: "amd64/generic",
         cpu_count: 4,
         cpu_test_status: {
-          status: scriptStatus.RUNNING,
+          status: ScriptResultStatus.RUNNING,
         },
         distro_series: "bionic",
         domain: {
@@ -37,10 +39,10 @@ describe("MachineListTable", () => {
         ip_addresses: [],
         memory: 8,
         memory_test_status: {
-          status: scriptStatus.PASSED,
+          status: ScriptResultStatus.PASSED,
         },
         network_test_status: {
-          status: scriptStatus.PASSED,
+          status: ScriptResultStatus.PASSED,
         },
         osystem: "ubuntu",
         owner: "admin",
@@ -50,14 +52,14 @@ describe("MachineListTable", () => {
         pxe_mac: "00:11:22:33:44:55",
         spaces: [],
         status: "Deployed",
-        status_code: nodeStatus.DEPLOYED,
+        status_code: NodeStatusCode.DEPLOYED,
         status_message: "",
         storage: 8,
         storage_test_status: {
-          status: scriptStatus.PASSED,
+          status: ScriptResultStatus.PASSED,
         },
         testing_status: {
-          status: scriptStatus.PASSED,
+          status: ScriptResultStatus.PASSED,
         },
         system_id: "abc123",
         zone: {},
@@ -67,7 +69,7 @@ describe("MachineListTable", () => {
         architecture: "amd64/generic",
         cpu_count: 2,
         cpu_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         distro_series: "xenial",
         domain: {
@@ -79,10 +81,10 @@ describe("MachineListTable", () => {
         ip_addresses: [],
         memory: 6,
         memory_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         network_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         osystem: "ubuntu",
         owner: "user",
@@ -92,14 +94,14 @@ describe("MachineListTable", () => {
         pxe_mac: "66:77:88:99:00:11",
         spaces: [],
         status: "Releasing",
-        status_code: nodeStatus.RELEASING,
+        status_code: NodeStatusCode.RELEASING,
         status_message: "",
         storage: 16,
         storage_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         testing_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         system_id: "def456",
         zone: {},
@@ -109,7 +111,7 @@ describe("MachineListTable", () => {
         architecture: "amd64/generic",
         cpu_count: 2,
         cpu_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         distro_series: "xenial",
         domain: {
@@ -121,10 +123,10 @@ describe("MachineListTable", () => {
         ip_addresses: [],
         memory: 6,
         memory_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         network_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         osystem: "ubuntu",
         owner: "user",
@@ -134,14 +136,14 @@ describe("MachineListTable", () => {
         pxe_mac: "66:77:88:99:00:11",
         spaces: [],
         status: "Releasing",
-        status_code: nodeStatus.DEPLOYED,
+        status_code: NodeStatusCode.DEPLOYED,
         status_message: "",
         storage: 16,
         storage_test_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         testing_status: {
-          status: scriptStatus.FAILED,
+          status: ScriptResultStatus.FAILED,
         },
         system_id: "ghi789",
         zone: {},
@@ -396,7 +398,7 @@ describe("MachineListTable", () => {
 
   it("displays correct selected string in group header", () => {
     const state = { ...initialState };
-    machines[1].status_code = nodeStatus.DEPLOYED;
+    machines[1].status_code = NodeStatusCode.DEPLOYED;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -484,7 +486,7 @@ describe("MachineListTable", () => {
 
     it("shows a checked checkbox in header row if all machines are selected", () => {
       const state = { ...initialState };
-      machines[1].status_code = nodeStatus.DEPLOYED;
+      machines[1].status_code = NodeStatusCode.DEPLOYED;
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/RamColumn/RamColumn.test.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/RamColumn/RamColumn.test.js
@@ -4,7 +4,8 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import { RamColumn } from "./RamColumn";
-import { scriptStatus } from "app/base/enum";
+
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 
 const mockStore = configureStore();
 
@@ -65,7 +66,9 @@ describe("RamColumn", () => {
 
   it("displays an error and tooltip if memory tests have failed", () => {
     state.machine.items[0].memory = 16;
-    state.machine.items[0].memory_test_status = { status: scriptStatus.FAILED };
+    state.machine.items[0].memory_test_status = {
+      status: ScriptResultStatus.FAILED,
+    };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -5,11 +5,14 @@ import configureStore from "redux-mock-store";
 
 import { StatusColumn } from "./StatusColumn";
 
-import { nodeStatus, scriptStatus } from "app/base/enum";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-import type { TestResult } from "app/store/types/node";
-import { NodeActions, NodeStatus } from "app/store/types/node";
+import {
+  NodeActions,
+  NodeStatus,
+  NodeStatusCode,
+  TestStatusStatus,
+} from "app/store/types/node";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -80,7 +83,7 @@ describe("StatusColumn", () => {
   describe("status text", () => {
     it("displays the machine's status if not deploying or deployed", () => {
       machine.status = NodeStatus.NEW;
-      machine.status_code = nodeStatus.NEW;
+      machine.status_code = NodeStatusCode.NEW;
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
@@ -97,7 +100,7 @@ describe("StatusColumn", () => {
 
     it("displays the short-form of Ubuntu release if deployed", () => {
       machine.status = NodeStatus.DEPLOYED;
-      machine.status_code = nodeStatus.DEPLOYED;
+      machine.status_code = NodeStatusCode.DEPLOYED;
       machine.osystem = "ubuntu";
       machine.distro_series = "bionic";
       const store = mockStore(state);
@@ -118,7 +121,7 @@ describe("StatusColumn", () => {
 
     it("displays the full OS and release if non-Ubuntu deployed", () => {
       machine.status = NodeStatus.DEPLOYED;
-      machine.status_code = nodeStatus.DEPLOYED;
+      machine.status_code = NodeStatusCode.DEPLOYED;
       machine.osystem = "centos";
       machine.distro_series = "centos70";
       const store = mockStore(state);
@@ -137,7 +140,7 @@ describe("StatusColumn", () => {
 
     it("displays 'Deploying OS release' if machine is deploying", () => {
       machine.status = NodeStatus.DEPLOYING;
-      machine.status_code = nodeStatus.DEPLOYING;
+      machine.status_code = NodeStatusCode.DEPLOYING;
       machine.osystem = "ubuntu";
       machine.distro_series = "bionic";
       const store = mockStore(state);
@@ -159,7 +162,7 @@ describe("StatusColumn", () => {
     it("displays an error message for broken machines", () => {
       machine.error_description = "machine is on fire";
       machine.status = NodeStatus.BROKEN;
-      machine.status_code = nodeStatus.BROKEN;
+      machine.status_code = NodeStatusCode.BROKEN;
       const store = mockStore(state);
 
       const wrapper = mount(
@@ -181,7 +184,7 @@ describe("StatusColumn", () => {
   describe("progress text", () => {
     it("displays the machine's status_message if in a transient state", () => {
       machine.status = NodeStatus.TESTING;
-      machine.status_code = nodeStatus.TESTING;
+      machine.status_code = NodeStatusCode.TESTING;
       machine.status_message = "2 of 6 tests complete";
       const store = mockStore(state);
       const wrapper = mount(
@@ -202,7 +205,7 @@ describe("StatusColumn", () => {
     it(`does not display the machine's status_message if
       not in a transient state`, () => {
       machine.status = NodeStatus.ALLOCATED;
-      machine.status_code = nodeStatus.ALLOCATED;
+      machine.status_code = NodeStatusCode.ALLOCATED;
       machine.status_message = "This machine is allocated";
       const store = mockStore(state);
       const wrapper = mount(
@@ -222,7 +225,7 @@ describe("StatusColumn", () => {
   describe("status icon", () => {
     it("shows a spinner if machine is in a transient state", () => {
       machine.status = NodeStatus.COMMISSIONING;
-      machine.status_code = nodeStatus.COMMISSIONING;
+      machine.status_code = NodeStatusCode.COMMISSIONING;
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>
@@ -240,8 +243,8 @@ describe("StatusColumn", () => {
     it(`shows a warning and tooltip if machine has failed tests and is not in a
       state where the warning should be hidden`, () => {
       machine.status = NodeStatus.ALLOCATED;
-      machine.status_code = nodeStatus.ALLOCATED;
-      machine.testing_status.status = scriptStatus.FAILED as TestResult;
+      machine.status_code = NodeStatusCode.ALLOCATED;
+      machine.testing_status.status = TestStatusStatus.FAILED;
       const store = mockStore(state);
       const wrapper = mount(
         <Provider store={store}>

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -7,43 +7,37 @@ import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import type { Props as TableMenuProps } from "app/base/components/TableMenu/TableMenu";
-import { nodeStatus, scriptStatus } from "app/base/enum";
 import { useMachineActions } from "app/base/hooks";
 import { useToggleMenu } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
-import { NodeActions } from "app/store/types/node";
+import {
+  NodeActions,
+  NodeStatusCode,
+  TestStatusStatus,
+} from "app/store/types/node";
 import { getStatusText } from "app/utils";
 
 // Node statuses for which the failed test warning is not shown.
 const hideFailedTestWarningStatuses = [
-  nodeStatus.COMMISSIONING,
-  nodeStatus.FAILED_COMMISSIONING,
-  nodeStatus.FAILED_TESTING,
-  nodeStatus.NEW,
-  nodeStatus.TESTING,
+  NodeStatusCode.COMMISSIONING,
+  NodeStatusCode.FAILED_COMMISSIONING,
+  NodeStatusCode.FAILED_TESTING,
+  NodeStatusCode.NEW,
+  NodeStatusCode.TESTING,
 ];
 
 // Node statuses that are temporary.
 const transientStatuses = [
-  nodeStatus.COMMISSIONING,
-  nodeStatus.DEPLOYING,
-  nodeStatus.DISK_ERASING,
-  nodeStatus.ENTERING_RESCUE_MODE,
-  nodeStatus.EXITING_RESCUE_MODE,
-  nodeStatus.RELEASING,
-  nodeStatus.TESTING,
-];
-
-// Script statuses associated with failure.
-const failedScriptStatuses = [
-  scriptStatus.DEGRADED,
-  scriptStatus.FAILED,
-  scriptStatus.FAILED_APPLYING_NETCONF,
-  scriptStatus.FAILED_INSTALLING,
-  scriptStatus.TIMEDOUT,
+  NodeStatusCode.COMMISSIONING,
+  NodeStatusCode.DEPLOYING,
+  NodeStatusCode.DISK_ERASING,
+  NodeStatusCode.ENTERING_RESCUE_MODE,
+  NodeStatusCode.EXITING_RESCUE_MODE,
+  NodeStatusCode.RELEASING,
+  NodeStatusCode.TESTING,
 ];
 
 const getProgressText = (machine: Machine) => {
@@ -57,7 +51,7 @@ const getStatusIcon = (machine: Machine) => {
   if (transientStatuses.includes(machine.status_code)) {
     return <Spinner data-test="status-icon" />;
   } else if (
-    failedScriptStatuses.includes(machine.testing_status.status) &&
+    machine.testing_status.status === TestStatusStatus.FAILED &&
     !hideFailedTestWarningStatuses.includes(machine.status_code)
   ) {
     return (
@@ -145,7 +139,7 @@ export const StatusColumn = ({
             </span>
             <span data-test="error-text">
               {machine.error_description &&
-              machine.status_code === nodeStatus.BROKEN
+              machine.status_code === NodeStatusCode.BROKEN
                 ? machine.error_description
                 : ""}
             </span>

--- a/ui/src/app/machines/views/Machines.test.js
+++ b/ui/src/app/machines/views/Machines.test.js
@@ -5,8 +5,8 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import Machines from "./Machines";
-import { NodeActions } from "app/store/types/node";
-import { nodeStatus, scriptStatus } from "app/base/enum";
+import { NodeActions, NodeStatusCode } from "app/store/types/node";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -48,7 +48,7 @@ describe("Machines", () => {
             architecture: "amd64/generic",
             cpu_count: 4,
             cpu_test_status: {
-              status: scriptStatus.RUNNING,
+              status: ScriptResultStatus.RUNNING,
             },
             distro_series: "bionic",
             domain: {
@@ -60,10 +60,10 @@ describe("Machines", () => {
             ip_addresses: [],
             memory: 8,
             memory_test_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             network_test_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             osystem: "ubuntu",
             owner: "admin",
@@ -73,14 +73,14 @@ describe("Machines", () => {
             pxe_mac: "00:11:22:33:44:55",
             spaces: [],
             status: "Deployed",
-            status_code: nodeStatus.DEPLOYED,
+            status_code: NodeStatusCode.DEPLOYED,
             status_message: "",
             storage: 8,
             storage_test_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             testing_status: {
-              status: scriptStatus.PASSED,
+              status: ScriptResultStatus.PASSED,
             },
             system_id: "abc123",
             zone: {},
@@ -90,7 +90,7 @@ describe("Machines", () => {
             architecture: "amd64/generic",
             cpu_count: 2,
             cpu_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             distro_series: "xenial",
             domain: {
@@ -102,10 +102,10 @@ describe("Machines", () => {
             ip_addresses: [],
             memory: 6,
             memory_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             network_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             osystem: "ubuntu",
             owner: "user",
@@ -115,14 +115,14 @@ describe("Machines", () => {
             pxe_mac: "66:77:88:99:00:11",
             spaces: [],
             status: "Releasing",
-            status_code: nodeStatus.RELEASING,
+            status_code: NodeStatusCode.RELEASING,
             status_message: "",
             storage: 16,
             storage_test_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             testing_status: {
-              status: scriptStatus.FAILED,
+              status: ScriptResultStatus.FAILED,
             },
             system_id: "def456",
             zone: {},

--- a/ui/src/app/store/machine/utils/hooks.test.tsx
+++ b/ui/src/app/store/machine/utils/hooks.test.tsx
@@ -16,11 +16,10 @@ import {
   useIsRackControllerConnected,
 } from "./hooks";
 
-import { nodeStatus } from "app/base/enum";
 import type { Machine } from "app/store/machine/types";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-import { NodeStatus } from "app/store/types/node";
+import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
   architecturesState as architecturesStateFactory,
   fabric as fabricFactory,
@@ -125,7 +124,7 @@ describe("machine hook utils", () => {
     it("handles a machine with editable storage", () => {
       const machine = machineFactory({
         locked: false,
-        status_code: nodeStatus.READY,
+        status_code: NodeStatusCode.READY,
         permissions: ["edit"],
       });
       const store = mockStore(state);
@@ -138,7 +137,7 @@ describe("machine hook utils", () => {
     it("handles a machine without editable storage", () => {
       const machine = machineFactory({
         locked: false,
-        status_code: nodeStatus.NEW,
+        status_code: NodeStatusCode.NEW,
         permissions: ["edit"],
       });
       const store = mockStore(state);

--- a/ui/src/app/store/machine/utils/storage.test.ts
+++ b/ui/src/app/store/machine/utils/storage.test.ts
@@ -34,9 +34,9 @@ import {
   usesStorage,
 } from "./storage";
 
-import { nodeStatus } from "app/base/enum";
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import { DiskTypes, StorageLayout } from "app/store/machine/types";
+import { NodeStatusCode } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineDisk as diskFactory,
@@ -727,12 +727,12 @@ describe("machine storage utils", () => {
     it("handles a machine in a configurable state", () => {
       expect(
         isMachineStorageConfigurable(
-          machineFactory({ status_code: nodeStatus.READY })
+          machineFactory({ status_code: NodeStatusCode.READY })
         )
       ).toBe(true);
       expect(
         isMachineStorageConfigurable(
-          machineFactory({ status_code: nodeStatus.ALLOCATED })
+          machineFactory({ status_code: NodeStatusCode.ALLOCATED })
         )
       ).toBe(true);
     });
@@ -740,7 +740,7 @@ describe("machine storage utils", () => {
     it("handles a machine in a non-configurable state", () => {
       expect(
         isMachineStorageConfigurable(
-          machineFactory({ status_code: nodeStatus.NEW })
+          machineFactory({ status_code: NodeStatusCode.NEW })
         )
       ).toBe(false);
     });

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -1,4 +1,3 @@
-import { nodeStatus } from "app/base/enum";
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import { DiskTypes, StorageLayout } from "app/store/machine/types";
 import type {
@@ -7,6 +6,7 @@ import type {
   Machine,
   Partition,
 } from "app/store/machine/types";
+import { NodeStatusCode } from "app/store/types/node";
 import { formatBytes } from "app/utils";
 
 /**
@@ -397,7 +397,9 @@ export const isMachineStorageConfigurable = (
   machine?: Machine | null
 ): boolean =>
   !!machine &&
-  [nodeStatus.READY, nodeStatus.ALLOCATED].includes(machine.status_code);
+  [NodeStatusCode.READY, NodeStatusCode.ALLOCATED].includes(
+    machine.status_code
+  );
 
 /**
  * Returns whether a filesystem is mounted.

--- a/ui/src/app/store/scriptresult/selectors.test.tsx
+++ b/ui/src/app/store/scriptresult/selectors.test.tsx
@@ -1,7 +1,10 @@
 import selectors from "./selectors";
 
-import { HardwareType, ResultType } from "app/base/enum";
-import { ResultStatus } from "app/store/scriptresult/types";
+import { HardwareType } from "app/base/enum";
+import {
+  ScriptResultStatus,
+  ScriptResultType,
+} from "app/store/scriptresult/types";
 import {
   nodeScriptResultState as nodeScriptResultStateFactory,
   rootState as rootStateFactory,
@@ -89,12 +92,12 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 1,
         hardware_type: HardwareType.CPU,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
     ];
     const items = [
@@ -102,11 +105,11 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 3,
         hardware_type: HardwareType.Storage,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 4,
-        result_type: ResultType.Commissioning,
+        result_type: ScriptResultType.COMMISSIONING,
       }),
     ];
 
@@ -129,13 +132,13 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 1,
         hardware_type: HardwareType.CPU,
-        result_type: ResultType.Testing,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
       }),
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
     ];
     const state = rootStateFactory({
@@ -155,7 +158,7 @@ describe("scriptResult selectors", () => {
     const commissioningResultsForMachine = scriptResultFactory({
       id: 1,
       hardware_type: HardwareType.Node,
-      result_type: ResultType.Commissioning,
+      result_type: ScriptResultType.COMMISSIONING,
     });
 
     const items = [
@@ -163,11 +166,11 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.CPU,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 3,
-        result_type: ResultType.Installation,
+        result_type: ScriptResultType.INSTALLATION,
       }),
     ];
 
@@ -190,17 +193,17 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 1,
         hardware_type: HardwareType.CPU,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 3,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
     ];
 
@@ -223,13 +226,13 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 1,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
       }),
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
     ];
     const state = rootStateFactory({
@@ -249,7 +252,7 @@ describe("scriptResult selectors", () => {
     const storageResultsForMachine = scriptResultFactory({
       id: 1,
       hardware_type: HardwareType.Storage,
-      result_type: ResultType.Testing,
+      result_type: ScriptResultType.TESTING,
     });
 
     const items = [
@@ -257,11 +260,11 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.CPU,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 3,
-        result_type: ResultType.Commissioning,
+        result_type: ScriptResultType.COMMISSIONING,
       }),
     ];
 
@@ -284,17 +287,17 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 1,
         hardware_type: HardwareType.Storage,
-        result_type: ResultType.Testing,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
       }),
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.Storage,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 3,
-        result_type: ResultType.Commissioning,
+        result_type: ScriptResultType.COMMISSIONING,
       }),
     ];
     const state = rootStateFactory({
@@ -314,7 +317,7 @@ describe("scriptResult selectors", () => {
     const otherResultsForMachine = scriptResultFactory({
       id: 1,
       hardware_type: HardwareType.Node,
-      result_type: ResultType.Testing,
+      result_type: ScriptResultType.TESTING,
     });
 
     const items = [
@@ -322,11 +325,11 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.CPU,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 3,
-        result_type: ResultType.Commissioning,
+        result_type: ScriptResultType.COMMISSIONING,
       }),
     ];
 
@@ -349,17 +352,17 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 1,
         hardware_type: HardwareType.Node,
-        result_type: ResultType.Testing,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
       }),
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.Node,
-        result_type: ResultType.Testing,
+        result_type: ScriptResultType.TESTING,
       }),
       scriptResultFactory({
         id: 3,
-        result_type: ResultType.Commissioning,
+        result_type: ScriptResultType.COMMISSIONING,
       }),
     ];
     const state = rootStateFactory({
@@ -380,39 +383,39 @@ describe("scriptResult selectors", () => {
       scriptResultFactory({
         id: 1,
         hardware_type: HardwareType.CPU,
-        result_type: ResultType.Testing,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
       }),
       scriptResultFactory({
         id: 2,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
       }),
       // Should not be returned because it passed.
       scriptResultFactory({
         id: 3,
         hardware_type: HardwareType.Network,
-        result_type: ResultType.Testing,
-        status: ResultStatus.PASSED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.PASSED,
       }),
       scriptResultFactory({
         id: 4,
         hardware_type: HardwareType.Storage,
-        result_type: ResultType.Testing,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.FAILED,
       }),
       // Should not be returned because it is not a testing script.
       scriptResultFactory({
         id: 5,
-        result_type: ResultType.Commissioning,
-        status: ResultStatus.FAILED,
+        result_type: ScriptResultType.COMMISSIONING,
+        status: ScriptResultStatus.FAILED,
       }),
       // Should not be returned because it passed.
       scriptResultFactory({
         id: 6,
-        result_type: ResultType.Testing,
-        status: ResultStatus.PASSED,
+        result_type: ScriptResultType.TESTING,
+        status: ScriptResultStatus.PASSED,
       }),
     ];
     const state = rootStateFactory({

--- a/ui/src/app/store/scriptresult/selectors.ts
+++ b/ui/src/app/store/scriptresult/selectors.ts
@@ -8,9 +8,10 @@ import type {
   ScriptResult,
   ScriptResultData,
 } from "./types";
-import { ResultStatusFailed } from "./types";
+import { ScriptResultType } from "./types";
+import { scriptResultFailed } from "./utils";
 
-import { HardwareType, ResultType } from "app/base/enum";
+import { HardwareType } from "app/base/enum";
 import type { TSFixMe } from "app/base/types";
 import type { NodeScriptResultState } from "app/store/nodescriptresult/types";
 import type { RootState } from "app/store/root/types";
@@ -111,9 +112,7 @@ const getResult = (
 const getFailed = (results: ScriptResult[] | null): ScriptResult[] | null => {
   if (results) {
     // Filter for only the failed results.
-    return results.filter(({ status }) =>
-      Object.keys(ResultStatusFailed).includes(status.toString())
-    );
+    return results.filter(({ status }) => scriptResultFailed(status));
   }
   return results;
 };
@@ -158,7 +157,7 @@ const getHardwareTestingByMachineId = createSelector(
       nodeScriptResult,
       scriptResults,
       machineId,
-      [ResultType.Testing],
+      [ScriptResultType.TESTING],
       [HardwareType.CPU, HardwareType.Memory, HardwareType.Network]
     );
     if (failed) {
@@ -193,7 +192,7 @@ const getCommissioningByMachineId = createSelector(
       nodeScriptResult,
       scriptResults,
       machineId,
-      [ResultType.Commissioning],
+      [ScriptResultType.COMMISSIONING],
       [HardwareType.Node]
     );
     if (failed) {
@@ -228,7 +227,7 @@ const getNetworkTestingByMachineId = createSelector(
       nodeScriptResult,
       scriptResults,
       machineId,
-      [ResultType.Testing],
+      [ScriptResultType.TESTING],
       [HardwareType.Network]
     );
     if (failed) {
@@ -263,7 +262,7 @@ const getStorageTestingByMachineId = createSelector(
       nodeScriptResult,
       scriptResults,
       machineId,
-      [ResultType.Testing],
+      [ScriptResultType.TESTING],
       [HardwareType.Storage]
     );
     if (failed) {
@@ -298,7 +297,7 @@ const getOtherTestingByMachineId = createSelector(
       nodeScriptResult,
       scriptResults,
       machineId,
-      [ResultType.Testing],
+      [ScriptResultType.TESTING],
       [HardwareType.Node]
     );
     if (failed) {
@@ -324,7 +323,7 @@ const getFailedTestingResultsByMachineIds = createSelector(
   (nodeScriptResult, scriptResults, machineIds): MachineScriptResults =>
     (machineIds || []).reduce<MachineScriptResults>((grouped, machineId) => {
       let results = getResult(nodeScriptResult, scriptResults, machineId, [
-        ResultType.Testing,
+        ScriptResultType.TESTING,
       ]);
       results = getFailed(results);
       if (results) {

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -1,19 +1,18 @@
 import type { NetworkInterface } from "../machine/types";
 
-import type {
-  HardwareType,
-  ResultType,
-  ScriptResultParamType,
-} from "app/base/enum";
+import type { HardwareType } from "app/base/enum";
 import type { TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
-export enum ExitStatus {
-  PASSED = 0,
+export enum ScriptResultType {
+  COMMISSIONING = 0,
+  INSTALLATION = 1,
+  TESTING = 2,
 }
 
-export enum ResultStatus {
+export enum ScriptResultStatus {
+  NONE = -1,
   PENDING = 0,
   RUNNING = 1,
   PASSED = 2,
@@ -28,11 +27,11 @@ export enum ResultStatus {
   FAILED_APPLYING_NETCONF = 11,
 }
 
-export enum ResultStatusFailed {
-  FAILED = ResultStatus.FAILED,
-  TIMEDOUT = ResultStatus.TIMEDOUT,
-  FAILED_INSTALLING = ResultStatus.FAILED_INSTALLING,
-  FAILED_APPLYING_NETCONF = ResultStatus.FAILED_APPLYING_NETCONF,
+export enum ScriptResultParamType {
+  INTERFACE = "interface",
+  RUNTIME = "runtime",
+  STORAGE = "storage",
+  URL = "url",
 }
 
 export type ScriptResultResult = {
@@ -48,7 +47,7 @@ export type PartialScriptResult = Model & {
   estimated_runtime: string;
   runtime: string;
   starttime: number;
-  status: ResultStatus;
+  status: ScriptResultStatus;
   status_name: string;
   suppressed: boolean;
   updated?: string;
@@ -56,13 +55,13 @@ export type PartialScriptResult = Model & {
 
 export type ScriptResult = PartialScriptResult & {
   ended?: string;
-  exit_status?: ExitStatus | number | null;
+  exit_status?: number | null;
   hardware_type: HardwareType;
   interface?: NetworkInterface | null;
   name: string;
   parameters?: {
     interface?: {
-      type: ScriptResultParamType.Interface;
+      type: ScriptResultParamType.INTERFACE;
       value: {
         name: string;
         mac_address: string;
@@ -72,12 +71,12 @@ export type ScriptResult = PartialScriptResult & {
       argument_format?: string;
     };
     runtime?: {
-      type: ScriptResultParamType.Runtime;
+      type: ScriptResultParamType.RUNTIME;
       value: number;
       argument_format?: string;
     };
     storage?: {
-      type: ScriptResultParamType.Storage;
+      type: ScriptResultParamType.STORAGE;
       value?: {
         id_path: string | null;
         model: string;
@@ -88,13 +87,13 @@ export type ScriptResult = PartialScriptResult & {
       argument_format?: string;
     };
     url?: {
-      type: ScriptResultParamType.Url;
+      type: ScriptResultParamType.URL;
       value: string;
       argument_format?: string;
     };
   };
   physical_blockdevice?: number | null;
-  result_type: ResultType;
+  result_type: ScriptResultType;
   results: ScriptResultResult[];
   script?: number;
   script_version?: number | null;

--- a/ui/src/app/store/scriptresult/utils.ts
+++ b/ui/src/app/store/scriptresult/utils.ts
@@ -1,0 +1,38 @@
+import type { ScriptResult } from "./types";
+import { ScriptResultStatus, ScriptResultType } from "./types";
+
+/**
+ * Determine whether a script's result status should be considered "failed".
+ * @param status - The script result's status.
+ * @returns Whether the script result should be considered "failed".
+ */
+export const scriptResultFailed = (status: ScriptResultStatus): boolean =>
+  [
+    ScriptResultStatus.DEGRADED,
+    ScriptResultStatus.FAILED_APPLYING_NETCONF,
+    ScriptResultStatus.FAILED_INSTALLING,
+    ScriptResultStatus.FAILED,
+    ScriptResultStatus.TIMEDOUT,
+  ].includes(status);
+
+/**
+ * Determine whether a script's result status should be considered "in progress".
+ * @param status - The script result's status.
+ * @returns Whether the script result should be considered "in progress".
+ */
+export const scriptResultInProgress = (status: ScriptResultStatus): boolean =>
+  [
+    ScriptResultStatus.APPLYING_NETCONF,
+    ScriptResultStatus.INSTALLING,
+    ScriptResultStatus.PENDING,
+    ScriptResultStatus.RUNNING,
+  ].includes(status);
+
+/**
+ * Check whether a script result can be suppressed.
+ * @param result - A script result.
+ * @returns Whether the script result can be suppressed.
+ */
+export const canBeSuppressed = (scriptResult: ScriptResult): boolean =>
+  scriptResult.result_type === ScriptResultType.TESTING &&
+  scriptResultFailed(scriptResult.status);

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -3,30 +3,57 @@ import type { Device } from "app/store/device/types";
 import type { Machine } from "app/store/machine/types";
 import type { Model, ModelRef } from "app/store/types/model";
 
-export type TestResult = -1 | 0 | 1 | 2 | 3;
-
-export type TestStatus = {
-  status: TestResult;
-  pending: number;
-  running: number;
-  passed: number;
-  failed: number;
-};
-
-/**
- * SimpleNode represents the intersection of Devices, Machines and Controllers
- */
-export type SimpleNode = Model & {
-  actions: string[];
-  domain: ModelRef;
-  hostname: string;
-  fqdn: string;
-  link_type: string;
-  node_type_display: string;
-  permissions: string[];
-  system_id: string;
-  tags: string[];
-};
+export enum NodeStatusCode {
+  // The node has been created and has a system ID assigned to it.
+  NEW = 0,
+  // Testing and other commissioning steps are taking place.
+  COMMISSIONING = 1,
+  // The commissioning step failed.
+  FAILED_COMMISSIONING = 2,
+  // The node can't be contacted.
+  MISSING = 3,
+  // The node is in the general pool ready to be deployed.
+  READY = 4,
+  // The node is ready for named deployment.
+  RESERVED = 5,
+  // The node has booted into the operating system of its owner's choice
+  // and is ready for use.
+  DEPLOYED = 6,
+  // The node has been removed from service manually until an admin
+  // overrides the retirement.
+  RETIRED = 7,
+  // The node is broken: a step in the node lifecycle failed.
+  // More details can be found in the node's event log.
+  BROKEN = 8,
+  // The node is being installed.
+  DEPLOYING = 9,
+  // The node has been allocated to a user and is ready for deployment.
+  ALLOCATED = 10,
+  // The deployment of the node failed.
+  FAILED_DEPLOYMENT = 11,
+  // The node is powering down after a release request.
+  RELEASING = 12,
+  // The releasing of the node failed.
+  FAILED_RELEASING = 13,
+  // The node is erasing its disks.
+  DISK_ERASING = 14,
+  // The node failed to erase its disks.
+  FAILED_DISK_ERASING = 15,
+  // The node is in rescue mode.
+  RESCUE_MODE = 16,
+  // The node is entering rescue mode.
+  ENTERING_RESCUE_MODE = 17,
+  // The node failed to enter rescue mode.
+  FAILED_ENTERING_RESCUE_MODE = 18,
+  // The node is exiting rescue mode.
+  EXITING_RESCUE_MODE = 19,
+  // The node failed to exit rescue mode.
+  FAILED_EXITING_RESCUE_MODE = 20,
+  // Running tests on Node
+  TESTING = 21,
+  // Testing has failed
+  FAILED_TESTING = 22,
+}
 
 export enum NodeStatus {
   ALLOCATED = "Allocated",
@@ -77,6 +104,37 @@ export enum NodeActions {
   UNLOCK = "unlock",
 }
 
+export enum TestStatusStatus {
+  NONE = -1,
+  PENDING = 0,
+  RUNNING = 1,
+  PASSED = 2,
+  FAILED = 3,
+}
+
+export type TestStatus = {
+  status: TestStatusStatus;
+  pending: number;
+  running: number;
+  passed: number;
+  failed: number;
+};
+
+/**
+ * SimpleNode represents the intersection of Devices, Machines and Controllers
+ */
+export type SimpleNode = Model & {
+  actions: string[];
+  domain: ModelRef;
+  hostname: string;
+  fqdn: string;
+  link_type: string;
+  node_type_display: string;
+  permissions: string[];
+  system_id: string;
+  tags: string[];
+};
+
 /**
  * BaseNode represents the intersection of Machines and Controllers
  */
@@ -97,7 +155,7 @@ export type BaseNode = SimpleNode & {
   pool?: ModelRef;
   status: NodeStatus;
   status_message: string;
-  status_code: number;
+  status_code: NodeStatusCode;
   storage_test_status: TestStatus;
 };
 

--- a/ui/src/app/utils/getStatusText.test.ts
+++ b/ui/src/app/utils/getStatusText.test.ts
@@ -1,20 +1,19 @@
 import { getStatusText } from "./getStatusText";
 
-import { nodeStatus } from "app/base/enum";
-import { NodeStatus } from "app/store/types/node";
+import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 import { machine as machineFactory } from "testing/factories";
 
 describe("getStatusText", () => {
   it("displays the machine's status if not deploying or deployed", () => {
     const machine = machineFactory({
       status: NodeStatus.NEW,
-      status_code: nodeStatus.NEW,
+      status_code: NodeStatusCode.NEW,
     });
     expect(getStatusText(machine, "Ubuntu 18.04 LTS")).toEqual("New");
   });
 
   it("displays the release name if machine is deployed", () => {
-    const machine = machineFactory({ status_code: nodeStatus.DEPLOYED });
+    const machine = machineFactory({ status_code: NodeStatusCode.DEPLOYED });
 
     expect(getStatusText(machine, "Ubuntu 18.04 LTS")).toEqual(
       "Ubuntu 18.04 LTS"
@@ -22,7 +21,7 @@ describe("getStatusText", () => {
   });
 
   it("displays 'Deploying OS release' if machine is deploying", () => {
-    const machine = machineFactory({ status_code: nodeStatus.DEPLOYING });
+    const machine = machineFactory({ status_code: NodeStatusCode.DEPLOYING });
 
     expect(getStatusText(machine, "Ubuntu 18.04 LTS")).toEqual(
       "Deploying Ubuntu 18.04 LTS"

--- a/ui/src/app/utils/getStatusText.ts
+++ b/ui/src/app/utils/getStatusText.ts
@@ -1,8 +1,11 @@
-import { nodeStatus } from "app/base/enum";
 import type { Host } from "app/store/types/host";
+import { NodeStatusCode } from "app/store/types/node";
 
 // Node statuses for which the OS + release is made human-readable.
-const formattedReleaseStatuses = [nodeStatus.DEPLOYED, nodeStatus.DEPLOYING];
+const formattedReleaseStatuses = [
+  NodeStatusCode.DEPLOYED,
+  NodeStatusCode.DEPLOYING,
+];
 
 /**
  * Returns formatted status text of a given node.
@@ -15,7 +18,7 @@ export const getStatusText = (node: Host | null, release: string): string => {
     return "Unknown";
   }
   if (release && formattedReleaseStatuses.includes(node.status_code)) {
-    return node.status_code === nodeStatus.DEPLOYING
+    return node.status_code === NodeStatusCode.DEPLOYING
       ? `Deploying ${release}`
       : release;
   }


### PR DESCRIPTION
## Done

- Moved the following enums from `app/base/enum.ts`
  - `nodeStatus` is now in `app/store/types/node.ts` as `NodeStatusCode` (which is what it's actually enumerating)
  - `scriptStatus` is now in `app/store/scriptresult/types.ts` as `ScriptResultStatus`
  - `ResultType` is now in `app/store/scriptresult/types.ts` as `ScriptResultType`
  - `ScriptResultParamType` is now in `app/store/scriptresult/types.ts`
- Renamed `TestResult` to `TestStatusStatus` (which is how it's arranged in the api) and converted to an enum.
- Added some simple scriptresult utils

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes #2271 