### PR TITLE
feat(ui): improve display of broken messages

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.test.tsx
@@ -6,7 +6,7 @@ import configureStore from "redux-mock-store";
 import StatusCard from "./StatusCard";
 
 import type { RootState } from "app/store/root/types";
-import { NodeStatus } from "app/store/types/node";
+import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -95,6 +95,29 @@ describe("StatusCard", () => {
 
     expect(wrapper.find("[data-test='failed-test-warning']").text()).toEqual(
       "Warning: Some tests failed, use with caution."
+    );
+  });
+
+  it("displays an error message for broken machines", () => {
+    const machine = machineDetailsFactory({
+      error_description: "machine is on fire",
+      status: NodeStatus.BROKEN,
+      status_code: NodeStatusCode.BROKEN,
+    });
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <StatusCard machine={machine} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='error-description']").text()).toBe(
+      "machine is on fire"
     );
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -48,6 +48,12 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
             {formattedOS}
           </p>
         ) : null}
+        {machine.error_description &&
+        machine.status_code === NodeStatusCode.BROKEN ? (
+          <p className="u-text--muted" data-test="error-description">
+            {machine.error_description}
+          </p>
+        ) : null}
       </div>
       {showFailedTestsWarning(machine) ? (
         <div

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/StatusCard/StatusCard.tsx
@@ -1,6 +1,9 @@
+import { Tooltip } from "@canonical/react-components";
+
 import type { MachineDetails } from "app/store/machine/types";
 import { useFormattedOS } from "app/store/machine/utils";
 import { NodeStatusCode, TestStatusStatus } from "app/store/types/node";
+import { breakLines } from "app/utils";
 
 type Props = {
   machine: MachineDetails;
@@ -50,8 +53,15 @@ const StatusCard = ({ machine }: Props): JSX.Element => {
         ) : null}
         {machine.error_description &&
         machine.status_code === NodeStatusCode.BROKEN ? (
-          <p className="u-text--muted" data-test="error-description">
-            {machine.error_description}
+          <p className="u-text--muted u-truncate" data-test="error-description">
+            <Tooltip
+              message={breakLines(machine.error_description)}
+              position="btm-left"
+              positionElementClassName="p-double-row__tooltip-inner"
+              tooltipClassName="p-tooltip--fixed-width"
+            >
+              {machine.error_description}
+            </Tooltip>
           </p>
         ) : null}
       </div>

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/_index.scss
@@ -32,7 +32,7 @@
       [row1-start] "status cpu memory storage" min-content [row1-end]
       [row2-start] "test-warning cpu-tests memory-tests storage-tests" min-content [row2-end]
       [row3-start] "details details details details" min-content [row2-end]
-      / 1fr 1fr 1fr 1fr;
+      / minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
 
     .overview-card__status {
       grid-area: status;
@@ -121,7 +121,7 @@
         [row3-start] "memory storage" min-content [row3-end]
         [row4-start] "memory-tests storage-tests" min-content [row4-end]
         [row5-start] "details details" min-content [row5-end]
-        / 1fr 1fr;
+        / minmax(0, 1fr) minmax(0, 1fr);
 
       .overview-card__status,
       .overview-card__memory {

--- a/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -17,7 +17,7 @@ import {
   NodeStatusCode,
   TestStatusStatus,
 } from "app/store/types/node";
-import { getStatusText } from "app/utils";
+import { breakLines, getStatusText } from "app/utils";
 
 // Node statuses for which the failed test warning is not shown.
 const hideFailedTestWarningStatuses = [
@@ -116,9 +116,18 @@ export const StatusColumn = ({
             </span>
             <span data-test="error-text">
               {machine.error_description &&
-              machine.status_code === NodeStatusCode.BROKEN
-                ? machine.error_description
-                : ""}
+              machine.status_code === NodeStatusCode.BROKEN ? (
+                <Tooltip
+                  message={breakLines(machine.error_description)}
+                  position="btm-left"
+                  positionElementClassName="p-double-row__tooltip-inner"
+                  tooltipClassName="p-tooltip--fixed-width"
+                >
+                  {machine.error_description}
+                </Tooltip>
+              ) : (
+                ""
+              )}
             </span>
           </>
         }

--- a/ui/src/app/utils/breakLines.test.ts
+++ b/ui/src/app/utils/breakLines.test.ts
@@ -19,7 +19,7 @@ describe("breakLines", () => {
         "Lorem ipsum dolor sit amet, consectetur adipiscinges lit. Nam dapibus"
       )
     ).toBe(
-      "Lorem ipsum dolor sit amet, consectetur adipiscinges \n lit. Nam dapibus"
+      "Lorem ipsum dolor sit amet, consectetur adipiscinges \nlit. Nam dapibus"
     );
   });
 
@@ -29,7 +29,7 @@ describe("breakLines", () => {
         "Lorem ipsum dolor sit amet, consectetur adipiscinges   lit. Nam dapibus"
       )
     ).toBe(
-      "Lorem ipsum dolor sit amet, consectetur adipiscinges \n lit. Nam dapibus"
+      "Lorem ipsum dolor sit amet, consectetur adipiscinges \nlit. Nam dapibus"
     );
   });
 
@@ -39,7 +39,7 @@ describe("breakLines", () => {
         "Lorem ipsum dolor sit amet, consectetur adipiscingeslit. Nam dapibus"
       )
     ).toBe(
-      "Lorem ipsum dolor sit amet, consectetur \n adipiscingeslit. Nam dapibus"
+      "Lorem ipsum dolor sit amet, consectetur \nadipiscingeslit. Nam dapibus"
     );
   });
 
