### PR TITLE
feat(ui): enable the network route

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -623,7 +623,8 @@
               role="tab"
               class="p-tabs__link"
               data-ng-class="{ 'is-active': section.area === 'network'}"
-              data-ng-click="openSection('network')"
+              data-ng-click="isController ? openSection('network') : navigateToNew('/machine/' + node.system_id + '/network')"
+              href="{$ isController ? undefined : newURLBase + '/machine/' + node.system_id + '/network' $}"
               >Network</a
             >
           </li>

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -150,9 +150,9 @@ const MachineHeader = ({
           : []),
         {
           active: pathname.startsWith(`${urlBase}/network`),
-          component: LegacyLink,
+          component: Link,
           label: "Network",
-          route: `${urlBase}?area=network`,
+          to: `${urlBase}/network`,
         },
         {
           active: pathname.startsWith(`${urlBase}/storage`),

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/NetworkCard/NetworkCard.tsx
@@ -2,13 +2,13 @@ import { Fragment, useEffect } from "react";
 
 import { Card, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import type { SetSelectedAction } from "../../types";
 import TestResults from "../TestResults";
 
 import NetworkCardTable from "./NetworkCardTable";
 
-import LegacyLink from "app/base/components/LegacyLink";
 import { HardwareType } from "app/base/enum";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
@@ -113,7 +113,7 @@ const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
   }, [dispatch]);
 
   let content: JSX.Element;
-  const networkRoute = `/machine/${id}?area=network`;
+  const networkRoute = `/machine/${id}/network`;
 
   // Confirm that the full machine details have been fetched. This also allows
   // TypeScript know we're using the right union type (otherwise it will
@@ -150,7 +150,7 @@ const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
         ))}
         <p>
           Information about tagged traffic can be seen in the{" "}
-          <LegacyLink route={networkRoute}>Network tab</LegacyLink>.
+          <Link to={networkRoute}>Network tab</Link>.
         </p>
         <TestResults
           machine={machine}
@@ -167,7 +167,7 @@ const NetworkCard = ({ id, setSelectedAction }: Props): JSX.Element => {
     <div className="machine-summary__network-card">
       <Card>
         <h4 className="p-muted-heading u-sv1">
-          <LegacyLink route={networkRoute}>Network&nbsp;&rsaquo;</LegacyLink>
+          <Link to={networkRoute}>Network&nbsp;&rsaquo;</Link>
         </h4>
         {content}
       </Card>

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.test.tsx
@@ -241,12 +241,8 @@ describe("NodeDevices", () => {
     );
 
     expect(
-      wrapper
-        .find("[data-test='group-label']")
-        .at(0)
-        .find("LegacyLink")
-        .prop("route")
-    ).toBe("/machine/abc123?area=network");
+      wrapper.find("[data-test='group-label']").at(0).find("Link").prop("to")
+    ).toBe("/machine/abc123/network");
     expect(
       wrapper.find("[data-test='group-label']").at(1).find("Link").prop("to")
     ).toBe("/machine/abc123/storage");

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -10,7 +10,6 @@ import type { SetSelectedAction } from "../types";
 import NodeDevicesWarning from "./NodeDevicesWarning";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import LegacyLink from "app/base/components/LegacyLink";
 import Placeholder from "app/base/components/Placeholder";
 import { HardwareType } from "app/base/enum";
 import type { MachineDetails } from "app/store/machine/types";
@@ -65,9 +64,9 @@ const generateGroup = (
         );
       } else if (group.pathname === "network") {
         groupLabel = (
-          <LegacyLink route={`/machine/${machine.system_id}?area=network`}>
+          <Link to={`/machine/${machine.system_id}/network`}>
             {group.label}
-          </LegacyLink>
+          </Link>
         );
       } else {
         groupLabel = group.label;


### PR DESCRIPTION
## Done

- Enable navigating to the react network tab in machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to the summary tab of a machine.
- Click the tab for network, you should be taken to the /r/ network route.
- Navigate back to summary and click the link at the top or bottom of the network card, you should be taken to the /r/ network route.
- Click on the events tab, it should take you to a /l/ route. Now click on the network tab, you should be taken back to the react page.
- Navigate to a controller details page and click on the network tab, you should stay on the /l/ route.

## Fixes

Fixes: #2325.