### PR TITLE
fix(ui): correctly filter filesystem select options in machine storage tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/FilesystemFields/FilesystemFields.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/FilesystemFields/FilesystemFields.test.tsx
@@ -14,6 +14,40 @@ import {
 const mockStore = configureStore();
 
 describe("FilesystemFields", () => {
+  it("only shows filesystem types that require a storage device", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            supported_filesystems: [
+              { key: "fat32", ui: "fat32" }, // reuuires storage
+              { key: "ramfs", ui: "ramfs" }, // does not require storage
+            ],
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik
+          initialValues={{ fstype: "", mountOptions: "", mountPoint: "" }}
+          onSubmit={jest.fn()}
+        >
+          <FilesystemFields systemId="abc123" />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("FormikField[name='fstype'] option[value='fat32']").exists()
+    ).toBe(true);
+    expect(
+      wrapper.find("FormikField[name='fstype'] option[value='ramfs']").exists()
+    ).toBe(false);
+  });
+
   it("disables mount point and options if no fstype selected", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/FilesystemFields/FilesystemFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/FilesystemFields/FilesystemFields.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 import FormikField from "app/base/components/FormikField";
 import machineSelectors from "app/store/machine/selectors";
 import type { Filesystem, Machine } from "app/store/machine/types";
+import { usesStorage } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 type FilesystemValues = {
@@ -24,12 +25,12 @@ export const FilesystemFields = ({ systemId }: Props): JSX.Element | null => {
   const { values } = useFormikContext<FilesystemValues>();
 
   if (machine && "supported_filesystems" in machine) {
-    const filesystemOptions = machine.supported_filesystems.map(
-      (filesystem) => ({
-        label: filesystem.ui,
-        value: filesystem.key,
-      })
-    );
+    const fsOptions = machine.supported_filesystems
+      .filter((fs) => usesStorage(fs.key))
+      .map((fs) => ({
+        label: fs.ui,
+        value: fs.key,
+      }));
     const disableOptions = !values.fstype;
     const swapSelected = values.fstype === "swap";
 
@@ -49,7 +50,7 @@ export const FilesystemFields = ({ systemId }: Props): JSX.Element | null => {
               label: "Unformatted",
               value: "",
             },
-            ...filesystemOptions,
+            ...fsOptions,
           ]}
         />
         <FormikField

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
@@ -16,6 +16,38 @@ import {
 const mockStore = configureStore();
 
 describe("AddSpecialFilesystem", () => {
+  it("only shows filesystems that do not require a storage device", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            supported_filesystems: [
+              { key: "fat32", ui: "fat32" }, // requires storage
+              { key: "ramfs", ui: "ramfs" }, // does not require storage
+            ],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <AddSpecialFilesystem closeForm={jest.fn()} systemId="abc123" />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("FormikField[name='fstype'] option[value='fat32']").exists()
+    ).toBe(false);
+    expect(
+      wrapper.find("FormikField[name='fstype'] option[value='ramfs']").exists()
+    ).toBe(true);
+  });
+
   it("can show errors", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
@@ -1,5 +1,5 @@
 import { Col, Row, Select } from "@canonical/react-components";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import FormCard from "app/base/components/FormCard";
@@ -8,7 +8,10 @@ import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import { usesStorage } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
 
 const AddSpecialFilesystemSchema = Yup.object().shape({
   fstype: Yup.string().required(),
@@ -26,8 +29,11 @@ type Props = {
 export const AddSpecialFilesystem = ({
   closeForm,
   systemId,
-}: Props): JSX.Element => {
+}: Props): JSX.Element | null => {
   const dispatch = useDispatch();
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
   const { errors, saved, saving } = useMachineDetailsForm(
     systemId,
     "mountingSpecial",
@@ -35,70 +41,83 @@ export const AddSpecialFilesystem = ({
     () => closeForm()
   );
 
-  return (
-    <FormCard data-test="confirmation-form" sidebar={false}>
-      <FormikForm
-        buttons={FormCardButtons}
-        cleanup={machineActions.cleanup}
-        errors={errors}
-        initialValues={{
-          fstype: "",
-          mountOptions: "",
-          mountPoint: "",
-        }}
-        onCancel={closeForm}
-        onSaveAnalytics={{
-          action: "Add special filesystem",
-          category: "Machine storage",
-          label: "Mount",
-        }}
-        onSubmit={(values) => {
-          dispatch(machineActions.cleanup());
-          const params = {
-            fstype: values.fstype,
-            mountOptions: values.mountOptions,
-            mountPoint: values.mountPoint,
-            systemId,
-          };
-          dispatch(machineActions.mountSpecial(params));
-        }}
-        saved={saved}
-        saving={saving}
-        submitLabel="Mount"
-        validationSchema={AddSpecialFilesystemSchema}
-      >
-        <Row>
-          <Col size="6">
-            <FormikField
-              component={Select}
-              label="Type"
-              name="fstype"
-              options={[
-                { label: "Select filesystem type", value: "", disabled: true },
-                { label: "tmpfs", value: "tmpfs" },
-                { label: "ramfs", value: "ramfs" },
-              ]}
-              required
-            />
-            <FormikField
-              help="Absolute path to filesystem"
-              label="Mount point"
-              name="mountPoint"
-              placeholder="/path/to/filesystem"
-              required
-              type="text"
-            />
-            <FormikField
-              help='Comma-separated list without spaces, e.g. "noexec,size=1024k"'
-              label="Mount options"
-              name="mountOptions"
-              type="text"
-            />
-          </Col>
-        </Row>
-      </FormikForm>
-    </FormCard>
-  );
+  if (machine && "supported_filesystems" in machine) {
+    const fsOptions = machine.supported_filesystems
+      .filter((fs) => !usesStorage(fs.key))
+      .map((fs) => ({
+        label: fs.ui,
+        value: fs.key,
+      }));
+
+    return (
+      <FormCard data-test="confirmation-form" sidebar={false}>
+        <FormikForm
+          buttons={FormCardButtons}
+          cleanup={machineActions.cleanup}
+          errors={errors}
+          initialValues={{
+            fstype: "",
+            mountOptions: "",
+            mountPoint: "",
+          }}
+          onCancel={closeForm}
+          onSaveAnalytics={{
+            action: "Add special filesystem",
+            category: "Machine storage",
+            label: "Mount",
+          }}
+          onSubmit={(values) => {
+            dispatch(machineActions.cleanup());
+            const params = {
+              fstype: values.fstype,
+              mountOptions: values.mountOptions,
+              mountPoint: values.mountPoint,
+              systemId,
+            };
+            dispatch(machineActions.mountSpecial(params));
+          }}
+          saved={saved}
+          saving={saving}
+          submitLabel="Mount"
+          validationSchema={AddSpecialFilesystemSchema}
+        >
+          <Row>
+            <Col size="6">
+              <FormikField
+                component={Select}
+                label="Type"
+                name="fstype"
+                options={[
+                  {
+                    label: "Select filesystem type",
+                    value: "",
+                    disabled: true,
+                  },
+                  ...fsOptions,
+                ]}
+                required
+              />
+              <FormikField
+                help="Absolute path to filesystem"
+                label="Mount point"
+                name="mountPoint"
+                placeholder="/path/to/filesystem"
+                required
+                type="text"
+              />
+              <FormikField
+                help='Comma-separated list without spaces, e.g. "noexec,size=1024k"'
+                label="Mount options"
+                name="mountOptions"
+                type="text"
+              />
+            </Col>
+          </Row>
+        </FormikForm>
+      </FormCard>
+    );
+  }
+  return null;
 };
 
 export default AddSpecialFilesystem;

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -69,7 +69,7 @@ const normaliseRowData = (
             actions={[
               {
                 label: "Unmount filesystem...",
-                show: usesStorage(fs),
+                show: usesStorage(fs.fstype),
                 type: FilesystemAction.UNMOUNT,
               },
               {

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -303,7 +303,7 @@ export type MachineDetails = BaseMachine & {
   storage_layout_issues: string[];
   storage_test_status: TestStatus;
   supported_filesystems: {
-    key: string;
+    key: Filesystem["fstype"];
     ui: string;
   }[];
   swap_size: number | null;

--- a/ui/src/app/store/machine/utils/storage.test.ts
+++ b/ui/src/app/store/machine/utils/storage.test.ts
@@ -868,10 +868,10 @@ describe("machine storage utils", () => {
       expect(usesStorage(null)).toBe(false);
     });
 
-    it("returns whether a filesystem uses storage", () => {
-      const fs1 = fsFactory({ fstype: "fat32" });
-      const fs2 = fsFactory({ fstype: "ramfs" });
-      const fs3 = fsFactory({ fstype: "tmpfs" });
+    it("returns whether a filesystem type uses storage", () => {
+      const fs1 = "fat32";
+      const fs2 = "ramfs";
+      const fs3 = "tmpfs";
       expect(usesStorage(fs1)).toBe(true);
       expect(usesStorage(fs2)).toBe(false);
       expect(usesStorage(fs3)).toBe(false);

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -491,13 +491,13 @@ export const splitDiskPartitionIds = (
   );
 
 /**
- * Returns whether a filesystem uses storage.
- * @param fs - the filesystem to check.
- * @returns whether the filesystem uses storage
+ * Returns whether a filesystem type uses storage.
+ * @param fs - the filesystem type to check.
+ * @returns whether the filesystem type uses storage
  */
-export const usesStorage = (fs: Filesystem | null): boolean => {
-  if (!fs?.fstype) {
+export const usesStorage = (fstype: Filesystem["fstype"] | null): boolean => {
+  if (!fstype) {
     return false;
   }
-  return !["ramfs", "tmpfs"].includes(fs.fstype);
+  return !["ramfs", "tmpfs"].includes(fstype);
 };


### PR DESCRIPTION
## Done

- correctly filter filesystem select options to those that are supported by the machine, and that use storage if from the storage device list, or do not use storage if adding a special filesystem

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready or Allocated machine
- Click "Add special filesystem" and check that the filesystem options are "ramfs" or "tmpfs"
- Add a partition to a disk and check that the filesystem options do not include "ramfs" or "tmpfs"

## Fixes

Fixes #2390 
