### PR TITLE
fix(ui): correctly select the installation log

### DIFF
--- a/ui/src/app/base/sagas/http.js
+++ b/ui/src/app/base/sagas/http.js
@@ -1,6 +1,7 @@
 import { call, put, takeEvery, takeLatest } from "redux-saga/effects";
 
 import bakery from "bakery";
+import { ScriptResultNames } from "app/store/scriptresult/types";
 import { getCookie } from "app/utils";
 
 const BAKERY_LOGIN_API = "/MAAS/accounts/discharge-request/";
@@ -190,7 +191,7 @@ export const api = {
       scriptresultsDownload(
         systemId,
         "current-installation",
-        "/tmp/curtin-logs.tar",
+        ScriptResultNames.CURTIN_LOG,
         "tar.xz"
       ),
   },

--- a/ui/src/app/base/sagas/http.test.js
+++ b/ui/src/app/base/sagas/http.test.js
@@ -3,6 +3,7 @@ import { throwError } from "redux-saga-test-plan/providers";
 
 import { expectSaga } from "redux-saga-test-plan";
 
+import { ScriptResultNames } from "app/store/scriptresult/types";
 import { getCookie } from "app/utils";
 import {
   api,
@@ -432,7 +433,7 @@ describe("http sagas", () => {
         const response = await api.scriptresults.download(
           "abc123",
           "current-installation",
-          "/tmp/curtin-logs.tar",
+          ScriptResultNames.CURTIN_LOG,
           "tar.xz"
         );
         expect(response).toMatchObject(blob);

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx
@@ -51,6 +51,7 @@ describe("DownloadMenu", () => {
         items: [
           scriptResultFactory({
             id: 1,
+            name: ScriptResultNames.INSTALL_LOG,
             result_type: ScriptResultType.INSTALLATION,
             status: ScriptResultStatus.PASSED,
           }),

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx
@@ -9,6 +9,7 @@ import { PowerState } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import type { ScriptResult } from "app/store/scriptresult/types";
 import {
+  ScriptResultNames,
   ScriptResultStatus,
   ScriptResultType,
 } from "app/store/scriptresult/types";
@@ -39,6 +40,7 @@ describe("InstallationOutput", () => {
         items: [
           scriptResultFactory({
             id: 1,
+            name: ScriptResultNames.INSTALL_LOG,
             result_type: ScriptResultType.INSTALLATION,
           }),
         ],
@@ -243,6 +245,7 @@ describe("InstallationOutput", () => {
     state.scriptresult.items = [
       scriptResultFactory({
         id: 1,
+        name: ScriptResultNames.INSTALL_LOG,
         result_type: ScriptResultType.INSTALLATION,
         status: "huh???",
       } as Partial<ScriptResult> & { status: string }),

--- a/ui/src/app/machines/views/MachineDetails/MachineLogs/hooks.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineLogs/hooks.test.tsx
@@ -9,6 +9,7 @@ import { useGetInstallationOutput } from "./hooks";
 
 import type { RootState } from "app/store/root/types";
 import {
+  ScriptResultNames,
   ScriptResultType,
   ScriptResultStatus,
 } from "app/store/scriptresult/types";
@@ -45,6 +46,7 @@ describe("machine utils", () => {
         items: [
           scriptResultFactory({
             id: 1,
+            name: ScriptResultNames.INSTALL_LOG,
             result_type: ScriptResultType.INSTALLATION,
             status: ScriptResultStatus.PASSED,
           }),

--- a/ui/src/app/store/scriptresult/selectors.test.tsx
+++ b/ui/src/app/store/scriptresult/selectors.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "app/store/scriptresult/types";
 import {
   nodeScriptResultState as nodeScriptResultStateFactory,
+  partialScriptResult as partialScriptResultFactory,
   rootState as rootStateFactory,
   scriptResult as scriptResultFactory,
   scriptResultData as scriptResultDataFactory,
@@ -542,5 +543,31 @@ describe("scriptResult selectors", () => {
     expect(
       selectors.getInstallationLogsByMachineId(state, "abc123")
     ).toStrictEqual([logs["1"], logs["2"]]);
+  });
+
+  it("returns a log by id", () => {
+    const logs = {
+      1: scriptResultDataFactory(),
+      2: scriptResultDataFactory(),
+    };
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        logs,
+      }),
+    });
+    expect(selectors.getLogById(state, 2)).toStrictEqual(logs["2"]);
+  });
+
+  it("returns history by id", () => {
+    const history = {
+      1: [partialScriptResultFactory()],
+      2: [partialScriptResultFactory()],
+    };
+    const state = rootStateFactory({
+      scriptresult: scriptResultStateFactory({
+        history,
+      }),
+    });
+    expect(selectors.getHistoryById(state, 2)).toStrictEqual(history["2"]);
   });
 });

--- a/ui/src/app/store/scriptresult/selectors.ts
+++ b/ui/src/app/store/scriptresult/selectors.ts
@@ -424,6 +424,19 @@ const getHistoryById = createSelector(
   }
 );
 
+const getLogById = createSelector(
+  [
+    logs,
+    (_: RootState, scriptResultId: ScriptResult["id"] | null | undefined) =>
+      scriptResultId,
+  ],
+  (logs, scriptResultId) => {
+    return scriptResultId && logs && scriptResultId in logs
+      ? logs[scriptResultId]
+      : null;
+  }
+);
+
 const scriptResult = {
   all,
   errors,
@@ -435,6 +448,7 @@ const scriptResult = {
   getHistoryById,
   getInstallationByMachineId,
   getInstallationLogsByMachineId,
+  getLogById,
   getNetworkTestingByMachineId,
   getOtherTestingByMachineId,
   getStorageTestingByMachineId,

--- a/ui/src/app/store/scriptresult/types.ts
+++ b/ui/src/app/store/scriptresult/types.ts
@@ -7,6 +7,7 @@ import type { GenericState } from "app/store/types/state";
 
 export enum ScriptResultNames {
   CURTIN_LOG = "/tmp/curtin-logs.tar",
+  INSTALL_LOG = "/tmp/install.log",
 }
 
 export enum ScriptResultEstimated {


### PR DESCRIPTION
## Done

- Fix the installation log so that the correct script result is selected.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Point your local UI to Bolla.
- Visit /MAAS/r/machine/mbfgbq/logs/installation-output
- You should see the installation output.
- Open the download menu and download the curtin logs and the installation output.
- Both files should contain what you expect.

## Fixes

Fixes: #2471.