### PR TITLE
feat(ui): add alias or vlan form

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -411,6 +411,15 @@ exports[`stricter compilation`] = {
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
     ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx:2329041630": [
+      [172, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
+      [176, 10, 21, "Argument of type \'{ ip_address: string; mode: NetworkLinkMode; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'ip_address\' does not exist in type \'FormEvent<{}>\'.", "2616770373"],
+      [221, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [222, 8, 21, "Argument of type \'{ ip_address: string; mode: NetworkLinkMode; subnet: number; system_id: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'ip_address\' does not exist in type \'FormEvent<{}>\'.", "2616770373"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx:3596158043": [
+      [92, 8, 8, "Type \'(values: AddAliasOrVlanValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'AddAliasOrVlanValues\'.\\n      Type \'unknown\' is not assignable to type \'{ tags?: string[] | undefined; }\'.", "1301647696"]
+    ],
     "src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx:1321088602": [
       [104, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [108, 10, 9, "Argument of type \'{ fabric: number; ip_address: string; mac_address: string; mode: NetworkLinkMode; name: string; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'fabric\' does not exist in type \'FormEvent<{}>\'.", "3240912851"]
@@ -428,7 +437,7 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx:695939926": [
       [143, 50, 13, "Argument of type \'number | undefined\' is not assignable to parameter of type \'string | number\'.\\n  Type \'undefined\' is not assignable to type \'string | number\'.", "3198180584"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:2884917413": [
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:3011299750": [
       [325, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"dhcp\\" | \\"speed\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"dhcp\\" | \\"speed\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"dhcp\\" | \\"speed\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
       [329, 4, 3, "Argument of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"dhcp\\" | \\"speed\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\" | null\' is not assignable to parameter of type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"dhcp\\" | \\"speed\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.\\n  Type \'null\' is not assignable to type \'\\"fabric\\" | \\"subnet\\" | \\"name\\" | \\"type\\" | \\"ip\\" | \\"dhcp\\" | \\"speed\\" | \\"bondOrBridge\\" | \\"isABondOrBridgeChild\\" | \\"isABondOrBridgeParent\\" | \\"pxe\\"\'.", "193424690"],
       [354, 35, 9, "Object is possibly \'null\'.", "1794230341"],

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
@@ -1,0 +1,248 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddAliasOrVlan from "./AddAliasOrVlan";
+
+import {
+  NetworkInterfaceTypes,
+  NetworkLinkMode,
+} from "app/store/machine/types";
+import type { NetworkInterface } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  fabric as fabricFactory,
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+  vlan as vlanFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AddAliasOrVlan", () => {
+  let state: RootState;
+  let nic: NetworkInterface;
+  beforeEach(() => {
+    nic = machineInterfaceFactory();
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            interfaces: [nic],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+  });
+
+  it("displays a spinner when data is loading", () => {
+    state.machine.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddAliasOrVlan
+            interfaceType={NetworkInterfaceTypes.VLAN}
+            systemId="abc123"
+            close={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a save-another button for aliases", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddAliasOrVlan
+            interfaceType={NetworkInterfaceTypes.ALIAS}
+            nic={nic}
+            systemId="abc123"
+            close={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikForm").prop("secondarySubmitDisabled")).toBe(
+      false
+    );
+    expect(wrapper.find("FormikForm").prop("secondarySubmitLabel")).toBe(
+      "Save and add another"
+    );
+  });
+
+  it("displays a save-another button when there are unused VLANS", () => {
+    const fabric = fabricFactory();
+    state.fabric.items = [fabric];
+    const vlan = vlanFactory({ fabric: fabric.id });
+    state.vlan.items = [vlan, vlanFactory({ fabric: fabric.id })];
+    const nic = machineInterfaceFactory({
+      type: NetworkInterfaceTypes.PHYSICAL,
+      vlan_id: vlan.id,
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddAliasOrVlan
+            interfaceType={NetworkInterfaceTypes.VLAN}
+            nic={nic}
+            systemId="abc123"
+            close={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikForm").prop("secondarySubmitDisabled")).toBe(
+      false
+    );
+    expect(wrapper.find("FormikForm").prop("secondarySubmitTooltip")).toBe(
+      null
+    );
+  });
+
+  it("disables the save-another button when there are no unused VLANS", () => {
+    state.vlan.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddAliasOrVlan
+            nic={nic}
+            interfaceType={NetworkInterfaceTypes.VLAN}
+            systemId="abc123"
+            close={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikForm").prop("secondarySubmitDisabled")).toBe(
+      true
+    );
+    expect(wrapper.find("FormikForm").prop("secondarySubmitTooltip")).toBe(
+      "There are no more unused VLANS for this interface."
+    );
+  });
+
+  it("correctly dispatches actions to add a VLAN", () => {
+    const nic = machineInterfaceFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddAliasOrVlan
+            interfaceType={NetworkInterfaceTypes.VLAN}
+            nic={nic}
+            systemId="abc123"
+            close={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper
+        .find("Formik")
+        .props()
+        .onSubmit({
+          ip_address: "1.2.3.4",
+          mode: NetworkLinkMode.AUTO,
+          tags: ["koala", "tag"],
+          vlan: 9,
+        })
+    );
+    expect(
+      store.getActions().find((action) => action.type === "machine/createVlan")
+    ).toStrictEqual({
+      type: "machine/createVlan",
+      meta: {
+        model: "machine",
+        method: "create_vlan",
+      },
+      payload: {
+        params: {
+          ip_address: "1.2.3.4",
+          mode: NetworkLinkMode.AUTO,
+          parent: nic.id,
+          system_id: "abc123",
+          tags: ["koala", "tag"],
+          vlan: 9,
+        },
+      },
+    });
+  });
+
+  it("correctly dispatches actions to add an alias", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddAliasOrVlan
+            interfaceType={NetworkInterfaceTypes.ALIAS}
+            nic={nic}
+            systemId="abc123"
+            close={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper.find("Formik").props().onSubmit({
+        ip_address: "1.2.3.4",
+        mode: NetworkLinkMode.AUTO,
+        subnet: 3,
+        system_id: "abc123",
+      })
+    );
+    expect(
+      store.getActions().find((action) => action.type === "machine/linkSubnet")
+    ).toStrictEqual({
+      type: "machine/linkSubnet",
+      meta: {
+        model: "machine",
+        method: "link_subnet",
+      },
+      payload: {
+        params: {
+          interface_id: nic.id,
+          ip_address: "1.2.3.4",
+          mode: NetworkLinkMode.AUTO,
+          subnet: 3,
+          system_id: "abc123",
+        },
+      },
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useState } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import {
+  networkFieldsInitialValues,
+  networkFieldsSchema,
+} from "../NetworkFields/NetworkFields";
+
+import AddAliasOrVlanFields from "./AddAliasOrVlanFields";
+import type { AddAliasOrVlanValues } from "./types";
+
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { useScrollOnRender } from "app/base/hooks";
+import { useMachineDetailsForm } from "app/machines/hooks";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type {
+  Machine,
+  MachineDetails,
+  NetworkInterface,
+} from "app/store/machine/types";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import vlanSelectors from "app/store/vlan/selectors";
+
+type Props = {
+  close: () => void;
+  nic?: NetworkInterface | null;
+  interfaceType: NetworkInterfaceTypes.ALIAS | NetworkInterfaceTypes.VLAN;
+  systemId: MachineDetails["system_id"];
+};
+
+const InterfaceSchema = Yup.object().shape({
+  ...networkFieldsSchema,
+  tags: Yup.array().of(Yup.string()),
+});
+
+const AddAliasOrVlan = ({
+  close,
+  nic,
+  interfaceType,
+  systemId,
+}: Props): JSX.Element | null => {
+  const [secondarySubmit, setSecondarySubmit] = useState(false);
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const unusedVLANs = useSelector((state: RootState) =>
+    vlanSelectors.getUnusedForInterface(state, machine, nic)
+  );
+  const cleanup = useCallback(() => machineActions.cleanup(), []);
+  const isAlias = interfaceType === NetworkInterfaceTypes.ALIAS;
+  const { errors, saved, saving } = useMachineDetailsForm(
+    systemId,
+    isAlias ? "linkingSubnet" : "creatingVlan",
+    isAlias ? "linkSubnet" : "createVlan",
+    () => {
+      if (secondarySubmit) {
+        // Reset the flag for the action that submitted the form.
+        setSecondarySubmit(false);
+      } else {
+        close();
+      }
+    }
+  );
+  const onRenderRef = useScrollOnRender<HTMLDivElement>();
+  const canAddAnother = isAlias || (!isAlias && unusedVLANs.length > 1);
+
+  if (!nic || !machine || !("interfaces" in machine)) {
+    return <Spinner text="Loading..." />;
+  }
+  return (
+    <div ref={onRenderRef}>
+      <FormikForm
+        buttons={FormCardButtons}
+        cleanup={cleanup}
+        errors={errors}
+        initialValues={{
+          ...networkFieldsInitialValues,
+          ...(isAlias ? {} : { tags: [] }),
+        }}
+        onSaveAnalytics={{
+          action: `Add ${interfaceType}`,
+          category: "Machine details networking",
+          label: `Add ${interfaceType} form`,
+        }}
+        onCancel={close}
+        onSubmit={(values: AddAliasOrVlanValues) => {
+          // Clear the errors from the previous submission.
+          dispatch(cleanup());
+          type Payload = AddAliasOrVlanValues & {
+            system_id: Machine["system_id"];
+          };
+          const payload: Payload = {
+            ...values,
+            system_id: systemId,
+          };
+          // Remove all empty values.
+          Object.entries(payload).forEach(([key, value]) => {
+            if (value === "") {
+              delete payload[key as keyof Payload];
+            }
+          });
+          if (isAlias) {
+            // Create an alias.
+            dispatch(
+              machineActions.linkSubnet({
+                ...payload,
+                interface_id: nic.id,
+              })
+            );
+          } else {
+            // Create a VLAN.
+            dispatch(
+              machineActions.createVlan({
+                ...payload,
+                parent: nic.id,
+              })
+            );
+          }
+        }}
+        resetOnSave
+        saved={saved}
+        saving={saving}
+        secondarySubmit={() => {
+          // Flag that the form was submitted by the secondary action.
+          setSecondarySubmit(true);
+        }}
+        secondarySubmitDisabled={!canAddAnother}
+        secondarySubmitLabel="Save and add another"
+        secondarySubmitTooltip={
+          canAddAnother
+            ? null
+            : "There are no more unused VLANS for this interface."
+        }
+        submitLabel="Save interface"
+        validationSchema={InterfaceSchema}
+      >
+        <AddAliasOrVlanFields
+          nic={nic}
+          interfaceType={interfaceType}
+          systemId={systemId}
+        />
+      </FormikForm>
+    </div>
+  );
+};
+
+export default AddAliasOrVlan;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
@@ -1,0 +1,58 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddAliasOrVlanFields from "./AddAliasOrVlanFields";
+
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AddAliasOrVlanFields", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory();
+  });
+
+  it("displays a tag field for a VLAN", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <AddAliasOrVlanFields
+              systemId="abc123"
+              interfaceType={NetworkInterfaceTypes.VLAN}
+            />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("TagField").exists()).toBe(true);
+  });
+
+  it("does not display a tag field for an ALIAS", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <AddAliasOrVlanFields
+              systemId="abc123"
+              interfaceType={NetworkInterfaceTypes.ALIAS}
+            />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("TagField").exists()).toBe(false);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.tsx
@@ -1,0 +1,74 @@
+import { Col, Input, Row } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+
+import NetworkFields from "../../NetworkFields";
+import type { AddAliasOrVlanValues } from "../types";
+
+import TagField from "app/base/components/TagField";
+import machineSelectors from "app/store/machine/selectors";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { MachineDetails, NetworkInterface } from "app/store/machine/types";
+import { getNextNicName } from "app/store/machine/utils";
+import { INTERFACE_TYPE_DISPLAY } from "app/store/machine/utils/networking";
+import type { RootState } from "app/store/root/types";
+import vlanSelectors from "app/store/vlan/selectors";
+import { toFormikNumber } from "app/utils";
+
+type Props = {
+  nic?: NetworkInterface | null;
+  interfaceType: NetworkInterfaceTypes.ALIAS | NetworkInterfaceTypes.VLAN;
+  systemId: MachineDetails["system_id"];
+};
+
+export const AddAliasOrVlanFields = ({
+  nic,
+  interfaceType,
+  systemId,
+}: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const { values } = useFormikContext<AddAliasOrVlanValues>();
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, toFormikNumber(values.vlan))
+  );
+  const unusedVLANs = useSelector((state: RootState) =>
+    vlanSelectors.getUnusedForInterface(state, machine, nic)
+  );
+  const isVLAN = interfaceType === NetworkInterfaceTypes.VLAN;
+  const isAlias = interfaceType === NetworkInterfaceTypes.ALIAS;
+  const nextNicName = getNextNicName(machine, interfaceType, nic, vlan?.vid);
+  return (
+    <Row>
+      <Col size="6">
+        <Input
+          disabled
+          label="Name"
+          value={nextNicName || ""}
+          type="text"
+          name="name"
+        />
+        <Input
+          disabled
+          label="Type"
+          value={INTERFACE_TYPE_DISPLAY[interfaceType]}
+          type="text"
+          name="type"
+        />
+        {isVLAN ? <TagField /> : null}
+      </Col>
+      <Col size="6">
+        <NetworkFields
+          fabricDisabled={true}
+          includeUnconfiguredSubnet={isVLAN}
+          interfaceType={interfaceType}
+          vlanDisabled={isAlias}
+          vlans={isVLAN ? unusedVLANs : null}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default AddAliasOrVlanFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddAliasOrVlanFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddAliasOrVlan";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/types.ts
@@ -1,0 +1,7 @@
+import type { NetworkValues } from "../NetworkFields/NetworkFields";
+
+import type { NetworkInterface } from "app/store/machine/types";
+
+export type AddAliasOrVlanValues = {
+  tags?: NetworkInterface["tags"];
+} & NetworkValues;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -200,7 +200,7 @@ const generateRow = (
       },
     ],
     expanded: isExpanded,
-    expandedContent: (
+    expandedContent: isExpanded ? (
       <NetworkTableConfirmation
         expanded={expanded}
         link={link}
@@ -208,7 +208,7 @@ const generateRow = (
         setExpanded={setExpanded}
         systemId={machine.system_id}
       />
-    ),
+    ) : null,
     key: name,
     sortData: {
       bondOrBridge:

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
@@ -335,4 +335,44 @@ describe("NetworkTableConfirmation", () => {
       });
     });
   });
+
+  it("can display an add alias form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableConfirmation
+          expanded={{
+            content: ExpandedState.ADD_ALIAS,
+          }}
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("AddAliasOrVlan").exists()).toBe(true);
+    expect(wrapper.find("AddAliasOrVlan").prop("interfaceType")).toBe(
+      NetworkInterfaceTypes.ALIAS
+    );
+  });
+
+  it("can display an add VLAN form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableConfirmation
+          expanded={{
+            content: ExpandedState.ADD_VLAN,
+          }}
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("AddAliasOrVlan").exists()).toBe(true);
+    expect(wrapper.find("AddAliasOrVlan").prop("interfaceType")).toBe(
+      NetworkInterfaceTypes.VLAN
+    );
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.tsx
@@ -3,11 +3,13 @@ import type { ReactNode } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionConfirm from "../../../ActionConfirm";
+import AddAliasOrVlan from "../../AddAliasOrVlan";
 import type { Expanded, SetExpanded } from "../types";
 import { ExpandedState } from "../types";
 
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type {
   Machine,
   NetworkInterface,
@@ -47,11 +49,12 @@ const NetworkTableConfirmation = ({
   }
   const removeTypeText = getRemoveTypeText(machine, nic, link);
   const isAnAlias = isAlias(machine, link);
+  const close = () => setExpanded(null);
   let content: ReactNode;
   if (expanded?.content === ExpandedState.REMOVE) {
     content = (
       <ActionConfirm
-        closeExpanded={() => setExpanded(null)}
+        closeExpanded={close}
         confirmLabel="Remove"
         eventName={isAnAlias ? "unlinkSubnet" : "deleteInterface"}
         message={`Are you sure you want to remove this ${removeTypeText}?`}
@@ -132,7 +135,7 @@ const NetworkTableConfirmation = ({
     }
     content = (
       <ActionConfirm
-        closeExpanded={() => setExpanded(null)}
+        closeExpanded={close}
         confirmLabel={`Mark as ${event}`}
         eventName="updateInterface"
         message={message}
@@ -148,9 +151,23 @@ const NetworkTableConfirmation = ({
       />
     );
   } else if (expanded?.content === ExpandedState.ADD_ALIAS) {
-    content = "Add alias.";
+    content = (
+      <AddAliasOrVlan
+        close={close}
+        interfaceType={NetworkInterfaceTypes.ALIAS}
+        nic={nic}
+        systemId={systemId}
+      />
+    );
   } else if (expanded?.content === ExpandedState.ADD_VLAN) {
-    content = "Add VLAN.";
+    content = (
+      <AddAliasOrVlan
+        close={close}
+        interfaceType={NetworkInterfaceTypes.VLAN}
+        nic={nic}
+        systemId={systemId}
+      />
+    );
   }
   return <div className="u-flex--grow">{content}</div>;
 };


### PR DESCRIPTION
## Done

- Add a form for creating aliases or vlans from the network table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the network tab for a machine.
- Using the row menus open the add vlan or add alias form.
- Fill out the details and submit the form via the "create another" button (if it's enabled)
- The vlan/alias should be created.
- Submit the form using the green button. The form should close when the item gets created.

## Fixes

Fixes: #2147.