### PR TITLE
feat(ui): add disabled an tooltip props for secondary button in formik form

### DIFF
--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.tsx
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.test.tsx
@@ -31,6 +31,20 @@ describe("FormCardButtons ", () => {
     expect(secondarySubmit).toHaveBeenCalled();
   });
 
+  it("can display a tooltip for the secondary submit action", () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+        <FormCardButtons
+          submitLabel="Save user"
+          secondarySubmit={jest.fn()}
+          secondarySubmitLabel="Save and add another"
+          secondarySubmitTooltip="Will add another"
+        />
+      </MemoryRouter>
+    );
+    expect(wrapper.find("Tooltip").exists()).toBe(true);
+  });
+
   it("displays a border if bordered is true", () => {
     const wrapper = mount(
       <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>

--- a/ui/src/app/base/components/FormCardButtons/FormCardButtons.tsx
+++ b/ui/src/app/base/components/FormCardButtons/FormCardButtons.tsx
@@ -1,4 +1,11 @@
-import { ActionButton, Button, Link } from "@canonical/react-components";
+import type { ReactNode } from "react";
+
+import {
+  ActionButton,
+  Button,
+  Link,
+  Tooltip,
+} from "@canonical/react-components";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 
@@ -12,12 +19,42 @@ export const FormCardButtons = ({
   loadingLabel,
   onCancel,
   secondarySubmit,
+  secondarySubmitDisabled,
   secondarySubmitLabel,
+  secondarySubmitTooltip,
   submitAppearance = "positive",
   submitDisabled,
   submitLabel,
   success,
 }: ButtonComponentProps): JSX.Element => {
+  let secondaryButton: ReactNode;
+  if (secondarySubmit && secondarySubmitLabel) {
+    const button = (
+      <Button
+        appearance="neutral"
+        className={classNames({ "u-no-margin--bottom": bordered })}
+        data-test="secondary-submit"
+        disabled={secondarySubmitDisabled || submitDisabled}
+        onClick={secondarySubmit}
+        type="button"
+      >
+        {secondarySubmitLabel}
+      </Button>
+    );
+    if (secondarySubmitTooltip) {
+      secondaryButton = (
+        <Tooltip
+          message={secondarySubmitTooltip}
+          position="top-center"
+          positionElementClassName="u-nudge-left"
+        >
+          {button}
+        </Tooltip>
+      );
+    } else {
+      secondaryButton = button;
+    }
+  }
   return (
     <>
       {bordered && <hr />}
@@ -49,18 +86,7 @@ export const FormCardButtons = ({
             Cancel
           </Button>
         )}
-        {secondarySubmit && secondarySubmitLabel && (
-          <Button
-            appearance="neutral"
-            className={classNames({ "u-no-margin--bottom": bordered })}
-            data-test="secondary-submit"
-            disabled={submitDisabled}
-            onClick={secondarySubmit}
-            type="button"
-          >
-            {secondarySubmitLabel}
-          </Button>
-        )}
+        {secondaryButton}
         <ActionButton
           appearance={submitAppearance}
           className={classNames({ "u-no-margin--bottom": bordered })}

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -50,7 +50,9 @@ const FormikForm = <V, E = FormErrors>({
   saved,
   savedRedirect,
   secondarySubmit,
+  secondarySubmitDisabled,
   secondarySubmitLabel,
+  secondarySubmitTooltip,
   submitAppearance,
   submitLabel,
   validationSchema,
@@ -101,7 +103,9 @@ const FormikForm = <V, E = FormErrors>({
         savingLabel={savingLabel}
         saved={saved}
         secondarySubmit={secondarySubmit}
+        secondarySubmitDisabled={secondarySubmitDisabled}
         secondarySubmitLabel={secondarySubmitLabel}
+        secondarySubmitTooltip={secondarySubmitTooltip}
         submitAppearance={submitAppearance}
         submitLabel={submitLabel}
       >

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -25,7 +25,9 @@ export type ButtonComponentProps = {
   onCancel?: () => void;
   loadingLabel?: string;
   secondarySubmit?: () => void;
+  secondarySubmitDisabled?: boolean;
   secondarySubmitLabel?: string;
+  secondarySubmitTooltip?: string | null;
   submitAppearance?: ButtonProps["appearance"];
   submitDisabled?: boolean;
   submitLabel?: string;
@@ -52,7 +54,9 @@ export type Props<V, E = FormErrors> = {
   saving?: boolean;
   savingLabel?: string;
   secondarySubmit?: () => void;
+  secondarySubmitDisabled?: boolean;
   secondarySubmitLabel?: string;
+  secondarySubmitTooltip?: string | null;
   submitAppearance?: string;
   submitLabel?: string;
 };
@@ -77,7 +81,9 @@ const FormikFormContent = <V, E = FormErrors>({
   savingLabel,
   saved,
   secondarySubmit,
+  secondarySubmitDisabled,
   secondarySubmitLabel,
+  secondarySubmitTooltip,
   submitAppearance,
   submitLabel = "Save",
 }: Props<V, E>): JSX.Element => {
@@ -131,7 +137,9 @@ const FormikFormContent = <V, E = FormErrors>({
                 }
               : undefined
           }
+          secondarySubmitDisabled={secondarySubmitDisabled}
           secondarySubmitLabel={secondarySubmitLabel}
+          secondarySubmitTooltip={secondarySubmitTooltip}
           submitAppearance={submitAppearance}
           submitDisabled={loading || saving || formDisabled}
           submitLabel={submitLabel}


### PR DESCRIPTION
## Done

- Add the ability to disable and provide a tooltip for the secondary submit button in the formik form.

## QA

N/A

## Fixes

Fixes: #2280.