### PR TITLE
fix(ui): fix active tab and navigation highlights

### DIFF
--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -86,6 +86,11 @@ input[type="radio"] {
 // 6-04-2021 Huw: Show the active state when active tabs are focused.
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/3686
 .p-tabs {
+  .p-tabs__link:not(:focus-visible):active,
+  .p-tabs__link:not(:focus-visible):focus {
+    @include vf-highlight-bar($color-mid-dark, bottom, false);
+  }
+
   .p-tabs__link[aria-selected="true"]:focus:not(:focus-visible)::before {
     content: "";
     position: absolute;

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -86,7 +86,7 @@ input[type="radio"] {
 // 6-04-2021 Huw: Show the active state when active tabs are focused.
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/3686
 .p-tabs {
-  .p-tabs__link[aria-selected="true"]:focus::before {
+  .p-tabs__link[aria-selected="true"]:focus:not(:focus-visible)::before {
     content: "";
     position: absolute;
   }
@@ -94,6 +94,6 @@ input[type="radio"] {
 
 // 6-04-2021 Huw: Show the active state when active sidebar links focused.
 // https://github.com/canonical-web-and-design/vanilla-framework/issues/3686
-.p-side-navigation__link.is-active:focus::before {
+.p-side-navigation__link.is-active:focus:not(:focus-visible)::before {
   display: block;
 }

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -82,3 +82,18 @@ input[type="radio"] {
 .p-top .p-top__link {
   background-color: $color-light;
 }
+
+// 6-04-2021 Huw: Show the active state when active tabs are focused.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3686
+.p-tabs {
+  .p-tabs__link[aria-selected="true"]:focus::before {
+    content: "";
+    position: absolute;
+  }
+}
+
+// 6-04-2021 Huw: Show the active state when active sidebar links focused.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3686
+.p-side-navigation__link.is-active:focus::before {
+  display: block;
+}


### PR DESCRIPTION
## Done

- Fix focused active tabs and sidebar navigation links so that the highlighted item is shown.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine details.
- Click on a tab. The active tab should be highlighted with a border.
- Go to settings (in the main nav).
- Click on a link in the sidebar. The active link should be highlighted with a border on the left.

## Fixes

Fixes: #2024.