### PR TITLE
feat(ui): rebuild KVM NUMA cards using resources data

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/LxdResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/LxdResources.test.tsx
@@ -1,14 +1,21 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LxdResources from "./LxdResources";
 
+import * as hooks from "app/base/hooks";
 import {
+  config as configFactory,
+  configState as configStateFactory,
+  pod as podFactory,
+  podNuma as podNumaFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -32,5 +39,82 @@ describe("LxdResources", () => {
     );
 
     expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("can view resources by NUMA node if pod includes data on at least one node", async () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            resources: podResourcesFactory({ numa: [podNumaFactory()] }),
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <Route
+            exact
+            path="/kvm/:id"
+            component={() => <LxdResources id={1} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("input[data-test='numa-switch']").exists()).toBe(true);
+    expect(wrapper.find("ProjectResourcesCard").exists()).toBe(true);
+    expect(wrapper.find("NumaResources").exists()).toBe(false);
+
+    wrapper
+      .find("input[data-test='numa-switch']")
+      .simulate("change", { target: { checked: true } });
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find("ProjectResourcesCard").exists()).toBe(false);
+    expect(wrapper.find("NumaResources").exists()).toBe(true);
+  });
+
+  it("can send an analytics event when toggling NUMA node view if analytics enabled", async () => {
+    const state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: "enable_analytics",
+            value: true,
+          }),
+        ],
+      }),
+      pod: podStateFactory({
+        items: [
+          podFactory({
+            id: 1,
+            resources: podResourcesFactory({ numa: [podNumaFactory()] }),
+          }),
+        ],
+      }),
+    });
+    const useSendMock = jest.spyOn(hooks, "useSendAnalytics");
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <Route
+            exact
+            path="/kvm/:id"
+            component={() => <LxdResources id={1} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper
+      .find("input[data-test='numa-switch']")
+      .simulate("change", { target: { checked: true } });
+    await waitForComponentToPaint(wrapper);
+
+    expect(useSendMock).toHaveBeenCalled();
+    useSendMock.mockRestore();
   });
 });

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/LxdResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/LxdResources.tsx
@@ -1,10 +1,13 @@
 import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+import { useStorageState } from "react-storage-hooks";
 
+import NumaResources from "./NumaResources";
 import OverallResourcesCard from "./OverallResourcesCard";
 import ProjectResourcesCard from "./ProjectResourcesCard";
 
-import { useWindowTitle } from "app/base/hooks";
+import Switch from "app/base/components/Switch";
+import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import PodStorage from "app/kvm/components/PodStorage";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
@@ -18,9 +21,19 @@ const LxdResources = ({ id }: Props): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, Number(id))
   );
