### PR TITLE
feat(ui): search events

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "@canonical/react-components";
+import { Col, Row, SearchBox, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import EventLogsTable from "./EventLogsTable";
@@ -13,6 +13,7 @@ import type { RootState } from "app/store/root/types";
 type Props = { systemId: Machine["system_id"] };
 
 const EventLogs = ({ systemId }: Props): JSX.Element => {
+  const [searchText, setSearchText] = useState("");
   const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
@@ -28,7 +29,22 @@ const EventLogs = ({ systemId }: Props): JSX.Element => {
     return <Spinner text="Loading..." />;
   }
 
-  return <EventLogsTable systemId={systemId} />;
+  return (
+    <>
+      <Row className="u-nudge-down--small">
+        <Col size="6">
+          <SearchBox
+            onChange={setSearchText}
+            placeholder="Search event logs"
+            value={searchText}
+          />
+        </Col>
+        <Col size="6"></Col>
+      </Row>
+      <hr />
+      <EventLogsTable searchText={searchText} systemId={systemId} />
+    </>
+  );
 };
 
 export default EventLogs;

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.test.tsx
@@ -41,7 +41,7 @@ describe("EventLogsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <EventLogsTable systemId="abc123" />
+          <EventLogsTable searchText="" systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -55,7 +55,7 @@ describe("EventLogsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <EventLogsTable systemId="abc123" />
+          <EventLogsTable searchText="" systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -73,7 +73,7 @@ describe("EventLogsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <EventLogsTable systemId="abc123" />
+          <EventLogsTable searchText="" systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -90,6 +90,35 @@ describe("EventLogsTable", () => {
         .last()
         .text()
         .includes("Tue, 16 Mar. 2021 03:04:00")
+    ).toBe(true);
+  });
+
+  it("can filter the events", () => {
+    state.event.items = [
+      eventRecordFactory({ description: "Failed commissioning", node_id: 1 }),
+      eventRecordFactory({ description: "Didn't fail", node_id: 1 }),
+      eventRecordFactory({ description: "Failed install", node_id: 1 }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <EventLogsTable searchText="failed" systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("td.event-col").length).toBe(2);
+    expect(
+      wrapper
+        .find("td.event-col")
+        .first()
+        .text()
+        .includes("Failed commissioning")
+    ).toBe(true);
+    expect(
+      wrapper.find("td.event-col").last().text().includes("Failed install")
     ).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.tsx
@@ -9,7 +9,10 @@ import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
-type Props = { systemId: Machine["system_id"] };
+type Props = {
+  searchText: string | null;
+  systemId: Machine["system_id"];
+};
 
 type EventRow = {
   className?: string | null;
@@ -52,7 +55,7 @@ const generateRow = (event: EventRecord): EventRow => {
   };
 };
 
-const EventLogsTable = ({ systemId }: Props): JSX.Element => {
+const EventLogsTable = ({ searchText, systemId }: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
@@ -62,8 +65,15 @@ const EventLogsTable = ({ systemId }: Props): JSX.Element => {
   if (!machine || !events) {
     return <Spinner text="Loading..." />;
   }
-
-  const rows = [...events]
+  const lowerSearchText = searchText?.toLowerCase();
+  const filteredEvents = lowerSearchText
+    ? events.filter(
+        (eventRecord) =>
+          eventRecord.description?.toLowerCase().includes(lowerSearchText) ||
+          eventRecord.type?.description?.toLowerCase().includes(lowerSearchText)
+      )
+    : [...events];
+  const rows = filteredEvents
     .sort(
       (a: EventRecord, b: EventRecord) =>
         new Date(b.created).getTime() - new Date(a.created).getTime()

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -26,6 +26,7 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
     return <Spinner text="Loading..." />;
   }
 
+  const showingOutput = pathname.startsWith(`${urlBase}/installation-output`);
   return (
     <>
       <div className="u-flex">
@@ -33,13 +34,14 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
           className="u-flex--grow"
           links={[
             {
-              active: pathname.startsWith(`${urlBase}/events`),
+              active:
+                pathname.startsWith(`${urlBase}/events`) || !showingOutput,
               component: Link,
               label: "Event log",
               to: `${urlBase}/events`,
             },
             {
-              active: pathname.startsWith(`${urlBase}/installation-output`),
+              active: showingOutput,
               component: Link,
               label: "Installation output",
               to: `${urlBase}/installation-output`,
@@ -53,6 +55,9 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
       </Route>
       <Route exact path="/machine/:id/logs/installation-output">
         <InstallationOutput systemId={systemId} />
+      </Route>
+      <Route exact path={["/machine/:id/logs", "/machine/:id/logs/events"]}>
+        <EventLogs systemId={systemId} />
       </Route>
     </>
   );

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -63,6 +63,18 @@
     text-transform: none !important;
   }
 
+  .u-nudge-down {
+    padding-top: $sph-inner !important;
+  }
+
+  .u-nudge-down--small {
+    padding-top: $sph-inner--small !important;
+  }
+
+  .u-nudge-down--x-small {
+    padding-top: $sp-x-small !important;
+  }
+
   .u-nudge-left--x-large {
     padding-right: $sph-inner * 2 !important;
   }


### PR DESCRIPTION
## Done

- Add a searchbox and filter the events in the logs tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the React logs tab for a machine (visit machine details and change the URL from '/summary' to '/logs').
- Type something in the search box. It should filter the results.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2218.