### PR TITLE
fix(ui): fix race condition when loading osinfo

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -47,9 +47,8 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const defaultMinHweKernel = useSelector(defaultMinHweKernelSelectors.get);
-  const { default_osystem, default_release, osystems, releases } = useSelector(
-    osInfoSelectors.get
-  );
+  const { default_osystem, default_release, osystems, releases } =
+    useSelector(osInfoSelectors.get) || {};
   const defaultMinHweKernelLoaded = useSelector(
     defaultMinHweKernelSelectors.loaded
   );
@@ -71,7 +70,7 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
   let initialOS = "";
   let initialRelease = "";
   if (osystems?.some((osChoice) => osChoice[0] === default_osystem)) {
-    initialOS = default_osystem;
+    initialOS = default_osystem || "";
   }
   if (
     releases?.some((releaseChoice) => {
@@ -79,7 +78,7 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
       return split.length > 1 && split[1] === default_release;
     })
   ) {
-    initialRelease = default_release;
+    initialRelease = default_release || "";
   }
 
   return (

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -128,7 +128,9 @@ describe("DeployFormFields", () => {
 
   it("correctly sets operating system to default", () => {
     const state = { ...initialState };
-    state.general.osInfo.data.default_osystem = "centos";
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_osystem = "centos";
+    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -144,7 +146,9 @@ describe("DeployFormFields", () => {
 
   it("correctly sets release to default", () => {
     const state = { ...initialState };
-    state.general.osInfo.data.default_release = "bionic";
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "bionic";
+    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -178,7 +182,9 @@ describe("DeployFormFields", () => {
 
   it("disables KVM checkbox if not Ubuntu 18.04 or 20.04", async () => {
     const state = { ...initialState };
-    state.general.osInfo.data.default_release = "xenial";
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "xenial";
+    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -214,7 +220,9 @@ describe("DeployFormFields", () => {
 
   it("enables KVM checkbox when switching to Ubuntu 18.04 from a different OS/Release", async () => {
     const state = { ...initialState };
-    state.general.osInfo.data.default_release = "bionic";
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "bionic";
+    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -269,8 +277,10 @@ describe("DeployFormFields", () => {
   it(`displays an error and disables form fields if there are no OSes or
     releases to choose from`, () => {
     const state = { ...initialState };
-    state.general.osInfo.data.osystems = [];
-    state.general.osInfo.data.releases = [];
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.osystems = [];
+      state.general.osInfo.data.releases = [];
+    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -295,7 +305,9 @@ describe("DeployFormFields", () => {
 
   it("can display the user data input", async () => {
     const state = { ...initialState };
-    state.general.osInfo.data.default_release = "bionic";
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "bionic";
+    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -318,7 +330,9 @@ describe("DeployFormFields", () => {
 
   it("resets kernel selection on OS/release change", async () => {
     const state = { ...initialState };
-    state.general.osInfo.data.default_release = "bionic";
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "bionic";
+    }
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -25,8 +25,9 @@ export const DeployFormFields = (): JSX.Element => {
 
   const user = useSelector(authSelectors.get);
   const osOptions = useSelector(configSelectors.defaultOSystemOptions);
-  const { osystems, releases } = useSelector(osInfoSelectors.get);
-  const allReleaseOptions = useSelector(osInfoSelectors.getAllOsReleases);
+  const { osystems = [], releases = [] } =
+    useSelector(osInfoSelectors.get) || {};
+  const allReleaseOptions = useSelector(osInfoSelectors.getAllOsReleases) || {};
   const releaseOptions = allReleaseOptions[values.oSystem] || [];
   const kernelOptions = useSelector((state: RootState) =>
     osInfoSelectors.getUbuntuKernelOptions(state, values.release)

--- a/ui/src/app/store/general/selectors/osInfo.test.ts
+++ b/ui/src/app/store/general/selectors/osInfo.test.ts
@@ -92,6 +92,19 @@ describe("osInfo selectors", () => {
         { value: "hwe-q", label: "precise (hwe-q)" },
       ]);
     });
+
+    it("handles no data", () => {
+      const state = rootStateFactory({
+        general: generalStateFactory({
+          osInfo: osInfoStateFactory({
+            data: null,
+          }),
+        }),
+      });
+      expect(osInfo.getUbuntuKernelOptions(state, "precise")).toEqual([
+        { value: "", label: "No minimum kernel" },
+      ]);
+    });
   });
 
   describe("getAllUbuntuKernelOptions", () => {
@@ -129,6 +142,17 @@ describe("osInfo selectors", () => {
           { value: "hwe-u", label: "trusty (hwe-u)" },
         ],
       });
+    });
+
+    it("handles no data", () => {
+      const state = rootStateFactory({
+        general: generalStateFactory({
+          osInfo: osInfoStateFactory({
+            data: null,
+          }),
+        }),
+      });
+      expect(osInfo.getAllUbuntuKernelOptions(state)).toEqual({});
     });
   });
 
@@ -168,6 +192,11 @@ describe("osInfo selectors", () => {
         },
         { value: "trusty", label: "Ubuntu 14.04 LTS 'Trusty Tahr'" },
       ]);
+    });
+
+    it("handles no data", () => {
+      state.general.osInfo.data = null;
+      expect(osInfo.getOsReleases(state, "ubuntu")).toEqual([]);
     });
   });
 
@@ -210,6 +239,11 @@ describe("osInfo selectors", () => {
         ],
       });
     });
+
+    it("handles no data", () => {
+      state.general.osInfo.data = null;
+      expect(osInfo.getAllOsReleases(state)).toEqual({});
+    });
   });
 
   describe("getLicensedOsReleases", () => {
@@ -243,6 +277,11 @@ describe("osInfo selectors", () => {
         windows: [{ value: "win2012", label: "Windows 2012 Server" }],
       });
     });
+
+    it("handles no data", () => {
+      state.general.osInfo.data = null;
+      expect(osInfo.getLicensedOsReleases(state)).toEqual({});
+    });
   });
 
   describe("getLicensedOsystems", () => {
@@ -275,6 +314,11 @@ describe("osInfo selectors", () => {
       expect(osInfo.getLicensedOsystems(state)).toEqual([
         ["windows", "Windows"],
       ]);
+    });
+
+    it("handles no data", () => {
+      state.general.osInfo.data = null;
+      expect(osInfo.getLicensedOsystems(state)).toEqual([]);
     });
   });
 });

--- a/ui/src/app/store/general/selectors/osInfo.ts
+++ b/ui/src/app/store/general/selectors/osInfo.ts
@@ -6,7 +6,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import { generateGeneralSelector } from "./utils";
 
 import type {
-  OSInfo,
+  OSInfoState,
   OSInfoOsKernelEntry,
   OSInfoOSystem,
   OSInfoRelease,
@@ -29,12 +29,12 @@ export type OSInfoOptions = { [x: string]: OSInfoOption[] };
  * @returns {OSInfoOption[]} - The available kernel options.
  */
 const _getUbuntuKernelOptions = (
-  data: OSInfo,
+  data: OSInfoState["data"],
   release: string
 ): OSInfoOption[] => {
   let kernelOptions: OSInfoOsKernelEntry[] = [];
 
-  if (data.kernels && data.kernels.ubuntu && data.kernels.ubuntu[release]) {
+  if (data?.kernels?.ubuntu[release]) {
     kernelOptions = data.kernels.ubuntu[release];
   }
   const noMin = ["", "No minimum kernel"];
@@ -63,10 +63,10 @@ const getUbuntuKernelOptions = createSelector(
  */
 const getAllUbuntuKernelOptions = createSelector(
   [generalSelectors.get],
-  (allOsInfo: OSInfo) => {
+  (allOsInfo: OSInfoState["data"]) => {
     const allUbuntuKernelOptions: OSInfoOptions = {};
 
-    if (allOsInfo.kernels && allOsInfo.kernels.ubuntu) {
+    if (allOsInfo?.kernels?.ubuntu) {
       Object.keys(allOsInfo.kernels.ubuntu).forEach((key) => {
         allUbuntuKernelOptions[key] = _getUbuntuKernelOptions(allOsInfo, key);
       });
@@ -82,10 +82,13 @@ const getAllUbuntuKernelOptions = createSelector(
  * @param {String} os - the OS to get releases of
  * @returns {OSInfoOption[]} - the available OS releases
  */
-const _getOsReleases = (allOsInfo: OSInfo, os?: string): OSInfoOption[] => {
+const _getOsReleases = (
+  allOsInfo: OSInfoState["data"],
+  os?: string
+): OSInfoOption[] => {
   let osReleases: OSInfoOption[] = [];
 
-  if (allOsInfo.releases) {
+  if (allOsInfo?.releases) {
     let releases = allOsInfo.releases;
     if (os) {
       releases = releases.filter((release: OSInfoRelease) =>
@@ -119,10 +122,10 @@ const getOsReleases = createSelector(
  */
 const getAllOsReleases = createSelector(
   [generalSelectors.get],
-  (allOsInfo: OSInfo): OSInfoOptions => {
+  (allOsInfo: OSInfoState["data"]): OSInfoOptions => {
     const allOsReleases: OSInfoOptions = {};
 
-    if (allOsInfo.osystems && allOsInfo.releases) {
+    if (allOsInfo?.osystems && allOsInfo?.releases) {
       allOsInfo.osystems.forEach((osystem: OSInfoOSystem) => {
         const os = osystem[0];
         allOsReleases[os] = _getOsReleases(allOsInfo, os);

--- a/ui/src/app/store/general/types.ts
+++ b/ui/src/app/store/general/types.ts
@@ -161,7 +161,7 @@ export type OSInfo = {
 
 export type OSInfoState = {
   errors: TSFixMe;
-  data: OSInfo;
+  data: OSInfo | null;
   loaded: boolean;
   loading: boolean;
 };


### PR DESCRIPTION
## Done

- Fix the selectors and components that fetch osinfo so that they can handle no data.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load the react network tab in machine details.
- Click 'Machines' in the header.
- The machine list should load without falling over.

## Fixes

Fixes: #2348.