### PR TITLE
feat(proxy): dev console messages

### DIFF
--- a/proxy/package.json
+++ b/proxy/package.json
@@ -17,12 +17,16 @@
     "serve-ui": "cd ../ui && BROWSER=none PORT=8401 yarn run start",
     "serve-ui-proxy": "node ./ui.js",
     "serve-ui-standalone": "yarn build-root-css && cd ../ui && BROWSER=none PORT=8401 yarn run standalone",
-    "start": "yarn build-shared && concurrently \"yarn serve-apps\" \"yarn serve-base-wait\"",
-    "start-ui": "concurrently \"yarn serve-ui-standalone\" \"yarn watch-shared\" \"yarn serve-ui-proxy\"",
+    "show-ready": "wait-on http://0.0.0.0:8404 && node ./scripts/ready.js",
+    "show-ready-ui": "wait-on http-get://0.0.0.0:8401 && node ./scripts/ui.js",
+    "start": "node ./scripts/start.js && yarn build-shared && concurrently \"yarn serve-apps\" \"yarn serve-base-wait\" \"yarn show-ready\"",
+    "start-ui": "concurrently \"yarn serve-ui-standalone\" \"yarn watch-shared\" \"yarn serve-ui-proxy\" \"yarn show-ready-ui\"",
     "watch-shared": "cd ../shared && concurrently \"yarn watch\" \"yarn watch-declaration\""
   },
   "devDependencies": {
     "@maas-ui/maas-ui-shared": "1.3.1",
+    "address": "1.1.2",
+    "colors": "1.4.0",
     "concurrently": "6.0.2",
     "dotenv-flow": "3.2.0",
     "http-proxy-middleware": "1.3.0",

--- a/proxy/scripts/ready.js
+++ b/proxy/scripts/ready.js
@@ -1,0 +1,14 @@
+const address = require('address');
+const colors = require('colors');
+
+console.log("");
+console.log("*****************");
+console.log("");
+console.log("All clients have loaded.".green);
+console.log("");
+console.log("maas-ui is ready to be viewed at", `http://${address.ip()}:8400`.blue);
+console.log("");
+console.log("When working on the React client it is more performant to run `yarn ui` but beware that the legacy client is unavailable and there may be some CSS differences.");
+console.log("");
+console.log("*****************");
+console.log("");

--- a/proxy/scripts/start.js
+++ b/proxy/scripts/start.js
@@ -1,0 +1,10 @@
+const address = require('address');
+const colors = require('colors');
+
+console.log("");
+console.log("*****************");
+console.log("");
+console.log("Wait for all clients to load.".red);
+console.log("");
+console.log("*****************");
+console.log("");

--- a/proxy/scripts/ui.js
+++ b/proxy/scripts/ui.js
@@ -1,0 +1,13 @@
+const address = require('address');
+const colors = require('colors');
+
+console.log("");
+console.log("*****************");
+console.log("");
+console.log("Wait for the React dev server to start and then visit:".red, `http://${address.ip()}:8400`.blue);
+console.log("The URL displayed by the React dev server message will be incorrect.".red);
+console.log("");
+console.log("Warning:".yellow, "This is the React client only. The legacy client will be unavailable and there may be some CSS differences.");
+console.log("");
+console.log("*****************");
+console.log("");

--- a/yarn.lock
+++ b/yarn.lock
@@ -4778,7 +4778,7 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
## Done

- Display message when loading clients in the console.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run `dotrun` or `yarn start`.
- At the start you should see a red message about waiting for the clients to load.
- After all the clients have started you should see a message with the URL to load.
- Visiting that URL should show you the app.
- Run `dotrun ui` or `yarn ui`.
- Shortly you should see a message about waiting for the React client to load.
- When it loads visit the URL and the app should be ready.

## Fixes

Fixes: #858.