### PR TITLE
fix(ui): refetch testing and commissioning scripts

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
@@ -121,12 +121,12 @@ describe("MachineCommissioning", () => {
     // Mock the previous value to something different to the current machine.
     jest
       .spyOn(reactComponentHooks, "usePrevious")
-      .mockImplementation(() => TestStatusStatus.RUNNING);
+      .mockImplementation(() => TestStatusStatus.PASSED);
     state.machine.items = [
       machineDetailsFactory({
         commissioning_status: testStatusFactory({
           // This value is different to the value stored by usePrevious.
-          status: TestStatusStatus.PASSED,
+          status: TestStatusStatus.PENDING,
         }),
         locked: false,
         permissions: ["edit"],

--- a/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
@@ -1,17 +1,31 @@
+import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { Route, MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachineCommissioning from ".";
 
+import { HardwareType } from "app/base/enum";
 import type { RootState } from "app/store/root/types";
+import { ScriptResultType } from "app/store/scriptresult/types";
+import { TestStatusStatus } from "app/store/types/node";
 import {
   machineState as machineStateFactory,
   machineDetails as machineDetailsFactory,
+  scriptResult as scriptResultFactory,
   scriptResultState as scriptResultStateFactory,
+  testStatus as testStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+jest.mock("@canonical/react-components/dist/hooks", () => {
+  const hooks = jest.requireActual("@canonical/react-components/dist/hooks");
+  return {
+    ...hooks,
+    usePrevious: jest.fn(),
+  };
+});
 
 const mockStore = configureStore();
 
@@ -49,5 +63,102 @@ describe("MachineCommissioning", () => {
     );
 
     expect(wrapper.find("Spinner").exists()).toEqual(true);
+  });
+
+  it("fetches script results if they haven't been fetched", () => {
+    state.nodescriptresult.items = { abc123: [] };
+    state.scriptresult.items = [];
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineCommissioning />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "scriptresult/getByMachineId")
+    ).toBe(true);
+  });
+
+  it("does not fetch script results if they have already been loaded", () => {
+    state.nodescriptresult.items = { abc123: [] };
+    state.scriptresult.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineCommissioning />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "scriptresult/getByMachineId")
+        .length
+    ).toBe(1);
+    wrapper.setProps({});
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "scriptresult/getByMachineId")
+        .length
+    ).toBe(1);
+  });
+
+  it("refetchs script results when the machine commissioning status changes", () => {
+    // Mock the previous value to something different to the current machine.
+    jest
+      .spyOn(reactComponentHooks, "usePrevious")
+      .mockImplementation(() => TestStatusStatus.RUNNING);
+    state.machine.items = [
+      machineDetailsFactory({
+        commissioning_status: testStatusFactory({
+          // This value is different to the value stored by usePrevious.
+          status: TestStatusStatus.PASSED,
+        }),
+        locked: false,
+        permissions: ["edit"],
+        system_id: "abc123",
+      }),
+    ];
+    state.nodescriptresult.items = { abc123: [1] };
+    // Add existing script results.
+    state.scriptresult.items = [
+      scriptResultFactory({
+        id: 1,
+        result_type: ScriptResultType.TESTING,
+        hardware_type: HardwareType.CPU,
+      }),
+    ];
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineCommissioning />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "scriptresult/getByMachineId")
+        .length
+    ).toBe(1);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.tsx
@@ -13,6 +13,7 @@ import machineSelectors from "app/store/machine/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultSelectors from "app/store/scriptresult/selectors";
+import { TestStatusStatus } from "app/store/types/node";
 
 const MachineCommissioning = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -44,9 +45,11 @@ const MachineCommissioning = (): JSX.Element => {
     if (
       !loading &&
       (!scriptResults?.length ||
-        // Refetch the script results when the commissioning status changes, otherwise
-        // the new script results won't be associated with the machine.
-        previousCommissioningStatus !== machine?.commissioning_status.status)
+        // Refetch the script results when the commissioning status changes to
+        // pending, otherwise the new script results won't be associated with
+        // the machine.
+        (machine?.commissioning_status.status === TestStatusStatus.PENDING &&
+          previousCommissioningStatus !== machine?.commissioning_status.status))
     ) {
       dispatch(scriptResultActions.getByMachineId(id));
     }

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -271,7 +271,7 @@ describe("MachineTests", () => {
     // Mock the previous value to something different to the current machine.
     jest
       .spyOn(reactComponentHooks, "usePrevious")
-      .mockImplementation(() => TestStatusStatus.RUNNING);
+      .mockImplementation(() => TestStatusStatus.PASSED);
     state.machine.items = [
       machineDetailsFactory({
         locked: false,
@@ -279,7 +279,7 @@ describe("MachineTests", () => {
         system_id: "abc123",
         testing_status: testStatusFactory({
           // This value is different to the value stored by usePrevious.
-          status: TestStatusStatus.PASSED,
+          status: TestStatusStatus.PENDING,
         }),
       }),
     ];

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -1,3 +1,4 @@
+import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { Route, MemoryRouter } from "react-router-dom";
@@ -11,13 +12,23 @@ import {
   ScriptResultType,
   ScriptResultParamType,
 } from "app/store/scriptresult/types";
+import { TestStatusStatus } from "app/store/types/node";
 import {
   machineState as machineStateFactory,
   machineDetails as machineDetailsFactory,
   scriptResult as scriptResultFactory,
   scriptResultState as scriptResultStateFactory,
+  testStatus as testStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+jest.mock("@canonical/react-components/dist/hooks", () => {
+  const hooks = jest.requireActual("@canonical/react-components/dist/hooks");
+  return {
+    ...hooks,
+    usePrevious: jest.fn(),
+  };
+});
 
 const mockStore = configureStore();
 
@@ -202,5 +213,102 @@ describe("MachineTests", () => {
     expect(
       wrapper.find("[data-test='hardware-device-heading']").first().text()
     ).toEqual("ens4 (52:54:00:57:e9:ac)");
+  });
+
+  it("fetches script results if they haven't been fetched", () => {
+    state.nodescriptresult.items = { abc123: [] };
+    state.scriptresult.items = [];
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineTests />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "scriptresult/getByMachineId")
+    ).toBe(true);
+  });
+
+  it("does not fetch script results if they have already been loaded", () => {
+    state.nodescriptresult.items = { abc123: [] };
+    state.scriptresult.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineTests />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "scriptresult/getByMachineId")
+        .length
+    ).toBe(1);
+    wrapper.setProps({});
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "scriptresult/getByMachineId")
+        .length
+    ).toBe(1);
+  });
+
+  it("refetchs script results when the machine testing status changes", () => {
+    // Mock the previous value to something different to the current machine.
+    jest
+      .spyOn(reactComponentHooks, "usePrevious")
+      .mockImplementation(() => TestStatusStatus.RUNNING);
+    state.machine.items = [
+      machineDetailsFactory({
+        locked: false,
+        permissions: ["edit"],
+        system_id: "abc123",
+        testing_status: testStatusFactory({
+          // This value is different to the value stored by usePrevious.
+          status: TestStatusStatus.PASSED,
+        }),
+      }),
+    ];
+    state.nodescriptresult.items = { abc123: [1] };
+    // Add existing script results.
+    state.scriptresult.items = [
+      scriptResultFactory({
+        id: 1,
+        result_type: ScriptResultType.TESTING,
+        hardware_type: HardwareType.CPU,
+      }),
+    ];
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route path="/machine/:id">
+            <MachineTests />
+          </Route>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      store
+        .getActions()
+        .filter((action) => action.type === "scriptresult/getByMachineId")
+        .length
+    ).toBe(1);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -15,6 +15,7 @@ import type { RootState } from "app/store/root/types";
 import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultSelectors from "app/store/scriptresult/selectors";
 import type { ScriptResult } from "app/store/scriptresult/types";
+import { TestStatusStatus } from "app/store/types/node";
 
 /**
  * Group items by key
@@ -64,9 +65,11 @@ const MachineTests = (): JSX.Element => {
     if (
       !loading &&
       (!scriptResults?.length ||
-        // Refetch the script results when the testing status changes, otherwise
-        // the new script results won't be associated with the machine.
-        previousTestingStatus !== machine?.testing_status.status)
+        // Refetch the script results when the testing status changes to
+        // pending, otherwise the new script results won't be associated with
+        // the machine.
+        (machine?.testing_status.status === TestStatusStatus.PENDING &&
+          previousTestingStatus !== machine?.testing_status.status))
     ) {
       dispatch(scriptResultActions.getByMachineId(id));
     }

--- a/ui/src/app/store/scriptresult/reducers.test.ts
+++ b/ui/src/app/store/scriptresult/reducers.test.ts
@@ -117,9 +117,63 @@ describe("script result reducer", () => {
     );
   });
 
+  it("reduces createNotify", () => {
+    const scriptResultState = scriptResultStateFactory({
+      items: [],
+    });
+    const newScriptResult = scriptResultFactory({ id: 1 });
+
+    expect(
+      reducers(scriptResultState, {
+        type: "noderesult/createNotify",
+        payload: newScriptResult,
+      })
+    ).toEqual(
+      scriptResultStateFactory({
+        items: [newScriptResult],
+      })
+    );
+  });
+
+  it("reduces createNotify for a script result that already exists", () => {
+    const scriptResultState = scriptResultStateFactory({
+      items: [scriptResultFactory({ id: 1 })],
+    });
+    const newScriptResult = scriptResultFactory({ id: 1 });
+
+    expect(
+      reducers(scriptResultState, {
+        type: "noderesult/createNotify",
+        payload: newScriptResult,
+      })
+    ).toEqual(
+      scriptResultStateFactory({
+        items: [newScriptResult],
+      })
+    );
+  });
+
   it("reduce updateNotify for noderesult", () => {
     const scriptResultState = scriptResultStateFactory({
       items: [scriptResultFactory({ id: 1 })],
+    });
+    const updatedScriptResult = scriptResultFactory({ id: 1 });
+
+    expect(
+      reducers(scriptResultState, {
+        type: "noderesult/updateNotify",
+        payload: updatedScriptResult,
+      })
+    ).toEqual(
+      scriptResultStateFactory({
+        items: [updatedScriptResult],
+      })
+    );
+  });
+
+  it("reduces updateNotify for a script result that doesn't exist", () => {
+    const scriptResultState = scriptResultStateFactory({
+      items: [],
     });
     const updatedScriptResult = scriptResultFactory({ id: 1 });
 

--- a/ui/src/app/store/scriptresult/slice.ts
+++ b/ui/src/app/store/scriptresult/slice.ts
@@ -238,11 +238,24 @@ const scriptResultSlice = generateSlice<
   },
 
   extraReducers: {
+    "noderesult/createNotify": (state, action) => {
+      const existingIdx = state.items.findIndex(
+        (existingItem) => existingItem.id === action.payload.id
+      );
+      if (existingIdx !== -1) {
+        state.items[existingIdx] = action.payload;
+      } else {
+        state.items.push(action.payload);
+      }
+    },
     "noderesult/updateNotify": (state, action) => {
-      for (const i in state.items) {
-        if (state.items[i]["id"] === action.payload["id"]) {
-          state.items[i] = action.payload;
-        }
+      const existingIdx = state.items.findIndex(
+        (existingItem) => existingItem.id === action.payload.id
+      );
+      if (existingIdx !== -1) {
+        state.items[existingIdx] = action.payload;
+      } else {
+        state.items.push(action.payload);
       }
     },
   },


### PR DESCRIPTION
## Done

- Refetch testing and commissioning scripts when the testing/commissioning status changes.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### QA steps

- Go to machine details for a new/un-commissioned machine.
- Go to the commissioning tab.
- Use the take action menu to start commissioning.
- The list of scripts should update as commissioning happens.
- Go to the tests tab.
- Use the take action menu to start some tests.
- The tests tables should update as the tests run.

Fixes: #2314.