### PR TITLE
fix(ui): correctly type machine parameters

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/IPColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/IPColumn/IPColumn.tsx
@@ -20,15 +20,16 @@ const IPColumn = ({ systemId, version }: Props): JSX.Element => {
     return <Spinner />;
   }
 
-  const ips = machine.ip_addresses.reduce<string[]>((ips, { ip }) => {
-    if (
-      (version === 4 && IPV4_REGEX.test(ip)) ||
-      (version === 6 && !IPV4_REGEX.test(ip))
-    ) {
-      ips.push(ip);
-    }
-    return ips;
-  }, []);
+  const ips =
+    machine.ip_addresses?.reduce<string[]>((ips, { ip }) => {
+      if (
+        (version === 4 && IPV4_REGEX.test(ip)) ||
+        (version === 6 && !IPV4_REGEX.test(ip))
+      ) {
+        ips.push(ip);
+      }
+      return ips;
+    }, []) || [];
   return (
     <>
       {ips.length

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -240,7 +240,7 @@ export type BaseMachine = BaseNode & {
   extra_macs: string[];
   fabrics: string[];
   has_logs: boolean;
-  ip_addresses: MachineIpAddress[];
+  ip_addresses?: MachineIpAddress[];
   link_speeds: number[];
   numa_nodes_count: number;
   owner: string;
@@ -249,15 +249,16 @@ export type BaseMachine = BaseNode & {
   pool: ModelRef;
   power_state: PowerState;
   power_type: string;
-  pxe_mac_vendor: string;
-  pxe_mac: string;
+  pxe_mac_vendor?: string;
+  pxe_mac?: string;
   spaces: string[];
   sriov_support: boolean;
+  status_message: string;
   storage_tags: string[];
   storage: number;
   subnets: string[];
   testing_status: TestStatus;
-  vlan: Vlan | null;
+  vlan?: Vlan | null;
   workload_annotations: { [x: string]: string };
   zone: ModelRef;
 };


### PR DESCRIPTION
## Done

- Updated `BaseMachine` type to correctly reflect what parameters are optional, e.g. if no boot interface is set a few things are missing.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- In a LXD pod, compose a new machine or go to the machine details page of an existing one that can have its network edited
- Remove all of its interfaces
- Go to the project details page of the pod and check that the browser doesn't crash

## Fixes

Fixes #2421 
