### PR TITLE
feat(ui): add a switch form component

### DIFF
--- a/ui/src/app/base/components/SwitchField/SwitchField.test.tsx
+++ b/ui/src/app/base/components/SwitchField/SwitchField.test.tsx
@@ -1,0 +1,20 @@
+import { shallow } from "enzyme";
+
+import SwitchField from "./SwitchField";
+
+describe("SwitchField", () => {
+  it("renders", () => {
+    const wrapper = shallow(<SwitchField />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can add additional classes", () => {
+    const wrapper = shallow(
+      <SwitchField type="text" className="extra-class" />
+    );
+    const className = wrapper.find("Switch").prop("className") || "";
+    expect(className.includes("p-form-validation__input")).toBe(true);
+    expect(className.includes("extra-class")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/SwitchField/SwitchField.tsx
+++ b/ui/src/app/base/components/SwitchField/SwitchField.tsx
@@ -1,0 +1,74 @@
+import type { HTMLProps, ReactNode } from "react";
+
+import { Field } from "@canonical/react-components";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+
+import Switch from "../Switch";
+
+export type Props = {
+  caution?: string;
+  className?: string;
+  error?: string;
+  help?: string;
+  id?: string;
+  label?: ReactNode;
+  labelClassName?: string;
+  required?: boolean;
+  stacked?: boolean;
+  success?: string;
+  type?: string;
+  wrapperClassName?: string;
+} & HTMLProps<HTMLInputElement>;
+
+const SwitchField = ({
+  caution,
+  className,
+  error,
+  help,
+  id,
+  label,
+  labelClassName,
+  required,
+  stacked,
+  success,
+  wrapperClassName,
+  ...props
+}: Props): JSX.Element => {
+  return (
+    <Field
+      caution={caution}
+      className={wrapperClassName}
+      error={error}
+      forId={id}
+      help={help}
+      label={label}
+      labelClassName={labelClassName}
+      required={required}
+      stacked={stacked}
+      success={success}
+    >
+      <Switch
+        className={classNames("p-form-validation__input", className)}
+        id={id}
+        {...props}
+      />
+    </Field>
+  );
+};
+
+SwitchField.propTypes = {
+  caution: PropTypes.node,
+  className: PropTypes.string,
+  error: PropTypes.node,
+  help: PropTypes.node,
+  id: PropTypes.string,
+  label: PropTypes.node,
+  labelClassName: PropTypes.string,
+  required: PropTypes.bool,
+  stacked: PropTypes.bool,
+  success: PropTypes.node,
+  wrapperClassName: PropTypes.string,
+};
+
+export default SwitchField;

--- a/ui/src/app/base/components/SwitchField/__snapshots__/SwitchField.test.tsx.snap
+++ b/ui/src/app/base/components/SwitchField/__snapshots__/SwitchField.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SwitchField renders 1`] = `
+<Field>
+  <Switch
+    className="p-form-validation__input"
+  />
+</Field>
+`;

--- a/ui/src/app/base/components/SwitchField/index.ts
+++ b/ui/src/app/base/components/SwitchField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SwitchField";


### PR DESCRIPTION
## Done

- Add a component for handling switches in forms. This follows the same shape as the inputs, selectors etc. in react components: https://github.com/canonical-web-and-design/react-components/blob/master/src/components/Input/Input.js.

## QA

N/A

### QA steps

- Steps for QA.

## Fixes

Fixes: #2319.