### PR TITLE
feat(ui): prefill mac address from member

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
@@ -7,6 +7,7 @@ import * as Yup from "yup";
 import BondFormFields from "../BondForm/BondFormFields";
 import ToggleMembers from "../BondForm/ToggleMembers";
 import type { BondFormValues } from "../BondForm/types";
+import { MacSource } from "../BondForm/types";
 import {
   getFirstSelected,
   getValidNics,
@@ -153,7 +154,7 @@ const AddBondForm = ({
   const rows = editingMembers
     ? validNics.map(({ id, links }) => ({ nicId: id, linkId: links[0]?.id }))
     : selected;
-
+  const macAddress = firstNic?.mac_address || "";
   return (
     <FormCard sidebar={false} stacked title="Create bond">
       <FormikForm
@@ -171,8 +172,10 @@ const AddBondForm = ({
           bond_xmit_hash_policy: "",
           fabric: vlan?.fabric || "",
           linkMonitoring: "",
-          mac_address: firstNic?.mac_address || "",
+          mac_address: macAddress,
           name: nextName,
+          macSource: MacSource.NIC,
+          macNic: macAddress,
           subnet: subnet?.id || "",
           tags: [],
           vlan: bondVLAN || "",
@@ -209,7 +212,7 @@ const AddBondForm = ({
           setEditingMembers={setEditingMembers}
           validNics={validNics}
         />
-        <BondFormFields />
+        <BondFormFields selected={selected} systemId={systemId} />
       </FormikForm>
     </FormCard>
   );

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import { LinkMonitoring } from "../types";
+import { LinkMonitoring, MacSource } from "../types";
 
 import BondFormFields from "./BondFormFields";
 
@@ -13,8 +13,12 @@ import {
   BondMode,
   BondXmitHashPolicy,
 } from "app/store/general/types";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
   generalState as generalStateFactory,
   bondOptions as bondOptionsFactory,
   bondOptionsState as bondOptionsStateFactory,
@@ -55,6 +59,20 @@ describe("BondFormFields", () => {
           loaded: true,
         }),
       }),
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            system_id: "abc123",
+            interfaces: [
+              machineInterfaceFactory({
+                id: 17,
+                type: NetworkInterfaceTypes.PHYSICAL,
+                mac_address: "6a:6e:4a:29:a5:42",
+              }),
+            ],
+          }),
+        ],
+      }),
     });
   });
 
@@ -66,7 +84,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields />
+            <BondFormFields selected={[]} systemId="abc123" />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -83,7 +101,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields />
+            <BondFormFields selected={[]} systemId="abc123" />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -106,7 +124,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields />
+            <BondFormFields selected={[]} systemId="abc123" />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -123,7 +141,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields />
+            <BondFormFields selected={[]} systemId="abc123" />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -146,7 +164,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields />
+            <BondFormFields selected={[]} systemId="abc123" />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -171,7 +189,7 @@ describe("BondFormFields", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <Formik initialValues={{}} onSubmit={jest.fn()}>
-            <BondFormFields />
+            <BondFormFields selected={[]} systemId="abc123" />
           </Formik>
         </MemoryRouter>
       </Provider>
@@ -189,6 +207,141 @@ describe("BondFormFields", () => {
     );
     expect(wrapper.find("FormikField[name='bond_downdelay']").exists()).toBe(
       true
+    );
+  });
+
+  it("sets the mac address field when the nic field changes", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Formik initialValues={{ mac_address: "" }} onSubmit={jest.fn()}>
+            <BondFormFields selected={[]} systemId="abc123" />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("select[name='macNic']").simulate("change", {
+      target: {
+        name: "macNic",
+        value: "6a:6e:4a:29:a5:42",
+      },
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("input[name='mac_address']").prop("value")).toBe(
+      "6a:6e:4a:29:a5:42"
+    );
+  });
+
+  it("enables the mac address field when the radio is changed to manual", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <BondFormFields selected={[]} systemId="abc123" />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("input[name='macSource']")
+      .first()
+      .simulate("change", {
+        target: {
+          name: "macSource",
+          value: MacSource.MANUAL,
+        },
+      });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("input[name='mac_address']").prop("disabled")).toBe(
+      false
+    );
+    expect(wrapper.find("select[name='macNic']").prop("disabled")).toBe(true);
+  });
+
+  it("enables the mac nic field when the radio is changed to 'nic'", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <BondFormFields selected={[]} systemId="abc123" />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("input[name='macSource']")
+      .last()
+      .simulate("change", {
+        target: {
+          name: "macSource",
+          value: MacSource.NIC,
+        },
+      });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("select[name='macNic']").prop("disabled")).toBe(false);
+    expect(wrapper.find("input[name='mac_address']").prop("disabled")).toBe(
+      true
+    );
+  });
+
+  it("resets the mac address field when the radio is changed to 'nic'", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ macNic: "6a:6e:4a:29:a5:42", mac_address: "" }}
+            onSubmit={jest.fn()}
+          >
+            <BondFormFields selected={[{ nicId: 17 }]} systemId="abc123" />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    // Enable the mac address field so it can be changed.
+    wrapper
+      .find("input[name='macSource']")
+      .last()
+      .simulate("change", {
+        target: {
+          name: "macSource",
+          value: MacSource.MANUAL,
+        },
+      });
+    await waitForComponentToPaint(wrapper);
+    // Change the mac address.
+    wrapper.find("input[name='mac_address']").simulate("change", {
+      target: {
+        name: "mac_address",
+        value: "11:11:11:11:11:11",
+      },
+    });
+    await waitForComponentToPaint(wrapper);
+    // Enable the nic select again
+    wrapper
+      .find("input[name='macSource']")
+      .first()
+      .simulate("change", {
+        target: {
+          name: "macSource",
+          value: MacSource.NIC,
+        },
+      });
+    await waitForComponentToPaint(wrapper);
+    // The mac address field should be updated to the nic select value.
+    expect(wrapper.find("input[name='mac_address']").prop("value")).toBe(
+      "6a:6e:4a:29:a5:42"
     );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.tsx
