### PR TITLE
refactor(ui): share validation and types for network fields between the forms

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
@@ -6,6 +6,7 @@ import * as Yup from "yup";
 import type Reference from "yup/lib/Reference";
 
 import NetworkFields from "../NetworkFields";
+import { networkFieldsSchema } from "../NetworkFields/NetworkFields";
 import type { NetworkValues } from "../NetworkFields/NetworkFields";
 
 import FormCardButtons from "app/base/components/FormCardButtons";
@@ -25,7 +26,6 @@ import type {
   NetworkInterface,
   NetworkLink,
 } from "app/store/machine/types";
-import { NetworkLinkMode } from "app/store/machine/types";
 import {
   getInterfaceIPAddress,
   getInterfaceSubnet,
@@ -54,8 +54,8 @@ export type EditInterfaceValues = {
 } & NetworkValues;
 
 const InterfaceSchema = Yup.object().shape({
+  ...networkFieldsSchema,
   interface_speed: Yup.number().nullable(),
-  ip_address: Yup.string(),
   link_speed: Yup.number()
     .nullable()
     .max(
@@ -67,12 +67,8 @@ const InterfaceSchema = Yup.object().shape({
   mac_address: Yup.string()
     .matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
     .required("MAC address is required"),
-  mode: Yup.mixed().oneOf(Object.values(NetworkLinkMode)),
   name: Yup.string(),
-  fabric: Yup.number().required("Fabric is required"),
-  subnet: Yup.number(),
   tags: Yup.array().of(Yup.string()),
-  vlan: Yup.number().required("VLAN is required"),
 });
 
 const EditPhysicalForm = ({

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -1,5 +1,6 @@
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
+import * as Yup from "yup";
 
 import FabricSelect from "app/base/components/FabricSelect";
 import FormikField from "app/base/components/FormikField";
@@ -25,6 +26,22 @@ export type NetworkValues = {
   fabric: Vlan["fabric_id"];
   subnet?: NetworkLink["subnet_id"];
   vlan: NetworkInterface["vlan_id"];
+};
+
+export const networkFieldsSchema = {
+  ip_address: Yup.string(),
+  mode: Yup.mixed().oneOf(Object.values(NetworkLinkMode)),
+  fabric: Yup.number().required("Fabric is required"),
+  subnet: Yup.number(),
+  vlan: Yup.number().required("VLAN is required"),
+};
+
+export const networkFieldsInitialValues = {
+  ip_address: "",
+  mode: "",
+  fabric: "",
+  subnet: "",
+  vlan: "",
 };
 
 const fieldOrder = ["fabric", "vlan", "subnet", "mode", "ip_address"];


### PR DESCRIPTION
## Done

- Reuse the network validation and default values between the forms.

## QA

N/A

## Fixes

Fixes: #2281.