### PR TITLE
feat(ui): page size selector

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -448,11 +448,14 @@ exports[`stricter compilation`] = {
       [119, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
       [122, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx:1273936016": [
-      [147, 46, 14, "Property \'setCurrentPage\' does not exist on type \'HTMLAttributes\'.", "3476818685"],
-      [210, 6, 42, "Cannot invoke an object which is possibly \'undefined\'.", "2514116111"],
-      [210, 49, 8, "Argument of type \'string\' is not assignable to parameter of type \'FormEvent<{}>\'.", "1726186598"],
-      [213, 11, 45, "Object is of type \'unknown\'.", "3327518388"]
+    "src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx:3259621198": [
+      [151, 46, 14, "Property \'setCurrentPage\' does not exist on type \'HTMLAttributes\'.", "3476818685"],
+      [214, 6, 42, "Cannot invoke an object which is possibly \'undefined\'.", "2514116111"],
+      [214, 49, 8, "Argument of type \'string\' is not assignable to parameter of type \'FormEvent<{}>\'.", "1726186598"],
+      [217, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
+      [249, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
+      [257, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
+      [296, 11, 45, "Object is of type \'unknown\'.", "3327518388"]
     ],
     "src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx:689686888": [
       [80, 11, 42, "Object is of type \'unknown\'.", "3300537276"],

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
 
-import { Col, Row, SearchBox, Spinner } from "@canonical/react-components";
+import {
+  Col,
+  Row,
+  SearchBox,
+  Select,
+  Spinner,
+} from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { useStorageState } from "react-storage-hooks";
 
 import EventLogsTable from "./EventLogsTable";
 
@@ -57,8 +64,12 @@ const EventLogs = ({ systemId }: Props): JSX.Element => {
     eventSelectors.getByNodeId(state, machine?.id)
   );
   const loading = useSelector(eventSelectors.loading);
+  const [pageSize, setPageSize] = useStorageState(
+    localStorage,
+    "eventLogPageSize",
+    25
+  );
   const unpaginatedEvents = filterEvents(events, searchText);
-  const pageSize = 25;
   const startIndex = (currentPage - 1) * pageSize;
   if (startIndex > unpaginatedEvents.length) {
     // If the rows have changed e.g. when filtering and the user is on a page
@@ -117,7 +128,15 @@ const EventLogs = ({ systemId }: Props): JSX.Element => {
       dispatch(eventActions.fetch(machine.id, PRELOAD_COUNT, lastItem.id));
       setLastRequested(lastItem.id);
     }
-  }, [dispatch, machine, currentPage, events, lastRequested, setLastRequested]);
+  }, [
+    dispatch,
+    machine,
+    currentPage,
+    events,
+    lastRequested,
+    pageSize,
+    setLastRequested,
+  ]);
 
   if (!machine) {
     return <Spinner text="Loading..." />;
@@ -134,7 +153,36 @@ const EventLogs = ({ systemId }: Props): JSX.Element => {
           />
         </Col>
         <Col className="u-align--right" size="6">
+          Show
+          <Select
+            className="u-auto-width"
+            defaultValue={pageSize.toString()}
+            name="page-size"
+            onChange={(evt: React.ChangeEvent<HTMLSelectElement>) => {
+              setPageSize(Number(evt.target.value));
+            }}
+            options={[
+              {
+                value: "25",
+                label: "25",
+              },
+              {
+                value: "50",
+                label: "50",
+              },
+              {
+                value: "100",
+                label: "100",
+              },
+              {
+                value: "200",
+                label: "200",
+              },
+            ]}
+            wrapperClassName="u-display-inline-block u-nudge-right"
+          />
           <ArrowPagination
+            className="u-display-inline-block u-nudge-right"
             currentPage={currentPage}
             itemCount={unpaginatedEvents.length}
             pageSize={pageSize}

--- a/ui/src/scss/_patterns_forms.scss
+++ b/ui/src/scss/_patterns_forms.scss
@@ -29,6 +29,10 @@
     }
   }
 
+  select.u-auto-width {
+    min-width: auto;
+  }
+
   .p-checkbox--mixed:checked {
     + label::after {
       border-left: 0;


### PR DESCRIPTION
## Done

- Add a page size selector and persist the size to local storage

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the react logs page for a machine.
- There should be a "Show" selector next to the pagination buttons.
- Change the selector and the number of events should change.
- Refresh your window and the number should be restored.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2373.