### PR TITLE
feat(ui): download machine output

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -4,10 +4,10 @@ exports[`stricter compilation`] = {
     "src/app/App.test.tsx:61152259": [
       [30, 16, 24, "Type \'Factory<NavigationOptions>\' is not assignable to type \'NavigationOptions | ArrayFactory<never> | AttributeFunction<NavigationOptions | null> | Factory<NavigationOptions | null> | DerivedFunction<...> | null | undefined\'.\\n  Type \'Factory<NavigationOptions>\' is not assignable to type \'Factory<NavigationOptions | null>\'.\\n    Types of parameters \'override\' and \'override\' are incompatible.\\n      Type \'Partial<Config<NavigationOptions | null>> | undefined\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.\\n        Type \'null\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.", "3717115723"]
     ],
-    "src/app/App.tsx:1101039025": [
-      [85, 30, 14, "Expected 1 arguments, but got 0.", "3293254978"],
-      [86, 30, 24, "Expected 1 arguments, but got 0.", "137640098"],
-      [185, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
+    "src/app/App.tsx:2276504198": [
+      [86, 30, 14, "Expected 1 arguments, but got 0.", "3293254978"],
+      [87, 30, 24, "Expected 1 arguments, but got 0.", "137640098"],
+      [190, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
     "src/app/base/components/ActionForm/ActionForm.test.tsx:1085409115": [
       [54, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -440,22 +440,34 @@ exports[`stricter compilation`] = {
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:989364269": [
-      [78, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [81, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [97, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [100, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [119, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [122, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"]
+    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:3880232383": [
+      [111, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [114, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [133, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [136, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [156, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [159, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [179, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [182, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [201, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [204, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [224, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [227, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [248, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [251, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [267, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [270, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
+      [289, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [292, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx:3259621198": [
-      [151, 46, 14, "Property \'setCurrentPage\' does not exist on type \'HTMLAttributes\'.", "3476818685"],
-      [214, 6, 42, "Cannot invoke an object which is possibly \'undefined\'.", "2514116111"],
-      [214, 49, 8, "Argument of type \'string\' is not assignable to parameter of type \'FormEvent<{}>\'.", "1726186598"],
-      [217, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
-      [249, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
-      [257, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
-      [296, 11, 45, "Object is of type \'unknown\'.", "3327518388"]
+    "src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx:3147327199": [
+      [154, 46, 14, "Property \'setCurrentPage\' does not exist on type \'HTMLAttributes\'.", "3476818685"],
+      [217, 6, 42, "Cannot invoke an object which is possibly \'undefined\'.", "2514116111"],
+      [217, 49, 8, "Argument of type \'string\' is not assignable to parameter of type \'FormEvent<{}>\'.", "1726186598"],
+      [220, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
+      [252, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
+      [260, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
+      [299, 11, 45, "Object is of type \'unknown\'.", "3327518388"]
     ],
     "src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx:689686888": [
       [80, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
@@ -775,10 +787,10 @@ exports[`stricter compilation`] = {
     "src/app/store/general/slice.ts:3812522415": [
       [94, 2, 8, "Type \'Reducers\' is not assignable to type \'ValidateSliceCaseReducers<{ architectures: { data: string | string[] | BondOptions | ComponentToDisable[] | HWEKernel[] | KnownArchitecture[] | ... 5 more ... | null; errors: {}; loaded: boolean; loading: boolean; }; ... 10 more ...; version: { ...; }; }, SliceCaseReducers<...>>\'.\\n  Type \'Reducers\' is not assignable to type \'SliceCaseReducers<{ architectures: { data: string | string[] | BondOptions | ComponentToDisable[] | HWEKernel[] | KnownArchitecture[] | ... 5 more ... | null; errors: {}; loaded: boolean; loading: boolean; }; ... 10 more ...; version: { ...; }; }>\'.\\n    Index signatures are incompatible.\\n      Type \'CaseReducer<GeneralState, { payload: any; type: string; }> | CaseReducerWithPrepare<GeneralState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<{ architectures: { data: string | string[] | BondOptions | ComponentToDisable[] | HWEKernel[] | KnownArchitecture[] | ... 5 more ... | null; errors: {}; loaded: boolean; loading: boolean; }; ... 10 more ...; version: { ...; }; }, { ...; }> | CaseReducerWithPrepare<...>\'.\\n        Type \'CaseReducer<GeneralState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<{ architectures: { data: string | string[] | BondOptions | ComponentToDisable[] | HWEKernel[] | KnownArchitecture[] | ... 5 more ... | null; errors: {}; loaded: boolean; loading: boolean; }; ... 10 more ...; version: { ...; }; }, { ...; }> | CaseReducerWithPrepare<...>\'.\\n          Type \'CaseReducer<GeneralState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<{ architectures: { data: string | string[] | BondOptions | ComponentToDisable[] | HWEKernel[] | KnownArchitecture[] | ... 5 more ... | null; errors: {}; loaded: boolean; loading: boolean; }; ... 10 more ...; version: { ...; }; }, { ...; }>\'.\\n            Types of parameters \'state\' and \'state\' are incompatible.\\n              Type \'WritableDraft<{ architectures: { data: string | string[] | BondOptions | ComponentToDisable[] | HWEKernel[] | KnownArchitecture[] | ... 5 more ... | null; errors: {}; loaded: boolean; loading: boolean; }; ... 10 more ...; version: { ...; }; }>\' is not assignable to type \'WritableDraft<GeneralState>\'.\\n                The types of \'architectures.data\' are incompatible between these types.\\n                  Type \'string | string[] | ComponentToDisable[] | KnownArchitecture[] | [string, string][] | PocketToDisable[] | WritableDraft<BondOptions> | ... 4 more ... | null\' is not assignable to type \'string[]\'.\\n                    Type \'null\' is not assignable to type \'string[]\'.", "2838615652"]
     ],
-    "src/app/store/machine/slice.ts:2096080864": [
-      [963, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
-      [971, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
-      [975, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
+    "src/app/store/machine/slice.ts:2536133856": [
+      [997, 2, 9, "Argument of type \'(state: MachineState, action: {    payload: MachineState[\\"errors\\"];    type: string;    meta: GenericItemMeta<Machine>;    error?: boolean;}, event: string) => MachineState\' is not assignable to parameter of type \'(state: WritableDraft<MachineState>, action: { payload: any; type: string; }, event: string) => WritableDraft<MachineState>\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Property \'meta\' is missing in type \'{ payload: any; type: string; }\' but required in type \'{ payload: any; type: string; meta: GenericItemMeta<Machine>; error?: boolean | undefined; }\'.", "1744849004"],
+      [1005, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
+      [1009, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
     "src/app/store/machine/utils/hooks.ts:2707451908": [
       [71, 28, 13, "Expected 1 arguments, but got 0.", "1814494730"],
@@ -857,7 +869,7 @@ exports[`stricter compilation`] = {
       [401, 10, 14, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.", "368191931"],
       [402, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.", "678288096"]
     ],
-    "src/app/store/utils/slice.ts:1342138730": [
+    "src/app/store/utils/slice.ts:1776626427": [
       [128, 21, 9, "Argument of type \'EventError<I, S[\\"eventErrors\\"][0][\\"error\\"], K>\' is not assignable to parameter of type \'never\'.", "162781256"],
       [134, 4, 5, "Type \'S[\\"eventErrors\\"][0][\\"error\\"]\' is not assignable to type \'never\'.\\n  Type \'any\' is not assignable to type \'never\'.", "165548477"],
       [134, 11, 6, "Object is possibly \'null\'.", "1314712411"],
@@ -871,9 +883,9 @@ exports[`stricter compilation`] = {
       [344, 2, 200, "Type \'Slice<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>, \\"domain\\" | ... 23 more ... | \\"user\\">\' is not assignable to type \'Slice<GenericState<I, E>, R, \\"domain\\" | \\"pod\\" | \\"vlan\\" | \\"zone\\" | \\"machine\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"event\\" | \\"fabric\\" | \\"licensekeys\\" | ... 13 more ... | \\"user\\">\'.\\n  The types returned by \'reducer(...)\' are incompatible between these types.\\n    Type \'{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }\' is not assignable to type \'GenericState<I, E>\'.", "2116018653"],
       [350, 4, 8, "Type \'{ fetch: { prepare: () => { meta: { model: \\"domain\\" | \\"pod\\" | \\"vlan\\" | \\"zone\\" | \\"machine\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"event\\" | \\"fabric\\" | \\"licensekeys\\" | \\"nodedevice\\" | \\"notification\\" | ... 11 more ... | \\"user\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup: (...\' is not assignable to type \'ValidateSliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, SliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>>\'.\\n  Type \'{ fetch: { prepare: () => { meta: { model: \\"domain\\" | \\"pod\\" | \\"vlan\\" | \\"zone\\" | \\"machine\\" | \\"controller\\" | \\"device\\" | \\"dhcpsnippet\\" | \\"event\\" | \\"fabric\\" | \\"licensekeys\\" | \\"nodedevice\\" | \\"notification\\" | ... 11 more ... | \\"user\\"; method: string; }; payload: null; }; reducer: () => void; }; ... 18 more ...; cleanup: (...\' is not assignable to type \'SliceCaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\'.\\n    Property \'fetchStart\' is incompatible with index signature.\\n      Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { payload: any; type: string; }> | CaseReducerWithPrepare<{ errors: E | null; ... 4 more ...; saving: boolean; }, PayloadAction<...>>\'.\\n        Type \'(state: GenericState<I, E>) => void\' is not assignable to type \'CaseReducer<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\' is not assignable to type \'GenericState<I, E>\'.\\n              Types of property \'errors\' are incompatible.\\n                Type \'Draft<E> | null\' is not assignable to type \'E\'.\\n                  \'Draft<E> | null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.\\n                    Type \'null\' is not assignable to type \'E\'.\\n                      \'null\' is assignable to the constraint of type \'E\', but \'E\' could be instantiated with a different subtype of constraint \'unknown\'.", "2838615652"],
       [354, 4, 13, "Type \'CaseReducers<GenericState<I, E>, any> | ((builder: ActionReducerMapBuilder<GenericState<I, E>>) => void) | undefined\' is not assignable to type \'CaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, any> | ((builder: ActionReducerMapBuilder<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>) => void) | undefined\'.\\n  Type \'CaseReducers<GenericState<I, E>, any>\' is not assignable to type \'CaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, any> | ((builder: ActionReducerMapBuilder<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>) => void) | undefined\'.\\n    Type \'CaseReducers<GenericState<I, E>, any>\' is not assignable to type \'CaseReducers<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, any>\'.\\n      Index signatures are incompatible.\\n        Type \'void | CaseReducer<GenericState<I, E>, any>\' is not assignable to type \'void | CaseReducer<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, any>\'.\\n          Type \'CaseReducer<GenericState<I, E>, any>\' is not assignable to type \'void | CaseReducer<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, any>\'.\\n            Type \'CaseReducer<GenericState<I, E>, any>\' is not assignable to type \'CaseReducer<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }, any>\'.\\n              Types of parameters \'state\' and \'state\' are incompatible.\\n                Type \'WritableDraft<{ errors: E | null; items: never[] | I[]; loaded: boolean; loading: boolean; saved: boolean; saving: boolean; }>\' is not assignable to type \'WritableDraft<GenericState<I, E>>\'.\\n                  Types of property \'errors\' are incompatible.\\n                    Type \'Draft<E> | null\' is not assignable to type \'Draft<E>\'.\\n                      Type \'null\' is not assignable to type \'Draft<E>\'.", "3257995358"],
-      [444, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
-      [463, 27, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
-      [490, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"]
+      [447, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
+      [466, 27, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"],
+      [493, 8, 50, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.\\n  No index signature with a parameter of type \'string\' was found on type \'WritableDraft<MachineStatuses> | WritableDraft<PodStatuses>\'.", "3883490613"]
     ],
     "src/app/utils/getCookie.ts:940992619": [
       [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
@@ -887,12 +899,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:3855646593": [
-      [253, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [374, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [375, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [377, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [382, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:1210162081": [
+      [255, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [376, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [377, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [379, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [384, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -957,10 +969,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [11, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:2766068399": [
+    "src/app/store/machine/types.ts:3461652849": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [379, 34, 8, "RegExp match", "1152173309"],
-      [382, 25, 8, "RegExp match", "1152173309"]
+      [382, 34, 8, "RegExp match", "1152173309"],
+      [385, 25, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/nodedevice/types.ts:2713937479": [
       [1, 13, 8, "RegExp match", "1152173309"],
@@ -1034,13 +1046,14 @@ exports[`no TSFixMe types`] = {
       [18, 9, 8, "RegExp match", "1152173309"],
       [28, 22, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/utils/slice.ts:1342138730": [
+    "src/app/store/utils/slice.ts:1776626427": [
       [12, 13, 8, "RegExp match", "1152173309"],
       [176, 38, 8, "RegExp match", "1152173309"],
       [216, 23, 8, "RegExp match", "1152173309"],
       [259, 23, 8, "RegExp match", "1152173309"],
       [372, 20, 8, "RegExp match", "1152173309"],
-      [413, 24, 8, "RegExp match", "1152173309"]
+      [374, 25, 8, "RegExp match", "1152173309"],
+      [415, 24, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/vlan/types.ts:3430900440": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,10 +1,10 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
-    "src/app/App.test.tsx:61152259": [
+    "src/app/App.test.tsx:1989824429": [
       [30, 16, 24, "Type \'Factory<NavigationOptions>\' is not assignable to type \'NavigationOptions | ArrayFactory<never> | AttributeFunction<NavigationOptions | null> | Factory<NavigationOptions | null> | DerivedFunction<...> | null | undefined\'.\\n  Type \'Factory<NavigationOptions>\' is not assignable to type \'Factory<NavigationOptions | null>\'.\\n    Types of parameters \'override\' and \'override\' are incompatible.\\n      Type \'Partial<Config<NavigationOptions | null>> | undefined\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.\\n        Type \'null\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.", "3717115723"]
     ],
-    "src/app/App.tsx:2276504198": [
+    "src/app/App.tsx:1300342147": [
       [86, 30, 14, "Expected 1 arguments, but got 0.", "3293254978"],
       [87, 30, 24, "Expected 1 arguments, but got 0.", "137640098"],
       [190, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
@@ -35,7 +35,7 @@ exports[`stricter compilation`] = {
     "src/app/base/components/ArchitectureSelect/ArchitectureSelect.tsx:463990503": [
       [27, 28, 20, "Expected 1 arguments, but got 0.", "1113156766"]
     ],
-    "src/app/base/components/DhcpForm/DhcpForm.test.tsx:3203494782": [
+    "src/app/base/components/DhcpForm/DhcpForm.test.tsx:538955982": [
       [87, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [88, 8, 17, "Argument of type \'{ name: string; id: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "2541047863"],
       [122, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
@@ -87,15 +87,15 @@ exports[`stricter compilation`] = {
     "src/app/base/components/MinimumKernelSelect/MinimumKernelSelect.tsx:2651835335": [
       [27, 28, 17, "Expected 1 arguments, but got 0.", "656389642"]
     ],
-    "src/app/base/components/NotificationGroup/Notification/Notification.tsx:911498555": [
+    "src/app/base/components/NotificationGroup/Notification/Notification.tsx:4288796383": [
       [25, 26, 12, "Argument of type \'Notification | null\' is not assignable to parameter of type \'Notification\'.\\n  Type \'null\' is not assignable to type \'Notification\'.\\n    Type \'null\' is not assignable to type \'Model\'.", "148512008"],
       [30, 8, 12, "Object is possibly \'null\'.", "148512008"],
       [39, 43, 12, "Object is possibly \'null\'.", "148512008"]
     ],
-    "src/app/base/components/NotificationList/NotificationList.test.tsx:845561780": [
+    "src/app/base/components/NotificationList/NotificationList.test.tsx:1654777991": [
       [70, 47, 5, "Property \'close\' does not exist on type \'HTMLAttributes\'.", "176908083"]
     ],
-    "src/app/base/components/NotificationList/NotificationList.tsx:3181376772": [
+    "src/app/base/components/NotificationList/NotificationList.tsx:1342383037": [
       [57, 21, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"],
       [58, 12, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"],
       [63, 29, 20, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ warnings: { items: Notification[]; type: string; }; errors: { items: Notification[]; type: string; }; success: { items: Notification[]; type: string; }; info: { ...; }; }\'.", "3004607778"]
@@ -167,7 +167,7 @@ exports[`stricter compilation`] = {
     "src/app/base/hooks.test.ts:598202842": [
       [12, 6, 4, "Type \'HTMLHtmlElement | null\' is not assignable to type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "2087820472"]
     ],
-    "src/app/base/hooks.ts:2007934660": [
+    "src/app/base/hooks.ts:4148321495": [
       [388, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
       [389, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
       [394, 31, 5, "Object is of type \'unknown\'.", "195909086"],
@@ -175,7 +175,7 @@ exports[`stricter compilation`] = {
       [397, 31, 5, "Object is of type \'unknown\'.", "195909086"],
       [397, 39, 5, "Object is of type \'unknown\'.", "195909085"]
     ],
-    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:3152488813": [
+    "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:2047321814": [
       [141, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
       [141, 27, 4, "Object is possibly \'undefined\'.", "2087386672"],
       [141, 41, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -265,7 +265,7 @@ exports[`stricter compilation`] = {
       [76, 6, 68, "Object is possibly \'undefined\'.", "2960886801"],
       [102, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
-    "src/app/kvm/views/KVMDetails/KVMResources/KVMResources.test.tsx:1392659926": [
+    "src/app/kvm/views/KVMDetails/KVMResources/KVMResources.test.tsx:1078388923": [
       [42, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"],
       [78, 6, 63, "Cannot invoke an object which is possibly \'undefined\'.", "4080916967"]
     ],
@@ -440,25 +440,25 @@ exports[`stricter compilation`] = {
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:3880232383": [
-      [111, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [114, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [133, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [136, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [156, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [159, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [179, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [182, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [201, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [204, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [224, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [227, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [248, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [251, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [267, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [270, 17, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"],
-      [289, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [292, 15, 8, "Binding element \'children\' implicitly has an \'any\' type.", "1925793782"]
+    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:2783161423": [
+      [97, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [100, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [119, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [122, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [142, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [145, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [165, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [168, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [187, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [190, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [210, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [213, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [234, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [237, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [253, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [256, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [275, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [278, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"]
     ],
     "src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx:3147327199": [
       [154, 46, 14, "Property \'setCurrentPage\' does not exist on type \'HTMLAttributes\'.", "3476818685"],
@@ -731,7 +731,7 @@ exports[`stricter compilation`] = {
     "src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx:3278830891": [
       [25, 10, 4, "Type \'{ osystems: [string, string][]; releases: [string, string][]; }\' is missing the following properties from type \'OSInfo\': kernels, default_osystem, default_release", "2087377941"]
     ],
-    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx:2378435003": [
+    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx:4083115147": [
       [118, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
       [118, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
       [120, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
@@ -758,7 +758,7 @@ exports[`stricter compilation`] = {
       [163, 4, 4, "Argument of type \'null\' is not assignable to parameter of type \'() => void\'.", "2087897566"],
       [208, 8, 10, "Argument of type \'null\' is not assignable to parameter of type \'number\'.", "668428687"]
     ],
-    "src/app/settings/views/Users/UserForm/UserForm.test.tsx:1137023264": [
+    "src/app/settings/views/Users/UserForm/UserForm.test.tsx:1181495248": [
       [87, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
       [133, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
       [179, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],
@@ -869,7 +869,7 @@ exports[`stricter compilation`] = {
       [401, 10, 14, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.", "368191931"],
       [402, 10, 12, "Type \'CaseReducer<PodState, { payload: any; type: string; }> | CaseReducerWithPrepare<PodState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Pod, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Pod, any>, PayloadAction<any, string, any, any>>\'.", "678288096"]
     ],
-    "src/app/store/utils/slice.ts:1776626427": [
+    "src/app/store/utils/slice.ts:966799464": [
       [128, 21, 9, "Argument of type \'EventError<I, S[\\"eventErrors\\"][0][\\"error\\"], K>\' is not assignable to parameter of type \'never\'.", "162781256"],
       [134, 4, 5, "Type \'S[\\"eventErrors\\"][0][\\"error\\"]\' is not assignable to type \'never\'.\\n  Type \'any\' is not assignable to type \'never\'.", "165548477"],
       [134, 11, 6, "Object is possibly \'null\'.", "1314712411"],
@@ -899,7 +899,7 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:1210162081": [
+    "src/testing/factories/state.ts:4063649970": [
       [255, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
       [376, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
       [377, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
@@ -911,8 +911,8 @@ exports[`stricter compilation`] = {
 
 exports[`no TSFixMe types`] = {
   value: `{
-    "src/app/base/hooks.ts:2007934660": [
-      [9, 13, 8, "RegExp match", "1152173309"],
+    "src/app/base/hooks.ts:4148321495": [
+      [8, 13, 8, "RegExp match", "1152173309"],
       [24, 39, 8, "RegExp match", "1152173309"]
     ],
     "src/app/base/types.ts:1483624430": [
@@ -1024,7 +1024,7 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [13, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/status/types.ts:3358556468": [
+    "src/app/store/status/types.ts:4123989684": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [5, 22, 8, "RegExp match", "1152173309"],
       [8, 8, 8, "RegExp match", "1152173309"]
@@ -1046,7 +1046,7 @@ exports[`no TSFixMe types`] = {
       [18, 9, 8, "RegExp match", "1152173309"],
       [28, 22, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/utils/slice.ts:1776626427": [
+    "src/app/store/utils/slice.ts:966799464": [
       [12, 13, 8, "RegExp match", "1152173309"],
       [176, 38, 8, "RegExp match", "1152173309"],
       [216, 23, 8, "RegExp match", "1152173309"],
@@ -1067,6 +1067,6 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `350
+  value: `335
 `
 };

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -19,6 +19,7 @@ import { auth as authActions } from "app/base/actions";
 import Login from "app/base/components/Login";
 import Section from "app/base/components/Section";
 import StatusBar from "app/base/components/StatusBar";
+import FileContext, { fileContextStore } from "app/base/file-context";
 import { config as configActions } from "app/settings/actions";
 import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
@@ -127,7 +128,11 @@ export const App = (): JSX.Element => {
       </Section>
     );
   } else if (connected) {
-    content = <Routes />;
+    content = (
+      <FileContext.Provider value={fileContextStore}>
+        <Routes />
+      </FileContext.Provider>
+    );
   }
 
   if (analyticsEnabled && process.env.REACT_APP_SENTRY_DSN) {

--- a/ui/src/app/base/file-context.test.ts
+++ b/ui/src/app/base/file-context.test.ts
@@ -1,0 +1,27 @@
+import { fileContextStore } from "./file-context";
+
+describe("FileContext", () => {
+  const fileKey = "file1";
+
+  afterEach(() => {
+    fileContextStore.remove(fileKey);
+  });
+
+  it("can retrieve a file", () => {
+    fileContextStore.add(fileKey, "test file");
+    expect(fileContextStore.get(fileKey)).toBe("test file");
+  });
+
+  it("can store a file", () => {
+    expect(fileContextStore.get(fileKey)).toBeUndefined();
+    fileContextStore.add(fileKey, "test file");
+    expect(fileContextStore.get(fileKey)).toBe("test file");
+  });
+
+  it("can remove a file", () => {
+    fileContextStore.add(fileKey, "test file");
+    expect(fileContextStore.get(fileKey)).toBe("test file");
+    fileContextStore.remove(fileKey);
+    expect(fileContextStore.get(fileKey)).toBeUndefined();
+  });
+});

--- a/ui/src/app/base/file-context.ts
+++ b/ui/src/app/base/file-context.ts
@@ -1,0 +1,36 @@
+import React from "react";
+
+// A simple map between unique keys and file strings.
+const files = new Map();
+
+// The store to pass to the React context.
+export const fileContextStore = {
+  /**
+   * Add a file to the store.
+   * @param key - A unique key to store the file with.
+   * @param file The file string.
+   */
+  add: (key: string, file: string): void => {
+    files.set(key, file);
+  },
+  /**
+   * Get a file from the store.
+   * @param key - The file's unique key.
+   * @returns The file as a string.
+   */
+  get: (key: string): string => {
+    return files.get(key);
+  },
+  /**
+   * Remove a file from the store.
+   * @param key - The file's unique key.
+   */
+  remove: (key: string): void => {
+    files.delete(key);
+  },
+};
+
+// The context to be used by the React context providers and consumers.
+const FileContext = React.createContext(fileContextStore);
+
+export default FileContext;

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
@@ -29,20 +29,6 @@ jest.mock("js-file-download", () => jest.fn());
 describe("DownloadMenu", () => {
   let state: RootState;
 
-  // beforeAll(() => {
-  //   jest.mock("@reduxjs/toolkit", () => {
-  //     const toolkit = jest.requireActual("@reduxjs/toolkit");
-  //     return {
-  //       ...toolkit,
-  //       nanoid: jest.fn(() => "Uakgb_J5m9g-0JDMbcJqLJ"),
-  //     };
-  //   });
-
-  //   jest.mock("nanoid", () => ({
-  //     nanoid: jest.fn(() => "Uakgb_J5m9g-0JDMbcJqLJ"),
-  //   }));
-  // });
-
   beforeEach(() => {
     state = rootStateFactory({
       machine: machineStateFactory({
@@ -66,7 +52,7 @@ describe("DownloadMenu", () => {
         ],
         logs: {
           1: scriptResultDataFactory({
-            combined: "Installation output log",
+            combined: "installation-output log",
           }),
         },
       }),
@@ -112,7 +98,7 @@ describe("DownloadMenu", () => {
       wrapper
         .find("ContextualMenu")
         .prop("links")
-        .some(({ children }) => children === "Machine output (YAML)")
+        .some((link) => link["data-test"] === "machine-output-yaml")
     ).toBe(false);
   });
 
@@ -134,7 +120,7 @@ describe("DownloadMenu", () => {
       wrapper
         .find("ContextualMenu")
         .prop("links")
-        .some(({ children }) => children === "Machine output (YAML)")
+        .some((link) => link["data-test"] === "machine-output-yaml")
     ).toBe(true);
   });
 
@@ -157,7 +143,7 @@ describe("DownloadMenu", () => {
     wrapper
       .find("ContextualMenu")
       .prop("links")
-      .find(({ children }) => children === "Machine output (YAML)")
+      .find((link) => link["data-test"] === "machine-output-yaml")
       .onClick();
     expect(downloadSpy).toHaveBeenCalledWith(
       "test yaml file",
@@ -180,7 +166,7 @@ describe("DownloadMenu", () => {
       wrapper
         .find("ContextualMenu")
         .prop("links")
-        .some(({ children }) => children === "Machine output (XML)")
+        .some((link) => link["data-test"] === "machine-output-xml")
     ).toBe(false);
   });
 
@@ -202,7 +188,7 @@ describe("DownloadMenu", () => {
       wrapper
         .find("ContextualMenu")
         .prop("links")
-        .some(({ children }) => children === "Machine output (XML)")
+        .some((link) => link["data-test"] === "machine-output-xml")
     ).toBe(true);
   });
 
@@ -225,7 +211,7 @@ describe("DownloadMenu", () => {
     wrapper
       .find("ContextualMenu")
       .prop("links")
-      .find(({ children }) => children === "Machine output (XML)")
+      .find((link) => link["data-test"] === "machine-output-xml")
       .onClick();
     expect(downloadSpy).toHaveBeenCalledWith(
       "test xml file",
@@ -249,7 +235,7 @@ describe("DownloadMenu", () => {
       wrapper
         .find("ContextualMenu")
         .prop("links")
-        .some(({ children }) => children === "Installation output")
+        .some((link) => link["data-test"] === "installation-output")
     ).toBe(false);
   });
 
@@ -268,7 +254,7 @@ describe("DownloadMenu", () => {
       wrapper
         .find("ContextualMenu")
         .prop("links")
-        .some(({ children }) => children === "Installation output")
+        .some((link) => link["data-test"] === "installation-output")
     ).toBe(true);
   });
 
@@ -290,10 +276,10 @@ describe("DownloadMenu", () => {
     wrapper
       .find("ContextualMenu")
       .prop("links")
-      .find(({ children }) => children === "Installation output")
+      .find((link) => link["data-test"] === "installation-output")
       .onClick();
     expect(downloadSpy).toHaveBeenCalledWith(
-      "Installation output log",
+      "installation-output log",
       "hungry-wombat.aus-installation-output-2021-03-25.log"
     );
   });

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
@@ -1,19 +1,80 @@
+import { useContext, useEffect, useRef } from "react";
+
 import { ContextualMenu } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
 import { format } from "date-fns";
 import fileDownload from "js-file-download";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { useGetInstallationOutput } from "../hooks";
 
+import FileContext from "app/base/file-context";
+import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-type Props = { systemId: Machine["system_id"] };
+type Props = {
+  systemId: Machine["system_id"];
+};
 export const DownloadMenu = ({ systemId }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
   const installationOutput = useGetInstallationOutput(systemId);
+  const getSummaryXmlKey = useRef(nanoid());
+  const getSummaryYamlKey = useRef(nanoid());
+  const fileContext = useContext(FileContext);
+  const summaryXML = fileContext.get(getSummaryXmlKey.current);
+  const summaryYAML = fileContext.get(getSummaryYamlKey.current);
+  const today = format(new Date(), "yyyy-MM-dd");
+  const toggleDisabled =
+    !installationOutput?.log && !summaryYAML && !summaryXML;
+
+  useEffect(() => {
+    if (machine) {
+      // Request the files for this
+      dispatch(
+        machineActions.getSummaryXml(systemId, getSummaryXmlKey.current)
+      );
+      dispatch(
+        machineActions.getSummaryYaml(systemId, getSummaryYamlKey.current)
+      );
+    }
+  }, [dispatch, systemId, machine]);
+
+  // Clean up the requested files when the component unmounts.
+  useEffect(
+    () => () => {
+      fileContext.remove(getSummaryXmlKey.current);
+      fileContext.remove(getSummaryYamlKey.current);
+    },
+    [fileContext]
+  );
+
+  const generateItem = (
+    title: string,
+    filename: string,
+    extension: string,
+    fileContent?: string | null
+  ) =>
+    fileContent
+      ? [
+          {
+            children: title,
+            onClick: () => {
+              if (fileContent && machine) {
+                fileDownload(
+                  fileContent,
+                  `${machine.fqdn}-${filename}-${today}.${extension}`
+                );
+              }
+            },
+          },
+        ]
+      : // If there is no file then return an empty array so it can be spread.
+        [];
+
   if (!machine) {
     return null;
   }
@@ -23,34 +84,31 @@ export const DownloadMenu = ({ systemId }: Props): JSX.Element | null => {
         className="download-menu"
         hasToggleIcon
         links={[
-          {
-            children: "Machine output (YAML)",
-          },
-          {
-            children: "Machine output (XML)",
-          },
+          ...generateItem(
+            "Machine output (YAML)",
+            "machine-output",
+            "yaml",
+            summaryYAML
+          ),
+          ...generateItem(
+            "Machine output (XML)",
+            "machine-output",
+            "xml",
+            summaryXML
+          ),
           {
             children: "curtin-logs.tar",
           },
-          ...(installationOutput.log
-            ? [
-                {
-                  children: "Installation output",
-                  onClick: () => {
-                    if (installationOutput.log) {
-                      const today = format(new Date(), "yyyy-MM-dd");
-                      fileDownload(
-                        installationOutput.log,
-                        `${machine.fqdn}-installation-output-${today}.txt`
-                      );
-                    }
-                  },
-                },
-              ]
-            : []),
+          ...generateItem(
+            "Installation output",
+            "installation-output",
+            "log",
+            installationOutput.log
+          ),
         ]}
         position="right"
         toggleAppearance="neutral"
+        toggleDisabled={toggleDisabled}
         toggleLabel="Download"
       />
     </div>

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.tsx
@@ -56,24 +56,28 @@ export const DownloadMenu = ({ systemId }: Props): JSX.Element | null => {
     title: string,
     filename: string,
     extension: string,
+    testKey: string,
     fileContent?: string | null
-  ) =>
-    fileContent
-      ? [
-          {
-            children: title,
-            onClick: () => {
-              if (fileContent && machine) {
-                fileDownload(
-                  fileContent,
-                  `${machine.fqdn}-${filename}-${today}.${extension}`
-                );
-              }
-            },
-          },
-        ]
-      : // If there is no file then return an empty array so it can be spread.
-        [];
+  ) => {
+    if (!fileContent) {
+      // If there is no file then return an empty array so it can be spread.
+      return [];
+    }
+    return [
+      {
+        children: title,
+        "data-test": testKey,
+        onClick: () => {
+          if (fileContent && machine) {
+            fileDownload(
+              fileContent,
+              `${machine.fqdn}-${filename}-${today}.${extension}`
+            );
+          }
+        },
+      },
+    ];
+  };
 
   if (!machine) {
     return null;
@@ -88,12 +92,14 @@ export const DownloadMenu = ({ systemId }: Props): JSX.Element | null => {
             "Machine output (YAML)",
             "machine-output",
             "yaml",
+            "machine-output-yaml",
             summaryYAML
           ),
           ...generateItem(
             "Machine output (XML)",
             "machine-output",
             "xml",
+            "machine-output-xml",
             summaryXML
           ),
           {
@@ -103,6 +109,7 @@ export const DownloadMenu = ({ systemId }: Props): JSX.Element | null => {
             "Installation output",
             "installation-output",
             "log",
+            "installation-output",
             installationOutput.log
           ),
         ]}

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -214,6 +214,40 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle getting a summary XML file", () => {
+    expect(actions.getSummaryXml("abc123", "file1")).toEqual({
+      type: "machine/getSummaryXml",
+      meta: {
+        fileContextKey: "file1",
+        model: "machine",
+        method: "get_summary_xml",
+        useFileContext: true,
+      },
+      payload: {
+        params: {
+          system_id: "abc123",
+        },
+      },
+    });
+  });
+
+  it("can handle getting a summary YAML file", () => {
+    expect(actions.getSummaryYaml("abc123", "file1")).toEqual({
+      type: "machine/getSummaryYaml",
+      meta: {
+        fileContextKey: "file1",
+        model: "machine",
+        method: "get_summary_yaml",
+        useFileContext: true,
+      },
+      payload: {
+        params: {
+          system_id: "abc123",
+        },
+      },
+    });
+  });
+
   it("can handle aborting a machine", () => {
     expect(actions.abort("abc123")).toEqual({
       type: "machine/abort",

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -155,6 +155,14 @@ export const ACTIONS = [
     status: "exitingRescueMode",
   },
   {
+    name: "get-summary-xml",
+    status: "gettingSummaryXml",
+  },
+  {
+    name: "get-summary-yaml",
+    status: "gettingSummaryYaml",
+  },
+  {
     name: "link-subnet",
     status: "linkingSubnet",
   },
@@ -267,6 +275,8 @@ const DEFAULT_STATUSES = {
   deploying: false,
   enteringRescueMode: false,
   exitingRescueMode: false,
+  gettingSummaryXml: false,
+  gettingSummaryYaml: false,
   linkingSubnet: false,
   locking: false,
   markingBroken: false,
@@ -323,6 +333,8 @@ type MachineReducers = SliceCaseReducers<MachineState> & {
   deploy: WithPrepare;
   fetchComplete: CaseReducer<MachineState, PayloadAction<void>>;
   getStart: CaseReducer<MachineState, PayloadAction<void>>;
+  getSummaryXml: WithPrepare;
+  getSummaryYaml: WithPrepare;
   rescueMode: WithPrepare;
   exitRescueMode: WithPrepare;
   linkSubnet: WithPrepare;
@@ -751,6 +763,28 @@ const statusHandlers = generateStatusHandlers<
           system_id: systemId,
         });
         break;
+      case "get-summary-xml":
+        handler.method = "get_summary_xml";
+        handler.prepare = (systemId: Machine["system_id"]) => ({
+          system_id: systemId,
+        });
+        handler.prepareMeta = (_, fileId: string) => ({
+          // This request needs to store the results in the file context.
+          fileContextKey: fileId,
+          useFileContext: true,
+        });
+        break;
+      case "get-summary-yaml":
+        handler.method = "get_summary_yaml";
+        handler.prepare = (systemId: Machine["system_id"]) => ({
+          system_id: systemId,
+        });
+        handler.prepareMeta = (_, fileId: string) => ({
+          // This request needs to store the results in the file context.
+          fileContextKey: fileId,
+          useFileContext: true,
+        });
+        break;
       case "link-subnet":
         handler.method = "link_subnet";
         handler.prepare = (params: {
@@ -1082,6 +1116,14 @@ const machineSlice = generateSlice<
     exitRescueModeStart: statusHandlers.exitRescueModeStart,
     exitRescueModeSuccess: statusHandlers.exitRescueModeSuccess,
     exitRescueModeError: statusHandlers.exitRescueModeError,
+    getSummaryXml: statusHandlers.getSummaryXml,
+    getSummaryXmlStart: statusHandlers.getSummaryXmlStart,
+    getSummaryXmlSuccess: statusHandlers.getSummaryXmlSuccess,
+    getSummaryXmlError: statusHandlers.getSummaryXmlError,
+    getSummaryYaml: statusHandlers.getSummaryYaml,
+    getSummaryYamlStart: statusHandlers.getSummaryYamlStart,
+    getSummaryYamlSuccess: statusHandlers.getSummaryYamlSuccess,
+    getSummaryYamlError: statusHandlers.getSummaryYamlError,
     linkSubnet: statusHandlers.linkSubnet,
     linkSubnetStart: statusHandlers.linkSubnetStart,
     linkSubnetSuccess: statusHandlers.linkSubnetSuccess,

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -349,6 +349,8 @@ export type MachineStatus = {
   deploying: boolean;
   enteringRescueMode: boolean;
   exitingRescueMode: boolean;
+  gettingSummaryXml: boolean;
+  gettingSummaryYaml: boolean;
   linkingSubnet: boolean;
   locking: boolean;
   markingBroken: boolean;

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -371,6 +371,8 @@ export type StatusHandlers<
   statusKey: string;
   // A method to convert the args for the inital action into payload params.
   prepare: (...args: TSFixMe[]) => unknown;
+  // A method to add additional meta details to pass to the prepare action.
+  prepareMeta?: (...args: TSFixMe[]) => { [x: string]: unknown };
   // The handler for when there is an error.
   error?: CaseReducer<S, PayloadAction<I, string, GenericItemMeta<I>>>;
   // The initial handler.
@@ -415,6 +417,7 @@ export const generateStatusHandlers = <
         meta: {
           model: modelName,
           method: status.method || status.status,
+          ...(status.prepareMeta ? status.prepareMeta(...args) : {}),
         },
         payload: {
           params: status.prepare(...args),

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -69,14 +69,16 @@ input[type="radio"] {
     margin: 0;
   }
 }
-
+// 26-03-2021 Huw: Display tooltips above contextual menus.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3668
 .p-tooltip__message {
   // Display tooltips above contextual menus which have a z-index of 9.
   z-index: 10 !important;
 }
 
-// Set the background of the back-to-top link to match the grey background of
-// maas-ui.
+// 26-03-2021 Huw: Set the background of the back-to-top link to match the grey
+// background of maas-ui.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3667
 .p-top .p-top__link {
   background-color: $color-light;
 }

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -138,6 +138,8 @@ export const machineStatus = define<MachineStatus>({
   deploying: false,
   enteringRescueMode: false,
   exitingRescueMode: false,
+  gettingSummaryXml: false,
+  gettingSummaryYaml: false,
   linkingSubnet: false,
   locking: false,
   markingBroken: false,


### PR DESCRIPTION




## Done

- Fetch machine summary files and storing them in the React context and allow downloading the files.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the React logs tab for a commissioned or deployed machine (change /summary to /logs).
- Open the download menu to the right of the sub-tabs.
- Click the YAML and XML items and the files should download.

## Fixes

Fixes: canonical-web-and-design/maas-ui#2426.
Fixes: canonical-web-and-design/maas-squad#2367.