### PR TITLE
feat(ui): paginate the event log

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -440,13 +440,19 @@ exports[`stricter compilation`] = {
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:2578322392": [
-      [72, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [75, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [91, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [94, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [110, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [113, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"]
+    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:989364269": [
+      [78, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [81, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [97, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [100, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [119, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [122, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"]
+    ],
+    "src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx:1273936016": [
+      [147, 46, 14, "Property \'setCurrentPage\' does not exist on type \'HTMLAttributes\'.", "3476818685"],
+      [210, 6, 42, "Cannot invoke an object which is possibly \'undefined\'.", "2514116111"],
+      [210, 49, 8, "Argument of type \'string\' is not assignable to parameter of type \'FormEvent<{}>\'.", "1726186598"],
+      [213, 11, 45, "Object is of type \'unknown\'.", "3327518388"]
     ],
     "src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx:689686888": [
       [80, 11, 42, "Object is of type \'unknown\'.", "3300537276"],

--- a/ui/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
+++ b/ui/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
@@ -16,6 +16,19 @@ describe("ArrowPagination", () => {
     expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
   });
 
+  it("activates both buttons when between the start and end", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={2}
+        itemCount={75}
+        pageSize={25}
+        setCurrentPage={() => null}
+      />
+    );
+    expect(wrapper.find("Button").first().prop("disabled")).toBe(false);
+    expect(wrapper.find("Button").last().prop("disabled")).toBe(false);
+  });
+
   it("disables the back button when on the first page", () => {
     const wrapper = mount(
       <ArrowPagination

--- a/ui/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
+++ b/ui/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
@@ -1,0 +1,42 @@
+import { mount } from "enzyme";
+
+import ArrowPagination from "./ArrowPagination";
+
+describe("ArrowPagination", () => {
+  it("disables both buttons when there are no items", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={1}
+        itemCount={0}
+        pageSize={25}
+        setCurrentPage={() => null}
+      />
+    );
+    expect(wrapper.find("Button").first().prop("disabled")).toBe(true);
+    expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
+  });
+
+  it("disables the back button when on the first page", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={1}
+        itemCount={50}
+        pageSize={25}
+        setCurrentPage={() => null}
+      />
+    );
+    expect(wrapper.find("Button").first().prop("disabled")).toBe(true);
+  });
+
+  it("disables the forward button when on the last page", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={2}
+        itemCount={50}
+        pageSize={25}
+        setCurrentPage={() => null}
+      />
+    );
+    expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
+  });
+});

--- a/ui/src/app/base/components/ArrowPagination/ArrowPagination.tsx
+++ b/ui/src/app/base/components/ArrowPagination/ArrowPagination.tsx
@@ -1,0 +1,48 @@
+import { Button, Icon } from "@canonical/react-components";
+
+type Props = {
+  currentPage: number;
+  itemCount: number;
+  pageSize: number;
+  setCurrentPage: (page: number) => void;
+};
+
+const ArrowPagination = ({
+  currentPage,
+  itemCount,
+  pageSize,
+  setCurrentPage,
+}: Props): JSX.Element => {
+  const onFirstPage = currentPage === 1;
+  const onLastPage =
+    itemCount === 0 || currentPage === Math.ceil(itemCount / pageSize);
+
+  return (
+    <>
+      <Button
+        appearance="base"
+        className="u-no-margin--right u-no-margin--bottom"
+        disabled={onFirstPage}
+        onClick={() => {
+          setCurrentPage(currentPage - 1);
+        }}
+        hasIcon
+      >
+        <Icon className="u-rotate-right" name="chevron-down" />
+      </Button>
+      <Button
+        appearance="base"
+        className="u-no-margin--bottom"
+        disabled={onLastPage}
+        onClick={() => {
+          setCurrentPage(currentPage + 1);
+        }}
+        hasIcon
+      >
+        <Icon className="u-rotate-left" name="chevron-down" />
+      </Button>
+    </>
+  );
+};
+
+export default ArrowPagination;

--- a/ui/src/app/base/components/ArrowPagination/ArrowPagination.tsx
+++ b/ui/src/app/base/components/ArrowPagination/ArrowPagination.tsx
@@ -1,3 +1,5 @@
+import type { HTMLProps } from "react";
+
 import { Button, Icon } from "@canonical/react-components";
 
 type Props = {
@@ -5,22 +7,24 @@ type Props = {
   itemCount: number;
   pageSize: number;
   setCurrentPage: (page: number) => void;
-};
+} & HTMLProps<HTMLElement>;
 
 const ArrowPagination = ({
   currentPage,
   itemCount,
   pageSize,
   setCurrentPage,
+  ...props
 }: Props): JSX.Element => {
   const onFirstPage = currentPage === 1;
   const onLastPage =
     itemCount === 0 || currentPage === Math.ceil(itemCount / pageSize);
 
   return (
-    <>
+    <nav aria-label="pagination" {...props}>
       <Button
         appearance="base"
+        aria-label={onFirstPage ? "" : `Page ${currentPage - 1}`}
         className="u-no-margin--right u-no-margin--bottom"
         disabled={onFirstPage}
         onClick={() => {
@@ -32,6 +36,7 @@ const ArrowPagination = ({
       </Button>
       <Button
         appearance="base"
+        aria-label={onLastPage ? "" : `Page ${currentPage + 1}`}
         className="u-no-margin--bottom"
         disabled={onLastPage}
         onClick={() => {
@@ -41,7 +46,7 @@ const ArrowPagination = ({
       >
         <Icon className="u-rotate-left" name="chevron-down" />
       </Button>
-    </>
+    </nav>
   );
 };
 

--- a/ui/src/app/base/components/ArrowPagination/index.ts
+++ b/ui/src/app/base/components/ArrowPagination/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ArrowPagination";

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -1,5 +1,6 @@
 import { Button, Icon, SearchBox, Spinner } from "@canonical/react-components";
 
+import ArrowPagination from "app/base/components/ArrowPagination";
 import type { Machine } from "app/store/machine/types";
 
 type Props = {
@@ -29,17 +30,15 @@ const VMsActionBar = ({ loading = false, vms }: Props): JSX.Element => {
         <SearchBox className="u-no-margin--bottom" onChange={() => null} />
       </div>
       <div className="vms-action-bar__pagination">
-        <p className="u-no-margin--bottom">
-          <span className="u-text--muted u-nudge-left" data-test="vms-count">
-            {loading ? <Spinner /> : `1 - ${vms.length} of ${vms.length}`}
-          </span>
-          <Button appearance="base" hasIcon small>
-            <Icon className="u-rotate-right" name="chevron-down" />
-          </Button>
-          <Button appearance="base" className="u-no-margin--top" hasIcon small>
-            <Icon className="u-rotate-left" name="chevron-down" />
-          </Button>
-        </p>
+        <span className="u-text--muted u-nudge-left" data-test="vms-count">
+          {loading ? <Spinner /> : `1 - ${vms.length} of ${vms.length}`}
+        </span>
+        <ArrowPagination
+          currentPage={1}
+          itemCount={vms.length}
+          pageSize={25}
+          setCurrentPage={() => null}
+        />
       </div>
     </div>
   );

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -34,6 +34,7 @@ const VMsActionBar = ({ loading = false, vms }: Props): JSX.Element => {
           {loading ? <Spinner /> : `1 - ${vms.length} of ${vms.length}`}
         </span>
         <ArrowPagination
+          className="u-display-inline-block"
           currentPage={1}
           itemCount={vms.length}
           pageSize={25}

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/__snapshots__/VMsActionBar.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/__snapshots__/VMsActionBar.test.tsx.snap
@@ -64,6 +64,7 @@ exports[`VMsActionBar renders 1`] = `
       1 - 1 of 1
     </span>
     <ArrowPagination
+      className="u-display-inline-block"
       currentPage={1}
       itemCount={1}
       pageSize={25}

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/__snapshots__/VMsActionBar.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/__snapshots__/VMsActionBar.test.tsx.snap
@@ -57,37 +57,18 @@ exports[`VMsActionBar renders 1`] = `
   <div
     className="vms-action-bar__pagination"
   >
-    <p
-      className="u-no-margin--bottom"
+    <span
+      className="u-text--muted u-nudge-left"
+      data-test="vms-count"
     >
-      <span
-        className="u-text--muted u-nudge-left"
-        data-test="vms-count"
-      >
-        1 - 1 of 1
-      </span>
-      <Button
-        appearance="base"
-        hasIcon={true}
-        small={true}
-      >
-        <Icon
-          className="u-rotate-right"
-          name="chevron-down"
-        />
-      </Button>
-      <Button
-        appearance="base"
-        className="u-no-margin--top"
-        hasIcon={true}
-        small={true}
-      >
-        <Icon
-          className="u-rotate-left"
-          name="chevron-down"
-        />
-      </Button>
-    </p>
+      1 - 1 of 1
+    </span>
+    <ArrowPagination
+      currentPage={1}
+      itemCount={1}
+      pageSize={25}
+      setCurrentPage={[Function]}
+    />
   </div>
 </div>
 `;

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -7,10 +8,13 @@ import EventLogs from "./EventLogs";
 
 import type { RootState } from "app/store/root/types";
 import {
+  eventRecord as eventRecordFactory,
+  eventState as eventStateFactory,
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -19,8 +23,14 @@ describe("EventLogs", () => {
 
   beforeEach(() => {
     state = rootStateFactory({
+      event: eventStateFactory({
+        items: [
+          eventRecordFactory({ node_id: 1 }),
+          eventRecordFactory({ node_id: 2 }),
+        ],
+      }),
       machine: machineStateFactory({
-        items: [machineDetailsFactory({ system_id: "abc123" })],
+        items: [machineDetailsFactory({ id: 1, system_id: "abc123" })],
       }),
     });
   });
@@ -54,7 +64,16 @@ describe("EventLogs", () => {
     expect(wrapper.find("EventLogsTable").exists()).toBe(true);
   });
 
-  it("fetches the events", () => {
+  it("fetches the events from the last day", () => {
+    // Create more than the preload amount of events.
+    for (let i = 0; i < 203; i++) {
+      state.event.items.push(
+        eventRecordFactory({
+          node_id: 1,
+          created: "Tue, 16 Mar. 2021 03:04:00",
+        })
+      );
+    }
     const store = mockStore(state);
     mount(
       <Provider store={store}>
@@ -65,8 +84,143 @@ describe("EventLogs", () => {
         </MemoryRouter>
       </Provider>
     );
+    const dispatches = store
+      .getActions()
+      .filter(({ type }) => type === "event/fetch");
+    expect(dispatches.length).toBe(1);
+    expect(dispatches[0].payload).toStrictEqual({
+      params: {
+        max_days: 1,
+        node_id: 1,
+      },
+    });
+  });
+
+  it("fetches more events if the first day contains less than the preload amount", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <EventLogs systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    const dispatches = store
+      .getActions()
+      .filter(({ type }) => type === "event/fetch");
+    expect(dispatches.length).toBe(2);
+    expect(dispatches[1].payload).toStrictEqual({
+      params: {
+        limit: 201,
+        node_id: 1,
+      },
+    });
+  });
+
+  it("fetches more events when the last page is reached", () => {
+    // Create more than the preload amount of events.
+    state.event.items = [];
+    for (let i = 0; i < 203; i++) {
+      state.event.items.push(
+        eventRecordFactory({
+          node_id: 1,
+          created: "Tue, 16 Mar. 2021 03:04:00",
+        })
+      );
+    }
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <EventLogs systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    let dispatches = store
+      .getActions()
+      .filter(({ type }) => type === "event/fetch");
+    expect(dispatches.length).toBe(1);
+    act(() => {
+      wrapper.find("ArrowPagination").props().setCurrentPage(9);
+    });
+    dispatches = store
+      .getActions()
+      .filter(({ type }) => type === "event/fetch");
+    expect(dispatches.length).toBe(2);
+    expect(dispatches[1].payload).toStrictEqual({
+      params: {
+        limit: 201,
+        node_id: 1,
+        start: state.event.items[202].id,
+      },
+    });
+  });
+
+  it("orders the rows by most recent first", () => {
+    state.event.items = [
+      eventRecordFactory({ created: "Tue, 16 Mar. 2021 03:04:00", node_id: 1 }),
+      eventRecordFactory({ created: "Tue, 17 Mar. 2021 03:04:00", node_id: 1 }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <EventLogs systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
     expect(
-      store.getActions().some(({ type }) => type === "event/fetch")
-    ).toEqual(true);
+      wrapper
+        .find("td.time-col")
+        .first()
+        .text()
+        .includes("Tue, 17 Mar. 2021 03:04:00")
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("td.time-col")
+        .last()
+        .text()
+        .includes("Tue, 16 Mar. 2021 03:04:00")
+    ).toBe(true);
+  });
+
+  it("can filter the events", async () => {
+    state.event.items = [
+      eventRecordFactory({ description: "Failed commissioning", node_id: 1 }),
+      eventRecordFactory({ description: "Didn't fail", node_id: 1 }),
+      eventRecordFactory({ description: "Failed install", node_id: 1 }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <EventLogs systemId="abc123" />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => {
+      wrapper.find("SearchBox").props().onChange("failed");
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("EventLogsTable").prop("events").length).toBe(2);
+    expect(
+      wrapper
+        .find("td.event-col")
+        .first()
+        .text()
+        .includes("Failed commissioning")
+    ).toBe(true);
+    expect(
+      wrapper.find("td.event-col").last().text().includes("Failed install")
+    ).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
@@ -5,25 +5,119 @@ import { useDispatch, useSelector } from "react-redux";
 
 import EventLogsTable from "./EventLogsTable";
 
+import ArrowPagination from "app/base/components/ArrowPagination";
 import { actions as eventActions } from "app/store/event";
+import eventSelectors from "app/store/event/selectors";
+import type { EventRecord } from "app/store/event/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = { systemId: Machine["system_id"] };
 
+// The amount of events to preload. This is 1 more than would fit on a page so
+// that the next page arrow appears.
+const PRELOAD_COUNT = 201;
+
+const filterEvents = (events: EventRecord[], searchText: string) => {
+  const lowerSearchText = searchText?.toLowerCase();
+  return lowerSearchText
+    ? events.filter(
+        (eventRecord) =>
+          eventRecord.description?.toLowerCase().includes(lowerSearchText) ||
+          eventRecord.type?.description?.toLowerCase().includes(lowerSearchText)
+      )
+    : [...events];
+};
+
+const getPageEvents = (
+  events: EventRecord[],
+  pageSize: number,
+  startIndex: number
+) => {
+  return events
+    .sort(
+      (a: EventRecord, b: EventRecord) =>
+        new Date(b.created).getTime() - new Date(a.created).getTime()
+    )
+    .slice(startIndex, startIndex + pageSize);
+};
+
 const EventLogs = ({ systemId }: Props): JSX.Element => {
   const [searchText, setSearchText] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [requestedDay, setRequestedDay] = useState(false);
+  const [requestedCount, setRequestedCount] = useState(false);
+  const [lastRequested, setLastRequested] = useState<number | null>(null);
   const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
+  const events = useSelector((state: RootState) =>
+    eventSelectors.getByNodeId(state, machine?.id)
+  );
+  const loading = useSelector(eventSelectors.loading);
+  const unpaginatedEvents = filterEvents(events, searchText);
+  const pageSize = 25;
+  const startIndex = (currentPage - 1) * pageSize;
+  if (startIndex > unpaginatedEvents.length) {
+    // If the rows have changed e.g. when filtering and the user is on a page
+    // that no longer exists then send them to the start.
+    setCurrentPage(1);
+  }
+  const paginatedEvents = getPageEvents(
+    unpaginatedEvents,
+    pageSize,
+    startIndex
+  );
 
   useEffect(() => {
-    if (machine) {
-      dispatch(eventActions.fetch(machine.id, 50));
+    // If the events haven't been requested yet then get all the events for the
+    // last day.
+    if (machine && !requestedDay) {
+      dispatch(eventActions.fetch(machine.id, null, null, 1));
+      setRequestedDay(true);
     }
-  }, [dispatch, systemId, machine]);
+  }, [dispatch, machine, requestedDay, setRequestedDay]);
+
+  useEffect(() => {
+    // If the events have been requested but less than the preload amount were
+    // returned then request the preload number of events.
+    if (
+      machine &&
+      requestedDay &&
+      !requestedCount &&
+      events.length < PRELOAD_COUNT
+    ) {
+      dispatch(eventActions.fetch(machine.id, PRELOAD_COUNT));
+      setRequestedCount(true);
+    }
+  }, [
+    dispatch,
+    events,
+    machine,
+    requestedCount,
+    requestedDay,
+    setRequestedCount,
+    setRequestedDay,
+  ]);
+
+  useEffect(() => {
+    const onLastPage =
+      events.length === 0 ||
+      currentPage === Math.ceil(events.length / pageSize);
+    const lastItem = events?.[events.length - 1];
+    const alreadyRequested = events.length && lastRequested === lastItem.id;
+    // There's no need to fetch more events if the initial preload hasn't
+    // happend or if it returned less events than requested.
+    const initialEventsLoaded = events.length >= PRELOAD_COUNT;
+
+    // Once the last page is reached then fetch more events.
+    if (machine && initialEventsLoaded && onLastPage && !alreadyRequested) {
+      dispatch(eventActions.fetch(machine.id, PRELOAD_COUNT, lastItem.id));
+      setLastRequested(lastItem.id);
+    }
+  }, [dispatch, machine, currentPage, events, lastRequested, setLastRequested]);
 
   if (!machine) {
     return <Spinner text="Loading..." />;
@@ -39,10 +133,18 @@ const EventLogs = ({ systemId }: Props): JSX.Element => {
             value={searchText}
           />
         </Col>
-        <Col size="6"></Col>
+        <Col className="u-align--right" size="6">
+          <ArrowPagination
+            currentPage={currentPage}
+            itemCount={unpaginatedEvents.length}
+            pageSize={pageSize}
+            setCurrentPage={setCurrentPage}
+          />
+        </Col>
       </Row>
       <hr />
-      <EventLogsTable searchText={searchText} systemId={systemId} />
+      <EventLogsTable events={paginatedEvents} systemId={systemId} />
+      {loading && <Spinner text="Loading..." />}
     </>
   );
 };

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.test.tsx
@@ -41,7 +41,7 @@ describe("EventLogsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <EventLogsTable searchText="" systemId="abc123" />
+          <EventLogsTable events={state.event.items} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
@@ -55,70 +55,10 @@ describe("EventLogsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
         >
-          <EventLogsTable searchText="" systemId="abc123" />
+          <EventLogsTable events={state.event.items} systemId="abc123" />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("EventLogsTable").exists()).toBe(true);
-  });
-
-  it("orders the rows by most recent first", () => {
-    state.event.items = [
-      eventRecordFactory({ created: "Tue, 16 Mar. 2021 03:04:00", node_id: 1 }),
-      eventRecordFactory({ created: "Tue, 17 Mar. 2021 03:04:00", node_id: 1 }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <EventLogsTable searchText="" systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(
-      wrapper
-        .find("td.time-col")
-        .first()
-        .text()
-        .includes("Tue, 17 Mar. 2021 03:04:00")
-    ).toBe(true);
-    expect(
-      wrapper
-        .find("td.time-col")
-        .last()
-        .text()
-        .includes("Tue, 16 Mar. 2021 03:04:00")
-    ).toBe(true);
-  });
-
-  it("can filter the events", () => {
-    state.event.items = [
-      eventRecordFactory({ description: "Failed commissioning", node_id: 1 }),
-      eventRecordFactory({ description: "Didn't fail", node_id: 1 }),
-      eventRecordFactory({ description: "Failed install", node_id: 1 }),
-    ];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <EventLogsTable searchText="failed" systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("td.event-col").length).toBe(2);
-    expect(
-      wrapper
-        .find("td.event-col")
-        .first()
-        .text()
-        .includes("Failed commissioning")
-    ).toBe(true);
-    expect(
-      wrapper.find("td.event-col").last().text().includes("Failed install")
-    ).toBe(true);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable/EventLogsTable.tsx
@@ -3,14 +3,13 @@ import type { ReactNode } from "react";
 import { Icon, MainTable, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import eventSelectors from "app/store/event/selectors";
 import type { EventRecord } from "app/store/event/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
-  searchText: string | null;
+  events: EventRecord[];
   systemId: Machine["system_id"];
 };
 
@@ -55,30 +54,14 @@ const generateRow = (event: EventRecord): EventRow => {
   };
 };
 
-const EventLogsTable = ({ searchText, systemId }: Props): JSX.Element => {
+const EventLogsTable = ({ events, systemId }: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
-  const events = useSelector((state: RootState) =>
-    eventSelectors.getByNodeId(state, machine?.id)
-  );
-  if (!machine || !events) {
+  if (!machine) {
     return <Spinner text="Loading..." />;
   }
-  const lowerSearchText = searchText?.toLowerCase();
-  const filteredEvents = lowerSearchText
-    ? events.filter(
-        (eventRecord) =>
-          eventRecord.description?.toLowerCase().includes(lowerSearchText) ||
-          eventRecord.type?.description?.toLowerCase().includes(lowerSearchText)
-      )
-    : [...events];
-  const rows = filteredEvents
-    .sort(
-      (a: EventRecord, b: EventRecord) =>
-        new Date(b.created).getTime() - new Date(a.created).getTime()
-    )
-    .map((event) => generateRow(event));
+  const rows = events?.map((event) => generateRow(event));
 
   return (
     <MainTable

--- a/ui/src/app/store/event/slice.ts
+++ b/ui/src/app/store/event/slice.ts
@@ -44,7 +44,13 @@ const eventSlice = generateSlice<
           nocache: true,
         },
         payload: {
-          params: { limit, max_days: maxDays, node_id, start },
+          params: {
+            node_id,
+            // Only send the params that are provided.
+            ...(limit || limit === 0 ? { limit } : {}),
+            ...(maxDays || maxDays === 0 ? { max_days: maxDays } : {}),
+            ...(start || start === 0 ? { start } : {}),
+          },
         },
       }),
       reducer: () => {


### PR DESCRIPTION
## Done

- Paginate the event log and fetch additional events.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the React logs tab for a machine (change /summary to /logs).
- You should see < > arrows to the right of the search box.
- Use those to navigate forward and back through the events.
- As you navigate forward it'll load more events if they exist.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2372.