### PR TITLE
feat(ui): paginate LXD VMs table

### DIFF
--- a/ui/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
+++ b/ui/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
@@ -52,4 +52,63 @@ describe("ArrowPagination", () => {
     );
     expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
   });
+
+  it("can show the page bounds when there are no items", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={1}
+        itemCount={0}
+        pageSize={25}
+        setCurrentPage={jest.fn()}
+        showPageBounds
+      />
+    );
+    expect(wrapper.find("[data-test='page-bounds']").text()).toBe("0 - 0 of 0");
+  });
+
+  it("can show the page bounds when there are more items than the current page shows", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={1}
+        itemCount={26}
+        pageSize={25}
+        setCurrentPage={jest.fn()}
+        showPageBounds
+      />
+    );
+    expect(wrapper.find("[data-test='page-bounds']").text()).toBe(
+      "1 - 25 of 26"
+    );
+  });
+
+  it("can show the page bounds when there are less items than the current page shows", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={1}
+        itemCount={24}
+        pageSize={25}
+        setCurrentPage={jest.fn()}
+        showPageBounds
+      />
+    );
+    expect(wrapper.find("[data-test='page-bounds']").text()).toBe(
+      "1 - 24 of 24"
+    );
+  });
+
+  it("shows a spinner in the page bound section if items are loading", () => {
+    const wrapper = mount(
+      <ArrowPagination
+        currentPage={1}
+        itemCount={24}
+        loading
+        pageSize={25}
+        setCurrentPage={jest.fn()}
+        showPageBounds
+      />
+    );
+    expect(wrapper.find("[data-test='page-bounds'] Spinner").exists()).toBe(
+      true
+    );
+  });
 });

--- a/ui/src/app/base/components/ArrowPagination/ArrowPagination.tsx
+++ b/ui/src/app/base/components/ArrowPagination/ArrowPagination.tsx
@@ -1,19 +1,34 @@
 import type { HTMLProps } from "react";
 
-import { Button, Icon } from "@canonical/react-components";
+import { Button, Icon, Spinner } from "@canonical/react-components";
 
 type Props = {
   currentPage: number;
   itemCount: number;
+  loading?: boolean;
   pageSize: number;
   setCurrentPage: (page: number) => void;
+  showPageBounds?: boolean;
 } & HTMLProps<HTMLElement>;
