### PR TITLE
fix(ui): add help text to Add LXD project form

### DIFF
--- a/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
+++ b/ui/src/app/kvm/views/KVMList/AddKVM/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
@@ -68,6 +68,8 @@ export const SelectProjectFormFields = ({ authValues }: Props): JSX.Element => {
         />
         <FormikField
           disabled={!newProject}
+          help={`A project name must be less than 63 characters and must not
+                 contain spaces or special characters (i.e. / . ' " *)`}
           name="newProject"
           type="text"
           wrapperClassName="u-nudge-right--x-large u-sv2"


### PR DESCRIPTION
## Done

- added help text to the "Add LXD project" form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to bolla and click "Add KVM"
- Use any name and any existing LXD address and click "Authenticate"
- Check that there is help text under the "Add new project" field

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2384
