### PR TITLE
fix(ui): fix closing action forms

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -91,6 +91,7 @@ const getLabel = (
 };
 
 type Props = {
+  actionDisabled?: boolean;
   actionName?: string;
   allowUnchanged?: boolean;
   allowAllEmpty?: boolean;
@@ -112,6 +113,7 @@ type Props = {
 };
 
 const ActionForm = ({
+  actionDisabled,
   actionName,
   allowUnchanged = false,
   allowAllEmpty = false,
@@ -130,7 +132,7 @@ const ActionForm = ({
   selectedCount,
   submitAppearance = "positive",
   validationSchema,
-}: Props): JSX.Element => {
+}: Props): JSX.Element | null => {
   const [processing, setProcessing] = useState(false);
   const [saved, setSaved] = useState(false);
   const [selectedOnSubmit, setSelectedOnSubmit] = useState(selectedCount);
@@ -154,6 +156,14 @@ const ActionForm = ({
       clearSelectedAction();
     }
   }, [clearSelectedAction, saved]);
+
+  // Don't display the form when the action is disabled, an update selection
+  // notification is show instead. However, we do still need to render this
+  // component so that the clearSelectedAction useEffect can still run when the
+  // action completes.
+  if (actionDisabled) {
+    return null;
+  }
 
   if (loaded) {
     return (

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -102,6 +102,8 @@ describe("ActionFormWrapper", () => {
     expect(wrapper.find("[data-test='machine-action-warning']").exists()).toBe(
       true
     );
+    // The form should still be rendered
+    expect(wrapper.find("CommissionForm").exists()).toBe(true);
   });
 
   it(`does not display a warning when processing and not all selected machines

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -58,10 +58,14 @@ export type CommissionFormValues = {
 };
 
 type Props = {
+  actionDisabled?: boolean;
   setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
 };
 
-export const CommissionForm = ({ setSelectedAction }: Props): JSX.Element => {
+export const CommissionForm = ({
+  actionDisabled,
+  setSelectedAction,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const scriptsLoaded = useSelector(scriptSelectors.loaded);
@@ -106,6 +110,7 @@ export const CommissionForm = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.COMMISSION}
       allowUnchanged
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -37,13 +37,17 @@ export type DeployFormValues = {
 };
 
 type Props = {
+  actionDisabled?: boolean;
   setSelectedAction: (
     action?: MachineAction | null,
     deselect?: boolean
   ) => void;
 };
 
-export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
+export const DeployForm = ({
+  actionDisabled,
+  setSelectedAction,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const defaultMinHweKernel = useSelector(defaultMinHweKernelSelectors.get);
@@ -83,6 +87,7 @@ export const DeployForm = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.DEPLOY}
       allowUnchanged={osystems?.length !== 0 && releases?.length !== 0}
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.js
@@ -26,7 +26,11 @@ const fieldlessActions = [
   NodeActions.UNLOCK,
 ];
 
-export const FieldlessForm = ({ selectedAction, setSelectedAction }) => {
+export const FieldlessForm = ({
+  actionDisabled,
+  selectedAction,
+  setSelectedAction,
+}) => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const { errors, machinesToAction, processingCount } = useMachineActionForm(
@@ -35,6 +39,7 @@ export const FieldlessForm = ({ selectedAction, setSelectedAction }) => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={selectedAction.name}
       allowUnchanged
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -22,10 +22,14 @@ type MarkBrokenFormValues = {
 };
 
 type Props = {
+  actionDisabled?: boolean;
   setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
 };
 
-export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
+export const MarkBrokenForm = ({
+  actionDisabled,
+  setSelectedAction,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const { errors, machinesToAction, processingCount } = useMachineActionForm(
@@ -41,6 +45,7 @@ export const MarkBrokenForm = ({ setSelectedAction }: Props): JSX.Element => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.MARK_BROKEN}
       allowAllEmpty
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.js
@@ -60,7 +60,7 @@ const OverrideTestFormSchema = Yup.object().shape({
   suppressResults: Yup.boolean(),
 });
 
-export const OverrideTestForm = ({ setSelectedAction }) => {
+export const OverrideTestForm = ({ actionDisabled, setSelectedAction }) => {
   const dispatch = useDispatch();
   const [requestedScriptResults, setRequestedScriptResults] = useState([]);
   const activeMachine = useSelector(machineSelectors.active);
@@ -103,6 +103,7 @@ export const OverrideTestForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.OVERRIDE_FAILED_TESTING}
       allowUnchanged
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
@@ -29,10 +29,14 @@ const ReleaseSchema = Yup.object().shape({
 });
 
 type Props = {
+  actionDisabled?: boolean;
   setSelectedAction: SetSelectedAction;
 };
 
-export const ReleaseForm = ({ setSelectedAction }: Props): JSX.Element => {
+export const ReleaseForm = ({
+  actionDisabled,
+  setSelectedAction,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const configLoaded = useSelector(configSelectors.loaded);
@@ -54,6 +58,7 @@ export const ReleaseForm = ({ setSelectedAction }: Props): JSX.Element => {
     <Strip shallow>
       {configLoaded ? (
         <ActionForm
+          actionDisabled={actionDisabled}
           actionName={NodeActions.RELEASE}
           allowAllEmpty
           cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.js
@@ -19,7 +19,7 @@ const SetPoolSchema = Yup.object().shape({
   poolSelection: Yup.string().oneOf(["create", "select"]).required(),
 });
 
-export const SetPoolForm = ({ setSelectedAction }) => {
+export const SetPoolForm = ({ actionDisabled, setSelectedAction }) => {
   const dispatch = useDispatch();
   const [initialValues, setInitialValues] = useState({
     poolSelection: "select",
@@ -52,6 +52,7 @@ export const SetPoolForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.SET_POOL}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.js
@@ -17,7 +17,7 @@ const SetZoneSchema = Yup.object().shape({
   zone: Yup.string().required("Zone is required"),
 });
 
-export const SetZoneForm = ({ setSelectedAction }) => {
+export const SetZoneForm = ({ actionDisabled, setSelectedAction }) => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const zones = useSelector(zoneSelectors.all);
@@ -32,6 +32,7 @@ export const SetZoneForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.SET_ZONE}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.js
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.js
@@ -19,7 +19,7 @@ const TagFormSchema = Yup.object().shape({
     .required("You must select at least one tag."),
 });
 
-export const TagForm = ({ setSelectedAction }) => {
+export const TagForm = ({ actionDisabled, setSelectedAction }) => {
   const dispatch = useDispatch();
   const activeMachine = useSelector(machineSelectors.active);
   const [initialValues, setInitialValues] = useState({ tags: [] });
@@ -40,6 +40,7 @@ export const TagForm = ({ setSelectedAction }) => {
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.TAG}
       cleanup={machineActions.cleanup}
       clearSelectedAction={() => setSelectedAction(null, true)}

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -41,12 +41,14 @@ export type FormValues = {
 };
 
 type Props = {
+  actionDisabled?: boolean;
   setSelectedAction: (action: MachineAction | null, deselect?: boolean) => void;
   hardwareType?: HardwareType;
   applyConfiguredNetworking?: Scripts["apply_configured_networking"];
 };
 
 export const TestForm = ({
+  actionDisabled,
   setSelectedAction,
   hardwareType,
   applyConfiguredNetworking,
@@ -105,6 +107,7 @@ export const TestForm = ({
 
   return (
     <ActionForm
+      actionDisabled={actionDisabled}
       actionName={NodeActions.TEST}
       allowUnchanged
       cleanup={machineActions.cleanup}


### PR DESCRIPTION
## Done

- Fix a race condition when action forms are saved.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Select a couple of machines that can be commissioned.
- Use the take action menu to start commissioning.
- Wait about 30 seconds and you shouldn't end up with the warning about updating your selection.
- Use the take action menu to abort commissioning.
- Wait about 30 seconds and you shouldn't end up with the warning about updating your selection.
- Try that a couple more times.

## Fixes

Fixes: #2246.