### PR TITLE
feat(ui): add ips, hugepages and cores columns to LXD VM table

### DIFF
--- a/ui/src/app/base/validation.ts
+++ b/ui/src/app/base/validation.ts
@@ -1,4 +1,9 @@
 /**
+ * Validate IPv4 address e.g 192.168.1.1
+ */
+export const IPV4_REGEX = /\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)(?::\d{0,4})?\b/;
+
+/**
  * Validate MAC address e.g 78:9a:bc:de:f0
  */
 export const MAC_ADDRESS_REGEX = /^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$/;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/CoresColumn/CoresColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/CoresColumn/CoresColumn.test.tsx
@@ -1,0 +1,71 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CoresColumn from "./CoresColumn";
+
+import {
+  pod as podFactory,
+  podResources as podResourcesFactory,
+  podState as podStateFactory,
+  podVM as podVMFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("CoresColumn", () => {
+  it("can show the pinned cores of a VM", () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        vms: [
+          podVMFactory({
+            pinned_cores: [0, 1, 2, 4],
+            system_id: "abc123",
+            unpinned_cores: 0,
+          }),
+        ],
+      }),
+    });
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CoresColumn machineId="abc123" podId={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe("0-2, 4");
+    expect(wrapper.find("DoubleRow").prop("secondary")).toBe("pinned");
+  });
+
+  it("can show the unpinned cores of a VM", () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        vms: [
+          podVMFactory({
+            pinned_cores: [],
+            system_id: "abc123",
+            unpinned_cores: 4,
+          }),
+        ],
+      }),
+    });
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CoresColumn machineId="abc123" podId={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find("DoubleRow").prop("primary")).toBe("Any 4");
+    expect(wrapper.find("DoubleRow").prop("secondary")).toBe("");
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/CoresColumn/CoresColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/CoresColumn/CoresColumn.tsx
@@ -1,0 +1,40 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import type { Machine } from "app/store/machine/types";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import { getRanges } from "app/utils";
+
+type Props = {
+  machineId: Machine["system_id"];
+  podId: Pod["id"];
+};
+
+const CoresColumn = ({ machineId, podId }: Props): JSX.Element => {
+  const vmResource = useSelector((state: RootState) =>
+    podSelectors.getVmResource(state, podId, machineId)
+  );
+
+  if (!vmResource) {
+    return <Spinner />;
+  }
+
+  const pinnedRanges = getRanges(vmResource.pinned_cores).join(", ");
+  const primaryText = pinnedRanges || `Any ${vmResource.unpinned_cores}`;
+  const secondaryText = pinnedRanges && "pinned";
+  return (
+    <DoubleRow
+      primary={primaryText}
+      primaryClassName="u-align--right"
+      primaryTitle={primaryText}
+      secondary={secondaryText}
+      secondaryClassName="u-align--right"
+      secondaryTitle={secondaryText}
+    />
+  );
+};
+
+export default CoresColumn;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/CoresColumn/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/CoresColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CoresColumn";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/HugepagesColumn/HugepagesColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/HugepagesColumn/HugepagesColumn.test.tsx
@@ -1,0 +1,67 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import HugepagesColumn from "./HugepagesColumn";
+
+import {
+  pod as podFactory,
+  podResources as podResourcesFactory,
+  podState as podStateFactory,
+  podVM as podVMFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("HugepagesColumn", () => {
+  it("can show if a VM is backed by hugepages", () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        vms: [
+          podVMFactory({
+            hugepages_backed: true,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <HugepagesColumn machineId="abc123" podId={1} />
+      </Provider>
+    );
+
+    expect(wrapper.text()).toBe("Enabled");
+  });
+
+  it("can show if a VM is not backed by hugepages", () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        vms: [
+          podVMFactory({
+            hugepages_backed: false,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <HugepagesColumn machineId="abc123" podId={1} />
+      </Provider>
+    );
+
+    expect(wrapper.text()).toBe("");
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/HugepagesColumn/HugepagesColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/HugepagesColumn/HugepagesColumn.tsx
@@ -1,0 +1,26 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import type { Machine } from "app/store/machine/types";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  machineId: Machine["system_id"];
+  podId: Pod["id"];
+};
+
+const HugepagesColumn = ({ machineId, podId }: Props): JSX.Element => {
+  const vmResource = useSelector((state: RootState) =>
+    podSelectors.getVmResource(state, podId, machineId)
+  );
+
+  if (!vmResource) {
+    return <Spinner />;
+  }
+
+  return <span>{vmResource.hugepages_backed ? "Enabled" : ""}</span>;
+};
+
+export default HugepagesColumn;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/HugepagesColumn/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/HugepagesColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HugepagesColumn";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/IPColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/IPColumn.test.tsx
@@ -1,0 +1,105 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import IPColumn from "./IPColumn";
+
+import type { MachineIpAddress } from "app/store/machine/types";
+import {
+  machine as machineFactory,
+  machineIpAddress as ipAddressFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("IPColumn", () => {
+  let ipAddresses: MachineIpAddress[] = [];
+
+  beforeEach(() => {
+    ipAddresses = [
+      ipAddressFactory({ ip: "192.168.1.1", is_boot: true }),
+      ipAddressFactory({ ip: "192.168.1.2:8000", is_boot: false }),
+      ipAddressFactory({ ip: "2001:db8::ff00:42:8329", is_boot: false }),
+    ];
+  });
+
+  it("shows a spinner if the machine is still loading", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <IPColumn systemId="abc123" version={4} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("can show a list of the machine's ipv4s", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineFactory({
+            ip_addresses: ipAddresses,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <IPColumn systemId="abc123" version={4} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='ip']").length).toBe(2);
+    expect(wrapper.find("[data-test='ip']").at(0).text()).toBe("192.168.1.1");
+    expect(wrapper.find("[data-test='ip']").at(1).text()).toBe(
+      "192.168.1.2:8000"
+    );
+  });
+
+  it("can show a list of the machine's ipv6s", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineFactory({
+            ip_addresses: ipAddresses,
+            system_id: "abc123",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <IPColumn systemId="abc123" version={6} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='ip']").length).toBe(1);
+    expect(wrapper.find("[data-test='ip']").text()).toBe(
+      "2001:db8::ff00:42:8329"
+    );
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/IPColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/IPColumn.tsx
@@ -1,0 +1,45 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import { IPV4_REGEX } from "app/base/validation";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  systemId: Machine["system_id"];
+  version: 4 | 6;
+};
+
+const IPColumn = ({ systemId, version }: Props): JSX.Element => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
+
+  if (!machine) {
+    return <Spinner />;
+  }
+
+  const ips = machine.ip_addresses.reduce<string[]>((ips, { ip }) => {
+    if (
+      (version === 4 && IPV4_REGEX.test(ip)) ||
+      (version === 6 && !IPV4_REGEX.test(ip))
+    ) {
+      ips.push(ip);
+    }
+    return ips;
+  }, []);
+  return (
+    <>
+      {ips.length
+        ? ips.map((ip) => (
+            <div data-test="ip" key={ip}>
+              {ip}
+            </div>
+          ))
+        : "-"}
+    </>
+  );
+};
+
+export default IPColumn;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IPColumn";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/NameColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/NameColumn/NameColumn.tsx
@@ -29,7 +29,9 @@ const NameColumn = ({ systemId }: Props): JSX.Element => {
           item={systemId}
           items={[]}
           inputLabel={
-            <Link to={`/machine/${machine.system_id}`}>{machine.hostname}</Link>
+            <Link to={`/machine/${machine.system_id}`}>
+              <strong>{machine.hostname}</strong>
+            </Link>
           }
         />
       }

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
@@ -1,6 +1,9 @@
 import { MainTable, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import CoresColumn from "./CoresColumn";
+import HugepagesColumn from "./HugepagesColumn";
+import IPColumn from "./IPColumn";
 import NameColumn from "./NameColumn";
 import StatusColumn from "./StatusColumn";
 
@@ -30,7 +33,7 @@ const getSortValue = (sortKey: SortKey, vm: Machine) => {
   }
 };
 
-const generateRows = (vms: Machine[]) =>
+const generateRows = (vms: Machine[], podId: Pod["id"]) =>
   vms.map((vm) => {
     const memory = formatBytes(vm.memory, "GiB", { binary: true });
     const storage = formatBytes(vm.storage, "GB");
@@ -47,19 +50,19 @@ const generateRows = (vms: Machine[]) =>
         },
         {
           className: "ipv4-col",
-          content: "",
+          content: <IPColumn systemId={vm.system_id} version={4} />,
         },
         {
           className: "ipv6-col",
-          content: "",
+          content: <IPColumn systemId={vm.system_id} version={6} />,
         },
         {
           className: "hugepages-col",
-          content: "",
+          content: <HugepagesColumn machineId={vm.system_id} podId={podId} />,
         },
         {
           className: "cores-col u-align--right",
-          content: "",
+          content: <CoresColumn machineId={vm.system_id} podId={podId} />,
         },
         {
           className: "ram-col u-align--right",
@@ -205,7 +208,7 @@ const VMsTable = ({ id }: Props): JSX.Element => {
           ),
         },
       ]}
-      rows={generateRows(sortedVms)}
+      rows={generateRows(sortedVms, pod.id)}
     />
   );
 };

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -9,7 +9,7 @@ import type { Model, ModelRef } from "app/store/types/model";
 import type { BaseNode, TestStatus } from "app/store/types/node";
 import type { EventError, GenericState } from "app/store/types/state";
 
-export type IpAddresses = {
+export type MachineIpAddress = {
   ip: string;
   is_boot: boolean;
 };
@@ -240,7 +240,7 @@ export type BaseMachine = BaseNode & {
   extra_macs: string[];
   fabrics: string[];
   has_logs: boolean;
-  ip_addresses: IpAddresses[];
+  ip_addresses: MachineIpAddress[];
   link_speeds: number[];
   numa_nodes_count: number;
   owner: string;

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -8,7 +8,9 @@ import {
   machineState as machineStateFactory,
   pod as podFactory,
   podProject as podProjectFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
+  podVM as podVMFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -298,5 +300,25 @@ describe("pod selectors", () => {
       }),
     });
     expect(pod.getProjectsByLxdServer(state, "172.0.0.1")).toEqual(projects);
+  });
+
+  it("can get a specific VM resource of a pod", () => {
+    const [thisVmResource, otherVmResource] = [
+      podVMFactory({ system_id: "abc123" }),
+      podVMFactory({ system_id: "def456" }),
+    ];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            resources: podResourcesFactory({
+              vms: [thisVmResource, otherVmResource],
+            }),
+          }),
+        ],
+      }),
+    });
+    expect(pod.getVmResource(state, 1, "abc123")).toEqual(thisVmResource);
   });
 });

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -212,6 +212,21 @@ const getProjectsByLxdServer = createSelector(
   (projects, address) => projects[address] || []
 );
 
