### PR TITLE
fix(ui): network tab UX review fixes

### DIFF
--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -23,7 +23,9 @@ export type Props<V, E = FormErrors> = {
   };
   onSubmit: (values?: V, formikHelpers?: FormikHelpers<V>) => void;
   savedRedirect?: string;
+  validateOnChange?: boolean;
   validationSchema?: SchemaOf<V>;
+  validateOnMount?: boolean;
 } & ContentProps<V, E>;
 
 const FormikForm = <V, E = FormErrors>({
@@ -56,7 +58,9 @@ const FormikForm = <V, E = FormErrors>({
   submitAppearance,
   submitDisabled,
   submitLabel,
+  validateOnChange,
   validationSchema,
+  validateOnMount,
   ...props
 }: Props<V, E>): JSX.Element => {
   const dispatch = useDispatch();
@@ -82,6 +86,8 @@ const FormikForm = <V, E = FormErrors>({
     <Formik
       initialValues={initialValues}
       onSubmit={onSubmit}
+      validateOnChange={validateOnChange}
+      validateOnMount={validateOnMount}
       validationSchema={validationSchema}
       {...props}
     >

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -21,6 +21,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -53,9 +54,9 @@ describe("AddInterface", () => {
     });
   });
 
-  it("fetches the necessary data on load", () => {
+  it("fetches the necessary data on load", async () => {
     const store = mockStore(state);
-    mount(
+    const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
@@ -64,6 +65,7 @@ describe("AddInterface", () => {
         </MemoryRouter>
       </Provider>
     );
+    await waitForComponentToPaint(wrapper);
     const expectedActions = ["fabric/fetch", "vlan/fetch"];
     expectedActions.forEach((expectedAction) => {
       expect(
@@ -72,7 +74,7 @@ describe("AddInterface", () => {
     });
   });
 
-  it("displays a spinner when data is loading", () => {
+  it("displays a spinner when data is loading", async () => {
     state.vlan.loaded = false;
     state.fabric.loaded = false;
     const store = mockStore(state);
@@ -85,10 +87,11 @@ describe("AddInterface", () => {
         </MemoryRouter>
       </Provider>
     );
+    await waitForComponentToPaint(wrapper);
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
-  it("correctly dispatches actions to add a physical interface", () => {
+  it("correctly dispatches actions to add a physical interface", async () => {
     state.machine.selected = ["abc123", "def456"];
     const store = mockStore(state);
     const wrapper = mount(
@@ -100,7 +103,7 @@ describe("AddInterface", () => {
         </MemoryRouter>
       </Provider>
     );
-
+    await waitForComponentToPaint(wrapper);
     act(() =>
       wrapper
         .find("Formik")

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
@@ -110,6 +110,7 @@ const AddInterface = ({ close, systemId }: Props): JSX.Element | null => {
           saved={saved}
           saving={saving}
           submitLabel="Save interface"
+          validateOnMount
           validationSchema={InterfaceSchema}
         >
           <Row>

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -14,6 +14,7 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -37,7 +38,7 @@ describe("MachineNetwork", () => {
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
-  it("displays the add interface form when expanded", () => {
+  it("displays the add interface form when expanded", async () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [machineDetailsFactory({ system_id: "abc123" })],
@@ -63,6 +64,7 @@ describe("MachineNetwork", () => {
       </Provider>
     );
     wrapper.find("Button[children='Add interface']").simulate("click");
+    await waitForComponentToPaint(wrapper);
     expect(wrapper.find("AddInterface").exists()).toBe(true);
   });
 

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -85,7 +85,7 @@ const MachineNetwork = ({ setSelectedAction }: Props): JSX.Element => {
         setSelectedAction={setSelectedAction}
         systemId={id}
       />
-      <Strip>
+      <Strip shallow>
         <NetworkTable
           expanded={interfaceExpanded}
           selected={selected}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkActions/NetworkActions.tsx
@@ -169,10 +169,11 @@ const NetworkActions = ({
   return (
     <Row>
       <Col size="8">
-        <List inline items={buttons} />
+        <List className="u-no-margin--bottom" inline items={buttons} />
       </Col>
       <Col className="u-align--right" size="4">
         <Button
+          className="u-no-margin--bottom"
           disabled={isAllNetworkingDisabled}
           onClick={() => {
             setSelectedAction({

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NameColumn/NameColumn.tsx
@@ -75,7 +75,9 @@ const NameColumn = ({
       }
       secondary={nic.mac_address}
       primaryClassName={checkboxSpace ? "u-nudge--primary-row" : null}
-      secondaryClassName={checkboxSpace ? "u-nudge--secondary-row" : null}
+      secondaryClassName={
+        checkboxSpace || showCheckbox ? "u-nudge--secondary-row" : null
+      }
     />
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -477,6 +477,7 @@ const NetworkTable = ({
           ),
         },
         {
+          className: "u-align--center",
           content: (
             <>
               <TableHeader


### PR DESCRIPTION
## Done

- Centre align the PXE header in the network table.
- Indent mac addresses when there is a checkbox.
- Fix the space above the network table.
- Disable the save button when opening the add interface form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the network tab for a machine.
- Check that there is a sensible amount of space between the add buttons and the interface table.
- Click 'Add interface'.
- The save button should be disabled.
- Enter a mac address, the save button should become enabled.
- Check that the PXE tick and table header are aligned.
- Check that the mac addresses are indented to match the nic name.

## Fixes

Fixes: #2187.
Fixes: #2321.
Fixes: #2391.