@@ -1,25 +1,64 @@
 import { Col, Input, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
 
 import NetworkFields from "../../NetworkFields";
+import type { Selected } from "../../NetworkTable/types";
 import BondModeSelect from "../BondModeSelect";
 import HashPolicySelect from "../HashPolicySelect";
 import LACPRateSelect from "../LACPRateSelect";
 import type { BondFormValues } from "../types";
-import { LinkMonitoring } from "../types";
+import { MacSource, LinkMonitoring } from "../types";
 
 import FormikField from "app/base/components/FormikField";
 import MacAddressField from "app/base/components/MacAddressField";
 import TagField from "app/base/components/TagField";
 import { BondMode } from "app/store/general/types";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
 import { NetworkInterfaceTypes } from "app/store/machine/types";
+import {
+  getInterfaceById,
+  getInterfaceName,
+  getLinkFromNic,
+} from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
 
-const BondFormFields = (): JSX.Element | null => {
+type Props = {
+  selected: Selected[];
+  systemId: Machine["system_id"];
+};
+
+type Option = {
+  label: string;
+  value: string;
+};
+
+const getMacOptions = (machine: Machine, selected: Selected[]) =>
+  selected.reduce<Option[]>((options, { nicId, linkId }) => {
+    const nic = getInterfaceById(machine, nicId, linkId);
+    const link = getLinkFromNic(nic, linkId);
+    if (nic) {
+      options.push({
+        label: getInterfaceName(machine, nic, link),
+        value: nic.mac_address,
+      });
+    }
+    return options;
+  }, []);
+
+const BondFormFields = ({ selected, systemId }: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
   const {
     handleChange,
     setFieldValue,
     values,
   } = useFormikContext<BondFormValues>();
+  if (!machine) {
+    return null;
+  }
   const showHashPolicy = [
     BondMode.BALANCE_XOR,
     BondMode.LINK_AGGREGATION,
@@ -44,10 +83,43 @@ const BondFormFields = (): JSX.Element | null => {
         )}
         <FormikField label="Bond name" name="name" type="text" />
         <TagField className="u-sv2" />
-        <h3 className="p-heading--five u-no-margin--bottom">
-          Advanced options
-        </h3>
-        <MacAddressField label="MAC address" name="mac_address" />
+        <h3 className="p-heading--five">Advanced options</h3>
+        <FormikField
+          label="Use MAC address from bond member"
+          name="macSource"
+          onChange={(evt: React.ChangeEvent<HTMLSelectElement>) => {
+            handleChange(evt);
+            // Reset the mac address field from the select box.
+            setFieldValue("mac_address", values.macNic);
+          }}
+          type="radio"
+          value={MacSource.NIC}
+        />
+        <FormikField
+          component={Select}
+          disabled={values.macSource !== MacSource.NIC}
+          label={null}
+          name="macNic"
+          onChange={(evt: React.ChangeEvent<HTMLSelectElement>) => {
+            handleChange(evt);
+            // Fill the mac addres field from the value of this select.
+            setFieldValue("mac_address", evt.target.value);
+          }}
+          options={getMacOptions(machine, selected)}
+          wrapperClassName="u-nudge-right--x-large u-sv2"
+        />
+        <FormikField
+          label="Manual MAC address"
+          name="macSource"
+          type="radio"
+          value={MacSource.MANUAL}
+        />
+        <MacAddressField
+          disabled={values.macSource !== MacSource.MANUAL}
+          label={null}
+          name="mac_address"
+          wrapperClassName="u-nudge-right--x-large"
+        />
         <FormikField
           component={Select}
           label="Link monitoring"

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/types.ts
@@ -14,6 +14,11 @@ export enum LinkMonitoring {
   MII = "mii",
 }
 
+export enum MacSource {
+  NIC = "nic",
+  MANUAL = "manual",
+}
+
 export type BondFormValues = {
   bond_downdelay: NetworkInterfaceParams["bond_downdelay"];
   bond_lacp_rate: BondLacpRate;
@@ -21,8 +26,10 @@ export type BondFormValues = {
   bond_mode: BondMode;
   bond_updelay: NetworkInterfaceParams["bond_updelay"];
   bond_xmit_hash_policy: BondXmitHashPolicy;
-  linkMonitoring: string;
+  linkMonitoring: LinkMonitoring;
   mac_address: NetworkInterface["mac_address"];
+  macNic: NetworkInterface["mac_address"];
   name: NetworkInterface["name"];
+  macSource: MacSource;
   tags: NetworkInterface["tags"];
 } & NetworkValues;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.test.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.test.ts
@@ -1,4 +1,4 @@
-import { LinkMonitoring } from "./types";
+import { LinkMonitoring, MacSource } from "./types";
 import { getFirstSelected, getValidNics, preparePayload } from "./utils";
 
 import {
@@ -141,8 +141,9 @@ describe("BondForm utils", () => {
       const values = {
         // Should be removed.
         linkMonitoring: LinkMonitoring.MII,
-        // Should be removed.
         mac_address: "",
+        macNic: "aa:bb:cc:dd:ee:ff",
+        macSource: MacSource.NIC,
         // Should not be removed,
         bond_downdelay: 0,
         bond_lacp_rate: BondLacpRate.FAST,
@@ -200,6 +201,8 @@ describe("BondForm utils", () => {
         bond_xmit_hash_policy: BondXmitHashPolicy.ENCAP2_3,
         fabric: 1,
         ip_address: "1.2.3.4",
+        macNic: "aa:bb:cc:dd:ee:ff",
+        macSource: MacSource.NIC,
         mode: NetworkLinkMode.LINK_UP,
         name: "bond2",
         subnet: 1,

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/utils.ts
@@ -97,7 +97,9 @@ export const preparePayload = (
       value === "" ||
       value === undefined ||
       // Remove fields that are not API values.
-      key === "linkMonitoring"
+      key === "linkMonitoring" ||
+      key === "macSource" ||
+      key === "macNic"
     ) {
       delete payload[key as keyof BondFormPayload];
     }

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -236,7 +236,7 @@ export const machineInterface = extend<Model, NetworkInterface>(model, {
   link_connected: true,
   link_speed: 10000,
   links: () => [],
-  mac_address: "00.00.00.00.00.00",
+  mac_address: (i: number) => `00.00.00.00.00.${i}`,
   name: (i: number) => `eth${i}`,
   numa_node: 0,
   params: null,


### PR DESCRIPTION
## Done

- Provide a way to use a mac address from a bond member in the bond forms.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the react network tab in machine details.
- Add two physical interfaces with the same VLAN.
- Tick the interfaces and click 'Create bond'.
- In the advanced options choose to either use a nic's MAC address or manually provide an address.
- Save and the mac should be set correctly on the new bond.

## Fixes

Fixes: #2363.