### PR TITLE
feat(ui): default sizes to the available disk space

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.test.tsx
@@ -73,6 +73,58 @@ describe("AddLogicalVolume", () => {
     expect(wrapper.find("Input[name='name']").prop("value")).toBe("lv2");
   });
 
+  it("sets the initial size to the available space", () => {
+    const volumeGroup = diskFactory({
+      available_size: 8000000000,
+      name: "voldemort",
+      type: DiskTypes.VOLUME_GROUP,
+    });
+    const logicalVolumes = [
+      diskFactory({
+        name: "lv0",
+        parent: {
+          id: volumeGroup.id,
+          uuid: volumeGroup.name,
+          type: volumeGroup.type,
+        },
+        type: DiskTypes.VIRTUAL,
+      }),
+      diskFactory({
+        name: "lv1",
+        parent: {
+          id: volumeGroup.id,
+          uuid: volumeGroup.name,
+          type: volumeGroup.type,
+        },
+        type: DiskTypes.VIRTUAL,
+      }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [volumeGroup, ...logicalVolumes],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddLogicalVolume
+          closeExpanded={jest.fn()}
+          disk={volumeGroup}
+          systemId="abc123"
+        />
+      </Provider>
+    );
+    expect(wrapper.find("Input[name='size']").prop("value")).toBe(8);
+  });
+
   it("can validate if the size meets the minimum requirement", async () => {
     const disk = diskFactory({
       available_size: 1000000000, // 1GB

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
@@ -108,7 +108,8 @@ export const AddLogicalVolume = ({
           mountOptions: "",
           mountPoint: "",
           name: initialName,
-          size: formatBytes(disk.available_size, "GB").value,
+          size: formatBytes(disk.available_size, "B", { convertTo: "GB" })
+            .value,
           tags: [],
           unit: "GB",
         }}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
@@ -99,6 +99,7 @@ export const AddLogicalVolume = ({
 
     return (
       <FormikForm
+        allowUnchanged
         buttons={FormCardButtons}
         cleanup={machineActions.cleanup}
         errors={errors}
@@ -107,7 +108,7 @@ export const AddLogicalVolume = ({
           mountOptions: "",
           mountPoint: "",
           name: initialName,
-          size: "",
+          size: formatBytes(disk.available_size, "GB").value,
           tags: [],
           unit: "GB",
         }}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.test.tsx
@@ -44,6 +44,30 @@ describe("AddPartition", () => {
     );
   });
 
+  it("sets the initial size to the available space", () => {
+    const disk = diskFactory({
+      available_size: 8000000000,
+      id: 1,
+      name: "floppy-disk",
+      partitions: [partitionFactory(), partitionFactory()],
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddPartition closeExpanded={jest.fn()} disk={disk} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("Input[name='partitionSize']").prop("value")).toBe(8);
+  });
+
   it("can validate if the size meets the minimum requirement", async () => {
     const disk = diskFactory({
       available_size: 1000000000, // 1GB

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -102,7 +102,9 @@ export const AddPartition = ({
           fstype: "",
           mountOptions: "",
           mountPoint: "",
-          partitionSize: formatBytes(disk.available_size, "GB").value,
+          partitionSize: formatBytes(disk.available_size, "B", {
+            convertTo: "GB",
+          }).value,
           unit: "GB",
         }}
         onCancel={closeExpanded}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -94,6 +94,7 @@ export const AddPartition = ({
 
     return (
       <FormikForm
+        allowUnchanged
         buttons={FormCardButtons}
         cleanup={machineActions.cleanup}
         errors={errors}
@@ -101,7 +102,7 @@ export const AddPartition = ({
           fstype: "",
           mountOptions: "",
           mountPoint: "",
-          partitionSize: "",
+          partitionSize: formatBytes(disk.available_size, "GB").value,
           unit: "GB",
         }}
         onCancel={closeExpanded}


### PR DESCRIPTION
## Done

- Use the available disk space as the default value for the sizes in the storage forms.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the storage tab for a machine.
- In the available storage table click 'Add partition'
- The form should open and the size field should match the disk's free space.
- Click 'Add partition'.
- Tick the new partition and click 'Create volume group' and submit.
- Open the action menu for the volume group and click 'Add logical volume'.
- The form should open and the size field should match the volume group's free space.

## Fixes

Fixes: #2375.