### PR TITLE
feat(ui): add LXD version to KVM list

### DIFF
--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
@@ -97,9 +97,12 @@ const LxdTable = (): JSX.Element => {
             {
               className: "vms-col u-align--right",
               content: (
-                <TableHeader data-test="vms-header">
-                  VM<span className="u-no-text-transform">s</span>
-                </TableHeader>
+                <>
+                  <TableHeader data-test="vms-header">
+                    VM<span className="u-no-text-transform">s</span>
+                  </TableHeader>
+                  <TableHeader>LXD version</TableHeader>
+                </>
               ),
             },
             {

--- a/ui/src/app/kvm/views/KVMList/LxdTable/_index.scss
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/_index.scss
@@ -12,7 +12,7 @@
     }
 
     .vms-col {
-      @include breakpoint-widths(0, 0, 0, 0, 3.5rem);
+      @include breakpoint-widths(0, 0, 0, 0, 6rem);
     }
 
     .tags-col {

--- a/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.test.tsx
@@ -4,6 +4,7 @@ import configureStore from "redux-mock-store";
 
 import VMsColumn from "./VMsColumn";
 
+import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
@@ -14,10 +15,10 @@ import {
 const mockStore = configureStore();
 
 describe("VMsColumn", () => {
-  let initialState: RootState;
+  let state: RootState;
 
   beforeEach(() => {
-    initialState = rootStateFactory({
+    state = rootStateFactory({
       pod: podStateFactory({
         items: [
           podFactory({
@@ -30,7 +31,6 @@ describe("VMsColumn", () => {
   });
 
   it("displays the pod's VM count", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -38,5 +38,18 @@ describe("VMsColumn", () => {
       </Provider>
     );
     expect(wrapper.find("[data-test='pod-machines-count']").text()).toBe("10");
+  });
+
+  it("shows the pod version for LXD pods", () => {
+    state.pod.items = [
+      podFactory({ id: 1, type: PodType.LXD, version: "1.2.3" }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <VMsColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='pod-version']").text()).toBe("1.2.3");
   });
 });

--- a/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.tsx
@@ -2,6 +2,7 @@ import { useSelector } from "react-redux";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import podSelectors from "app/store/pod/selectors";
+import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = { id: number };
@@ -10,6 +11,7 @@ const VMsColumn = ({ id }: Props): JSX.Element | null => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, id)
   );
+  const showVersion = pod?.type === PodType.LXD;
 
   if (pod) {
     return (
@@ -20,6 +22,9 @@ const VMsColumn = ({ id }: Props): JSX.Element | null => {
           </span>
         }
         primaryClassName="u-align--right"
+        secondary={
+          showVersion && <span data-test="pod-version">{pod.version}</span>
+        }
       />
     );
   }

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -163,6 +163,7 @@ export type BasePod = Model & {
   type: PodType;
   updated: string;
   used: PodHint;
+  version: string;
   zone: number;
 };
 

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -462,6 +462,7 @@ export const pod = extend<Model, Pod>(model, {
   type: PodType.VIRSH,
   updated: "Fri, 03 Jul. 2020 02:44:12",
   used: podHint,
+  version: "4.0.2",
   zone: 1,
 });
 


### PR DESCRIPTION
## Done

- Added LXD version to KVM list

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and check that LXD KVMs show the version
- If the version is empty that means it hasn't been refreshed since `version` was added to the pod model

## Fixes

Fixes #2398 
