### PR TITLE
feat(ui): only allow physical bond interfaces

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.test.tsx
@@ -290,7 +290,7 @@ describe("NetworkActions", () => {
       ).toBe(true);
     });
 
-    it("disables the button when an alias is selected", () => {
+    it("disables the button when some selected interfaces are not physical", () => {
       state.machine.items = [
         machineDetailsFactory({
           interfaces: [
@@ -321,48 +321,6 @@ describe("NetworkActions", () => {
             <NetworkActions
               expanded={null}
               selected={[{ nicId: 1, linkId: 2 }, { nicId: 2 }]}
-              setExpanded={jest.fn()}
-              setSelectedAction={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
-      );
-      expect(wrapper.find("Button[data-test='addBond']").prop("disabled")).toBe(
-        true
-      );
-      expect(
-        wrapper.find("Tooltip[data-test='addBond-tooltip']").exists()
-      ).toBe(true);
-    });
-
-    it("disables the button when a bond is selected", () => {
-      state.machine.items = [
-        machineDetailsFactory({
-          interfaces: [
-            machineInterfaceFactory({
-              id: 1,
-              type: NetworkInterfaceTypes.BOND,
-              vlan_id: 1,
-            }),
-            machineInterfaceFactory({
-              id: 2,
-              type: NetworkInterfaceTypes.PHYSICAL,
-              vlan_id: 1,
-            }),
-          ],
-          system_id: "abc123",
-        }),
-      ];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <NetworkActions
-              expanded={null}
-              selected={[{ nicId: 1 }, { nicId: 2 }]}
               setExpanded={jest.fn()}
               setSelectedAction={jest.fn()}
               systemId="abc123"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
@@ -44,6 +44,18 @@ const selectedIncludesType = (
     return interfaceType === getInterfaceType(machine, nic, link);
   });
 
+// Check if any of the selected interfaces does not have the provided type.
+const selectedAllOfType = (
+  machine: Machine,
+  selected: Selected[],
+  interfaceType: NetworkInterfaceTypes
+): boolean =>
+  selected.every(({ nicId, linkId }) => {
+    const nic = getInterfaceById(machine, nicId, linkId);
+    const link = getLinkFromNic(nic, linkId);
+    return interfaceType === getInterfaceType(machine, nic, link);
+  });
+
 // Check if any of the selected interfaces has a different VLAN.
 const selectedDifferentVLANs = (
   machine: Machine,
@@ -95,12 +107,8 @@ const NetworkActions = ({
         [selected.length === 0, "No interfaces are selected"],
         [selected.length === 1, "A bond must include more than one interface"],
         [
-          selectedIncludesType(machine, selected, NetworkInterfaceTypes.ALIAS),
-          "A bond can not include an alias",
-        ],
-        [
-          selectedIncludesType(machine, selected, NetworkInterfaceTypes.BOND),
-          "A bond can not include another bond",
+          !selectedAllOfType(machine, selected, NetworkInterfaceTypes.PHYSICAL),
+          "A bond can only include physical interfaces",
         ],
         [
           selectedDifferentVLANs(machine, selected),


### PR DESCRIPTION
## Done

- Update the network table action to only allow physical interfaces for a bond.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the react network tab.
- Tick a physical interfaces and alias that have the same VLAN.
- The 'Add bond' button should be disabled with a tooltip.
- Tick two physical interfaces that have the same VLAN.
- The 'Add bond' button should not be disabled.

## Fixes

Fixes: #2325.