### PR TITLE
feat(ui): scroll to top when opening KVM action form

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/KVMActionFormWrapper.tsx
@@ -2,6 +2,7 @@ import ComposeForm from "./ComposeForm";
 import DeleteForm from "./DeleteForm";
 import RefreshForm from "./RefreshForm";
 
+import { useScrollOnRender } from "app/base/hooks";
 import type {
   SelectedAction,
   SetSelectedAction,
@@ -14,14 +15,15 @@ type Props = {
   setSelectedAction: SetSelectedAction;
 };
 
-const KVMActionFormWrapper = ({
-  selectedAction,
-  setSelectedAction,
-}: Props): JSX.Element | null => {
-  if (!selectedAction) {
-    return null;
-  }
-  if (typeof selectedAction === "object" && "name" in selectedAction) {
+const getFormComponent = (
+  selectedAction: SelectedAction,
+  setSelectedAction: SetSelectedAction
+) => {
+  if (
+    selectedAction &&
+    typeof selectedAction === "object" &&
+    "name" in selectedAction
+  ) {
     return (
       <MachineActionForms
         selectedAction={selectedAction}
@@ -29,6 +31,7 @@ const KVMActionFormWrapper = ({
       />
     );
   }
+
   switch (selectedAction) {
     case KVMAction.COMPOSE:
       return <ComposeForm setSelectedAction={setSelectedAction} />;
@@ -39,6 +42,22 @@ const KVMActionFormWrapper = ({
     default:
       return null;
   }
+};
+
+const KVMActionFormWrapper = ({
+  selectedAction,
+  setSelectedAction,
+}: Props): JSX.Element | null => {
+  const onRenderRef = useScrollOnRender<HTMLDivElement>();
+
+  if (!selectedAction) {
+    return null;
+  }
+  return (
+    <div ref={onRenderRef}>
+      {getFormComponent(selectedAction, setSelectedAction)}
+    </div>
+  );
 };
 
 export default KVMActionFormWrapper;


### PR DESCRIPTION
## Done

- Used scroll hook to scroll to top when KVM action form renders

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a LXD project page and scroll down a bit
- Check that the window scrolls to the top when you click any of the buttons in the VM table'saction toolbar