### PR TITLE
build(all): don't install Cypress when building

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "betterer": "yarn --cwd ui betterer",
     "build": "yarn build-shared",
     "cleanbuild": "yarn clean-all && yarn build-all",
-    "build-all": "yarn build-shared && yarn build-legacy && yarn build-ui && yarn build-root && yarn copy-build",
+    "build-all": "CYPRESS_INSTALL_BINARY=0 yarn build-shared && yarn build-legacy && yarn build-ui && yarn build-root && yarn copy-build",
     "build-shared": "cd shared && yarn install && yarn build",
     "build-legacy": "cd legacy && yarn install && yarn build",
     "build-root": "cd root && yarn install && yarn build",


### PR DESCRIPTION
## Done

- Make it so that Cypress doesn't install when building the app.

## QA

N/A build should pass in CI.

## Fixes

Fixes: #2430.