+  const [viewByNuma, setViewByNuma] = useStorageState(
+    localStorage,
+    `viewPod${id}ByNuma`,
+    false
+  );
+  const sendAnalytics = useSendAnalytics();
   useWindowTitle(`LXD resources ${pod?.name || ""}`);
 
   if (!!pod) {
+    const canViewByNuma = pod.resources?.numa.length >= 1;
+    // Safeguard in case local storage is set to true even though the pod has no
+    // known NUMA nodes.
+    const showNumaCards = viewByNuma && canViewByNuma;
     return (
       <>
         <Strip className="u-no-padding--top" shallow>
@@ -30,8 +43,29 @@ const LxdResources = ({ id }: Props): JSX.Element => {
         <Strip shallow>
           <div className="u-flex--between u-flex--column-x-small">
             <h4 className="u-sv1">{pod.project}</h4>
+            {canViewByNuma && (
+              <Switch
+                checked={showNumaCards}
+                className="p-switch--inline-label"
+                data-test="numa-switch"
+                label="View by NUMA node"
+                onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                  const checked = evt.target.checked;
+                  setViewByNuma(checked);
+                  sendAnalytics(
+                    "LXD resources",
+                    "Toggle NUMA view",
+                    checked ? "View by NUMA node" : "View aggregate"
+                  );
+                }}
+              />
+            )}
           </div>
-          <ProjectResourcesCard id={pod.id} />
+          {showNumaCards ? (
+            <NumaResources id={pod.id} />
+          ) : (
+            <ProjectResourcesCard id={pod.id} />
+          )}
         </Strip>
         <Strip shallow>
           <PodStorage id={pod.id} />

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResources.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResources.test.tsx
@@ -1,0 +1,110 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import NumaResources, { TRUNCATION_POINT } from "./NumaResources";
+
+import * as hooks from "app/base/hooks";
+import {
+  config as configFactory,
+  configState as configStateFactory,
+  pod as podFactory,
+  podNuma as podNumaFactory,
+  podResources as podResourcesFactory,
+  podState as podStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("NumaResources", () => {
+  it("can expand truncated NUMA nodes if above truncation point", async () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        numa: Array.from(Array(TRUNCATION_POINT + 1)).map(() =>
+          podNumaFactory()
+        ),
+      }),
+    });
+    const state = rootStateFactory({ pod: podStateFactory({ items: [pod] }) });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <NumaResources id={pod.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Button[data-test='show-more-numas']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("NumaResourcesCard").length).toBe(TRUNCATION_POINT);
+
+    wrapper.find("Button[data-test='show-more-numas']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    expect(
+      wrapper.find("Button[data-test='show-more-numas'] span").text()
+    ).toBe("Show less NUMA nodes");
+    expect(wrapper.find("NumaResourcesCard").length).toBe(TRUNCATION_POINT + 1);
+  });
+
+  it("shows wide cards if the pod has less than or equal to 2 NUMA nodes", () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        numa: [podNumaFactory()],
+      }),
+    });
+    const state = rootStateFactory({ pod: podStateFactory({ items: [pod] }) });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <NumaResources id={pod.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find(".numa-resources.is-wide").exists()).toBe(true);
+  });
+
+  it("can send an analytics event when expanding NUMA nodes if analytics enabled", async () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        numa: Array.from(Array(TRUNCATION_POINT + 1)).map(() =>
+          podNumaFactory()
+        ),
+      }),
+    });
+    const state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: "enable_analytics",
+            value: false,
+          }),
+        ],
+      }),
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const useSendMock = jest.spyOn(hooks, "useSendAnalytics");
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <NumaResources id={pod.id} />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Button[data-test='show-more-numas']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    expect(useSendMock).toHaveBeenCalled();
+    useSendMock.mockRestore();
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResources.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+
+import { Button, Spinner } from "@canonical/react-components";
+import classNames from "classnames";
+import pluralize from "pluralize";
+import { useSelector } from "react-redux";
+
+import NumaResourcesCard from "./NumaResourcesCard";
+
+import { useSendAnalytics } from "app/base/hooks";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+
+export const TRUNCATION_POINT = 4;
+
+type Props = { id: Pod["id"] };
+
+const NumaResources = ({ id }: Props): JSX.Element => {
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, id)
+  );
+  const [expanded, setExpanded] = useState(false);
+  const sendAnalytics = useSendAnalytics();
+
+  if (!!pod) {
+    const { resources } = pod;
+    const numaNodes = resources.numa;
+    const canBeTruncated = numaNodes.length > TRUNCATION_POINT;
+    const shownNumaNodes =
+      canBeTruncated && !expanded
+        ? numaNodes.slice(0, TRUNCATION_POINT)
+        : numaNodes;
+    const showWideCards = numaNodes.length <= 2;
+
+    return (
+      <>
+        <div
+          className={classNames("numa-resources", {
+            "is-wide": showWideCards,
+          })}
+        >
+          {shownNumaNodes.map((numa) => (
+            <NumaResourcesCard
+              key={`numa-${numa.node_id}`}
+              numaId={numa.node_id}
+              podId={pod.id}
+            />
+          ))}
+        </div>
+        {canBeTruncated && (
+          <div className="u-align--center">
+            <Button
+              appearance="base"
+              data-test="show-more-numas"
+              hasIcon
+              onClick={() => {
+                setExpanded(!expanded);
+                sendAnalytics(
+                  "KVM details",
+                  "Toggle expanded NUMA nodes",
+                  expanded ? "Show less NUMA nodes" : "Show more NUMA nodes"
+                );
+              }}
+            >
+              {expanded ? (
+                <>
+                  <span>Show less NUMA nodes</span>
+                  <i className="p-icon--contextual-menu u-mirror--y"></i>
+                </>
+              ) : (
+                <>
+                  <span>
+                    {pluralize(
+                      "more NUMA node",
+                      numaNodes.length - TRUNCATION_POINT,
+                      true
+                    )}
+                  </span>
+                  <i className="p-icon--contextual-menu"></i>
+                </>
+              )}
+            </Button>
+            <hr />
+          </div>
+        )}
+      </>
+    );
+  }
+  return <Spinner text="Loading" />;
+};
+
+export default NumaResources;

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
@@ -1,0 +1,139 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import NumaResourcesCard from "./NumaResourcesCard";
+
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  pod as podFactory,
+  podNetworkInterface as podInterfaceFactory,
+  podNuma as podNumaFactory,
+  podNumaMemory as podNumaMemoryFactory,
+  podNumaHugepageMemory as podNumaHugepageFactory,
+  podResources as podResourcesFactory,
+  podState as podStateFactory,
+  podVM as podVmFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("NumaResourcesCard", () => {
+  it("aggregates the individual NUMA hugepages memory", () => {
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        numa: [
+          podNumaFactory({
+            memory: podNumaMemoryFactory({
+              hugepages: [
+                podNumaHugepageFactory({
+                  allocated: 1,
+                  free: 2,
+                  page_size: 1024,
+                }),
+                podNumaHugepageFactory({
+                  allocated: 4,
+                  free: 5,
+                  page_size: 1024,
+                }),
+              ],
+            }),
+            node_id: 11,
+          }),
+        ],
+      }),
+    });
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NumaResourcesCard numaId={11} podId={1} />
+      </Provider>
+    );
+    expect(wrapper.find("RamResources").prop("hugepages")).toStrictEqual({
+      allocated: 5,
+      free: 7,
+      pageSize: 1024,
+    });
+  });
+
+  it("filters interface resources to those that belong to the NUMA node", () => {
+    const podInterfaces = [
+      podInterfaceFactory({ id: 11 }),
+      podInterfaceFactory({ id: 22 }),
+      podInterfaceFactory({ id: 33 }),
+    ];
+    const numaNode = podNumaFactory({ interfaces: [11, 33], node_id: 111 });
+    const pod = podFactory({
+      id: 1,
+      resources: podResourcesFactory({
+        interfaces: podInterfaces,
+        numa: [numaNode],
+      }),
+    });
+    const state = rootStateFactory({
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NumaResourcesCard numaId={111} podId={1} />
+      </Provider>
+    );
+    expect(wrapper.find("VfResources").prop("interfaces")).toStrictEqual([
+      podInterfaces[0],
+      podInterfaces[2],
+    ]);
+  });
+
+  it("correctly filters VMs dropdown to those that belong to each NUMA node", () => {
+    const podID = 1;
+    const podName = "pod";
+    const machines = [
+      machineFactory({
+        pod: { id: podID, name: podName },
+        system_id: "abc123",
+      }),
+      machineFactory({
+        pod: { id: podID, name: podName },
+        system_id: "def456",
+      }),
+      machineFactory({
+        pod: { id: podID, name: podName },
+        system_id: "ghi789",
+      }),
+    ];
+    const pod = podFactory({
+      id: podID,
+      name: podName,
+      resources: podResourcesFactory({
+        numa: [podNumaFactory({ node_id: 11, vms: [111, 333] })],
+        vms: [
+          podVmFactory({ id: 111, system_id: "abc123" }),
+          podVmFactory({ id: 222, system_id: "def456" }),
+          podVmFactory({ id: 333, system_id: "ghi789" }),
+        ],
+      }),
+    });
+    const state = rootStateFactory({
+      machine: machineStateFactory({ items: machines }),
+      pod: podStateFactory({ items: [pod] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <NumaResourcesCard numaId={11} podId={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find("VmResources").prop("vms")).toStrictEqual([
+      machines[0],
+      machines[2],
+    ]);
+  });
+});

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/NumaResourcesCard.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/NumaResourcesCard.tsx
@@ -1,0 +1,102 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import CoreResources from "app/kvm/views/KVMDetails/CoreResources";
+import RamResources from "app/kvm/views/KVMDetails/RamResources";
+import VfResources from "app/kvm/views/KVMDetails/VfResources";
+import VmResources from "app/kvm/views/KVMDetails/VmResources";
+import type { Machine } from "app/store/machine/types";
+import podSelectors from "app/store/pod/selectors";
+import type { Pod, PodNetworkInterface, PodNuma } from "app/store/pod/types";
+import type { RootState } from "app/store/root/types";
+
+export const TRUNCATION_POINT = 4;
+
+type Props = { numaId: PodNuma["node_id"]; podId: Pod["id"] };
+
+const NumaResourcesCard = ({ numaId, podId }: Props): JSX.Element => {
+  const pod = useSelector((state: RootState) =>
+    podSelectors.getById(state, podId)
+  );
+  const podVMs = useSelector((state: RootState) =>
+    podSelectors.getVMs(state, podId)
+  );
+
+  if (!!pod) {
+    const { resources } = pod;
+    const numa = resources.numa.find((numa) => numa.node_id === numaId);
+
+    if (!!numa) {
+      const { hpAllocated, hpFree, pageSize } = numa.memory.hugepages.reduce(
+        ({ hpAllocated, hpFree, pageSize }, hp) => {
+          if (!pageSize) {
+            // Only the first hugepage page_size is used because as of MAAS 3.0
+            // different page sizes aren't supported. This may change in the
+            // future.
+            pageSize = hp.page_size;
+          }
+          hpAllocated += hp.allocated;
+          hpFree += hp.free;
+          return { hpAllocated, hpFree, pageSize };
+        },
+        { hpAllocated: 0, hpFree: 0, pageSize: 0 }
+      );
+      // NUMA interfaces and VMs only provide a reference ID, so we need to
+      // retrieve the interface resource and full VM data.
+      const numaInterfaces = numa.interfaces.reduce<PodNetworkInterface[]>(
+        (numaInterfaces, ifaceId) => {
+          const ifaceResource = resources.interfaces.find(
+            (iface) => iface.id === ifaceId
+          );
+          if (ifaceResource) {
+            numaInterfaces.push(ifaceResource);
+          }
+          return numaInterfaces;
+        },
+        []
+      );
+      const numaVms = numa.vms.reduce<Machine[]>((numaVms, vmId) => {
+        const vmResource = resources.vms.find((vm) => vm.id === vmId);
+        if (vmResource) {
+          const numaVm = podVMs.find(
+            (podVm) => podVm.system_id === vmResource.system_id
+          );
+          if (numaVm) {
+            numaVms.push(numaVm);
+          }
+        }
+        return numaVms;
+      }, []);
+
+      return (
+        <div className="numa-resources-card">
+          <h5 className="numa-resources-card__title p-text--paragraph u-no-max-width">
+            NUMA node {numa.node_id}
+          </h5>
+          <RamResources
+            general={{
+              allocated: numa.memory.general.allocated,
+              free: numa.memory.general.free,
+            }}
+            hugepages={{
+              allocated: hpAllocated,
+              free: hpFree,
+              pageSize,
+            }}
+          />
+          <CoreResources
+            cores={{
+              allocated: numa.cores.allocated.length,
+              free: numa.cores.free.length,
+            }}
+          />
+          <VfResources interfaces={numaInterfaces} />
+          <VmResources vms={numaVms} />
+        </div>
+      );
+    }
+  }
+  return <Spinner text="Loading" />;
+};
+
+export default NumaResourcesCard;

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/_index.scss
@@ -1,0 +1,28 @@
+@mixin NumaResourcesCard {
+  .numa-resources-card {
+    @extend %vf-is-bordered;
+    @extend %vf-bg--x-light;
+    margin-bottom: $spv-outer--scaleable;
+  }
+
+  .numa-resources-card__title {
+    border-bottom: $border;
+    margin: 0 $sph-inner;
+    padding: $spv-inner--medium 0 $spv-inner--small 0;
+  }
+
+  .core-resources {
+    border-top: $border;
+    grid-area: cor;
+  }
+
+  .vf-resources {
+    border-top: $border;
+    grid-area: vfs;
+  }
+
+  .vm-resources {
+    border-top: $border;
+    grid-area: vms;
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NumaResourcesCard";

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/_index.scss
@@ -1,0 +1,16 @@
+@mixin NumaResources {
+  .numa-resources {
+    @extend %base-grid;
+    grid-template-columns: 1fr;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    @media only screen and (min-width: $breakpoint-x-large) {
+      &:not(.is-wide) {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+      }
+    }
+  }
+}

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/index.ts
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/NumaResources/index.ts
@@ -1,0 +1,1 @@
+export { default, TRUNCATION_POINT } from "./NumaResources";

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/OverallResourcesCard/OverallRam/OverallRam.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/OverallResourcesCard/OverallRam/OverallRam.tsx
@@ -34,7 +34,7 @@ const OverallRam = ({ memory }: Props): JSX.Element => {
             },
             {
               color: COLOURS.LINK_FADED,
-              tooltip: `Freee ${memoryWithUnit(freeMemory)}`,
+              tooltip: `Free ${memoryWithUnit(freeMemory)}`,
               value: freeMemory,
             },
           ]}

--- a/ui/src/app/kvm/views/KVMDetails/LxdResources/OverallResourcesCard/OverallRam/__snapshots__/OverallRam.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/LxdResources/OverallResourcesCard/OverallRam/__snapshots__/OverallRam.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`OverallRam renders 1`] = `
           },
           Object {
             "color": "#D3E4ED",
-            "tooltip": "Freee 9B",
+            "tooltip": "Free 9B",
             "value": 9,
           },
         ]

--- a/ui/src/app/kvm/views/KVMDetails/VfResources/VfResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/VfResources/VfResources.tsx
@@ -11,6 +11,7 @@ const VfResources = ({
   dynamicLayout = false,
   interfaces,
 }: Props): JSX.Element => {
+  const noInterfaces = interfaces.length === 0;
   return (
     <div
       className={classNames("vf-resources", {
@@ -40,6 +41,17 @@ const VfResources = ({
             </tr>
           </thead>
           <tbody>
+            {noInterfaces && (
+              <tr data-test="no-interfaces">
+                <td>
+                  <p>
+                    <em>None</em>
+                  </p>
+                </td>
+                <td></td>
+                <td></td>
+              </tr>
+            )}
             {interfaces.map((iface) => {
               const { id, name, virtual_functions } = iface;
               const {

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -101,6 +101,8 @@
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectSummaryCard";
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar";
 @import "~app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable";
+@import "~app/kvm/views/KVMDetails/LxdResources/NumaResources";
+@import "~app/kvm/views/KVMDetails/LxdResources/NumaResources/NumaResourcesCard";
 @import "~app/kvm/views/KVMDetails/LxdResources/OverallResourcesCard";
 @import "~app/kvm/views/KVMDetails/LxdResources/ProjectResourcesCard";
 @import "~app/kvm/views/KVMDetails/LxdResources/OverallResourcesCard/OverallCores";
@@ -123,6 +125,8 @@
 @include KVMPoolSelect;
 @include KVMSubnetSelect;
 @include LxdTable;
+@include NumaResources;
+@include NumaResourcesCard;
 @include OverallCores;
 @include OverallRam;
 @include OverallResourcesCard;


### PR DESCRIPTION
## Done

- Rebuilt KVM NUMA cards using resources data instead of the now defunct numa_pinning data

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Resources tab of a LXD KVM
- Check that you can toggle the NUMA view on and off
- Open `NumaResources.tsx` and change line 28 so that between 2-4 and nodes show, e.g. `const numaNodes = [...resources.numa, ...resources.numa, ...resources.numa]`
- Check that the cards become thin so that up to 4 can fit on one row
- Update `NumaResources.tsx` so that more than 4 nodes show
- Check that you can expand and contract showing more NUMA nodes

## Fixes

Fixes #2360 