### PR TITLE
feat(ui): add bond form table

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondForm.test.tsx
@@ -1,0 +1,266 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import BondForm from "./BondForm";
+
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("BondForm", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+      vlan: vlanStateFactory({
+        items: [
+          vlanFactory({
+            id: 1,
+          }),
+        ],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("displays a table", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <BondForm
+            close={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const table = wrapper.find("InterfaceFormTable");
+    expect(table.exists()).toBe(true);
+  });
+
+  it("displays the selected interfaces when not editing members", () => {
+    const interfaces = [
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+    ];
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        interfaces,
+      }),
+    ];
+    const store = mockStore(state);
+    const selected = [{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }];
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <BondForm
+            close={jest.fn()}
+            selected={selected}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("InterfaceFormTable").prop("interfaces")).toStrictEqual(
+      selected
+    );
+  });
+
+  it("displays all valid interfaces when editing members", () => {
+    const interfaces = [
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      // VLANs are not valid.
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.VLAN,
+        vlan_id: 1,
+      }),
+      // Bridges are not valid.
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.BRIDGE,
+        vlan_id: 1,
+      }),
+      // Bonds are not valid.
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.BOND,
+        vlan_id: 1,
+      }),
+      // Physical interfaces in other VLANs are not valid.
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 2,
+      }),
+      // Physical interfaces in the same VLAN are valid.
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+    ];
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        interfaces,
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <BondForm
+            close={jest.fn()}
+            selected={[
+              { nicId: interfaces[0].id },
+              { nicId: interfaces[1].id },
+            ]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("button[data-test='edit-members']").simulate("click");
+    wrapper.update();
+    expect(wrapper.find("InterfaceFormTable").prop("interfaces")).toStrictEqual(
+      [
+        { linkId: undefined, nicId: interfaces[0].id },
+        { linkId: undefined, nicId: interfaces[1].id },
+        { linkId: undefined, nicId: interfaces[6].id },
+      ]
+    );
+  });
+
+  it("disables the edit button if there are no additional valid interfaces", () => {
+    const interfaces = [
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+    ];
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        interfaces,
+      }),
+    ];
+    const store = mockStore(state);
+    const selected = [{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }];
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <BondForm
+            close={jest.fn()}
+            selected={selected}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("Button[data-test='edit-members']").prop("disabled")
+    ).toBe(true);
+  });
+
+  it("disables the update button if two interfaces aren't selected", () => {
+    const interfaces = [
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+    ];
+    state.machine.items = [
+      machineDetailsFactory({
+        system_id: "abc123",
+        interfaces,
+      }),
+    ];
+    const store = mockStore(state);
+    // Use a component to pass props to the form so that setProps can be used
+    // below.
+    const PassthroughComponent = ({ ...props }) => (
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <BondForm
+            close={jest.fn()}
+            selected={[
+              { nicId: interfaces[0].id },
+              { nicId: interfaces[1].id },
+            ]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+            {...props}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    const wrapper = mount(<PassthroughComponent />);
+    wrapper.find("button[data-test='edit-members']").simulate("click");
+    wrapper.update();
+    wrapper.setProps({ selected: [] });
+    wrapper.update();
+    expect(
+      wrapper.find("Button[data-test='edit-members']").prop("disabled")
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondForm.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+
+import { Button, Spinner, Tooltip } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import InterfaceFormTable from "../InterfaceFormTable";
+import type { Selected, SetSelected } from "../NetworkTable/types";
+
+import FormCard from "app/base/components/FormCard";
+import machineSelectors from "app/store/machine/selectors";
+import type { MachineDetails, NetworkInterface } from "app/store/machine/types";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import { isBondOrBridgeParent } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+
+type Props = {
+  close: () => void;
+  selected: Selected[];
+  setSelected: SetSelected;
+  systemId: MachineDetails["system_id"];
+};
+
+const BondForm = ({
+  close,
+  selected,
+  setSelected,
+  systemId,
+}: Props): JSX.Element | null => {
+  const [editingMembers, setEditingMembers] = useState(false);
+  const [bondVLAN, setBondVLAN] = useState<NetworkInterface["vlan_id"] | null>(
+    null
+  );
+  const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  // Use the first selected interface as the canary for the fabric and VLAN.
+  const [firstSelected] = selected;
+  const firstNic = useSelector((state: RootState) =>
+    machineSelectors.getInterfaceById(
+      state,
+      systemId,
+      firstSelected?.nicId,
+      firstSelected?.linkId
+    )
+  );
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, bondVLAN || firstNic?.vlan_id)
+  );
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  useEffect(() => {
+    // When the form is first show then store the VLAN for this bond. This needs
+    // to be done so that if all interfaces become deselected then the VLAN
+    // information is not lost.
+    if (!bondVLAN && selected.length > 1 && firstNic) {
+      setBondVLAN(firstNic?.vlan_id);
+    }
+  }, [bondVLAN, firstNic, selected, setBondVLAN]);
+
+  if (!machine || !("interfaces" in machine) || !vlansLoaded) {
+    return <Spinner />;
+  }
+  // Find other nics that could be in this bond. They need to be physical
+  // interfaces on the same vlan that are not already in a bond or bridge.
+  const validNics = machine.interfaces.filter(
+    (networkInterface) =>
+      networkInterface.vlan_id === vlan?.id &&
+      networkInterface.type === NetworkInterfaceTypes.PHYSICAL &&
+      !isBondOrBridgeParent(machine, networkInterface)
+  );
+  // When editing the bond members then display all valid nics, otherwise just
+  // show the selected nics.
+  const rows = editingMembers
+    ? validNics.map(({ id, links }) => ({ nicId: id, linkId: links[0]?.id }))
+    : selected;
+  let editTooltip: string | null = null;
+  let editDisabled = false;
+  if (!editingMembers && validNics.length === 2) {
+    // Disable the button to add more members if there are no more to choose
+    // from.
+    editTooltip = "There are no additional valid members";
+    editDisabled = true;
+  } else if (editingMembers && selected.length < 2) {
+    // Don't let the user update the selection if they haven't chosen at least
+    // two interfaces.
+    editTooltip = "At least two interfaces must be selected";
+    editDisabled = true;
+  }
+
+  return (
+    <FormCard sidebar={false} stacked title="Create bond">
+      <InterfaceFormTable
+        editPrimary
+        interfaces={rows}
+        selected={selected}
+        selectedEditable={editingMembers}
+        setSelected={setSelected}
+        systemId={systemId}
+      />
+      <Tooltip message={editTooltip}>
+        <Button
+          data-test="edit-members"
+          disabled={editDisabled}
+          onClick={() => setEditingMembers(!editingMembers)}
+        >
+          {editingMembers ? "Update bond members" : "Edit bond members"}
+        </Button>
+      </Tooltip>
+      <button onClick={close}>Cancel</button>
+    </FormCard>
+  );
+};
+
+export default BondForm;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BondForm";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.test.tsx
@@ -45,22 +45,19 @@ describe("BridgeForm", () => {
         interfaces: [nic],
       }),
     ];
+    const selected = [{ nicId: nic.id }];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BridgeForm
-            close={jest.fn()}
-            selected={[{ nicId: nic.id }]}
-            systemId="abc123"
-          />
+          <BridgeForm close={jest.fn()} selected={selected} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
     const table = wrapper.find("InterfaceFormTable");
     expect(table.exists()).toBe(true);
-    expect(table.prop("nicId")).toBe(nic.id);
+    expect(table.prop("interfaces")).toStrictEqual(selected);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BridgeForm/BridgeForm.tsx
@@ -19,15 +19,9 @@ const BridgeForm = ({
   if (selected.length !== 1) {
     return null;
   }
-  const [{ linkId, nicId }] = selected;
   return (
     <FormCard sidebar={false} stacked title="Create bridge">
-      <InterfaceFormTable
-        isPrimary
-        linkId={linkId}
-        nicId={nicId}
-        systemId={systemId}
-      />
+      <InterfaceFormTable interfaces={selected} systemId={systemId} />
       <button onClick={close}>Cancel</button>
     </FormCard>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
@@ -78,7 +78,10 @@ const EditInterface = ({
         interfaceType ? `Edit ${INTERFACE_TYPE_DISPLAY[interfaceType]}` : null
       }
     >
-      <InterfaceFormTable linkId={linkId} nicId={nicId} systemId={systemId} />
+      <InterfaceFormTable
+        interfaces={[{ linkId, nicId }]}
+        systemId={systemId}
+      />
       {form}
     </FormCard>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
@@ -34,7 +34,7 @@ describe("InterfaceFormTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <InterfaceFormTable systemId="abc123" />
+        <InterfaceFormTable interfaces={[]} systemId="abc123" />
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
@@ -51,7 +51,10 @@ describe("InterfaceFormTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <InterfaceFormTable nicId={nic.id} systemId="abc123" />
+        <InterfaceFormTable
+          interfaces={[{ nicId: nic.id }]}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("MainTable").exists()).toBe(true);
@@ -68,13 +71,16 @@ describe("InterfaceFormTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <InterfaceFormTable nicId={nic.id} systemId="abc123" />
+        <InterfaceFormTable
+          interfaces={[{ nicId: nic.id }]}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("PXEColumn").exists()).toBe(true);
   });
 
-  it("can display a primary icon instead of the PXE column", () => {
+  it("can display radio buttons to choose the primary", () => {
     const nic = machineInterfaceFactory();
     state.machine.items = [
       machineDetailsFactory({
@@ -85,10 +91,63 @@ describe("InterfaceFormTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <InterfaceFormTable isPrimary nicId={nic.id} systemId="abc123" />
+        <InterfaceFormTable
+          editPrimary
+          interfaces={[{ nicId: nic.id }]}
+          systemId="abc123"
+        />
       </Provider>
     );
     expect(wrapper.find("PXEColumn").exists()).toBe(false);
-    expect(wrapper.find("Icon[name='tick']").exists()).toBe(true);
+    expect(wrapper.find("input[name='primary']").exists()).toBe(true);
+  });
+
+  it("can show checkboxes to update the selection", () => {
+    const nic = machineInterfaceFactory();
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <InterfaceFormTable
+          interfaces={[{ nicId: nic.id }]}
+          selectedEditable
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("NameColumn").prop("showCheckbox")).toBe(true);
+  });
+
+  it("mutes a row if its not selected", () => {
+    const nic = machineInterfaceFactory();
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [nic],
+        system_id: "abc123",
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <InterfaceFormTable
+          interfaces={[{ nicId: nic.id }]}
+          selectedEditable
+          selected={[]}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("TableRow")
+        .last()
+        ?.prop("className")
+        ?.includes("p-table__row--muted")
+    ).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router";
 import type { SetSelectedAction } from "../types";
 
 import AddInterface from "./AddInterface";
+import BondForm from "./BondForm";
 import BridgeForm from "./BridgeForm";
 import DHCPTable from "./DHCPTable";
 import EditInterface from "./EditInterface";
@@ -49,12 +50,16 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
       />
     );
   } else if (interfaceExpanded?.content === ExpandedState.ADD_BOND) {
-    // Temporary placeholder for the form.
     return (
-      <>
-        Add bond{" "}
-        <button onClick={() => setInterfaceExpanded(null)}>cancel</button>
-      </>
+      <BondForm
+        close={() => {
+          setInterfaceExpanded(null);
+          setSelected([]);
+        }}
+        selected={selected}
+        setSelected={setSelected}
+        systemId={id}
+      />
     );
   } else if (interfaceExpanded?.content === ExpandedState.ADD_BRIDGE) {
     // Temporary placeholder for the form.

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -369,7 +369,7 @@ const rowSort = (
   return 0;
 };
 
-const generateUniqueId = ({ linkId, nicId }: Selected): string =>
+export const generateUniqueId = ({ linkId, nicId }: Selected): string =>
   `${nicId || ""}-${linkId || ""}`;
 
 type Props = {

--- a/ui/src/app/utils/simpleSortByKey.ts
+++ b/ui/src/app/utils/simpleSortByKey.ts
@@ -1,17 +1,12 @@
-type KeyedObject<K extends string> = Partial<Record<K, unknown>>;
-
 /**
  * Simple sort objects by key value.
  *
  * @param key - the key of the objects to sort by
  * @returns sort function
  */
-export const simpleSortByKey = <K extends string>(
+export const simpleSortByKey = <O, K extends keyof O>(
   attr: K
-): ((a: KeyedObject<K>, b: KeyedObject<K>) => number) => (
-  a: KeyedObject<K>,
-  b: KeyedObject<K>
-) => {
+): ((a: O, b: O) => number) => (a: O, b: O) => {
   if (a[attr] > b[attr]) return 1;
   if (a[attr] < b[attr]) return -1;
   return 0;

--- a/ui/src/scss/_patterns_tables.scss
+++ b/ui/src/scss/_patterns_tables.scss
@@ -55,4 +55,8 @@
       right: 0;
     }
   }
+
+.p-table__row--muted {
+  background-color: $color-light;
+}
 }


### PR DESCRIPTION
## Done

- Add a table for managing the interfaces in a bond.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the react network tab for a machine.
- Create three physical interfaces with the same VLAN.
- Tick two of the interfaces and click "Create bond".
- You should see a table with the two interfaces you selected.
- Click "Edit bond members". You should see the third interface (and possibly others if there are other valid interfaces).
- Change the selected interfaces and click "Update bond members". The unselected interfaces should get hidden.

## Fixes

Fixes: #2306.