### PR TITLE
fix(ui): fix general websocket caching

### DIFF
--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -142,6 +142,23 @@ describe("websocket sagas", () => {
     expect(saga.next().done).toBe(true);
   });
 
+  it("continues if data has already been fetched for methods with cache", () => {
+    const action = {
+      type: "FETCH_TEST",
+      meta: {
+        cache: true,
+        model: "test",
+        method: "test.getAll",
+        type: MESSAGE_TYPES.REQUEST,
+      },
+    };
+    const previous = sendMessage(socketClient, action);
+    previous.next();
+    const saga = sendMessage(socketClient, action);
+    // The saga should have finished.
+    expect(saga.next().done).toBe(true);
+  });
+
   it("fetches list methods if no-cache is set", () => {
     const action = {
       type: "FETCH_TEST",

--- a/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
+++ b/ui/src/app/settings/views/Configuration/Commissioning/Commissioning.test.js
@@ -92,6 +92,7 @@ describe("Commissioning", () => {
       {
         type: "general/fetchOsInfo",
         meta: {
+          cache: true,
           model: "general",
           method: "osinfo",
         },

--- a/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
+++ b/ui/src/app/settings/views/Configuration/Deploy/Deploy.test.js
@@ -51,6 +51,7 @@ describe("Deploy", () => {
       {
         type: "general/fetchOsInfo",
         meta: {
+          cache: true,
           model: "general",
           method: "osinfo",
         },

--- a/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.js
@@ -60,6 +60,7 @@ describe("RepositoryForm", () => {
       {
         type: "general/fetchComponentsToDisable",
         meta: {
+          cache: true,
           model: "general",
           method: "components_to_disable",
         },
@@ -68,6 +69,7 @@ describe("RepositoryForm", () => {
       {
         type: "general/fetchKnownArchitectures",
         meta: {
+          cache: true,
           model: "general",
           method: "known_architectures",
         },
@@ -76,6 +78,7 @@ describe("RepositoryForm", () => {
       {
         type: "general/fetchPocketsToDisable",
         meta: {
+          cache: true,
           model: "general",
           method: "pockets_to_disable",
         },

--- a/ui/src/app/store/general/actions.test.ts
+++ b/ui/src/app/store/general/actions.test.ts
@@ -5,6 +5,7 @@ describe("general actions", () => {
     expect(general.fetchArchitectures()).toEqual({
       type: "general/fetchArchitectures",
       meta: {
+        cache: true,
         model: "general",
         method: "architectures",
       },
@@ -16,6 +17,7 @@ describe("general actions", () => {
     expect(general.fetchBondOptions()).toEqual({
       type: "general/fetchBondOptions",
       meta: {
+        cache: true,
         model: "general",
         method: "bond_options",
       },
@@ -27,6 +29,7 @@ describe("general actions", () => {
     expect(general.fetchComponentsToDisable()).toEqual({
       type: "general/fetchComponentsToDisable",
       meta: {
+        cache: true,
         model: "general",
         method: "components_to_disable",
       },
@@ -38,6 +41,7 @@ describe("general actions", () => {
     expect(general.fetchDefaultMinHweKernel()).toEqual({
       type: "general/fetchDefaultMinHweKernel",
       meta: {
+        cache: true,
         model: "general",
         method: "default_min_hwe_kernel",
       },
@@ -49,6 +53,7 @@ describe("general actions", () => {
     expect(general.fetchHweKernels()).toEqual({
       type: "general/fetchHweKernels",
       meta: {
+        cache: true,
         model: "general",
         method: "hwe_kernels",
       },
@@ -60,6 +65,7 @@ describe("general actions", () => {
     expect(general.fetchKnownArchitectures()).toEqual({
       type: "general/fetchKnownArchitectures",
       meta: {
+        cache: true,
         model: "general",
         method: "known_architectures",
       },
@@ -71,6 +77,7 @@ describe("general actions", () => {
     expect(general.fetchMachineActions()).toEqual({
       type: "general/fetchMachineActions",
       meta: {
+        cache: true,
         model: "general",
         method: "machine_actions",
       },
@@ -82,6 +89,7 @@ describe("general actions", () => {
     expect(general.fetchNavigationOptions()).toEqual({
       type: "general/fetchNavigationOptions",
       meta: {
+        cache: true,
         model: "general",
         method: "navigation_options",
       },
@@ -93,6 +101,7 @@ describe("general actions", () => {
     expect(general.fetchOsInfo()).toEqual({
       type: "general/fetchOsInfo",
       meta: {
+        cache: true,
         model: "general",
         method: "osinfo",
       },
@@ -104,6 +113,7 @@ describe("general actions", () => {
     expect(general.fetchPocketsToDisable()).toEqual({
       type: "general/fetchPocketsToDisable",
       meta: {
+        cache: true,
         model: "general",
         method: "pockets_to_disable",
       },
@@ -115,6 +125,7 @@ describe("general actions", () => {
     expect(general.fetchPowerTypes()).toEqual({
       type: "general/fetchPowerTypes",
       meta: {
+        cache: true,
         model: "general",
         method: "power_types",
       },
@@ -126,6 +137,7 @@ describe("general actions", () => {
     expect(general.fetchVersion()).toEqual({
       type: "general/fetchVersion",
       meta: {
+        cache: true,
         model: "general",
         method: "version",
       },

--- a/ui/src/app/store/general/slice.ts
+++ b/ui/src/app/store/general/slice.ts
@@ -46,6 +46,7 @@ const generateGeneralReducers = <K extends keyof GeneralState>(
   [`fetch${capitaliseFirst(key)}`]: {
     prepare: () => ({
       meta: {
+        cache: true,
         model: "general",
         method,
       },


### PR DESCRIPTION
## Done

- Don't request general data if it has already been requested.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open your browsers network tab.
- Load the machine list.
- Click on Settings in the main nav.
- Find the websocket and clear the messages.
- Click on the machine list again.
- You should not see a bunch of general requests.

## Fixes

Fixes: #2213.