### PR TITLE
feat(ui): add analytics for editing bond members

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
@@ -1,10 +1,18 @@
 import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import ToggleMembers from "./ToggleMembers";
 
 import { NetworkInterfaceTypes } from "app/store/machine/types";
-import { machineInterface as machineInterfaceFactory } from "testing/factories";
+import {
+  machineInterface as machineInterfaceFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
 
 describe("ToggleMembers", () => {
   it("disables the edit button if there are no additional valid interfaces", async () => {
@@ -19,12 +27,19 @@ describe("ToggleMembers", () => {
       }),
     ];
     const selected = [{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }];
+    const store = mockStore(rootStateFactory());
     const wrapper = mount(
-      <ToggleMembers
-        selected={selected}
-        setEditingMembers={jest.fn()}
-        validNics={interfaces}
-      />
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ToggleMembers
+            selected={selected}
+            setEditingMembers={jest.fn()}
+            validNics={interfaces}
+          />
+        </MemoryRouter>
+      </Provider>
     );
     await waitForComponentToPaint(wrapper);
     expect(
@@ -47,14 +62,26 @@ describe("ToggleMembers", () => {
         vlan_id: 1,
       }),
     ];
-    const wrapper = mount(
-      <ToggleMembers
-        editingMembers
-        selected={[{ nicId: interfaces[0].id }, { nicId: interfaces[1].id }]}
-        setEditingMembers={jest.fn()}
-        validNics={interfaces}
-      />
+    const store = mockStore(rootStateFactory());
+    const PassProps = ({ ...props }) => (
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <ToggleMembers
+            editingMembers
+            selected={[
+              { nicId: interfaces[0].id },
+              { nicId: interfaces[1].id },
+            ]}
+            setEditingMembers={jest.fn()}
+            validNics={interfaces}
+            {...props}
+          />
+        </MemoryRouter>
+      </Provider>
     );
+    const wrapper = mount(<PassProps />);
     wrapper.find("button[data-test='edit-members']").simulate("click");
     await waitForComponentToPaint(wrapper);
     wrapper.setProps({ selected: [] });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.tsx
@@ -2,6 +2,7 @@ import { Button, Tooltip } from "@canonical/react-components";
 
 import type { Selected } from "../../NetworkTable/types";
 
+import { useSendAnalytics } from "app/base/hooks";
 import type { NetworkInterface } from "app/store/machine/types";
 
 type Props = {
@@ -17,6 +18,7 @@ export const ToggleMembers = ({
   setEditingMembers,
   validNics,
 }: Props): JSX.Element => {
+  const sendAnalytics = useSendAnalytics();
   let editTooltip: string | null = null;
   let editDisabled = false;
   if (!editingMembers && validNics.length === 2) {
@@ -35,7 +37,14 @@ export const ToggleMembers = ({
       <Button
         data-test="edit-members"
         disabled={editDisabled}
-        onClick={() => setEditingMembers(!editingMembers)}
+        onClick={() => {
+          sendAnalytics(
+            "Machine details networking",
+            "Bond form",
+            editingMembers ? "Update bond members" : "Edit bond members"
+          );
+          setEditingMembers(!editingMembers);
+        }}
         type="button"
       >
         {editingMembers ? "Update bond members" : "Edit bond members"}


### PR DESCRIPTION
## Done

- Add analytics to the bond forms when users edit the bond members.

## QA

N/A

## Fixes

Fixes: #2185.