### PR TITLE
feat(ui): Build project VM action bar scaffolding.

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
@@ -3,6 +3,7 @@ import { useSelector } from "react-redux";
 import { Redirect } from "react-router";
 
 import ProjectResourcesCard from "./ProjectResourcesCard";
+import ProjectVMs from "./ProjectVMs";
 
 import { useWindowTitle } from "app/base/hooks";
 import podSelectors from "app/store/pod/selectors";
@@ -42,6 +43,7 @@ const LxdProjects = ({ id }: Props): JSX.Element => {
         {pod.project}
       </h4>
       <ProjectResourcesCard id={id} />
+      <ProjectVMs id={id} />
     </>
   );
 };

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.test.tsx
@@ -1,0 +1,39 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ProjectVMs from "./ProjectVMs";
+
+import {
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ProjectVMs", () => {
+  it("fetches machines on load", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ id: 1 })],
+        loaded: false,
+      }),
+    });
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <ProjectVMs id={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "machine/fetch")
+    );
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+
+import { Strip } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import VMsActionBar from "./VMsActionBar";
+import VMsTable from "./VMsTable";
+
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = { id: Pod["id"] };
+
+const ProjectVMs = ({ id }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const machinesLoading = useSelector(machineSelectors.loading);
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, Number(id))
+  );
+  const podVMs = useSelector((state: RootState) =>
+    podSelectors.getVMs(state, pod)
+  );
+
+  useEffect(() => {
+    dispatch(machineActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Strip shallow>
+      <VMsActionBar loading={machinesLoading} vms={podVMs} />
+      <VMsTable loading={machinesLoading} vms={podVMs} />
+    </Strip>
+  );
+};
+
+export default ProjectVMs;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
@@ -1,0 +1,27 @@
+import { shallow } from "enzyme";
+
+import VMsActionBar from "./VMsActionBar";
+
+import { machine as machineFactory } from "testing/factories";
+
+describe("VMsActionBar", () => {
+  it("renders", () => {
+    const wrapper = shallow(<VMsActionBar vms={[machineFactory()]} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("shows a spinner instead of VM count if machines are loading", () => {
+    const wrapper = shallow(<VMsActionBar loading vms={[]} />);
+
+    expect(wrapper.find("[data-test='vms-count'] Spinner").exists()).toBe(true);
+  });
+
+  it("shows a VM count if machines have loaded", () => {
+    const wrapper = shallow(
+      <VMsActionBar loading={false} vms={[machineFactory()]} />
+    );
+
+    expect(wrapper.find("[data-test='vms-count']").text()).toBe("1 - 1 of 1");
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -1,0 +1,48 @@
+import { Button, Icon, SearchBox, Spinner } from "@canonical/react-components";
+
+import type { Machine } from "app/store/machine/types";
+
+type Props = {
+  loading?: boolean;
+  vms: Machine[];
+};
+
+const VMsActionBar = ({ loading = false, vms }: Props): JSX.Element => {
+  return (
+    <div className="vms-action-bar">
+      <div className="vms-action-bar__actions">
+        <Button className="u-no-margin--bottom" hasIcon>
+          <Icon name="plus" />
+          <span>Compose VM</span>
+        </Button>
+        <Button appearance="base" hasIcon small>
+          <Icon name="menu" />
+        </Button>
+        <Button appearance="base" hasIcon small>
+          <Icon name="restart" />
+        </Button>
+        <Button appearance="base" hasIcon small>
+          <Icon name="delete" />
+        </Button>
+      </div>
+      <div className="vms-action-bar__search">
+        <SearchBox className="u-no-margin--bottom" onChange={() => null} />
+      </div>
+      <div className="vms-action-bar__pagination">
+        <p className="u-no-margin--bottom">
+          <span className="u-text--muted u-nudge-left" data-test="vms-count">
+            {loading ? <Spinner /> : `1 - ${vms.length} of ${vms.length}`}
+          </span>
+          <Button appearance="base" hasIcon small>
+            <Icon className="u-rotate-right" name="chevron-down" />
+          </Button>
+          <Button appearance="base" className="u-no-margin--top" hasIcon small>
+            <Icon className="u-rotate-left" name="chevron-down" />
+          </Button>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default VMsActionBar;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/__snapshots__/VMsActionBar.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/__snapshots__/VMsActionBar.test.tsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VMsActionBar renders 1`] = `
+<div
+  className="vms-action-bar"
+>
+  <div
+    className="vms-action-bar__actions"
+  >
+    <Button
+      className="u-no-margin--bottom"
+      hasIcon={true}
+    >
+      <Icon
+        name="plus"
+      />
+      <span>
+        Compose VM
+      </span>
+    </Button>
+    <Button
+      appearance="base"
+      hasIcon={true}
+      small={true}
+    >
+      <Icon
+        name="menu"
+      />
+    </Button>
+    <Button
+      appearance="base"
+      hasIcon={true}
+      small={true}
+    >
+      <Icon
+        name="restart"
+      />
+    </Button>
+    <Button
+      appearance="base"
+      hasIcon={true}
+      small={true}
+    >
+      <Icon
+        name="delete"
+      />
+    </Button>
+  </div>
+  <div
+    className="vms-action-bar__search"
+  >
+    <SearchBox
+      className="u-no-margin--bottom"
+      onChange={[Function]}
+    />
+  </div>
+  <div
+    className="vms-action-bar__pagination"
+  >
+    <p
+      className="u-no-margin--bottom"
+    >
+      <span
+        className="u-text--muted u-nudge-left"
+        data-test="vms-count"
+      >
+        1 - 1 of 1
+      </span>
+      <Button
+        appearance="base"
+        hasIcon={true}
+        small={true}
+      >
+        <Icon
+          className="u-rotate-right"
+          name="chevron-down"
+        />
+      </Button>
+      <Button
+        appearance="base"
+        className="u-no-margin--top"
+        hasIcon={true}
+        small={true}
+      >
+        <Icon
+          className="u-rotate-left"
+          name="chevron-down"
+        />
+      </Button>
+    </p>
+  </div>
+</div>
+`;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/_index.scss
@@ -1,0 +1,53 @@
+@mixin VMsActionBar {
+  .vms-action-bar {
+    display: grid;
+    grid-template-areas:
+      "act"
+      "pag"
+      "sea";
+    grid-template-columns: auto;
+    grid-template-rows: min-content min-content min-content;
+    padding: $spv-inner--medium 0;
+
+    .vms-action-bar__actions {
+      grid-area: act;
+    }
+
+    .vms-action-bar__pagination {
+      grid-area: pag;
+      margin-top: $spv-inner--small;
+    }
+
+    .vms-action-bar__search {
+      grid-area: sea;
+      margin-top: $spv-inner--medium;
+    }
+
+    [class*="p-button"] {
+      margin-right: $sph-inner;
+    }
+
+    @media only screen and (min-width: $breakpoint-x-small) {
+      grid-template-areas:
+      "act pag"
+      "sea sea";
+      grid-template-columns: auto auto;
+      grid-template-rows: min-content min-content;
+
+      .vms-action-bar__pagination {
+        margin-top: 0;
+        text-align: right;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-large) {
+      grid-template-areas: "act sea pag";
+      grid-template-columns: max-content 1fr max-content;
+      grid-template-rows: min-content;
+
+      .vms-action-bar__search {
+        margin: 0 $sph-inner;
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VMsActionBar";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.test.tsx
@@ -1,0 +1,11 @@
+import { mount } from "enzyme";
+
+import VMsTable from "./VMsTable";
+
+describe("VMsTable", () => {
+  it("shows a spinner if machines are loading", () => {
+    const wrapper = mount(<VMsTable loading vms={[]} />);
+
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
@@ -1,0 +1,26 @@
+import { Spinner, Strip } from "@canonical/react-components";
+
+import type { Machine } from "app/store/machine/types";
+
+type Props = {
+  loading?: boolean;
+  vms: Machine[];
+};
+
+const VMsTable = ({ loading = false, vms }: Props): JSX.Element => {
+  return (
+    <Strip shallow>
+      {loading ? (
+        <Spinner text="Loading" />
+      ) : (
+        <ul>
+          {vms.map((vm) => (
+            <li key={vm.system_id}>{vm.hostname}</li>
+          ))}
+        </ul>
+      )}
+    </Strip>
+  );
+};
+
+export default VMsTable;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VMsTable";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProjectVMs";

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -103,6 +103,14 @@
     padding-left: $sp-x-small !important;
   }
 
+  .u-rotate-left {
+    transform: rotate(-90deg) !important;
+  }
+
+  .u-rotate-right {
+    transform: rotate(90deg) !important;
+  }
+
   .u-text--light {
     color: $color-mid-dark !important;
   }

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -10,6 +10,7 @@
 @include vf-b-button;
 @include vf-b-grid-definitions;
 @include vf-p-icons-common;
+@include vf-p-icon-restart;
 @include vf-p-lists;
 @include vf-u-baseline-grid;
 
@@ -96,6 +97,7 @@
 @import "~app/kvm/views/KVMDetails/CoreResources";
 @import "~app/kvm/views/KVMDetails/KVMResources/KVMNumaResources";
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard";
+@import "~app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar";
 @import "~app/kvm/views/KVMDetails/RamResources";
 @import "~app/kvm/views/KVMDetails/StorageResources";
 @import "~app/kvm/views/KVMList/CPUColumn/CPUPopover";
@@ -120,6 +122,7 @@
 @include StoragePopover;
 @include StorageResources;
 @include VirshTable;
+@include VMsActionBar;
 
 // machines
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";


### PR DESCRIPTION
## Done

- Built non-interactive project VM action bar
- Added placeholder component for VMs table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the project tab of a LXD KVM
- Check that there is an action bar. Nothing happens when you click anything (...yet)
- Check that it looks alright on all screen sizes

## Fixes

Fixes #2232 

## Screenshot
![Screenshot_2021-03-17 LXD project default bolla MAAS](https://user-images.githubusercontent.com/25733845/111422298-2abfd500-873a-11eb-9741-07a4ee2642fd.png)
