### PR TITLE
feat(ui): improve validation of VM compose core pinning

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -10,12 +10,14 @@ import FormikField from "app/base/components/FormikField";
 import ResourcePoolSelect from "app/base/components/ResourcePoolSelect";
 import ZoneSelect from "app/base/components/ZoneSelect";
 import type { Pod } from "app/store/pod/types";
+import { getRanges } from "app/utils";
 
 type Props = {
   architectures: Pod["architectures"];
   available: {
     cores: number;
     memory: number; // MiB
+    pinnedCores: number[];
   };
   defaults: ComposeFormDefaults;
 };
@@ -123,8 +125,11 @@ export const ComposeFormFields = ({
         />
         {pinningCores && (
           <FormikField
-            // TODO: Replace when changing over to new resources data shape
-            // help={`Available cores: ${getRanges(available.pinnedCores)}`}
+            help={`${
+              available.cores
+            } cores available (free indices: ${getRanges(
+              available.pinnedCores
+            )})`}
             name="pinnedCores"
             placeholder='Separate by comma or input a range, e.g. "1,2,4-12"'
             type="text"

--- a/ui/src/app/store/pod/utils.test.ts
+++ b/ui/src/app/store/pod/utils.test.ts
@@ -1,0 +1,53 @@
+import { getCoreIndices } from "./utils";
+
+import {
+  pod as podFactory,
+  podNuma as podNumaFactory,
+  podNumaCores as podNumaCoresFactory,
+  podResources as podResourcesFactory,
+} from "testing/factories";
+
+describe("pod utils", () => {
+  describe("getCoreIndices", () => {
+    it("handles pods without numa data", () => {
+      const pod = podFactory({
+        resources: podResourcesFactory({
+          numa: [],
+        }),
+      });
+      expect(getCoreIndices(pod, "allocated")).toStrictEqual([]);
+    });
+
+    it("can collate the indices of the pod's allocated cores", () => {
+      const pod = podFactory({
+        resources: podResourcesFactory({
+          numa: [
+            podNumaFactory({
+              cores: podNumaCoresFactory({ allocated: [3] }),
+            }),
+            podNumaFactory({
+              cores: podNumaCoresFactory({ allocated: [1, 5] }),
+            }),
+          ],
+        }),
+      });
+      expect(getCoreIndices(pod, "allocated")).toStrictEqual([1, 3, 5]);
+    });
+
+    it("can collate the indices of the pod's free cores", () => {
+      const pod = podFactory({
+        resources: podResourcesFactory({
+          numa: [
+            podNumaFactory({
+              cores: podNumaCoresFactory({ free: [0, 4] }),
+            }),
+            podNumaFactory({
+              cores: podNumaCoresFactory({ free: [1, 2] }),
+            }),
+          ],
+        }),
+      });
+      expect(getCoreIndices(pod, "free")).toStrictEqual([0, 1, 2, 4]);
+    });
+  });
+});

--- a/ui/src/app/store/pod/utils.ts
+++ b/ui/src/app/store/pod/utils.ts
@@ -1,5 +1,5 @@
 import type { Machine } from "app/store/machine/types";
-import type { Pod } from "app/store/pod/types";
+import type { Pod, PodNuma } from "app/store/pod/types";
 import { PodType } from "app/store/pod/types";
 
 export const formatHostType = (type: PodType): string => {
@@ -28,4 +28,22 @@ export const getPodNumaID = (machine: Machine, pod: Pod): number | null => {
     }
   }
   return null;
+};
+
+/**
+ * Returns the indices of the pod cores that are either allocated or free.
+ * @param pod - the pod to check.
+ * @param key - which of either "allocated" or "free" to collate
+ * @returns list of core indices that are either allocated or free
+ */
+export const getCoreIndices = (
+  pod: Pod,
+  key: keyof PodNuma["cores"]
+): number[] => {
+  if (!pod?.resources?.numa?.length) {
+    return [];
+  }
+  return pod.resources.numa
+    .reduce<number[]>((cores, numa) => [...cores, ...numa.cores[key]], [])
+    .sort();
 };


### PR DESCRIPTION
## Done

- Improved validation of VM compose core pinning

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM details page and open the Compose VM form
- Switch to pinning cores and check that help text shows which core indices are available
- Enter a core index that is unavailable and check that an error shows (you may need to blur the field)
- Enter duplicate core values and check that an error shows
- Check that you can submit the form with available core indices

## Fixes

Fixes #2342 