@@ -49,7 +49,7 @@ describe("breakLines", () => {
         "LoremipsumdolorsitametconsecteturadipiscingeslitNamdapibustellusvitaevenenatisfacilesisis"
       )
     ).toBe(
-      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvitaevenenatisfacilesisis"
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \napibustellusvitaevenenatisfacilesisis"
     );
   });
 
@@ -59,7 +59,7 @@ describe("breakLines", () => {
         "LoremipsumdolorsitametconsecteturadipiscingeslitNamdapibustellusvita evenenatisfacilesisis"
       )
     ).toBe(
-      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvita evenenatisfacilesisis"
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \napibustellusvita evenenatisfacilesisis"
     );
   });
 
@@ -70,7 +70,7 @@ describe("breakLines", () => {
         false
       )
     ).toBe(
-      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvitaevenenatisfacilesisis"
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \napibustellusvitaevenenatisfacilesisis"
     );
   });
 
@@ -81,13 +81,13 @@ describe("breakLines", () => {
         false
       )
     ).toBe(
-      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvitaevenenatisfacilesisis"
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \napibustellusvitaevenenatisfacilesisis"
     );
   });
 
   it("can break at a provided length", () => {
     expect(breakLines("Lorem ipsum dolor sit amet", true, 15)).toBe(
-      "Lorem ipsum \n dolor sit amet"
+      "Lorem ipsum \ndolor sit amet"
     );
   });
 });

--- a/ui/src/app/utils/breakLines.test.ts
+++ b/ui/src/app/utils/breakLines.test.ts
@@ -1,0 +1,93 @@
+import breakLines from "./breakLines";
+
+describe("breakLines", () => {
+  it("handles lines that are the exact expected length", () => {
+    expect(
+      breakLines("Lorem ipsum dolor sit amet, consectetur adipiscinges")
+    ).toBe("Lorem ipsum dolor sit amet, consectetur adipiscinges");
+  });
+
+  it("handles lines with trailing whitespace", () => {
+    expect(
+      breakLines("Lorem ipsum dolor sit amet, consectetur adipiscinges ")
+    ).toBe("Lorem ipsum dolor sit amet, consectetur adipiscinges");
+  });
+
+  it("breaks words at the desired length", () => {
+    expect(
+      breakLines(
+        "Lorem ipsum dolor sit amet, consectetur adipiscinges lit. Nam dapibus"
+      )
+    ).toBe(
+      "Lorem ipsum dolor sit amet, consectetur adipiscinges \n lit. Nam dapibus"
+    );
+  });
+
+  it("handles extra whitespace at the line break", () => {
+    expect(
+      breakLines(
+        "Lorem ipsum dolor sit amet, consectetur adipiscinges   lit. Nam dapibus"
+      )
+    ).toBe(
+      "Lorem ipsum dolor sit amet, consectetur adipiscinges \n lit. Nam dapibus"
+    );
+  });
+
+  it("breaks at the previous word break for longer lines", () => {
+    expect(
+      breakLines(
+        "Lorem ipsum dolor sit amet, consectetur adipiscingeslit. Nam dapibus"
+      )
+    ).toBe(
+      "Lorem ipsum dolor sit amet, consectetur \n adipiscingeslit. Nam dapibus"
+    );
+  });
+
+  it("handles no whitespace", () => {
+    expect(
+      breakLines(
+        "LoremipsumdolorsitametconsecteturadipiscingeslitNamdapibustellusvitaevenenatisfacilesisis"
+      )
+    ).toBe(
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvitaevenenatisfacilesisis"
+    );
+  });
+
+  it("handles no whitespace within the line limit", () => {
+    expect(
+      breakLines(
+        "LoremipsumdolorsitametconsecteturadipiscingeslitNamdapibustellusvita evenenatisfacilesisis"
+      )
+    ).toBe(
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvita evenenatisfacilesisis"
+    );
+  });
+
+  it("handles breaking mid word", () => {
+    expect(
+      breakLines(
+        "LoremipsumdolorsitametconsecteturadipiscingeslitNamdapibustellusvitaevenenatisfacilesisis",
+        false
+      )
+    ).toBe(
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvitaevenenatisfacilesisis"
+    );
+  });
+
+  it("handles whitespace at the breakpoint", () => {
+    expect(
+      breakLines(
+        "LoremipsumdolorsitametconsecteturadipiscingeslitNamd apibustellusvitaevenenatisfacilesisis",
+        false
+      )
+    ).toBe(
+      "LoremipsumdolorsitametconsecteturadipiscingeslitNamd \n apibustellusvitaevenenatisfacilesisis"
+    );
+  });
+
+  it("can break at a provided length", () => {
+    expect(breakLines("Lorem ipsum dolor sit amet", true, 15)).toBe(
+      "Lorem ipsum \n dolor sit amet"
+    );
+  });
+});

