### PR TITLE
fix(ui): display a message if a machine does not exist

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.test.tsx
@@ -66,20 +66,21 @@ describe("MachineDetails", () => {
     });
   });
 
-  it(`redirects to machine list if machines have loaded but machine is not in
-    state`, () => {
+  it("displays a message if the machine does not exist", () => {
     const store = mockStore(state);
+    state.machine.loading = false;
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+          initialEntries={[
+            { pathname: "/machine/not-valid-id", key: "testKey" },
+          ]}
         >
           <MachineDetails />
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Redirect").exists()).toBe(true);
-    expect(wrapper.find("Redirect").props().to).toBe("/machines");
+    expect(wrapper.find("[data-test='not-found']").exists()).toBe(true);
   });
 
   it("cleans up when unmounting", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { Redirect, Route, Switch, useLocation } from "react-router-dom";
+import { Link, Redirect, Route, Switch, useLocation } from "react-router-dom";
 
 import MachineComissioning from "./MachineCommissioning";
 import MachineConfiguration from "./MachineConfiguration";
@@ -35,7 +35,7 @@ const MachineDetails = (): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
-  const machinesLoaded = useSelector(machineSelectors.loaded);
+  const machinesLoading = useSelector(machineSelectors.loading);
   const [selectedAction, setSelectedAction] = useState<SelectedAction | null>(
     null
   );
@@ -57,9 +57,16 @@ const MachineDetails = (): JSX.Element => {
     };
   }, [dispatch, id]);
 
-  // If machine has been deleted, redirect to machine list.
-  if (machinesLoaded && !machine) {
-    return <Redirect to="/machines" />;
+  // Display a message if the machine does not exist.
+  if (!machinesLoading && !machine) {
+    return (
+      <Section header="Machine not found" data-test="not-found">
+        <p>
+          This machine could not be found.{" "}
+          <Link to="/machines">View all machines</Link>.
+        </p>
+      </Section>
+    );
   }
 
   return (

--- a/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -62,7 +62,7 @@ const MachineDetails = (): JSX.Element => {
     return (
       <Section header="Machine not found" data-test="not-found">
         <p>
-          This machine could not be found.{" "}
+          Unable to find machine with system id "{id}".{" "}
           <Link to="/machines">View all machines</Link>.
         </p>
       </Section>


### PR DESCRIPTION
## Done

- Display a message if a machine can not be found.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Try to view the machine details for a machine that does not exist e.g. `/MAAS/r/machine/notamachine/summary`.
- You should see a message.

## Fixes

Fixes: #2195.