### PR TITLE
Remove optional chaining

### DIFF
--- a/legacy/src/app/directives/pod-details/kvm_storage_dropdown.js
+++ b/legacy/src/app/directives/pod-details/kvm_storage_dropdown.js
@@ -50,7 +50,7 @@ function KVMStorageDropdownController($scope, $filter) {
   $scope.poolOverCapacity = storage => {
     const { compose, pod } = $scope;
 
-    if (compose?.obj?.requests && pod?.storage_pools && storage?.pool) {
+    if (compose && compose.obj && compose.obj.requests && pod && pod.storage_pools && storage && storage.pool) {
       const storagePool = pod.storage_pools.find(
         (pool) => pool.id === storage.pool.id
       );

--- a/legacy/src/app/factories/nodes.js
+++ b/legacy/src/app/factories/nodes.js
@@ -359,8 +359,8 @@ function NodesManager(RegionConnection, Manager, KVMDeployOSBlacklist, $log) {
   };
 
   NodesManager.prototype.canBeKvmHost = (osSelection) =>
-    osSelection?.osystem === "ubuntu" &&
-    !KVMDeployOSBlacklist.includes(osSelection?.release);
+  !!osSelection && osSelection.osystem === "ubuntu" &&
+    !KVMDeployOSBlacklist.includes(osSelection.release);
 
   NodesManager.prototype.suppressTests = function (node, scripts) {
     return RegionConnection.callMethod(


### PR DESCRIPTION
## Done

- Remove optional chaining that isn't supported in 2.7.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### QA steps

- Run `CYPRESS_INSTALL_BINARY=0 yarn install && yarn build && yarn serve`.
- It should start without any errors about optional chaining in babel.

## Fixes

Fixes: #2444.