### PR TITLE
feat(ui): download log component

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
@@ -1,0 +1,34 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DownloadMenu from "./DownloadMenu";
+
+import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DownloadMenu", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory();
+  });
+
+  it("renders", () => {
+    state.machine.selected = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DownloadMenu />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("DownloadMenu").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
@@ -1,0 +1,31 @@
+import { ContextualMenu } from "@canonical/react-components";
+export const DownloadMenu = (): JSX.Element => {
+  return (
+    <div>
+      <ContextualMenu
+        className="download-menu"
+        data-test="take-action-dropdown"
+        hasToggleIcon
+        links={[
+          {
+            children: "Machine output (YAML)",
+          },
+          {
+            children: "Machine output (XML)",
+          },
+          {
+            children: "curtin-logs.tar",
+          },
+          {
+            children: "Installation output",
+          },
+        ]}
+        position="right"
+        toggleAppearance="neutral"
+        toggleLabel="Download"
+      />
+    </div>
+  );
+};
+
+export default DownloadMenu;

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/_index.scss
@@ -1,0 +1,5 @@
+@mixin DownloadMenu {
+  .download-menu {
+    @extend %vf-pseudo-border--bottom;
+  }
+}

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DownloadMenu";

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -2,6 +2,7 @@ import { Spinner, Tabs } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Link, Route, useLocation } from "react-router-dom";
 
+import DownloadMenu from "./DownloadMenu";
 import EventLogs from "./EventLogs";
 import InstallationOutput from "./InstallationOutput";
 
@@ -27,22 +28,26 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
 
   return (
     <>
-      <Tabs
-        links={[
-          {
-            active: pathname.startsWith(`${urlBase}/events`),
-            component: Link,
-            label: "Event log",
-            to: `${urlBase}/events`,
-          },
-          {
-            active: pathname.startsWith(`${urlBase}/installation-output`),
-            component: Link,
-            label: "Installation output",
-            to: `${urlBase}/installation-output`,
-          },
-        ]}
-      />
+      <div className="u-flex">
+        <Tabs
+          className="u-flex--grow"
+          links={[
+            {
+              active: pathname.startsWith(`${urlBase}/events`),
+              component: Link,
+              label: "Event log",
+              to: `${urlBase}/events`,
+            },
+            {
+              active: pathname.startsWith(`${urlBase}/installation-output`),
+              component: Link,
+              label: "Installation output",
+              to: `${urlBase}/installation-output`,
+            },
+          ]}
+        />
+        <DownloadMenu />
+      </div>
       <Route exact path="/machine/:id/logs/events">
         <EventLogs systemId={systemId} />
       </Route>

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -135,12 +135,14 @@
 @import "~app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/DHCPTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/NetworkTable";
+@import "~app/machines/views/MachineDetails/MachineLogs/DownloadMenu";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/OverviewCard";
 @import "~app/machines/views/MachineDetails/MachineTests/MachineTestsTable";
 @import "~app/machines/views/MachineDetails/NodeDevices";
+@include DownloadMenu;
 @include EventLogsTable;
 @include MachineList;
 @include MachineDHCPTable;


### PR DESCRIPTION
## Done

- Add a component for downloading logs.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the React logs tab for a machine (visit machine details and change the URL from '/summary' to '/logs').
- You should see a download button to the right of the event/output sub-tabs.
- Clicking on the download button should show links, but they don't yet work.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2219.