+
+const getBounds = (
+  itemCount: number,
+  currentPage: number,
+  pageSize: number
+) => {
+  const lowerBound = itemCount === 0 ? 0 : pageSize * (currentPage - 1) + 1;
+  const upperBound =
+    itemCount > pageSize * currentPage ? pageSize * currentPage : itemCount;
+  return `${lowerBound} - ${upperBound} of ${itemCount}`;
+};
 
 const ArrowPagination = ({
   currentPage,
   itemCount,
+  loading = false,
   pageSize,
   setCurrentPage,
+  showPageBounds = false,
   ...props
 }: Props): JSX.Element => {
   const onFirstPage = currentPage === 1;
@@ -22,6 +37,11 @@ const ArrowPagination = ({
 
   return (
     <nav aria-label="pagination" {...props}>
+      {showPageBounds && (
+        <span className="u-text--muted u-nudge-left" data-test="page-bounds">
+          {loading ? <Spinner /> : getBounds(itemCount, currentPage, pageSize)}
+        </span>
+      )}
       <Button
         appearance="base"
         aria-label={onFirstPage ? "" : `Page ${currentPage - 1}`}

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { Strip } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
@@ -15,8 +15,11 @@ type Props = {
   setSelectedAction: SetSelectedAction;
 };
 
+export const VMS_PER_PAGE = 10;
+
 const ProjectVMs = ({ id, setSelectedAction }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     dispatch(machineActions.fetch());
@@ -29,9 +32,14 @@ const ProjectVMs = ({ id, setSelectedAction }: Props): JSX.Element => {
 
   return (
     <Strip shallow>
-      <VMsActionBar id={id} setSelectedAction={setSelectedAction} />
+      <VMsActionBar
+        currentPage={currentPage}
+        id={id}
+        setCurrentPage={setCurrentPage}
+        setSelectedAction={setSelectedAction}
+      />
       <Strip shallow>
-        <VMsTable id={id} />
+        <VMsTable currentPage={currentPage} id={id} />
       </Strip>
     </Strip>
   );

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
@@ -16,45 +16,6 @@ import {
 const mockStore = configureStore();
 
 describe("VMsActionBar", () => {
-  it("shows a spinner instead of VM count if machines are loading", () => {
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        loading: true,
-      }),
-      pod: podStateFactory({
-        items: [podFactory({ id: 1 })],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <VMsActionBar id={1} setSelectedAction={jest.fn()} />
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='vms-count'] Spinner").exists()).toBe(true);
-  });
-
-  it("shows a VM count if machines have loaded", () => {
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [machineFactory({ pod: { id: 1, name: "pod" } })],
-        loading: false,
-      }),
-      pod: podStateFactory({
-        items: [podFactory({ id: 1 })],
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <VMsActionBar id={1} setSelectedAction={jest.fn()} />
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='vms-count']").text()).toBe("1 - 1 of 1");
-  });
-
   it("can open the 'Compose VM' form", () => {
     const setSelectedAction = jest.fn();
     const state = rootStateFactory({
@@ -65,7 +26,12 @@ describe("VMsActionBar", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <VMsActionBar id={1} setSelectedAction={setSelectedAction} />
+        <VMsActionBar
+          currentPage={1}
+          id={1}
+          setCurrentPage={jest.fn()}
+          setSelectedAction={setSelectedAction}
+        />
       </Provider>
     );
 
@@ -84,7 +50,12 @@ describe("VMsActionBar", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <VMsActionBar id={1} setSelectedAction={setSelectedAction} />
+        <VMsActionBar
+          currentPage={1}
+          id={1}
+          setCurrentPage={jest.fn()}
+          setSelectedAction={setSelectedAction}
+        />
       </Provider>
     );
 
@@ -105,7 +76,12 @@ describe("VMsActionBar", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <VMsActionBar id={1} setSelectedAction={jest.fn()} />
+        <VMsActionBar
+          currentPage={1}
+          id={1}
+          setCurrentPage={jest.fn()}
+          setSelectedAction={jest.fn()}
+        />
       </Provider>
     );
 
@@ -132,7 +108,12 @@ describe("VMsActionBar", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <VMsActionBar id={1} setSelectedAction={jest.fn()} />
+        <VMsActionBar
+          currentPage={1}
+          id={1}
+          setCurrentPage={jest.fn()}
+          setSelectedAction={jest.fn()}
+        />
       </Provider>
     );
 

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -1,11 +1,7 @@
-import {
-  Button,
-  Icon,
-  SearchBox,
-  Spinner,
-  Tooltip,
-} from "@canonical/react-components";
+import { Button, Icon, SearchBox, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+
+import { VMS_PER_PAGE } from "../ProjectVMs";
 
 import ArrowPagination from "app/base/components/ArrowPagination";
 import type { SetSelectedAction } from "app/kvm/views/KVMDetails";
@@ -16,11 +12,18 @@ import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
+  currentPage: number;
   id: Pod["id"];
+  setCurrentPage: (page: number) => void;
   setSelectedAction: SetSelectedAction;
 };
 
-const VMsActionBar = ({ id, setSelectedAction }: Props): JSX.Element | null => {
+const VMsActionBar = ({
+  currentPage,
+  id,
+  setCurrentPage,
+  setSelectedAction,
+}: Props): JSX.Element | null => {
   const loading = useSelector(machineSelectors.loading);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
   const pod = useSelector((state: RootState) =>
@@ -96,15 +99,14 @@ const VMsActionBar = ({ id, setSelectedAction }: Props): JSX.Element | null => {
         <SearchBox className="u-no-margin--bottom" onChange={() => null} />
       </div>
       <div className="vms-action-bar__pagination">
-        <span className="u-text--muted u-nudge-left" data-test="vms-count">
-          {loading ? <Spinner /> : `1 - ${vms.length} of ${vms.length}`}
-        </span>
         <ArrowPagination
           className="u-display-inline-block"
-          currentPage={1}
+          currentPage={currentPage}
           itemCount={vms.length}
-          pageSize={25}
-          setCurrentPage={() => null}
+          loading={loading}
+          pageSize={VMS_PER_PAGE}
+          setCurrentPage={setCurrentPage}
+          showPageBounds
         />
       </div>
     </div>

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.tsx
@@ -1,6 +1,8 @@
 import { MainTable, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
+import { VMS_PER_PAGE } from "../ProjectVMs";
+
 import CoresColumn from "./CoresColumn";
 import HugepagesColumn from "./HugepagesColumn";
 import IPColumn from "./IPColumn";
@@ -20,6 +22,7 @@ import type { RootState } from "app/store/root/types";
 import { formatBytes, generateCheckboxHandlers } from "app/utils";
 
 type Props = {
+  currentPage: number;
   id: Pod["id"];
 };
 
@@ -94,7 +97,7 @@ const generateRows = (vms: Machine[], podId: Pod["id"]) =>
     };
   });
 
-const VMsTable = ({ id }: Props): JSX.Element => {
+const VMsTable = ({ currentPage, id }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const loading = useSelector(machineSelectors.loading);
   const pod = useSelector((state: RootState) =>
@@ -113,6 +116,10 @@ const VMsTable = ({ id }: Props): JSX.Element => {
     }
   );
   const sortedVms = sortRows(vms);
+  const paginatedVms = sortedVms.slice(
+    (currentPage - 1) * VMS_PER_PAGE,
+    currentPage * VMS_PER_PAGE
+  );
   const { handleGroupCheckbox } = generateCheckboxHandlers<
     Machine["system_id"]
   >((machineIDs) => {
@@ -217,7 +224,7 @@ const VMsTable = ({ id }: Props): JSX.Element => {
           ),
         },
       ]}
-      rows={generateRows(sortedVms, pod.id)}
+      rows={generateRows(paginatedVms, pod.id)}
     />
   );
 };

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./ProjectVMs";
+export { default, VMS_PER_PAGE } from "./ProjectVMs";


### PR DESCRIPTION
## Done

- Paginated the LXD VMs table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open `ProjectVMs.tsx` and change the constant `VMS_PER_PAGE` to something low like 2 or 3.
- Go to the project tab of a LXD KVM and check that you can change the VMs table page by clicking the chevrons
- Check that the page bounds are correct

## Fixes

Fixes #2233 