### PR TITLE
feat(ui): add the bridge form table

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.test.tsx
@@ -1,0 +1,66 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import BridgeForm from "./BridgeForm";
+
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("BridgeForm", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+  });
+
+  it("displays a table", () => {
+    const nic = machineInterfaceFactory({
+      type: NetworkInterfaceTypes.PHYSICAL,
+    });
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        interfaces: [nic],
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <BridgeForm
+            close={jest.fn()}
+            selected={[{ nicId: nic.id }]}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const table = wrapper.find("InterfaceFormTable");
+    expect(table.exists()).toBe(true);
+    expect(table.prop("nicId")).toBe(nic.id);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.tsx
@@ -1,0 +1,36 @@
+import InterfaceFormTable from "../InterfaceFormTable";
+import type { Selected } from "../NetworkTable/types";
+
+import FormCard from "app/base/components/FormCard";
+import type { MachineDetails } from "app/store/machine/types";
+
+type Props = {
+  close: () => void;
+  selected: Selected[];
+  systemId: MachineDetails["system_id"];
+};
+
+const BridgeForm = ({
+  close,
+  selected,
+  systemId,
+}: Props): JSX.Element | null => {
+  // A bridge can only be created with one interface.
+  if (selected.length !== 1) {
+    return null;
+  }
+  const [{ linkId, nicId }] = selected;
+  return (
+    <FormCard sidebar={false} stacked title="Create bridge">
+      <InterfaceFormTable
+        isPrimary
+        linkId={linkId}
+        nicId={nicId}
+        systemId={systemId}
+      />
+      <button onClick={close}>Cancel</button>
+    </FormCard>
+  );
+};
+
+export default BridgeForm;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BridgeForm";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
@@ -56,4 +56,39 @@ describe("InterfaceFormTable", () => {
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
   });
+
+  it("displays a PXE column by default", () => {
+    const nic = machineInterfaceFactory();
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <InterfaceFormTable nicId={nic.id} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("PXEColumn").exists()).toBe(true);
+  });
+
+  it("can display a primary icon instead of the PXE column", () => {
+    const nic = machineInterfaceFactory();
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <InterfaceFormTable isPrimary nicId={nic.id} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("PXEColumn").exists()).toBe(false);
+    expect(wrapper.find("Icon[name='tick']").exists()).toBe(true);
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { MainTable, Spinner } from "@canonical/react-components";
+import { Icon, MainTable, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DHCPColumn from "../NetworkTable/DHCPColumn";
@@ -32,7 +32,8 @@ type NetworkRow = {
 const generateRow = (
   machine: Machine,
   nic: NetworkInterface,
-  link?: NetworkLink | null
+  link?: NetworkLink | null,
+  isPrimary?: boolean
 ): NetworkRow => {
   const name = getInterfaceName(machine, nic);
   return {
@@ -43,7 +44,11 @@ const generateRow = (
         ),
       },
       {
-        content: (
+        content: isPrimary ? (
+          <span className="u-align--center">
+            <Icon name="tick" />
+          </span>
+        ) : (
           <PXEColumn link={link} nic={nic} systemId={machine.system_id} />
         ),
         className: "u-align--center",
@@ -82,12 +87,14 @@ const generateRow = (
 };
 
 type Props = {
+  isPrimary?: boolean;
   linkId?: NetworkLink["id"] | null;
   nicId?: NetworkInterface["id"] | null;
   systemId: Machine["system_id"];
 };
 
 const InterfaceFormTable = ({
+  isPrimary,
   linkId,
   nicId,
   systemId,
@@ -104,7 +111,7 @@ const InterfaceFormTable = ({
     return <Spinner />;
   }
 
-  const row = generateRow(machine, nic, link);
+  const row = generateRow(machine, nic, link, isPrimary);
   return (
     <MainTable
       headers={[
@@ -119,7 +126,9 @@ const InterfaceFormTable = ({
         {
           content: (
             <>
-              <TableHeader className="u-align--center">PXE</TableHeader>
+              <TableHeader className="u-align--center">
+                {isPrimary ? "Primary" : "PXE"}
+              </TableHeader>
             </>
           ),
         },

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router";
 import type { SetSelectedAction } from "../types";
 
 import AddInterface from "./AddInterface";
+import BridgeForm from "./BridgeForm";
 import DHCPTable from "./DHCPTable";
 import EditInterface from "./EditInterface";
 import NetworkActions from "./NetworkActions";
@@ -58,10 +59,14 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
   } else if (interfaceExpanded?.content === ExpandedState.ADD_BRIDGE) {
     // Temporary placeholder for the form.
     return (
-      <>
-        Add bridge{" "}
-        <button onClick={() => setInterfaceExpanded(null)}>cancel</button>
-      </>
+      <BridgeForm
+        close={() => {
+          setInterfaceExpanded(null);
+          setSelected([]);
+        }}
+        selected={selected}
+        systemId={id}
+      />
     );
   }
 


### PR DESCRIPTION
## Done

- Added a component to display the bridge table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to the react network tab for a machine.
- Select an interface and click the "Create bridge" button.
- A table should appear displaying the selected interface's details.

## Fixes

Fixes: #2307.