--- a/ui/src/app/utils/breakLines.ts
+++ b/ui/src/app/utils/breakLines.ts
@@ -1,0 +1,44 @@
+/**
+ * Insert newlines into a string at a given point. This can be useful for text
+ * that is inserted into a <pre> block.
+ */
+export const breakLines = (
+  text: string,
+  breakAtSpaces = true,
+  lineLength = 52
+): string => {
+  let chunks = [];
+  // Check that the text includes whitespace, otherwise we'll treat it as if we
+  // are not breaking at spaces.
+  if (breakAtSpaces && text.includes(" ")) {
+    let remainingText = text.trim();
+    while (remainingText.length) {
+      // Get the next chunk.
+      const chunk = remainingText.slice(0, lineLength);
+      // Find the position of the last space in the chunk.
+      const lastSpace = chunk.lastIndexOf(" ");
+      // Check if this is the last section of text.
+      const isRemainder = chunk === remainingText;
+      // Check if this chunk is followed by a space.
+      const nextCharIsSpace =
+        remainingText.slice(chunk.length, chunk.length + 1) === " ";
+      let chunkLength = chunk.length;
+      // Check if we should break at the last space.
+      if (!isRemainder && !nextCharIsSpace && lastSpace > 0) {
+        chunkLength = lastSpace + 1;
+      }
+      // Add the chunk.
+      chunks.push(chunk.slice(0, chunkLength));
+      // Remove the current chunk and trim any whitespace from the start of the
+      // remainder.
+      remainingText = remainingText.slice(chunkLength).trim();
+    }
+  } else {
+    // Split the text into chunks of the provided size.
+    chunks = text.match(new RegExp(`.{1,${lineLength}}`, "g")) || [];
+  }
+  // Trim any wrapping whitespace from the chunks and add the newlines.
+  return chunks.map((chunk) => chunk.trim()).join(" \n ");
+};
+
+export default breakLines;

--- a/ui/src/app/utils/breakLines.ts
+++ b/ui/src/app/utils/breakLines.ts
@@ -38,7 +38,7 @@ export const breakLines = (
     chunks = text.match(new RegExp(`.{1,${lineLength}}`, "g")) || [];
   }
   // Trim any wrapping whitespace from the chunks and add the newlines.
-  return chunks.map((chunk) => chunk.trim()).join(" \n ");
+  return chunks.map((chunk) => chunk.trim()).join(" \n");
 };
 
 export default breakLines;

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -1,5 +1,6 @@
 export { arrayFromRangesString } from "./arrayFromRangesString";
 export { arrayItemsEqual } from "./arrayItemsEqual";
+export { breakLines } from "./breakLines";
 export { capitaliseFirst } from "./capitaliseFirst";
 export { chunk } from "./chunk";
 export { formatBytes } from "./formatBytes";


### PR DESCRIPTION
## Done

- Display the broken message in a tooltip in the machine list.
- Display the broken message in the machine summary.
Add a util for adding newlines to text for the tooltip.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Mark a machine as broken.
- Go to the machine list and hover the message, it should appear in a tooltip.
- Go to the machine's summary and the message should appear below the status.

## Fixes

Fixes: #2140.