### PR TITLE
feat(ui): link back to top

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import {
   Col,
+  Link,
   Row,
   SearchBox,
   Select,
@@ -81,6 +82,9 @@ const EventLogs = ({ systemId }: Props): JSX.Element => {
     pageSize,
     startIndex
   );
+  // Check the number of events on this page not the page size in case there are
+  // less items.
+  const showBackToTop = paginatedEvents.length >= 50;
 
   useEffect(() => {
     // If the events haven't been requested yet then get all the events for the
@@ -193,6 +197,22 @@ const EventLogs = ({ systemId }: Props): JSX.Element => {
       <hr />
       <EventLogsTable events={paginatedEvents} systemId={systemId} />
       {loading && <Spinner text="Loading..." />}
+      {showBackToTop && (
+        <Link
+          data-test="backToTop"
+          onClick={(evt: React.MouseEvent<HTMLAnchorElement>) => {
+            evt.preventDefault();
+            window.scrollTo({
+              top: 0,
+              left: 0,
+              behavior: "smooth",
+            });
+          }}
+          top
+        >
+          Back to top
+        </Link>
+      )}
     </>
   );
 };

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -74,3 +74,9 @@ input[type="radio"] {
   // Display tooltips above contextual menus which have a z-index of 9.
   z-index: 10 !important;
 }
+
+// Set the background of the back-to-top link to match the grey background of
+// maas-ui.
+.p-top .p-top__link {
+  background-color: $color-light;
+}


### PR DESCRIPTION
## Done

- Display a back to top link when there are at least 50 events.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the react logs tab for a machine.
- Make sure your page size selector is set to 25.
- There should be no back-to-top link at the bottom of the event list.
- Change the page size selector to show 50 or more events.
- There should no be a back-to-top link at the bottom of the event list.
- Click the link and you should scroll to the top.

## Fixes

Fixes: canonical-web-and-design/maas-squad#2371.