### PR TITLE
fix(ui): show full Ubuntu release in machine summary page

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsTable/StatusColumn/StatusColumn.tsx
@@ -16,7 +16,7 @@ const StatusColumn = ({ systemId }: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
-  const formattedOS = useFormattedOS(machine);
+  const formattedOS = useFormattedOS(machine, true);
 
   if (!machine) {
     return <Spinner />;

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -73,7 +73,7 @@ describe("StatusCard", () => {
     );
 
     expect(wrapper.find("[data-test='os-info']").text()).toEqual(
-      "Ubuntu 20.04 LTS"
+      'Ubuntu 20.04 LTS "Focal Fossa"'
     );
   });
 

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -66,7 +66,7 @@ export const StatusColumn = ({
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
-  const formattedOS = useFormattedOS(machine);
+  const formattedOS = useFormattedOS(machine, true);
   const toggleMenu = useToggleMenu(onToggleMenu, systemId);
   const actionLinks = useMachineActions(systemId, [
     NodeActions.ABORT,

--- a/ui/src/app/store/machine/utils/hooks.test.tsx
+++ b/ui/src/app/store/machine/utils/hooks.test.tsx
@@ -159,7 +159,19 @@ describe("machine hook utils", () => {
       expect(result.current).toBe("");
     });
 
-    it("handles Ubuntu releases", () => {
+    it("does not return anything if os info is loading", () => {
+      state.machine.items[0].osystem = "ubuntu";
+      state.machine.items[0].distro_series = "focal";
+      state.general.osInfo.loading = true;
+      const store = mockStore(state);
+      const { result } = renderHook(() => useFormattedOS(machine), {
+        wrapper: generateWrapper(store),
+      });
+
+      expect(result.current).toBe("");
+    });
+
+    it("can show the full Ubuntu release", () => {
       state.machine.items[0].osystem = "ubuntu";
       state.machine.items[0].distro_series = "focal";
       state.general.osInfo.data = osInfoFactory({
@@ -168,6 +180,21 @@ describe("machine hook utils", () => {
       const store = mockStore(state);
 
       const { result } = renderHook(() => useFormattedOS(machine), {
+        wrapper: generateWrapper(store),
+      });
+
+      expect(result.current).toBe('Ubuntu 20.04 LTS "Focal Fossa"');
+    });
+
+    it("can show the short-form for Ubuntu releases", () => {
+      state.machine.items[0].osystem = "ubuntu";
+      state.machine.items[0].distro_series = "focal";
+      state.general.osInfo.data = osInfoFactory({
+        releases: [["ubuntu/focal", 'Ubuntu 20.04 LTS "Focal Fossa"']],
+      });
+      const store = mockStore(state);
+
+      const { result } = renderHook(() => useFormattedOS(machine, true), {
         wrapper: generateWrapper(store),
       });
 

--- a/ui/src/app/store/machine/utils/hooks.ts
+++ b/ui/src/app/store/machine/utils/hooks.ts
@@ -60,10 +60,15 @@ export const useCanEditStorage = (machine: Machine | null): boolean => {
 /**
  * Format a node's OS and release into human-readable text.
  * @param node - A node object.
+ * @param hideUbuntuTitle - Whether to hide the title of the Ubuntu release
  * @returns Formatted OS string.
  */
-export const useFormattedOS = (node?: Host | null): string => {
+export const useFormattedOS = (
+  node?: Host | null,
+  hideUbuntuTitle?: boolean
+): string => {
   const dispatch = useDispatch();
+  const loading = useSelector(osInfoSelectors.loading);
   const osReleases = useSelector((state: RootState) =>
     osInfoSelectors.getOsReleases(state, node?.osystem)
   );
@@ -72,7 +77,7 @@ export const useFormattedOS = (node?: Host | null): string => {
     dispatch(generalActions.fetchOsInfo());
   }, [dispatch]);
 
-  if (!node || !node.osystem || !node.distro_series) {
+  if (!node || !node.osystem || !node.distro_series || loading) {
     return "";
   }
 
@@ -80,7 +85,7 @@ export const useFormattedOS = (node?: Host | null): string => {
     (release) => release.value === node.distro_series
   );
   if (machineRelease) {
-    return node.osystem === "ubuntu"
+    return node.osystem === "ubuntu" && hideUbuntuTitle
       ? machineRelease.label.split('"')[0].trim()
       : machineRelease.label;
   }


### PR DESCRIPTION
## Done

- updated OS hook to show the full Ubuntu release by default, unless a flag is specifically passed to hide the title
- also updated it to not render until the os's have loaded, otherwise there'd be a flash of the unformatted version.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/machine/fbknqx/summary and check that the Ubuntu release includes the title "Focal Fossa"
- Refresh the page and check that it doesn't initially show up as `ubuntu/focal`

## Fixes

Fixes #2309 
