### PR TITLE
feat(ui): add the events tab component

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -105,11 +105,11 @@ const MachineDetails = (): JSX.Element => {
           <Route exact path="/machine/:id/testing/:scriptResultId/details">
             <MachineTestsDetails />
           </Route>
-          <Route exact path="/machine/:id/logs">
+          <Route path="/machine/:id/logs">
             <MachineLogs systemId={id} />
           </Route>
           <Route exact path="/machine/:id/events">
-            <Redirect to={`/machine/${id}/logs`} />
+            <Redirect to={`/machine/${id}/logs/events`} />
           </Route>
           <Route exact path="/machine/:id/configuration">
             <MachineConfiguration />

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx
@@ -3,7 +3,7 @@ import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
-import MachineLogs from "./MachineLogs";
+import EventLogs from "./EventLogs";
 
 import {
   machineDetails as machineDetailsFactory,
@@ -13,7 +13,7 @@ import {
 
 const mockStore = configureStore();
 
-describe("MachineLogs", () => {
+describe("EventLogs", () => {
   it("displays a spinner if machine is loading", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
@@ -26,14 +26,14 @@ describe("MachineLogs", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineLogs systemId="abc123" />
+          <EventLogs systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
-  it("can display the event logs", () => {
+  it("does not display a spinner if the machine has loaded", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [machineDetailsFactory({ system_id: "abc123" })],
@@ -43,14 +43,12 @@ describe("MachineLogs", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[
-            { pathname: "/machine/abc123/logs/events", key: "testKey" },
-          ]}
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <MachineLogs systemId="abc123" />
+          <EventLogs systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("EventLogs").exists()).toBe(true);
+    expect(wrapper.find("Spinner").exists()).toBe(false);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
@@ -1,0 +1,22 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = { systemId: Machine["system_id"] };
+
+const EventLogs = ({ systemId }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+
+  if (!machine) {
+    return <Spinner text="Loading..." />;
+  }
+
+  return <>Events</>;
+};
+
+export default EventLogs;

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EventLogs";

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -1,5 +1,8 @@
-import { Spinner } from "@canonical/react-components";
+import { Spinner, Tabs } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+import { Link, Route, useLocation } from "react-router-dom";
+
+import EventLogs from "./EventLogs";
 
 import { useWindowTitle } from "app/base/hooks";
 import machineSelectors from "app/store/machine/selectors";
@@ -12,6 +15,8 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
+  const { pathname } = useLocation();
+  const urlBase = `/machine/${systemId}/logs`;
 
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} logs`);
 
@@ -19,7 +24,30 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
     return <Spinner text="Loading..." />;
   }
 
-  return <>Logs</>;
+  return (
+    <>
+      <Tabs
+        links={[
+          {
+            active: pathname.startsWith(`${urlBase}/events`),
+            component: Link,
+            label: "Event log",
+            to: `${urlBase}/events`,
+          },
+          {
+            active: pathname.startsWith(`${urlBase}/installation-output`),
+            component: Link,
+            label: "Installation output",
+            to: `${urlBase}/installation-output`,
+          },
+        ]}
+      />
+
+      <Route exact path="/machine/:id/logs/events">
+        <EventLogs systemId={systemId} />
+      </Route>
+    </>
+  );
 };
 
 export default MachineNetwork;


### PR DESCRIPTION
## Done

- Add a component to hold the event log.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the react logs tab for a machine.
- You should see sub tabs for events and installation output.
- Clicking on either tab should change the url.
- Clicking on the events log tab should display "Events"

## Fixes

Fixes: canonical-web-and-design/maas-squad#2370