### PR TITLE
feat(ui): download installation output

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -440,22 +440,30 @@ exports[`stricter compilation`] = {
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx:601447620": [
-      [97, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:2578322392": [
+      [72, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [75, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [91, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [94, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [110, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [113, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx:689686888": [
+      [80, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [98, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
       [115, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
       [132, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [149, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [156, 11, 23, "Object is possibly \'null\'.", "2510184035"],
-      [156, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
+      [139, 11, 23, "Object is possibly \'null\'.", "2510184035"],
+      [139, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
+      [150, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
       [167, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [184, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [191, 11, 23, "Object is possibly \'null\'.", "2510184035"],
-      [191, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
+      [174, 11, 23, "Object is possibly \'null\'.", "2510184035"],
+      [174, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
+      [185, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
       [202, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
       [219, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
       [236, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [253, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [276, 11, 42, "Object is of type \'unknown\'.", "3300537276"]
+      [259, 11, 42, "Object is of type \'unknown\'.", "3300537276"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx:2329041630": [
       [172, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,6 +33,7 @@
     "date-fns": "2.19.0",
     "formik": "2.2.6",
     "http-proxy-middleware": "1.0.6",
+    "js-file-download": "0.4.12",
     "path-parse": "1.0.6",
     "pluralize": "8.0.0",
     "prop-types": "15.7.2",

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from "enzyme";
+import * as fileDownload from "js-file-download";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -6,29 +7,115 @@ import configureStore from "redux-mock-store";
 import DownloadMenu from "./DownloadMenu";
 
 import type { RootState } from "app/store/root/types";
-import { rootState as rootStateFactory } from "testing/factories";
+import {
+  ScriptResultStatus,
+  ScriptResultType,
+} from "app/store/scriptresult/types";
+import {
+  machineState as machineStateFactory,
+  machineDetails as machineDetailsFactory,
+  rootState as rootStateFactory,
+  scriptResult as scriptResultFactory,
+  scriptResultData as scriptResultDataFactory,
+  scriptResultState as scriptResultStateFactory,
+  nodeScriptResultState as nodeScriptResultStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
+
+jest.mock("js-file-download", () => jest.fn());
 
 describe("DownloadMenu", () => {
   let state: RootState;
 
   beforeEach(() => {
-    state = rootStateFactory();
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1] },
+      }),
+      scriptresult: scriptResultStateFactory({
+        items: [
+          scriptResultFactory({
+            id: 1,
+            result_type: ScriptResultType.INSTALLATION,
+            status: ScriptResultStatus.PASSED,
+          }),
+        ],
+        logs: {
+          1: scriptResultDataFactory({
+            combined: "Installation output log",
+          }),
+        },
+      }),
+    });
   });
 
-  it("renders", () => {
-    state.machine.selected = [];
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not display an installation output item when there is no log", () => {
+    state.scriptresult.logs = {};
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
-          <DownloadMenu />
+          <DownloadMenu systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("DownloadMenu").exists()).toBe(true);
+    expect(
+      wrapper
+        .find("ContextualMenu")
+        .prop("links")
+        .some(({ children }) => children === "Installation output")
+    ).toBe(false);
+  });
+
+  it("can display an installation output item", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DownloadMenu systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("ContextualMenu")
+        .prop("links")
+        .some(({ children }) => children === "Installation output")
+    ).toBe(true);
+  });
+
+  it("can generates a download when the installation item is clicked", () => {
+    const downloadSpy = jest.spyOn(fileDownload, "default");
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <DownloadMenu systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("ContextualMenu")
+      .prop("links")
+      .find(({ children }) => children === "Installation output")
+      .onClick();
+    expect(downloadSpy).toHaveBeenCalledWith(
+      "Installation output log",
+      "installation-output.txt"
+    );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
@@ -31,7 +31,12 @@ describe("DownloadMenu", () => {
   beforeEach(() => {
     state = rootStateFactory({
       machine: machineStateFactory({
-        items: [machineDetailsFactory({ system_id: "abc123" })],
+        items: [
+          machineDetailsFactory({
+            fqdn: "hungry-wombat.aus",
+            system_id: "abc123",
+          }),
+        ],
       }),
       nodescriptresult: nodeScriptResultStateFactory({
         items: { abc123: [1] },
@@ -55,6 +60,7 @@ describe("DownloadMenu", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
   it("does not display an installation output item when there is no log", () => {
@@ -97,6 +103,9 @@ describe("DownloadMenu", () => {
   });
 
   it("can generates a download when the installation item is clicked", () => {
+    jest
+      .useFakeTimers("modern")
+      .setSystemTime(new Date("2021-03-25").getTime());
     const downloadSpy = jest.spyOn(fileDownload, "default");
     const store = mockStore(state);
     const wrapper = mount(
@@ -115,7 +124,7 @@ describe("DownloadMenu", () => {
       .onClick();
     expect(downloadSpy).toHaveBeenCalledWith(
       "Installation output log",
-      "installation-output.txt"
+      "hungry-wombat.aus-installation-output-2021-03-25.txt"
     );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
@@ -1,10 +1,16 @@
 import { ContextualMenu } from "@canonical/react-components";
-export const DownloadMenu = (): JSX.Element => {
+import fileDownload from "js-file-download";
+
+import { useGetInstallationOutput } from "../hooks";
+
+import type { Machine } from "app/store/machine/types";
+type Props = { systemId: Machine["system_id"] };
+export const DownloadMenu = ({ systemId }: Props): JSX.Element => {
+  const installationOutput = useGetInstallationOutput(systemId);
   return (
     <div>
       <ContextualMenu
         className="download-menu"
-        data-test="take-action-dropdown"
         hasToggleIcon
         links={[
           {
@@ -16,9 +22,21 @@ export const DownloadMenu = (): JSX.Element => {
           {
             children: "curtin-logs.tar",
           },
-          {
-            children: "Installation output",
-          },
+          ...(installationOutput.log
+            ? [
+                {
+                  children: "Installation output",
+                  onClick: () => {
+                    if (installationOutput.log) {
+                      fileDownload(
+                        installationOutput.log,
+                        "installation-output.txt"
+                      );
+                    }
+                  },
+                },
+              ]
+            : []),
         ]}
         position="right"
         toggleAppearance="neutral"

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
@@ -1,12 +1,22 @@
 import { ContextualMenu } from "@canonical/react-components";
+import { format } from "date-fns";
 import fileDownload from "js-file-download";
+import { useSelector } from "react-redux";
 
 import { useGetInstallationOutput } from "../hooks";
 
+import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
 type Props = { systemId: Machine["system_id"] };
-export const DownloadMenu = ({ systemId }: Props): JSX.Element => {
+export const DownloadMenu = ({ systemId }: Props): JSX.Element | null => {
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, systemId)
+  );
   const installationOutput = useGetInstallationOutput(systemId);
+  if (!machine) {
+    return null;
+  }
   return (
     <div>
       <ContextualMenu
@@ -28,9 +38,10 @@ export const DownloadMenu = ({ systemId }: Props): JSX.Element => {
                   children: "Installation output",
                   onClick: () => {
                     if (installationOutput.log) {
+                      const today = format(new Date(), "yyyy-MM-dd");
                       fileDownload(
                         installationOutput.log,
-                        "installation-output.txt"
+                        `${machine.fqdn}-installation-output-${today}.txt`
                       );
                     }
                   },

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx
@@ -66,23 +66,6 @@ describe("InstallationOutput", () => {
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
-  it("fetches the logs if they're not already loaded", () => {
-    state.scriptresult.logs = {};
-    const store = mockStore(state);
-    mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <InstallationOutput systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(
-      store.getActions().some(({ type }) => type === "scriptresult/getLogs")
-    ).toEqual(true);
-  });
-
   it("displays the state when there is no result", () => {
     state.scriptresult.items = [];
     const store = mockStore(state);

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.tsx
@@ -1,14 +1,13 @@
-import { useEffect } from "react";
-
 import { CodeSnippet, Spinner } from "@canonical/react-components";
 import { CodeSnippetBlockAppearance } from "@canonical/react-components/dist/components/CodeSnippet";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
+
+import { useGetInstallationOutput } from "../hooks";
 
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { PowerState } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultSelectors from "app/store/scriptresult/selectors";
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 import type {
@@ -20,7 +19,7 @@ type Props = { systemId: Machine["system_id"] };
 
 const generateOutput = (
   machine: Machine,
-  log: ScriptResultData | null,
+  log: ScriptResultData["combined"] | null,
   result: ScriptResult | null
 ) => {
   if (!result) {
@@ -35,15 +34,15 @@ const generateOutput = (
     case ScriptResultStatus.RUNNING:
       return "Installation has begun!";
     case ScriptResultStatus.PASSED:
-      if (!log?.combined) {
+      if (!log) {
         return "Installation has succeeded but no output was given.";
       }
-      return log?.combined;
+      return log;
     case ScriptResultStatus.FAILED:
-      if (!log?.combined) {
+      if (!log) {
         return "Installation has failed and no output was given.";
       }
-      return log?.combined;
+      return log;
     case ScriptResultStatus.TIMEDOUT:
       return "Installation failed after 40 minutes.";
     case ScriptResultStatus.ABORTED:
@@ -54,51 +53,15 @@ const generateOutput = (
 };
 
 const InstallationOutput = ({ systemId }: Props): JSX.Element => {
-  const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
   const loading = useSelector((state: RootState) =>
     scriptResultSelectors.loading(state)
   );
-  const scriptResults = useSelector((state: RootState) =>
-    scriptResultSelectors.getByMachineId(state, systemId)
-  );
-  const installationLogs = useSelector((state: RootState) =>
-    scriptResultSelectors.getInstallationLogsByMachineId(state, systemId)
-  );
-  const installationResults = useSelector((state: RootState) =>
-    scriptResultSelectors.getInstallationByMachineId(state, systemId)
-  );
+  const installationOutput = useGetInstallationOutput(systemId);
 
-  const [installationResult] = installationResults || [];
-  const [log] = installationLogs || [];
-
-  useEffect(() => {
-    // If the script results for this machine haven't been loaded yet then
-    // request them.
-    if (!scriptResults?.length && !loading) {
-      dispatch(scriptResultActions.getByMachineId(systemId));
-    }
-  }, [dispatch, scriptResults, loading, systemId]);
-
-  useEffect(() => {
-    if (
-      !log &&
-      installationResults &&
-      [ScriptResultStatus.PASSED, ScriptResultStatus.FAILED].includes(
-        installationResult?.status
-      )
-    ) {
-      // We expect there to only be one result, but loop through the results to
-      // be sure.
-      installationResults.forEach((result) => {
-        dispatch(scriptResultActions.getLogs(result.id, "combined"));
-      });
-    }
-  }, [dispatch, installationResult, log, installationResults, scriptResults]);
-
-  if (!machine) {
+  if (!machine || loading) {
     return <Spinner text="Loading..." />;
   }
 
@@ -107,7 +70,11 @@ const InstallationOutput = ({ systemId }: Props): JSX.Element => {
       blocks={[
         {
           appearance: CodeSnippetBlockAppearance.NUMBERED,
-          code: generateOutput(machine, log, installationResult),
+          code: generateOutput(
+            machine,
+            installationOutput.log,
+            installationOutput.result
+          ),
         },
       ]}
     />

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.tsx
@@ -48,11 +48,8 @@ const MachineNetwork = ({ systemId }: Props): JSX.Element => {
             },
           ]}
         />
-        <DownloadMenu />
+        <DownloadMenu systemId={systemId} />
       </div>
-      <Route exact path="/machine/:id/logs/events">
-        <EventLogs systemId={systemId} />
-      </Route>
       <Route exact path="/machine/:id/logs/installation-output">
         <InstallationOutput systemId={systemId} />
       </Route>

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/hooks.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/hooks.test.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+
+import { renderHook } from "@testing-library/react-hooks";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import type { MockStoreEnhanced } from "redux-mock-store";
+
+import { useGetInstallationOutput } from "./hooks";
+
+import type { RootState } from "app/store/root/types";
+import {
+  ScriptResultType,
+  ScriptResultStatus,
+} from "app/store/scriptresult/types";
+import {
+  machineState as machineStateFactory,
+  machineDetails as machineDetailsFactory,
+  rootState as rootStateFactory,
+  scriptResult as scriptResultFactory,
+  scriptResultData as scriptResultDataFactory,
+  scriptResultState as scriptResultStateFactory,
+  nodeScriptResultState as nodeScriptResultStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+const generateWrapper = (store: MockStoreEnhanced<unknown>) => ({
+  children,
+}: {
+  children: ReactNode;
+}) => <Provider store={store}>{children}</Provider>;
+
+describe("machine utils", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1] },
+      }),
+      scriptresult: scriptResultStateFactory({
+        items: [
+          scriptResultFactory({
+            id: 1,
+            result_type: ScriptResultType.INSTALLATION,
+            status: ScriptResultStatus.PASSED,
+          }),
+        ],
+        logs: {
+          1: scriptResultDataFactory({
+            combined: "Installation output",
+          }),
+        },
+      }),
+    });
+  });
+
+  describe("useGetInstallationOutput", () => {
+    it("fetches the logs if they're not already loaded", () => {
+      state.scriptresult.logs = {};
+      const store = mockStore(state);
+      renderHook(() => useGetInstallationOutput("abc123"), {
+        wrapper: generateWrapper(store),
+      });
+      expect(
+        store.getActions().some(({ type }) => type === "scriptresult/getLogs")
+      ).toEqual(true);
+    });
+
+    it("retrieves the installation log", () => {
+      const store = mockStore(state);
+      const { result } = renderHook(() => useGetInstallationOutput("abc123"), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current.log).toBe("Installation output");
+      expect(result.current.result).toStrictEqual(state.scriptresult.items[0]);
+    });
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/hooks.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/hooks.ts
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import { actions as scriptResultActions } from "app/store/scriptresult";
+import scriptResultSelectors from "app/store/scriptresult/selectors";
+import { ScriptResultStatus } from "app/store/scriptresult/types";
+import type {
+  ScriptResult,
+  ScriptResultData,
+} from "app/store/scriptresult/types";
+
+/**
+ * Fetch the installation log for a machine.
+ * @param systemId - The machine id.
+ * @returns The toggle callback.
+ */
+export const useGetInstallationOutput = (
+  systemId: Machine["system_id"]
+): {
+  log: ScriptResultData["combined"] | null;
+  result: ScriptResult | null;
+} => {
+  const dispatch = useDispatch();
+  const loading = useSelector((state: RootState) =>
+    scriptResultSelectors.loading(state)
+  );
+  const scriptResults = useSelector((state: RootState) =>
+    scriptResultSelectors.getByMachineId(state, systemId)
+  );
+  const installationLogs = useSelector((state: RootState) =>
+    scriptResultSelectors.getInstallationLogsByMachineId(state, systemId)
+  );
+  const installationResults = useSelector((state: RootState) =>
+    scriptResultSelectors.getInstallationByMachineId(state, systemId)
+  );
+
+  const [installationResult] = installationResults || [];
+  const [log] = installationLogs || [];
+
+  useEffect(() => {
+    // If the script results for this machine haven't been loaded yet then
+    // request them.
+    if (!scriptResults?.length && !loading) {
+      dispatch(scriptResultActions.getByMachineId(systemId));
+    }
+  }, [dispatch, scriptResults, loading, systemId]);
+
+  useEffect(() => {
+    if (
+      !log &&
+      installationResults &&
+      [ScriptResultStatus.PASSED, ScriptResultStatus.FAILED].includes(
+        installationResult?.status
+      )
+    ) {
+      // We expect there to only be one result, but loop through the results to
+      // be sure.
+      installationResults.forEach((result) => {
+        dispatch(scriptResultActions.getLogs(result.id, "combined"));
+      });
+    }
+  }, [dispatch, installationResult, log, installationResults, scriptResults]);
+
+  return { log: log?.combined || null, result: installationResult || null };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10239,7 +10239,7 @@ js-cookie@2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
-js-file-download@^0.4.12:
+js-file-download@0.4.12:
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
   integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10239,6 +10239,11 @@ js-cookie@2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
+js-file-download@^0.4.12:
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.12.tgz#10c70ef362559a5b23cdbdc3bd6f399c3d91d821"
+  integrity sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## Done

- Add downloading of installation output to the logs tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View a new machine.
- Go to the React logs tab (change /summary in the URL to /logs).
- There should be no "Installation output" in the download selector.
- Go to the React logs tab of a deployed machine.
- There should be an "Installation output" download. Click it and it should download a file containing the log.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2369.