### PR TITLE
feat(ui): show Open vSwitch labels

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
@@ -30,7 +30,7 @@ import {
   getLinkMode,
   useIsAllNetworkingDisabled,
 } from "app/store/machine/utils";
-import { INTERFACE_TYPE_DISPLAY } from "app/store/machine/utils/networking";
+import { getInterfaceTypeText } from "app/store/machine/utils/networking";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -102,6 +102,7 @@ const EditAliasOrVlanForm = ({
     link
   );
   const ipAddress = getInterfaceIPAddress(machine, fabrics, vlans, nic, link);
+  const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
   return (
     <FormikForm
       buttons={FormCardButtons}
@@ -145,7 +146,7 @@ const EditAliasOrVlanForm = ({
       resetOnSave
       saved={saved}
       saving={saving}
-      submitLabel={`Save ${INTERFACE_TYPE_DISPLAY[interfaceType]}`}
+      submitLabel={`Save ${interfaceTypeDisplay}`}
       validationSchema={AliasOrVlanSchema}
     >
       <Row>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx
@@ -20,6 +20,7 @@ import type {
   NetworkInterface,
   NetworkLink,
 } from "app/store/machine/types";
+import { getInterfaceTypeText } from "app/store/machine/utils/networking";
 import type { RootState } from "app/store/root/types";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
@@ -72,7 +73,7 @@ const EditBridgeForm = ({
   if (vlansLoading || !nic || !machine || !("interfaces" in machine)) {
     return <Spinner text="Loading..." />;
   }
-
+  const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
   return (
     <FormikForm
       allowUnchanged
@@ -123,7 +124,7 @@ const EditBridgeForm = ({
       resetOnSave
       saved={saved}
       saving={saving}
-      submitLabel="Save bridge"
+      submitLabel={`Save ${interfaceTypeDisplay}`}
       validationSchema={InterfaceSchema}
     >
       <BridgeFormFields typeDisabled />

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditInterface/EditInterface.tsx
@@ -17,7 +17,7 @@ import type {
   NetworkLink,
 } from "app/store/machine/types";
 import { getInterfaceType, getLinkFromNic } from "app/store/machine/utils";
-import { INTERFACE_TYPE_DISPLAY } from "app/store/machine/utils/networking";
+import { getInterfaceTypeText } from "app/store/machine/utils/networking";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -45,6 +45,7 @@ const EditInterface = ({
   }
   const interfaceType = getInterfaceType(machine, nic, link);
   let form: ReactNode;
+  const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
   if (interfaceType === NetworkInterfaceTypes.PHYSICAL) {
     form = (
       <EditPhysicalForm
@@ -73,13 +74,7 @@ const EditInterface = ({
     );
   }
   return (
-    <FormCard
-      sidebar={false}
-      stacked
-      title={
-        interfaceType ? `Edit ${INTERFACE_TYPE_DISPLAY[interfaceType]}` : null
-      }
-    >
+    <FormCard sidebar={false} stacked title={`Edit ${interfaceTypeDisplay}`}>
       <InterfaceFormTable
         interfaces={[{ linkId, nicId }]}
         systemId={systemId}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -113,7 +113,7 @@ const generateRow = (
   const vlan = vlans.find(({ id }) => id === nic?.vlan_id);
   const fabric = getInterfaceFabric(machine, fabrics, vlans, nic, link);
   const name = getInterfaceName(machine, nic, link);
-  const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
+  const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link, true);
   const shouldShowDHCP = !isABondOrBridgeParent && fabricsLoaded && vlansLoaded;
   const fabricContent = !isABondOrBridgeParent
     ? fabric?.name || "Disconnected"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableConfirmation/NetworkTableConfirmation.test.tsx
@@ -145,7 +145,7 @@ describe("NetworkTableConfirmation", () => {
       const confirmation = wrapper.find("ActionConfirm");
       expect(confirmation.prop("eventName")).toBe("unlinkSubnet");
       expect(confirmation.prop("message")).toBe(
-        "Are you sure you want to remove this alias?"
+        "Are you sure you want to remove this Alias?"
       );
       expect(confirmation.prop("statusKey")).toBe("unlinkingSubnet");
     });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/TypeColumn/TypeColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/TypeColumn/TypeColumn.tsx
@@ -28,7 +28,7 @@ const TypeColumn = ({ link, nic, systemId }: Props): JSX.Element | null => {
     return null;
   }
   const numaNodes = getInterfaceNumaNodes(machine, nic, link);
-  const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
+  const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link, true);
 
   return (
     <DoubleRow

--- a/ui/src/app/store/machine/utils/networking.test.ts
+++ b/ui/src/app/store/machine/utils/networking.test.ts
@@ -615,7 +615,7 @@ describe("machine networking utils", () => {
         type: NetworkInterfaceTypes.BRIDGE,
       });
       const machine = machineDetailsFactory({ interfaces: [nic] });
-      expect(getRemoveTypeText(machine, nic)).toBe("bridge");
+      expect(getRemoveTypeText(machine, nic)).toBe("Bridge");
     });
 
     it("returns the text via an alias", () => {

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -670,7 +670,7 @@ export const getRemoveTypeText = (
   } else if (interfaceType === NetworkInterfaceTypes.VLAN) {
     return "VLAN";
   } else {
-    return interfaceType;
+    return getInterfaceTypeText(machine, nic, link);
   }
 };
 


### PR DESCRIPTION
## Done

- Display the Open vSwitch label for bridges.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the react network tab for a machine.
- Create a physical interface if there isn't one.
- Tick the physical interface and click "Create bridge".
- Selected "Open vSwitch" for the bridge type and submit.
- When the bridge appears check that the type is displayed as "Open vSwitch".
- Open the action menu for the bridge and check that the edit/remove actions refer to it as "Open vSwitch".
- Click "Edit Open vSwitch" and check that the form title and save button both refer to "Open vSwitch".

## Fixes

Fixes: #2340.