### PR TITLE
Fix machine details header

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -162,29 +162,30 @@
                     </form>
                 </div>
             </div>
-          </form>
-        </div>
-      <div
-        class="row ng-hide"
-        data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || action.option.name !== 'commission'"
-        data-ng-if="hasCustomCommissioningScripts()"
-      >
-        <div class="page-header__section">
-          <form class="p-form row">
-            <div class="col-8">
-              <div class="p-form__group">
-                <label for="commissioning-scripts"
-                  >Additional commissioning scripts</label
-                >
-                <span
-                  id="commissioning-scripts"
-                  data-maas-script-select="script"
-                  data-script-type="0"
-                  data-ng-model="commissioningSelection"
-                  class="tags--inline"
-                  check-test-parameter-values="checkTestParameterValues"
-                  set-default-values="setDefaultValues"
-                ></span>
+            <div
+              class="row ng-hide"
+              data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || action.option.name !== 'commission'"
+              data-ng-if="hasCustomCommissioningScripts()"
+            >
+              <div class="page-header__section">
+                <form class="p-form row">
+                  <div class="col-8">
+                    <div class="p-form__group">
+                      <label for="commissioning-scripts"
+                        >Additional commissioning scripts</label
+                      >
+                      <span
+                        id="commissioning-scripts"
+                        data-maas-script-select="script"
+                        data-script-type="0"
+                        data-ng-model="commissioningSelection"
+                        class="tags--inline"
+                        check-test-parameter-values="checkTestParameterValues"
+                        set-default-values="setDefaultValues"
+                      ></span>
+                    </div>
+                  </div>
+                </form>
               </div>
             </div>
             <div class="row u-no-margin--top ng-hide" data-ng-hide="isActionError() || isDeployError() || isSSHKeyError() || hasActionPowerError(action.option.name) || (action.option.name !== 'commission' && action.option.name !== 'test')">
@@ -222,18 +223,18 @@
                     <div data-ng-repeat="confirmation_detail in action.confirmation_details">
                         <span>{$ confirmation_detail $}</span>
                     </div>
-            <div class="u-equal-height">
-            <div class="col-9 u-vertically-center">
-                <p class="u-remove-max-width">
-                Are you sure you want to {$ action.actionOption.name $} this {$ type_name $}?
-                </p>
-            </div>
-            <div class="col-3">
-                <div class="u-align--right">
-                <button class="p-button--base" data-ng-click="actionCancel()">No</button>
-                <button class="p-button--negative" data-ng-click="actionGo()">Yes</button>
-                </div>
-            </div>
+                    <div class="u-equal-height">
+                      <div class="col-9 u-vertically-center">
+                          <p class="u-remove-max-width">
+                          Are you sure you want to {$ action.actionOption.name $} this {$ type_name $}?
+                          </p>
+                      </div>
+                      <div class="col-3">
+                          <div class="u-align--right">
+                            <button class="p-button--base" data-ng-click="actionCancel()">No</button>
+                            <button class="p-button--negative" data-ng-click="actionGo()">Yes</button>
+                          </div>
+                      </div>
                     </div>
                 </div>
             </div>
@@ -3566,7 +3567,7 @@
                             <div class="p-notification--caution is-subtle" data-ng-if="newLayout.id === 'blank'">
                                 <p class="p-notification__response">
                                     <strong>Are you sure you want to change this storage layout to blank?</strong><br />
-                                    Used disks will be returned to available, and any volume groups, raid sets,  caches, and filesystems removed.<br />
+                                    Used disks will be returned to available, and any volume groups, raid sets,  caches, and filesystems removed.<br />
                                     The storage layout will be applied to a node when it is deployed.
                                 </p>
                             </div>


### PR DESCRIPTION
## Done

- Fix the machine details header so that the tabs display and forms aren't broken

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the machine details page for a machine.
- You should see the summary, storage, config etc. tabs in the details header.
- Open the commission form via the take action menu and submit.
- The form should close and you should see the tabs again or an error with cancel/retry (if so press cancel and you should see the tabs again).
- Open the test form via the take action menu.
- You should see a bunch of checkboxes, the test selector and buttons to cancel/test.
- Click test and you should see the tabs again or an error.

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-ui/issues/2293.
