### PR TITLE
feat(legacy): add controller VLANs column

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -860,6 +860,19 @@ function NodesListController(
       : null;
   };
 
+  // Get the HA VLAN info for a controller.
+  $scope.getHaVlans = function (controller) {
+    const vlansHA = controller.vlans_ha || {};
+    return (
+      [
+        vlansHA.false && `Non-HA(${vlansHA.false})`,
+        vlansHA.true && `HA(${vlansHA.true})`,
+      ]
+        .filter(Boolean)
+        .join(", ") || null
+    );
+  };
+
   // Switch to the specified tab, if specified.
   angular.forEach(["devices", "controllers"], function (node_type) {
     if ($location.path().indexOf("/" + node_type) !== -1) {

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -1429,4 +1429,56 @@ describe("NodesListController", function () {
       expect($scope.getUpgradeVersion(controller)).toBe(null);
     });
   });
+
+  describe("getHaVlans", () => {
+    it("can display HA and non-HA VLANs", () => {
+      makeController();
+      const controller = {
+        vlans_ha: {
+          false: 5,
+          true: 2,
+        },
+      };
+      expect($scope.getHaVlans(controller)).toBe("Non-HA(5), HA(2)");
+    });
+
+    it("can display HA only VLANs", () => {
+      makeController();
+      const controller = {
+        vlans_ha: {
+          false: 0,
+          true: 2,
+        },
+      };
+      expect($scope.getHaVlans(controller)).toBe("HA(2)");
+    });
+
+    it("can display non-HA only VLANs", () => {
+      makeController();
+      const controller = {
+        vlans_ha: {
+          false: 5,
+          true: 0,
+        },
+      };
+      expect($scope.getHaVlans(controller)).toBe("Non-HA(5)");
+    });
+
+    it("can handle no HA or non-HA VLANs", () => {
+      makeController();
+      const controller = {
+        vlans_ha: {
+          false: 0,
+          true: 0,
+        },
+      };
+      expect($scope.getHaVlans(controller)).toBe(null);
+    });
+
+    it("can handle no HA VLAN info", () => {
+      makeController();
+      const controller = {};
+      expect($scope.getHaVlans(controller)).toBe(null);
+    });
+  });
 });

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -1280,6 +1280,7 @@ sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ ta
             >
               Type
             </th>
+            <th class="p-table__cell" role="columnheader"># of VLANs</th>
             <th
               class="p-table__cell"
               role="columnheader"
@@ -1340,6 +1341,14 @@ sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ ta
               title="{$ controller.node_type_display $}"
             >
               <div class="u-truncate">{$ controller.node_type_display $}</div>
+            </td>
+            <td class="p-double-row" aria-label="# of VLANs">
+              <div class="p-double-row__rows-container">
+                <div class="p-double-row__main-row"></div>
+                <div class="p-double-row__muted-row u-truncate">
+                  {$ getHaVlans(controller) $}
+                </div>
+              </div>
             </td>
             <td class="p-table__cell" aria-label="Version">
               <div

--- a/legacy/src/scss/tables/_patterns_table-controllers.scss
+++ b/legacy/src/scss/tables/_patterns_table-controllers.scss
@@ -11,18 +11,22 @@
         }
 
         &:nth-child(3) {
-          width: 20%;
-        }
-
-        &:nth-child(4) {
           width: 15%;
         }
 
+        &:nth-child(4) {
+          width: 10%;
+        }
+
         &:nth-child(5) {
-          width: 20%;
+          width: 15%;
         }
 
         &:nth-child(6) {
+          width: 15%;
+        }
+
+        &:nth-child(7) {
           width: 15%;
         }
       }

--- a/ui/src/app/store/controller/types.ts
+++ b/ui/src/app/store/controller/types.ts
@@ -10,7 +10,7 @@ export enum ControllerInstallType {
 
 export type ControllerVersionInfo = {
   origin?: string;
-  revision?: string;
+  snap_revision?: string;
   version: string;
 };
 
@@ -19,6 +19,11 @@ export type ControllerVersions = {
   install_type?: ControllerInstallType;
   snap_cohort?: string;
   update?: ControllerVersionInfo;
+};
+
+export type ControllerVlansHA = {
+  false: number;
+  true: number;
 };
 
 export type ControllerActions =
@@ -39,6 +44,7 @@ export type Controller = BaseNode & {
     | NodeType.REGION_AND_RACK_CONTROLLER;
   service_ids: number[];
   versions: ControllerVersions | null;
+  vlans_ha?: ControllerVlansHA;
 };
 
 export type ControllerState = GenericState<Controller, TSFixMe>;


### PR DESCRIPTION
## Done

- Add the VLAN column to the controller table.
- Update controller types.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Connect your UI to Bolla.
- Load the controllers list.
- You should see a VLAN column and it should display HA/non-HA counts (if available).

## Fixes

Fixes: #2489.
Fixes: #2576.