### PR TITLE
fix(ui): make link speed a warning instead of error

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -137,7 +137,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -519,12 +519,12 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx:2591370152": [
       [101, 6, 8, "Type \'(values: BridgeFormValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'BridgeFormValues\'.\\n      Type \'unknown\' is not assignable to type \'{ bridge_fd?: number | undefined; bridge_stp?: boolean | undefined; bridge_type: BridgeType | undefined; mac_address: string; name: string; tags?: string[] | undefined; }\'.", "1301647696"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.test.tsx:2708100290": [
-      [140, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
-      [144, 8, 9, "Argument of type \'{ fabric: number; interface_speed: number; ip_address: string; link_speed: number; mac_address: string; mode: NetworkLinkMode; name: string; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'fabric\' does not exist in type \'FormEvent<{}>\'.", "3240912851"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.test.tsx:4211601066": [
+      [108, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
+      [112, 8, 9, "Argument of type \'{ fabric: number; interface_speed: number; ip_address: string; link_speed: number; mac_address: string; mode: NetworkLinkMode; name: string; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'fabric\' does not exist in type \'FormEvent<{}>\'.", "3240912851"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx:3472288293": [
-      [155, 6, 8, "Type \'(values: EditInterfaceValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'EditInterfaceValues\'.\\n      Type \'unknown\' is not assignable to type \'{ interface_speed: number; link_speed: number; mac_address: string; name?: string | undefined; tags?: string[] | undefined; }\'.", "1301647696"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx:200088332": [
+      [136, 6, 8, "Type \'(values: EditPhysicalValues) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'EditPhysicalValues\'.\\n      Type \'unknown\' is not assignable to type \'{ interface_speed: number; link_speed: number; mac_address: string; name?: string | undefined; tags?: string[] | undefined; }\'.", "1301647696"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:2321145835": [
       [333, 4, 3, "Argument of type \'keyof NetworkRowSortData | null\' is not assignable to parameter of type \'keyof NetworkRowSortData\'.\\n  Type \'null\' is not assignable to type \'keyof NetworkRowSortData\'.", "193424690"],

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.test.tsx
@@ -1,0 +1,100 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import EditPhysicalFields from "./EditPhysicalFields";
+
+import type { NetworkInterface } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("EditPhysicalFields", () => {
+  let nic: NetworkInterface;
+  let state: RootState;
+
+  beforeEach(() => {
+    nic = machineInterfaceFactory({
+      id: 1,
+    });
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        items: [fabricFactory({}), fabricFactory()],
+        loaded: true,
+      }),
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            interfaces: [nic],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+      subnet: subnetStateFactory({
+        items: [subnetFactory(), subnetFactory()],
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        items: [vlanFactory(), vlanFactory()],
+        loaded: true,
+      }),
+    });
+  });
+
+  it("does not allow the link speed to be higher than the interface speed", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ interface_speed: 0, link_speed: 0 }}
+            onSubmit={jest.fn()}
+          >
+            <EditPhysicalFields nic={nic} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("input[name='interface_speed']").simulate("change", {
+      target: {
+        name: "interface_speed",
+        value: 1,
+      },
+    });
+    await waitForComponentToPaint(wrapper);
+    wrapper.find("input[name='link_speed']").simulate("change", {
+      target: {
+        name: "link_speed",
+        value: 2,
+      },
+    });
+    wrapper.find("input[name='link_speed']").simulate("blur");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find(".p-form-validation__message").exists()).toBe(true);
+    expect(wrapper.find(".p-form-validation__message").text()).toBe(
+      "Caution: Link speed should not be higher than interface speed"
+    );
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.test.tsx
@@ -61,7 +61,7 @@ describe("EditPhysicalFields", () => {
     });
   });
 
-  it("does not allow the link speed to be higher than the interface speed", async () => {
+  it("shows a warning if link speed is higher than interface speed", async () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/EditPhysicalFields.tsx
@@ -1,0 +1,58 @@
+import { Col, Row } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import NetworkFields from "../../NetworkFields";
+import type { EditPhysicalValues } from "../types";
+
+import FormikField from "app/base/components/FormikField";
+import MacAddressField from "app/base/components/MacAddressField";
+import TagField from "app/base/components/TagField";
+import type { NetworkInterface } from "app/store/machine/types";
+import { NetworkInterfaceTypes } from "app/store/machine/types";
+
+type Props = {
+  nic: NetworkInterface | null;
+};
+
+const generateCaution = (values: EditPhysicalValues) =>
+  values.link_speed > values.interface_speed
+    ? "Link speed should not be higher than interface speed"
+    : null;
+
+const EditPhysicalFields = ({ nic }: Props): JSX.Element | null => {
+  const { values } = useFormikContext<EditPhysicalValues>();
+  if (!nic) {
+    return null;
+  }
+  return (
+    <Row>
+      <Col size="6">
+        <h3 className="p-heading--five u-no-margin--bottom">
+          Physical details
+        </h3>
+        <FormikField label="Name" type="text" name="name" />
+        <MacAddressField label="MAC address" name="mac_address" />
+        <TagField />
+        <FormikField
+          caution={generateCaution(values)}
+          label="Link speed (Gbps)"
+          type="text"
+          name="link_speed"
+          disabled={!nic.link_connected}
+        />
+        <FormikField
+          label="Interface speed (Gbps)"
+          type="text"
+          name="interface_speed"
+          disabled={!nic.link_connected}
+        />
+      </Col>
+      <Col size="6">
+        <h3 className="p-heading--five u-no-margin--bottom">Network</h3>
+        <NetworkFields editing interfaceType={NetworkInterfaceTypes.PHYSICAL} />
+      </Col>
+    </Row>
+  );
+};
+
+export default EditPhysicalFields;

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EditPhysicalFields";

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.test.tsx
@@ -94,38 +94,6 @@ describe("EditPhysicalForm", () => {
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
-  it("does not allow the link speed to be higher than the interface speed", async () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <EditPhysicalForm nicId={1} systemId="abc123" close={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-    wrapper.find("input[name='interface_speed']").simulate("change", {
-      target: {
-        name: "interface_speed",
-        value: 1,
-      },
-    });
-    await waitForComponentToPaint(wrapper);
-    wrapper.find("input[name='link_speed']").simulate("change", {
-      target: {
-        name: "link_speed",
-        value: 2,
-      },
-    });
-    wrapper.find("input[name='link_speed']").simulate("blur");
-    await waitForComponentToPaint(wrapper);
-    expect(wrapper.find(".p-form-validation__message").exists()).toBe(true);
-    expect(wrapper.find(".p-form-validation__message").text()).toBe(
-      "Error: Link speed cannot be higher than interface speed"
-    );
-  });
-
   it("correctly dispatches actions to edit a physical interface", async () => {
     const store = mockStore(state);
     const wrapper = mount(

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/types.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/types.ts
@@ -1,0 +1,11 @@
+import type { NetworkValues } from "../NetworkFields/NetworkFields";
+
+import type { NetworkInterface } from "app/store/machine/types";
+
+export type EditPhysicalValues = {
+  interface_speed: NetworkInterface["interface_speed"];
+  link_speed: NetworkInterface["link_speed"];
+  mac_address: NetworkInterface["mac_address"];
+  name?: NetworkInterface["name"];
+  tags?: NetworkInterface["tags"];
+} & NetworkValues;


### PR DESCRIPTION
## Done

- Update the edit physical interface form to show a warning instead of error when the link speed is
higher than the interface speed.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a machine's network tab.
- Open the action menu for a physical interface and click 'Edit ...'.
- Change the link speed to be higher than the interface speed.
- You should see a warning.
- Click save and it should let you save the change.

## Fixes

Fixes: #2180.