### PR TITLE
fix(ui): fix interfaces with multiple children

### DIFF
--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -284,6 +284,26 @@ describe("machine networking utils", () => {
       expect(getBondOrBridgeChild(machine, parent)).toStrictEqual(nic);
     });
 
+    it("gets the child interface for a parent with multiple children", () => {
+      const nic = machineInterfaceFactory({
+        parents: [99],
+        type: NetworkInterfaceTypes.BOND,
+      });
+      const vlan = machineInterfaceFactory({
+        parents: [99],
+        type: NetworkInterfaceTypes.VLAN,
+      });
+      const parent = machineInterfaceFactory({
+        children: [vlan.id, nic.id],
+        id: 99,
+        type: NetworkInterfaceTypes.PHYSICAL,
+      });
+      const machine = machineDetailsFactory({
+        interfaces: [nic, parent, vlan],
+      });
+      expect(getBondOrBridgeChild(machine, parent)).toStrictEqual(nic);
+    });
+
     it("gets the child interface via an alias", () => {
       const nic = machineInterfaceFactory({
         parents: [99],
@@ -316,31 +336,23 @@ describe("machine networking utils", () => {
       expect(isBondOrBridgeParent(machine, parent)).toBe(true);
     });
 
-    it("is not an interface parent when there are multiple children", () => {
-      const nic = machineInterfaceFactory({
-        parents: [99],
-        type: NetworkInterfaceTypes.BOND,
-      });
-      const parent = machineInterfaceFactory({
-        children: [nic.id, 101],
-        id: 99,
-        type: NetworkInterfaceTypes.PHYSICAL,
-      });
-      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
-      expect(isBondOrBridgeParent(machine, parent)).toBe(false);
-    });
-
     it("is not an interface parent when the child interface is not a bond or bridge", () => {
       const nic = machineInterfaceFactory({
         parents: [99],
         type: NetworkInterfaceTypes.ALIAS,
       });
+      const vlan = machineInterfaceFactory({
+        parents: [99],
+        type: NetworkInterfaceTypes.VLAN,
+      });
       const parent = machineInterfaceFactory({
-        children: [nic.id, 101],
+        children: [nic.id, vlan.id],
         id: 99,
         type: NetworkInterfaceTypes.PHYSICAL,
       });
-      const machine = machineDetailsFactory({ interfaces: [nic, parent] });
+      const machine = machineDetailsFactory({
+        interfaces: [nic, parent, vlan],
+      });
       expect(isBondOrBridgeParent(machine, parent)).toBe(false);
     });
 


### PR DESCRIPTION
## Done

- Correctly check interfaces for bond or bridge children.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the legacy network tab for a machine.
- Add a physical interface.
- Use the physical interface's action menu to open the VLAN form and submit.
- Tick the checkbox for the physical interface and click the 'Create bridge' button and submit the form.
- Switch to the react network tab.
- You should see the bridge row and the physical interface should be nested below it.

## Fixes

Fixes: #2318.