### PR TITLE
fix(ui): use pod.resources for VM compose validation

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { Col, Input, Row, Select, Tooltip } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import pluralize from "pluralize";
 
 import type { ComposeFormDefaults } from "../ComposeForm";
 
@@ -47,6 +48,7 @@ export const ComposeFormFields = ({
   const memoryCaution = available.memory < defaults.memory;
   const isLxd = podType === PodType.LXD;
   const hasFreeHugepages = available.hugepages > 0;
+  const availableCoresString = pluralize("core", available.cores, true);
 
   return (
     <Row>
@@ -82,9 +84,7 @@ export const ComposeFormFields = ({
                 recommended default (${defaults.memory}MiB).`
               : undefined
           }
-          help={
-            memoryCaution ? undefined : `${available.memory} MiB available.`
-          }
+          help={memoryCaution ? undefined : `${available.memory}MiB available.`}
           label="RAM (MiB)"
           max={`${available.memory}`}
           min="1024"
@@ -124,7 +124,7 @@ export const ComposeFormFields = ({
                 : undefined
             }
             help={
-              coresCaution ? undefined : `${available.cores} cores available.`
+              coresCaution ? undefined : `${availableCoresString} available.`
             }
             max={`${available.cores}`}
             min="1"
@@ -153,9 +153,7 @@ export const ComposeFormFields = ({
         </Tooltip>
         {pinningCores && (
           <FormikField
-            help={`${
-              available.cores
-            } cores available (free indices: ${getRanges(
+            help={`${availableCoresString} available (free indices: ${getRanges(
               available.pinnedCores
             )})`}
             name="pinnedCores"

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.test.tsx
@@ -193,9 +193,9 @@ describe("StorageTable", () => {
         } as React.ChangeEvent<HTMLSelectElement>);
     });
     wrapper.update();
-    expect(wrapper.find(".p-form-validation__message").text()).toBe(
-      `Error: Only 20GB available in ${pool.name}.`
-    );
+    expect(
+      wrapper.find("StorageTable .p-form-validation__message").text()
+    ).toBe(`Error: Only 20GB available in ${pool.name}.`);
   });
 
   it(`displays an error message if the sum of disk sizes from a pool is higher
@@ -241,9 +241,9 @@ describe("StorageTable", () => {
     wrapper.update();
 
     // Each is lower than 25GB, but the sum is higher, so an error should show
-    expect(wrapper.find(".p-form-validation__message").text()).toBe(
-      `Error: Only 25GB available in ${pool.name}.`
-    );
+    expect(
+      wrapper.find("StorageTable .p-form-validation__message").text()
+    ).toBe(`Error: Only 25GB available in ${pool.name}.`);
   });
 
   it("displays an error message on render if not enough space", async () => {

--- a/ui/src/app/utils/formatBytes.test.ts
+++ b/ui/src/app/utils/formatBytes.test.ts
@@ -32,6 +32,12 @@ describe("formatBytes", () => {
       value: 123,
       unit: "B",
     });
+    expect(
+      formatBytes(1234000, "B", { convertTo: "KB", precision: 1 })
+    ).toStrictEqual({
+      value: 1234, // Precision is ignored if converting to higher value and is integer
+      unit: "KB",
+    });
   });
 
   it("can handle binary units", () => {

--- a/ui/src/app/utils/formatBytes.ts
+++ b/ui/src/app/utils/formatBytes.ts
@@ -43,8 +43,10 @@ export const formatBytes = (
     : Math.floor(Math.log(valueInBytes) / Math.log(k));
   let valueInUnit = valueInBytes / Math.pow(k, j);
 
-  // Only truncate value if converting to a higher unit, e.g. "KB" => "MB"
-  if (j > i) {
+  // Only truncate value if it has a decimal place and converting to a higher
+  // unit, e.g. "1234B" => "1.23KB" but not "1234000B" => "1230KB"
+  const hasDecimal = valueInUnit % 1 !== 0;
+  if (hasDecimal && j > i) {
     valueInUnit = parseFloat(valueInUnit.toPrecision(precision));
   }
 


### PR DESCRIPTION
## Done

- Updated VM compose validation to use pod.resources data instead of the (now incorrect for LXD VM hosts) pod hints.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the Compose form for a LXD VM host and check that the help text for free RAM and free cores matches what's shown in the charts below.

## Fixes

Fixes #2562
