### PR TITLE
feat(ui): add search to LXD VM table

### DIFF
--- a/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
+++ b/ui/src/app/kvm/components/PodAggregateResources/PodAggregateResources.tsx
@@ -98,11 +98,9 @@ const normaliseResources = (
 const PodAggregateResources = ({ id }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const pod = useSelector((state: RootState) =>
-    podSelectors.getById(state, Number(id))
+    podSelectors.getById(state, id)
   );
-  const vms = useSelector((state: RootState) =>
-    podSelectors.getVMs(state, pod)
-  );
+  const vms = useSelector((state: RootState) => podSelectors.getVMs(state, id));
 
   useEffect(() => {
     dispatch(machineActions.fetch());

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
@@ -48,6 +48,31 @@ describe("KVMDetails", () => {
     expect(wrapper.find("Redirect").props().to).toBe("/kvm");
   });
 
+  it("sets the search filter from the URL", () => {
+    state.pod.items[0] = podFactory({ id: 1, type: PodType.LXD });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              key: "testKey",
+              pathname: "/kvm/1/project",
+              search: "?q=test+search",
+            },
+          ]}
+        >
+          <Route
+            exact
+            path="/kvm/:id/project"
+            component={() => <KVMDetails />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("LxdProject").prop("searchFilter")).toBe("test search");
+  });
+
   it("renders LXD resources component if pod is a LXD pod", () => {
     state.pod.items[0] = podFactory({ id: 1, type: PodType.LXD });
     const store = mockStore(state);

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMNumaResources/KVMNumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/KVMNumaResources/KVMNumaResources.tsx
@@ -68,10 +68,10 @@ const normaliseNuma = (
 const KVMNumaResources = ({ id }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const pod = useSelector((state: RootState) =>
-    podSelectors.getById(state, Number(id))
+    podSelectors.getById(state, id)
   );
   const podVMs = useSelector((state: RootState) =>
-    podSelectors.getVMs(state, pod)
+    podSelectors.getVMs(state, id)
   );
   const [expanded, setExpanded] = useState(false);
 

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.test.tsx
@@ -28,7 +28,12 @@ describe("LxdProject", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <LxdProject id={1} setSelectedAction={jest.fn()} />
+          <LxdProject
+            id={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -49,7 +54,12 @@ describe("LxdProject", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <LxdProject id={1} setSelectedAction={jest.fn()} />
+          <LxdProject
+            id={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -70,7 +80,12 @@ describe("LxdProject", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <LxdProject id={1} setSelectedAction={jest.fn()} />
+          <LxdProject
+            id={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -94,7 +109,12 @@ describe("LxdProject", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <LxdProject id={1} setSelectedAction={jest.fn()} />
+          <LxdProject
+            id={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/LxdProject.tsx
@@ -6,7 +6,10 @@ import ProjectSummaryCard from "./ProjectSummaryCard";
 import ProjectVMs from "./ProjectVMs";
 
 import { useWindowTitle } from "app/base/hooks";
-import type { SetSelectedAction } from "app/kvm/views/KVMDetails";
+import type {
+  SetSearchFilter,
+  SetSelectedAction,
+} from "app/kvm/views/KVMDetails";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import { PodType } from "app/store/pod/types";
@@ -14,10 +17,17 @@ import type { RootState } from "app/store/root/types";
 
 type Props = {
   id: Pod["id"];
+  searchFilter: string;
+  setSearchFilter: SetSearchFilter;
   setSelectedAction: SetSelectedAction;
 };
 
-const LxdProjects = ({ id, setSelectedAction }: Props): JSX.Element => {
+const LxdProject = ({
+  id,
+  searchFilter,
+  setSearchFilter,
+  setSelectedAction,
+}: Props): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
@@ -47,9 +57,14 @@ const LxdProjects = ({ id, setSelectedAction }: Props): JSX.Element => {
         {pod.project}
       </h4>
       <ProjectSummaryCard id={id} />
-      <ProjectVMs id={id} setSelectedAction={setSelectedAction} />
+      <ProjectVMs
+        id={id}
+        searchFilter={searchFilter}
+        setSearchFilter={setSearchFilter}
+        setSelectedAction={setSelectedAction}
+      />
     </>
   );
 };
 
-export default LxdProjects;
+export default LxdProject;

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.test.tsx
@@ -28,7 +28,12 @@ describe("ProjectVMs", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <ProjectVMs id={1} setSelectedAction={jest.fn()} />
+          <ProjectVMs
+            id={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );
@@ -51,7 +56,12 @@ describe("ProjectVMs", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <ProjectVMs id={1} setSelectedAction={jest.fn()} />
+          <ProjectVMs
+            id={1}
+            searchFilter=""
+            setSearchFilter={jest.fn()}
+            setSelectedAction={jest.fn()}
+          />
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/ProjectVMs.tsx
@@ -6,18 +6,28 @@ import { useDispatch } from "react-redux";
 import VMsActionBar from "./VMsActionBar";
 import VMsTable from "./VMsTable";
 
-import type { SetSelectedAction } from "app/kvm/views/KVMDetails";
+import type {
+  SetSearchFilter,
+  SetSelectedAction,
+} from "app/kvm/views/KVMDetails";
 import { actions as machineActions } from "app/store/machine";
 import type { Pod } from "app/store/pod/types";
 
 type Props = {
   id: Pod["id"];
+  searchFilter: string;
+  setSearchFilter: SetSearchFilter;
   setSelectedAction: SetSelectedAction;
 };
 
 export const VMS_PER_PAGE = 10;
 
-const ProjectVMs = ({ id, setSelectedAction }: Props): JSX.Element => {
+const ProjectVMs = ({
+  id,
+  searchFilter,
+  setSearchFilter,
+  setSelectedAction,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -35,11 +45,17 @@ const ProjectVMs = ({ id, setSelectedAction }: Props): JSX.Element => {
       <VMsActionBar
         currentPage={currentPage}
         id={id}
+        searchFilter={searchFilter}
         setCurrentPage={setCurrentPage}
+        setSearchFilter={setSearchFilter}
         setSelectedAction={setSelectedAction}
       />
       <Strip shallow>
-        <VMsTable currentPage={currentPage} id={id} />
+        <VMsTable
+          currentPage={currentPage}
+          id={id}
+          searchFilter={searchFilter}
+        />
       </Strip>
     </Strip>
   );

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
@@ -29,7 +29,9 @@ describe("VMsActionBar", () => {
         <VMsActionBar
           currentPage={1}
           id={1}
+          searchFilter=""
           setCurrentPage={jest.fn()}
+          setSearchFilter={jest.fn()}
           setSelectedAction={setSelectedAction}
         />
       </Provider>
@@ -53,7 +55,9 @@ describe("VMsActionBar", () => {
         <VMsActionBar
           currentPage={1}
           id={1}
+          searchFilter=""
           setCurrentPage={jest.fn()}
+          setSearchFilter={jest.fn()}
           setSelectedAction={setSelectedAction}
         />
       </Provider>
@@ -79,7 +83,9 @@ describe("VMsActionBar", () => {
         <VMsActionBar
           currentPage={1}
           id={1}
+          searchFilter=""
           setCurrentPage={jest.fn()}
+          setSearchFilter={jest.fn()}
           setSelectedAction={jest.fn()}
         />
       </Provider>
@@ -111,7 +117,9 @@ describe("VMsActionBar", () => {
         <VMsActionBar
           currentPage={1}
           id={1}
+          searchFilter=""
           setCurrentPage={jest.fn()}
+          setSearchFilter={jest.fn()}
           setSelectedAction={jest.fn()}
         />
       </Provider>

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -4,7 +4,10 @@ import { useSelector } from "react-redux";
 import { VMS_PER_PAGE } from "../ProjectVMs";
 
 import ArrowPagination from "app/base/components/ArrowPagination";
-import type { SetSelectedAction } from "app/kvm/views/KVMDetails";
+import type {
+  SetSearchFilter,
+  SetSelectedAction,
+} from "app/kvm/views/KVMDetails";
 import { KVMAction } from "app/kvm/views/KVMDetails";
 import machineSelectors from "app/store/machine/selectors";
 import podSelectors from "app/store/pod/selectors";
@@ -14,32 +17,27 @@ import type { RootState } from "app/store/root/types";
 type Props = {
   currentPage: number;
   id: Pod["id"];
+  searchFilter: string;
   setCurrentPage: (page: number) => void;
+  setSearchFilter: SetSearchFilter;
   setSelectedAction: SetSelectedAction;
 };
 
 const VMsActionBar = ({
   currentPage,
   id,
+  searchFilter,
   setCurrentPage,
+  setSearchFilter,
   setSelectedAction,
 }: Props): JSX.Element | null => {
   const loading = useSelector(machineSelectors.loading);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
-  const pod = useSelector((state: RootState) =>
-    podSelectors.getById(state, Number(id))
-  );
   const vms = useSelector((state: RootState) =>
-    podSelectors.getVMs(state, pod)
+    podSelectors.filteredVMs(state, id, searchFilter)
   );
+  const vmActionsDisabled = selectedIDs.length === 0;
 
-  if (!pod) {
-    return null;
-  }
-  const selectedPodVms = selectedIDs.filter((id) =>
-    vms.some((vm) => vm.system_id === id)
-  );
-  const vmActionsDisabled = selectedPodVms.length === 0;
   return (
     <div className="vms-action-bar">
       <div className="vms-action-bar__actions">
@@ -96,7 +94,14 @@ const VMsActionBar = ({
         </Tooltip>
       </div>
       <div className="vms-action-bar__search">
-        <SearchBox className="u-no-margin--bottom" onChange={() => null} />
+        <SearchBox
+          className="u-no-margin--bottom"
+          externallyControlled
+          onChange={(searchFilter: string) => {
+            setSearchFilter(searchFilter);
+          }}
+          value={searchFilter}
+        />
       </div>
       <div className="vms-action-bar__pagination">
         <ArrowPagination

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/VMsTable.test.tsx
@@ -34,7 +34,7 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable id={1} currentPage={1} />
+          <VMsTable currentPage={1} id={1} searchFilter="" />
         </MemoryRouter>
       </Provider>
     );
@@ -62,7 +62,7 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable id={1} currentPage={1} />
+          <VMsTable currentPage={1} id={1} searchFilter="" />
         </MemoryRouter>
       </Provider>
     );
@@ -114,7 +114,7 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable id={1} currentPage={1} />
+          <VMsTable currentPage={1} id={1} searchFilter="" />
         </MemoryRouter>
       </Provider>
     );
@@ -157,7 +157,7 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable id={1} currentPage={1} />
+          <VMsTable currentPage={1} id={1} searchFilter="" />
         </MemoryRouter>
       </Provider>
     );
@@ -196,7 +196,7 @@ describe("VMsTable", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
         >
-          <VMsTable id={1} currentPage={currentPage} />
+          <VMsTable currentPage={currentPage} id={1} searchFilter="" />
         </MemoryRouter>
       </Provider>
     );
@@ -206,5 +206,42 @@ describe("VMsTable", () => {
     wrapper.setProps({ currentPage: 2 });
     wrapper.update();
     expect(wrapper.find("tbody tr").length).toBe(1);
+  });
+
+  it("shows a message if no VMs match the search filter", () => {
+    const pod = podFactory({ id: 1, type: PodType.LXD });
+    const vms = [
+      machineFactory({
+        pod: { id: pod.id, name: pod.name },
+        system_id: "abc123",
+      }),
+      machineFactory({
+        pod: { id: pod.id, name: pod.name },
+        system_id: "def456",
+      }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: vms,
+      }),
+      pod: podStateFactory({
+        items: [pod],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
+        >
+          <VMsTable currentPage={1} id={1} searchFilter="system_id:(=ghi789)" />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='no-vms']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='no-vms']").text()).toBe(
+      "No VMs in this VM host match the search criteria."
+    );
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/ProjectResourcesCard/ProjectResourcesCard.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/ProjectResourcesCard/ProjectResourcesCard.tsx
@@ -22,7 +22,7 @@ const ProjectResourcesCard = ({ id }: Props): JSX.Element => {
     podSelectors.getById(state, id)
   );
   const podVMs = useSelector((state: RootState) =>
-    podSelectors.getVMs(state, pod)
+    podSelectors.getVMs(state, id)
   );
 
   if (pod) {

--- a/ui/src/app/kvm/views/KVMDetails/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/index.ts
@@ -1,2 +1,6 @@
 export { default, KVMAction } from "./KVMDetails";
-export type { SelectedAction, SetSelectedAction } from "./KVMDetails";
+export type {
+  SelectedAction,
+  SetSearchFilter,
+  SetSelectedAction,
+} from "./KVMDetails";

--- a/ui/src/app/store/pod/selectors.test.ts
+++ b/ui/src/app/store/pod/selectors.test.ts
@@ -240,7 +240,36 @@ describe("pod selectors", () => {
         items: [podWithVMs],
       }),
     });
-    expect(pod.getVMs(state, podWithVMs)).toStrictEqual(machinesInPod);
+    expect(pod.getVMs(state, podWithVMs.id)).toStrictEqual(machinesInPod);
+  });
+
+  it("can filter a pod's VMs", () => {
+    const podWithVms = podFactory();
+    const vms = [
+      machineFactory({
+        hostname: "foo",
+        pod: { id: podWithVms.id, name: podWithVms.name },
+      }),
+      machineFactory({
+        hostname: "bar",
+        pod: { id: podWithVms.id, name: podWithVms.name },
+      }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: vms,
+      }),
+      pod: podStateFactory({
+        items: [podWithVms],
+      }),
+    });
+    expect(
+      pod.filteredVMs(state, podWithVms.id, "hostname:(=foo)")
+    ).toStrictEqual([vms[0]]);
+    expect(
+      pod.filteredVMs(state, podWithVms.id, "hostname:(=bar)")
+    ).toStrictEqual([vms[1]]);
+    expect(pod.filteredVMs(state, podWithVms.id, "")).toStrictEqual(vms);
   });
 
   it("can group LXD pods by LXD server address", () => {


### PR DESCRIPTION
## Done

- Added search to the LXD VM table
- Updated the `getVMs` pod selector to take the podId instead of the entire pod object

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the "Project" tab of a LXD KVM
- Enter search terms in the search bar and check that the VMs get filtered accordingly (it uses the same search DSL as the machine list)
- Check that filtering to 0 VMs shows a message

## Fixes

Fixes #2234 
