### PR TITLE
feat(ui): improve LXD project selection step in KVM form

### DIFF
--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
@@ -10,6 +10,7 @@ import SelectProjectForm from "./SelectProjectForm";
 
 import type { RootState } from "app/store/root/types";
 import {
+  pod as podFactory,
   podProject as podProjectFactory,
   podState as podStateFactory,
   resourcePool as resourcePoolFactory,
@@ -97,6 +98,24 @@ describe("SelectProjectForm", () => {
         .find("FormikField[name='newProject'] .p-form-validation__message")
         .text()
     ).toBe("Error: A project with this name already exists.");
+  });
+
+  it("redirects to the KVM details page of a newly created KVM", async () => {
+    state.pod.saved = true;
+    state.pod.items = [podFactory({ id: 111, name: "pod-name" })];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <SelectProjectForm authValues={authValues} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+    expect(wrapper.find("Redirect").prop("to")).toBe("/kvm/111");
   });
 
   it("can handle creating a LXD KVM with a new project", async () => {

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
@@ -11,7 +11,6 @@ import SelectProjectFormFields from "./SelectProjectFormFields";
 
 import FormCardButtons from "app/base/components/FormCardButtons";
 import FormikForm from "app/base/components/FormikForm";
-import { useAddMessage } from "app/base/hooks";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { PodType } from "app/store/pod/types";
@@ -32,15 +31,12 @@ export const SelectProjectForm = ({ authValues }: Props): JSX.Element => {
   const errors = useSelector(podSelectors.errors);
   const saved = useSelector(podSelectors.saved);
   const saving = useSelector(podSelectors.saving);
+  const pods = useSelector(podSelectors.all);
   const projects = useSelector((state: RootState) =>
     podSelectors.getProjectsByLxdServer(state, authValues.power_address)
   );
   const cleanup = useCallback(() => podActions.cleanup(), []);
-  const [savingPod, setSavingPod] = useState("");
-
-  useAddMessage(saved, cleanup, `${savingPod} added successfully.`, () =>
-    setSavingPod("")
-  );
+  const newPod = pods.find((pod) => pod.name === authValues.name);
 
   const SelectProjectSchema: SchemaOf<SelectProjectFormValues> = Yup.object()
     .shape({
@@ -98,12 +94,11 @@ export const SelectProjectForm = ({ authValues }: Props): JSX.Element => {
           zone: Number(authValues.zone),
         };
         dispatch(podActions.create(params));
-        setSavingPod(authValues.name || "LXD VM host");
       }}
       saved={saved}
-      savedRedirect="/kvm"
+      savedRedirect={newPod ? `/kvm/${newPod.id}` : "/kvm"}
       saving={saving}
-      submitLabel="Save KVM"
+      submitLabel="Next"
       validationSchema={SelectProjectSchema}
     >
       <SelectProjectFormFields authValues={authValues} />

--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
@@ -1,0 +1,221 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import type { AuthenticateFormValues } from "../../AddLxd";
+
+import SelectProjectFormFields from "./SelectProjectFormFields";
+
+import { PodType } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import {
+  pod as podFactory,
+  podProject as podProjectFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("SelectProjectFormFields", () => {
+  let state: RootState;
+  let authValues: AuthenticateFormValues;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      pod: podStateFactory({
+        loaded: true,
+      }),
+    });
+    authValues = {
+      name: "pod-name",
+      password: "password",
+      pool: "0",
+      power_address: "192.168.1.1",
+      zone: "0",
+    };
+  });
+
+  it("shows a warning if an existing project is selected", async () => {
+    const project = podProjectFactory();
+    state.pod.projects = {
+      "192.168.1.1": [project],
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ existingProject: "", newProject: "" }}
+            onSubmit={jest.fn()}
+          >
+            <SelectProjectFormFields authValues={authValues} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Check radio button for selecting existing project
+    wrapper.find("input[id='existing-project']").simulate("change", {
+      target: { name: "project-select", value: "checked" },
+    });
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper
+        .find("Notification[data-test='existing-project-warning']")
+        .exists()
+    ).toBe(true);
+    expect(
+      wrapper.find("Notification[data-test='existing-project-warning']").text()
+    ).toBe("MAAS will recommission all VMs in the selected project.");
+  });
+
+  it("selects the first available project when switching to existing projects", async () => {
+    state.pod = podStateFactory({
+      items: [
+        podFactory({
+          power_address: "192.168.1.1",
+          project: "default",
+          type: PodType.LXD,
+        }),
+      ],
+      loaded: true,
+      projects: {
+        "192.168.1.1": [
+          podProjectFactory({ name: "default" }), // default is in use
+          podProjectFactory({ name: "other" }), // other is not
+        ],
+      },
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ existingProject: "", newProject: "" }}
+            onSubmit={jest.fn()}
+          >
+            <SelectProjectFormFields authValues={authValues} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Check radio button for selecting existing project
+    wrapper.find("input[id='existing-project']").simulate("change", {
+      target: { name: "project-select", value: "checked" },
+    });
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper
+        .find("Input[name='existingProject'][value='default']")
+        .prop("disabled")
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("Input[name='existingProject'][value='other']")
+        .prop("disabled")
+    ).toBe(false);
+    expect(
+      wrapper
+        .find("Input[name='existingProject'][value='other']")
+        .prop("checked")
+    ).toBe(true);
+  });
+
+  it("disables the existing project radio button if no existing projects are free", async () => {
+    state.pod = podStateFactory({
+      items: [
+        podFactory({
+          power_address: "192.168.1.1",
+          project: "default",
+          type: PodType.LXD,
+        }),
+        podFactory({
+          power_address: "192.168.1.1",
+          project: "other",
+          type: PodType.LXD,
+        }),
+      ],
+      loaded: true,
+      projects: {
+        "192.168.1.1": [
+          podProjectFactory({ name: "default" }),
+          podProjectFactory({ name: "other" }),
+        ],
+      },
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ existingProject: "", newProject: "" }}
+            onSubmit={jest.fn()}
+          >
+            <SelectProjectFormFields authValues={authValues} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("input[id='existing-project']").prop("disabled")).toBe(
+      true
+    );
+  });
+
+  it("disables radio and shows a link to an existing LXD project", async () => {
+    const pod = podFactory({
+      power_address: "192.168.1.1",
+      project: "default",
+      type: PodType.LXD,
+    });
+    state.pod = podStateFactory({
+      items: [pod],
+      loaded: true,
+      projects: {
+        "192.168.1.1": [
+          podProjectFactory({ name: "default" }),
+          podProjectFactory({ name: "other" }),
+        ],
+      },
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ existingProject: "", newProject: "" }}
+            onSubmit={jest.fn()}
+          >
+            <SelectProjectFormFields authValues={authValues} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Check radio button for selecting existing project
+    wrapper.find("input[id='existing-project']").simulate("change", {
+      target: { name: "project-select", value: "checked" },
+    });
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find("[data-test='existing-pod']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='existing-pod'] Link").prop("to")).toBe(
+      `/kvm/${pod.id}`
+    );
+  });
+});


### PR DESCRIPTION
## Done

- Changed project select dropdown to list of radio buttons.
- Projects already in use are now disabled with a link to the existing pod.
- User is now redirected to details page on save.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click Add KVM
- Authenticate to an LXD server (bolla LXD at `10.1.238.1:8443` will work)
- Select the existing project radio button
- Check that projects that are currently in use are disabled with a link to the details page
- Select a project that's not in use and submit the form
- Check that you are redirected to the details page once it is successfully saved. 

## Fixes

Fixes #2388 

## Screenshot
![2021-03-16_12-31](https://user-images.githubusercontent.com/25733845/111247389-9da25080-8653-11eb-9089-1aa44a315b88.png)
