### PR TITLE
feat(ui): add storage section to project resources card

### DIFF
--- a/ui/src/app/kvm/components/PodMeter/PodMeter.test.tsx
+++ b/ui/src/app/kvm/components/PodMeter/PodMeter.test.tsx
@@ -8,4 +8,10 @@ describe("PodMeter", () => {
 
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("can invert the position of the text", () => {
+    const wrapper = shallow(<PodMeter allocated={0} free={0} inverted />);
+
+    expect(wrapper.find(".pod-meter--inverted").exists()).toBe(true);
+  });
 });

--- a/ui/src/app/kvm/components/PodMeter/PodMeter.tsx
+++ b/ui/src/app/kvm/components/PodMeter/PodMeter.tsx
@@ -1,22 +1,32 @@
+import classNames from "classnames";
+
 import Meter from "app/base/components/Meter";
 
 type Props = {
   allocated: number;
+  className?: string;
   free: number;
+  inverted?: boolean;
   segmented?: boolean;
   unit?: string;
 };
 
 const PodMeter = ({
   allocated,
+  className,
   free,
+  inverted = false,
   segmented = false,
   unit = "",
 }: Props): JSX.Element | null => {
-  const total = allocated + free;
+  const total = Number((allocated + free).toPrecision(4));
 
   return (
-    <div className="pod-meter">
+    <div
+      className={classNames(className, "pod-meter", {
+        "pod-meter--inverted": inverted,
+      })}
+    >
       <div>
         <p className="p-heading--small u-text--light">Total</p>
         <div data-test="total">{`${total}${unit}`}</div>

--- a/ui/src/app/kvm/components/PodMeter/_index.scss
+++ b/ui/src/app/kvm/components/PodMeter/_index.scss
@@ -8,4 +8,16 @@
     grid-template-columns: 1fr max-content 1fr;
     grid-template-rows: min-content;
   }
+
+  .pod-meter--inverted {
+    grid-template-areas:
+      "meter meter meter"
+      "total allocated free";
+
+    .p-meter,
+    .p-meter--small,
+    .p-meter__bar {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
+++ b/ui/src/app/kvm/components/PodStorage/PodStorage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Button, Card, Spinner } from "@canonical/react-components";
+import { Button, Card } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 
@@ -16,113 +16,98 @@ export const TRUNCATION_POINT = 3;
 type Props = { id: Pod["id"] };
 
 const PodStorage = ({ id }: Props): JSX.Element | null => {
-  const pod = useSelector((state: RootState) =>
-    podSelectors.getById(state, Number(id))
+  const sortedPools = useSelector((state: RootState) =>
+    podSelectors.getSortedPools(state, Number(id))
   );
   const [expanded, setExpanded] = useState(false);
   const sendAnalytics = useSendAnalytics();
 
-  if (!!pod) {
-    const pools = pod.storage_pools || [];
-    const sortedPools = [...pools].sort((a, b) => {
-      if (a.id === pod.default_storage_pool || b.id > a.id) {
-        return -1;
-      }
-      if (b.id === pod.default_storage_pool || a.id > b.id) {
-        return 1;
-      }
-      return 0;
-    });
-    const canBeTruncated = sortedPools.length > TRUNCATION_POINT;
-    const shownPools =
-      canBeTruncated && !expanded
-        ? sortedPools.slice(0, TRUNCATION_POINT)
-        : sortedPools;
+  const canBeTruncated = sortedPools.length > TRUNCATION_POINT;
+  const shownPools =
+    canBeTruncated && !expanded
+      ? sortedPools.slice(0, TRUNCATION_POINT)
+      : sortedPools;
 
-    return (
-      <>
-        <h4 className="u-sv1">
-          Storage&nbsp;
-          <span className="p-text--paragraph u-text--light">
-            (Sorted by id, default first)
-          </span>
-        </h4>
-        <div className="pod-storage-grid">
-          {shownPools.map((pool) => {
-            const total = formatBytes(pool.total, "B");
-            const allocated = formatBytes(pool.used, "B", {
-              convertTo: total.unit,
-            });
-            const free = formatBytes(pool.total - pool.used, "B", {
-              convertTo: total.unit,
-            });
+  return (
+    <>
+      <h4 className="u-sv1">
+        Storage&nbsp;
+        <span className="p-text--paragraph u-text--light">
+          (Sorted by id, default first)
+        </span>
+      </h4>
+      <div className="pod-storage-grid">
+        {shownPools.map((pool) => {
+          const total = formatBytes(pool.total, "B");
+          const allocated = formatBytes(pool.used, "B", {
+            convertTo: total.unit,
+          });
+          const free = formatBytes(pool.total - pool.used, "B", {
+            convertTo: total.unit,
+          });
 
-            return (
-              <Card className="u-no-padding--bottom" key={pool.id}>
-                <h5>
-                  <span data-test="pool-name">{pool.name}</span>
-                  <br />
-                  <span className="p-text--paragraph u-text--light">
-                    {pool.path}
-                  </span>
-                </h5>
-                <hr />
-                <div className="pod-storage-meter-grid">
-                  <div>
-                    <p className="p-heading--small u-text--light">Type</p>
-                    <div>{pool.type}</div>
-                  </div>
-                  <PodMeter
-                    allocated={allocated.value}
-                    free={free.value}
-                    unit={total.unit}
-                  />
+          return (
+            <Card className="u-no-padding--bottom" key={pool.id}>
+              <h5>
+                <span data-test="pool-name">{pool.name}</span>
+                <br />
+                <span className="p-text--paragraph u-text--light">
+                  {pool.path}
+                </span>
+              </h5>
+              <hr />
+              <div className="pod-storage-meter-grid">
+                <div>
+                  <p className="p-heading--small u-text--light">Type</p>
+                  <div>{pool.type}</div>
                 </div>
-              </Card>
-            );
-          })}
+                <PodMeter
+                  allocated={allocated.value}
+                  free={free.value}
+                  unit={total.unit}
+                />
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+      {canBeTruncated && (
+        <div className="u-align--center">
+          <Button
+            appearance="base"
+            data-test="show-more-pools"
+            hasIcon
+            onClick={() => {
+              setExpanded(!expanded);
+              sendAnalytics(
+                "KVM details",
+                "Toggle expanded storage pools",
+                expanded ? "Show less storage pools" : "Show more storage pools"
+              );
+            }}
+          >
+            {expanded ? (
+              <>
+                <span>Show less storage pools</span>
+                <i className="p-icon--contextual-menu u-mirror--y"></i>
+              </>
+            ) : (
+              <>
+                <span>
+                  {pluralize(
+                    "more storage pool",
+                    sortedPools.length - TRUNCATION_POINT,
+                    true
+                  )}
+                </span>
+                <i className="p-icon--contextual-menu"></i>
+              </>
+            )}
+          </Button>
         </div>
-        {canBeTruncated && (
-          <div className="u-align--center">
-            <Button
-              appearance="base"
-              data-test="show-more-pools"
-              hasIcon
-              onClick={() => {
-                setExpanded(!expanded);
-                sendAnalytics(
-                  "KVM details",
-                  "Toggle expanded storage pools",
-                  expanded
-                    ? "Show less storage pools"
-                    : "Show more storage pools"
-                );
-              }}
-            >
-              {expanded ? (
-                <>
-                  <span>Show less storage pools</span>
-                  <i className="p-icon--contextual-menu u-mirror--y"></i>
-                </>
-              ) : (
-                <>
-                  <span>
-                    {pluralize(
-                      "more storage pool",
-                      sortedPools.length - TRUNCATION_POINT,
-                      true
-                    )}
-                  </span>
-                  <i className="p-icon--contextual-menu"></i>
-                </>
-              )}
-            </Button>
-          </div>
-        )}
-      </>
-    );
-  }
-  return <Spinner text="Loading" />;
+      )}
+    </>
+  );
 };
 
 export default PodStorage;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/ProjectResourcesCard.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/ProjectResourcesCard.tsx
@@ -32,7 +32,7 @@ const ProjectResourcesCard = ({ id }: Props): JSX.Element => {
           hugepages={formatPodResource(memory.hugepages)}
         />
         <CoreResources cores={formatPodResource(cores)} dynamicLayout />
-        <StorageResources />
+        <StorageResources id={pod.id} />
       </div>
     );
   }

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard/_index.scss
@@ -33,7 +33,7 @@
     }
 
     @media only screen and (min-width: $breakpoint-large) {
-      grid-template-areas: "ram ram ram ram ram cor cor cor sto sto sto sto";
+      grid-template-areas: "ram ram ram ram cor cor cor sto sto sto sto sto";
       grid-template-columns: repeat(12, minmax(0, 1fr));
 
       .core-resources,

--- a/ui/src/app/kvm/views/KVMDetails/RamResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/RamResources/_index.scss
@@ -5,6 +5,7 @@
   .ram-resources {
     display: flex;
     flex-direction: column;
+    overflow: auto;
     padding: $spv-inner--medium $sph-inner;
 
     .ram-resources__chart-container {

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.test.tsx
@@ -1,0 +1,44 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import StorageResources from "./StorageResources";
+
+import {
+  pod as podFactory,
+  podHint as podHintFactory,
+  podState as podStateFactory,
+  podStoragePool as storagePoolFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("StorageResources", () => {
+  it("renders", () => {
+    const storagePools = [
+      storagePoolFactory({ id: "a", total: 3, used: 1 }),
+      storagePoolFactory({ id: "b", total: 5, used: 3 }),
+    ];
+    const pod = podFactory({
+      default_storage_pool: storagePools[0].id,
+      id: 1,
+      storage_pools: storagePools,
+      total: podHintFactory({ local_storage: 8 }),
+      used: podHintFactory({ local_storage: 4 }),
+    });
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [pod],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <StorageResources id={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find("StorageResources")).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
@@ -1,9 +1,77 @@
-// TODO: Build storage section
-// https://github.com/canonical-web-and-design/maas-ui/issues/2240
-const StorageResources = (): JSX.Element => {
+import { useSelector } from "react-redux";
+
+import PodMeter from "app/kvm/components/PodMeter";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+import { formatBytes } from "app/utils";
+
+export const TRUNCATION_POINT = 3;
+
+type Props = { id: Pod["id"] };
+
+const StorageResources = ({ id }: Props): JSX.Element | null => {
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, id)
+  );
+  const sortedPools = useSelector((state: RootState) =>
+    podSelectors.getSortedPools(state, id)
+  );
+
+  if (!pod) {
+    return null;
+  }
+
+  const total = formatBytes(pod.total.local_storage, "B");
+  const free = formatBytes(
+    pod.total.local_storage - pod.used.local_storage,
+    "B"
+  );
   return (
     <div className="storage-resources">
-      <h4 className="p-heading--small u-sv1">Storage</h4>
+      <div className="storage-resources__stats">
+        <h4 className="p-heading--small u-sv1">Storage</h4>
+        <div className="storage-resources__usage">
+          <div className="u-nudge-left">
+            <div className="p-heading--small u-text--muted">Total</div>
+            <div className="u-nudge-right u-sv1">
+              {total.value}
+              {total.unit}
+            </div>
+          </div>
+          <div className="u-nudge-left">
+            <div className="p-heading--small u-text--muted">Free</div>
+            <div className="u-nudge-right u-sv1">
+              {free.value}
+              {free.unit}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="storage-resources__pools-container">
+        {sortedPools.map((pool) => {
+          const total = formatBytes(pool.total, "B");
+          const allocated = formatBytes(pool.used, "B", {
+            convertTo: total.unit,
+          });
+          const free = formatBytes(pool.total - pool.used, "B", {
+            convertTo: total.unit,
+          });
+
+          return (
+            <div className="storage-resources__pool" key={pool.id}>
+              <div className="storage-resources__pool-name">Default pool</div>
+              <PodMeter
+                allocated={allocated.value}
+                className="storage-resources__pool-meter"
+                free={free.value}
+                inverted
+                unit={total.unit}
+              />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/__snapshots__/StorageResources.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/__snapshots__/StorageResources.test.tsx.snap
@@ -1,0 +1,307 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StorageResources renders 1`] = `
+<StorageResources
+  id={1}
+>
+  <div
+    className="storage-resources"
+  >
+    <div
+      className="storage-resources__stats"
+    >
+      <h4
+        className="p-heading--small u-sv1"
+      >
+        Storage
+      </h4>
+      <div
+        className="storage-resources__usage"
+      >
+        <div
+          className="u-nudge-left"
+        >
+          <div
+            className="p-heading--small u-text--muted"
+          >
+            Total
+          </div>
+          <div
+            className="u-nudge-right u-sv1"
+          >
+            8
+            B
+          </div>
+        </div>
+        <div
+          className="u-nudge-left"
+        >
+          <div
+            className="p-heading--small u-text--muted"
+          >
+            Free
+          </div>
+          <div
+            className="u-nudge-right u-sv1"
+          >
+            4
+            B
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="storage-resources__pools-container"
+    >
+      <div
+        className="storage-resources__pool"
+        key="a"
+      >
+        <div
+          className="storage-resources__pool-name"
+        >
+          Default pool
+        </div>
+        <PodMeter
+          allocated={1}
+          className="storage-resources__pool-meter"
+          free={2}
+          inverted={true}
+          unit="B"
+        >
+          <div
+            className="storage-resources__pool-meter pod-meter pod-meter--inverted"
+          >
+            <div>
+              <p
+                className="p-heading--small u-text--light"
+              >
+                Total
+              </p>
+              <div
+                data-test="total"
+              >
+                3B
+              </div>
+            </div>
+            <div
+              className="u-align--right"
+            >
+              <p
+                className="p-heading--small u-text--light"
+              >
+                Allocated
+                <span
+                  className="u-nudge-right--small"
+                >
+                  <i
+                    className="p-circle--link u-no-margin--top"
+                  />
+                </span>
+              </p>
+              <div
+                className="u-nudge-left"
+                data-test="allocated"
+              >
+                1B
+              </div>
+            </div>
+            <div
+              className="u-align--right"
+            >
+              <p
+                className="p-heading--small u-text--light"
+              >
+                Free
+                <span
+                  className="u-nudge-right--small"
+                >
+                  <i
+                    className="p-circle--link-faded u-no-margin--top"
+                  />
+                </span>
+              </p>
+              <div
+                className="u-nudge-left"
+                data-test="free"
+              >
+                2B
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "gridArea": "meter",
+                }
+              }
+            >
+              <Meter
+                data={
+                  Array [
+                    Object {
+                      "value": 1,
+                    },
+                  ]
+                }
+                max={3}
+                segmented={false}
+                small={true}
+              >
+                <div
+                  className="p-meter--small"
+                >
+                  <div
+                    className="p-meter__bar"
+                    style={
+                      Object {
+                        "backgroundColor": "#D3E4ED",
+                      }
+                    }
+                  >
+                    <div
+                      className="p-meter__filled"
+                      key="meter-0"
+                      style={
+                        Object {
+                          "backgroundColor": "#0066CC",
+                          "borderRight": undefined,
+                          "left": "0%",
+                          "width": "33.33333333333333%",
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+              </Meter>
+            </div>
+          </div>
+        </PodMeter>
+      </div>
+      <div
+        className="storage-resources__pool"
+        key="b"
+      >
+        <div
+          className="storage-resources__pool-name"
+        >
+          Default pool
+        </div>
+        <PodMeter
+          allocated={3}
+          className="storage-resources__pool-meter"
+          free={2}
+          inverted={true}
+          unit="B"
+        >
+          <div
+            className="storage-resources__pool-meter pod-meter pod-meter--inverted"
+          >
+            <div>
+              <p
+                className="p-heading--small u-text--light"
+              >
+                Total
+              </p>
+              <div
+                data-test="total"
+              >
+                5B
+              </div>
+            </div>
+            <div
+              className="u-align--right"
+            >
+              <p
+                className="p-heading--small u-text--light"
+              >
+                Allocated
+                <span
+                  className="u-nudge-right--small"
+                >
+                  <i
+                    className="p-circle--link u-no-margin--top"
+                  />
+                </span>
+              </p>
+              <div
+                className="u-nudge-left"
+                data-test="allocated"
+              >
+                3B
+              </div>
+            </div>
+            <div
+              className="u-align--right"
+            >
+              <p
+                className="p-heading--small u-text--light"
+              >
+                Free
+                <span
+                  className="u-nudge-right--small"
+                >
+                  <i
+                    className="p-circle--link-faded u-no-margin--top"
+                  />
+                </span>
+              </p>
+              <div
+                className="u-nudge-left"
+                data-test="free"
+              >
+                2B
+              </div>
+            </div>
+            <div
+              style={
+                Object {
+                  "gridArea": "meter",
+                }
+              }
+            >
+              <Meter
+                data={
+                  Array [
+                    Object {
+                      "value": 3,
+                    },
+                  ]
+                }
+                max={5}
+                segmented={false}
+                small={true}
+              >
+                <div
+                  className="p-meter--small"
+                >
+                  <div
+                    className="p-meter__bar"
+                    style={
+                      Object {
+                        "backgroundColor": "#D3E4ED",
+                      }
+                    }
+                  >
+                    <div
+                      className="p-meter__filled"
+                      key="meter-0"
+                      style={
+                        Object {
+                          "backgroundColor": "#0066CC",
+                          "borderRight": undefined,
+                          "left": "0%",
+                          "width": "60%",
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+              </Meter>
+            </div>
+          </div>
+        </PodMeter>
+      </div>
+    </div>
+  </div>
+</StorageResources>
+`;

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/_index.scss
@@ -1,5 +1,81 @@
 @mixin StorageResources {
   .storage-resources {
+    display: grid;
+    grid-template-areas:
+      "stats"
+      "pools";
+    grid-template-columns: 100%;
+    grid-template-rows: min-content;
+  }
+
+  .storage-resources__stats {
+    grid-area: stats;
     padding: $spv-inner--medium $sph-inner;
+  }
+
+  .storage-resources__usage {
+    border-bottom: $border;
+    display: flex;
+    flex-direction: row;
+  }
+
+  .storage-resources__pools-container {
+    grid-area: pools;
+    overflow: auto;
+    padding: 0 $sph-inner $spv-inner--medium $sph-inner;
+  }
+
+  .storage-resources__pool {
+    display: flex;
+    flex-direction: column;
+    padding-top: $spv-inner--x-small;
+
+    &:not(:last-of-type) {
+      border-bottom: $border;
+      padding-bottom: $spv-inner--x-small;
+    }
+  }
+
+  .storage-resources__pool-name {
+    flex: 1 0;
+    margin-right: $sph-inner--large;
+  }
+
+  .storage-resources__pool-meter {
+    flex: 3;
+  }
+
+  @media only screen and (min-width: $breakpoint-medium) {
+    .storage-resources__pool {
+      flex-direction: row;
+    }
+  }
+
+  @media only screen and (min-width: $breakpoint-large) {
+    .storage-resources {
+      grid-template-areas: "stats pools";
+      grid-template-columns: min-content 3fr;
+      grid-template-rows: min-content;
+    }
+
+    .storage-resources__stats {
+      padding: $spv-inner--medium 0 $spv-inner--medium $sph-inner;
+    }
+
+    .storage-resources__usage {
+      border-bottom: 0;
+      border-right: $border;
+      flex-direction: column;
+    }
+
+    .storage-resources__pools-container {
+      height: $sp-unit * 21;
+      overflow: auto;
+    }
+
+    .storage-resources__pool {
+      position: relative;
+      top: $sp-unit * 3;
+    }
   }
 }

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -10,6 +10,7 @@ import {
   podProject as podProjectFactory,
   podResources as podResourcesFactory,
   podState as podStateFactory,
+  podStoragePool as storagePoolFactory,
   podVM as podVMFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -320,5 +321,24 @@ describe("pod selectors", () => {
       }),
     });
     expect(pod.getVmResource(state, 1, "abc123")).toEqual(thisVmResource);
+  });
+
+  it("can get a pod's storage pools, sorted by default first then id", () => {
+    const defaultPool = storagePoolFactory({ id: "c" });
+    const aPool = storagePoolFactory({ id: "a" });
+    const bPool = storagePoolFactory({ id: "b" });
+
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            default_storage_pool: defaultPool.id,
+            id: 1,
+            storage_pools: [bPool, aPool, defaultPool],
+          }),
+        ],
+      }),
+    });
+    expect(pod.getSortedPools(state, 1)).toEqual([defaultPool, aPool, bPool]);
   });
 });

--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -207,11 +207,24 @@ const getByLxdServer = createSelector(
   }
 );
 
+/**
+ * Returns projects in a given LXD server.
+ * @param state - The redux state.
+ * @param address - The address of the LXD server.
+ * @returns A list of LXD projects in the server.
+ */
 const getProjectsByLxdServer = createSelector(
   [projects, (_: RootState, address: LxdServerGroup["address"]) => address],
   (projects, address) => projects[address] || []
 );
 
+/**
+ * Returns a VM's resource details, given its system_id.
+ * @param state - The redux state.
+ * @param podId - The id of the pod.
+ * @param machineId - The system_id of the machine in the pod.
+ * @returns The VM's resource details.
+ */
 const getVmResource = createSelector(
   [
     (state: RootState, podId: Pod["id"], machineId: Machine["system_id"]) => ({
@@ -227,6 +240,34 @@ const getVmResource = createSelector(
   }
 );
 
+/**
+ * Returns a pod's storage pools, sorted by default first then id.
+ * @param state - The redux state.
+ * @param podId - The id of the pod.
+ * @returns A list of the pod's storage pools, sorted by default first then id.
+ */
+const getSortedPools = createSelector(
+  [
+    (state: RootState, podId: Pod["id"]) =>
+      defaultSelectors.getById(state, podId),
+  ],
+  (pod) => {
+    if (!pod) {
+      return [];
+    }
+    const pools = pod.storage_pools || [];
+    return pools.sort((a, b) => {
+      if (a.id === pod.default_storage_pool || b.id > a.id) {
+        return -1;
+      }
+      if (b.id === pod.default_storage_pool || a.id > b.id) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+);
+
 const selectors = {
   ...defaultSelectors,
   active,
@@ -235,6 +276,7 @@ const selectors = {
   deleting,
   getAllHosts,
   getHost,
+  getSortedPools,
   getVMs,
   getByLxdServer,
   getProjectsByLxdServer,


### PR DESCRIPTION
## Done

- Built the initial version of the project storage section. Follow ups will include #2415 and #2432
- Added a selector to get a pod's storage pools sorted by default then id

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the project tab of a LXD KVM
- Check that the storage section of the card matches the [design](https://github.com/canonical-web-and-design/maas-ui/issues/2240) for 1-4 storage pools

## Fixes

Fixes #2240 

## Screenshot

![Screenshot_2021-03-25 LXD project default bolla MAAS](https://user-images.githubusercontent.com/25733845/112408204-1fd0fa00-8d63-11eb-939e-069b6f18e601.png)
