### PR TITLE
fix(ui): validate VM compose storage on render

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -29,6 +29,7 @@ import {
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -243,5 +244,24 @@ describe("StorageTable", () => {
     expect(wrapper.find(".p-form-validation__message").text()).toBe(
       `Error: Only 25GB available in ${pool.name}.`
     );
+  });
+
+  it("displays an error message on render if not enough space", async () => {
+    const pool = podStoragePoolFactory({ available: 0, name: "pool" });
+    const pod = podDetailsFactory({
+      id: 1,
+      default_storage_pool: pool.id,
+      storage_pools: [pool],
+    });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+    await waitForComponentToPaint(wrapper);
+    expect(
+      wrapper
+        .find("FormikField[name='disks[0].size'] .p-form-validation__message")
+        .text()
+    ).toBe("Error: Only 0GB available in pool.");
   });
 });

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect } from "react";
 
 import {
   Button,
@@ -35,9 +35,17 @@ export const StorageTable = ({ defaultDisk }: Props): JSX.Element => {
     handleChange,
     setFieldTouched,
     setFieldValue,
+    touched,
     values,
   } = useFormikContext<ComposeFormValues>();
   const { bootDisk, disks } = values;
+
+  // Ensure initial disk is always validated correctly.
+  useEffect(() => {
+    if (disks.length && !(touched.disks?.length && touched.disks[0].size)) {
+      setFieldTouched("disks[0].size", true, true);
+    }
+  }, [disks, setFieldTouched, touched]);
 
   const addDisk = () => {
     const ids = disks.map((disk) => disk.id);


### PR DESCRIPTION
## Done

- VM compose storage table is now validated on render

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the Compose form for a KVM with less than 8GB of space and check that an error shows up by default

## Fixes

Fixes #2338 