+const getVmResource = createSelector(
+  [
+    (state: RootState, podId: Pod["id"], machineId: Machine["system_id"]) => ({
+      pod: defaultSelectors.getById(state, podId),
+      machineId,
+    }),
+  ],
+  ({ machineId, pod }) => {
+    if (!pod || !machineId) {
+      return null;
+    }
+    return pod.resources.vms.find((vm) => vm.system_id === machineId) || null;
+  }
+);
+
 const selectors = {
   ...defaultSelectors,
   active,
@@ -223,6 +238,7 @@ const selectors = {
   getVMs,
   getByLxdServer,
   getProjectsByLxdServer,
+  getVmResource,
   groupByLxdServer,
   kvms,
   lxd,

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -55,6 +55,7 @@ export { config } from "./config";
 export { domain } from "./domain";
 export { eventRecord, eventType } from "./event";
 export {
+  controller,
   device,
   machine,
   machineDetails,
@@ -64,17 +65,27 @@ export {
   machineEventType,
   machineFilesystem,
   machineInterface,
+  machineIpAddress,
   machineNumaNode,
   machinePartition,
   networkDiscoveredIP,
   networkLink,
-  controller,
   pod,
   podDetails,
   podHint,
+  podMemoryResource,
+  podNetworkInterface,
+  podNuma,
+  podNumaCores,
+  podNumaGeneralMemory,
+  podNumaHugepageMemory,
+  podNumaMemory,
   podNumaNode,
   podProject,
+  podResource,
+  podResources,
   podStoragePool,
+  podVM,
   testStatus,
 } from "./nodes";
 export { dhcpSnippet } from "./dhcpsnippet";

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -13,6 +13,7 @@ import type {
   MachineDetails,
   MachineDevice,
   MachineEvent,
+  MachineIpAddress,
   MachineNumaNode,
   NetworkInterface,
   NetworkLink,
@@ -254,6 +255,11 @@ export const machineInterface = extend<Model, NetworkInterface>(model, {
 export const machineDevice = define<MachineDevice>({
   fqdn: "device.maas",
   interfaces: () => [],
+});
+
+export const machineIpAddress = define<MachineIpAddress>({
+  ip: "192.168.1.1",
+  is_boot: false,
 });
 
 export const machineDetails = extend<Machine, MachineDetails>(machine, {


### PR DESCRIPTION
## Done

- Added remaining columns to the LXD VM table. The only thing that's missing is the name of the interface associated with an ip address, which I'll bring up with the core team.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the project tab of a LXD KVM and compose some machines with pinned/unpinned cores and hugepages backed/not backed.
- Check that the data in the table matches why you just composed.

## Fixes

Fixes #2408

## Screenshot
![Screenshot_2021-03-19 LXD project default bolla MAAS](https://user-images.githubusercontent.com/25733845/111716604-1c8cc880-88a2-11eb-910b-88fe915153fb.png)
