### PR TITLE
fix(ui): fix KVM page crashing when trying to sort storage pools

### DIFF
--- a/ui/src/app/store/pod/selectors.ts
+++ b/ui/src/app/store/pod/selectors.ts
@@ -279,7 +279,7 @@ const getSortedPools = createSelector(
       return [];
     }
     const pools = pod.storage_pools || [];
-    return pools.sort((a, b) => {
+    return [...pools].sort((a, b) => {
       if (a.id === pod.default_storage_pool || b.id > a.id) {
         return -1;
       }


### PR DESCRIPTION
## Done

- Fixed KVM page crashing when navigating to KVM details page (only seems to happen with a `make sampledata` MAAS though, not sure why...)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Using a `make sampledata` MAAS, navigate to any KVM details page and check that the app doesn't crash

## Fixes

Fixes #2506 