### PR TITLE
feat(ui): show KVM power address in section header

### DIFF
--- a/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/ui/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -43,11 +43,12 @@ const SectionHeader = ({
     <>
       <div className="u-flex--between u-flex--wrap">
         <ul className="p-inline-list">
-          <li
-            className="p-inline-list__item p-heading--four"
-            data-test="section-header-title"
-          >
-            {title}
+          <li className="p-inline-list__item" data-test="section-header-title">
+            {typeof title === "string" ? (
+              <span className="p-heading--four">{title}</span>
+            ) : (
+              title
+            )}
           </li>
           {loading ? (
             <li className="p-inline-list__item last-item u-text--light">

--- a/ui/src/app/base/components/SectionHeader/__snapshots__/SectionHeader.test.tsx.snap
+++ b/ui/src/app/base/components/SectionHeader/__snapshots__/SectionHeader.test.tsx.snap
@@ -9,10 +9,14 @@ exports[`SectionHeader can render 1`] = `
       className="p-inline-list"
     >
       <li
-        className="p-inline-list__item p-heading--four"
+        className="p-inline-list__item"
         data-test="section-header-title"
       >
-        Title
+        <span
+          className="p-heading--four"
+        >
+          Title
+        </span>
       </li>
       <li
         className="p-inline-list__item u-text--light last-item"

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -49,9 +49,11 @@ describe("KVMDetailsHeader", () => {
     expect(wrapper.find("Spinner").exists()).toBe(true);
   });
 
-  it("displays pod name in header strip when loaded", () => {
+  it("displays pod name and address when loaded", () => {
     const state = { ...initialState };
-    state.pod.items = [podFactory({ id: 1, name: "pod-name" })];
+    state.pod.items = [
+      podFactory({ id: 1, name: "pod-name", power_address: "192.168.1.1" }),
+    ];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -60,8 +62,9 @@ describe("KVMDetailsHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find('[data-test="section-header-title"]').text()).toBe(
-      "pod-name"
+    expect(wrapper.find('[data-test="pod-name"]').text()).toBe("pod-name");
+    expect(wrapper.find('[data-test="pod-address"]').text()).toBe(
+      "192.168.1.1"
     );
   });
 
@@ -83,13 +86,8 @@ describe("KVMDetailsHeader", () => {
       </Provider>
     );
     expect(wrapper.find("[data-test='section-header-subtitle']").text()).toBe(
-      "5 composed machines"
+      "5 VMs available"
     );
-    expect(
-      wrapper.find("[data-test='section-header-tabs'] Link").at(0).props()[
-        "aria-selected"
-      ]
-    ).toBe(true);
   });
 
   it("shows a tab for project if the pod is a LXD pod", () => {

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import pluralize from "pluralize";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link, useLocation } from "react-router-dom";
@@ -55,12 +55,9 @@ const KVMDetailsHeader = (): JSX.Element => {
         )) ||
         undefined
       }
-      loading={!pod}
-      subtitle={pluralize(
-        "composed machine",
-        pod?.composed_machines_count,
-        true
-      )}
+      subtitle={`${pod?.composed_machines_count || 0} VM${
+        pod?.composed_machines_count === 1 ? "" : "s"
+      } available`}
       tabLinks={[
         ...(pod?.type === PodType.LXD
           ? [
@@ -86,7 +83,26 @@ const KVMDetailsHeader = (): JSX.Element => {
           to: `/kvm/${id}/edit`,
         },
       ]}
-      title={pod?.name || ""}
+      title={
+        pod ? (
+          <div className="kvm-details-header">
+            <h1
+              className="p-heading--four u-no-margin--bottom"
+              data-test="pod-name"
+            >
+              {pod.name}
+            </h1>
+            <p
+              className="u-text--muted u-no-margin--bottom u-no-padding--top"
+              data-test="pod-address"
+            >
+              {pod.power_address}
+            </p>
+          </div>
+        ) : (
+          <Spinner text="Loading..." />
+        )
+      }
     />
   );
 };

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/_index.scss
@@ -1,0 +1,9 @@
+@mixin KVMDetailsHeader {
+  .kvm-details-header {
+    border-right: $border;
+    display: inline-flex;
+    flex-direction: column;
+    margin-bottom: -$spv-inner--small;
+    padding-right: $sph-inner;
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.test.tsx
@@ -85,29 +85,4 @@ describe("KVMResources", () => {
     expect(useSendMock).toHaveBeenCalled();
     useSendMock.mockRestore();
   });
-
-  it("can display the power address", () => {
-    const state = rootStateFactory({
-      pod: podStateFactory({
-        items: [
-          podFactory({
-            id: 1,
-            power_address: "qemu+ssh://ubuntu@171.16.4.28/system",
-          }),
-        ],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <Route exact path="/kvm/:id" component={() => <KVMResources />} />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Code").exists()).toBe(true);
-    expect(wrapper.find("Code input").prop("value")).toBe(
-      "qemu+ssh://ubuntu@171.16.4.28/system"
-    );
-  });
 });

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMResources.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import * as React from "react";
 
-import { Code, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { useStorageState } from "react-storage-hooks";
@@ -15,7 +15,6 @@ import PodAggregateResources from "app/kvm/components/PodAggregateResources";
 import PodStorage from "app/kvm/components/PodStorage";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
-import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 
 const KVMResources = (): JSX.Element => {
@@ -41,15 +40,6 @@ const KVMResources = (): JSX.Element => {
   if (!!pod) {
     return (
       <>
-        <div className="u-flex">
-          <p className="u-nudge-left">
-            {pod.type === PodType.VIRSH ? "Virsh:" : "LXD URL:"}
-          </p>
-          <Code copyable className="u-flex--grow">
-            {pod.power_address}
-          </Code>
-        </div>
-        <hr className="u-sv1" />
         <div className="u-flex--between u-flex--column-x-small">
           <h4 className="u-sv1">Resources</h4>
           {pod.numa_pinning && pod.numa_pinning.length >= 1 && (

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
@@ -60,7 +60,7 @@ const StorageResources = ({ id }: Props): JSX.Element | null => {
 
           return (
             <div className="storage-resources__pool" key={pool.id}>
-              <div className="storage-resources__pool-name">Default pool</div>
+              <div className="storage-resources__pool-name">{pod.name}</div>
               <PodMeter
                 allocated={allocated.value}
                 className="storage-resources__pool-meter"

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/__snapshots__/StorageResources.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/__snapshots__/StorageResources.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`StorageResources renders 1`] = `
         <div
           className="storage-resources__pool-name"
         >
-          Default pool
+          pod1
         </div>
         <PodMeter
           allocated={1}
@@ -184,7 +184,7 @@ exports[`StorageResources renders 1`] = `
         <div
           className="storage-resources__pool-name"
         >
-          Default pool
+          pod1
         </div>
         <PodMeter
           allocated={3}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -96,6 +96,7 @@
 @import "~app/kvm/components/PodResourcesCard";
 @import "~app/kvm/components/PodStorage";
 @import "~app/kvm/views/KVMDetails/CoreResources";
+@import "~app/kvm/views/KVMDetails/KVMDetailsHeader";
 @import "~app/kvm/views/KVMDetails/KVMResources/KVMNumaResources";
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectResourcesCard";
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar";
@@ -111,6 +112,7 @@
 @include CPUPopover;
 @include KVMComposeInterfacesTable;
 @include KVMComposeStorageTable;
+@include KVMDetailsHeader;
 @include KVMNumaResources;
 @include KVMPoolSelect;
 @include KVMSubnetSelect;


### PR DESCRIPTION
## Done

- Updated KVM details header to include power address. Right now this is bespoke to `KVMDetailsHeader`. Originally I was going to update the `SectionHeader` component to allow a subtitle and "sidetext", but it seems like every instance `SectionHeader` uses a different set of props and it's getting a bit out of hand. I think this will all be removed when the application layout is applied anyway.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM details page and check that the section header matches the [design](https://app.zeplin.io/project/601454d5d1141e1b6ea271b7/screen/602aaa0ceae2c4808226adfe).

## Fixes

Fixes #2252

## Screenshot

![2021-03-25_17-53](https://user-images.githubusercontent.com/25733845/112438580-cb923e00-8d93-11eb-921d-d178a26f42c0.png)

