### PR TITLE
feat(ui): enable logs URL

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -9,7 +9,6 @@ import type { SelectedAction, SetSelectedAction } from "../types";
 
 import MachineName from "./MachineName";
 
-import LegacyLink from "app/base/components/LegacyLink";
 import PowerIcon from "app/base/components/PowerIcon";
 import ScriptStatus from "app/base/components/ScriptStatus";
 import SectionHeader from "app/base/components/SectionHeader";
@@ -192,19 +191,13 @@ const MachineHeader = ({
         },
         {
           active: pathname.startsWith(`${urlBase}/logs`),
-          component: LegacyLink,
+          component: Link,
           label: (
             <ScriptStatus status={machine.installation_status}>
               Logs
             </ScriptStatus>
           ),
-          route: `${urlBase}?area=logs`,
-        },
-        {
-          active: pathname.startsWith(`${urlBase}/events`),
-          component: LegacyLink,
-          label: "Events",
-          route: `${urlBase}?area=events`,
+          to: `${urlBase}/logs`,
         },
         {
           active: pathname.startsWith(`${urlBase}/configuration`),

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import LegacyLink from "app/base/components/LegacyLink";
 import MachineNotifications from "app/machines/views/MachineDetails/MachineNotifications";
@@ -67,12 +68,12 @@ const SummaryNotifications = ({ id }: Props): JSX.Element | null => {
           content: (
             <>
               {formatEventText(machine.events[0])}.{" "}
-              <LegacyLink
-                route={`/machine/${machine.system_id}?area=logs`}
+              <Link
+                to={`/machine/${machine.system_id}/logs`}
                 className="p-notification__action"
               >
                 See logs
-              </LegacyLink>
+              </Link>
             </>
           ),
           status: "Error:",

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
 
 import { Spinner, Tooltip } from "@canonical/react-components";
-import { generateLegacyURL, navigateToLegacy } from "@maas-ui/maas-ui-shared";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import type { Props as TableMenuProps } from "app/base/components/TableMenu/TableMenu";
 import { useMachineActions } from "app/base/hooks";
 import { useToggleMenu } from "app/machines/hooks";
 import machineSelectors from "app/store/machine/selectors";
@@ -86,24 +85,13 @@ export const StatusColumn = ({
   ]);
 
   const statusText = getStatusText(machine, formattedOS);
-  const menuLinks: TableMenuProps["links"] = [
+  const menuLinks = [
     actionLinks,
     [
       {
         children: "See logs",
-        element: "a",
-        href: generateLegacyURL(`/machine/${systemId}?area=logs`),
-        onClick: (evt: React.MouseEvent) => {
-          navigateToLegacy(`/machine/${systemId}?area=logs`, evt);
-        },
-      },
-      {
-        children: "See events",
-        element: "a",
-        href: generateLegacyURL(`/machine/${systemId}?area=events`),
-        onClick: (evt: React.MouseEvent) => {
-          navigateToLegacy(`/machine/${systemId}?area=events`, evt);
-        },
+        element: Link,
+        to: `/machine/${systemId}/logs`,
       },
     ],
   ];

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/__snapshots__/StatusColumn.test.tsx.snap
@@ -180,33 +180,43 @@ exports[`StatusColumn can show a menu with all possible options 1`] = `
   >
     <Button
       className="p-contextual-menu__link"
-      element="a"
-      href="/MAAS/l/machine/abc123?area=logs"
+      element={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "propTypes": Object {
+            "innerRef": [Function],
+            "onClick": [Function],
+            "replace": [Function],
+            "target": [Function],
+            "to": [Function],
+          },
+          "render": [Function],
+        }
+      }
       key="0"
-      onClick={[Function]}
+      onClick={null}
+      to="/machine/abc123/logs"
     >
-      <a
+      <Link
         className="p-button--neutral p-contextual-menu__link"
-        href="/MAAS/l/machine/abc123?area=logs"
-        onClick={[Function]}
+        onClick={null}
+        to="/machine/abc123/logs"
       >
-        See logs
-      </a>
-    </Button>
-    <Button
-      className="p-contextual-menu__link"
-      element="a"
-      href="/MAAS/l/machine/abc123?area=events"
-      key="1"
-      onClick={[Function]}
-    >
-      <a
-        className="p-button--neutral p-contextual-menu__link"
-        href="/MAAS/l/machine/abc123?area=events"
-        onClick={[Function]}
-      >
-        See events
-      </a>
+        <LinkAnchor
+          className="p-button--neutral p-contextual-menu__link"
+          href="/machine/abc123/logs"
+          navigate={[Function]}
+          onClick={null}
+        >
+          <a
+            className="p-button--neutral p-contextual-menu__link"
+            href="/machine/abc123/logs"
+            onClick={[Function]}
+          >
+            See logs
+          </a>
+        </LinkAnchor>
+      </Link>
     </Button>
   </span>
 </span>
@@ -226,15 +236,18 @@ exports[`StatusColumn renders 1`] = `
         Array [
           Object {
             "children": "See logs",
-            "element": "a",
-            "href": "/MAAS/l/machine/abc123?area=logs",
-            "onClick": [Function],
-          },
-          Object {
-            "children": "See events",
-            "element": "a",
-            "href": "/MAAS/l/machine/abc123?area=events",
-            "onClick": [Function],
+            "element": Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "propTypes": Object {
+                "innerRef": [Function],
+                "onClick": [Function],
+                "replace": [Function],
+                "target": [Function],
+                "to": [Function],
+              },
+              "render": [Function],
+            },
+            "to": "/machine/abc123/logs",
           },
         ],
       ]
@@ -298,15 +311,18 @@ exports[`StatusColumn renders 1`] = `
                 Array [
                   Object {
                     "children": "See logs",
-                    "element": "a",
-                    "href": "/MAAS/l/machine/abc123?area=logs",
-                    "onClick": [Function],
-                  },
-                  Object {
-                    "children": "See events",
-                    "element": "a",
-                    "href": "/MAAS/l/machine/abc123?area=events",
-                    "onClick": [Function],
+                    "element": Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "propTypes": Object {
+                        "innerRef": [Function],
+                        "onClick": [Function],
+                        "replace": [Function],
+                        "target": [Function],
+                        "to": [Function],
+                      },
+                      "render": [Function],
+                    },
+                    "to": "/machine/abc123/logs",
                   },
                 ],
               ]
@@ -325,15 +341,18 @@ exports[`StatusColumn renders 1`] = `
                   Array [
                     Object {
                       "children": "See logs",
-                      "element": "a",
-                      "href": "/MAAS/l/machine/abc123?area=logs",
-                      "onClick": [Function],
-                    },
-                    Object {
-                      "children": "See events",
-                      "element": "a",
-                      "href": "/MAAS/l/machine/abc123?area=events",
-                      "onClick": [Function],
+                      "element": Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "propTypes": Object {
+                          "innerRef": [Function],
+                          "onClick": [Function],
+                          "replace": [Function],
+                          "target": [Function],
+                          "to": [Function],
+                        },
+                        "render": [Function],
+                      },
+                      "to": "/machine/abc123/logs",
                     },
                   ],
                 ]


### PR DESCRIPTION
## Done

- Update the URLs to navigate to the React logs tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to the machine list.
- In the status column open the menu in one of the rows and click "See logs". It should take you to the new logs tab.
- Click on another tab and then click back on the "Logs" tab and it should show you the React tab.

## Fixes

Fixes: #2440.