### PR TITLE
feat(ui): display script history details

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/__snapshots__/MachineTestsDetails.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsDetails/__snapshots__/MachineTestsDetails.test.tsx.snap
@@ -55,7 +55,13 @@ exports[`MachineTestDetails renders 1`] = `
         }
       }
     >
-      <MachineTestsDetails />
+      <MachineTestsDetails>
+        <h4
+          data-test="not-found"
+        >
+          Script result could not be found.
+        </h4>
+      </MachineTestsDetails>
     </Router>
   </MemoryRouter>
 </Provider>

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.test.tsx
@@ -108,6 +108,26 @@ describe("TestHistory", () => {
     expect(wrapper.find("[data-test='history-table']").exists()).toBe(true);
   });
 
+  it("displays a link to the history details", () => {
+    const scriptResult = scriptResultFactory({ id: 1 });
+    state.scriptresult.items = [scriptResult];
+    state.scriptresult.history = {
+      1: [partialScriptResultFactory(), partialScriptResultFactory()],
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <TestHistory close={jest.fn()} scriptResult={scriptResult} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='details-link']").exists()).toBe(true);
+  });
+
   it("displays a message if the test has no history", () => {
     const scriptResult = scriptResultFactory({ id: 1 });
     state.scriptresult.items = [scriptResult];

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/TestHistory/TestHistory.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { Button, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import ScriptStatus from "app/base/components/ScriptStatus";
 import type { RootState } from "app/store/root/types";
@@ -52,7 +53,15 @@ const TestHistory = ({ close, scriptResult }: Props): JSX.Element => {
                   <td className="tags-col"></td>
                   <td className="result-col">
                     <ScriptStatus status={historyResult.status}>
-                      {historyResult.status_name}
+                      {historyResult.status_name}{" "}
+                      <Link
+                        data-test="details-link"
+                        to={(location) =>
+                          `${location.pathname}/${historyResult.id}/details`
+                        }
+                      >
+                        View log
+                      </Link>
                     </ScriptStatus>
                   </td>
                   <td className="date-col">{historyResult.updated || "—"}</td>

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.scss
@@ -13,11 +13,11 @@
     }
 
     .result-col {
-      @include breakpoint-widths(0, 60, 60, 35, 30, true);
+      @include breakpoint-widths(0, 60, 60, 30, 20, true);
     }
 
     .date-col {
-      @include breakpoint-widths(0, 0, 0, 30, 12, true);
+      @include breakpoint-widths(0, 0, 0, 35, 22, true);
     }
 
     .runtime-col {

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.scss
@@ -13,11 +13,11 @@
     }
 
     .result-col {
-      @include breakpoint-widths(0, 60, 60, 30, 20, true);
+      @include breakpoint-widths(0, 60, 60, 35, 30, true);
     }
 
     .date-col {
-      @include breakpoint-widths(0, 0, 0, 35, 22, true);
+      @include breakpoint-widths(0, 0, 0, 30, 12, true);
     }
 
     .runtime-col {

--- a/ui/src/app/store/scriptresult/reducers.test.ts
+++ b/ui/src/app/store/scriptresult/reducers.test.ts
@@ -20,6 +20,51 @@ describe("script result reducer", () => {
     });
   });
 
+  describe("get", () => {
+    it("reduces getStart", () => {
+      const scriptResultState = scriptResultStateFactory({
+        items: [],
+        loading: false,
+      });
+      expect(reducers(scriptResultState, actions.getStart(null))).toEqual(
+        scriptResultStateFactory({ loading: true })
+      );
+    });
+
+    it("reduces getSuccess", () => {
+      const existingScriptResult = scriptResultFactory();
+      const newScriptResult = scriptResultFactory({ id: 2 });
+      const scriptResultState = scriptResultStateFactory({
+        items: [existingScriptResult],
+        loading: true,
+      });
+      expect(
+        reducers(scriptResultState, actions.getSuccess(newScriptResult))
+      ).toEqual(
+        scriptResultStateFactory({
+          items: [existingScriptResult, newScriptResult],
+          loading: false,
+          history: { 2: [] },
+        })
+      );
+    });
+
+    it("reduces getError", () => {
+      const scriptResultState = scriptResultStateFactory({ loading: true });
+      expect(
+        reducers(
+          scriptResultState,
+          actions.getError("Could not get script result")
+        )
+      ).toEqual(
+        scriptResultStateFactory({
+          errors: "Could not get script result",
+          loading: false,
+        })
+      );
+    });
+  });
+
   it("reduces getByMachineIdStart", () => {
     const scriptResultState = scriptResultStateFactory({
       items: [],
@@ -32,7 +77,7 @@ describe("script result reducer", () => {
   });
 
   it("reduces getByMachineIdSuccess", () => {
-    const existingScriptResult = scriptResultFactory();
+    const existingScriptResult = scriptResultFactory({ id: 1 });
     const newScriptResult = scriptResultFactory({ id: 2 });
     const newScriptResult2 = scriptResultFactory({ id: 3 });
 

--- a/ui/src/app/store/scriptresult/selectors.test.tsx
+++ b/ui/src/app/store/scriptresult/selectors.test.tsx
@@ -55,6 +55,23 @@ describe("scriptResult selectors", () => {
     expect(selectors.errors(state)).toStrictEqual("Data is incorrect");
   });
 
+  it("returns script results by id", () => {
+    const items = [
+      scriptResultFactory({ id: 1 }),
+      scriptResultFactory({ id: 2 }),
+      scriptResultFactory({ id: 3 }),
+    ];
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        items,
+      }),
+      nodescriptresult: nodeScriptResultStateFactory({
+        items: { abc123: [1, 2] },
+      }),
+    });
+    expect(selectors.getById(state, 2)).toStrictEqual(items[1]);
+  });
+
   it("returns script results by machine id", () => {
     const resultsForMachine = [
       scriptResultFactory({ id: 1 }),

--- a/ui/src/app/store/scriptresult/selectors.ts
+++ b/ui/src/app/store/scriptresult/selectors.ts
@@ -73,6 +73,22 @@ const saved = (state: RootState): boolean => state.scriptresult.saved;
 const errors = (state: RootState): TSFixMe => state.scriptresult.errors;
 
 /**
+ * Get a script result by id.
+ * @param state - The redux state.
+ * @param id - A script result id.
+ * @returns A script result.
+ */
+const getById = createSelector(
+  [all, (_state: RootState, id: ScriptResult["id"] | null | undefined) => id],
+  (items, id) => {
+    if (!id && id !== 0) {
+      return null;
+    }
+    return items.find((item) => item.id === id) || null;
+  }
+);
+
+/**
  * Returns true if script results have errors
  * @param {RootState} state - Redux state
  * @returns {Boolean} Script results have errors
@@ -411,6 +427,7 @@ const getHistoryById = createSelector(
 const scriptResult = {
   all,
   errors,
+  getById,
   getByMachineId,
   getCommissioningByMachineId,
   getFailedTestingResultsByMachineIds,

--- a/ui/src/app/store/scriptresult/slice.ts
+++ b/ui/src/app/store/scriptresult/slice.ts
@@ -55,6 +55,50 @@ const scriptResultSlice = generateSlice<
   } as ScriptResultState,
   name: "scriptresult",
   reducers: {
+    get: {
+      prepare: (id: ScriptResult["id"]) => ({
+        meta: {
+          model: "noderesult",
+          method: "get",
+        },
+        payload: {
+          params: {
+            id,
+          },
+        },
+      }),
+      reducer: () => {
+        // no state changes needed
+      },
+    },
+    getStart: (state: ScriptResultState, _action: PayloadAction<null>) => {
+      state.loading = true;
+    },
+    getError: (
+      state: ScriptResultState,
+      action: PayloadAction<ScriptResultState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.loading = false;
+    },
+    getSuccess: (
+      state: ScriptResultState,
+      action: PayloadAction<ScriptResult, string, GenericItemMeta<ItemMeta>>
+    ) => {
+      const result = action.payload;
+      const i = state.items.findIndex(
+        (draftItem: ScriptResult) => draftItem.id === result.id
+      );
+      if (i !== -1) {
+        state.items[i] = result;
+      } else {
+        state.items.push(result);
+      }
+      if (!(result.id in state.history)) {
+        state.history[result.id] = [];
+      }
+      state.loading = false;
+    },
     getByMachineId: {
       prepare: (machineID: Machine["system_id"]) => ({
         meta: {


### PR DESCRIPTION
## Done

- Link to details for script history and fetch the results.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to machine details and then commissioning or tests.
- Open the action menu for a result and click "view previous tests".
- There should be a "View log" link next to each result.
- Click "View log" and it should load the results.

## Fixes

Fixes: #2312.