### PR TITLE
fix(ui): fix disabled machine details action menu

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -4,7 +4,7 @@ exports[`stricter compilation`] = {
     "src/app/App.test.tsx:2628562419": [
       [30, 16, 24, "Type \'Factory<NavigationOptions>\' is not assignable to type \'NavigationOptions | ArrayFactory<never> | AttributeFunction<NavigationOptions | null> | Factory<NavigationOptions | null> | DerivedFunction<...> | null | undefined\'.\\n  Type \'Factory<NavigationOptions>\' is not assignable to type \'Factory<NavigationOptions | null>\'.\\n    Types of parameters \'override\' and \'override\' are incompatible.\\n      Type \'Partial<Config<NavigationOptions | null>> | undefined\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.\\n        Type \'null\' is not assignable to type \'Partial<Config<NavigationOptions>> | undefined\'.", "3717115723"]
     ],
-    "src/app/App.tsx:2374153353": [
+    "src/app/App.tsx:3973292467": [
       [86, 30, 14, "Expected 1 arguments, but got 0.", "3293254978"],
       [87, 30, 24, "Expected 1 arguments, but got 0.", "137640098"],
       [190, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
@@ -137,7 +137,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -308,11 +308,11 @@ exports[`stricter compilation`] = {
     "src/app/kvm/views/KVMList/VirshTable/VirshTable.tsx:254800136": [
       [78, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, pools: ResourcePool[]) => string | number | string[] | PodHint | PodResources | PodNumaNode[] | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:4042019210": [
-      [68, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
-      [102, 14, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"]
+    "src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx:3809056997": [
+      [67, 26, 17, "Argument of type \'string\' is not assignable to parameter of type \'never\'.", "936314937"],
+      [101, 14, 17, "Type \'SetSelectedAction\' is not assignable to type \'(action?: MachineAction | null | undefined, deselect?: boolean | undefined) => void\'.\\n  Types of parameters \'action\' and \'action\' are incompatible.\\n    Type \'MachineAction | null | undefined\' is not assignable to type \'SelectedAction | null\'.\\n      Type \'undefined\' is not assignable to type \'SelectedAction | null\'.", "167402512"]
     ],
-    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:48126874": [
+    "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:151484698": [
       [109, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
       [113, 10, 15, "Argument of type \'{ enableSSH: boolean; skipBMCConfig: boolean; skipNetworking: boolean; skipStorage: boolean; updateFirmware: boolean; configureHBA: boolean; testingScripts: Script[]; commissioningScripts: Script[]; scriptInputs: { ...; }; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableSSH\' does not exist in type \'FormEvent<{}>\'.", "2907345984"],
       [204, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],
@@ -373,7 +373,7 @@ exports[`stricter compilation`] = {
       [159, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [160, 8, 17, "Argument of type \'{ enableErase: boolean; quickErase: boolean; secureErase: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'enableErase\' does not exist in type \'FormEvent<{}>\'.", "2843185352"]
     ],
-    "src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx:2192503258": [
+    "src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx:770475936": [
       [79, 10, 8, "Type \'(values: ReleaseFormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ReleaseFormValues\'.", "1301647696"]
     ],
     "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.test.tsx:302400524": [
@@ -387,21 +387,20 @@ exports[`stricter compilation`] = {
       [94, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"],
       [127, 6, 8, "Type \'(values: FormValues) => void\' is not assignable to type \'(...args: unknown[]) => void\'.\\n  Types of parameters \'values\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'FormValues\'.", "1301647696"]
     ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx:355834529": [
-      [345, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [346, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [347, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [348, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [349, 11, 5, "Object is of type \'unknown\'.", "173192470"]
+    "src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx:2315609313": [
+      [367, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [368, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [369, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [370, 11, 5, "Object is of type \'unknown\'.", "173192470"],
+      [371, 11, 5, "Object is of type \'unknown\'.", "173192470"]
     ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:1659601370": [
-      [39, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
-      [40, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
-      [55, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
-      [56, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
-      [82, 28, 21, "Expected 1 arguments, but got 0.", "759451472"],
-      [87, 6, 7, "Type \'false | \\"Select machines below to perform an action.\\"\' is not assignable to type \'string | null | undefined\'.\\n  Type \'false\' is not assignable to type \'string | null | undefined\'.", "1236122734"],
-      [98, 10, 16, "Argument of type \'(Machine | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "4020685210"]
+    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:3765348386": [
+      [43, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
+      [44, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
+      [59, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
+      [60, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
+      [85, 28, 21, "Expected 1 arguments, but got 0.", "759451472"],
+      [117, 10, 16, "Argument of type \'(Machine | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "2366246550"]
     ],
     "src/app/machines/hooks.tsx:3897133276": [
       [55, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 67 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 67 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
@@ -709,7 +708,7 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx:741676544": [
       [69, 35, 12, "Argument of type \'((systemId: string, open: boolean) => void) | undefined\' is not assignable to parameter of type \'(systemId: string, open: boolean) => void\'.\\n  Type \'undefined\' is not assignable to type \'(systemId: string, open: boolean) => void\'.", "786298661"]
     ],
-    "src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx:1934760491": [
+    "src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx:1485312273": [
       [63, 6, 8, "Type \'(values: any, { resetForm }: { resetForm: any; }) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'__1\' and \'formikHelpers\' are incompatible.\\n    Type \'FormikHelpers<unknown> | undefined\' is not assignable to type \'{ resetForm: any; }\'.\\n      Type \'undefined\' is not assignable to type \'{ resetForm: any; }\'.", "1301647696"],
       [63, 17, 6, "Parameter \'values\' implicitly has an \'any\' type.", "1972944509"],
       [63, 27, 9, "Binding element \'resetForm\' implicitly has an \'any\' type.", "1069256230"]
@@ -718,7 +717,7 @@ exports[`stricter compilation`] = {
       [87, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [92, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
     ],
-    "src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx:3915637960": [
+    "src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx:239426194": [
       [62, 6, 8, "Type \'(values: any, { resetForm }: { resetForm: any; }) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'__1\' and \'formikHelpers\' are incompatible.\\n    Type \'FormikHelpers<unknown> | undefined\' is not assignable to type \'{ resetForm: any; }\'.\\n      Type \'undefined\' is not assignable to type \'{ resetForm: any; }\'.", "1301647696"],
       [62, 17, 6, "Parameter \'values\' implicitly has an \'any\' type.", "1972944509"],
       [62, 27, 9, "Binding element \'resetForm\' implicitly has an \'any\' type.", "1069256230"]
@@ -894,12 +893,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:3029786704": [
       [11, 2, 5, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<Notification, string>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:1810081368": [
-      [258, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [379, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [380, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [382, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [387, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:3964556116": [
+      [259, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [380, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [381, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [383, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [388, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -1062,6 +1061,6 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `316
+  value: `308
 `
 };

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx
@@ -32,8 +32,9 @@ describe("TakeActionMenu", () => {
     });
   });
 
-  it("is disabled if no are machines selected", () => {
+  it("is disabled if no are machines selected and no machine is active", () => {
     const state = { ...initialState };
+    state.machine.active = null;
     state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
@@ -52,10 +53,31 @@ describe("TakeActionMenu", () => {
 
   it("is enabled if at least one machine selected", () => {
     const state = { ...initialState };
+    state.machine.active = null;
     state.machine.items = [
       machineFactory({ system_id: "a", actions: ["lifecycle1", "lifecycle2"] }),
     ];
     state.machine.selected = ["a"];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <TakeActionMenu setSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find('[data-test="take-action-dropdown"] button').props().disabled
+    ).toBe(false);
+  });
+
+  it("is enabled if a machine is active", () => {
+    const state = { ...initialState };
+    state.machine.active = "abc123";
+    state.machine.items = [machineFactory({ system_id: "abc123" })];
+    state.machine.selected = [];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -107,7 +107,7 @@ export const TakeActionMenu = ({
 
   return (
     <Tooltip
-      message={!selectedMachines.length ? variations.tooltipMessage : null}
+      message={!machinesToAction.length ? variations.tooltipMessage : null}
       position={variations.tooltipPosition}
     >
       <ContextualMenu
@@ -115,7 +115,7 @@ export const TakeActionMenu = ({
         hasToggleIcon
         links={getTakeActionLinks(
           actionOptions,
-          selectedMachines,
+          machinesToAction,
           setSelectedAction,
           appearance
         )}


### PR DESCRIPTION
## Done

- Fixed take action menu being unusable in machine details (forgot to rename a couple of variables :grimacing:) 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to any machine details page
- Check that the take action menu is not disabled and that you can perform actions as normal
- Check the machine list and LXD VM list as well

## Fixes

Fixes #2511 
