### PR TITLE
fix(ui): fix KVM list resource usage calculations

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallCores/OverallCores.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallCores/OverallCores.tsx
@@ -22,7 +22,7 @@ const OverallCores = ({ cores, overCommit }: Props): JSX.Element => {
           <p className="p-heading--small u-text--light">
             Project
             <span className="u-nudge-right--small">
-              <i className="p-circle--positive u-no-margin--top"></i>
+              <i className="p-circle--link u-no-margin--top"></i>
             </span>
           </p>
           <div className="u-nudge-left">{allocated_tracked}</div>
@@ -31,7 +31,7 @@ const OverallCores = ({ cores, overCommit }: Props): JSX.Element => {
           <p className="p-heading--small u-text--light">
             Others
             <span className="u-nudge-right--small">
-              <i className="p-circle--link u-no-margin--top"></i>
+              <i className="p-circle--positive u-no-margin--top"></i>
             </span>
           </p>
           <div className="u-nudge-left">{allocated_other}</div>
@@ -51,11 +51,11 @@ const OverallCores = ({ cores, overCommit }: Props): JSX.Element => {
           <Meter
             data={[
               {
-                color: COLOURS.POSITIVE,
+                color: COLOURS.LINK,
                 value: allocated_tracked,
               },
               {
-                color: COLOURS.LINK,
+                color: COLOURS.POSITIVE,
                 value: allocated_other,
               },
               {

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallCores/__snapshots__/OverallCores.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallCores/__snapshots__/OverallCores.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`OverallCores renders 1`] = `
           className="u-nudge-right--small"
         >
           <i
-            className="p-circle--positive u-no-margin--top"
+            className="p-circle--link u-no-margin--top"
           />
         </span>
       </p>
@@ -44,7 +44,7 @@ exports[`OverallCores renders 1`] = `
           className="u-nudge-right--small"
         >
           <i
-            className="p-circle--link u-no-margin--top"
+            className="p-circle--positive u-no-margin--top"
           />
         </span>
       </p>
@@ -87,11 +87,11 @@ exports[`OverallCores renders 1`] = `
         data={
           Array [
             Object {
-              "color": "#0E8420",
+              "color": "#0066CC",
               "value": 1,
             },
             Object {
-              "color": "#0066CC",
+              "color": "#0E8420",
               "value": 2,
             },
             Object {

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallRam/OverallRam.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallRam/OverallRam.tsx
@@ -37,12 +37,12 @@ const OverallRam = ({ memory, overCommit }: Props): JSX.Element => {
                 ]
               : [
                   {
-                    color: COLOURS.POSITIVE,
+                    color: COLOURS.LINK,
                     tooltip: `Project ${memoryWithUnit(projectMemory)}`,
                     value: projectMemory,
                   },
                   {
-                    color: COLOURS.LINK,
+                    color: COLOURS.POSITIVE,
                     tooltip: `Others ${memoryWithUnit(otherMemory)}`,
                     value: otherMemory,
                   },
@@ -71,7 +71,7 @@ const OverallRam = ({ memory, overCommit }: Props): JSX.Element => {
             <td className="u-align--right">
               {memoryWithUnit(projectMemory)}
               <span className="u-nudge-right--small">
-                <i className="p-circle--positive"></i>
+                <i className="p-circle--link"></i>
               </span>
             </td>
           </tr>
@@ -80,7 +80,7 @@ const OverallRam = ({ memory, overCommit }: Props): JSX.Element => {
             <td className="u-align--right">
               {memoryWithUnit(otherMemory)}
               <span className="u-nudge-right--small">
-                <i className="p-circle--link"></i>
+                <i className="p-circle--positive"></i>
               </span>
             </td>
           </tr>

--- a/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallRam/__snapshots__/OverallRam.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMDetails/KVMResources/OverallResourcesCard/OverallRam/__snapshots__/OverallRam.test.tsx.snap
@@ -20,12 +20,12 @@ exports[`OverallRam renders 1`] = `
       segments={
         Array [
           Object {
-            "color": "#0E8420",
+            "color": "#0066CC",
             "tooltip": "Project 5B",
             "value": 5,
           },
           Object {
-            "color": "#0066CC",
+            "color": "#0E8420",
             "tooltip": "Others 7B",
             "value": 7,
           },
@@ -69,7 +69,7 @@ exports[`OverallRam renders 1`] = `
             className="u-nudge-right--small"
           >
             <i
-              className="p-circle--positive"
+              className="p-circle--link"
             />
           </span>
         </td>
@@ -86,7 +86,7 @@ exports[`OverallRam renders 1`] = `
             className="u-nudge-right--small"
           >
             <i
-              className="p-circle--link"
+              className="p-circle--positive"
             />
           </span>
         </td>

--- a/ui/src/app/kvm/views/KVMList/CPUColumn/CPUColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/CPUColumn/CPUColumn.test.tsx
@@ -4,10 +4,12 @@ import configureStore from "redux-mock-store";
 
 import CPUColumn from "./CPUColumn";
 
+import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
-  podHint as podHintFactory,
+  podResource as podResourceFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -15,45 +17,51 @@ import {
 const mockStore = configureStore();
 
 describe("CPUColumn", () => {
-  let initialState: RootState;
+  let state: RootState;
+  let pod: Pod;
 
   beforeEach(() => {
-    initialState = rootStateFactory({
+    pod = podFactory({
+      id: 1,
+      name: "pod-1",
+    });
+    state = rootStateFactory({
       pod: podStateFactory({
-        items: [
-          podFactory({
-            cpu_over_commit_ratio: 1,
-            id: 1,
-            name: "pod-1",
-            total: podHintFactory({
-              cores: 8,
-            }),
-            used: podHintFactory({
-              cores: 4,
-            }),
-          }),
-        ],
+        items: [pod],
       }),
     });
   });
 
   it("can display correct cpu core information without overcommit", () => {
-    const state = { ...initialState };
+    pod.cpu_over_commit_ratio = 1;
+    pod.resources = podResourcesFactory({
+      cores: podResourceFactory({
+        allocated_other: 0,
+        allocated_tracked: 4,
+        free: 4,
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <CPUColumn id={1} />
+        <CPUColumn id={pod.id} />
       </Provider>
     );
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
       "4 of 8 allocated"
     );
-    expect(wrapper.find("Meter").props().max).toBe(8);
+    expect(wrapper.find("Meter").prop("max")).toBe(8);
   });
 
   it("can display correct cpu core information with overcommit", () => {
-    const state = { ...initialState };
-    state.pod.items[0].cpu_over_commit_ratio = 2;
+    pod.cpu_over_commit_ratio = 2;
+    pod.resources = podResourcesFactory({
+      cores: podResourceFactory({
+        allocated_other: 0,
+        allocated_tracked: 4,
+        free: 4,
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -63,6 +71,28 @@ describe("CPUColumn", () => {
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
       "4 of 16 allocated"
     );
-    expect(wrapper.find("Meter").props().max).toBe(16);
+    expect(wrapper.find("Meter").prop("max")).toBe(16);
+  });
+
+  it("can display when cpu has been overcommitted", () => {
+    pod.cpu_over_commit_ratio = 1;
+    pod.resources = podResourcesFactory({
+      cores: podResourceFactory({
+        allocated_other: 0,
+        allocated_tracked: 4,
+        free: -1,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CPUColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='meter-overflow']").exists()).toBe(true);
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
+      "4 of 3 allocated"
+    );
+    expect(wrapper.find("Meter").prop("max")).toBe(3);
   });
 });

--- a/ui/src/app/kvm/views/KVMList/CPUColumn/CPUPopover/CPUPopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/CPUColumn/CPUPopover/CPUPopover.test.tsx
@@ -2,25 +2,89 @@ import { mount } from "enzyme";
 
 import CPUPopover from "./CPUPopover";
 
-describe("CPUPopover", () => {
-  const body = document.querySelector("body");
-  const app = document.createElement("div");
-  if (body && app) {
-    app.setAttribute("id", "app");
-    body.appendChild(app);
-  }
+import { podResource as podResourceFactory } from "testing/factories";
 
-  it("correctly displays CPU core data", () => {
+describe("CPUPopover", () => {
+  it("renders", () => {
     const wrapper = mount(
-      <CPUPopover allocated={10} physical={6} overcommit={3}>
+      <CPUPopover
+        cores={podResourceFactory({
+          allocated_other: 1,
+          allocated_tracked: 2,
+          free: 3,
+        })}
+        overCommit={2}
+      >
         Child
       </CPUPopover>
     );
     wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-test='allocated']").text()).toBe("10");
-    expect(wrapper.find("[data-test='free']").text()).toBe("8");
-    expect(wrapper.find("[data-test='physical']").text()).toBe("6");
-    expect(wrapper.find("[data-test='overcommit']").text()).toBe("3");
-    expect(wrapper.find("[data-test='total']").text()).toBe("18");
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("shows if cores are used by any other projects in the group", () => {
+    const wrapper = mount(
+      <CPUPopover
+        cores={podResourceFactory({
+          allocated_other: 1,
+        })}
+        overCommit={1}
+      >
+        Child
+      </CPUPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
+      "Project"
+    );
+    expect(wrapper.find("[data-test='other']").exists()).toBe(true);
+  });
+
+  it("does not show other cores if no other projects in the group use them", () => {
+    const wrapper = mount(
+      <CPUPopover
+        cores={podResourceFactory({
+          allocated_other: 0,
+        })}
+        overCommit={1}
+      >
+        Child
+      </CPUPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
+      "Allocated"
+    );
+    expect(wrapper.find("[data-test='other']").exists()).toBe(false);
+  });
+
+  it("shows CPU over-commit ratio if it is not equal to 1", () => {
+    const wrapper = mount(
+      <CPUPopover
+        cores={podResourceFactory({
+          allocated_other: 1,
+        })}
+        overCommit={2}
+      >
+        Child
+      </CPUPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='overcommit']").exists()).toBe(true);
+  });
+
+  it("does not show CPU over-commit ratio if it is equal to 1", () => {
+    const wrapper = mount(
+      <CPUPopover
+        cores={podResourceFactory({
+          allocated_other: 1,
+        })}
+        overCommit={1}
+      >
+        Child
+      </CPUPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='overcommit']").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/views/KVMList/CPUColumn/CPUPopover/CPUPopover.tsx
+++ b/ui/src/app/kvm/views/KVMList/CPUColumn/CPUPopover/CPUPopover.tsx
@@ -1,22 +1,25 @@
-import PropTypes from "prop-types";
+import type { ReactNode } from "react";
 
 import Popover from "app/base/components/Popover";
+import type { Pod, PodResource } from "app/store/pod/types";
+import { resourceWithOverCommit } from "app/store/pod/utils";
 
 type Props = {
-  allocated: number;
-  children: JSX.Element | string;
-  physical: number;
-  overcommit: number;
+  children: ReactNode;
+  cores: PodResource;
+  overCommit: Pod["cpu_over_commit_ratio"];
 };
 
-const CPUPopover = ({
-  allocated,
-  children,
-  physical,
-  overcommit,
-}: Props): JSX.Element => {
-  const total = physical * overcommit;
-  const free = total - allocated;
+const CPUPopover = ({ children, cores, overCommit }: Props): JSX.Element => {
+  const overCommitted = resourceWithOverCommit(cores, overCommit);
+  const hostCores =
+    cores.allocated_other + cores.allocated_tracked + cores.free;
+  const overCommitCores =
+    overCommitted.allocated_other +
+    overCommitted.allocated_tracked +
+    overCommitted.free;
+  const showOther = cores.allocated_other > 0;
+  const hasOverCommit = overCommit !== 1;
 
   return (
     <Popover
@@ -26,14 +29,27 @@ const CPUPopover = ({
           <div className="cpu-popover__header p-table__header">CPU cores</div>
           <div className="cpu-popover__primary">
             <div className="u-align--right" data-test="allocated">
-              {allocated}
+              {overCommitted.allocated_tracked}
             </div>
             <div className="u-vertically-center">
               <i className="p-circle--link"></i>
             </div>
-            <div>Allocated</div>
+            <div data-test="allocated-label">
+              {showOther ? "Project" : "Allocated"}
+            </div>
+            {showOther && (
+              <>
+                <div className="u-align--right" data-test="other">
+                  {overCommitted.allocated_other}
+                </div>
+                <div className="u-vertically-center">
+                  <i className="p-circle--positive"></i>
+                </div>
+                <div>Others</div>
+              </>
+            )}
             <div className="u-align--right" data-test="free">
-              {free}
+              {overCommitted.free}
             </div>
             <div className="u-vertically-center">
               <i className="p-circle--link-faded"></i>
@@ -41,20 +57,24 @@ const CPUPopover = ({
             <div>Free</div>
           </div>
           <div className="cpu-popover__secondary">
-            <div className="u-align--right" data-test="physical">
-              {physical}
-            </div>
-            <div />
-            <div>{`Physical core${physical === 1 ? "" : "s"}`}</div>
-            <div className="u-align--right">
-              &times;&nbsp;
-              <span data-test="overcommit">{overcommit}</span>
-            </div>
-            <div />
-            <div>Overcommit ratio</div>
-            <hr className="cpu-popover__separator" />
+            {hasOverCommit && (
+              <>
+                <div className="u-align--right" data-test="host">
+                  {hostCores}
+                </div>
+                <div />
+                <div>{`Host core${hostCores === 1 ? "" : "s"}`}</div>
+                <div className="u-align--right">
+                  &times;&nbsp;
+                  <span data-test="overcommit">{overCommit}</span>
+                </div>
+                <div />
+                <div>Overcommit ratio</div>
+                <hr className="cpu-popover__separator" />
+              </>
+            )}
             <div className="u-align--right" data-test="total">
-              {total}
+              {overCommitCores}
             </div>
             <div />
             <div>Total</div>
@@ -65,13 +85,6 @@ const CPUPopover = ({
       {children}
     </Popover>
   );
-};
-
-CPUPopover.propTypes = {
-  allocated: PropTypes.number.isRequired,
-  children: PropTypes.node.isRequired,
-  physical: PropTypes.number.isRequired,
-  overcommit: PropTypes.number.isRequired,
 };
 
 export default CPUPopover;

--- a/ui/src/app/kvm/views/KVMList/CPUColumn/CPUPopover/__snapshots__/CPUPopover.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMList/CPUColumn/CPUPopover/__snapshots__/CPUPopover.test.tsx.snap
@@ -1,0 +1,362 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CPUPopover renders 1`] = `
+<CPUPopover
+  cores={
+    Object {
+      "allocated_other": 1,
+      "allocated_tracked": 2,
+      "free": 3,
+    }
+  }
+  overCommit={2}
+>
+  <Popover
+    className="cpu-popover"
+    content={
+      <React.Fragment>
+        <div
+          className="cpu-popover__header p-table__header"
+        >
+          CPU cores
+        </div>
+        <div
+          className="cpu-popover__primary"
+        >
+          <div
+            className="u-align--right"
+            data-test="allocated"
+          >
+            2
+          </div>
+          <div
+            className="u-vertically-center"
+          >
+            <i
+              className="p-circle--link"
+            />
+          </div>
+          <div
+            data-test="allocated-label"
+          >
+            Project
+          </div>
+          <React.Fragment>
+            <div
+              className="u-align--right"
+              data-test="other"
+            >
+              1
+            </div>
+            <div
+              className="u-vertically-center"
+            >
+              <i
+                className="p-circle--positive"
+              />
+            </div>
+            <div>
+              Others
+            </div>
+          </React.Fragment>
+          <div
+            className="u-align--right"
+            data-test="free"
+          >
+            9
+          </div>
+          <div
+            className="u-vertically-center"
+          >
+            <i
+              className="p-circle--link-faded"
+            />
+          </div>
+          <div>
+            Free
+          </div>
+        </div>
+        <div
+          className="cpu-popover__secondary"
+        >
+          <React.Fragment>
+            <div
+              className="u-align--right"
+              data-test="host"
+            >
+              6
+            </div>
+            <div />
+            <div>
+              Host cores
+            </div>
+            <div
+              className="u-align--right"
+            >
+              × 
+              <span
+                data-test="overcommit"
+              >
+                2
+              </span>
+            </div>
+            <div />
+            <div>
+              Overcommit ratio
+            </div>
+            <hr
+              className="cpu-popover__separator"
+            />
+          </React.Fragment>
+          <div
+            className="u-align--right"
+            data-test="total"
+          >
+            12
+          </div>
+          <div />
+          <div>
+            Total
+          </div>
+        </div>
+      </React.Fragment>
+    }
+  >
+    <div
+      data-test="popover-container"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseOut={[Function]}
+      onMouseOver={[Function]}
+    >
+      Child
+      <Component>
+        <Portal
+          containerInfo={
+            <div>
+              <div
+                class="p-popover cpu-popover"
+                style="position: absolute; top: 0px; right: 1024px;"
+              >
+                <div
+                  class="cpu-popover__header p-table__header"
+                >
+                  CPU cores
+                </div>
+                <div
+                  class="cpu-popover__primary"
+                >
+                  <div
+                    class="u-align--right"
+                    data-test="allocated"
+                  >
+                    2
+                  </div>
+                  <div
+                    class="u-vertically-center"
+                  >
+                    <i
+                      class="p-circle--link"
+                    />
+                  </div>
+                  <div
+                    data-test="allocated-label"
+                  >
+                    Project
+                  </div>
+                  <div
+                    class="u-align--right"
+                    data-test="other"
+                  >
+                    1
+                  </div>
+                  <div
+                    class="u-vertically-center"
+                  >
+                    <i
+                      class="p-circle--positive"
+                    />
+                  </div>
+                  <div>
+                    Others
+                  </div>
+                  <div
+                    class="u-align--right"
+                    data-test="free"
+                  >
+                    9
+                  </div>
+                  <div
+                    class="u-vertically-center"
+                  >
+                    <i
+                      class="p-circle--link-faded"
+                    />
+                  </div>
+                  <div>
+                    Free
+                  </div>
+                </div>
+                <div
+                  class="cpu-popover__secondary"
+                >
+                  <div
+                    class="u-align--right"
+                    data-test="host"
+                  >
+                    6
+                  </div>
+                  <div />
+                  <div>
+                    Host cores
+                  </div>
+                  <div
+                    class="u-align--right"
+                  >
+                    × 
+                    <span
+                      data-test="overcommit"
+                    >
+                      2
+                    </span>
+                  </div>
+                  <div />
+                  <div>
+                    Overcommit ratio
+                  </div>
+                  <hr
+                    class="cpu-popover__separator"
+                  />
+                  <div
+                    class="u-align--right"
+                    data-test="total"
+                  >
+                    12
+                  </div>
+                  <div />
+                  <div>
+                    Total
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
+        >
+          <div
+            className="p-popover cpu-popover"
+            style={
+              Object {
+                "left": null,
+                "position": "absolute",
+                "right": 1024,
+                "top": 0,
+              }
+            }
+          >
+            <div
+              className="cpu-popover__header p-table__header"
+            >
+              CPU cores
+            </div>
+            <div
+              className="cpu-popover__primary"
+            >
+              <div
+                className="u-align--right"
+                data-test="allocated"
+              >
+                2
+              </div>
+              <div
+                className="u-vertically-center"
+              >
+                <i
+                  className="p-circle--link"
+                />
+              </div>
+              <div
+                data-test="allocated-label"
+              >
+                Project
+              </div>
+              <div
+                className="u-align--right"
+                data-test="other"
+              >
+                1
+              </div>
+              <div
+                className="u-vertically-center"
+              >
+                <i
+                  className="p-circle--positive"
+                />
+              </div>
+              <div>
+                Others
+              </div>
+              <div
+                className="u-align--right"
+                data-test="free"
+              >
+                9
+              </div>
+              <div
+                className="u-vertically-center"
+              >
+                <i
+                  className="p-circle--link-faded"
+                />
+              </div>
+              <div>
+                Free
+              </div>
+            </div>
+            <div
+              className="cpu-popover__secondary"
+            >
+              <div
+                className="u-align--right"
+                data-test="host"
+              >
+                6
+              </div>
+              <div />
+              <div>
+                Host cores
+              </div>
+              <div
+                className="u-align--right"
+              >
+                × 
+                <span
+                  data-test="overcommit"
+                >
+                  2
+                </span>
+              </div>
+              <div />
+              <div>
+                Overcommit ratio
+              </div>
+              <hr
+                className="cpu-popover__separator"
+              />
+              <div
+                className="u-align--right"
+                data-test="total"
+              >
+                12
+              </div>
+              <div />
+              <div>
+                Total
+              </div>
+            </div>
+          </div>
+        </Portal>
+      </Component>
+    </div>
+  </Popover>
+</CPUPopover>
+`;

--- a/ui/src/app/kvm/views/KVMList/RAMColumn/RAMColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/RAMColumn/RAMColumn.test.tsx
@@ -4,10 +4,13 @@ import configureStore from "redux-mock-store";
 
 import RAMColumn from "./RAMColumn";
 
+import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
-  podHint as podHintFactory,
+  podMemoryResource as podMemoryResourceFactory,
+  podResource as podResourceFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -15,54 +18,108 @@ import {
 const mockStore = configureStore();
 
 describe("RAMColumn", () => {
-  let initialState: RootState;
+  let state: RootState;
+  let pod: Pod;
 
   beforeEach(() => {
-    initialState = rootStateFactory({
+    pod = podFactory({
+      id: 1,
+      name: "pod-1",
+    });
+    state = rootStateFactory({
       pod: podStateFactory({
-        items: [
-          podFactory({
-            id: 1,
-            memory_over_commit_ratio: 1,
-            name: "pod-1",
-            total: podHintFactory({
-              memory: 8192,
-            }),
-            used: podHintFactory({
-              memory: 2048,
-            }),
-          }),
-        ],
+        items: [pod],
       }),
     });
   });
 
-  it("can display correct RAM information without overcommit", () => {
-    const state = { ...initialState };
+  it("can display correct memory information without overcommit", () => {
+    pod.memory_over_commit_ratio = 1;
+    pod.resources = podResourcesFactory({
+      memory: podMemoryResourceFactory({
+        general: podResourceFactory({
+          allocated_other: 1,
+          allocated_tracked: 2,
+          free: 3,
+        }),
+        hugepages: podResourceFactory({
+          allocated_other: 4,
+          allocated_tracked: 5,
+          free: 6,
+        }),
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <RAMColumn id={1} />
+        <RAMColumn id={pod.id} />
       </Provider>
     );
+    // Allocated tracked = 2 + 5 = 7
+    // Total = (1 + 2 + 3) + (4 + 5 + 6) = 6 + 15 = 21
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "2 of 8 GiB allocated"
+      "7 of 21B allocated"
     );
-    expect(wrapper.find("Meter").props().max).toBe(8192);
+    expect(wrapper.find("Meter").prop("max")).toBe(21);
   });
 
-  it("can display correct RAM information with overcommit", () => {
-    const state = { ...initialState };
-    state.pod.items[0].memory_over_commit_ratio = 2;
+  it("can display correct memory information with overcommit", () => {
+    pod.memory_over_commit_ratio = 2;
+    pod.resources = podResourcesFactory({
+      memory: podMemoryResourceFactory({
+        general: podResourceFactory({
+          allocated_other: 1,
+          allocated_tracked: 2,
+          free: 3,
+        }),
+        hugepages: podResourceFactory({
+          allocated_other: 4,
+          allocated_tracked: 5,
+          free: 6,
+        }),
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <RAMColumn id={1} />
       </Provider>
     );
+    // Allocated tracked = 2 + 5 = 7
+    // Hugepages do not take overcommit into account, so
+    // Total = ((1 + 2 + 3) * 2) + (4 + 5 + 6) = 12 + 15 = 27
     expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "2 of 16 GiB allocated"
+      "7 of 27B allocated"
     );
-    expect(wrapper.find("Meter").props().max).toBe(16384);
+    expect(wrapper.find("Meter").prop("max")).toBe(27);
+  });
+
+  it("can display when memory has been overcommitted", () => {
+    pod.memory_over_commit_ratio = 1;
+    pod.resources = podResourcesFactory({
+      memory: podMemoryResourceFactory({
+        general: podResourceFactory({
+          allocated_other: 0,
+          allocated_tracked: 2,
+          free: -1,
+        }),
+        hugepages: podResourceFactory({
+          allocated_other: 0,
+          allocated_tracked: 5,
+          free: -1,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <RAMColumn id={1} />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='meter-overflow']").exists()).toBe(true);
+    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
+      "7 of 5B allocated"
+    );
+    expect(wrapper.find("Meter").prop("max")).toBe(5);
   });
 });

--- a/ui/src/app/kvm/views/KVMList/RAMColumn/RAMPopover/RAMPopover.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/RAMColumn/RAMPopover/RAMPopover.test.tsx
@@ -2,25 +2,95 @@ import { mount } from "enzyme";
 
 import RAMPopover from "./RAMPopover";
 
-describe("RAMPopover", () => {
-  const body = document.querySelector("body");
-  const app = document.createElement("div");
-  if (body && app) {
-    app.setAttribute("id", "app");
-    body.appendChild(app);
-  }
+import {
+  podMemoryResource as podMemoryResourceFactory,
+  podResource as podResourceFactory,
+} from "testing/factories";
 
-  it("correctly displays RAM data", () => {
+describe("RAMPopover", () => {
+  it("renders", () => {
     const wrapper = mount(
-      <RAMPopover allocated={4096} physical={8192} overcommit={2}>
+      <RAMPopover
+        memory={podMemoryResourceFactory({
+          general: podResourceFactory({
+            allocated_other: 1,
+            allocated_tracked: 2,
+            free: 3,
+          }),
+          hugepages: podResourceFactory({
+            allocated_other: 4,
+            allocated_tracked: 5,
+            free: 3,
+          }),
+        })}
+        overCommit={2}
+      >
         Child
       </RAMPopover>
     );
     wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-test='allocated']").text()).toBe("4 GiB");
-    expect(wrapper.find("[data-test='free']").text()).toBe("12 GiB");
-    expect(wrapper.find("[data-test='physical']").text()).toBe("8 GiB");
-    expect(wrapper.find("[data-test='overcommit']").text()).toBe("2");
-    expect(wrapper.find("[data-test='total']").text()).toBe("16 GiB");
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("shows if memory is used by any other projects in the group", () => {
+    const wrapper = mount(
+      <RAMPopover
+        memory={podMemoryResourceFactory({
+          general: podResourceFactory({
+            allocated_other: 1,
+          }),
+          hugepages: podResourceFactory({
+            allocated_other: 1,
+          }),
+        })}
+        overCommit={1}
+      >
+        Child
+      </RAMPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
+      "Project"
+    );
+    expect(wrapper.find("[data-test='other']").exists()).toBe(true);
+  });
+
+  it("does not show other memory if no other projects in the group use them", () => {
+    const wrapper = mount(
+      <RAMPopover
+        memory={podMemoryResourceFactory({
+          general: podResourceFactory({ allocated_other: 0 }),
+          hugepages: podResourceFactory({ allocated_other: 0 }),
+        })}
+        overCommit={1}
+      >
+        Child
+      </RAMPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='allocated-label']").text()).toBe(
+      "Allocated"
+    );
+    expect(wrapper.find("[data-test='other']").exists()).toBe(false);
+  });
+
+  it("shows memory over-commit ratio if it is not equal to 1", () => {
+    const wrapper = mount(
+      <RAMPopover memory={podMemoryResourceFactory()} overCommit={2}>
+        Child
+      </RAMPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='overcommit']").exists()).toBe(true);
+  });
+
+  it("does not show memory over-commit ratio if it is equal to 1", () => {
+    const wrapper = mount(
+      <RAMPopover memory={podMemoryResourceFactory()} overCommit={1}>
+        Child
+      </RAMPopover>
+    );
+    wrapper.find("Popover").simulate("focus");
+    expect(wrapper.find("[data-test='overcommit']").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/views/KVMList/RAMColumn/RAMPopover/__snapshots__/RAMPopover.test.tsx.snap
+++ b/ui/src/app/kvm/views/KVMList/RAMColumn/RAMPopover/__snapshots__/RAMPopover.test.tsx.snap
@@ -1,0 +1,369 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RAMPopover renders 1`] = `
+<RAMPopover
+  memory={
+    Object {
+      "general": Object {
+        "allocated_other": 1,
+        "allocated_tracked": 2,
+        "free": 3,
+      },
+      "hugepages": Object {
+        "allocated_other": 4,
+        "allocated_tracked": 5,
+        "free": 3,
+      },
+    }
+  }
+  overCommit={2}
+>
+  <Popover
+    className="ram-popover"
+    content={
+      <React.Fragment>
+        <div
+          className="ram-popover__header p-table__header"
+        >
+          RAM
+        </div>
+        <div
+          className="ram-popover__primary"
+        >
+          <div
+            className="u-align--right"
+            data-test="allocated"
+          >
+            7B
+          </div>
+          <div
+            className="u-vertically-center"
+          >
+            <i
+              className="p-circle--link"
+            />
+          </div>
+          <div
+            data-test="allocated-label"
+          >
+            Project
+          </div>
+          <React.Fragment>
+            <div
+              className="u-align--right"
+              data-test="other"
+            >
+              5B
+            </div>
+            <div
+              className="u-vertically-center"
+            >
+              <i
+                className="p-circle--positive"
+              />
+            </div>
+            <div>
+              Others
+            </div>
+          </React.Fragment>
+          <div
+            className="u-align--right"
+            data-test="free"
+          >
+            12B
+          </div>
+          <div
+            className="u-vertically-center"
+          >
+            <i
+              className="p-circle--link-faded"
+            />
+          </div>
+          <div>
+            Free
+          </div>
+        </div>
+        <div
+          className="ram-popover__secondary"
+        >
+          <React.Fragment>
+            <div
+              className="u-align--right"
+              data-test="host"
+            >
+              18B
+            </div>
+            <div />
+            <div>
+              Host RAM
+            </div>
+            <div
+              className="u-align--right"
+            >
+              × 
+              <span
+                data-test="overcommit"
+              >
+                2
+              </span>
+            </div>
+            <div />
+            <div>
+              Overcommit ratio
+            </div>
+            <hr
+              className="ram-popover__separator"
+            />
+          </React.Fragment>
+          <div
+            className="u-align--right"
+            data-test="total"
+          >
+            24B
+          </div>
+          <div />
+          <div>
+            Total
+          </div>
+        </div>
+      </React.Fragment>
+    }
+  >
+    <div
+      data-test="popover-container"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseOut={[Function]}
+      onMouseOver={[Function]}
+    >
+      Child
+      <Component>
+        <Portal
+          containerInfo={
+            <div>
+              <div
+                class="p-popover ram-popover"
+                style="position: absolute; top: 0px; right: 1024px;"
+              >
+                <div
+                  class="ram-popover__header p-table__header"
+                >
+                  RAM
+                </div>
+                <div
+                  class="ram-popover__primary"
+                >
+                  <div
+                    class="u-align--right"
+                    data-test="allocated"
+                  >
+                    7B
+                  </div>
+                  <div
+                    class="u-vertically-center"
+                  >
+                    <i
+                      class="p-circle--link"
+                    />
+                  </div>
+                  <div
+                    data-test="allocated-label"
+                  >
+                    Project
+                  </div>
+                  <div
+                    class="u-align--right"
+                    data-test="other"
+                  >
+                    5B
+                  </div>
+                  <div
+                    class="u-vertically-center"
+                  >
+                    <i
+                      class="p-circle--positive"
+                    />
+                  </div>
+                  <div>
+                    Others
+                  </div>
+                  <div
+                    class="u-align--right"
+                    data-test="free"
+                  >
+                    12B
+                  </div>
+                  <div
+                    class="u-vertically-center"
+                  >
+                    <i
+                      class="p-circle--link-faded"
+                    />
+                  </div>
+                  <div>
+                    Free
+                  </div>
+                </div>
+                <div
+                  class="ram-popover__secondary"
+                >
+                  <div
+                    class="u-align--right"
+                    data-test="host"
+                  >
+                    18B
+                  </div>
+                  <div />
+                  <div>
+                    Host RAM
+                  </div>
+                  <div
+                    class="u-align--right"
+                  >
+                    × 
+                    <span
+                      data-test="overcommit"
+                    >
+                      2
+                    </span>
+                  </div>
+                  <div />
+                  <div>
+                    Overcommit ratio
+                  </div>
+                  <hr
+                    class="ram-popover__separator"
+                  />
+                  <div
+                    class="u-align--right"
+                    data-test="total"
+                  >
+                    24B
+                  </div>
+                  <div />
+                  <div>
+                    Total
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
+        >
+          <div
+            className="p-popover ram-popover"
+            style={
+              Object {
+                "left": null,
+                "position": "absolute",
+                "right": 1024,
+                "top": 0,
+              }
+            }
+          >
+            <div
+              className="ram-popover__header p-table__header"
+            >
+              RAM
+            </div>
+            <div
+              className="ram-popover__primary"
+            >
+              <div
+                className="u-align--right"
+                data-test="allocated"
+              >
+                7B
+              </div>
+              <div
+                className="u-vertically-center"
+              >
+                <i
+                  className="p-circle--link"
+                />
+              </div>
+              <div
+                data-test="allocated-label"
+              >
+                Project
+              </div>
+              <div
+                className="u-align--right"
+                data-test="other"
+              >
+                5B
+              </div>
+              <div
+                className="u-vertically-center"
+              >
+                <i
+                  className="p-circle--positive"
+                />
+              </div>
+              <div>
+                Others
+              </div>
+              <div
+                className="u-align--right"
+                data-test="free"
+              >
+                12B
+              </div>
+              <div
+                className="u-vertically-center"
+              >
+                <i
+                  className="p-circle--link-faded"
+                />
+              </div>
+              <div>
+                Free
+              </div>
+            </div>
+            <div
+              className="ram-popover__secondary"
+            >
+              <div
+                className="u-align--right"
+                data-test="host"
+              >
+                18B
+              </div>
+              <div />
+              <div>
+                Host RAM
+              </div>
+              <div
+                className="u-align--right"
+              >
+                × 
+                <span
+                  data-test="overcommit"
+                >
+                  2
+                </span>
+              </div>
+              <div />
+              <div>
+                Overcommit ratio
+              </div>
+              <hr
+                className="ram-popover__separator"
+              />
+              <div
+                className="u-align--right"
+                data-test="total"
+              >
+                24B
+              </div>
+              <div />
+              <div>
+                Total
+              </div>
+            </div>
+          </div>
+        </Portal>
+      </Component>
+    </div>
+  </Popover>
+</RAMPopover>
+`;


### PR DESCRIPTION
## Done

- Fixed KVM list resource usage, taking resource over-commit into account
- Changed the colours for the Overall charts so that Project is blue and Others is green. I think this makes more sense because it's consistent with everywhere else that uses blue to mean the resources used by the VM host itself.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the KVM list and take note of the values that show for Cores and RAM (hover over the chart for actual numbers)
- Check that the numbers match what's found in the KVM details Resources tab in the Overall card.

## Fixes

Fixes #2512 

## Screenshots
### Updated KVM list
![2021-04-22_17-39](https://user-images.githubusercontent.com/25733845/115675217-bfe56780-a391-11eb-8f07-cc95ab068491.png)


### Updated Overall tab
![2021-04-22_17-39_1](https://user-images.githubusercontent.com/25733845/115675240-c2e05800-a391-11eb-8ac5-d4e7ca007919.png)


