### PR TITLE
feat(ui): add machine action forms to LXD VM table

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.test.tsx
@@ -7,6 +7,7 @@ import KVMActionFormWrapper from "./KVMActionFormWrapper";
 
 import { KVMAction } from "app/kvm/views/KVMDetails";
 import { PodType } from "app/store/pod/types";
+import { NodeActions } from "app/store/types/node";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -98,5 +99,24 @@ describe("KVMActionFormWrapper", () => {
       </Provider>
     );
     expect(wrapper.find("RefreshForm").exists()).toBe(true);
+  });
+
+  it("renders machine action forms if a machine action is selected", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
+          <KVMActionFormWrapper
+            selectedAction={{ name: NodeActions.COMMISSION }}
+            setSelectedAction={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("ActionFormWrapper CommissionForm").exists()).toBe(
+      true
+    );
   });
 });

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.tsx
@@ -7,6 +7,7 @@ import type {
   SetSelectedAction,
 } from "app/kvm/views/KVMDetails";
 import { KVMAction } from "app/kvm/views/KVMDetails";
+import MachineActionForms from "app/machines/components/ActionFormWrapper";
 
 type Props = {
   selectedAction: SelectedAction;
@@ -20,19 +21,24 @@ const KVMActionFormWrapper = ({
   if (!selectedAction) {
     return null;
   }
-  return (
-    <>
-      {selectedAction === KVMAction.COMPOSE && (
-        <ComposeForm setSelectedAction={setSelectedAction} />
-      )}
-      {selectedAction === KVMAction.DELETE && (
-        <DeleteForm setSelectedAction={setSelectedAction} />
-      )}
-      {selectedAction === KVMAction.REFRESH && (
-        <RefreshForm setSelectedAction={setSelectedAction} />
-      )}
-    </>
-  );
+  if (typeof selectedAction === "object" && "name" in selectedAction) {
+    return (
+      <MachineActionForms
+        selectedAction={selectedAction}
+        setSelectedAction={setSelectedAction}
+      />
+    );
+  }
+  switch (selectedAction) {
+    case KVMAction.COMPOSE:
+      return <ComposeForm setSelectedAction={setSelectedAction} />;
+    case KVMAction.DELETE:
+      return <DeleteForm setSelectedAction={setSelectedAction} />;
+    case KVMAction.REFRESH:
+      return <RefreshForm setSelectedAction={setSelectedAction} />;
+    default:
+      return null;
+  }
 };
 
 export default KVMActionFormWrapper;

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.tsx
@@ -24,6 +24,7 @@ import {
   getCurrentFilters,
   queryStringToFilters,
 } from "app/machines/search";
+import type { SelectedAction as MachineAction } from "app/machines/views/MachineDetails/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import { PodType } from "app/store/pod/types";
@@ -34,7 +35,7 @@ export enum KVMAction {
   DELETE = "delete",
   REFRESH = "refresh",
 }
-export type SelectedAction = KVMAction | null;
+export type SelectedAction = KVMAction | MachineAction | null;
 export type SetSelectedAction = Dispatch<SetStateAction<SelectedAction>>;
 export type SetSearchFilter = (searchFilter: string) => void;
 

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.test.tsx
@@ -92,7 +92,7 @@ describe("VMsActionBar", () => {
     );
 
     expect(
-      wrapper.find("button[data-test='vm-actions']").prop("disabled")
+      wrapper.find("[data-test='vm-actions'] button").prop("disabled")
     ).toBe(true);
     expect(wrapper.find("button[data-test='delete-vm']").prop("disabled")).toBe(
       true
@@ -126,7 +126,7 @@ describe("VMsActionBar", () => {
     );
 
     expect(
-      wrapper.find("button[data-test='vm-actions']").prop("disabled")
+      wrapper.find("[data-test='vm-actions'] button").prop("disabled")
     ).toBe(false);
     expect(wrapper.find("button[data-test='delete-vm']").prop("disabled")).toBe(
       false

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -9,10 +9,12 @@ import type {
   SetSelectedAction,
 } from "app/kvm/views/KVMDetails";
 import { KVMAction } from "app/kvm/views/KVMDetails";
+import VmActionMenu from "app/machines/components/TakeActionMenu";
 import machineSelectors from "app/store/machine/selectors";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
+import { NodeActions } from "app/store/types/node";
 
 type Props = {
   currentPage: number;
@@ -50,21 +52,11 @@ const VMsActionBar = ({
           <Icon name="plus" />
           <span>Compose VM</span>
         </Button>
-        <Tooltip
-          message={
-            vmActionsDisabled ? "Select VMs below to perform an action." : null
-          }
-        >
-          <Button
-            appearance="base"
-            data-test="vm-actions"
-            disabled={vmActionsDisabled}
-            hasIcon
-            small
-          >
-            <Icon name="menu" />
-          </Button>
-        </Tooltip>
+        <VmActionMenu
+          data-test="vm-actions"
+          appearance="vmTable"
+          setSelectedAction={setSelectedAction}
+        />
         <span className="u-nudge-right">
           <Button
             appearance="base"
@@ -87,6 +79,7 @@ const VMsActionBar = ({
             data-test="delete-vm"
             disabled={vmActionsDisabled}
             hasIcon
+            onClick={() => setSelectedAction({ name: NodeActions.DELETE })}
             small
           >
             <Icon name="delete" />

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/_index.scss
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/_index.scss
@@ -23,10 +23,6 @@
       margin-top: $spv-inner--medium;
     }
 
-    [class*="p-button"] {
-      margin-right: $sph-inner;
-    }
-
     @media only screen and (min-width: $breakpoint-x-small) {
       grid-template-areas:
       "act pag"

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -3,8 +3,7 @@ import { useEffect } from "react";
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import PropTypes from "prop-types";
-import { useDispatch } from "react-redux";
-import { useParams } from "react-router";
+import { useDispatch, useSelector } from "react-redux";
 
 import CommissionForm from "./CommissionForm";
 import DeployForm from "./DeployForm";
@@ -17,13 +16,13 @@ import SetZoneForm from "./SetZoneForm";
 import TagForm from "./TagForm";
 import TestForm from "./TestForm";
 
-import type { RouteParams } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import type {
   SelectedAction,
   SetSelectedAction,
 } from "app/machines/views/MachineDetails/types";
 import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
 import { NodeActions } from "app/store/types/node";
 
 const getErrorSentence = (action: SelectedAction, count: number) => {
@@ -59,7 +58,7 @@ export const ActionFormWrapper = ({
   setSelectedAction,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const { id } = useParams<RouteParams>();
+  const activeMachineId = useSelector(machineSelectors.activeID);
   const { machinesToAction, processingCount } = useMachineActionForm(
     selectedAction.name
   );
@@ -75,7 +74,7 @@ export const ActionFormWrapper = ({
   // the selected action. When machines are processing the available actions
   // can change, so the action should not be disabled while processing.
   const actionDisabled =
-    !id &&
+    !activeMachineId &&
     processingCount === 0 &&
     actionableMachineIDs.length !== machinesToAction.length;
 

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -380,4 +380,120 @@ describe("TakeActionMenu", () => {
       state.general.machineActions.data[0]
     );
   });
+
+  it("can display the default variation", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu appearance="default" setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const getTooltipProp = (propName: string) =>
+      wrapper.find("Tooltip").prop(propName);
+    const getMenuProp = (propName: string) =>
+      wrapper.find("ContextualMenu").prop(propName);
+
+    expect(getTooltipProp("message")).toBe(
+      "Select machines below to perform an action."
+    );
+    expect(getTooltipProp("position")).toBe("left");
+
+    expect(getMenuProp("position")).toBe("right");
+    expect(getMenuProp("toggleAppearance")).toBe("positive");
+    expect(getMenuProp("toggleClassName")).toBe(undefined);
+    expect(getMenuProp("toggleLabel")).toBe("Take action");
+  });
+
+  it("can display the VM table variation", () => {
+    const state = { ...initialState };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu appearance="vmTable" setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const getTooltipProp = (propName: string) =>
+      wrapper.find("Tooltip").prop(propName);
+    const getMenuProp = (propName: string) =>
+      wrapper.find("ContextualMenu").prop(propName);
+
+    expect(getTooltipProp("message")).toBe(
+      "Select VMs below to perform an action."
+    );
+    expect(getTooltipProp("position")).toBe("top-left");
+
+    expect(getMenuProp("position")).toBe("left");
+    expect(getMenuProp("toggleAppearance")).toBe("base");
+    expect(getMenuProp("toggleClassName")).toBe(
+      "take-action-menu--vm-table is-small"
+    );
+    expect(getMenuProp("toggleLabel")).toBe("");
+  });
+
+  it("displays the delete action if using the default variation", () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      machineActionFactory({
+        name: NodeActions.DELETE,
+        title: "Delete...",
+        type: "misc",
+      }),
+    ];
+    state.machine.items = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.DELETE] }),
+    ];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu appearance="default" setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
+    expect(wrapper.find("[data-test='action-title-delete']").exists()).toBe(
+      true
+    );
+  });
+
+  it("does not display the delete action if using the VM table variation", () => {
+    const state = { ...initialState };
+    state.general.machineActions.data = [
+      machineActionFactory({
+        name: NodeActions.DELETE,
+        title: "Delete...",
+        type: "misc",
+      }),
+    ];
+    state.machine.items = [
+      machineFactory({ system_id: "abc123", actions: [NodeActions.DELETE] }),
+    ];
+    state.machine.selected = ["abc123"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu appearance="vmTable" setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find('[data-test="take-action-dropdown"] button').simulate("click");
+    expect(wrapper.find("[data-test='action-title-delete']").exists()).toBe(
+      false
+    );
+  });
 });

--- a/ui/src/app/machines/components/TakeActionMenu/_index.scss
+++ b/ui/src/app/machines/components/TakeActionMenu/_index.scss
@@ -1,0 +1,5 @@
+@mixin TakeActionMenu {
+  .take-action-menu--vm-table i {
+    @include vf-icon-menu($color-mid-dark);
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -143,6 +143,7 @@
 
 // machines
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
+@import "~app/machines/components/TakeActionMenu";
 @import "~app/machines/views/MachineList";
 @import "~app/machines/views/MachineList/MachineListControls/FilterAccordion";
 @import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
@@ -158,18 +159,19 @@
 @import "~app/machines/views/MachineDetails/NodeDevices";
 @include DownloadMenu;
 @include EventLogsTable;
-@include MachineList;
+@include FilterAccordion;
 @include MachineDHCPTable;
+@include MachineList;
 @include MachineName;
 @include MachineNetworkTable;
 @include MachineSummary;
+@include MachineTestsTable;
 @include MarkBrokenFormFields;
 @include NetworkCard;
+@include NodeDevices;
 @include NumaCard;
 @include OverviewCard;
-@include FilterAccordion;
-@include MachineTestsTable;
-@include NodeDevices;
+@include TakeActionMenu;
 
 // preferences
 @import "~app/preferences/views/APIKeys/APIKeyList";


### PR DESCRIPTION
## Done

- added machine action forms to LXD VM table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Project tab of a LXD KVM
- Select at least one VM and click the "bin" icon
- Check that the delete form shows up, and you can close it by clicking "Cancel" or by deselecting all the selected machines
- Select some VMs and click the "menu" icon
- Check that the dropdown functions exactly like the one in the machine list, except the "Delete" action is missing (since you do that via the bin icon)
  - Count of machines that can perform actions is correct
  - Selecting an action that not all machines can perform results in "update selection" warning
  - Actions can successfully be performed and is immediately reflected in the VM table

## Fixes

Fixes #2254 
