### PR TITLE
feat(ui): add upgrade notifications

### DIFF
--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.test.tsx
@@ -89,9 +89,35 @@ describe("NotificationGroupNotification", () => {
     expect(wrapper.find("button.p-icon--close").exists()).toBe(false);
   });
 
+  it("shows the date for upgrade notifications", () => {
+    const notification = notificationFactory({
+      created: "Tue, 27 Apr. 2021 00:34:39",
+      ident: NotificationIdent.UPGRADE_STATUS,
+    });
+    const state = rootStateFactory({
+      config,
+      notification: notificationStateFactory({
+        items: [notification],
+      }),
+      user,
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
+          <NotificationGroupNotification id={notification.id} type="negative" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find(".p-notification__date").exists()).toBe(true);
+    expect(wrapper.find(".p-notification__date").text()).toBe(
+      notification.created
+    );
+  });
+
   it("shows a settings link for release notifications", () => {
     const notification = notificationFactory({
-      ident: NotificationIdent.release,
+      ident: NotificationIdent.RELEASE,
     });
     const state = rootStateFactory({
       config,
@@ -115,7 +141,7 @@ describe("NotificationGroupNotification", () => {
 
   it("does not show the release notification menu to non-admins", () => {
     const notification = notificationFactory({
-      ident: NotificationIdent.release,
+      ident: NotificationIdent.RELEASE,
     });
     const state = rootStateFactory({
       config,

--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -1,6 +1,6 @@
 import { Notification } from "@canonical/react-components";
 import type { notificationTypes } from "@canonical/react-components";
-import PropTypes from "prop-types";
+import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
@@ -8,25 +8,38 @@ import authSelectors from "app/store/auth/selectors";
 import { actions as notificationActions } from "app/store/notification";
 import notificationSelectors from "app/store/notification/selectors";
 import type { Notification as NotificationType } from "app/store/notification/types";
+import {
+  isReleaseNotification,
+  isUpgradeNotification,
+} from "app/store/notification/utils";
 import type { RootState } from "app/store/root/types";
-import { isReleaseNotification } from "app/store/utils";
 
 type Props = {
   id: NotificationType["id"];
   type: notificationTypes;
 };
 
-const NotificationGroupNotification = ({ id, type }: Props): JSX.Element => {
+const NotificationGroupNotification = ({
+  id,
+  type,
+}: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const authUser = useSelector(authSelectors.get);
   const notification = useSelector((state: RootState) =>
     notificationSelectors.getById(state, id)
   );
+  if (!notification) {
+    return null;
+  }
   const showSettings =
     isReleaseNotification(notification) && authUser?.is_superuser;
+  const showDate = isUpgradeNotification(notification);
   return (
     <Notification
-      className={showSettings ? "p-notification--has-action" : null}
+      className={classNames({
+        "p-notification--has-action": showSettings,
+        "p-notification--has-date": showDate,
+      })}
       close={
         notification.dismissable
           ? () => dispatch(notificationActions.dismiss(id))
@@ -50,14 +63,13 @@ const NotificationGroupNotification = ({ id, type }: Props): JSX.Element => {
           </Link>
         </>
       ) : null}
+      {showDate ? (
+        <span className="p-notification__date u-text--muted">
+          {notification.created}
+        </span>
+      ) : null}
     </Notification>
   );
-};
-
-NotificationGroupNotification.propTypes = {
-  id: PropTypes.number,
-  type: PropTypes.oneOf(["caution", "negative", "positive", "information"])
-    .isRequired,
 };
 
 export default NotificationGroupNotification;

--- a/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/ui/src/app/base/components/NotificationGroup/Notification/__snapshots__/Notification.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`NotificationGroupNotification renders 1`] = `
   type="negative"
 >
   <Notification
-    className={null}
+    className=""
     close={[Function]}
     type="negative"
   >

--- a/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/ui/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -5,7 +5,10 @@ import configureStore from "redux-mock-store";
 
 import NotificationList from "./NotificationList";
 
-import { NotificationIdent } from "app/store/notification/types";
+import {
+  NotificationCategory,
+  NotificationIdent,
+} from "app/store/notification/types";
 import type { Notification } from "app/store/notification/types";
 import type { RootState } from "app/store/root/types";
 import {
@@ -30,7 +33,7 @@ describe("NotificationList", () => {
     notifications = [
       notificationFactory({
         id: 1,
-        category: "error",
+        category: NotificationCategory.ERROR,
         message: "an error",
       }),
     ];
@@ -120,8 +123,8 @@ describe("NotificationList", () => {
       notification: notificationStateFactory({
         items: [
           notificationFactory({
-            category: "info",
-            ident: NotificationIdent.release,
+            category: NotificationCategory.INFO,
+            ident: NotificationIdent.RELEASE,
           }),
         ],
       }),
@@ -150,7 +153,7 @@ describe("NotificationList", () => {
       notification: notificationStateFactory({
         items: [
           notificationFactory({
-            ident: NotificationIdent.release,
+            ident: NotificationIdent.RELEASE,
           }),
         ],
       }),

--- a/ui/src/app/base/components/NotificationList/__snapshots__/NotificationList.test.tsx.snap
+++ b/ui/src/app/base/components/NotificationList/__snapshots__/NotificationList.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`NotificationList renders a list of messages 1`] = `
         type="negative"
       >
         <Notification
-          className={null}
+          className=""
           close={[Function]}
           type="negative"
         >

--- a/ui/src/app/store/notification/selectors.test.ts
+++ b/ui/src/app/store/notification/selectors.test.ts
@@ -31,7 +31,7 @@ describe("notification selectors", () => {
       notification: notificationStateFactory({
         items: [
           notificationFactory({ message: "Test message" }),
-          notificationFactory({ ident: NotificationIdent.release }),
+          notificationFactory({ ident: NotificationIdent.RELEASE }),
         ],
       }),
       router: routerStateFactory({
@@ -53,7 +53,7 @@ describe("notification selectors", () => {
       notification: notificationStateFactory({
         items: [
           notificationFactory({ message: "Test message" }),
-          notificationFactory({ ident: NotificationIdent.release }),
+          notificationFactory({ ident: NotificationIdent.RELEASE }),
         ],
       }),
       router: routerStateFactory({
@@ -75,7 +75,7 @@ describe("notification selectors", () => {
       notification: notificationStateFactory({
         items: [
           notificationFactory({ message: "Test message" }),
-          notificationFactory({ ident: NotificationIdent.release }),
+          notificationFactory({ ident: NotificationIdent.RELEASE }),
         ],
       }),
       router: routerStateFactory({
@@ -92,7 +92,7 @@ describe("notification selectors", () => {
   it("can include release notifications", () => {
     const notifications = [
       notificationFactory({ message: "Test message" }),
-      notificationFactory({ ident: NotificationIdent.release }),
+      notificationFactory({ ident: NotificationIdent.RELEASE }),
     ];
     const state = rootStateFactory({
       config: configStateFactory({

--- a/ui/src/app/store/notification/selectors.ts
+++ b/ui/src/app/store/notification/selectors.ts
@@ -2,6 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import configSelectors from "app/store/config/selectors";
 import {
+  NotificationCategory,
   NotificationIdent,
   ReleaseNotificationPaths,
 } from "app/store/notification/types";
@@ -57,7 +58,7 @@ const allEnabled = createSelector(
     if (!releaseNotificationsEnabled || !matchesReleaseNotificationPath) {
       return notifications.filter(
         (notification: Notification) =>
-          notification.ident !== NotificationIdent.release
+          notification.ident !== NotificationIdent.RELEASE
       );
     }
     return notifications;
@@ -71,7 +72,8 @@ const allEnabled = createSelector(
  */
 const warnings = createSelector([allEnabled], (notifications) =>
   notifications.filter(
-    (notification: Notification) => notification.category === "warning"
+    (notification: Notification) =>
+      notification.category === NotificationCategory.WARNING
   )
 );
 
@@ -82,7 +84,8 @@ const warnings = createSelector([allEnabled], (notifications) =>
  */
 const errors = createSelector([allEnabled], (notifications) =>
   notifications.filter(
-    (notification: Notification) => notification.category === "error"
+    (notification: Notification) =>
+      notification.category === NotificationCategory.ERROR
   )
 );
 
@@ -93,7 +96,8 @@ const errors = createSelector([allEnabled], (notifications) =>
  */
 const success = createSelector([allEnabled], (notifications) =>
   notifications.filter(
-    (notification: Notification) => notification.category === "success"
+    (notification: Notification) =>
+      notification.category === NotificationCategory.SUCCESS
   )
 );
 
@@ -104,7 +108,8 @@ const success = createSelector([allEnabled], (notifications) =>
  */
 const info = createSelector([allEnabled], (notifications) =>
   notifications.filter(
-    (notification: Notification) => notification.category === "info"
+    (notification: Notification) =>
+      notification.category === NotificationCategory.INFO
   )
 );
 

--- a/ui/src/app/store/notification/types.ts
+++ b/ui/src/app/store/notification/types.ts
@@ -4,7 +4,9 @@ import type { GenericState } from "app/store/types/state";
 import type { User } from "app/store/user/types";
 
 export enum NotificationIdent {
-  release = "release_notification",
+  RELEASE = "release_notification",
+  UPGRADE_STATUS = "upgrade_status",
+  UPGRADE_VERSION_ISSUE = "upgrade_version_issue",
 }
 
 export enum ReleaseNotificationPaths {
@@ -12,12 +14,17 @@ export enum ReleaseNotificationPaths {
   settings = "/settings",
 }
 
-export type NotificationCategory = "error" | "warning" | "success" | "info";
+export enum NotificationCategory {
+  ERROR = "error",
+  WARNING = "warning",
+  SUCCESS = "success",
+  INFO = "info",
+}
 
 export type Notification = Model & {
   created: string;
   updated: string;
-  ident: string;
+  ident: NotificationIdent;
   user: User;
   users: boolean;
   admins: boolean;

--- a/ui/src/app/store/notification/utils.test.ts
+++ b/ui/src/app/store/notification/utils.test.ts
@@ -1,0 +1,45 @@
+import { isReleaseNotification, isUpgradeNotification } from "./utils";
+
+import { NotificationIdent } from "app/store/notification/types";
+import { notification as notificationFactory } from "testing/factories";
+
+describe("utils", () => {
+  describe("isReleaseNotification", () => {
+    it("it identifies a release notification", () => {
+      const notification = notificationFactory({
+        ident: NotificationIdent.RELEASE,
+      });
+      expect(isReleaseNotification(notification)).toBe(true);
+    });
+
+    it("it handles other notifications", () => {
+      const notification = notificationFactory({
+        ident: NotificationIdent.UPGRADE_STATUS,
+      });
+      expect(isReleaseNotification(notification)).toBe(false);
+    });
+  });
+
+  describe("isUpgradeNotification", () => {
+    it("it identifies upgrade status as an upgrade notification", () => {
+      const notification = notificationFactory({
+        ident: NotificationIdent.UPGRADE_STATUS,
+      });
+      expect(isUpgradeNotification(notification)).toBe(true);
+    });
+
+    it("it identifies upgrade version issue as an upgrade notification", () => {
+      const notification = notificationFactory({
+        ident: NotificationIdent.UPGRADE_VERSION_ISSUE,
+      });
+      expect(isUpgradeNotification(notification)).toBe(true);
+    });
+
+    it("it handles other notifications", () => {
+      const notification = notificationFactory({
+        ident: NotificationIdent.RELEASE,
+      });
+      expect(isUpgradeNotification(notification)).toBe(false);
+    });
+  });
+});

--- a/ui/src/app/store/notification/utils.ts
+++ b/ui/src/app/store/notification/utils.ts
@@ -1,0 +1,19 @@
+import { NotificationIdent } from "app/store/notification/types";
+import type { Notification } from "app/store/notification/types";
+
+/**
+ * Util to check if a notification is a release notification.
+ * @param notification - a notification.
+ */
+export const isReleaseNotification = (notification: Notification): boolean =>
+  notification.ident === NotificationIdent.RELEASE;
+
+/**
+ * Util to check if a notification is an upgrade notification.
+ * @param notification - a notification.
+ */
+export const isUpgradeNotification = (notification: Notification): boolean =>
+  [
+    NotificationIdent.UPGRADE_STATUS,
+    NotificationIdent.UPGRADE_VERSION_ISSUE,
+  ].includes(notification.ident);

--- a/ui/src/app/store/utils/identifiers.ts
+++ b/ui/src/app/store/utils/identifiers.ts
@@ -1,6 +1,4 @@
 import type { Machine } from "app/store/machine/types";
-import { NotificationIdent } from "app/store/notification/types";
-import type { Notification } from "app/store/notification/types";
 import type { Host } from "app/store/types/host";
 
 /**
@@ -9,10 +7,3 @@ import type { Host } from "app/store/types/host";
  */
 export const isMachine = (host: Host): host is Machine =>
   (host as Machine).link_type === "machine";
-
-/**
- * Util to check if a notification is a release notification.
- * @param {Host} host - a machine or controller.
- */
-export const isReleaseNotification = (notification: Notification): boolean =>
-  notification.ident === NotificationIdent.release;

--- a/ui/src/app/store/utils/index.ts
+++ b/ui/src/app/store/utils/index.ts
@@ -1,4 +1,4 @@
-export { isMachine, isReleaseNotification } from "./identifiers";
+export { isMachine } from "./identifiers";
 export { generateBaseSelectors } from "./selectors";
 export { generateSlice, generateStatusHandlers, updateErrors } from "./slice";
 export type {

--- a/ui/src/scss/_patterns_notifications.scss
+++ b/ui/src/scss/_patterns_notifications.scss
@@ -34,6 +34,7 @@
     }
   }
 
+  .p-notification--has-date,
   .p-notification--has-action {
     .p-notification__response {
       display: flex;
@@ -44,6 +45,7 @@
       flex: 1;
     }
 
+    .p-notification__date,
     .p-notification__action {
       flex: 0;
       white-space: nowrap;

--- a/ui/src/testing/factories/notification.ts
+++ b/ui/src/testing/factories/notification.ts
@@ -2,6 +2,7 @@ import { extend } from "cooky-cutter";
 
 import { model } from "./model";
 
+import { NotificationCategory } from "app/store/notification/types";
 import type { Notification } from "app/store/notification/types";
 import type { Model } from "app/store/types/model";
 import { user } from "testing/factories/user";
@@ -14,6 +15,6 @@ export const notification = extend<Model, Notification>(model, {
   users: true,
   admins: true,
   message: "Testing notification",
-  category: "warning",
+  category: NotificationCategory.WARNING,
   dismissable: true,
 });


### PR DESCRIPTION
## Done

- Handle upgrade notifications in the React client.
- Cleanup of notification types.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- SSH to bolla.
- Log in to the MAAS CLI (`maas login [PROFILE_NAME] http://localhost:5240/MAAS/`).
- To make the following commands easer run `export PROFILE_NAME=[PROFILE_NAME_FROM_LOGIN]`.
- Run:
```
maas $PROFILE_NAME notifications create ident='upgrade_version_issue' category='warning' users=true admins=true dismissable=false message='MAAS 2.9.3 is available but multiple controller versions are detected. <a href="/MAAS/l/controllers">Review controllers.</a>.'
```
- Then run:
```
maas $PROFILE_NAME notifications create ident='upgrade_status' category='info' users=true admins=true dismissable=false message='MAAS 2.9.3 is available and snap will upgrade soon. <a href="/MAAS/l/controllers">Review controllers</a>. Visit <a href="http://maas.io/docs">more info</a> to find out why controllers are not upgrading. '
```
- Point your local ui to Bolla and start it.
- Visit a React page and you should see two non-dismissable notifications with the date on the right side.
- Run:
```
maas $PROFILE_NAME notifications read
```
- Take note of the two notification ids and then run the following to remove BOTH notifications:
```
maas $PROFILE_NAME notification delete [id]
```
- Now run
```
maas $PROFILE_NAME notifications create ident='upgrade_status' category='success' users=true admins=true message='MAAS 2.9.3 upgrade is complete.'
```
- This time you should see a green dismissable notification with the date on the right.
- Now clean up the notification for the next person:
```
maas $PROFILE_NAME notifications read
maas $PROFILE_NAME notification delete [id]
```
- If you've dismissed the notification you can find the id by running:
```
sudo -u postgres psql maasdb -c "SELECT * FROM maasserver_notification WHERE ident = 'upgrade_version_issue' OR ident = 'upgrade_status';"
```

## Fixes

Fixes: #2494.