### PR TITLE
fix(ui): add proxmox field names to add_chassis parameter map

### DIFF
--- a/ui/src/app/store/general/utils/powerTypes.test.ts
+++ b/ui/src/app/store/general/utils/powerTypes.test.ts
@@ -36,7 +36,10 @@ describe("powerTypes utils", () => {
           powerFieldFactory({ name: "power_pass" }),
           powerFieldFactory({ name: "power_port" }),
           powerFieldFactory({ name: "power_protocol" }),
+          powerFieldFactory({ name: "power_token_name" }),
+          powerFieldFactory({ name: "power_token_secret" }),
           powerFieldFactory({ name: "power_user" }),
+          powerFieldFactory({ name: "power_verify_ssl" }),
         ],
       });
 
@@ -45,7 +48,10 @@ describe("powerTypes utils", () => {
         power_pass: "value2",
         power_port: "value3",
         power_protocol: "value4",
-        power_user: "value5",
+        power_token_name: "value5",
+        power_token_secret: "value6",
+        power_user: "value7",
+        power_verify_ssl: "value8",
       };
       expect(
         formatPowerParameters(powerType, powerParameters, undefined, true)
@@ -54,7 +60,10 @@ describe("powerTypes utils", () => {
         password: "value2",
         port: "value3",
         protocol: "value4",
-        username: "value5",
+        token_name: "value5",
+        token_secret: "value6",
+        username: "value7",
+        verify_ssl: "value8",
       });
     });
 

--- a/ui/src/app/store/general/utils/powerTypes.ts
+++ b/ui/src/app/store/general/utils/powerTypes.ts
@@ -25,7 +25,10 @@ const chassisParameterMap = new Map([
   ["power_pass", "password"],
   ["power_port", "port"],
   ["power_protocol", "protocol"],
+  ["power_token_name", "token_name"],
+  ["power_token_secret", "token_secret"],
   ["power_user", "username"],
+  ["power_verify_ssl", "verify_ssl"],
 ]);
 export const formatPowerParameters = (
   powerType: PowerType | undefined,
@@ -38,7 +41,7 @@ export const formatPowerParameters = (
       if (forChassis) {
         // The add_chassis api expects different field names than what's given
         // in the list of power type fields.
-        const fieldName = chassisParameterMap.get(field.name) || "";
+        const fieldName = chassisParameterMap.get(field.name) || field.name;
         params[fieldName] = powerParameters[field.name];
       } else {
         params[field.name] = powerParameters[field.name];


### PR DESCRIPTION
## Done

- Added proxmox field names to the add_chassis parameter map

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Make sure you're running the UI using `yarn start` not `yarn ui` because `add_chassis` is an http method
- Open the add chassis form from the machine list and choose Proxmox
- Submit the form without a password or token and check that you get an error
- Submit the form with both a password and token and check that you get an error
- Check the network tab and see that the add_chassis request includes all the entered form values

## Fixes

Fixes #2327 