### PR TITLE
feat(ui): add ability to fetch LXD projects

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -137,7 +137,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -272,12 +272,16 @@ exports[`stricter compilation`] = {
     "src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx:2787447767": [
       [29, 28, 17, "Expected 1 arguments, but got 0.", "3763407084"]
     ],
-    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.test.tsx:214784015": [
-      [92, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [93, 8, 24, "Argument of type \'{ name: string; pool: number; power_parameters: { power_address: string; password: string; }; type: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"]
+    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.test.tsx:3091382184": [
+      [76, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [77, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; project: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"],
+      [122, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [123, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; project: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"],
+      [135, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [136, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; project: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"]
     ],
-    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.tsx:3105943377": [
-      [91, 8, 8, "Type \'(values: AddLxdValues) => void\' is not assignable to type \'(values?: AddLxdValues | undefined, formikHelpers?: FormikHelpers<AddLxdValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'AddLxdValues | undefined\' is not assignable to type \'AddLxdValues\'.\\n      Type \'undefined\' is not assignable to type \'AddLxdValues\'.", "1301647696"]
+    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.tsx:4238528085": [
+      [84, 8, 8, "Type \'(values: AddLxdValues) => void\' is not assignable to type \'(values?: AddLxdValues | undefined, formikHelpers?: FormikHelpers<AddLxdValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'AddLxdValues | undefined\' is not assignable to type \'AddLxdValues\'.\\n      Type \'undefined\' is not assignable to type \'AddLxdValues\'.", "1301647696"]
     ],
     "src/app/kvm/views/KVMList/AddKVM/AddVirsh/AddVirsh.test.tsx:723256513": [
       [92, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
@@ -741,11 +745,11 @@ exports[`stricter compilation`] = {
     "src/app/store/notification/selectors.ts:2780531046": [
       [25, 39, 12, "Object is possibly \'undefined\'.", "964199671"]
     ],
-    "src/app/store/pod/reducers.test.ts:3859796446": [
-      [77, 38, 10, "Expected 1 arguments, but got 0.", "2565503122"]
+    "src/app/store/pod/reducers.test.ts:3314540519": [
+      [79, 38, 10, "Expected 1 arguments, but got 0.", "2565503122"]
     ],
-    "src/app/store/pod/slice.ts:2721144854": [
-      [56, 56, 11, "Type \'PodReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Pod, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Pod, any>>\' is missing the following properties from type \'WritableDraft<PodState>\': active, statuses", "1022550047"]
+    "src/app/store/pod/slice.ts:1575638247": [
+      [62, 56, 11, "Type \'PodReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Pod, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<PodState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Pod, any>>\' is missing the following properties from type \'WritableDraft<PodState>\': active, projects, statuses", "1022550047"]
     ],
     "src/app/store/resourcepool/actions.test.ts:9201512": [
       [71, 52, 24, "Expected 1 arguments, but got 2.", "3295119724"]
@@ -830,12 +834,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:2842853449": [
-      [246, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [367, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [368, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [370, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [375, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:2918864150": [
+      [247, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [368, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [369, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [371, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [376, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -918,9 +922,9 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [20, 68, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/pod/types.ts:4123168747": [
+    "src/app/store/pod/types.ts:2046210235": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [192, 21, 8, "RegExp match", "1152173309"]
+      [202, 21, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/resourcepool/types.ts:1043464479": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -177,6 +177,7 @@ Object {
     "items": Array [],
     "loaded": false,
     "loading": false,
+    "projects": Object {},
     "saved": false,
     "saving": false,
     "statuses": Object {},

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxdFields/AddLxdFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxdFields/AddLxdFields.tsx
@@ -2,16 +2,15 @@ import { Col, Row } from "@canonical/react-components";
 
 import type { SetKvmType } from "../../AddKVM";
 import KvmTypeSelect from "../../KvmTypeSelect";
-import type { AddLxdValues } from "../AddLxd";
 
 import FormikField from "app/base/components/FormikField";
-import PowerTypeFields from "app/base/components/PowerTypeFields";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
 import ZoneSelect from "app/base/components/ZoneSelect";
-import { PowerFieldScope } from "app/store/general/types";
 import { PodType } from "app/store/pod/types";
 
-type Props = { setKvmType: SetKvmType };
+type Props = {
+  setKvmType: SetKvmType;
+};
 
 export const AddLxdFields = ({ setKvmType }: Props): JSX.Element => {
   return (
@@ -23,11 +22,18 @@ export const AddLxdFields = ({ setKvmType }: Props): JSX.Element => {
         <FormikField label="Name" name="name" type="text" />
         <ZoneSelect name="zone" required valueKey="id" />
         <ResourcePoolSelect name="pool" required valueKey="id" />
-        <PowerTypeFields<AddLxdValues>
-          fieldScopes={[PowerFieldScope.BMC]}
-          powerTypeValueName="type"
-          showSelect={false}
+        <FormikField
+          label="LXD address"
+          name="power_address"
+          required
+          type="text"
         />
+        <FormikField
+          label="LXD password (optional)"
+          name="password"
+          type="password"
+        />
+        <FormikField label="LXD project" name="project" type="text" />
       </Col>
     </Row>
   );

--- a/ui/src/app/store/pod/reducers.test.ts
+++ b/ui/src/app/store/pod/reducers.test.ts
@@ -3,6 +3,7 @@ import reducers, { actions } from "./slice";
 import {
   pod as podFactory,
   podDetails as podDetailsFactory,
+  podProject as podProjectFactory,
   podState as podStateFactory,
   podStatus as podStatusFactory,
 } from "testing/factories";
@@ -15,6 +16,7 @@ describe("pod reducer", () => {
       items: [],
       loaded: false,
       loading: false,
+      projects: {},
       saved: false,
       saving: false,
       statuses: {},
@@ -377,6 +379,39 @@ describe("pod reducer", () => {
     ).toEqual(
       podStateFactory({
         active: 101,
+      })
+    );
+  });
+
+  it("reduces getProjectsSuccess", () => {
+    const serverAddress = "192.168.1.1";
+    const newProjects = [podProjectFactory()];
+    const podState = podStateFactory({
+      items: [],
+      projects: {},
+    });
+
+    expect(
+      reducers(podState, {
+        meta: { item: { power_address: serverAddress } },
+        ...actions.getProjectsSuccess(newProjects),
+      })
+    ).toEqual(
+      podStateFactory({
+        projects: { [serverAddress]: newProjects },
+      })
+    );
+  });
+
+  it("reduces getProjectsError", () => {
+    const podState = podStateFactory();
+
+    expect(
+      reducers(podState, actions.getProjectsError("Could not get projects"))
+    ).toEqual(
+      podStateFactory({
+        errors: "Could not get projects",
+        loading: false,
       })
     );
   });

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -7,6 +7,7 @@ import {
   machine as machineFactory,
   machineState as machineStateFactory,
   pod as podFactory,
+  podProject as podProjectFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -20,6 +21,19 @@ describe("pod selectors", () => {
       }),
     });
     expect(pod.all(state)).toEqual(items);
+  });
+
+  it("can get all projects", () => {
+    const projects = {
+      "172.0.0.1": [podProjectFactory()],
+      "192.168.1.1": [podProjectFactory()],
+    };
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        projects,
+      }),
+    });
+    expect(pod.projects(state)).toEqual(projects);
   });
 
   it("can get all KVMs that MAAS supports", () => {
@@ -272,5 +286,17 @@ describe("pod selectors", () => {
       items[1],
       items[2],
     ]);
+  });
+
+  it("can get projects by LXD server address", () => {
+    const projects = [podProjectFactory(), podProjectFactory()];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        projects: {
+          "172.0.0.1": projects,
+        },
+      }),
+    });
+    expect(pod.getProjectsByLxdServer(state, "172.0.0.1")).toEqual(projects);
   });
 });

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -59,6 +59,13 @@ const activeID = (state: RootState): number | null => state.pod.active;
 const statuses = (state: RootState): PodState["statuses"] => state.pod.statuses;
 
 /**
+ * Returns pod projects keyed by power address.
+ * @param state - The redux state.
+ * @returns Pod projects.
+ */
+const projects = (state: RootState): PodState["projects"] => state.pod.projects;
+
+/**
  * Returns active pod.
  * @param state - The redux state.
  * @returns Active pod.
@@ -200,6 +207,11 @@ const getByLxdServer = createSelector(
   }
 );
 
+const getProjectsByLxdServer = createSelector(
+  [projects, (_: RootState, address: LxdServerGroup["address"]) => address],
+  (projects, address) => projects[address] || []
+);
+
 const selectors = {
   ...defaultSelectors,
   active,
@@ -210,9 +222,11 @@ const selectors = {
   getHost,
   getVMs,
   getByLxdServer,
+  getProjectsByLxdServer,
   groupByLxdServer,
   kvms,
   lxd,
+  projects,
   refreshing,
   statuses,
   virsh,

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -187,7 +187,17 @@ export type PodStatuses = {
   [x: number]: PodStatus;
 };
 
+export type PodProject = {
+  description: string;
+  name: string;
+};
+
+export type PodProjects = {
+  [x: string]: PodProject[];
+};
+
 export type PodState = {
   active: number | null;
+  projects: PodProjects;
   statuses: PodStatuses;
 } & GenericState<Pod, TSFixMe>;

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -71,6 +71,7 @@ export {
   podDetails,
   podHint,
   podNumaNode,
+  podProject,
   podStoragePool,
   testStatus,
 } from "./nodes";

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -36,6 +36,7 @@ import type {
   PodNumaMemory,
   PodNumaNode,
   PodNumaResource,
+  PodProject,
   PodResource,
   PodResources,
   PodStoragePool,
@@ -426,6 +427,11 @@ export const podResources = define<PodResources>({
   memory: podMemoryResource,
   numa: () => [podNuma()],
   vms: () => [podVM()],
+});
+
+export const podProject = define<PodProject>({
+  description: "this is a description",
+  name: "project-name",
 });
 
 export const pod = extend<Model, Pod>(model, {

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -225,6 +225,7 @@ export const podState = define<PodState>({
   ...defaultState,
   active: null,
   errors: null,
+  projects: () => ({}),
   statuses: () => ({}),
 });
 


### PR DESCRIPTION
## Done

- Added `projects` key to pod state, which maps LXD server address to their projects
- Added actions/reducers/selectors for fetching projects
- Updated AddLXD form so that it first fetches projects before being able to add the KVM.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click "Add KVM"
- Select LXD type and check that the submit button says "Authenticate"
- Enter a gibberish address and check that an action is dispatched and an error displays
- Enter a known LXD address and password (if necessary - the `bolla` LXD address does not need a password) and check that projects are successfully added to state
- Check that the submit label changes to "Next"

## Fixes

Fixes #2224 