### PR TITLE
feat(ui): show errors from non field keys

### DIFF
--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -54,6 +54,7 @@ const FormikForm = <V, E = FormErrors>({
   secondarySubmitLabel,
   secondarySubmitTooltip,
   submitAppearance,
+  submitDisabled,
   submitLabel,
   validationSchema,
   ...props
@@ -107,6 +108,7 @@ const FormikForm = <V, E = FormErrors>({
         secondarySubmitLabel={secondarySubmitLabel}
         secondarySubmitTooltip={secondarySubmitTooltip}
         submitAppearance={submitAppearance}
+        submitDisabled={submitDisabled}
         submitLabel={submitLabel}
       >
         {children}

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -35,6 +35,50 @@ describe("FormikFormContent", () => {
     expect(wrapper.find("Notification").text()).toEqual("Error:Uh oh!");
   });
 
+  it("can display non-field errors from the unknown keys with strings", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent
+          initialValues={{}}
+          errors={{ username: "Wrong username" }}
+        >
+          Content
+        </FormikFormContent>
+      </Formik>
+    );
+    expect(wrapper.find("Notification").text()).toEqual("Error:Wrong username");
+  });
+
+  it("does not display non-field errors for fields", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ username: "" }} onSubmit={jest.fn()}>
+        <FormikFormContent
+          initialValues={{}}
+          errors={{ username: "Wrong username" }}
+        >
+          Content
+        </FormikFormContent>
+      </Formik>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(false);
+  });
+
+  it("can display non-field errors from the unknown keys with arrays", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent
+          initialValues={{}}
+          errors={{ username: ["Wrong username", "Username must be provided"] }}
+        >
+          Content
+        </FormikFormContent>
+      </Formik>
+    );
+    expect(wrapper.find("Notification").text()).toEqual(
+      "Error:Wrong username, Username must be provided"
+    );
+  });
+
   it("can be inline", () => {
     const wrapper = mount(
       <Formik initialValues={{}} onSubmit={jest.fn()}>
@@ -48,8 +92,10 @@ describe("FormikFormContent", () => {
 
   it("does not render buttons if editable is set to false", () => {
     const wrapper = mount(
-      <Formik initialValues={{}}>
-        <FormikFormContent editable={false}>Content</FormikFormContent>
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent initialValues={{}} editable={false}>
+          Content
+        </FormikFormContent>
       </Formik>
     );
     expect(wrapper.find("button").exists()).toBe(false);

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -58,6 +58,7 @@ export type Props<V, E = FormErrors> = {
   secondarySubmitLabel?: string;
   secondarySubmitTooltip?: string | null;
   submitAppearance?: string;
+  submitDisabled?: boolean;
   submitLabel?: string;
 };
 
@@ -85,6 +86,7 @@ const FormikFormContent = <V, E = FormErrors>({
   secondarySubmitLabel,
   secondarySubmitTooltip,
   submitAppearance,
+  submitDisabled = false,
   submitLabel = "Save",
 }: Props<V, E>): JSX.Element => {
   const formikContext = useFormikContext<V>();
@@ -107,8 +109,20 @@ const FormikFormContent = <V, E = FormErrors>({
   if (errors) {
     if (typeof errors === "string") {
       nonFieldError = errors;
-    } else if ("__all__" in errors) {
-      nonFieldError = errors["__all__"].join(" ");
+    } else if (typeof errors === "object") {
+      let otherErrors: string[] = [];
+      // Display any errors for keys that don't match form fields.
+      Object.entries(errors).forEach(([key, value]) => {
+        if (!(key in values)) {
+          if (typeof value === "string") {
+            otherErrors.push(value);
+          }
+          if (Array.isArray(value)) {
+            otherErrors = otherErrors.concat(value);
+          }
+        }
+      });
+      nonFieldError = otherErrors.join(", ");
     }
   }
 
@@ -141,7 +155,7 @@ const FormikFormContent = <V, E = FormErrors>({
           secondarySubmitLabel={secondarySubmitLabel}
           secondarySubmitTooltip={secondarySubmitTooltip}
           submitAppearance={submitAppearance}
-          submitDisabled={loading || saving || formDisabled}
+          submitDisabled={loading || saving || formDisabled || submitDisabled}
           submitLabel={submitLabel}
           success={saved}
         />


### PR DESCRIPTION
## Done

- Update the non-field error handling to show errors from keys that don't match form fields.
- Pass the `submitDisabled` prop through the form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

Check that the existing errors work:
- Visit the react network tab for a machine.
- Click "Add interface".
- Enter a mac address that is already in use.
- Submit the form. An error should be displayed below the mac address field.

## Fixes

Fixes: #2350.