### PR TITLE
fix(legacy): fix device network tab route

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -623,8 +623,8 @@
               role="tab"
               class="p-tabs__link"
               data-ng-class="{ 'is-active': section.area === 'network'}"
-              data-ng-click="isController ? openSection('network') : navigateToNew('/machine/' + node.system_id + '/network')"
-              href="{$ isController ? undefined : newURLBase + '/machine/' + node.system_id + '/network' $}"
+              data-ng-click="isController || isDevice ? openSection('network') : navigateToNew('/machine/' + node.system_id + '/network')"
+              href="{$ isController || isDevice ? undefined : newURLBase + '/machine/' + node.system_id + '/network' $}"
               >Network</a
             >
           </li>


### PR DESCRIPTION
## Done

- Fix the route for the network tab in device details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to the details page for a device.
- Click on the "Network" tab.
- You should navigate to `/MAAS/l/device/[system_id]?area=network`

## Fixes

Fixes: #2384.