### PR TITLE
feat(ui): Add RAM and Cores info to LXD project tab

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/CoreResources/CoreResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/CoreResources/CoreResources.test.tsx
@@ -1,0 +1,26 @@
+import { shallow } from "enzyme";
+
+import CoreResources from "./CoreResources";
+
+describe("CoreResources", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <CoreResources cores={{ allocated: 1, free: 2 }} />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can be made to have a dynamic layout", () => {
+    const wrapper = shallow(
+      <CoreResources cores={{ allocated: 1, free: 2 }} dynamicLayout />
+    );
+
+    expect(
+      wrapper
+        .find(".core-resources")
+        .prop("className")
+        ?.includes("core-resources--dynamic-layout")
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/CoreResources/CoreResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/CoreResources/CoreResources.tsx
@@ -1,0 +1,30 @@
+import classNames from "classnames";
+
+import PodMeter from "app/kvm/components/PodMeter";
+
+export type Props = {
+  cores: {
+    allocated: number;
+    free: number;
+  };
+  dynamicLayout?: boolean;
+};
+
+const CoreResources = ({ cores, dynamicLayout }: Props): JSX.Element => {
+  return (
+    <div
+      className={classNames("core-resources", {
+        "core-resources--dynamic-layout": dynamicLayout,
+      })}
+    >
+      <h4 className="core-resources__header p-heading--small u-sv1">
+        CPU cores
+      </h4>
+      <div className="core-resources__meter">
+        <PodMeter allocated={cores.allocated} free={cores.free} segmented />
+      </div>
+    </div>
+  );
+};
+
+export default CoreResources;

--- a/ui/src/app/kvm/views/KVMDetails/CoreResources/__snapshots__/CoreResources.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/CoreResources/__snapshots__/CoreResources.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CoreResources renders 1`] = `
+<div
+  className="core-resources"
+>
+  <h4
+    className="core-resources__header p-heading--small u-sv1"
+  >
+    CPU cores
+  </h4>
+  <div
+    className="core-resources__meter"
+  >
+    <PodMeter
+      allocated={1}
+      free={2}
+      segmented={true}
+    />
+  </div>
+</div>
+`;

--- a/ui/src/app/kvm/views/KVMDetails/CoreResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/CoreResources/_index.scss
@@ -1,0 +1,37 @@
+@mixin CoreResources {
+  .core-resources {
+    display: flex;
+    flex-direction: column;
+    padding: $spv-inner--medium $sph-inner;
+  }
+
+  // Additional styles for when the component changes layout depending on the
+  // viewport size. Otherwise, the component keeps the "mobile" styling.
+  .core-resources--dynamic-layout {
+    @media only screen and (min-width: $breakpoint-medium) {
+      flex-direction: row;
+
+      .core-resources__header {
+        flex: 1;
+        margin-right: $sph-inner--large;
+      }
+
+      .core-resources__meter {
+        flex: 3;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-large) {
+      flex-direction: column;
+
+      .core-resources__header {
+        flex: 0;
+        margin-right: 0;
+      }
+
+      .core-resources__meter {
+        flex: 0;
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/CoreResources/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/CoreResources/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CoreResources";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
@@ -2,6 +2,8 @@ import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Redirect } from "react-router";
 
+import ProjectResourcesCard from "./ProjectResourcesCard";
+
 import { useWindowTitle } from "app/base/hooks";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
@@ -35,9 +37,12 @@ const LxdProjects = ({ id }: Props): JSX.Element => {
   }
 
   return (
-    <h4 className="u-sv1" data-test="project-name">
-      {pod.project}
-    </h4>
+    <>
+      <h4 className="u-sv1" data-test="project-name">
+        {pod.project}
+      </h4>
+      <ProjectResourcesCard id={id} />
+    </>
   );
 };
 

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/ProjectResourcesCard.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/ProjectResourcesCard.test.tsx
@@ -1,0 +1,31 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import ProjectResourcesCard from "./ProjectResourcesCard";
+
+import {
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ProjectResourcesCard", () => {
+  it("shows a spinner if pod has not loaded yet", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [],
+        loaded: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <ProjectResourcesCard id={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/ProjectResourcesCard.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/ProjectResourcesCard.tsx
@@ -1,0 +1,43 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import CoreResources from "../../CoreResources";
+import RamResources from "../../RamResources";
+import StorageResources from "../../StorageResources";
+
+import podSelectors from "app/store/pod/selectors";
+import type { Pod, PodResource } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = { id: Pod["id"] };
+
+const formatPodResource = (resource: PodResource) => ({
+  allocated: resource.allocated_other + resource.allocated_tracked,
+  free: resource.free,
+});
+
+const ProjectResourcesCard = ({ id }: Props): JSX.Element => {
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  );
+
+  if (pod) {
+    const { resources } = pod;
+    const { cores, memory } = resources;
+    return (
+      <div className="project-resources-card">
+        <RamResources
+          dynamicLayout
+          general={formatPodResource(memory.general)}
+          hugepages={formatPodResource(memory.hugepages)}
+        />
+        <CoreResources cores={formatPodResource(cores)} dynamicLayout />
+        <StorageResources />
+      </div>
+    );
+  }
+
+  return <Spinner text="Loading" />;
+};
+
+export default ProjectResourcesCard;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/_index.scss
@@ -1,0 +1,46 @@
+@mixin ProjectResourcesCard {
+  .project-resources-card {
+    @extend %vf-is-bordered;
+    @extend %vf-bg--x-light;
+    display: grid;
+    grid-template-areas:
+      "ram ram ram ram"
+      "cor cor cor cor"
+      "sto sto sto sto";
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-rows: min-content;
+
+    .ram-resources {
+      grid-area: ram;
+    }
+
+    .core-resources {
+      border-top: $border;
+      grid-area: cor;
+    }
+
+    .storage-resources {
+      border-top: $border;
+      grid-area: sto;
+    }
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      grid-template-areas:
+        "ram ram ram ram ram ram"
+        "cor cor cor cor cor cor"
+        "sto sto sto sto sto sto";
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+
+    @media only screen and (min-width: $breakpoint-large) {
+      grid-template-areas: "ram ram ram ram ram cor cor cor sto sto sto sto";
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+
+      .core-resources,
+      .storage-resources {
+        border-left: $border;
+        border-top: 0;
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProjectResourcesCard";

--- a/ui/src/app/kvm/views/KVMDetails/RamResources/RamResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/RamResources/RamResources.test.tsx
@@ -1,0 +1,78 @@
+import { shallow } from "enzyme";
+
+import RamResources from "./RamResources";
+
+describe("RamResources", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <RamResources
+        general={{ allocated: 1, free: 2 }}
+        hugepages={{ allocated: 3, free: 4, pageSize: 5 }}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can be made to have a dynamic layout", () => {
+    const wrapper = shallow(
+      <RamResources
+        dynamicLayout
+        general={{ allocated: 1, free: 2 }}
+        hugepages={{ allocated: 3, free: 4 }}
+      />
+    );
+
+    expect(
+      wrapper
+        .find(".ram-resources")
+        .prop("className")
+        ?.includes("ram-resources--dynamic-layout")
+    ).toBe(true);
+  });
+
+  it("shows hugepages data if provided", () => {
+    const wrapper = shallow(
+      <RamResources
+        general={{ allocated: 1, free: 2 }}
+        hugepages={{ allocated: 3, free: 4 }}
+      />
+    );
+
+    expect(wrapper.find("[data-test='hugepages-data']").exists()).toBe(true);
+  });
+
+  it("does not show hugepages data if not provided", () => {
+    const wrapper = shallow(
+      <RamResources
+        general={{ allocated: 1, free: 2 }}
+        hugepages={{ allocated: 0, free: 0 }}
+      />
+    );
+
+    expect(wrapper.find("[data-test='hugepages-data']").exists()).toBe(false);
+  });
+
+  it("show hugepages page size if provided", () => {
+    const wrapper = shallow(
+      <RamResources
+        general={{ allocated: 1, free: 2 }}
+        hugepages={{ allocated: 3, free: 4, pageSize: 5 }}
+      />
+    );
+
+    expect(wrapper.find("[data-test='page-size']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='page-size']").text()).toBe("(Size: 5B)");
+  });
+
+  it("does not show hugepages page size if not provided", () => {
+    const wrapper = shallow(
+      <RamResources
+        general={{ allocated: 1, free: 2 }}
+        hugepages={{ allocated: 3, free: 4 }}
+      />
+    );
+
+    expect(wrapper.find("[data-test='page-size']").exists()).toBe(false);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/RamResources/RamResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/RamResources/RamResources.tsx
@@ -1,0 +1,148 @@
+import classNames from "classnames";
+
+import DoughnutChart from "app/base/components/DoughnutChart";
+import { COLOURS } from "app/base/constants";
+import { formatBytes } from "app/utils";
+
+export type Props = {
+  dynamicLayout?: boolean;
+  general: {
+    allocated: number; // B
+    free: number; // B
+  };
+  hugepages: {
+    allocated: number; // B
+    free: number; // B
+    pageSize?: number;
+  };
+};
+
+/**
+ * Returns a string with the formatted byte value and unit, e.g 1024 => "1KiB"
+ *
+ * @param memory - the memory in bytes
+ * @returns formatted memory string with value and unit
+ */
+const memoryWithUnit = (memory: number): string => {
+  const formatted = formatBytes(memory, "B", { binary: true });
+  return `${formatted.value}${formatted.unit}`;
+};
+
+const RamResources = ({
+  dynamicLayout = false,
+  general,
+  hugepages,
+}: Props): JSX.Element => {
+  const totalGeneral = general.allocated + general.free;
+  const totalHugepages = hugepages.allocated + hugepages.free;
+  const totalMemory = totalGeneral + totalHugepages;
+
+  return (
+    <div
+      className={classNames("ram-resources", {
+        "ram-resources--dynamic-layout": dynamicLayout,
+      })}
+    >
+      <div className="ram-resources__chart-container">
+        <h4 className="p-heading--small">RAM</h4>
+        <DoughnutChart
+          className="ram-resources__chart"
+          label={memoryWithUnit(totalMemory)}
+          segmentHoverWidth={18}
+          segmentWidth={15}
+          segments={[
+            {
+              color: COLOURS.LINK,
+              tooltip: `General allocated ${memoryWithUnit(general.allocated)}`,
+              value: general.allocated,
+            },
+            ...(totalHugepages > 0
+              ? [
+                  {
+                    color: COLOURS.POSITIVE,
+                    tooltip: `Hugepage allocated ${memoryWithUnit(
+                      hugepages.allocated
+                    )}`,
+                    value: hugepages.allocated,
+                  },
+                  {
+                    color: COLOURS.POSITIVE_MID,
+                    tooltip: `Hugepage free ${memoryWithUnit(hugepages.free)}`,
+                    value: hugepages.free,
+                  },
+                ]
+              : []),
+            {
+              color: COLOURS.LINK_FADED,
+              tooltip: `General free ${memoryWithUnit(general.free)}`,
+              value: general.free,
+            },
+          ]}
+          size={96}
+        />
+      </div>
+      <table className="ram-resources__table">
+        <thead>
+          <tr>
+            <th></th>
+            <th className="u-align--right u-text--light">
+              <span className="u-nudge-left">Allocated</span>
+            </th>
+            <th className="u-align--right u-text--light">
+              <span className="u-nudge-left">Free</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>General</td>
+            <td className="u-align--right">
+              {memoryWithUnit(general.allocated)}
+              <span className="u-nudge-right--small">
+                <i className="p-circle--link"></i>
+              </span>
+            </td>
+            <td className="u-align--right">
+              {memoryWithUnit(general.free)}
+              <span className="u-nudge-right--small">
+                <i className="p-circle--link-faded"></i>
+              </span>
+            </td>
+          </tr>
+          {totalHugepages > 0 && (
+            <tr data-test="hugepages-data">
+              <td>
+                Hugepage
+                {hugepages.pageSize && (
+                  <>
+                    <br />
+                    <strong
+                      className="p-text--x-small u-text--light"
+                      data-test="page-size"
+                    >
+                      {`(Size: ${memoryWithUnit(hugepages.pageSize)})`}
+                    </strong>
+                  </>
+                )}
+              </td>
+              <td className="u-align--right">
+                {memoryWithUnit(hugepages.allocated)}
+                <span className="u-nudge-right--small">
+                  <i className="p-circle--positive"></i>
+                </span>
+              </td>
+              <td className="u-align--right">
+                {memoryWithUnit(hugepages.free)}
+                <span className="u-nudge-right--small">
+                  <i className="p-circle--positive-faded"></i>
+                </span>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default RamResources;

--- a/ui/src/app/kvm/views/KVMDetails/RamResources/__snapshots__/RamResources.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/RamResources/__snapshots__/RamResources.test.tsx.snap
@@ -1,0 +1,144 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RamResources renders 1`] = `
+<div
+  className="ram-resources"
+>
+  <div
+    className="ram-resources__chart-container"
+  >
+    <h4
+      className="p-heading--small"
+    >
+      RAM
+    </h4>
+    <DoughnutChart
+      className="ram-resources__chart"
+      label="10B"
+      segmentHoverWidth={18}
+      segmentWidth={15}
+      segments={
+        Array [
+          Object {
+            "color": "#0066CC",
+            "tooltip": "General allocated 1B",
+            "value": 1,
+          },
+          Object {
+            "color": "#0E8420",
+            "tooltip": "Hugepage allocated 3B",
+            "value": 3,
+          },
+          Object {
+            "color": "#4DAB4D",
+            "tooltip": "Hugepage free 4B",
+            "value": 4,
+          },
+          Object {
+            "color": "#D3E4ED",
+            "tooltip": "General free 2B",
+            "value": 2,
+          },
+        ]
+      }
+      size={96}
+    />
+  </div>
+  <table
+    className="ram-resources__table"
+  >
+    <thead>
+      <tr>
+        <th />
+        <th
+          className="u-align--right u-text--light"
+        >
+          <span
+            className="u-nudge-left"
+          >
+            Allocated
+          </span>
+        </th>
+        <th
+          className="u-align--right u-text--light"
+        >
+          <span
+            className="u-nudge-left"
+          >
+            Free
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          General
+        </td>
+        <td
+          className="u-align--right"
+        >
+          1B
+          <span
+            className="u-nudge-right--small"
+          >
+            <i
+              className="p-circle--link"
+            />
+          </span>
+        </td>
+        <td
+          className="u-align--right"
+        >
+          2B
+          <span
+            className="u-nudge-right--small"
+          >
+            <i
+              className="p-circle--link-faded"
+            />
+          </span>
+        </td>
+      </tr>
+      <tr
+        data-test="hugepages-data"
+      >
+        <td>
+          Hugepage
+          <br />
+          <strong
+            className="p-text--x-small u-text--light"
+            data-test="page-size"
+          >
+            (Size: 5B)
+          </strong>
+        </td>
+        <td
+          className="u-align--right"
+        >
+          3B
+          <span
+            className="u-nudge-right--small"
+          >
+            <i
+              className="p-circle--positive"
+            />
+          </span>
+        </td>
+        <td
+          className="u-align--right"
+        >
+          4B
+          <span
+            className="u-nudge-right--small"
+          >
+            <i
+              className="p-circle--positive-faded"
+            />
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/ui/src/app/kvm/views/KVMDetails/RamResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/RamResources/_index.scss
@@ -1,0 +1,71 @@
+@mixin RamResources {
+  $donut-size: 6.5rem;
+  $donut-width: 14px;
+
+  .ram-resources {
+    display: flex;
+    flex-direction: column;
+    padding: $spv-inner--medium $sph-inner;
+
+    .ram-resources__chart-container {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .ram-resources__chart {
+      align-self: center;
+      width: $donut-size;
+    }
+
+    .ram-resources__table {
+      margin-bottom: 0;
+      margin-top: -$spv-inner--small;
+      width: auto;
+
+      th,
+      td {
+        &:nth-child(1) {
+          padding-left: 0;
+          width: 50%;
+        }
+
+        &:nth-child(2) {
+          width: 6.25rem;
+        }
+
+        &:nth-child(3) {
+          padding-right: 0;
+          width: 50%;
+        }
+      }
+    }
+  }
+
+  // Additional styles for when the component changes layout depending on the
+  // viewport size. Otherwise, the component keeps the "mobile" styling.
+  .ram-resources--dynamic-layout {
+    @media only screen and (min-width: $breakpoint-medium) {
+      flex-direction: row;
+
+      .ram-resources__chart-container {
+        flex: 1;
+        margin-right: $sph-inner--large;
+      }
+
+      .ram-resources__table {
+        flex: 3;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-large) {
+      .ram-resources__chart-container {
+        flex: 0;
+        margin-right: $sph-inner;
+      }
+
+      .ram-resources__chart {
+        align-self: flex-start;
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/RamResources/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/RamResources/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RamResources";

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
@@ -1,0 +1,11 @@
+// TODO: Build storage section
+// https://github.com/canonical-web-and-design/maas-ui/issues/2240
+const StorageResources = (): JSX.Element => {
+  return (
+    <div className="storage-resources">
+      <h4 className="p-heading--small u-sv1">Storage</h4>
+    </div>
+  );
+};
+
+export default StorageResources;

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/_index.scss
@@ -1,0 +1,5 @@
+@mixin StorageResources {
+  .storage-resources {
+    padding: $spv-inner--medium $sph-inner;
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StorageResources";

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -93,12 +93,17 @@
 @import "~app/kvm/components/PodMeter";
 @import "~app/kvm/components/PodResourcesCard";
 @import "~app/kvm/components/PodStorage";
+@import "~app/kvm/views/KVMDetails/CoreResources";
 @import "~app/kvm/views/KVMDetails/KVMResources/KVMNumaResources";
+@import "~app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard";
+@import "~app/kvm/views/KVMDetails/RamResources";
+@import "~app/kvm/views/KVMDetails/StorageResources";
 @import "~app/kvm/views/KVMList/CPUColumn/CPUPopover";
 @import "~app/kvm/views/KVMList/LxdTable";
 @import "~app/kvm/views/KVMList/RAMColumn/RAMPopover";
 @import "~app/kvm/views/KVMList/StorageColumn/StoragePopover";
 @import "~app/kvm/views/KVMList/VirshTable";
+@include CoreResources;
 @include CPUPopover;
 @include KVMComposeInterfacesTable;
 @include KVMComposeStorageTable;
@@ -109,8 +114,11 @@
 @include PodMeter;
 @include PodResourcesCard;
 @include PodStorage;
+@include ProjectResourcesCard;
+@include RamResources;
 @include RAMPopover;
 @include StoragePopover;
+@include StorageResources;
 @include VirshTable;
 
 // machines


### PR DESCRIPTION
## Done

- Created `RamResources` and `CoreResources` components which have mostly been lifted from `PodResourcesCard`, with some changes to work with the new data structure. The plan is to create all the resource sections as individual components then remove `PodResourcesCard`.
- Added `ProjectResourcesCard` to the projects tab, which currently includes the project's RAM and Core data.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the project tab of a LXD pod.
- Check that the RAM and core data is shown.
- Resize the viewport and check that the layout changes properly.

## Fixes

Fixes #2230 