### PR TITLE
fix(ui): fix KVM compose interface constraint validation

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -15,7 +15,7 @@ import {
   domainState as domainStateFactory,
   fabricState as fabricStateFactory,
   generalState as generalStateFactory,
-  pod as podFactory,
+  podDetails as podDetailsFactory,
   podHint as podHintFactory,
   podNuma as podNumaFactory,
   podNumaCores as podNumaCoresFactory,
@@ -53,7 +53,7 @@ describe("ComposeFormFields", () => {
         }),
       }),
       pod: podStateFactory({
-        items: [podFactory({ id: 1 })],
+        items: [podDetailsFactory({ id: 1 })],
         loaded: true,
         statuses: { 1: podStatusFactory() },
       }),
@@ -132,7 +132,7 @@ describe("ComposeFormFields", () => {
     });
     state.general.powerTypes.data = [powerType];
     state.pod.items = [
-      podFactory({
+      podDetailsFactory({
         cpu_over_commit_ratio: 1,
         id: 1,
         memory_over_commit_ratio: 1,

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.test.tsx
@@ -176,26 +176,22 @@ describe("InterfacesTable", () => {
     const wrapper = generateWrapper(store, pod);
 
     // Click "Define" button
-    // Fabric and VLAN should be auto assigned, PXE should be unknown
+    // Fabric, VLAN and PXE cells should be empty.
     await act(async () => {
       wrapper.find("[data-test='define-interfaces'] button").simulate("click");
     });
     wrapper.update();
-    expect(wrapper.find("TableCell[aria-label='Fabric']").text()).toBe(
-      "Auto-assign"
-    );
-    expect(wrapper.find("TableCell[aria-label='VLAN']").text()).toBe(
-      "Auto-assign"
-    );
+    expect(wrapper.find("TableCell[aria-label='Fabric']").text()).toBe("");
+    expect(wrapper.find("TableCell[aria-label='VLAN']").text()).toBe("");
     expect(
       wrapper.find("TableCell[aria-label='PXE'] i").prop("className")
-    ).toBe("p-icon--power-unknown");
+    ).toBe("p-icon--placeholder");
 
     // Choose the subnet in state from the dropdown
     // Fabric and VLAN nams should display, PXE should be true
     await act(async () => {
       const links = wrapper.find("SubnetSelect ContextualMenu").prop("links");
-      links[2].onClick();
+      links[1].onClick();
     });
     wrapper.update();
     expect(wrapper.find("TableCell[aria-label='Fabric']").text()).toBe(

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/InterfacesTable.tsx
@@ -52,7 +52,7 @@ const generateNewInterface = (id: number): InterfaceField => {
  */
 export const getPxeIconClass = (pod: PodDetails, vlan: VLAN): string => {
   if (!vlan || !pod) {
-    return "p-icon--power-unknown";
+    return "p-icon--placeholder";
   }
   return pod.boot_vlans?.includes(vlan.id)
     ? "p-icon--success"
@@ -173,16 +173,17 @@ export const InterfacesTable = (): JSX.Element => {
                   <TableCell aria-label="Subnet">
                     <SubnetSelect
                       iface={iface}
+                      index={i}
                       selectSubnet={(subnetID: number) => {
                         setFieldValue(`interfaces[${i}].subnet`, subnetID);
                       }}
                     />
                   </TableCell>
                   <TableCell aria-label="Fabric" className="u-align-non-field">
-                    {fabric?.name || <em>Auto-assign</em>}
+                    {fabric?.name || ""}
                   </TableCell>
                   <TableCell aria-label="VLAN" className="u-align-non-field">
-                    {vlan?.name || <em>Auto-assign</em>}
+                    {vlan?.name || ""}
                   </TableCell>
                   <TableCell aria-label="PXE" className="u-align-non-field">
                     <i className={getPxeIconClass(pod, vlan)}></i>

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -4,7 +4,7 @@ import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import type { MockStoreEnhanced } from "redux-mock-store";
+import type { MockStore } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
 import ComposeForm from "../../ComposeForm";
@@ -15,6 +15,7 @@ import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   domainState as domainStateFactory,
+  fabric as fabricFactory,
   fabricState as fabricStateFactory,
   generalState as generalStateFactory,
   podDetails as podDetailsFactory,
@@ -28,13 +29,15 @@ import {
   spaceState as spaceStateFactory,
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
+  vlan as vlanFactory,
   vlanState as vlanStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
-const generateWrapper = (store: MockStoreEnhanced, pod: Pod) =>
+const generateWrapper = (store: MockStore, pod: Pod) =>
   mount(
     <Provider store={store}>
       <MemoryRouter
@@ -119,10 +122,10 @@ describe("SubnetSelect", () => {
       .find("SubnetSelect ContextualMenu")
       .prop("links") as MenuLink[];
 
-    // "Any" subnet + "Space: Outer" + outer subnets + "Space: Safe" + safe subnets
-    expect(links.length).toBe(6);
-    expect(links[1]).toBe("Space: Outer");
-    expect(links[4]).toBe("Space: Safe");
+    // "Space: Outer" + outer subnets + "Space: Safe" + safe subnets
+    expect(links.length).toBe(5);
+    expect(links[0]).toBe("Space: Outer");
+    expect(links[3]).toBe("Space: Safe");
   });
 
   it("filters subnets by selected space", async () => {
@@ -151,10 +154,10 @@ describe("SubnetSelect", () => {
       .find("SubnetSelect ContextualMenu")
       .prop("links") as MenuLink[];
     filteredLinks = links.filter((link) => typeof link !== "string");
-    expect(filteredLinks.length).toBe(3);
+    expect(filteredLinks.length).toBe(2);
 
     // Choose the space in state from the dropdown
-    // Only the subnet in the selected space + "Any" should be available
+    // Only the subnet in the selected space should be available
     await act(async () => {
       wrapper
         .find("FormikField[name='interfaces[0].space']")
@@ -172,6 +175,65 @@ describe("SubnetSelect", () => {
       .find("SubnetSelect ContextualMenu")
       .prop("links") as MenuLink[];
     filteredLinks = links.filter((link) => typeof link !== "string");
-    expect(filteredLinks.length).toBe(2);
+    expect(filteredLinks.length).toBe(1);
+  });
+
+  it("shows an error if multiple interfaces defined without at least one PXE network", async () => {
+    const fabric = fabricFactory();
+    const space = spaceFactory();
+    const pxeVlan = vlanFactory({ fabric: fabric.id, id: 1 });
+    const nonPxeVlan = vlanFactory({ fabric: fabric.id, id: 2 });
+    const pxeSubnet = subnetFactory({ name: "pxe", vlan: pxeVlan.id });
+    const nonPxeSubnet = subnetFactory({
+      name: "non-pxe",
+      vlan: nonPxeVlan.id,
+    });
+    const pod = podDetailsFactory({
+      attached_vlans: [pxeVlan.id, nonPxeVlan.id],
+      boot_vlans: [pxeVlan.id],
+      id: 1,
+    });
+    const state = { ...initialState };
+    state.pod.items = [pod];
+    state.space.items = [space];
+    state.subnet.items = [pxeSubnet, nonPxeSubnet];
+    state.vlan.items = [pxeVlan, nonPxeVlan];
+    const store = mockStore(state);
+    const wrapper = generateWrapper(store, pod);
+
+    // Click "Define" button
+    wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    // Add a second interface
+    wrapper.find("[data-test='define-interfaces'] button").simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    // Select non-PXE network for the first interface
+    wrapper.find("SubnetSelect button").at(0).simulate("click");
+    await waitForComponentToPaint(wrapper);
+    wrapper.find("ContextualMenuDropdown button").at(1).simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    // Select non-PXE network for the second interface - error should be present.
+    wrapper.find("SubnetSelect button").at(1).simulate("click");
+    await waitForComponentToPaint(wrapper);
+    wrapper.find("ContextualMenuDropdown button").at(1).simulate("click");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("[data-test='no-pxe']").text()).toBe(
+      "Error: Select at least 1 PXE network when creating multiple interfaces."
+    );
+
+    // Select PXE network for the second interface - error should be removed.
+    wrapper.find("SubnetSelect button").at(1).simulate("click");
+    await waitForComponentToPaint(wrapper);
+    wrapper.find("ContextualMenuDropdown button").at(0).simulate("click");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("[data-test='no-pxe']").exists()).toBe(false);
+
+    // Remove second interface with PXE network - error should still not show.
+    wrapper.find("TableActions button").at(1).simulate("click");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("[data-test='no-pxe']").exists()).toBe(false);
   });
 });

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/_index.scss
@@ -22,21 +22,27 @@ $pxe-col-compensation: $pxe-col-width - $sph-inner--small;
       }
     }
 
-    .kvm-subnet-select__toggle.has-icon {
-      align-items: center;
-      display: flex;
-      justify-content: space-between;
-      margin-bottom: 0;
-      padding-left: $sph-inner--small;
-      width: 100%;
+    .kvm-subnet-select__toggle {
+      &.has-icon {
+        align-items: center;
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 0;
+        padding-left: $sph-inner--small;
+        width: 100%;
 
-      > :nth-child(1) {
-        text-overflow: ellipsis;
-        overflow: hidden;
+        > :nth-child(1) {
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
+
+        > :nth-child(2) {
+          flex-shrink: 0;
+        }
       }
 
-      > :nth-child(2) {
-        flex-shrink: 0;
+      &.is-error {
+        border-color: $color-negative;
       }
     }
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/_index.scss
@@ -49,5 +49,9 @@ $pxe-col-width: 2.5rem;
         width: 4.5rem;
       }
     }
+
+    .kvm-compose-interfaces-table__error-row {
+      border: 0;
+    }
   }
 }


### PR DESCRIPTION
## Done

- Made "Subnet" a required field in the VM compose interface table
- Added validation for when there's multiple interfaces that at least one is connected to a PXE bootable network

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the VM compose form and choose to define interfaces
- Check that the Subnet select shows an error by default, urging the user to select a subnet
- Select a non-PXE network and check that no error shows
- Add another interface and again select a non-PXE network
- Check that an error shows, saying you must select at least one PXE network
- Change one of the interfaces to a PXE network and check that the error disappears

## Fixes

Fixes #2361 