### PR TITLE
fix(legacy): devices list QA fixes

### DIFF
--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -557,7 +557,9 @@
       <form class="p-form p-form--stacked row">
         <div class="col-6 u-sv3">
           <div class="p-form__group row">
-            <label for="device-name" class="p-form__label col-2">Name</label>
+            <label for="device-name" class="p-form__label col-2 is-required">
+              Name
+            </label>
             <div class="p-form__control col-4">
               <div
                 class="p-form-validation"
@@ -574,7 +576,9 @@
             </div>
           </div>
           <div class="p-form__group row">
-            <label for="domain3" class="p-form__label col-2">Domain</label>
+            <label for="domain3" class="p-form__label col-2 is-required">
+              Domain
+            </label>
             <div class="p-form__control col-4">
               <select
                 name="domain"

--- a/legacy/src/scss/_patterns_filter.scss
+++ b/legacy/src/scss/_patterns_filter.scss
@@ -69,6 +69,7 @@
       background-position: right $sph-inner center;
       background-size: map-get($icon-sizes, accordion);
       border-bottom: 0 !important;
+      margin-right: 0;
       padding: $spv-inner--small $sph-inner;
 
       &.is-open {

--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -82,3 +82,9 @@ input[type="radio"] {
 .p-top .p-top__link {
   background-color: $color-light;
 }
+
+// 29-04-2021 Caleb: Remove margin from accordion button in dropdown. Can be
+// removed once react-components updated >v0.16.3
+.filter-accordion .p-accordion__tab {
+  margin-right: 0;
+}


### PR DESCRIPTION
## Done

- Fixed a couple of minor QA issues in the devices pages:
  - removed internal scrollbar from device filter dropdown (also hotfixed in the React machine list)
  - added "is-required" class to required fields in "Add device" form. This form has bigger issues with validation but fixing it in angular is a huge pain. Same goes for the Edit interface form - would be more work than it's worth fixing it now, will just get it right when we migrate the pages to React.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check there is no scrollbar for the machine list or device list filter dropdown
- Go to Devices and click "Add device" and check that Name and Domain both have the required asterisk

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2404
