### PR TITLE
refactor(ui): make parts of bond form reusable

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -436,7 +436,14 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx:3596158043": [
       [92, 8, 8, "Type \'(values: AddAliasOrVlanValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'AddAliasOrVlanValues\'.\\n      Type \'unknown\' is not assignable to type \'{ tags?: string[] | undefined; }\'.", "1301647696"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx:4124460125": [
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx:3216952464": [
+      [324, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
+      [328, 8, 18, "Argument of type \'{ bond_downdelay: number; bond_lacp_rate: string; bond_mode: BondMode; bond_miimon: number; bond_updelay: number; fabric: number; ip_address: string; linkMonitoring: LinkMonitoring; ... 5 more ...; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bond_downdelay\' does not exist in type \'FormEvent<{}>\'.", "796132353"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx:1640091892": [
+      [185, 8, 8, "Type \'(values: BondFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BondFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bond_downdelay: number | undefined; bond_lacp_rate: BondLacpRate; bond_miimon: number | undefined; bond_mode: BondMode; bond_updelay: number | undefined; ... 4 more ...; tags: string[]; }\'.", "1301647696"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx:1512454196": [
       [132, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [136, 10, 13, "Argument of type \'{ bridge_fd: number; bridge_stp: boolean; fabric: number; ip_address: string; mac_address: string; mode: NetworkLinkMode; name: string; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bridge_fd\' does not exist in type \'FormEvent<{}>\'.", "3725868217"]
     ],
@@ -449,15 +456,6 @@ exports[`stricter compilation`] = {
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx:4275889191": [
       [90, 10, 8, "Type \'(values: AddInterfaceValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'AddInterfaceValues\'.\\n      Type \'unknown\' is not assignable to type \'{ mac_address: string; name?: string | undefined; tags?: string[] | undefined; }\'.", "1301647696"]
-    ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondForm.test.tsx:1297857550": [
-      [362, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
-      [366, 8, 18, "Argument of type \'{ bond_downdelay: number; bond_lacp_rate: string; bond_mode: BondMode; bond_miimon: number; bond_updelay: number; fabric: number; ip_address: string; linkMonitoring: MIIOptions; ... 6 more ...; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bond_downdelay\' does not exist in type \'FormEvent<{}>\'.", "796132353"],
-      [446, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
-      [450, 8, 18, "Argument of type \'{ bond_downdelay: number; bond_lacp_rate: string; bond_mode: BondMode; bond_miimon: number; bond_updelay: number; fabric: number; ip_address: string; linkMonitoring: string; mac_address: string; ... 5 more ...; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bond_downdelay\' does not exist in type \'FormEvent<{}>\'.", "796132353"]
-    ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondForm.tsx:3875960657": [
-      [244, 8, 8, "Type \'(values: BondFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BondFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bond_downdelay: number | undefined; bond_lacp_rate: BondLacpRate; bond_miimon: number | undefined; bond_mode: BondMode; bond_updelay: number | undefined; ... 5 more ...; tags: string[]; }\'.", "1301647696"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondModeSelect/BondModeSelect.test.tsx:2694028039": [
       [109, 11, 43, "Object is of type \'unknown\'.", "2224745896"],
@@ -491,15 +489,15 @@ exports[`stricter compilation`] = {
       [202, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
       [206, 8, 9, "Argument of type \'{ fabric: number; ip_address: string; mode: NetworkLinkMode; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'fabric\' does not exist in type \'FormEvent<{}>\'.", "3240912851"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx:1928945104": [
-      [123, 6, 8, "Type \'(values: EditAliasOrVlanValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'EditAliasOrVlanValues\'.\\n      Type \'unknown\' is not assignable to type \'{ tags?: string[] | undefined; }\'.", "1301647696"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx:2508225538": [
+      [124, 6, 8, "Type \'(values: EditAliasOrVlanValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'EditAliasOrVlanValues\'.\\n      Type \'unknown\' is not assignable to type \'{ tags?: string[] | undefined; }\'.", "1301647696"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx:1263648396": [
       [110, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [114, 10, 13, "Argument of type \'{ bridge_fd: number; bridge_stp: boolean; bridge_type: BridgeType; fabric: number; ip_address: string; mac_address: string; mode: NetworkLinkMode; name: string; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bridge_fd\' does not exist in type \'FormEvent<{}>\'.", "3725868217"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx:565377694": [
-      [100, 6, 8, "Type \'(values: BridgeFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BridgeFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bridge_fd?: number | undefined; bridge_stp?: boolean | undefined; bridge_type: BridgeType | undefined; mac_address: string; name: string; tags?: string[] | undefined; }\'.", "1301647696"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx:2591370152": [
+      [101, 6, 8, "Type \'(values: BridgeFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BridgeFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bridge_fd?: number | undefined; bridge_stp?: boolean | undefined; bridge_type: BridgeType | undefined; mac_address: string; name: string; tags?: string[] | undefined; }\'.", "1301647696"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.test.tsx:2708100290": [
       [140, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
@@ -508,7 +506,7 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx:3472288293": [
       [155, 6, 8, "Type \'(values: EditInterfaceValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'EditInterfaceValues\'.\\n      Type \'unknown\' is not assignable to type \'{ interface_speed: number; link_speed: number; mac_address: string; name?: string | undefined; tags?: string[] | undefined; }\'.", "1301647696"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:2077494481": [
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:2321145835": [
       [333, 4, 3, "Argument of type \'keyof NetworkRowSortData | null\' is not assignable to parameter of type \'keyof NetworkRowSortData\'.\\n  Type \'null\' is not assignable to type \'keyof NetworkRowSortData\'.", "193424690"],
       [337, 4, 3, "Argument of type \'keyof NetworkRowSortData | null\' is not assignable to parameter of type \'keyof NetworkRowSortData\'.", "193424690"],
       [362, 35, 9, "Object is possibly \'null\'.", "1794230341"],

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -3,8 +3,9 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import BondForm from "./BondForm";
-import { LinkMonitoring } from "./types";
+import { LinkMonitoring } from "../BondForm/types";
+
+import AddBondForm from "./AddBondForm";
 
 import { BondMode } from "app/store/general/types";
 import {
@@ -28,7 +29,7 @@ import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
-describe("BondForm", () => {
+describe("AddBondForm", () => {
   let state: RootState;
   beforeEach(() => {
     state = rootStateFactory({
@@ -66,7 +67,7 @@ describe("BondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BondForm
+          <AddBondForm
             close={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
@@ -104,7 +105,7 @@ describe("BondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BondForm
+          <AddBondForm
             close={jest.fn()}
             selected={selected}
             setSelected={jest.fn()}
@@ -167,7 +168,7 @@ describe("BondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BondForm
+          <AddBondForm
             close={jest.fn()}
             selected={[
               { nicId: interfaces[0].id },
@@ -190,46 +191,7 @@ describe("BondForm", () => {
     );
   });
 
-  it("disables the edit button if there are no additional valid interfaces", async () => {
-    const interfaces = [
-      machineInterfaceFactory({
-        type: NetworkInterfaceTypes.PHYSICAL,
-        vlan_id: 1,
-      }),
-      machineInterfaceFactory({
-        type: NetworkInterfaceTypes.PHYSICAL,
-        vlan_id: 1,
-      }),
-    ];
-    state.machine.items = [
-      machineDetailsFactory({
-        system_id: "abc123",
-        interfaces,
-      }),
-    ];
-    const store = mockStore(state);
-    const selected = [{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }];
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <BondForm
-            close={jest.fn()}
-            selected={selected}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-    await waitForComponentToPaint(wrapper);
-    expect(
-      wrapper.find("Button[data-test='edit-members']").prop("disabled")
-    ).toBe(true);
-  });
-
-  it("disables the update button if two interfaces aren't selected", async () => {
+  it("disables the submit button if two interfaces aren't selected", async () => {
     const interfaces = [
       machineInterfaceFactory({
         type: NetworkInterfaceTypes.PHYSICAL,
@@ -258,7 +220,7 @@ describe("BondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BondForm
+          <AddBondForm
             close={jest.fn()}
             selected={[
               { nicId: interfaces[0].id },
@@ -289,7 +251,7 @@ describe("BondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BondForm
+          <AddBondForm
             close={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
@@ -314,7 +276,7 @@ describe("BondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BondForm
+          <AddBondForm
             close={jest.fn()}
             selected={[]}
             setSelected={jest.fn()}
@@ -351,7 +313,7 @@ describe("BondForm", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <BondForm
+          <AddBondForm
             close={jest.fn()}
             selected={[{ nicId: 9 }, { nicId: 10 }]}
             setSelected={jest.fn()}
@@ -375,7 +337,6 @@ describe("BondForm", () => {
         mac_address: "28:21:c6:b9:1b:22",
         mode: NetworkLinkMode.LINK_UP,
         name: "bond1",
-        primary: "9",
         subnet: 1,
         tags: ["a", "tag"],
         vlan: 1,
@@ -396,87 +357,6 @@ describe("BondForm", () => {
           bond_mode: BondMode.ACTIVE_BACKUP,
           bond_miimon: 20,
           bond_updelay: 30,
-          fabric: 1,
-          ip_address: "1.2.3.4",
-          mac_address: "28:21:c6:b9:1b:22",
-          mode: NetworkLinkMode.LINK_UP,
-          name: "bond1",
-          parents: [9, 10],
-          subnet: 1,
-          system_id: "abc123",
-          tags: ["a", "tag"],
-          vlan: 1,
-        },
-      },
-    });
-  });
-
-  it("does not include link monitoring fields if they're not set", async () => {
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [
-          machineInterfaceFactory({
-            id: 9,
-            type: NetworkInterfaceTypes.PHYSICAL,
-            vlan_id: 1,
-          }),
-          machineInterfaceFactory({
-            id: 10,
-            type: NetworkInterfaceTypes.PHYSICAL,
-            vlan_id: 1,
-          }),
-        ],
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <BondForm
-            close={jest.fn()}
-            selected={[{ nicId: 9 }, { nicId: 10 }]}
-            setSelected={jest.fn()}
-            systemId="abc123"
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-    wrapper
-      .find("Formik")
-      .props()
-      .onSubmit({
-        bond_downdelay: 10,
-        bond_lacp_rate: "fast",
-        bond_mode: BondMode.ACTIVE_BACKUP,
-        bond_miimon: 20,
-        bond_updelay: 30,
-        fabric: 1,
-        ip_address: "1.2.3.4",
-        linkMonitoring: "",
-        mac_address: "28:21:c6:b9:1b:22",
-        mode: NetworkLinkMode.LINK_UP,
-        name: "bond1",
-        primary: "9",
-        subnet: 1,
-        tags: ["a", "tag"],
-        vlan: 1,
-      });
-    await waitForComponentToPaint(wrapper);
-    expect(
-      store.getActions().find((action) => action.type === "machine/createBond")
-    ).toStrictEqual({
-      type: "machine/createBond",
-      meta: {
-        model: "machine",
-        method: "create_bond",
-      },
-      payload: {
-        params: {
-          bond_lacp_rate: "fast",
-          bond_mode: BondMode.ACTIVE_BACKUP,
           fabric: 1,
           ip_address: "1.2.3.4",
           mac_address: "28:21:c6:b9:1b:22",

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddBondForm";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
@@ -66,7 +66,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields selected={[]} systemId="abc123" />
+            <BondFormFields />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -83,7 +83,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields selected={[]} systemId="abc123" />
+            <BondFormFields />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -106,7 +106,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields selected={[]} systemId="abc123" />
+            <BondFormFields />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -123,7 +123,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields selected={[]} systemId="abc123" />
+            <BondFormFields />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -146,7 +146,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields selected={[]} systemId="abc123" />
+            <BondFormFields />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -171,7 +171,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields selected={[]} systemId="abc123" />
+            <BondFormFields />
           </Formik>
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
@@ -15,7 +15,11 @@ import { BondMode } from "app/store/general/types";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
 
 const BondFormFields = (): JSX.Element | null => {
-  const { values, setFieldValue } = useFormikContext<BondFormValues>();
+  const {
+    handleChange,
+    setFieldValue,
+    values,
+  } = useFormikContext<BondFormValues>();
   const showHashPolicy = [
     BondMode.BALANCE_XOR,
     BondMode.LINK_AGGREGATION,
@@ -49,9 +53,7 @@ const BondFormFields = (): JSX.Element | null => {
           label="Link monitoring"
           name="linkMonitoring"
           onChange={(evt: React.ChangeEvent<HTMLSelectElement>) => {
-            const { value } = evt.target;
-            // Manually set the value because we've overwritten the onChange.
-            setFieldValue("linkMonitoring", value);
+            handleChange(evt);
             // Reset the link monitoring fields.
             setFieldValue("bond_downdelay", 0);
             setFieldValue("bond_miimon", 0);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
@@ -1,39 +1,21 @@
-import { useEffect } from "react";
-
 import { Col, Input, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import { useSelector } from "react-redux";
 
 import NetworkFields from "../../NetworkFields";
-import type { Selected } from "../../NetworkTable/types";
 import BondModeSelect from "../BondModeSelect";
 import HashPolicySelect from "../HashPolicySelect";
 import LACPRateSelect from "../LACPRateSelect";
 import type { BondFormValues } from "../types";
 import { LinkMonitoring } from "../types";
-import { getFirstSelected } from "../utils";
 
 import FormikField from "app/base/components/FormikField";
 import MacAddressField from "app/base/components/MacAddressField";
 import TagField from "app/base/components/TagField";
 import { BondMode } from "app/store/general/types";
-import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
-import { toFormikNumber } from "app/utils";
 
-type Props = {
-  selected: Selected[];
-  systemId: Machine["system_id"];
-};
-
-const BondFormFields = ({ selected, systemId }: Props): JSX.Element | null => {
-  const machine = useSelector((state: RootState) =>
-    machineSelectors.getById(state, systemId)
-  );
+const BondFormFields = (): JSX.Element | null => {
   const { values, setFieldValue } = useFormikContext<BondFormValues>();
-  const { primary } = values;
   const showHashPolicy = [
     BondMode.BALANCE_XOR,
     BondMode.LINK_AGGREGATION,
@@ -41,18 +23,6 @@ const BondFormFields = ({ selected, systemId }: Props): JSX.Element | null => {
   ].includes(values.bond_mode);
   const showLACPRate = values.bond_mode === BondMode.LINK_AGGREGATION;
   const showMonitoring = values.linkMonitoring === LinkMonitoring.MII;
-
-  useEffect(() => {
-    // If the interface that is marked as primary becomes unselected then set a
-    // new primary.
-    if (!selected.find(({ nicId }) => nicId === toFormikNumber(primary))) {
-      const firstSelected = machine
-        ? getFirstSelected(machine, selected)
-        : null;
-      setFieldValue("primary", firstSelected?.nicId?.toString());
-    }
-  }, [machine, primary, selected, setFieldValue]);
-
   return (
     <Row>
       <Col size="6">
@@ -78,6 +48,15 @@ const BondFormFields = ({ selected, systemId }: Props): JSX.Element | null => {
           component={Select}
           label="Link monitoring"
           name="linkMonitoring"
+          onChange={(evt: React.ChangeEvent<HTMLSelectElement>) => {
+            const { value } = evt.target;
+            // Manually set the value because we've overwritten the onChange.
+            setFieldValue("linkMonitoring", value);
+            // Reset the link monitoring fields.
+            setFieldValue("bond_downdelay", 0);
+            setFieldValue("bond_miimon", 0);
+            setFieldValue("bond_updelay", 0);
+          }}
           options={[
             {
               label: "No link monitoring",

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
@@ -62,6 +62,5 @@ describe("ToggleMembers", () => {
     expect(
       wrapper.find("Button[data-test='edit-members']").prop("disabled")
     ).toBe(true);
-    expect(wrapper.find("FormikForm").prop("submitDisabled")).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
@@ -1,0 +1,67 @@
+import { mount } from "enzyme";
+
+import ToggleMembers from "./ToggleMembers";
+
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+import { machineInterface as machineInterfaceFactory } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+describe("ToggleMembers", () => {
+  it("disables the edit button if there are no additional valid interfaces", async () => {
+    const interfaces = [
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+    ];
+    const selected = [{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }];
+    const wrapper = mount(
+      <ToggleMembers
+        selected={selected}
+        setEditingMembers={jest.fn()}
+        validNics={interfaces}
+      />
+    );
+    await waitForComponentToPaint(wrapper);
+    expect(
+      wrapper.find("Button[data-test='edit-members']").prop("disabled")
+    ).toBe(true);
+  });
+
+  it("disables the update button if two interfaces aren't selected", async () => {
+    const interfaces = [
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+      machineInterfaceFactory({
+        type: NetworkInterfaceTypes.PHYSICAL,
+        vlan_id: 1,
+      }),
+    ];
+    const wrapper = mount(
+      <ToggleMembers
+        editingMembers
+        selected={[{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }]}
+        setEditingMembers={jest.fn()}
+        validNics={interfaces}
+      />
+    );
+    wrapper.find("button[data-test='edit-members']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+    wrapper.setProps({ selected: [] });
+    await waitForComponentToPaint(wrapper);
+    expect(
+      wrapper.find("Button[data-test='edit-members']").prop("disabled")
+    ).toBe(true);
+    expect(wrapper.find("FormikForm").prop("submitDisabled")).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.tsx
@@ -1,0 +1,47 @@
+import { Button, Tooltip } from "@canonical/react-components";
+
+import type { Selected } from "../../NetworkTable/types";
+
+import type { NetworkInterface } from "app/store/machine/types";
+
+type Props = {
+  editingMembers?: boolean;
+  selected: Selected[];
+  setEditingMembers: (editingMembers: boolean) => void;
+  validNics: NetworkInterface[];
+};
+
+export const BondModeSelect = ({
+  editingMembers = false,
+  selected,
+  setEditingMembers,
+  validNics,
+}: Props): JSX.Element => {
+  let editTooltip: string | null = null;
+  let editDisabled = false;
+  if (!editingMembers && validNics.length === 2) {
+    // Disable the button to add more members if there are no more to choose
+    // from.
+    editTooltip = "There are no additional valid members";
+    editDisabled = true;
+  } else if (editingMembers && selected.length < 2) {
+    // Don't let the user update the selection if they haven't chosen at least
+    // two interfaces.
+    editTooltip = "At least two interfaces must be selected";
+    editDisabled = true;
+  }
+  return (
+    <Tooltip message={editTooltip}>
+      <Button
+        data-test="edit-members"
+        disabled={editDisabled}
+        onClick={() => setEditingMembers(!editingMembers)}
+        type="button"
+      >
+        {editingMembers ? "Update bond members" : "Edit bond members"}
+      </Button>
+    </Tooltip>
+  );
+};
+
+export default BondModeSelect;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.tsx
@@ -11,7 +11,7 @@ type Props = {
   validNics: NetworkInterface[];
 };
 
-export const BondModeSelect = ({
+export const ToggleMembers = ({
   editingMembers = false,
   selected,
   setEditingMembers,
@@ -44,4 +44,4 @@ export const BondModeSelect = ({
   );
 };
 
-export default BondModeSelect;
+export default ToggleMembers;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ToggleMembers";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./BondForm";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/types.ts
@@ -24,6 +24,5 @@ export type BondFormValues = {
   linkMonitoring: string;
   mac_address: NetworkInterface["mac_address"];
   name: NetworkInterface["name"];
-  primary: NetworkInterface["id"];
   tags: NetworkInterface["tags"];
 } & NetworkValues;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.test.ts
@@ -1,32 +1,195 @@
-import { getFirstSelected } from "./utils";
+import { LinkMonitoring } from "./types";
+import { getFirstSelected, getValidNics, preparePayload } from "./utils";
 
+import {
+  BondLacpRate,
+  BondMode,
+  BondXmitHashPolicy,
+} from "app/store/general/types";
+import {
+  NetworkInterfaceTypes,
+  NetworkLinkMode,
+} from "app/store/machine/types";
 import {
   machineDetails as machineDetailsFactory,
   machineInterface as machineInterfaceFactory,
+  networkLink as networkLinkFactory,
 } from "testing/factories";
 
 describe("BondForm utils", () => {
-  it("sorts the nics by name and gets the first interface", () => {
-    const interfaces = [
-      machineInterfaceFactory({
-        name: "bbb",
-      }),
-      machineInterfaceFactory({
-        name: "ccc",
-      }),
-      machineInterfaceFactory({
-        name: "aaa",
-      }),
-    ];
-    const machine = machineDetailsFactory({
-      interfaces,
+  describe("getFirstSelected", () => {
+    it("sorts the nics by name and gets the first interface", () => {
+      const interfaces = [
+        machineInterfaceFactory({
+          name: "bbb",
+        }),
+        machineInterfaceFactory({
+          name: "ccc",
+        }),
+        machineInterfaceFactory({
+          name: "aaa",
+        }),
+      ];
+      const machine = machineDetailsFactory({
+        interfaces,
+      });
+      expect(
+        getFirstSelected(machine, [
+          { nicId: interfaces[0].id },
+          { nicId: interfaces[1].id },
+          { nicId: interfaces[2].id },
+        ])
+      ).toStrictEqual({ nicId: interfaces[2].id });
     });
-    expect(
-      getFirstSelected(machine, [
-        { nicId: interfaces[0].id },
-        { nicId: interfaces[1].id },
-        { nicId: interfaces[2].id },
-      ])
-    ).toStrictEqual({ nicId: interfaces[2].id });
+  });
+
+  describe("getValidNics", () => {
+    it("gets interfaces without an existing bond", () => {
+      const interfaces = [
+        machineInterfaceFactory({
+          type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+        // Invalid because it has a different VLAN.
+        machineInterfaceFactory({
+          type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 2,
+        }),
+        machineInterfaceFactory({
+          type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+        // Invalid because it is not physical.
+        machineInterfaceFactory({
+          type: NetworkInterfaceTypes.VLAN,
+          vlan_id: 1,
+        }),
+        // Invalid because it is already in a bond
+        machineInterfaceFactory({
+          children: [9],
+          type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+      ];
+      const machine = machineDetailsFactory({
+        interfaces,
+      });
+      expect(getValidNics(machine, 1)).toStrictEqual([
+        interfaces[0],
+        interfaces[2],
+      ]);
+    });
+
+    it("gets physical interfaces in the same vlan", () => {
+      const interfaces = [
+        // This is the bond
+        machineInterfaceFactory({
+          id: 8,
+          type: NetworkInterfaceTypes.BOND,
+          vlan_id: 1,
+        }),
+        // Valid because it is not in a bond.
+        machineInterfaceFactory({
+          type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+        // Valid because it is in the bond.
+        machineInterfaceFactory({
+          type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+        // Invalid because it is in a different bond.
+        machineInterfaceFactory({
+          children: [9],
+          type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+      ];
+      const machine = machineDetailsFactory({
+        interfaces,
+      });
+      expect(getValidNics(machine, 1, interfaces[0])).toStrictEqual([
+        interfaces[1],
+        interfaces[2],
+      ]);
+    });
+  });
+
+  describe("preparePayload", () => {
+    it("cleans and prepares the payload with a nic and link", () => {
+      const nic = machineInterfaceFactory();
+      const link = networkLinkFactory();
+      const values = {
+        // Should be removed.
+        linkMonitoring: LinkMonitoring.MII,
+        // Should be removed.
+        mac_address: "",
+        // Should not be removed,
+        bond_downdelay: 0,
+        bond_lacp_rate: BondLacpRate.FAST,
+        bond_mode: BondMode.ACTIVE_BACKUP,
+        bond_miimon: 20,
+        bond_updelay: 30,
+        bond_xmit_hash_policy: BondXmitHashPolicy.ENCAP2_3,
+        fabric: 1,
+        ip_address: "1.2.3.4",
+        mode: NetworkLinkMode.LINK_UP,
+        name: "bond2",
+        subnet: 1,
+        tags: ["a", "tag"],
+        vlan: 1,
+      };
+      expect(
+        preparePayload(
+          values,
+          [{ nicId: 1 }, { nicId: 2 }],
+          "abc123",
+          nic,
+          link
+        )
+      ).toStrictEqual({
+        bond_downdelay: 0,
+        bond_lacp_rate: BondLacpRate.FAST,
+        bond_mode: BondMode.ACTIVE_BACKUP,
+        bond_miimon: 20,
+        bond_updelay: 30,
+        bond_xmit_hash_policy: BondXmitHashPolicy.ENCAP2_3,
+        fabric: 1,
+        ip_address: "1.2.3.4",
+        mode: NetworkLinkMode.LINK_UP,
+        name: "bond2",
+        subnet: 1,
+        tags: ["a", "tag"],
+        vlan: 1,
+        // The following fields should be appended.
+        interface_id: nic.id,
+        link_id: link.id,
+        parents: [1, 2],
+        system_id: "abc123",
+      });
+    });
+
+    it("can ignore the nic and link if not provided", () => {
+      const values = {
+        linkMonitoring: LinkMonitoring.MII,
+        mac_address: "",
+        bond_downdelay: 0,
+        bond_lacp_rate: BondLacpRate.FAST,
+        bond_mode: BondMode.ACTIVE_BACKUP,
+        bond_miimon: 20,
+        bond_updelay: 30,
+        bond_xmit_hash_policy: BondXmitHashPolicy.ENCAP2_3,
+        fabric: 1,
+        ip_address: "1.2.3.4",
+        mode: NetworkLinkMode.LINK_UP,
+        name: "bond2",
+        subnet: 1,
+        tags: ["a", "tag"],
+        vlan: 1,
+      };
+      const payload = preparePayload(values, [], "abc123");
+      expect(payload.link_id).toBeUndefined();
+      expect(payload.interface_id).toBeUndefined();
+    });
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.test.ts
@@ -44,7 +44,7 @@ describe("BondForm utils", () => {
   });
 
   describe("getValidNics", () => {
-    it("gets interfaces without an existing bond", () => {
+    it("finds valid interfaces for a new bond", () => {
       const interfaces = [
         machineInterfaceFactory({
           type: NetworkInterfaceTypes.PHYSICAL,
@@ -66,8 +66,16 @@ describe("BondForm utils", () => {
         }),
         // Invalid because it is already in a bond
         machineInterfaceFactory({
-          children: [9],
+          id: 2200,
+          children: [900],
           type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+        // Invalid because it is a bond
+        machineInterfaceFactory({
+          parents: [2200],
+          id: 900,
+          type: NetworkInterfaceTypes.BOND,
           vlan_id: 1,
         }),
       ];
@@ -80,11 +88,12 @@ describe("BondForm utils", () => {
       ]);
     });
 
-    it("gets physical interfaces in the same vlan", () => {
+    it("finds valid interfaces for an existing bond", () => {
       const interfaces = [
         // This is the bond
         machineInterfaceFactory({
-          id: 8,
+          children: [900],
+          id: 800,
           type: NetworkInterfaceTypes.BOND,
           vlan_id: 1,
         }),
@@ -95,13 +104,23 @@ describe("BondForm utils", () => {
         }),
         // Valid because it is in the bond.
         machineInterfaceFactory({
+          id: 900,
+          parents: [800],
           type: NetworkInterfaceTypes.PHYSICAL,
           vlan_id: 1,
         }),
         // Invalid because it is in a different bond.
         machineInterfaceFactory({
-          children: [9],
+          children: [2300],
+          id: 2200,
           type: NetworkInterfaceTypes.PHYSICAL,
+          vlan_id: 1,
+        }),
+        // Invalid because it is a different bond.
+        machineInterfaceFactory({
+          id: 2300,
+          parents: [2200],
+          type: NetworkInterfaceTypes.BOND,
           vlan_id: 1,
         }),
       ];

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.test.tsx
@@ -1,5 +1,4 @@
 import { mount } from "enzyme";
-import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -79,30 +78,6 @@ describe("InterfaceFormTable", () => {
       </Provider>
     );
     expect(wrapper.find("PXEColumn").exists()).toBe(true);
-  });
-
-  it("can display radio buttons to choose the primary", () => {
-    const nic = machineInterfaceFactory();
-    state.machine.items = [
-      machineDetailsFactory({
-        interfaces: [nic],
-        system_id: "abc123",
-      }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <InterfaceFormTable
-            editPrimary
-            interfaces={[{ nicId: nic.id }]}
-            systemId="abc123"
-          />
-        </Formik>
-      </Provider>
-    );
-    expect(wrapper.find("PXEColumn").exists()).toBe(false);
-    expect(wrapper.find("FormikField[name='primary']").exists()).toBe(true);
   });
 
   it("can show checkboxes to update the selection", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/InterfaceFormTable/InterfaceFormTable.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { Input, MainTable, Spinner } from "@canonical/react-components";
+import { MainTable, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import DHCPColumn from "../NetworkTable/DHCPColumn";
@@ -14,7 +14,6 @@ import SubnetColumn from "../NetworkTable/SubnetColumn";
 import TypeColumn from "../NetworkTable/TypeColumn";
 import type { Selected, SetSelected } from "../NetworkTable/types";
 
-import FormikField from "app/base/components/FormikField";
 import TableHeader from "app/base/components/TableHeader";
 import machineSelectors from "app/store/machine/selectors";
 import type {
@@ -47,7 +46,6 @@ export type InterfaceRow = {
 const generateRow = (
   machine: Machine,
   interfaceRow: InterfaceRow,
-  editPrimary = false,
   selected: Selected[] = [],
   handleRowCheckbox?: CheckboxHandlers<Selected>["handleRowCheckbox"] | null,
   checkSelected?: CheckboxHandlers<Selected>["checkSelected"] | null,
@@ -76,19 +74,7 @@ const generateRow = (
         ),
       },
       {
-        content: editPrimary ? (
-          <span className="u-align--center">
-            <FormikField
-              component={Input}
-              disabled={!isSelected}
-              label=" "
-              labelClassName="u-display-inline"
-              name="primary"
-              type="radio"
-              value={nic?.id?.toString()}
-            />
-          </span>
-        ) : (
+        content: (
           <PXEColumn link={link} nic={nic} systemId={machine.system_id} />
         ),
         className: "u-align--center",
@@ -127,7 +113,6 @@ const generateRow = (
 };
 
 type Props = {
-  editPrimary?: boolean;
   interfaces: InterfaceRow[];
   selected?: Selected[];
   selectedEditable?: boolean;
@@ -136,7 +121,6 @@ type Props = {
 };
 
 const InterfaceFormTable = ({
-  editPrimary = false,
   interfaces,
   selected = [],
   selectedEditable,
@@ -166,7 +150,6 @@ const InterfaceFormTable = ({
       generateRow(
         machine,
         interfaceRow,
-        editPrimary,
         selected,
         handleRowCheckbox,
         checkSelected,
@@ -188,9 +171,7 @@ const InterfaceFormTable = ({
         {
           content: (
             <>
-              <TableHeader className="u-align--center">
-                {editPrimary ? "Primary" : "PXE"}
-              </TableHeader>
+              <TableHeader className="u-align--center">PXE</TableHeader>
             </>
           ),
         },

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -6,9 +6,9 @@ import { useParams } from "react-router";
 
 import type { SetSelectedAction } from "../types";
 
+import AddBondForm from "./AddBondForm";
 import AddBridgeForm from "./AddBridgeForm";
 import AddInterface from "./AddInterface";
-import BondForm from "./BondForm";
 import DHCPTable from "./DHCPTable";
 import EditInterface from "./EditInterface";
 import NetworkActions from "./NetworkActions";
@@ -51,7 +51,7 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
     );
   } else if (interfaceExpanded?.content === ExpandedState.ADD_BOND) {
     return (
-      <BondForm
+      <AddBondForm
         close={() => {
           setInterfaceExpanded(null);
           setSelected([]);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -68,7 +68,11 @@ const NetworkFields = ({
 }: Props): JSX.Element | null => {
   const fabrics: Fabric[] = useSelector(fabricSelectors.all);
   const subnets: Subnet[] = useSelector(subnetSelectors.all);
-  const { setFieldValue, values } = useFormikContext<NetworkValues>();
+  const {
+    handleChange,
+    setFieldValue,
+    values,
+  } = useFormikContext<NetworkValues>();
   const resetFollowingFields = (name: keyof NetworkValues) => {
     // Reset all fields after this one.
     const position = fieldOrder.indexOf(name);
@@ -88,8 +92,7 @@ const NetworkFields = ({
         name="fabric"
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
           const { value } = evt.target;
-          // Manually set the value because we've overwritten the onChange.
-          setFieldValue("fabric", toFormikNumber(value));
+          handleChange(evt);
           if (value || typeof value === "number") {
             const fabric = fabrics.find(
               ({ id }) => id === toFormikNumber(value)
@@ -110,9 +113,7 @@ const NetworkFields = ({
         includeDefaultVlan={includeDefaultVlan}
         name="vlan"
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-          const { value } = evt.target;
-          // Manually set the value because we've overwritten the onChange.
-          setFieldValue("vlan", toFormikNumber(value));
+          handleChange(evt);
           resetFollowingFields("vlan");
         }}
         vlans={vlans}
@@ -128,9 +129,7 @@ const NetworkFields = ({
         }
         name="subnet"
         onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-          const { value } = evt.target;
-          // Manually set the value so that the next fields get reset.
-          setFieldValue("subnet", toFormikNumber(value));
+          handleChange(evt);
           resetFollowingFields("subnet");
         }}
         vlan={toFormikNumber(values.vlan)}
@@ -142,8 +141,7 @@ const NetworkFields = ({
           name="mode"
           onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
             const { value } = evt.target;
-            // Manually set the value because we've overwritten the onChange.
-            setFieldValue("mode", value as NetworkLinkMode);
+            handleChange(evt);
             if (value === NetworkLinkMode.STATIC) {
               const subnet = subnets.find(
                 ({ id }) => id === toFormikNumber(values.subnet)


### PR DESCRIPTION
## Done

- Extract parts of the bond form to be reused in the edit bond form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a bond in the new network tab, it should not have any errors.

## Fixes

Fixes: #2364.