### PR TITLE
feat(legacy): redirect to new machine details

### DIFF
--- a/legacy/src/app/routes.js
+++ b/legacy/src/app/routes.js
@@ -43,19 +43,30 @@ const configureRoutes = ($stateProvider, $urlRouterProvider) => {
     })
     .state("master.machineResultDetails", {
       url: generateLegacyURL("/machine/:system_id/:result_type/:id"),
-      template: nodeResultTmpl,
-      controller: "NodeResultController",
+      redirectTo: (transition) => {
+        const params = transition.params();
+        navigateToNew(
+          `/machine/${params.system_id}/${params.result_type}/${params.id}/details`
+        );
+      },
     })
     .state("master.machineEvents", {
       url: generateLegacyURL("/machine/:system_id/events"),
-      template: nodeEventsTmpl,
-      controller: "NodeEventsController",
+      redirectTo: (transition) => {
+        const params = transition.params();
+        navigateToNew(`/machine/${params.system_id}/logs/events`);
+      },
     })
     .state("master.machineDetails", {
-      url: generateLegacyURL("/machine/:system_id"),
-      template: nodeDetailsTmpl,
-      controller: "NodeDetailsController",
-      reloadOnSearch: false,
+      url: generateLegacyURL("/machine/:system_id?{area}"),
+      redirectTo: (transition) => {
+        const params = transition.params();
+        let url = `/machine/${params.system_id}`;
+        if (params.area) {
+          url = `${url}/${params.area}`;
+        }
+        navigateToNew(url);
+      },
     })
     .state("master.devices", {
       url: generateLegacyURL("/devices"),


### PR DESCRIPTION
## Done

- Update legacy links to redirect to the react machine details.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit some legacy machine details urls e.g. /MAAS/l/machine/834see?area=logs and you should get redirected to the new tab.

## Fixes

Fixes: #2107.