### PR TITLE
fix(legacy): always display power password fields with type="password"

### DIFF
--- a/legacy/src/app/directives/power_parameters.js
+++ b/legacy/src/app/directives/power_parameters.js
@@ -107,11 +107,7 @@ export function maasPowerInput($compile) {
         // Build an input element with the correct attributes.
         var input_type = 'type="text"';
         if (type === "password") {
-          // If the input field is a password field, display it
-          // as text or password depending on if we're editing
-          // the fields.
-          input_type =
-            'data-ng-type="ngModel.editing && ' + "'text' || 'password'\"";
+          input_type = 'type="password"';
         }
         html =
           "<input " +

--- a/legacy/src/app/directives/tests/test_power_parameters.js
+++ b/legacy/src/app/directives/tests/test_power_parameters.js
@@ -163,9 +163,7 @@ describe("maasPowerParameters", function () {
       var input = directive.find("input");
       expect(input.attr("name")).toBe("test");
       expect(input.attr("data-ng-model")).toBe("value");
-      expect(input.attr("data-ng-type")).toBe(
-        "ngModel.editing && 'text' || 'password'"
-      );
+      expect(input.attr("type")).toBe("password");
     });
   });
 


### PR DESCRIPTION
## Done

- Always display power password fields with type="password", regardless of whether it's being edited.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the legacy controller details page of a controller that can have its power configuration edited
- Change the power type to something that uses a password and check that the password field stays as a password field while in editing state

## Fixes

Fixes #2274 

