### PR TITLE
feat(ui): add project selection step to Add LXD KVM form

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -269,25 +269,34 @@ exports[`stricter compilation`] = {
       [42, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"],
       [78, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"]
     ],
-    "src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx:2787447767": [
-      [29, 28, 17, "Expected 1 arguments, but got 0.", "3763407084"]
+    "src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx:2097291202": [
+      [30, 28, 17, "Expected 1 arguments, but got 0.", "3763407084"]
     ],
-    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.test.tsx:3091382184": [
-      [76, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [77, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; project: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"],
-      [122, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [123, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; project: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"],
-      [135, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
-      [136, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; project: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"]
+    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.test.tsx:3638565741": [
+      [99, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [100, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"]
     ],
-    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.tsx:4238528085": [
-      [84, 8, 8, "Type \'(values: AddLxdValues) => void\' is not assignable to type \'(values?: AddLxdValues | undefined, formikHelpers?: FormikHelpers<AddLxdValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'AddLxdValues | undefined\' is not assignable to type \'AddLxdValues\'.\\n      Type \'undefined\' is not assignable to type \'AddLxdValues\'.", "1301647696"]
+    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateForm.test.tsx:3108327293": [
+      [56, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [57, 8, 24, "Argument of type \'{ name: string; pool: number; power_address: string; password: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"]
+    ],
+    "src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateForm.tsx:2913313264": [
+      [66, 6, 8, "Type \'(values: AuthenticateFormValues) => void\' is not assignable to type \'(values?: AuthenticateFormValues | undefined, formikHelpers?: FormikHelpers<AuthenticateFormValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'AuthenticateFormValues | undefined\' is not assignable to type \'AuthenticateFormValues\'.\\n      Type \'undefined\' is not assignable to type \'AuthenticateFormValues\'.", "1301647696"]
+    ],
+    "src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx:3416020808": [
+      [118, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [119, 8, 19, "Argument of type \'{ existingProject: string; newProject: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'existingProject\' does not exist in type \'FormEvent<{}>\'.", "1472460409"],
+      [164, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
+      [165, 8, 35, "Argument of type \'{ existingProject: string; newProject: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'existingProject\' does not exist in type \'FormEvent<{}>\'.", "1982018706"]
+    ],
+    "src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.tsx:3133914474": [
+      [88, 6, 8, "Type \'(values: SelectProjectFormValues) => void\' is not assignable to type \'(values?: SelectProjectFormValues | undefined, formikHelpers?: FormikHelpers<SelectProjectFormValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'SelectProjectFormValues | undefined\' is not assignable to type \'SelectProjectFormValues\'.\\n      Type \'undefined\' is not assignable to type \'SelectProjectFormValues\'.", "1301647696"]
     ],
     "src/app/kvm/views/KVMList/AddKVM/AddVirsh/AddVirsh.test.tsx:723256513": [
       [92, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [93, 8, 24, "Argument of type \'{ name: string; pool: number; power_parameters: { power_address: string; power_pass: string; }; type: string; zone: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "243796029"]
     ],
-    "src/app/kvm/views/KVMList/AddKVM/AddVirsh/AddVirsh.tsx:2182348183": [
+    "src/app/kvm/views/KVMList/AddKVM/AddVirsh/AddVirsh.tsx:2501390533": [
       [91, 8, 8, "Type \'(values: AddVirshValues) => void\' is not assignable to type \'(values?: AddVirshValues | undefined, formikHelpers?: FormikHelpers<AddVirshValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'AddVirshValues | undefined\' is not assignable to type \'AddVirshValues\'.\\n      Type \'undefined\' is not assignable to type \'AddVirshValues\'.", "1301647696"]
     ],
     "src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx:827005847": [
@@ -444,8 +453,8 @@ exports[`stricter compilation`] = {
       [321, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
       [325, 8, 18, "Argument of type \'{ bond_downdelay: number; bond_lacp_rate: string; bond_mode: BondMode; bond_miimon: number; bond_updelay: number; fabric: number; ip_address: string; linkMonitoring: LinkMonitoring; ... 5 more ...; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bond_downdelay\' does not exist in type \'FormEvent<{}>\'.", "796132353"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx:136967930": [
-      [185, 8, 8, "Type \'(values: BondFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BondFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bond_downdelay: number | undefined; bond_lacp_rate: BondLacpRate; bond_miimon: number | undefined; bond_mode: BondMode; bond_updelay: number | undefined; ... 4 more ...; tags: string[]; }\'.", "1301647696"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx:2215633109": [
+      [188, 8, 8, "Type \'(values: BondFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BondFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bond_downdelay: number | undefined; bond_lacp_rate: BondLacpRate; bond_miimon: number | undefined; bond_mode: BondMode; bond_updelay: number | undefined; ... 6 more ...; tags: string[]; }\'.", "1301647696"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx:1512454196": [
       [132, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -500,8 +509,8 @@ exports[`stricter compilation`] = {
       [400, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
       [404, 8, 18, "Argument of type \'{ bond_downdelay: number; bond_lacp_rate: string; bond_mode: BondMode; bond_miimon: number; bond_updelay: number; fabric: number; ip_address: string; linkMonitoring: LinkMonitoring; ... 5 more ...; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bond_downdelay\' does not exist in type \'FormEvent<{}>\'.", "796132353"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx:3032943128": [
-      [189, 6, 8, "Type \'(values: BondFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BondFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bond_downdelay: number | undefined; bond_lacp_rate: BondLacpRate; bond_miimon: number | undefined; bond_mode: BondMode; bond_updelay: number | undefined; ... 4 more ...; tags: string[]; }\'.", "1301647696"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx:2229988456": [
+      [191, 6, 8, "Type \'(values: BondFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BondFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bond_downdelay: number | undefined; bond_lacp_rate: BondLacpRate; bond_miimon: number | undefined; bond_mode: BondMode; bond_updelay: number | undefined; ... 6 more ...; tags: string[]; }\'.", "1301647696"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx:1263648396": [
       [110, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],

--- a/ui/src/app/base/components/FormCard/FormCard.tsx
+++ b/ui/src/app/base/components/FormCard/FormCard.tsx
@@ -32,7 +32,12 @@ export const FormCard = ({
 }: Props): JSX.Element => {
   const { CARD_TITLE } = COL_SIZES;
   const contentSize = getContentSize(sidebar, title);
-  const titleNode = <h4 className="form-card__title">{title}</h4>;
+  const titleNode =
+    typeof title === "string" ? (
+      <h4 className="form-card__title">{title}</h4>
+    ) : (
+      title
+    );
   const content = stacked ? (
     <>
       {titleNode}

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx
@@ -9,6 +9,7 @@ import AddVirsh from "./AddVirsh";
 import { useWindowTitle } from "app/base/hooks";
 import { actions as generalActions } from "app/store/general";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
+import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/types";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
@@ -28,6 +29,7 @@ export const AddKvmTypeSelect = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(generalActions.fetchPowerTypes());
+    dispatch(podActions.fetch());
     dispatch(resourcePoolActions.fetch());
     dispatch(zoneActions.fetch());
   }, [dispatch]);

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.test.tsx
@@ -61,7 +61,7 @@ describe("AddLxd", () => {
     });
   });
 
-  it("can handle fetching projects for a given LXD server address", () => {
+  it("shows the authentication form by default", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -73,37 +73,14 @@ describe("AddLxd", () => {
       </Provider>
     );
 
-    act(() => {
-      wrapper.find("Formik").prop("onSubmit")({
-        name: "my-favourite-kvm",
-        pool: 0,
-        power_address: "192.168.1.1",
-        password: "password",
-        project: "default",
-        zone: 0,
-      });
-    });
-    wrapper.update();
-
-    expect(
-      store.getActions().find((action) => action.type === "pod/getProjects")
-    ).toStrictEqual({
-      type: "pod/getProjects",
-      meta: {
-        method: "get_projects",
-        model: "pod",
-      },
-      payload: {
-        params: {
-          power_address: "192.168.1.1",
-          password: "password",
-          type: "lxd",
-        },
-      },
-    });
+    expect(wrapper.find("[data-test='step-number']").text()).toBe(
+      "Step 1 of 2"
+    );
+    expect(wrapper.find("AuthenticateForm").exists()).toBe(true);
+    expect(wrapper.find("SelectProjectForm").exists()).toBe(false);
   });
 
-  it("can handle saving a LXD KVM once projects have been fetched", () => {
+  it("shows the project select form once authenticated", () => {
     state.pod.projects = {
       "192.168.1.1": [podProjectFactory()],
     };
@@ -118,51 +95,22 @@ describe("AddLxd", () => {
       </Provider>
     );
 
-    // Fetch projects
+    // Submit authentication form
     act(() => {
       wrapper.find("Formik").prop("onSubmit")({
         name: "my-favourite-kvm",
         pool: 0,
         power_address: "192.168.1.1",
         password: "password",
-        project: "",
         zone: 0,
       });
     });
     wrapper.update();
 
-    // Submit again
-    act(() => {
-      wrapper.find("Formik").prop("onSubmit")({
-        name: "my-favourite-kvm",
-        pool: 0,
-        power_address: "192.168.1.1",
-        password: "password",
-        project: "default",
-        zone: 0,
-      });
-    });
-    wrapper.update();
-
-    expect(
-      store.getActions().find((action) => action.type === "pod/create")
-    ).toStrictEqual({
-      type: "pod/create",
-      meta: {
-        method: "create",
-        model: "pod",
-      },
-      payload: {
-        params: {
-          name: "my-favourite-kvm",
-          pool: 0,
-          power_address: "192.168.1.1",
-          password: "password",
-          project: "default",
-          type: "lxd",
-          zone: 0,
-        },
-      },
-    });
+    expect(wrapper.find("[data-test='step-number']").text()).toBe(
+      "Step 2 of 2"
+    );
+    expect(wrapper.find("SelectProjectForm").exists()).toBe(true);
+    expect(wrapper.find("AuthenticateForm").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.tsx
@@ -1,122 +1,61 @@
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 
-import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
-import type { SchemaOf } from "yup";
-import * as Yup from "yup";
+import { useSelector } from "react-redux";
 
-import type { SetKvmType } from "../AddKVM";
-
-import AddLxdFields from "./AddLxdFields";
+import AuthenticateForm from "./AuthenticateForm";
+import SelectProjectForm from "./SelectProjectForm";
 
 import FormCard from "app/base/components/FormCard";
-import FormCardButtons from "app/base/components/FormCardButtons";
-import FormikForm from "app/base/components/FormikForm";
-import { actions as podActions } from "app/store/pod";
+import type { SetKvmType } from "app/kvm/views/KVMList/AddKVM";
 import podSelectors from "app/store/pod/selectors";
-import { PodType } from "app/store/pod/types";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import type { RootState } from "app/store/root/types";
-import zoneSelectors from "app/store/zone/selectors";
 
 type Props = { setKvmType: SetKvmType };
 
-export type AddLxdValues = {
-  name?: string;
-  password?: string;
+export type AuthenticateFormValues = {
+  name: string;
+  password: string;
   pool: string;
   power_address: string;
-  project: string;
   zone: string;
 };
 
-const AddLxdSchema: SchemaOf<AddLxdValues> = Yup.object().shape({
-  name: Yup.string(),
-  password: Yup.string(),
-  pool: Yup.string().required("Resource pool required"),
-  power_address: Yup.string().required("Address is required"),
-  project: Yup.string().required("Project is required"),
-  zone: Yup.string().required("Zone required"),
-});
-
 export const AddLxd = ({ setKvmType }: Props): JSX.Element => {
-  const dispatch = useDispatch();
-  const history = useHistory();
-  const [lxdAddress, setLxdAddress] = useState("");
+  const [authValues, setAuthValues] = useState<AuthenticateFormValues>({
+    name: "",
+    password: "",
+    pool: "",
+    power_address: "",
+    zone: "",
+  });
   const projects = useSelector((state: RootState) =>
-    podSelectors.getProjectsByLxdServer(state, lxdAddress)
+    podSelectors.getProjectsByLxdServer(state, authValues.power_address)
   );
-  const errors = useSelector(podSelectors.errors);
-  const saving = useSelector(podSelectors.saving);
-  const resourcePools = useSelector(resourcePoolSelectors.all);
-  const zones = useSelector(zoneSelectors.all);
-  const cleanup = useCallback(() => podActions.cleanup(), []);
-  const [authenticating, setAuthenticating] = useState(false);
   // User is considered "authenticated" if they have set a LXD server address
   // and projects for it exist in state.
-  const authenticated = Boolean(lxdAddress) && projects.length >= 1;
-
-  useEffect(() => {
-    if (authenticated || Boolean(errors)) {
-      setAuthenticating(false);
-    }
-  }, [authenticated, errors]);
+  const authenticated =
+    Boolean(authValues.power_address) && projects.length >= 1;
 
   return (
-    <FormCard sidebar={false} title="Add KVM">
-      <FormikForm<AddLxdValues>
-        buttons={FormCardButtons}
-        cleanup={cleanup}
-        errors={errors}
-        initialValues={{
-          name: "",
-          password: "",
-          pool: resourcePools.length ? `${resourcePools[0].id}` : "",
-          power_address: "",
-          project: "default",
-          zone: zones.length ? `${zones[0].id}` : "",
-        }}
-        onCancel={() => history.push({ pathname: "/kvm" })}
-        onSaveAnalytics={{
-          action: "Save LXD KVM",
-          category: "Add KVM form",
-          label: "Save KVM",
-        }}
-        onSubmit={(values: AddLxdValues) => {
-          if (authenticated) {
-            dispatch(
-              podActions.create({
-                name: values.name,
-                password: values.password,
-                pool: Number(values.pool),
-                power_address: values.power_address,
-                project: values.project,
-                type: PodType.LXD,
-                zone: Number(values.zone),
-              })
-            );
-          } else {
-            dispatch(cleanup());
-            setLxdAddress(values.power_address);
-            if (projects.length === 0) {
-              setAuthenticating(true);
-              dispatch(
-                podActions.getProjects({
-                  password: values.password,
-                  power_address: values.power_address,
-                  type: PodType.LXD,
-                })
-              );
-            }
-          }
-        }}
-        saving={saving || authenticating}
-        savedRedirect="/kvm"
-        submitLabel={authenticated ? "Next" : "Authenticate"}
-        validationSchema={AddLxdSchema}
-      >
-        <AddLxdFields setKvmType={setKvmType} />
-      </FormikForm>
+    <FormCard
+      sidebar={false}
+      title={
+        <>
+          <h4>Add KVM</h4>
+          <small className="u-text--muted" data-test="step-number">
+            Step {!authenticated ? "1" : "2"} of 2
+          </small>
+        </>
+      }
+    >
+      {!authenticated ? (
+        <AuthenticateForm
+          setAuthValues={setAuthValues}
+          setKvmType={setKvmType}
+        />
+      ) : (
+        <SelectProjectForm authValues={authValues} />
+      )}
     </FormCard>
   );
 };

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxdFields/index.ts
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxdFields/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./AddLxdFields";

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateForm.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateForm.test.tsx
@@ -1,0 +1,91 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AuthenticateForm from "./AuthenticateForm";
+
+import type { RootState } from "app/store/root/types";
+import {
+  podState as podStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AuthenticateForm", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      pod: podStateFactory({
+        loaded: true,
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory()],
+        loaded: true,
+      }),
+      zone: zoneStateFactory({
+        items: [zoneFactory()],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("can handle fetching projects for a given LXD server address", () => {
+    const setAuthValues = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <AuthenticateForm
+            setAuthValues={setAuthValues}
+            setKvmType={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => {
+      wrapper.find("Formik").prop("onSubmit")({
+        name: "my-favourite-kvm",
+        pool: 0,
+        power_address: "192.168.1.1",
+        password: "password",
+        zone: 0,
+      });
+    });
+    wrapper.update();
+
+    expect(setAuthValues).toHaveBeenCalledWith({
+      name: "my-favourite-kvm",
+      password: "password",
+      pool: 0,
+      power_address: "192.168.1.1",
+      zone: 0,
+    });
+    expect(
+      store.getActions().find((action) => action.type === "pod/getProjects")
+    ).toStrictEqual({
+      type: "pod/getProjects",
+      meta: {
+        method: "get_projects",
+        model: "pod",
+      },
+      payload: {
+        params: {
+          power_address: "192.168.1.1",
+          password: "password",
+          type: "lxd",
+        },
+      },
+    });
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateForm.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import type { SchemaOf } from "yup";
+import * as Yup from "yup";
+
+import type { AuthenticateFormValues } from "../AddLxd";
+
+import AuthenticateFormFields from "./AuthenticateFormFields";
+
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import type { SetKvmType } from "app/kvm/views/KVMList/AddKVM";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import { PodType } from "app/store/pod/types";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
+import zoneSelectors from "app/store/zone/selectors";
+
+type Props = {
+  setAuthValues: (values: AuthenticateFormValues) => void;
+  setKvmType: SetKvmType;
+};
+
+const AuthenticateFormSchema: SchemaOf<AuthenticateFormValues> = Yup.object()
+  .shape({
+    name: Yup.string().required("Name is required"),
+    password: Yup.string(),
+    pool: Yup.string().required("Resource pool required"),
+    power_address: Yup.string().required("Address is required"),
+    zone: Yup.string().required("Zone required"),
+  })
+  .defined();
+
+export const AuthenticateForm = ({
+  setAuthValues,
+  setKvmType,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const errors = useSelector(podSelectors.errors);
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const zones = useSelector(zoneSelectors.all);
+  const cleanup = useCallback(() => podActions.cleanup(), []);
+  const [authenticating, setAuthenticating] = useState(false);
+
+  useEffect(() => {
+    if (Boolean(errors)) {
+      setAuthenticating(false);
+    }
+  }, [errors]);
+
+  return (
+    <FormikForm<AuthenticateFormValues>
+      buttons={FormCardButtons}
+      cleanup={cleanup}
+      errors={errors}
+      initialValues={{
+        name: "",
+        password: "",
+        pool: resourcePools.length ? `${resourcePools[0].id}` : "",
+        power_address: "",
+        zone: zones.length ? `${zones[0].id}` : "",
+      }}
+      onCancel={() => history.push({ pathname: "/kvm" })}
+      onSubmit={(values: AuthenticateFormValues) => {
+        dispatch(cleanup());
+        setAuthValues(values);
+        setAuthenticating(true);
+        dispatch(
+          podActions.getProjects({
+            password: values.password,
+            power_address: values.power_address,
+            type: PodType.LXD,
+          })
+        );
+      }}
+      saving={authenticating}
+      submitLabel="Authenticate"
+      validationSchema={AuthenticateFormSchema}
+    >
+      <AuthenticateFormFields setKvmType={setKvmType} />
+    </FormikForm>
+  );
+};
+
+export default AuthenticateForm;

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateFormFields/AuthenticateFormFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateFormFields/AuthenticateFormFields.tsx
@@ -1,25 +1,24 @@
 import { Col, Row } from "@canonical/react-components";
 
-import type { SetKvmType } from "../../AddKVM";
-import KvmTypeSelect from "../../KvmTypeSelect";
-
 import FormikField from "app/base/components/FormikField";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
 import ZoneSelect from "app/base/components/ZoneSelect";
+import type { SetKvmType } from "app/kvm/views/KVMList/AddKVM";
+import KvmTypeSelect from "app/kvm/views/KVMList/AddKVM/KvmTypeSelect";
 import { PodType } from "app/store/pod/types";
 
 type Props = {
   setKvmType: SetKvmType;
 };
 
-export const AddLxdFields = ({ setKvmType }: Props): JSX.Element => {
+export const AuthenticateFormFields = ({ setKvmType }: Props): JSX.Element => {
   return (
     <Row>
       <Col size="5">
         <KvmTypeSelect kvmType={PodType.LXD} setKvmType={setKvmType} />
       </Col>
       <Col size="5">
-        <FormikField label="Name" name="name" type="text" />
+        <FormikField label="Name" name="name" required type="text" />
         <ZoneSelect name="zone" required valueKey="id" />
         <ResourcePoolSelect name="pool" required valueKey="id" />
         <FormikField
@@ -33,10 +32,9 @@ export const AddLxdFields = ({ setKvmType }: Props): JSX.Element => {
           name="password"
           type="password"
         />
-        <FormikField label="LXD project" name="project" type="text" />
       </Col>
     </Row>
   );
 };
 
-export default AddLxdFields;
+export default AuthenticateFormFields;

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateFormFields/index.ts
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/AuthenticateFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AuthenticateFormFields";

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/index.ts
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/AuthenticateForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AuthenticateForm";

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
@@ -1,0 +1,193 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import type { AuthenticateFormValues } from "../AddLxd";
+
+import SelectProjectForm from "./SelectProjectForm";
+
+import type { RootState } from "app/store/root/types";
+import {
+  podProject as podProjectFactory,
+  podState as podStateFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("SelectProjectForm", () => {
+  let state: RootState;
+  let authValues: AuthenticateFormValues;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      pod: podStateFactory({
+        loaded: true,
+      }),
+      resourcepool: resourcePoolStateFactory({
+        items: [resourcePoolFactory()],
+        loaded: true,
+      }),
+      zone: zoneStateFactory({
+        items: [zoneFactory()],
+        loaded: true,
+      }),
+    });
+    authValues = {
+      name: "pod-name",
+      password: "password",
+      pool: "0",
+      power_address: "192.168.1.1",
+      zone: "0",
+    };
+  });
+
+  it("shows the LXD host details", () => {
+    const project = podProjectFactory();
+    state.pod.projects = {
+      "192.168.1.1": [project],
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <SelectProjectForm authValues={authValues} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='lxd-host-details']").text()).toBe(
+      "LXD host: pod-name (192.168.1.1)"
+    );
+  });
+
+  it("shows an error if attempting to add a project name that already exists", async () => {
+    const project = podProjectFactory({ name: "foo" });
+    state.pod.projects = {
+      "192.168.1.1": [project],
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <SelectProjectForm authValues={authValues} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find("input[name='newProject']").simulate("change", {
+      target: { name: "newProject", value: "foo" },
+    });
+    wrapper.find("input[name='newProject']").simulate("blur");
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper
+        .find("FormikField[name='newProject'] .p-form-validation__message")
+        .text()
+    ).toBe("Error: A project with this name already exists.");
+  });
+
+  it("can handle creating a LXD KVM with a new project", async () => {
+    const project = podProjectFactory({ name: "foo" });
+    state.pod.projects = {
+      "192.168.1.1": [project],
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <SelectProjectForm authValues={authValues} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => {
+      wrapper.find("Formik").prop("onSubmit")({
+        existingProject: "",
+        newProject: "new-project",
+      });
+    });
+    wrapper.update();
+
+    expect(
+      store.getActions().find((action) => action.type === "pod/create")
+    ).toStrictEqual({
+      type: "pod/create",
+      meta: {
+        method: "create",
+        model: "pod",
+      },
+      payload: {
+        params: {
+          name: "pod-name",
+          pool: 0,
+          power_address: "192.168.1.1",
+          password: "password",
+          project: "new-project",
+          type: "lxd",
+          zone: 0,
+        },
+      },
+    });
+  });
+
+  it("can handle saving a LXD KVM with an existing project", async () => {
+    const project = podProjectFactory({ name: "foo" });
+    state.pod.projects = {
+      "192.168.1.1": [project],
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <SelectProjectForm authValues={authValues} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() => {
+      wrapper.find("Formik").prop("onSubmit")({
+        existingProject: "existing-project",
+        newProject: "",
+      });
+    });
+    wrapper.update();
+
+    expect(
+      store.getActions().find((action) => action.type === "pod/create")
+    ).toStrictEqual({
+      type: "pod/create",
+      meta: {
+        method: "create",
+        model: "pod",
+      },
+      payload: {
+        params: {
+          name: "pod-name",
+          pool: 0,
+          power_address: "192.168.1.1",
+          password: "password",
+          project: "existing-project",
+          type: "lxd",
+          zone: 0,
+        },
+      },
+    });
+  });
+});

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useState } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import type { SchemaOf } from "yup";
+import * as Yup from "yup";
+
+import type { AuthenticateFormValues } from "../AddLxd";
+
+import SelectProjectFormFields from "./SelectProjectFormFields";
+
+import FormCardButtons from "app/base/components/FormCardButtons";
+import FormikForm from "app/base/components/FormikForm";
+import { useAddMessage } from "app/base/hooks";
+import { actions as podActions } from "app/store/pod";
+import podSelectors from "app/store/pod/selectors";
+import { PodType } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  authValues: AuthenticateFormValues;
+};
+
+export type SelectProjectFormValues = {
+  existingProject: string;
+  newProject: string;
+};
+
+export const SelectProjectForm = ({ authValues }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const errors = useSelector(podSelectors.errors);
+  const saved = useSelector(podSelectors.saved);
+  const saving = useSelector(podSelectors.saving);
+  const projects = useSelector((state: RootState) =>
+    podSelectors.getProjectsByLxdServer(state, authValues.power_address)
+  );
+  const cleanup = useCallback(() => podActions.cleanup(), []);
+  const [savingPod, setSavingPod] = useState("");
+
+  useAddMessage(saved, cleanup, `${savingPod} added successfully.`, () =>
+    setSavingPod("")
+  );
+
+  const SelectProjectSchema: SchemaOf<SelectProjectFormValues> = Yup.object()
+    .shape({
+      existingProject: Yup.string(),
+      newProject: Yup.string()
+        .max(63, "Must be less than 63 characters")
+        .matches(
+          /^[a-zA-Z0-9-_]*$/,
+          `Must not contain any spaces or special characters (i.e. / . ' " *)`
+        )
+        .test(
+          "alreadyExists",
+          "A project with this name already exists",
+          function test() {
+            const values: SelectProjectFormValues = this.parent;
+            const projectExists = projects.some(
+              (project) => project.name === values.newProject
+            );
+            if (projectExists) {
+              return this.createError({
+                message: "A project with this name already exists.",
+                path: "newProject",
+              });
+            }
+            return true;
+          }
+        ),
+    })
+    .defined();
+
+  return (
+    <FormikForm<SelectProjectFormValues>
+      buttons={FormCardButtons}
+      cleanup={cleanup}
+      errors={errors}
+      initialValues={{
+        existingProject: "",
+        newProject: "",
+      }}
+      onCancel={() => history.push({ pathname: "/kvm" })}
+      onSaveAnalytics={{
+        action: "Save LXD KVM",
+        category: "Add KVM form",
+        label: "Save KVM",
+      }}
+      onSubmit={(values: SelectProjectFormValues) => {
+        dispatch(cleanup());
+        const params = {
+          name: authValues.name,
+          password: authValues.password,
+          pool: Number(authValues.pool),
+          power_address: authValues.power_address,
+          project: values.newProject || values.existingProject,
+          type: PodType.LXD,
+          zone: Number(authValues.zone),
+        };
+        dispatch(podActions.create(params));
+        setSavingPod(authValues.name || "LXD VM host");
+      }}
+      saved={saved}
+      savedRedirect="/kvm"
+      saving={saving}
+      submitLabel="Save KVM"
+      validationSchema={SelectProjectSchema}
+    >
+      <SelectProjectFormFields authValues={authValues} />
+    </FormikForm>
+  );
+};
+
+export default SelectProjectForm;

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+
+import { Col, Icon, Input, Row, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+
+import FormikField from "app/base/components/FormikField";
+import type { AuthenticateFormValues } from "app/kvm/views/KVMList/AddKVM/AddLxd";
+import podSelectors from "app/store/pod/selectors";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  authValues: AuthenticateFormValues;
+};
+
+export const SelectProjectFormFields = ({ authValues }: Props): JSX.Element => {
+  const projects = useSelector((state: RootState) =>
+    podSelectors.getProjectsByLxdServer(state, authValues.power_address)
+  );
+  const { setFieldValue } = useFormikContext();
+  const [newProject, setNewProject] = useState(true);
+
+  return (
+    <Row>
+      <Col size="5">
+        <p data-test="lxd-host-details">
+          LXD host: {authValues.name && <strong>{authValues.name}</strong>} (
+          {authValues.power_address})
+        </p>
+        <p className="u-text--muted">
+          <span>Connected</span>
+          <span className="u-nudge-right--small">
+            <Icon name="success" />
+          </span>
+        </p>
+      </Col>
+      <Col size="5">
+        <Input
+          checked={newProject}
+          id="new-project"
+          label="Add new project"
+          name="project-select"
+          onChange={() => {
+            setNewProject(true);
+            setFieldValue("existingProject", "");
+          }}
+          type="radio"
+        />
+        <FormikField
+          disabled={!newProject}
+          name="newProject"
+          type="text"
+          wrapperClassName="u-nudge-right--x-large u-sv2"
+        />
+        <Input
+          checked={!newProject}
+          id="existing-project"
+          label="Select existing project"
+          name="project-select"
+          onChange={() => {
+            setNewProject(false);
+            setFieldValue("newProject", "");
+          }}
+          type="radio"
+        />
+        <FormikField
+          component={Select}
+          disabled={newProject}
+          name="existingProject"
+          options={[
+            { value: "", label: "Select project", disabled: true },
+            ...projects.map((project) => ({
+              label: project.name,
+              value: project.name,
+            })),
+          ]}
+          wrapperClassName="u-nudge-right--x-large"
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default SelectProjectFormFields;

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/index.ts
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SelectProjectFormFields";

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/index.ts
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SelectProjectForm";

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/index.ts
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./AddLxd";
+export type { AuthenticateFormValues } from "./AddLxd";


### PR DESCRIPTION
## Done

- Added project selection step to Add LXD KVM form
- Split `AddLxd` into two separate forms: `AuthenticateForm` and `SelectProjectForm`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click Add KVM
- Authenticate to an LXD server (bolla LXD at `10.1.238.1:8443` will work)
- Check that projects are successfully fetched and you are taken to the next step
- Enter the name of an existing project in the "New project" field and check that an error shows on blur
- Enter a new project name and submit the form.
- Check that a new LXD pod is added with the details you entered
- Do the same thing but this time choose an existing project (note that I will be adding validation for existing pod-projects in a follow-up, so for now just choose a project that isn't already associated with a pod)

## Fixes

Fixes #2226 