### PR TITLE
fix(legacy): remove irrelevant testing options

### DIFF
--- a/legacy/src/app/partials/node-details.html
+++ b/legacy/src/app/partials/node-details.html
@@ -132,24 +132,32 @@
                   >Allow SSH access and prevent machine from powering off</label
                 >
                 <input
+                  data-ng-hide="action.option.name === 'test'"
                   id="skipBMCConfig"
                   type="checkbox"
                   data-ng-model="commissionOptions.skipBMCConfig"
                 />
-                <label for="skipBMCConfig"
+                <label
+                  data-ng-hide="action.option.name === 'test'"
+                  for="skipBMCConfig"
                   >Skip configuring supported BMC controllers with a MAAS
                   generated username and password.</label
                 >
                 <input
+                  data-ng-hide="action.option.name === 'test'"
                   id="skipNetworking"
                   type="checkbox"
                   data-ng-model="commissionOptions.skipNetworking"
                 />
-                <label for="skipNetworking">Retain network configuration</label>
+                <label
+                  data-ng-hide="action.option.name === 'test'"
+                  for="skipNetworking"
+                  >Retain network configuration</label
+                >
               </div>
               <div
                 class="col-5 ng-hide"
-                data-ng-show="action.option.name === 'commission' || action.option.name === 'test'"
+                data-ng-show="action.option.name === 'commission'"
               >
                 <input
                   id="skipStorage"


### PR DESCRIPTION
## Done

- Remove the options from the test form are only supposed to appear when commissioning.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the controller list and tick a controller that can be tested and using take action menu to open the test form.
- You should only see one checkbox for "Allow SSH acces...".
- Click on the controller to view the details and open the test form again.
- You should only see one checkbox for "Allow SSH acces...".

## Fixes

Fixes: #2392.