### PR TITLE
feat(ui): add disabled alias or vlan action tooltips

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -7,7 +7,10 @@ import { ExpandedState } from "../types";
 import NetworkTableActions from "./NetworkTableActions";
 
 import type { NetworkInterface } from "app/store/machine/types";
-import { NetworkInterfaceTypes } from "app/store/machine/types";
+import {
+  NetworkInterfaceTypes,
+  NetworkLinkMode,
+} from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NodeStatus } from "app/store/types/node";
 import {
@@ -294,16 +297,42 @@ describe("NetworkTableActions", () => {
     // Open the menu:
     wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
     wrapper.update();
-    expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Add alias"
-        )
-        .exists()
-    ).toBe(true);
+    const addAlias = wrapper.findWhere(
+      (n) =>
+        n.type() === "button" &&
+        n.hasClass("p-contextual-menu__link") &&
+        n.text() === "Add alias"
+    );
+    expect(addAlias.exists()).toBe(true);
+    expect(addAlias.prop("disabled")).toBe(false);
+    expect(addAlias.find("Tooltip").exists()).toBe(false);
+  });
+
+  it("can display a disabled action to add an alias", () => {
+    nic.type = NetworkInterfaceTypes.PHYSICAL;
+    nic.links = [networkLinkFactory({ mode: NetworkLinkMode.LINK_UP })];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.update();
+    const addAlias = wrapper.findWhere(
+      (n) =>
+        n.type() === "button" &&
+        n.hasClass("p-contextual-menu__link") &&
+        n.text() === "Add alias"
+    );
+    expect(addAlias.exists()).toBe(true);
+    expect(addAlias.prop("disabled")).toBe(true);
+    expect(addAlias.find("Tooltip").exists()).toBe(true);
   });
 
   it("can display an action to add a VLAN", () => {
@@ -326,16 +355,42 @@ describe("NetworkTableActions", () => {
     // Open the menu:
     wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
     wrapper.update();
-    expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Add VLAN"
-        )
-        .exists()
-    ).toBe(true);
+    const addVLAN = wrapper.findWhere(
+      (n) =>
+        n.type() === "button" &&
+        n.hasClass("p-contextual-menu__link") &&
+        n.text() === "Add VLAN"
+    );
+    expect(addVLAN.exists()).toBe(true);
+    expect(addVLAN.prop("disabled")).toBe(false);
+    expect(addVLAN.find("Tooltip").exists()).toBe(false);
+  });
+
+  it("can display a disabled action to add a VLAN", () => {
+    nic.type = NetworkInterfaceTypes.PHYSICAL;
+    state.vlan.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NetworkTableActions
+          nic={nic}
+          setExpanded={jest.fn()}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    // Open the menu:
+    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
+    wrapper.update();
+    const addVLAN = wrapper.findWhere(
+      (n) =>
+        n.type() === "button" &&
+        n.hasClass("p-contextual-menu__link") &&
+        n.text() === "Add VLAN"
+    );
+    expect(addVLAN.exists()).toBe(true);
+    expect(addVLAN.prop("disabled")).toBe(true);
+    expect(addVLAN.find("Tooltip").exists()).toBe(true);
   });
 
   it("can not display an action to add an alias or vlan", () => {

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -69,3 +69,8 @@ input[type="radio"] {
     margin: 0;
   }
 }
+
+.p-tooltip__message {
+  // Display tooltips above contextual menus which have a z-index of 9.
+  z-index: 10 !important;
+}


### PR DESCRIPTION
## Done

- Add a tooltip when adding an alias or vlan is disabled.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab of a machine.
- Create (or edit) a physical interface and choose a subnet then set the IP mode to be unconfigured and submit.
- Now visit the legacy page of the interface and using the row's action menu add VLANs until it won't let you add any more.
- Go back to the react page and open the action menu for the interface and the add vlan/alias items should be disabled and there should be tooltips with the reasons why.

## Fixes

Fixes: #2278.