### PR TITLE
fix(ui): update network checkboxes to handle links and nics

### DIFF
--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
@@ -50,4 +50,16 @@ describe("GroupCheckbox", () => {
     );
     expect(wrapper.prop("disabled")).toBe(true);
   });
+
+  it("can check if it should be selected via a function", () => {
+    const wrapper = shallow(
+      <GroupCheckbox
+        checkSelected={() => true}
+        items={[]}
+        selectedItems={[]}
+        handleGroupCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper.prop("checked")).toBe(true);
+  });
 });

--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
@@ -6,19 +6,22 @@ import { nanoid } from "@reduxjs/toolkit";
 import classNames from "classnames";
 
 import { someInArray, someNotAll } from "app/utils";
+import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
-type Props<R, S> = {
+type Props<S> = {
+  checkSelected?: CheckboxHandlers<S>["checkSelected"] | null;
   disabled?: boolean;
-  handleGroupCheckbox: (rows: R[], selected: S[]) => void;
+  handleGroupCheckbox: CheckboxHandlers<S>["handleGroupCheckbox"];
   inRow?: boolean;
-  items: R[];
+  items: S[];
   // This needs to be something other than `label` to prevent conflicts with the
   // HTMLInputElement type.
   inputLabel?: ReactNode;
   selectedItems: S[];
 } & HTMLProps<HTMLInputElement>;
 
-const GroupCheckbox = <R, S>({
+const GroupCheckbox = <S,>({
+  checkSelected,
   disabled,
   handleGroupCheckbox,
   inRow,
@@ -26,11 +29,15 @@ const GroupCheckbox = <R, S>({
   inputLabel,
   selectedItems,
   ...props
-}: Props<R, S>): JSX.Element => {
+}: Props<S>): JSX.Element => {
   const id = useRef(nanoid());
   return (
     <Input
-      checked={someInArray(items, selectedItems)}
+      checked={
+        checkSelected
+          ? checkSelected(items, selectedItems)
+          : someInArray(items, selectedItems)
+      }
       className={classNames("has-inline-label", {
         "p-checkbox--mixed": someNotAll(items, selectedItems),
       })}

--- a/ui/src/app/base/components/RowCheckbox/RowCheckbox.test.tsx
+++ b/ui/src/app/base/components/RowCheckbox/RowCheckbox.test.tsx
@@ -21,4 +21,17 @@ describe("RowCheckbox", () => {
     );
     expect(wrapper.prop("label")).toBe("Check row");
   });
+
+  it("can check if it should be selected via a function", () => {
+    const wrapper = shallow(
+      <RowCheckbox
+        checkSelected={() => true}
+        items={[]}
+        label="Check row"
+        item={null}
+        handleRowCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper.prop("checked")).toBe(true);
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -11,13 +11,12 @@ import DHCPTable from "./DHCPTable";
 import EditInterface from "./EditInterface";
 import NetworkActions from "./NetworkActions";
 import NetworkTable from "./NetworkTable";
-import type { Expanded } from "./NetworkTable/types";
+import type { Expanded, Selected } from "./NetworkTable/types";
 import { ExpandedState } from "./NetworkTable/types";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
-import type { NetworkInterface } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = { setSelectedAction: SetSelectedAction };
@@ -25,7 +24,7 @@ type Props = { setSelectedAction: SetSelectedAction };
 const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
   const params = useParams<RouteParams>();
   const { id } = params;
-  const [selected, setSelected] = useState<NetworkInterface["id"][]>([]);
+  const [selected, setSelected] = useState<Selected[]>([]);
   const [interfaceExpanded, setInterfaceExpanded] = useState<Expanded | null>(
     null
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NameColumn/NameColumn.tsx
@@ -1,5 +1,7 @@
 import { useSelector } from "react-redux";
 
+import type { Selected } from "../types";
+
 import DoubleRow from "app/base/components/DoubleRow";
 import RowCheckbox from "app/base/components/RowCheckbox";
 import machineSelectors from "app/store/machine/selectors";
@@ -14,22 +16,22 @@ import {
   useIsAllNetworkingDisabled,
 } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
+import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
 type Props = {
   checkboxSpace?: boolean;
-  handleRowCheckbox?: (
-    item: NetworkInterface["id"],
-    rows: NetworkInterface["id"][]
-  ) => void | null;
+  checkSelected?: CheckboxHandlers<Selected>["checkSelected"] | null;
+  handleRowCheckbox?: CheckboxHandlers<Selected>["handleRowCheckbox"] | null;
   link?: NetworkLink | null;
   nic?: NetworkInterface | null;
-  selected?: NetworkInterface["id"][] | null;
+  selected?: Selected[] | null;
   showCheckbox?: boolean;
   systemId: Machine["system_id"];
 };
 
 const NameColumn = ({
   checkboxSpace,
+  checkSelected,
   handleRowCheckbox,
   link,
   nic,
@@ -57,9 +59,13 @@ const NameColumn = ({
       primary={
         showCheckbox && handleRowCheckbox && selected ? (
           <RowCheckbox
+            checkSelected={checkSelected}
             disabled={isAllNetworkingDisabled}
             handleRowCheckbox={handleRowCheckbox}
-            item={nic.id}
+            item={{
+              linkId: link?.id,
+              nicId: nic.id,
+            }}
             items={selected}
             inputLabel={<span data-test="name">{name}</span>}
           />

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.test.tsx
@@ -339,7 +339,9 @@ describe("NetworkTable", () => {
           />
         </Provider>
       );
-      expect(wrapper.find("GroupCheckbox").prop("items")).toStrictEqual([100]);
+      expect(wrapper.find("GroupCheckbox").prop("items")).toStrictEqual([
+        { linkId: undefined, nicId: 100 },
+      ]);
     });
 
     it("does not display a boot icon for parent interfaces", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/types.ts
@@ -2,6 +2,8 @@ import type { NetworkInterface, NetworkLink } from "app/store/machine/types";
 
 export enum ExpandedState {
   ADD_ALIAS = "addAlias",
+  ADD_BOND = "addBond",
+  ADD_BRIDGE = "addBridge",
   ADD_PHYSICAL = "addPhysical",
   ADD_VLAN = "addVlan",
   DISCONNECTED_WARNING = "disconnectedWarning",
@@ -18,3 +20,10 @@ export type Expanded = {
 };
 
 export type SetExpanded = (expanded: Expanded | null) => void;
+
+export type Selected = {
+  linkId?: NetworkLink["id"] | null;
+  nicId?: NetworkInterface["id"] | null;
+};
+
+export type SetSelected = (selected: Selected[]) => void;

--- a/ui/src/app/utils/generateCheckboxHandlers.test.ts
+++ b/ui/src/app/utils/generateCheckboxHandlers.test.ts
@@ -1,33 +1,119 @@
 import { generateCheckboxHandlers } from "./generateCheckboxHandlers";
+import type { CheckboxHandlers } from "./generateCheckboxHandlers";
 
 describe("generateCheckboxHandlers", () => {
-  const onChange = jest.fn();
-  const {
-    handleGroupCheckbox,
-    handleRowCheckbox,
-  } = generateCheckboxHandlers<number>((newIDs) => onChange(newIDs));
+  let onChange: jest.Mock;
+  let handlers: CheckboxHandlers<number>;
+  type Selected = { system_id: number };
+  let uniqueIdHandlers: CheckboxHandlers<Selected>;
+
+  beforeEach(() => {
+    onChange = jest.fn();
+    handlers = generateCheckboxHandlers<number>((newIDs) => onChange(newIDs));
+    uniqueIdHandlers = generateCheckboxHandlers<Selected>(
+      (newIDs) => onChange(newIDs),
+      ({ system_id }) => `unique-${system_id}`
+    );
+  });
 
   describe("handleGroupCheckbox", () => {
-    it("correctly runs onChange with all ids in a group if none already selected", () => {
-      handleGroupCheckbox([3, 4], [1, 2]);
+    it("runs onChange with all ids in a group if none already selected", () => {
+      handlers.handleGroupCheckbox([3, 4], [1, 2]);
       expect(onChange).toHaveBeenCalledWith([1, 2, 3, 4]);
     });
 
-    it("correctly runs onChange to remove all ids in a group if at least one already selected", () => {
-      handleGroupCheckbox([1, 2, 3], [3, 4]);
+    it("runs onChange to remove all ids in a group if at least one already selected", () => {
+      handlers.handleGroupCheckbox([1, 2, 3], [3, 4]);
       expect(onChange).toHaveBeenCalledWith([4]);
+    });
+
+    it("runs onChange with all ids in a group if none already selected with generateUniqueId", () => {
+      uniqueIdHandlers.handleGroupCheckbox(
+        [{ system_id: 3 }, { system_id: 4 }],
+        [{ system_id: 1 }, { system_id: 2 }]
+      );
+      expect(onChange).toHaveBeenCalledWith([
+        { system_id: 1 },
+        { system_id: 2 },
+        { system_id: 3 },
+        { system_id: 4 },
+      ]);
+    });
+
+    it("runs onChange to remove all ids in a group if at least one already selected with generateUniqueId", () => {
+      uniqueIdHandlers.handleGroupCheckbox(
+        [{ system_id: 1 }, { system_id: 2 }, { system_id: 3 }],
+        [{ system_id: 3 }, { system_id: 4 }]
+      );
+      expect(onChange).toHaveBeenCalledWith([{ system_id: 4 }]);
     });
   });
 
   describe("handleRowCheckbox", () => {
-    it("correctly runs onChange to add id if not already selected", () => {
-      handleRowCheckbox(3, [1, 2]);
+    it("runs onChange to add id if not already selected", () => {
+      handlers.handleRowCheckbox(3, [1, 2]);
       expect(onChange).toHaveBeenCalledWith([1, 2, 3]);
     });
 
-    it("correctly runs onChange to remove id if already selected", () => {
-      handleRowCheckbox(1, [1, 2]);
+    it("runs onChange to remove id if already selected", () => {
+      handlers.handleRowCheckbox(1, [1, 2]);
       expect(onChange).toHaveBeenCalledWith([2]);
+    });
+
+    it("runs onChange to add id if not already selected with generateUniqueId", () => {
+      uniqueIdHandlers.handleRowCheckbox({ system_id: 3 }, [
+        { system_id: 1 },
+        { system_id: 2 },
+      ]);
+      expect(onChange).toHaveBeenCalledWith([
+        { system_id: 1 },
+        { system_id: 2 },
+        { system_id: 3 },
+      ]);
+    });
+
+    it("runs onChange to remove id if already selected with generateUniqueId", () => {
+      uniqueIdHandlers.handleRowCheckbox({ system_id: 1 }, [
+        { system_id: 1 },
+        { system_id: 2 },
+      ]);
+      expect(onChange).toHaveBeenCalledWith([{ system_id: 2 }]);
+    });
+  });
+
+  describe("checkSelected", () => {
+    it("checks if a single id is selected", () => {
+      expect(handlers.checkSelected(2, [1, 2])).toBe(true);
+    });
+
+    it("checks if a single id is not selected", () => {
+      expect(handlers.checkSelected(3, [1, 2])).toBe(false);
+    });
+
+    it("checks if one of multiple ids is selected", () => {
+      expect(handlers.checkSelected([2, 3], [1, 2])).toBe(true);
+    });
+
+    it("checks if multiple ids are not selected", () => {
+      expect(handlers.checkSelected([3, 4], [1, 2])).toBe(false);
+    });
+
+    it("checks if a single id is selected with generateUniqueId", () => {
+      expect(
+        uniqueIdHandlers.checkSelected({ system_id: 2 }, [
+          { system_id: 1 },
+          { system_id: 2 },
+        ])
+      ).toBe(true);
+    });
+
+    it("checks if one of multiple ids is selected with generateUniqueId", () => {
+      expect(
+        uniqueIdHandlers.checkSelected(
+          [{ system_id: 2 }, { system_id: 3 }],
+          [{ system_id: 1 }, { system_id: 2 }]
+        )
+      ).toBe(true);
     });
   });
 });

--- a/ui/src/app/utils/generateCheckboxHandlers.ts
+++ b/ui/src/app/utils/generateCheckboxHandlers.ts
@@ -3,6 +3,7 @@ import { someInArray } from "./someInArray";
 export type CheckboxHandlers<ID> = {
   handleGroupCheckbox: (ids: ID[], selectedIDs: ID[]) => void;
   handleRowCheckbox: (rowID: ID, selectedIDs: ID[]) => void;
+  checkSelected: (rowIDs: ID | ID[], selectedIDs: ID[]) => boolean;
 };
 
 /**
@@ -11,23 +12,53 @@ export type CheckboxHandlers<ID> = {
  * @returns {CheckboxHandlers} Checkbox handlers object
  */
 export const generateCheckboxHandlers = <ID>(
-  onChange: (newSelectedIDs: ID[]) => void
-): CheckboxHandlers<ID> => ({
+  onChange: (newSelectedIDs: ID[]) => void,
+  generateUniqueId = (id: ID): unknown => id
+): CheckboxHandlers<ID> => {
   // Handler to update a group of checkboxes (including all items in a table).
-  handleGroupCheckbox: (ids, selectedIDs) => {
+  const handleGroupCheckbox: CheckboxHandlers<ID>["handleGroupCheckbox"] = (
+    ids,
+    selectedIDs
+  ) => {
+    // Generate unique ids.
+    const uniqueIds = ids.map((id: ID) => generateUniqueId(id));
+    const uniqueSelectedIds = selectedIDs.map((id: ID) => generateUniqueId(id));
     // If some items in a group are already selected, remove all items in that group.
     // Otherwise add them to the selected array, without duplicates.
-    const newSelectedIDs = someInArray(ids, selectedIDs)
-      ? selectedIDs.filter((id) => !ids.includes(id))
-      : selectedIDs.concat(ids.filter((id) => !selectedIDs.includes(id)));
+    const newSelectedIDs = someInArray(uniqueIds, uniqueSelectedIds)
+      ? selectedIDs.filter((id) => !uniqueIds.includes(generateUniqueId(id)))
+      : selectedIDs.concat(
+          ids.filter((id) => !uniqueSelectedIds.includes(generateUniqueId(id)))
+        );
     onChange(newSelectedIDs);
-  },
+  };
+  // Handler for checking whether a row is in the selected state.
+  const checkSelected: CheckboxHandlers<ID>["checkSelected"] = (
+    rowIDs,
+    selectedIDs
+  ) => {
+    const rowIDsList = Array.isArray(rowIDs) ? rowIDs : [rowIDs];
+    // Generate unique ids.
+    const uniqueRowIDs = rowIDsList.map((id: ID) => generateUniqueId(id));
+    const uniqueSelectedIds = selectedIDs.map((id: ID) => generateUniqueId(id));
+    return someInArray(uniqueRowIDs, uniqueSelectedIds);
+  };
   // Handler to update a single checkbox.
-  handleRowCheckbox: (rowID, selectedIDs) => {
+  const handleRowCheckbox: CheckboxHandlers<ID>["handleRowCheckbox"] = (
+    rowID,
+    selectedIDs
+  ) => {
     // If the item is selected, unselect it and vice versa.
-    const newSelectedIDs = someInArray(rowID, selectedIDs)
-      ? selectedIDs.filter((id) => id !== rowID)
+    const newSelectedIDs = checkSelected(rowID, selectedIDs)
+      ? selectedIDs.filter(
+          (id) => generateUniqueId(id) !== generateUniqueId(rowID)
+        )
       : [...selectedIDs, rowID];
     onChange(newSelectedIDs);
-  },
-});
+  };
+  return {
+    handleGroupCheckbox,
+    checkSelected,
+    handleRowCheckbox,
+  };
+};


### PR DESCRIPTION
## Done

- Update the selected state of the network checkboxes to store the nic and link ids.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the network details for a machine.
- If it doesn't already have an alias then create one.
- Tick the checkboxes for different machine types. It should tick them correctly.
- Use the header checkbox to check/uncheck them all. That should also work correctly.

## Fixes

Fixes: #2315.