### PR TITLE
feat(ui): build ScrollFade component

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -23,14 +23,14 @@ exports[`stricter compilation`] = {
       [133, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [133, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/base/components/ActionForm/ActionForm.tsx:3188481039": [
+    "src/app/base/components/ActionForm/ActionForm.tsx:4160058983": [
       [18, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [22, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [25, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [25, 22, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [27, 13, 13, "Object is possibly \'undefined\'.", "3155939599"],
-      [136, 39, 6, "Argument of type \'{ [x: string]: any; } | null | undefined\' is not assignable to parameter of type \'string | object | string[]\'.\\n  Type \'undefined\' is not assignable to type \'string | object | string[]\'.", "1168132398"],
-      [139, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
+      [138, 39, 6, "Argument of type \'{ [x: string]: any; } | null | undefined\' is not assignable to parameter of type \'string | object | string[]\'.\\n  Type \'undefined\' is not assignable to type \'string | object | string[]\'.", "1168132398"],
+      [141, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
     "src/app/base/components/ArchitectureSelect/ArchitectureSelect.tsx:463990503": [
       [27, 28, 20, "Expected 1 arguments, but got 0.", "1113156766"]
@@ -109,6 +109,9 @@ exports[`stricter compilation`] = {
     ],
     "src/app/base/components/ScriptStatus/ScriptStatus.tsx:4195111423": [
       [48, 14, 9, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "2450009324"]
+    ],
+    "src/app/base/components/ScrollFade/ScrollFade.tsx:3180616113": [
+      [42, 14, 11, "Argument of type \'null\' is not assignable to parameter of type \'HTMLElement | Window\'.", "1248879763"]
     ],
     "src/app/base/components/SubnetSelect/SubnetSelect.test.tsx:3417476149": [
       [88, 11, 43, "Object is of type \'unknown\'.", "2224745896"],
@@ -255,7 +258,7 @@ exports[`stricter compilation`] = {
     "src/app/kvm/views/KVMDetails/KVMResources/KVMStorageCards/KVMStorageCards.test.tsx:4290952102": [
       [106, 40, 16, "Cannot assign to \'useSendAnalytics\' because it is a read-only property.", "3235495692"]
     ],
-    "src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx:2097291202": [
+    "src/app/kvm/views/KVMList/AddKVM/AddKVM.tsx:744529668": [
       [30, 28, 17, "Expected 1 arguments, but got 0.", "3763407084"]
     ],
     "src/app/kvm/views/KVMList/AddKVM/AddLxd/AddLxd.test.tsx:3638565741": [
@@ -308,10 +311,9 @@ exports[`stricter compilation`] = {
     "src/app/kvm/views/KVMList/VirshTable/VirshTable.tsx:254800136": [
       [78, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, pools: ResourcePool[]) => string | number | string[] | PodHint | PodResources | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:1056284611": [
-      [69, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [104, 29, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"],
-      [136, 2, 656, "Type \'Element | null\' is not assignable to type \'Element\'.\\n  Type \'null\' is not assignable to type \'Element\'.", "2065603965"]
+    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:4042019210": [
+      [68, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
+      [102, 14, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"]
     ],
     "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:729308648": [
       [127, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -319,9 +321,9 @@ exports[`stricter compilation`] = {
       [222, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [226, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Scripts[]; commissioningScripts: Scripts[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
-    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx:4209162641": [
-      [131, 6, 8, "Type \'(values: CommissionFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'CommissionFormValues\'.", "1301647696"],
-      [165, 42, 25, "Argument of type \'(Scripts | undefined)[]\' is not assignable to parameter of type \'Scripts[]\'.\\n  Type \'Scripts | undefined\' is not assignable to type \'Scripts\'.\\n    Type \'undefined\' is not assignable to type \'Scripts\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "4025185665"]
+    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx:881387322": [
+      [136, 6, 8, "Type \'(values: CommissionFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'CommissionFormValues\'.", "1301647696"],
+      [170, 42, 25, "Argument of type \'(Scripts | undefined)[]\' is not assignable to parameter of type \'Scripts[]\'.\\n  Type \'Scripts | undefined\' is not assignable to type \'Scripts\'.\\n    Type \'undefined\' is not assignable to type \'Scripts\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "4025185665"]
     ],
     "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.test.tsx:12282955": [
       [150, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
@@ -336,10 +338,10 @@ exports[`stricter compilation`] = {
       [370, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [371, 8, 21, "Argument of type \'{ includeUserData: boolean; installKVM: boolean; kernel: string; oSystem: string; release: string; userData: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'includeUserData\' does not exist in type \'FormEvent<{}>\'.", "4050162228"]
     ],
-    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx:3655547000": [
-      [61, 28, 26, "Expected 1 arguments, but got 0.", "1955924760"],
-      [62, 28, 13, "Expected 1 arguments, but got 0.", "1814494730"],
-      [104, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"]
+    "src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx:3788154419": [
+      [65, 28, 26, "Expected 1 arguments, but got 0.", "1955924760"],
+      [66, 28, 13, "Expected 1 arguments, but got 0.", "1814494730"],
+      [109, 6, 8, "Type \'(values: DeployFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'DeployFormValues\'.", "1301647696"]
     ],
     "src/app/machines/components/ActionFormWrapper/DeployForm/DeployFormFields/UserDataField/UserDataField.test.tsx:1524992826": [
       [120, 10, 19, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "2609332470"]
@@ -361,8 +363,8 @@ exports[`stricter compilation`] = {
       [165, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [166, 8, 29, "Argument of type \'{ comment: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'comment\' does not exist in type \'FormEvent<{}>\'.", "940323754"]
     ],
-    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:2570863212": [
-      [57, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"]
+    "src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx:2500830023": [
+      [62, 6, 8, "Type \'(values: MarkBrokenFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'MarkBrokenFormValues\'.", "1301647696"]
     ],
     "src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx:3805907798": [
       [91, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
@@ -370,8 +372,8 @@ exports[`stricter compilation`] = {
       [159, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [160, 8, 17, "Argument of type \'{ enableErase: boolean; quickErase: boolean; secureErase: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableErase\' does not exist in type \'FormEvent<{}>\'.", "2843185352"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx:1441569873": [
-      [74, 10, 8, "Type \'(values: ReleaseFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ReleaseFormValues\'.", "1301647696"]
+    "src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx:2192503258": [
+      [79, 10, 8, "Type \'(values: ReleaseFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ReleaseFormValues\'.", "1301647696"]
     ],
     "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:2137936626": [
       [97, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -379,10 +381,10 @@ exports[`stricter compilation`] = {
       [265, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [269, 10, 15, "Argument of type \'{ enableSSH: boolean; scripts: Scripts[]; scriptInputs: { \\"internet-connectivity\\": string; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"]
     ],
-    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:1375872664": [
-      [82, 4, 11, "Type \'(FormattedScript | undefined)[]\' is not assignable to type \'FormattedScript[]\'.\\n  Type \'FormattedScript | undefined\' is not assignable to type \'FormattedScript\'.\\n    Type \'undefined\' is not assignable to type \'FormattedScript\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"],
-      [92, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"],
-      [124, 6, 8, "Type \'(values: FormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'FormValues\'.", "1301647696"]
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:3586701279": [
+      [84, 4, 11, "Type \'(FormattedScript | undefined)[]\' is not assignable to type \'FormattedScript[]\'.\\n  Type \'FormattedScript | undefined\' is not assignable to type \'FormattedScript\'.\\n    Type \'undefined\' is not assignable to type \'FormattedScript\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"],
+      [94, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"],
+      [127, 6, 8, "Type \'(values: FormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'FormValues\'.", "1301647696"]
     ],
     "src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx:355834529": [
       [345, 11, 5, "Object is of type \'unknown\'.", "173192470"],
@@ -426,31 +428,31 @@ exports[`stricter compilation`] = {
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:2651049192": [
-      [102, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [105, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [124, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [127, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [147, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [150, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [170, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [173, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [192, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [195, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [215, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [218, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [239, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [242, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [258, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [261, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [277, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [280, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [300, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [303, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [320, 6, 62, "Object is of type \'unknown\'.", "445141705"],
-      [323, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
-      [343, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
-      [346, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"]
+    "src/app/machines/views/MachineDetails/MachineLogs/DownloadMenu/DownloadMenu.test.tsx:1462327029": [
+      [103, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [106, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [125, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [128, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [148, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [151, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [171, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [174, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [193, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [196, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [216, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [219, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [240, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [243, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [259, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [262, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [278, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [281, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [301, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [304, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [321, 6, 62, "Object is of type \'unknown\'.", "445141705"],
+      [324, 15, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"],
+      [344, 4, 58, "Object is of type \'unknown\'.", "1673908681"],
+      [347, 13, 4, "Parameter \'link\' implicitly has an \'any\' type.", "2087656645"]
     ],
     "src/app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogs.test.tsx:3147327199": [
       [154, 46, 14, "Property \'setCurrentPage\' does not exist on type \'HTMLAttributes\'.", "3476818685"],
@@ -461,22 +463,22 @@ exports[`stricter compilation`] = {
       [260, 11, 45, "Object is of type \'unknown\'.", "3327518388"],
       [299, 11, 45, "Object is of type \'unknown\'.", "3327518388"]
     ],
-    "src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx:689686888": [
-      [80, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [98, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [115, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [132, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [139, 11, 23, "Object is possibly \'null\'.", "2510184035"],
-      [139, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
-      [150, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [167, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [174, 11, 23, "Object is possibly \'null\'.", "2510184035"],
-      [174, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
-      [185, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [202, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [219, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [236, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
-      [259, 11, 42, "Object is of type \'unknown\'.", "3300537276"]
+    "src/app/machines/views/MachineDetails/MachineLogs/InstallationOutput/InstallationOutput.test.tsx:721647388": [
+      [82, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [100, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [117, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [134, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [141, 11, 23, "Object is possibly \'null\'.", "2510184035"],
+      [141, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
+      [152, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [169, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [176, 11, 23, "Object is possibly \'null\'.", "2510184035"],
+      [176, 35, 3, "Element implicitly has an \'any\' type because index expression is not of type \'number\'.", "193343796"],
+      [187, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [204, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [221, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [238, 11, 42, "Object is of type \'unknown\'.", "3300537276"],
+      [262, 11, 42, "Object is of type \'unknown\'.", "3300537276"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx:2329041630": [
       [172, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -703,7 +705,7 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.tsx:1985822576": [
       [29, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
     ],
-    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:3688302714": [
+    "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:741676544": [
       [69, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
     ],
     "src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx:1934760491": [
@@ -787,10 +789,10 @@ exports[`stricter compilation`] = {
       [1005, 2, 15, "Type \'MachineReducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<Machine, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<MachineState, { payload: any; type: string; }> | CaseReducerWithPrepare<MachineState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n      Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<Machine, any>, PayloadAction<any, string, any, any>>\'.\\n        Type \'CaseReducer<MachineState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<Machine, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<Machine, any>>\' is missing the following properties from type \'WritableDraft<MachineState>\': active, eventErrors, selected, statuses", "4102082497"],
       [1009, 16, 75, "Conversion of type \'{ active: null; selected: never[]; statuses: {}; }\' to type \'MachineState\' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to \'unknown\' first.\\n  Property \'eventErrors\' is missing in type \'{ active: null; selected: never[]; statuses: {}; }\' but required in type \'{ active: string | null; eventErrors: EventError<Machine, any, \\"system_id\\">[]; selected: string[]; statuses: MachineStatuses; }\'.", "1433951465"]
     ],
-    "src/app/store/machine/utils/hooks.ts:2707451908": [
-      [71, 28, 13, "Expected 1 arguments, but got 0.", "1814494730"],
-      [101, 28, 20, "Expected 1 arguments, but got 0.", "1113156766"],
-      [143, 28, 17, "Expected 1 arguments, but got 0.", "3763407084"]
+    "src/app/store/machine/utils/hooks.ts:930651913": [
+      [76, 28, 13, "Expected 1 arguments, but got 0.", "1814494730"],
+      [106, 28, 20, "Expected 1 arguments, but got 0.", "1113156766"],
+      [148, 28, 17, "Expected 1 arguments, but got 0.", "3763407084"]
     ],
     "src/app/store/machine/utils/storage.ts:3023148110": [
       [164, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
@@ -814,7 +816,7 @@ exports[`stricter compilation`] = {
     "src/app/store/resourcepool/actions.test.ts:9201512": [
       [71, 52, 24, "Expected 1 arguments, but got 2.", "3295119724"]
     ],
-    "src/app/store/scriptresult/slice.ts:2065533704": [
+    "src/app/store/scriptresult/slice.ts:2945530735": [
       [47, 2, 8, "Type \'Reducers\' does not satisfy the constraint \'SliceCaseReducers<GenericState<ScriptResult, any>>\'.\\n  Index signatures are incompatible.\\n    Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }> | CaseReducerWithPrepare<ScriptResultState, PayloadAction<any, string, any, any>>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n      Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }> | CaseReducerWithPrepare<GenericState<ScriptResult, any>, PayloadAction<...>>\'.\\n        Type \'CaseReducer<ScriptResultState, { payload: any; type: string; }>\' is not assignable to type \'CaseReducer<GenericState<ScriptResult, any>, { payload: any; type: string; }>\'.\\n          Types of parameters \'state\' and \'state\' are incompatible.\\n            Type \'WritableDraft<GenericState<ScriptResult, any>>\' is missing the following properties from type \'WritableDraft<ScriptResultState>\': history, logs", "781891908"]
     ],
     "src/app/store/user/reducers.test.ts:698541338": [
@@ -989,13 +991,13 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 58, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/selectors.ts:2474784495": [
+    "src/app/store/scriptresult/selectors.ts:1601152711": [
       [14, 13, 8, "RegExp match", "1152173309"],
       [72, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/types.ts:133570425": [
+    "src/app/store/scriptresult/types.ts:2148794586": [
       [3, 13, 8, "RegExp match", "1152173309"],
-      [122, 58, 8, "RegExp match", "1152173309"]
+      [123, 58, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scripts/types.ts:980490450": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/base/components/ScrollFade/ScrollFade.test.tsx
+++ b/ui/src/app/base/components/ScrollFade/ScrollFade.test.tsx
@@ -1,0 +1,55 @@
+import { mount } from "enzyme";
+
+import ScrollFade, {
+  getScrollbarWidth,
+  getShowFade,
+  SCROLL_FADE_BUFFER,
+} from "./ScrollFade";
+
+describe("ScrollFade", () => {
+  it("renders", () => {
+    const wrapper = mount(<ScrollFade>Children</ScrollFade>);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe("getScrollbarWidth", () => {
+    it("correctly calculates an element's scrollbar width", () => {
+      const scrollbarEl = { clientWidth: 80, offsetWidth: 100 } as HTMLElement;
+      const noScrollbarEl = {
+        clientWidth: 100,
+        offsetWidth: 100,
+      } as HTMLElement;
+      expect(getScrollbarWidth(scrollbarEl)).toBe(20);
+      expect(getScrollbarWidth(noScrollbarEl)).toBe(0);
+    });
+  });
+
+  describe("getShowFade", () => {
+    it("returns true if element is not scrolled to the bottom", () => {
+      const el = {
+        offsetHeight: 0,
+        scrollHeight: 100,
+        scrollTop: 50,
+      } as HTMLElement;
+      expect(getShowFade(el)).toBe(true);
+    });
+
+    it("returns false if element is scrolled to the bottom", () => {
+      const el = {
+        offsetHeight: 0,
+        scrollHeight: 100,
+        scrollTop: 100,
+      } as HTMLElement;
+      expect(getShowFade(el)).toBe(false);
+    });
+
+    it("returns false if element is scrolled within the buffer from the bottom", () => {
+      const el = {
+        offsetHeight: 0,
+        scrollHeight: 100,
+        scrollTop: 100 - SCROLL_FADE_BUFFER,
+      } as HTMLElement;
+      expect(getShowFade(el)).toBe(false);
+    });
+  });
+});

--- a/ui/src/app/base/components/ScrollFade/ScrollFade.tsx
+++ b/ui/src/app/base/components/ScrollFade/ScrollFade.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { useListener } from "@canonical/react-components/dist/hooks";
+import classNames from "classnames";
+
+// Max distance from bottom scroll position in which to remove fade.
+export const SCROLL_FADE_BUFFER = 4;
+
+export const getScrollbarWidth = (el: HTMLElement | null): number => {
+  if (el) {
+    const { clientWidth, offsetWidth } = el;
+    const scrollbarWidth = offsetWidth - clientWidth;
+    return scrollbarWidth >= 0 ? scrollbarWidth : 0;
+  }
+  return 0;
+};
+
+export const getShowFade = (el: HTMLElement | null): boolean => {
+  if (el) {
+    const { offsetHeight, scrollHeight, scrollTop } = el;
+    const fromBottom = scrollHeight - scrollTop - offsetHeight;
+    return fromBottom > SCROLL_FADE_BUFFER;
+  }
+  return false;
+};
+
+type Props = {
+  children: ReactNode;
+};
+
+const ScrollFade = ({ children }: Props): JSX.Element => {
+  const ref = useRef(null);
+  const [showFade, setShowFade] = useState(false);
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  const onScroll = useCallback(() => {
+    setScrollbarWidth(getScrollbarWidth(ref.current));
+    setShowFade(getShowFade(ref.current));
+  }, [ref]);
+
+  // Initialise whether to show fade and attach scroll listener.
+  useEffect(() => onScroll(), [onScroll]);
+  useListener(ref.current, onScroll, "scroll", true, true);
+
+  return (
+    <div className="scroll-fade">
+      <div
+        className={classNames("scroll-fade__children", {
+          "scroll-fade__children--scrollbar": scrollbarWidth !== 0,
+        })}
+        ref={ref}
+      >
+        {children}
+      </div>
+      {showFade && (
+        <div
+          className="scroll-fade__overlay"
+          data-test="overlay"
+          style={{ right: scrollbarWidth }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ScrollFade;

--- a/ui/src/app/base/components/ScrollFade/__snapshots__/ScrollFade.test.tsx.snap
+++ b/ui/src/app/base/components/ScrollFade/__snapshots__/ScrollFade.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScrollFade renders 1`] = `
+<ScrollFade>
+  <div
+    className="scroll-fade"
+  >
+    <div
+      className="scroll-fade__children"
+    >
+      Children
+    </div>
+  </div>
+</ScrollFade>
+`;

--- a/ui/src/app/base/components/ScrollFade/_index.scss
+++ b/ui/src/app/base/components/ScrollFade/_index.scss
@@ -1,0 +1,28 @@
+@mixin ScrollFade {
+  .scroll-fade {
+    height: 100%;
+    position: relative;
+  }
+
+  .scroll-fade__children {
+    height: 100%;
+    overflow: auto;
+  }
+
+  .scroll-fade__children--scrollbar {
+    // Add a little bit of padding if a scrollbar exists.
+    padding-right: $sph-inner--small;
+  }
+
+  .scroll-fade__overlay {
+    background: linear-gradient(
+      to top,
+      rgba(255, 255, 255, 1) 0%,
+      rgba(255, 255, 255, 0) 100%
+    );
+    bottom: 0;
+    height: $sp-unit * 6;
+    left: 0;
+    position: absolute;
+  }
+}

--- a/ui/src/app/base/components/ScrollFade/index.ts
+++ b/ui/src/app/base/components/ScrollFade/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ScrollFade";

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from "react-redux";
 
+import ScrollFade from "app/base/components/ScrollFade";
 import PodMeter from "app/kvm/components/PodMeter";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
@@ -49,28 +50,30 @@ const StorageResources = ({ id }: Props): JSX.Element | null => {
         </div>
       </div>
       <div className="storage-resources__pools-container">
-        {sortedPools.map((pool) => {
-          const total = formatBytes(pool.total, "B");
-          const allocated = formatBytes(pool.used, "B", {
-            convertTo: total.unit,
-          });
-          const free = formatBytes(pool.total - pool.used, "B", {
-            convertTo: total.unit,
-          });
+        <ScrollFade>
+          {sortedPools.map((pool) => {
+            const total = formatBytes(pool.total, "B");
+            const allocated = formatBytes(pool.used, "B", {
+              convertTo: total.unit,
+            });
+            const free = formatBytes(pool.total - pool.used, "B", {
+              convertTo: total.unit,
+            });
 
-          return (
-            <div className="storage-resources__pool" key={pool.id}>
-              <div className="storage-resources__pool-name">{pool.name}</div>
-              <PodMeter
-                allocated={allocated.value}
-                className="storage-resources__pool-meter"
-                free={free.value}
-                inverted
-                unit={total.unit}
-              />
-            </div>
-          );
-        })}
+            return (
+              <div className="storage-resources__pool" key={pool.id}>
+                <div className="storage-resources__pool-name">{pool.name}</div>
+                <PodMeter
+                  allocated={allocated.value}
+                  className="storage-resources__pool-meter"
+                  free={free.value}
+                  inverted
+                  unit={total.unit}
+                />
+              </div>
+            );
+          })}
+        </ScrollFade>
       </div>
     </div>
   );

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/__snapshots__/StorageResources.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/__snapshots__/StorageResources.test.tsx.snap
@@ -53,254 +53,264 @@ exports[`StorageResources renders 1`] = `
     <div
       className="storage-resources__pools-container"
     >
-      <div
-        className="storage-resources__pool"
-        key="a"
-      >
+      <ScrollFade>
         <div
-          className="storage-resources__pool-name"
-        >
-          pool-1
-        </div>
-        <PodMeter
-          allocated={1}
-          className="storage-resources__pool-meter"
-          free={2}
-          inverted={true}
-          unit="B"
+          className="scroll-fade"
         >
           <div
-            className="storage-resources__pool-meter pod-meter pod-meter--inverted"
+            className="scroll-fade__children"
           >
-            <div>
-              <p
-                className="p-heading--small u-text--light"
-              >
-                Total
-              </p>
-              <div
-                data-test="total"
-              >
-                3B
-              </div>
-            </div>
             <div
-              className="u-align--right"
+              className="storage-resources__pool"
+              key="a"
             >
-              <p
-                className="p-heading--small u-text--light"
-              >
-                Allocated
-                <span
-                  className="u-nudge-right--small"
-                >
-                  <i
-                    className="p-circle--link u-no-margin--top"
-                  />
-                </span>
-              </p>
               <div
-                className="u-nudge-left"
-                data-test="allocated"
+                className="storage-resources__pool-name"
               >
-                1B
+                pool-1
               </div>
-            </div>
-            <div
-              className="u-align--right"
-            >
-              <p
-                className="p-heading--small u-text--light"
-              >
-                Free
-                <span
-                  className="u-nudge-right--small"
-                >
-                  <i
-                    className="p-circle--link-faded u-no-margin--top"
-                  />
-                </span>
-              </p>
-              <div
-                className="u-nudge-left"
-                data-test="free"
-              >
-                2B
-              </div>
-            </div>
-            <div
-              style={
-                Object {
-                  "gridArea": "meter",
-                }
-              }
-            >
-              <Meter
-                data={
-                  Array [
-                    Object {
-                      "value": 1,
-                    },
-                  ]
-                }
-                max={3}
-                segmented={false}
-                small={true}
+              <PodMeter
+                allocated={1}
+                className="storage-resources__pool-meter"
+                free={2}
+                inverted={true}
+                unit="B"
               >
                 <div
-                  className="p-meter--small"
+                  className="storage-resources__pool-meter pod-meter pod-meter--inverted"
                 >
+                  <div>
+                    <p
+                      className="p-heading--small u-text--light"
+                    >
+                      Total
+                    </p>
+                    <div
+                      data-test="total"
+                    >
+                      3B
+                    </div>
+                  </div>
                   <div
-                    className="p-meter__bar"
+                    className="u-align--right"
+                  >
+                    <p
+                      className="p-heading--small u-text--light"
+                    >
+                      Allocated
+                      <span
+                        className="u-nudge-right--small"
+                      >
+                        <i
+                          className="p-circle--link u-no-margin--top"
+                        />
+                      </span>
+                    </p>
+                    <div
+                      className="u-nudge-left"
+                      data-test="allocated"
+                    >
+                      1B
+                    </div>
+                  </div>
+                  <div
+                    className="u-align--right"
+                  >
+                    <p
+                      className="p-heading--small u-text--light"
+                    >
+                      Free
+                      <span
+                        className="u-nudge-right--small"
+                      >
+                        <i
+                          className="p-circle--link-faded u-no-margin--top"
+                        />
+                      </span>
+                    </p>
+                    <div
+                      className="u-nudge-left"
+                      data-test="free"
+                    >
+                      2B
+                    </div>
+                  </div>
+                  <div
                     style={
                       Object {
-                        "backgroundColor": "#D3E4ED",
+                        "gridArea": "meter",
                       }
                     }
                   >
-                    <div
-                      className="p-meter__filled"
-                      key="meter-0"
-                      style={
-                        Object {
-                          "backgroundColor": "#0066CC",
-                          "borderRight": undefined,
-                          "left": "0%",
-                          "width": "33.33333333333333%",
-                        }
+                    <Meter
+                      data={
+                        Array [
+                          Object {
+                            "value": 1,
+                          },
+                        ]
                       }
-                    />
+                      max={3}
+                      segmented={false}
+                      small={true}
+                    >
+                      <div
+                        className="p-meter--small"
+                      >
+                        <div
+                          className="p-meter__bar"
+                          style={
+                            Object {
+                              "backgroundColor": "#D3E4ED",
+                            }
+                          }
+                        >
+                          <div
+                            className="p-meter__filled"
+                            key="meter-0"
+                            style={
+                              Object {
+                                "backgroundColor": "#0066CC",
+                                "borderRight": undefined,
+                                "left": "0%",
+                                "width": "33.33333333333333%",
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </Meter>
                   </div>
                 </div>
-              </Meter>
-            </div>
-          </div>
-        </PodMeter>
-      </div>
-      <div
-        className="storage-resources__pool"
-        key="b"
-      >
-        <div
-          className="storage-resources__pool-name"
-        >
-          pool-2
-        </div>
-        <PodMeter
-          allocated={3}
-          className="storage-resources__pool-meter"
-          free={2}
-          inverted={true}
-          unit="B"
-        >
-          <div
-            className="storage-resources__pool-meter pod-meter pod-meter--inverted"
-          >
-            <div>
-              <p
-                className="p-heading--small u-text--light"
-              >
-                Total
-              </p>
-              <div
-                data-test="total"
-              >
-                5B
-              </div>
+              </PodMeter>
             </div>
             <div
-              className="u-align--right"
+              className="storage-resources__pool"
+              key="b"
             >
-              <p
-                className="p-heading--small u-text--light"
-              >
-                Allocated
-                <span
-                  className="u-nudge-right--small"
-                >
-                  <i
-                    className="p-circle--link u-no-margin--top"
-                  />
-                </span>
-              </p>
               <div
-                className="u-nudge-left"
-                data-test="allocated"
+                className="storage-resources__pool-name"
               >
-                3B
+                pool-2
               </div>
-            </div>
-            <div
-              className="u-align--right"
-            >
-              <p
-                className="p-heading--small u-text--light"
-              >
-                Free
-                <span
-                  className="u-nudge-right--small"
-                >
-                  <i
-                    className="p-circle--link-faded u-no-margin--top"
-                  />
-                </span>
-              </p>
-              <div
-                className="u-nudge-left"
-                data-test="free"
-              >
-                2B
-              </div>
-            </div>
-            <div
-              style={
-                Object {
-                  "gridArea": "meter",
-                }
-              }
-            >
-              <Meter
-                data={
-                  Array [
-                    Object {
-                      "value": 3,
-                    },
-                  ]
-                }
-                max={5}
-                segmented={false}
-                small={true}
+              <PodMeter
+                allocated={3}
+                className="storage-resources__pool-meter"
+                free={2}
+                inverted={true}
+                unit="B"
               >
                 <div
-                  className="p-meter--small"
+                  className="storage-resources__pool-meter pod-meter pod-meter--inverted"
                 >
+                  <div>
+                    <p
+                      className="p-heading--small u-text--light"
+                    >
+                      Total
+                    </p>
+                    <div
+                      data-test="total"
+                    >
+                      5B
+                    </div>
+                  </div>
                   <div
-                    className="p-meter__bar"
+                    className="u-align--right"
+                  >
+                    <p
+                      className="p-heading--small u-text--light"
+                    >
+                      Allocated
+                      <span
+                        className="u-nudge-right--small"
+                      >
+                        <i
+                          className="p-circle--link u-no-margin--top"
+                        />
+                      </span>
+                    </p>
+                    <div
+                      className="u-nudge-left"
+                      data-test="allocated"
+                    >
+                      3B
+                    </div>
+                  </div>
+                  <div
+                    className="u-align--right"
+                  >
+                    <p
+                      className="p-heading--small u-text--light"
+                    >
+                      Free
+                      <span
+                        className="u-nudge-right--small"
+                      >
+                        <i
+                          className="p-circle--link-faded u-no-margin--top"
+                        />
+                      </span>
+                    </p>
+                    <div
+                      className="u-nudge-left"
+                      data-test="free"
+                    >
+                      2B
+                    </div>
+                  </div>
+                  <div
                     style={
                       Object {
-                        "backgroundColor": "#D3E4ED",
+                        "gridArea": "meter",
                       }
                     }
                   >
-                    <div
-                      className="p-meter__filled"
-                      key="meter-0"
-                      style={
-                        Object {
-                          "backgroundColor": "#0066CC",
-                          "borderRight": undefined,
-                          "left": "0%",
-                          "width": "60%",
-                        }
+                    <Meter
+                      data={
+                        Array [
+                          Object {
+                            "value": 3,
+                          },
+                        ]
                       }
-                    />
+                      max={5}
+                      segmented={false}
+                      small={true}
+                    >
+                      <div
+                        className="p-meter--small"
+                      >
+                        <div
+                          className="p-meter__bar"
+                          style={
+                            Object {
+                              "backgroundColor": "#D3E4ED",
+                            }
+                          }
+                        >
+                          <div
+                            className="p-meter__filled"
+                            key="meter-0"
+                            style={
+                              Object {
+                                "backgroundColor": "#0066CC",
+                                "borderRight": undefined,
+                                "left": "0%",
+                                "width": "60%",
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </Meter>
                   </div>
                 </div>
-              </Meter>
+              </PodMeter>
             </div>
           </div>
-        </PodMeter>
-      </div>
+        </div>
+      </ScrollFade>
     </div>
   </div>
 </StorageResources>

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/_index.scss
@@ -21,8 +21,7 @@
 
   .storage-resources__pools-container {
     grid-area: pools;
-    overflow: auto;
-    padding: 0 $sph-inner $spv-inner--medium $sph-inner;
+    padding: 0 $sph-inner;
   }
 
   .storage-resources__pool {
@@ -70,7 +69,6 @@
 
     .storage-resources__pools-container {
       height: $sp-unit * 21;
-      overflow: auto;
     }
 
     .storage-resources__pool {

--- a/ui/src/app/kvm/views/KVMDetails/VfResources/VfResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/VfResources/VfResources.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 
+import ScrollFade from "app/base/components/ScrollFade";
 import type { PodNetworkInterface } from "app/store/pod/types";
 
 export type Props = {
@@ -12,6 +13,7 @@ const VfResources = ({
   interfaces,
 }: Props): JSX.Element => {
   const noInterfaces = interfaces.length === 0;
+
   return (
     <div
       className={classNames("vf-resources", {
@@ -22,77 +24,79 @@ const VfResources = ({
         Virtual functions
       </h4>
       <div className="vf-resources__table-container">
-        <table className="vf-resources__table">
-          <thead>
-            <tr>
-              <th></th>
-              <th className="u-align--right u-text--light">
-                Allocated
-                <span className="u-nudge-right--small">
-                  <i className="p-circle--link"></i>
-                </span>
-              </th>
-              <th className="u-align--right u-text--light">
-                Free
-                <span className="u-nudge-right--small">
-                  <i className="p-circle--link-faded"></i>
-                </span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {noInterfaces && (
-              <tr data-test="no-interfaces">
-                <td>
-                  <p>
-                    <em>None</em>
-                  </p>
-                </td>
-                <td></td>
-                <td></td>
+        <ScrollFade>
+          <table className="vf-resources__table">
+            <thead>
+              <tr>
+                <th></th>
+                <th className="u-align--right u-text--light">
+                  Allocated
+                  <span className="u-nudge-right--small">
+                    <i className="p-circle--link"></i>
+                  </span>
+                </th>
+                <th className="u-align--right u-text--light">
+                  Free
+                  <span className="u-nudge-right--small">
+                    <i className="p-circle--link-faded"></i>
+                  </span>
+                </th>
               </tr>
-            )}
-            {interfaces.map((iface) => {
-              const { id, name, virtual_functions } = iface;
-              const {
-                allocated_other,
-                allocated_tracked,
-                free,
-              } = virtual_functions;
-              const allocatedVfs = allocated_other + allocated_tracked;
-              const hasVfs = allocatedVfs + free > 0;
-
-              return (
-                <tr key={`interface-${id}`}>
-                  <td>{name}:</td>
-                  {hasVfs ? (
-                    <>
-                      <td className="u-align--right" data-test="has-vfs">
-                        {allocatedVfs}
-                        <span className="u-nudge-right--small">
-                          <i className="p-circle--link"></i>
-                        </span>
-                      </td>
-                      <td className="u-align--right">
-                        {free}
-                        <span className="u-nudge-right--small">
-                          <i className="p-circle--link-faded"></i>
-                        </span>
-                      </td>
-                    </>
-                  ) : (
-                    <>
-                      <td className="u-align--right" data-test="has-no-vfs">
-                        &mdash;
-                      </td>
-                      <td></td>
-                    </>
-                  )}
+            </thead>
+            <tbody>
+              {noInterfaces && (
+                <tr data-test="no-interfaces">
+                  <td>
+                    <p>
+                      <em>None</em>
+                    </p>
+                  </td>
+                  <td></td>
+                  <td></td>
                 </tr>
-              );
-            })}
-          </tbody>
-        </table>
+              )}
+              {interfaces.map((iface) => {
+                const { id, name, virtual_functions } = iface;
+                const {
+                  allocated_other,
+                  allocated_tracked,
+                  free,
+                } = virtual_functions;
+                const allocatedVfs = allocated_other + allocated_tracked;
+                const hasVfs = allocatedVfs + free > 0;
+
+                return (
+                  <tr key={`interface-${id}`}>
+                    <td>{name}:</td>
+                    {hasVfs ? (
+                      <>
+                        <td className="u-align--right" data-test="has-vfs">
+                          {allocatedVfs}
+                          <span className="u-nudge-right--small">
+                            <i className="p-circle--link"></i>
+                          </span>
+                        </td>
+                        <td className="u-align--right">
+                          {free}
+                          <span className="u-nudge-right--small">
+                            <i className="p-circle--link-faded"></i>
+                          </span>
+                        </td>
+                      </>
+                    ) : (
+                      <>
+                        <td className="u-align--right" data-test="has-no-vfs">
+                          &mdash;
+                        </td>
+                        <td></td>
+                      </>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </ScrollFade>
       </div>
     </div>
   );

--- a/ui/src/app/kvm/views/KVMDetails/VfResources/__snapshots__/VfResources.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/VfResources/__snapshots__/VfResources.test.tsx.snap
@@ -12,74 +12,76 @@ exports[`VfResources renders 1`] = `
   <div
     className="vf-resources__table-container"
   >
-    <table
-      className="vf-resources__table"
-    >
-      <thead>
-        <tr>
-          <th />
-          <th
-            className="u-align--right u-text--light"
-          >
-            Allocated
-            <span
-              className="u-nudge-right--small"
+    <ScrollFade>
+      <table
+        className="vf-resources__table"
+      >
+        <thead>
+          <tr>
+            <th />
+            <th
+              className="u-align--right u-text--light"
             >
-              <i
-                className="p-circle--link"
-              />
-            </span>
-          </th>
-          <th
-            className="u-align--right u-text--light"
-          >
-            Free
-            <span
-              className="u-nudge-right--small"
+              Allocated
+              <span
+                className="u-nudge-right--small"
+              >
+                <i
+                  className="p-circle--link"
+                />
+              </span>
+            </th>
+            <th
+              className="u-align--right u-text--light"
             >
-              <i
-                className="p-circle--link-faded"
-              />
-            </span>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          key="interface-1"
-        >
-          <td>
-            eth0
-            :
-          </td>
-          <td
-            className="u-align--right"
-            data-test="has-vfs"
+              Free
+              <span
+                className="u-nudge-right--small"
+              >
+                <i
+                  className="p-circle--link-faded"
+                />
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            key="interface-1"
           >
-            3
-            <span
-              className="u-nudge-right--small"
+            <td>
+              eth0
+              :
+            </td>
+            <td
+              className="u-align--right"
+              data-test="has-vfs"
             >
-              <i
-                className="p-circle--link"
-              />
-            </span>
-          </td>
-          <td
-            className="u-align--right"
-          >
-            3
-            <span
-              className="u-nudge-right--small"
+              3
+              <span
+                className="u-nudge-right--small"
+              >
+                <i
+                  className="p-circle--link"
+                />
+              </span>
+            </td>
+            <td
+              className="u-align--right"
             >
-              <i
-                className="p-circle--link-faded"
-              />
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              3
+              <span
+                className="u-nudge-right--small"
+              >
+                <i
+                  className="p-circle--link-faded"
+                />
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </ScrollFade>
   </div>
 </div>
 `;

--- a/ui/src/app/kvm/views/KVMDetails/VfResources/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/VfResources/_index.scss
@@ -7,8 +7,6 @@
 
   .vf-resources__table-container {
     max-height: $sp-unit * 17;
-    padding-right: $sph-inner--small;
-    overflow: auto;
   }
 
   .vf-resources__table {

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -72,6 +72,7 @@
 @import "~app/base/components/Meter";
 @import "~app/base/components/Placeholder";
 @import "~app/base/components/Popover";
+@import "~app/base/components/ScrollFade";
 @import "~app/base/components/Section";
 @import "~app/base/components/TableMenu";
 @import "~app/base/components/TagSelector";
@@ -83,6 +84,7 @@
 @include Meter;
 @include Placeholder;
 @include Popover;
+@include ScrollFade;
 @include Section;
 @include TableMenu;
 @include TagSelector;


### PR DESCRIPTION
## Done

- Built `ScrollFade` component, which adds a fade gradient to the bottom of a div if it's not at the bottom-most scroll position.
- Decided not to build a generic hook just yet - maybe when we need to track element scroll position for another component?

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open `StorageResources.tsx` and change line 54 so that at least 3 storage pools will render.
- Go to the Project tab of a LXD KVM and check that the storage pool section of the summary card has a scrollbar
- Check that the section has a fade gradient, then scroll down to the bottom and check that the scrollbar disappears
- The same should happen in the "Virtual functions" section of the Resources tab

## Fixes

Fixes #2432 

## Screenshot

![Screenshot_2021-04-12 LXD project default bolla MAAS](https://user-images.githubusercontent.com/25733845/114325688-c0e9ee00-9b74-11eb-8597-54a12e8ab6cb.png)
