### PR TITLE
feat(ui): add the base logs tab

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -8,6 +8,7 @@ import MachineComissioning from "./MachineCommissioning";
 import MachineConfiguration from "./MachineConfiguration";
 import MachineHeader from "./MachineHeader";
 import MachineInstances from "./MachineInstances";
+import MachineLogs from "./MachineLogs";
 import MachineNetwork from "./MachineNetwork";
 import NetworkNotifications from "./MachineNetwork/NetworkNotifications";
 import MachinePCIDevices from "./MachinePCIDevices";
@@ -103,6 +104,12 @@ const MachineDetails = (): JSX.Element => {
           </Route>
           <Route exact path="/machine/:id/testing/:scriptResultId/details">
             <MachineTestsDetails />
+          </Route>
+          <Route exact path="/machine/:id/logs">
+            <MachineLogs systemId={id} />
+          </Route>
+          <Route exact path="/machine/:id/events">
+            <Redirect to={`/machine/${id}/logs`} />
           </Route>
           <Route exact path="/machine/:id/configuration">
             <MachineConfiguration />

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
@@ -1,0 +1,54 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import MachineLogs from "./MachineLogs";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MachineLogs", () => {
+  it("displays a spinner if machine is loading", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineLogs systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("does not display a spinner if the machine has loaded", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <MachineLogs systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(false);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -1,0 +1,25 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import { useWindowTitle } from "app/base/hooks";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = { systemId: Machine["system_id"] };
+
+const MachineNetwork = ({ systemId }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+
+  useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} logs`);
+
+  if (!machine) {
+    return <Spinner text="Loading..." />;
+  }
+
+  return <>Logs</>;
+};
+
+export default MachineNetwork;

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineLogs";


### PR DESCRIPTION
## Done

- Add a component to hold the logs tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine details.
- Click on Logs.
- You should see "Logs"

## Fixes

Fixes: https://github.com/canonical-web-and-design/maas-squad/issues/2362.