### PR TITLE
feat(ui): first pass at building LXD project VM table

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
@@ -31,7 +31,9 @@ const ProjectVMs = ({ id }: Props): JSX.Element => {
   return (
     <Strip shallow>
       <VMsActionBar loading={machinesLoading} vms={podVMs} />
-      <VMsTable loading={machinesLoading} vms={podVMs} />
+      <Strip shallow>
+        <VMsTable id={id} />
+      </Strip>
     </Strip>
   );
 };

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/NameColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/NameColumn.test.tsx
@@ -1,0 +1,56 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import NameColumn from "./NameColumn";
+
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NameColumn", () => {
+  it("shows a spinner if the machine is still loading", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <NameColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("shows a link to the VM's details page", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineFactory({ system_id: "abc123" })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <NameColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Link").prop("to")).toBe("/machine/abc123");
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/NameColumn.tsx
@@ -1,0 +1,41 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import RowCheckbox from "app/base/components/RowCheckbox";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Machine["system_id"];
+};
+
+const NameColumn = ({ systemId }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+
+  if (!machine) {
+    return <Spinner />;
+  }
+  return (
+    <DoubleRow
+      data-test="name-col"
+      primary={
+        <RowCheckbox
+          handleRowCheckbox={() => null}
+          item={systemId}
+          items={[]}
+          inputLabel={
+            <Link to={`/machine/${machine.system_id}`}>{machine.hostname}</Link>
+          }
+        />
+      }
+      primaryTitle={machine.hostname}
+    />
+  );
+};
+
+export default NameColumn;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NameColumn";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/StatusColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/StatusColumn.test.tsx
@@ -1,0 +1,135 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import StatusColumn from "./StatusColumn";
+
+import { PowerState } from "app/store/machine/types";
+import { NodeStatusCode } from "app/store/types/node";
+import {
+  generalState as generalStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  osInfo as osInfoFactory,
+  osInfoState as osInfoStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NameColumn", () => {
+  it("shows a spinner if the machine is still loading", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("shows a spinner if the VM is in a transient state", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineFactory({
+            status_code: NodeStatusCode.COMMISSIONING,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Spinner[data-test='status-icon']").exists()).toBe(
+      true
+    );
+  });
+
+  it("shows a power icon if nthe VM is not in a transient state", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineFactory({
+            power_state: PowerState.OFF,
+            status_code: NodeStatusCode.READY,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(
+      wrapper
+        .find("[data-test='status-icon']")
+        .prop("className")
+        ?.includes("power-off")
+    ).toBe(true);
+  });
+
+  it("can show a VM's OS info", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        osInfo: osInfoStateFactory({
+          data: osInfoFactory({
+            releases: [["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"']],
+          }),
+        }),
+      }),
+      machine: machineStateFactory({
+        items: [
+          machineFactory({
+            distro_series: "focal",
+            osystem: "ubuntu",
+            status_code: NodeStatusCode.DEPLOYED,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <StatusColumn systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("DoubleRow").prop("secondary")).toBe(
+      "Ubuntu 20.04 LTS"
+    );
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/StatusColumn.tsx
@@ -1,0 +1,42 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import { isTransientStatus, useFormattedOS } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
+import { getPowerIcon } from "app/utils";
+
+type Props = {
+  systemId: Machine["system_id"];
+};
+
+const getIcon = (machine: Machine) => {
+  if (isTransientStatus(machine.status_code)) {
+    return <Spinner data-test="status-icon" />;
+  }
+  return <i className={getPowerIcon(machine)} data-test="status-icon"></i>;
+};
+
+const StatusColumn = ({ systemId }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+  const formattedOS = useFormattedOS(machine);
+
+  if (!machine) {
+    return <Spinner />;
+  }
+  return (
+    <DoubleRow
+      icon={getIcon(machine)}
+      primary={machine.status}
+      primaryTitle={machine.status}
+      secondary={formattedOS}
+      secondaryTitle={formattedOS}
+    />
+  );
+};
+
+export default StatusColumn;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StatusColumn";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.test.tsx
@@ -1,11 +1,86 @@
 import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import VMsTable from "./VMsTable";
 
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  pod as podFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
 describe("VMsTable", () => {
   it("shows a spinner if machines are loading", () => {
-    const wrapper = mount(<VMsTable loading vms={[]} />);
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        loading: true,
+      }),
+      pod: podStateFactory({
+        items: [podFactory({ id: 1 })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <VMsTable id={1} />
+        </MemoryRouter>
+      </Provider>
+    );
 
     expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("can change sort order", () => {
+    const [vm1, vm2, vm3] = [
+      machineFactory({ hostname: "b", pod: { id: 1, name: "pod" } }),
+      machineFactory({ hostname: "c", pod: { id: 1, name: "pod" } }),
+      machineFactory({ hostname: "a", pod: { id: 1, name: "pod" } }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [vm1, vm2, vm3],
+      }),
+      pod: podStateFactory({
+        items: [podFactory({ id: 1 })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <VMsTable id={1} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const getName = (index: number) =>
+      wrapper.find("[data-test='name-col']").at(index).text();
+
+    // Sorted descending by hostname by default
+    expect(getName(0)).toBe("a");
+    expect(getName(1)).toBe("b");
+    expect(getName(2)).toBe("c");
+
+    // Sorted ascending by hostname
+    wrapper.find("[data-test='name-header']").simulate("click");
+    expect(getName(0)).toBe("c");
+    expect(getName(1)).toBe("b");
+    expect(getName(2)).toBe("a");
+
+    // No sort
+    wrapper.find("[data-test='name-header']").simulate("click");
+    expect(getName(0)).toBe("b");
+    expect(getName(1)).toBe("c");
+    expect(getName(2)).toBe("a");
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
@@ -1,25 +1,212 @@
-import { Spinner, Strip } from "@canonical/react-components";
+import { MainTable, Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 
+import NameColumn from "./NameColumn";
+import StatusColumn from "./StatusColumn";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import GroupCheckbox from "app/base/components/GroupCheckbox";
+import TableHeader from "app/base/components/TableHeader";
+import { useTableSort } from "app/base/hooks";
+import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import { formatBytes } from "app/utils";
 
 type Props = {
-  loading?: boolean;
-  vms: Machine[];
+  id: Pod["id"];
 };
 
-const VMsTable = ({ loading = false, vms }: Props): JSX.Element => {
+type SortKey = keyof Machine;
+
+const getSortValue = (sortKey: SortKey, vm: Machine) => {
+  switch (sortKey) {
+    case "pool":
+      return vm.pool?.name;
+    default:
+      return vm[sortKey];
+  }
+};
+
+const generateRows = (vms: Machine[]) =>
+  vms.map((vm) => {
+    const memory = formatBytes(vm.memory, "GiB", { binary: true });
+    const storage = formatBytes(vm.storage, "GB");
+
+    return {
+      columns: [
+        {
+          className: "name-col",
+          content: <NameColumn systemId={vm.system_id} />,
+        },
+        {
+          className: "status-col",
+          content: <StatusColumn systemId={vm.system_id} />,
+        },
+        {
+          className: "ipv4-col",
+          content: "",
+        },
+        {
+          className: "ipv6-col",
+          content: "",
+        },
+        {
+          className: "hugepages-col",
+          content: "",
+        },
+        {
+          className: "cores-col u-align--right",
+          content: "",
+        },
+        {
+          className: "ram-col u-align--right",
+          content: (
+            <>
+              <span>{memory.value} </span>
+              <small className="u-text--muted">{memory.unit}</small>
+            </>
+          ),
+        },
+        {
+          className: "storage-col u-align--right",
+          content: (
+            <>
+              <span>{storage.value} </span>
+              <small className="u-text--muted">{storage.unit}</small>
+            </>
+          ),
+        },
+        {
+          className: "pool-col",
+          content: (
+            <DoubleRow primary={vm.pool.name} secondary={vm.zone.name} />
+          ),
+        },
+      ],
+      key: vm.system_id,
+    };
+  });
+
+const VMsTable = ({ id }: Props): JSX.Element => {
+  const loading = useSelector(machineSelectors.loading);
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, id)
+  );
+  const vms = useSelector((state: RootState) =>
+    podSelectors.getVMs(state, pod)
+  );
+  const { currentSort, sortRows, updateSort } = useTableSort<Machine, SortKey>(
+    getSortValue,
+    {
+      key: "hostname",
+      direction: "descending",
+    }
+  );
+  const sortedVms = sortRows(vms);
+
+  if (!pod || loading) {
+    return <Spinner text="Loading..." />;
+  }
   return (
-    <Strip shallow>
-      {loading ? (
-        <Spinner text="Loading" />
-      ) : (
-        <ul>
-          {vms.map((vm) => (
-            <li key={vm.system_id}>{vm.hostname}</li>
-          ))}
-        </ul>
-      )}
-    </Strip>
+    <MainTable
+      className="vms-table"
+      headers={[
+        {
+          className: "name-col",
+          content: (
+            <div className="u-flex">
+              <GroupCheckbox
+                items={vms.map((vm) => vm.system_id)}
+                selectedItems={[]}
+                handleGroupCheckbox={() => null}
+              />
+              <div>
+                <TableHeader
+                  currentSort={currentSort}
+                  data-test="name-header"
+                  onClick={() => updateSort("hostname")}
+                  sortKey="hostname"
+                >
+                  Name
+                </TableHeader>
+              </div>
+            </div>
+          ),
+        },
+        {
+          className: "status-col",
+          content: (
+            <TableHeader
+              className="p-double-row__header-spacer"
+              currentSort={currentSort}
+              onClick={() => updateSort("status")}
+              sortKey="status"
+            >
+              Status
+            </TableHeader>
+          ),
+        },
+        {
+          className: "ipv4-col",
+          content: <TableHeader>IPv4</TableHeader>,
+        },
+        {
+          className: "ipv6-col",
+          content: <TableHeader>IPv6</TableHeader>,
+        },
+        {
+          className: "hugepages-col",
+          content: <TableHeader>Hugepages</TableHeader>,
+        },
+        {
+          className: "cores-col u-align--right",
+          content: <TableHeader>Cores</TableHeader>,
+        },
+        {
+          className: "ram-col u-align--right",
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              onClick={() => updateSort("memory")}
+              sortKey="memory"
+            >
+              RAM
+            </TableHeader>
+          ),
+        },
+        {
+          className: "storage-col u-align--right",
+          content: (
+            <TableHeader
+              currentSort={currentSort}
+              onClick={() => updateSort("storage")}
+              sortKey="storage"
+            >
+              Storage
+            </TableHeader>
+          ),
+        },
+        {
+          className: "pool-col",
+          content: (
+            <>
+              <TableHeader
+                currentSort={currentSort}
+                onClick={() => updateSort("pool")}
+                sortKey="pool"
+              >
+                Resource pool
+              </TableHeader>
+              <TableHeader>AZ</TableHeader>
+            </>
+          ),
+        },
+      ]}
+      rows={generateRows(sortedVms)}
+    />
   );
 };
 

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/_index.scss
@@ -1,0 +1,31 @@
+@mixin VMsTable {
+  .vms-table {
+    .name-col {
+      @include breakpoint-widths(40%, 40%, 18%, 18%, 15%);
+    }
+    .status-col {
+      @include breakpoint-widths(60%, 60%, 22%, 20%, 17%);
+    }
+    .ipv4-col {
+      @include breakpoint-widths(0, 0, 20%, 19%, 16%);
+    }
+    .ipv6-col {
+      @include breakpoint-widths(0, 0, 40%, 31%, 29%);
+    }
+    .hugepages-col {
+      @include breakpoint-widths(0, 0, 0, 0, 6rem);
+    }
+    .cores-col {
+      @include breakpoint-widths(0, 0, 0, 12%, 10%);
+    }
+    .ram-col {
+      @include breakpoint-widths(0, 0, 0, 4.5rem, 4.5rem);
+    }
+    .storage-col {
+      @include breakpoint-widths(0, 0, 0, 4.5rem, 4.5rem);
+    }
+    .pool-col {
+      @include breakpoint-widths(0, 0, 0, 0, 13%);
+    }
+  }
+}

--- a/ui/src/app/machines/filter-nodes.test.ts
+++ b/ui/src/app/machines/filter-nodes.test.ts
@@ -1,6 +1,7 @@
 import filterNodes from "./filter-nodes";
 
 import type { Machine } from "app/store/machine/types";
+import { PowerState } from "app/store/machine/types";
 import { NodeStatus } from "app/store/types/node";
 import { machine as machineFactory } from "testing/factories";
 
@@ -281,8 +282,8 @@ describe("filterNodes", () => {
       description: "matches using power mapping function",
       filter: "power:on",
       nodes: [
-        machineFactory({ power_state: "on" }),
-        machineFactory({ power_state: "off" }),
+        machineFactory({ power_state: PowerState.ON }),
+        machineFactory({ power_state: PowerState.OFF }),
       ],
     },
     {
@@ -290,11 +291,11 @@ describe("filterNodes", () => {
       filter: "power:on zone:first",
       nodes: [
         machineFactory({
-          power_state: "on",
+          power_state: PowerState.ON,
           zone: { id: 1, name: "first" },
         }),
         machineFactory({
-          power_state: "on",
+          power_state: PowerState.OFF,
           zone: { id: 2, name: "second" },
         }),
       ],

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import MachineHeader from "./MachineHeader";
 
+import { PowerState } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
@@ -84,7 +85,7 @@ describe("MachineHeader", () => {
   });
 
   it("displays power status", () => {
-    state.machine.items[0].power_state = "on";
+    state.machine.items[0].power_state = PowerState.ON;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import SummaryNotifications from "./SummaryNotifications";
 
+import { PowerState } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
   architecturesState as architecturesStateFactory,
@@ -67,7 +68,7 @@ describe("SummaryNotifications", () => {
             description: "machine timed out",
           }),
         ],
-        power_state: "error",
+        power_state: PowerState.ERROR,
         system_id: "abc123",
       }),
     ];

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -8,6 +8,7 @@ import { actions as generalActions } from "app/store/general";
 import { architectures as architecturesSelectors } from "app/store/general/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineEvent, Machine } from "app/store/machine/types";
+import { PowerState } from "app/store/machine/types";
 import {
   useCanEdit,
   useHasInvalidArchitecture,
@@ -60,7 +61,9 @@ const SummaryNotifications = ({ id }: Props): JSX.Element | null => {
     <MachineNotifications
       notifications={[
         {
-          active: machine.power_state === "error" && machine.events?.length > 0,
+          active:
+            machine.power_state === PowerState.ERROR &&
+            machine.events?.length > 0,
           content: (
             <>
               {formatEventText(machine.events[0])}.{" "}

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -11,7 +11,7 @@ import { useMachineActions } from "app/base/hooks";
 import { useToggleMenu } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
-import { useFormattedOS } from "app/store/machine/utils";
+import { isTransientStatus, useFormattedOS } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import {
   NodeActions,
@@ -29,26 +29,15 @@ const hideFailedTestWarningStatuses = [
   NodeStatusCode.TESTING,
 ];
 
-// Node statuses that are temporary.
-const transientStatuses = [
-  NodeStatusCode.COMMISSIONING,
-  NodeStatusCode.DEPLOYING,
-  NodeStatusCode.DISK_ERASING,
-  NodeStatusCode.ENTERING_RESCUE_MODE,
-  NodeStatusCode.EXITING_RESCUE_MODE,
-  NodeStatusCode.RELEASING,
-  NodeStatusCode.TESTING,
-];
-
 const getProgressText = (machine: Machine) => {
-  if (transientStatuses.includes(machine.status_code)) {
+  if (isTransientStatus(machine.status_code)) {
     return machine.status_message;
   }
   return "";
 };
 
 const getStatusIcon = (machine: Machine) => {
-  if (transientStatuses.includes(machine.status_code)) {
+  if (isTransientStatus(machine.status_code)) {
     return <Spinner data-test="status-icon" />;
   } else if (
     machine.testing_status.status === TestStatusStatus.FAILED &&

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -223,7 +223,12 @@ export type MachineNumaNode = Model & {
 // Power parameters are dynamic and depend on the power type of the node.
 export type PowerParameters = { [x: string]: string | number };
 
-export type PowerState = "on" | "off" | "unknown" | "error";
+export enum PowerState {
+  ERROR = "error",
+  OFF = "off",
+  ON = "on",
+  UNKNOWN = "unknown",
+}
 
 // BaseMachine is returned from the server when using "machine.list", and is
 // used in the machine list. This type is missing some properties due to an

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -38,6 +38,8 @@ export {
   isInterfaceConnected,
 } from "./networking";
 
+export { isTransientStatus } from "./status";
+
 export {
   canBeDeleted,
   canBeFormatted,

--- a/ui/src/app/store/machine/utils/status.test.ts
+++ b/ui/src/app/store/machine/utils/status.test.ts
@@ -1,0 +1,39 @@
+import { isTransientStatus } from "./status";
+
+import { NodeStatusCode } from "app/store/types/node";
+
+describe("machine status utils", () => {
+  describe("isTransientStatus", () => {
+    it("returns whether a status is a transient status", () => {
+      expect(isTransientStatus(NodeStatusCode.ALLOCATED)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.BROKEN)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.COMMISSIONING)).toBe(true);
+      expect(isTransientStatus(NodeStatusCode.DEPLOYED)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.DEPLOYING)).toBe(true);
+      expect(isTransientStatus(NodeStatusCode.DISK_ERASING)).toBe(true);
+      expect(isTransientStatus(NodeStatusCode.ENTERING_RESCUE_MODE)).toBe(true);
+      expect(isTransientStatus(NodeStatusCode.EXITING_RESCUE_MODE)).toBe(true);
+      expect(isTransientStatus(NodeStatusCode.FAILED_COMMISSIONING)).toBe(
+        false
+      );
+      expect(isTransientStatus(NodeStatusCode.FAILED_DEPLOYMENT)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.FAILED_DISK_ERASING)).toBe(false);
+      expect(
+        isTransientStatus(NodeStatusCode.FAILED_ENTERING_RESCUE_MODE)
+      ).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.FAILED_EXITING_RESCUE_MODE)).toBe(
+        false
+      );
+      expect(isTransientStatus(NodeStatusCode.FAILED_RELEASING)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.FAILED_TESTING)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.MISSING)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.NEW)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.READY)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.RELEASING)).toBe(true);
+      expect(isTransientStatus(NodeStatusCode.RESCUE_MODE)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.RESERVED)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.RETIRED)).toBe(false);
+      expect(isTransientStatus(NodeStatusCode.TESTING)).toBe(true);
+    });
+  });
+});

--- a/ui/src/app/store/machine/utils/status.ts
+++ b/ui/src/app/store/machine/utils/status.ts
@@ -1,0 +1,17 @@
+import { NodeStatusCode } from "app/store/types/node";
+
+/**
+ * Returns whether a a status code represents a transient status.
+ * @param statusCode - the status code to check.
+ * @returns whether the status code is a transient status.
+ */
+export const isTransientStatus = (statusCode: NodeStatusCode): boolean =>
+  [
+    NodeStatusCode.COMMISSIONING,
+    NodeStatusCode.DEPLOYING,
+    NodeStatusCode.DISK_ERASING,
+    NodeStatusCode.ENTERING_RESCUE_MODE,
+    NodeStatusCode.EXITING_RESCUE_MODE,
+    NodeStatusCode.RELEASING,
+    NodeStatusCode.TESTING,
+  ].includes(statusCode);

--- a/ui/src/app/utils/getPowerIcon.test.ts
+++ b/ui/src/app/utils/getPowerIcon.test.ts
@@ -1,5 +1,6 @@
 import { getPowerIcon } from "./getPowerIcon";
 
+import { PowerState } from "app/store/machine/types";
 import {
   controller as controllerFactory,
   machine as machineFactory,
@@ -10,25 +11,25 @@ const controller = controllerFactory();
 
 describe("getPowerIcon", () => {
   it("returns an 'on' icon for a machine with an on power state", () => {
-    machine.power_state = "on";
+    machine.power_state = PowerState.ON;
 
     expect(getPowerIcon(machine)).toEqual("p-icon--power-on");
   });
 
   it("returns an 'off' icon for a machine with an off power state", () => {
-    machine.power_state = "off";
+    machine.power_state = PowerState.OFF;
 
     expect(getPowerIcon(machine)).toEqual("p-icon--power-off");
   });
 
   it("returns an 'error' icon for a machine with an error power state", () => {
-    machine.power_state = "error";
+    machine.power_state = PowerState.ERROR;
 
     expect(getPowerIcon(machine)).toEqual("p-icon--power-error");
   });
 
   it("returns an 'unknown' icon for a machine with an unknown power state", () => {
-    machine.power_state = "unknown";
+    machine.power_state = PowerState.UNKNOWN;
 
     expect(getPowerIcon(machine)).toEqual("p-icon--power-unknown");
     expect(getPowerIcon()).toEqual("p-icon--power-unknown");

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -98,6 +98,7 @@
 @import "~app/kvm/views/KVMDetails/KVMResources/KVMNumaResources";
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard";
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar";
+@import "~app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable";
 @import "~app/kvm/views/KVMDetails/RamResources";
 @import "~app/kvm/views/KVMDetails/StorageResources";
 @import "~app/kvm/views/KVMList/CPUColumn/CPUPopover";
@@ -123,6 +124,7 @@
 @include StorageResources;
 @include VirshTable;
 @include VMsActionBar;
+@include VMsTable;
 
 // machines
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -22,6 +22,7 @@ import {
   DiskTypes,
   NetworkLinkMode,
   NetworkInterfaceTypes,
+  PowerState,
   StorageLayout,
 } from "app/store/machine/types";
 import type {
@@ -139,7 +140,7 @@ export const machine = extend<BaseNode, Machine>(node, {
   owner: "admin",
   physical_disk_count: 1,
   pod: modelRef,
-  power_state: "on",
+  power_state: PowerState.ON,
   power_type: "manual",
   pxe_mac_vendor: "Unknown vendor",
   pxe_mac: "de:ad:be:ef:aa:b1",


### PR DESCRIPTION
## Done

- Built VMs table with column data for Name, Status, RAM, Storage and Resource pool (includes sorting).
- The remaining columns will require a bit more effort because they need to cross-reference `pod.resources`, so I'll do those as a follow-up ([GH issue](https://github.com/canonical-web-and-design/maas-ui/issues/2408))

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the project tab of a LXD KVM and check that data shows correctly for Name, Status, RAM, Storage and Resource pool/AZ.
- Perform an action that'll put one of the VMs in a transient state, e.g. "Testing" and check that the power icon gets replaced by a spinner
- Check that you can sort the table

## Fixes

Fixes #2231 

## Screenshot
![Screenshot_2021-03-18 LXD project default bolla MAAS](https://user-images.githubusercontent.com/25733845/111572353-27891f80-87f4-11eb-8790-65cfcbef125c.png)
