### PR TITLE
feat(ui): make LXD the default host type when adding KVM

### DIFF
--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx
@@ -25,7 +25,7 @@ export const AddKvmTypeSelect = (): JSX.Element => {
   const zonesLoaded = useSelector(zoneSelectors.loaded);
   const allLoaded = powerTypesLoaded && resourcePoolsLoaded && zonesLoaded;
 
-  const [kvmType, setKvmType] = useState<PodType>(PodType.VIRSH);
+  const [kvmType, setKvmType] = useState<PodType>(PodType.LXD);
 
   useEffect(() => {
     dispatch(generalActions.fetchPowerTypes());

--- a/ui/src/app/kvm/views/KVMList/AddKVM/KvmTypeSelect/KvmTypeSelect.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/KvmTypeSelect/KvmTypeSelect.tsx
@@ -16,19 +16,19 @@ export const KvmTypeSelect = ({ kvmType, setKvmType }: Props): JSX.Element => {
       <ul className="p-inline-list">
         <li className="p-inline-list__item u-display-inline-block">
           <Input
-            checked={kvmType === PodType.VIRSH}
-            id="add-virsh"
-            label="virsh"
-            onChange={() => setKvmType(PodType.VIRSH)}
+            checked={kvmType === PodType.LXD}
+            id="add-lxd"
+            label="LXD"
+            onChange={() => setKvmType(PodType.LXD)}
             type="radio"
           />
         </li>
         <li className="p-inline-list__item u-display-inline-block u-nudge-right">
           <Input
-            checked={kvmType === PodType.LXD}
-            id="add-lxd"
-            label="LXD"
-            onChange={() => setKvmType(PodType.LXD)}
+            checked={kvmType === PodType.VIRSH}
+            id="add-virsh"
+            label="virsh"
+            onChange={() => setKvmType(PodType.VIRSH)}
             type="radio"
           />
         </li>


### PR DESCRIPTION
## Done

- made LXD the default host type when adding a new KVM

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and click "Add KVM" (or go straight to /MAAS/r/kvm/add)
- Check that LXD is first in the list and selected by default

## Fixes

Fixes #2466 
