### PR TITLE
fix(ui): fix test device names

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -89,12 +89,6 @@ describe("MachineTests", () => {
     state.nodescriptresult.items = { abc123: [1, 2] };
     state.scriptresult.items = [
       scriptResultFactory({
-        id: 1,
-        result_type: ScriptResultType.TESTING,
-        hardware_type: HardwareType.Storage,
-        physical_blockdevice: 1,
-      }),
-      scriptResultFactory({
         id: 2,
         result_type: ScriptResultType.TESTING,
         hardware_type: HardwareType.Storage,
@@ -103,6 +97,7 @@ describe("MachineTests", () => {
           storage: {
             type: ScriptResultParamType.STORAGE,
             value: {
+              id: 44,
               model: "QEMU HARDDISK",
               name: "sda",
               serial: "lxd_root",
@@ -126,12 +121,86 @@ describe("MachineTests", () => {
         </MemoryRouter>
       </Provider>
     );
+    expect(
+      wrapper.find("[data-test='storage-heading']").first().text()
+    ).toEqual("/dev/sda (model: QEMU HARDDISK, serial: lxd_root)");
+  });
 
-    expect(wrapper.find("[data-test='storage-heading']").at(0).text()).toEqual(
-      "1"
+  it("shows a heading for a block device without a model and serial", () => {
+    state.nodescriptresult.items = { abc123: [1, 2] };
+    state.scriptresult.items = [
+      scriptResultFactory({
+        id: 2,
+        result_type: ScriptResultType.TESTING,
+        hardware_type: HardwareType.Storage,
+        physical_blockdevice: 2,
+        parameters: {
+          storage: {
+            type: ScriptResultParamType.STORAGE,
+            value: {
+              id: 9,
+              model: "",
+              name: "sda",
+              serial: "",
+              id_path: "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_lxd_root",
+              physical_blockdevice_id: 2,
+            },
+          },
+        },
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineTests />
+          </Route>
+        </MemoryRouter>
+      </Provider>
     );
-    expect(wrapper.find("[data-test='storage-heading']").at(1).text()).toEqual(
-      "/dev/sda (model: QEMU HARDDISK, serial: lxd_root)"
+    expect(
+      wrapper.find("[data-test='storage-heading']").first().text()
+    ).toEqual("/dev/sda");
+  });
+
+  it("shows a heading for a network interface", () => {
+    state.nodescriptresult.items = { abc123: [1, 2] };
+    state.scriptresult.items = [
+      scriptResultFactory({
+        id: 2,
+        result_type: ScriptResultType.TESTING,
+        hardware_type: HardwareType.Network,
+        parameters: {
+          interface: {
+            type: ScriptResultParamType.INTERFACE,
+            value: {
+              id: 856,
+              mac_address: "52:54:00:57:e9:ac",
+              name: "ens4",
+              product: null,
+              vendor: "Red Hat, Inc.",
+            },
+          },
+        },
+      }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineTests />
+          </Route>
+        </MemoryRouter>
+      </Provider>
     );
+    expect(
+      wrapper.find("[data-test='hardware-device-heading']").first().text()
+    ).toEqual("ens4 (52:54:00:57:e9:ac)");
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -69,11 +69,24 @@ const MachineTests = (): JSX.Element => {
         {hardwareResults?.length && hardwareResults.length > 0
           ? Object.entries(groupByKey(hardwareResults, "hardware_type")).map(
               ([hardware_type, scriptResults]: [string, ScriptResult[]]) => {
+                let title: string | null = null;
+                if (scriptResults[0].hardware_type === HardwareType.Network) {
+                  const { mac_address, name } =
+                    scriptResults[0]?.parameters?.interface?.value || {};
+                  if (name && mac_address) {
+                    title = `${name} (${mac_address})`;
+                  } else {
+                    title = name || null;
+                  }
+                }
                 return (
                   <div key={hardware_type}>
                     <h4 data-test="hardware-heading">
                       {HardwareType[parseInt(hardware_type, 0)]}
                     </h4>
+                    {title && (
+                      <h5 data-test="hardware-device-heading">{title}</h5>
+                    )}
                     <MachineTestsTable
                       machineId={id}
                       scriptResults={scriptResults}
@@ -95,13 +108,17 @@ const MachineTests = (): JSX.Element => {
               ]) => {
                 const { model, name, serial } =
                   scriptResults[0]?.parameters?.storage?.value || {};
+                let title = name ? `/dev/${name}` : null;
+                if (name && model && serial) {
+                  title = `${title} (model: ${model}, serial: ${serial})`;
+                }
                 return (
                   <div key={physical_blockdevice}>
-                    <h5 data-test="storage-heading">
-                      {model && name && serial
-                        ? `/dev/${name} (model: ${model}, serial: ${serial})`
-                        : physical_blockdevice}
-                    </h5>
+                    {title && (
+                      <h5 data-test="storage-heading">
+                        {title || physical_blockdevice}
+                      </h5>
+                    )}
                     <MachineTestsTable
                       machineId={id}
                       scriptResults={scriptResults}

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -109,16 +109,15 @@ const MachineTests = (): JSX.Element => {
                 const { model, name, serial } =
                   scriptResults[0]?.parameters?.storage?.value || {};
                 let title = name ? `/dev/${name}` : null;
-                if (name && model && serial) {
-                  title = `${title} (model: ${model}, serial: ${serial})`;
+                if (name && (model || serial)) {
+                  const additional = [`model: ${model}`, `serial: ${serial}`]
+                    .filter(Boolean)
+                    .join(", ");
+                  title = `${title} (${additional})`;
                 }
                 return (
                   <div key={physical_blockdevice}>
-                    {title && (
-                      <h5 data-test="storage-heading">
-                        {title || physical_blockdevice}
-                      </h5>
-                    )}
+                    {title && <h5 data-test="storage-heading">{title}</h5>}
                     <MachineTestsTable
                       machineId={id}
                       scriptResults={scriptResults}

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -70,11 +70,11 @@ export type ScriptResult = PartialScriptResult & {
   parameters?: {
     interface?: {
       type: ScriptResultParamType.INTERFACE;
-      value: {
+      value: Model & {
         name: string;
         mac_address: string;
         vendor: string;
-        product: string;
+        product?: string | null;
       };
       argument_format?: string;
     };
@@ -85,12 +85,12 @@ export type ScriptResult = PartialScriptResult & {
     };
     storage?: {
       type: ScriptResultParamType.STORAGE;
-      value?: {
+      value?: Model & {
         id_path: string | null;
-        model: string;
+        model?: string;
         name: string;
         physical_blockdevice_id: number;
-        serial: string;
+        serial?: string;
       };
       argument_format?: string;
     };


### PR DESCRIPTION
## Done

- Display names for tested devices where they exist.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Find a machine that has run storage and network tests (or using the take action menu to run some).
- For storage and network test groups you should see (for most, not all tests) the device name (something like `/dev/vda` for storage and `ens4 (52:54:00:57:e2:ac)` for network), but not names like "null" or "72".

## Fixes

Fixes: #2313.