### PR TITLE
feat(ui): display script elapsed time

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/MachineTestsTable.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Input, MainTable, Tooltip } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
 
+import ScriptRunTime from "./ScriptRunTime";
 import TestActions from "./TestActions";
 import TestHistory from "./TestHistory";
 import TestMetrics from "./TestMetrics";
@@ -129,7 +130,7 @@ const MachineTestsTable = ({
         },
         {
           className: "runtime-col",
-          content: result.runtime || "—",
+          content: <ScriptRunTime scriptResult={result} />,
         },
         {
           className: "actions-col u-align--right",

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.test.tsx
@@ -1,0 +1,121 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+
+import ScriptRunTime from "./ScriptRunTime";
+
+import {
+  ScriptResultStatus,
+  ScriptResultEstimated,
+} from "app/store/scriptresult/types";
+import { scriptResult as scriptResultFactory } from "testing/factories";
+
+describe("ScriptRunTime", () => {
+  beforeEach(() => {
+    jest
+      .useFakeTimers("modern")
+      .setSystemTime(new Date("Thu Apr 01 2021 05:21:58 GMT+0000").getTime());
+  });
+
+  it("displays the elapsed time when running and runtime is not known", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: ScriptResultEstimated.UNKNOWN,
+      status: ScriptResultStatus.RUNNING,
+      starttime: 1617254218,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:05:00");
+  });
+
+  it("displays the elapsed time when running and runtime is known", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: "00:10:00",
+      status: ScriptResultStatus.RUNNING,
+      starttime: 1617254218,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:05:00 of ~00:10:00");
+  });
+
+  it("displays the elapsed and estimated times when installing and runtime is not known", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: ScriptResultEstimated.UNKNOWN,
+      status: ScriptResultStatus.INSTALLING,
+      starttime: 1617254218,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:05:00");
+  });
+
+  it("displays the elapsed and estimated times when installing and runtime is known", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: "00:10:00",
+      status: ScriptResultStatus.INSTALLING,
+      starttime: 1617254218,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:05:00 of ~00:10:00");
+  });
+
+  it("updates the elapsed time every second", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: ScriptResultEstimated.UNKNOWN,
+      status: ScriptResultStatus.RUNNING,
+      starttime: 1617254218,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:05:00");
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    wrapper.update();
+    expect(wrapper.text()).toBe("00:05:01");
+  });
+
+  it("only shows the time if less than a day has elapsed", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: ScriptResultEstimated.UNKNOWN,
+      status: ScriptResultStatus.RUNNING,
+      starttime: 1617254218,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:05:00");
+  });
+
+  it("shows the day and time if one day has elapsed", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: ScriptResultEstimated.UNKNOWN,
+      status: ScriptResultStatus.RUNNING,
+      starttime: 1617167818,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("1 day, 00:05:00");
+  });
+
+  it("shows the days and time if more than one day has elapsed", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: ScriptResultEstimated.UNKNOWN,
+      status: ScriptResultStatus.RUNNING,
+      starttime: 1617081418,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("2 days, 00:05:00");
+  });
+
+  it("displays the estimated time when pending and runtime is known", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: "00:10:00",
+      status: ScriptResultStatus.PENDING,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("~00:10:00");
+  });
+
+  it("displays the runtime for other statuses", () => {
+    const scriptResult = scriptResultFactory({
+      runtime: "00:15:00",
+      status: ScriptResultStatus.FAILED_APPLYING_NETCONF,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:15:00");
+  });
+});

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.test.tsx
@@ -23,28 +23,28 @@ describe("ScriptRunTime", () => {
       starttime: 1617254218,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:05:00");
+    expect(wrapper.text()).toBe("0:05:00");
   });
 
   it("displays the elapsed time when running and runtime is known", () => {
     const scriptResult = scriptResultFactory({
-      estimated_runtime: "00:10:00",
+      estimated_runtime: "0:10:00",
       status: ScriptResultStatus.RUNNING,
       starttime: 1617254218,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:05:00 of ~00:10:00");
+    expect(wrapper.text()).toBe("0:05:00 of ~0:10:00");
   });
 
   it("displays the elapsed time when the the start time is not known", () => {
     const scriptResult = scriptResultFactory({
-      estimated_runtime: "00:10:00",
+      estimated_runtime: "0:10:00",
       status: ScriptResultStatus.RUNNING,
       // Use undefined here so that the factory does not set the start time.
       starttime: undefined,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:00:00 of ~00:10:00");
+    expect(wrapper.text()).toBe("0:00:00 of ~0:10:00");
   });
 
   it("displays the elapsed and estimated times when installing and runtime is not known", () => {
@@ -54,17 +54,17 @@ describe("ScriptRunTime", () => {
       starttime: 1617254218,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:05:00");
+    expect(wrapper.text()).toBe("0:05:00");
   });
 
   it("displays the elapsed and estimated times when installing and runtime is known", () => {
     const scriptResult = scriptResultFactory({
-      estimated_runtime: "00:10:00",
+      estimated_runtime: "0:10:00",
       status: ScriptResultStatus.INSTALLING,
       starttime: 1617254218,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:05:00 of ~00:10:00");
+    expect(wrapper.text()).toBe("0:05:00 of ~0:10:00");
   });
 
   it("updates the elapsed time every second", () => {
@@ -74,12 +74,12 @@ describe("ScriptRunTime", () => {
       starttime: 1617254218,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:05:00");
+    expect(wrapper.text()).toBe("0:05:00");
     act(() => {
       jest.advanceTimersByTime(1000);
     });
     wrapper.update();
-    expect(wrapper.text()).toBe("00:05:01");
+    expect(wrapper.text()).toBe("0:05:01");
   });
 
   it("only shows the time if less than a day has elapsed", () => {
@@ -89,7 +89,7 @@ describe("ScriptRunTime", () => {
       starttime: 1617254218,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:05:00");
+    expect(wrapper.text()).toBe("0:05:00");
   });
 
   it("shows the day and time if one day has elapsed", () => {
@@ -99,7 +99,7 @@ describe("ScriptRunTime", () => {
       starttime: 1617167818,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("1 day, 00:05:00");
+    expect(wrapper.text()).toBe("1 day, 0:05:00");
   });
 
   it("shows the days and time if more than one day has elapsed", () => {
@@ -109,24 +109,24 @@ describe("ScriptRunTime", () => {
       starttime: 1617081418,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("2 days, 00:05:00");
+    expect(wrapper.text()).toBe("2 days, 0:05:00");
   });
 
   it("displays the estimated time when pending and runtime is known", () => {
     const scriptResult = scriptResultFactory({
-      estimated_runtime: "00:10:00",
+      estimated_runtime: "0:10:00",
       status: ScriptResultStatus.PENDING,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("~00:10:00");
+    expect(wrapper.text()).toBe("~0:10:00");
   });
 
   it("displays the runtime for other statuses", () => {
     const scriptResult = scriptResultFactory({
-      runtime: "00:15:00",
+      runtime: "0:15:00",
       status: ScriptResultStatus.FAILED_APPLYING_NETCONF,
     });
     const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
-    expect(wrapper.text()).toBe("00:15:00");
+    expect(wrapper.text()).toBe("0:15:00");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.test.tsx
@@ -36,6 +36,17 @@ describe("ScriptRunTime", () => {
     expect(wrapper.text()).toBe("00:05:00 of ~00:10:00");
   });
 
+  it("displays the elapsed time when the the start time is not known", () => {
+    const scriptResult = scriptResultFactory({
+      estimated_runtime: "00:10:00",
+      status: ScriptResultStatus.RUNNING,
+      // Use undefined here so that the factory does not set the start time.
+      starttime: undefined,
+    });
+    const wrapper = mount(<ScriptRunTime scriptResult={scriptResult} />);
+    expect(wrapper.text()).toBe("00:00:00 of ~00:10:00");
+  });
+
   it("displays the elapsed and estimated times when installing and runtime is not known", () => {
     const scriptResult = scriptResultFactory({
       estimated_runtime: ScriptResultEstimated.UNKNOWN,

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.tsx
@@ -24,10 +24,10 @@ const getElapsedTime = (starttime: ScriptResult["starttime"]) => {
   const elapsed = [];
   // Show the elapsed days if more than a day has elapsed.
   if (days) {
-    elapsed.push(`${days} ${pluralize("day", days)}`);
+    elapsed.push(pluralize("day", days, true));
   }
   // Display time in the format hh:mm:ss.
-  elapsed.push(`${zeroPad(hours)}:${zeroPad(minutes)}:${zeroPad(seconds)}`);
+  elapsed.push(`${hours}:${zeroPad(minutes)}:${zeroPad(seconds)}`);
   return elapsed.join(", ");
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.tsx
@@ -18,7 +18,7 @@ const zeroPad = (time?: number) => `0${time || "0"}`.slice(-2);
 
 const getElapsedTime = (starttime: ScriptResult["starttime"]) => {
   const { days, hours, minutes, seconds } = intervalToDuration({
-    start: fromUnixTime(starttime),
+    start: starttime ? fromUnixTime(starttime) : Date.now(),
     end: Date.now(),
   });
   const elapsed = [];
@@ -67,6 +67,7 @@ const ScriptRunTime = ({ scriptResult }: Props): JSX.Element | null => {
   } else if (!isPending && !isRunning && !isInstalling) {
     runtime = scriptResult.runtime;
   }
+
   return <span>{runtime}</span>;
 };
 

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/ScriptRunTime.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+
+import { intervalToDuration, fromUnixTime } from "date-fns";
+import pluralize from "pluralize";
+
+import {
+  ScriptResultStatus,
+  ScriptResultEstimated,
+} from "app/store/scriptresult/types";
+import type { ScriptResult } from "app/store/scriptresult/types";
+
+type Props = {
+  scriptResult: ScriptResult;
+};
+
+// Add leading zeros to single digit numbers.
+const zeroPad = (time?: number) => `0${time || "0"}`.slice(-2);
+
+const getElapsedTime = (starttime: ScriptResult["starttime"]) => {
+  const { days, hours, minutes, seconds } = intervalToDuration({
+    start: fromUnixTime(starttime),
+    end: Date.now(),
+  });
+  const elapsed = [];
+  // Show the elapsed days if more than a day has elapsed.
+  if (days) {
+    elapsed.push(`${days} ${pluralize("day", days)}`);
+  }
+  // Display time in the format hh:mm:ss.
+  elapsed.push(`${zeroPad(hours)}:${zeroPad(minutes)}:${zeroPad(seconds)}`);
+  return elapsed.join(", ");
+};
+
+const ScriptRunTime = ({ scriptResult }: Props): JSX.Element | null => {
+  const [elapsedTime, setElapsedTime] = useState("");
+  const timerId = useRef<NodeJS.Timeout>();
+  const isInstalling = scriptResult.status === ScriptResultStatus.INSTALLING;
+  const isPending = scriptResult.status === ScriptResultStatus.PENDING;
+  const isRunning = scriptResult.status === ScriptResultStatus.RUNNING;
+  const estimatedRuntimeKnown =
+    scriptResult.estimated_runtime !== ScriptResultEstimated.UNKNOWN;
+
+  useEffect(() => {
+    if (isRunning || isInstalling) {
+      // If an action is in process then update the elapsed time every second.
+      setElapsedTime(getElapsedTime(scriptResult.starttime));
+      timerId.current = setInterval(() => {
+        setElapsedTime(getElapsedTime(scriptResult.starttime));
+      }, 1000);
+    }
+    return () => {
+      if (timerId.current) {
+        clearInterval(timerId.current);
+      }
+    };
+  }, [isRunning, isInstalling, scriptResult]);
+
+  let runtime: string | null = null;
+  if (isRunning || isInstalling) {
+    if (estimatedRuntimeKnown) {
+      runtime = `${elapsedTime} of ~${scriptResult.estimated_runtime}`;
+    } else {
+      runtime = elapsedTime;
+    }
+  } else if (isPending && estimatedRuntimeKnown) {
+    runtime = `~${scriptResult.estimated_runtime}`;
+  } else if (!isPending && !isRunning && !isInstalling) {
+    runtime = scriptResult.runtime;
+  }
+  return <span>{runtime}</span>;
+};
+
+export default ScriptRunTime;

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/index.ts
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/ScriptRunTime/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ScriptRunTime";

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -9,6 +9,10 @@ export enum ScriptResultNames {
   CURTIN_LOG = "/tmp/curtin-logs.tar",
 }
 
+export enum ScriptResultEstimated {
+  UNKNOWN = "Unknown",
+}
+
 export enum ScriptResultType {
   COMMISSIONING = 0,
   INSTALLATION = 1,
@@ -48,7 +52,7 @@ export type ScriptResultResult = {
 
 export type PartialScriptResult = Model & {
   endtime: number;
-  estimated_runtime: string;
+  estimated_runtime: ScriptResultEstimated | string;
   runtime: string;
   starttime: number;
   status: ScriptResultStatus;

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -54,7 +54,7 @@ export type PartialScriptResult = Model & {
   endtime: number;
   estimated_runtime: ScriptResultEstimated | string;
   runtime: string;
-  starttime: number;
+  starttime?: number;
   status: ScriptResultStatus;
   status_name: string;
   suppressed: boolean;


### PR DESCRIPTION
## Done

- Add a component to display the elapsed time of scripts.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to an LXD pod and compose a machine.
- Go to the machine details for the new machine and click on comissioning.
- Wait a while and you should see the scripts update and there should be elapsed times for some of them.

## Fixes

Fixes: #2311.