### PR TITLE
fix(ui): validate available cores + memory on VM compose form render

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -90,6 +90,8 @@ const getLabel = (
   }
 };
 
+// TODO: Refactor Formik components + types.
+// https://github.com/canonical-web-and-design/maas-ui/issues/2593
 export type Props = {
   actionDisabled?: boolean;
   actionName?: string;
@@ -99,6 +101,7 @@ export type Props = {
   cleanup?: () => void;
   clearSelectedAction?: (...args: unknown[]) => void;
   errors?: { [x: string]: TSFixMe } | null;
+  initialTouched?: { [x: string]: boolean };
   initialValues?: { [x: string]: TSFixMe };
   loaded?: boolean;
   loading?: boolean;
@@ -121,6 +124,7 @@ const ActionForm = ({
   cleanup,
   clearSelectedAction,
   errors,
+  initialTouched,
   initialValues = {},
   loaded = true,
   loading,
@@ -174,6 +178,7 @@ const ActionForm = ({
         buttonsBordered={false}
         cleanup={cleanup}
         errors={formattedErrors}
+        initialTouched={initialTouched}
         initialValues={initialValues}
         loading={loading}
         onCancel={clearSelectedAction}

--- a/ui/src/app/base/components/DhcpForm/DhcpForm.tsx
+++ b/ui/src/app/base/components/DhcpForm/DhcpForm.tsx
@@ -22,19 +22,21 @@ import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 
-const DhcpSchema = Yup.object().shape({
-  description: Yup.string(),
-  enabled: Yup.boolean(),
-  entity: Yup.string().when("type", {
-    is: (val: string) => val && val.length > 0,
-    then: Yup.string().required(
-      "You must choose an entity for this snippet type"
-    ),
-  }),
-  name: Yup.string().required("Snippet name is required"),
-  value: Yup.string().required("DHCP snippet is required"),
-  type: Yup.string(),
-});
+const DhcpSchema = Yup.object()
+  .shape({
+    description: Yup.string(),
+    enabled: Yup.boolean(),
+    entity: Yup.string().when("type", {
+      is: (val: string) => val && val.length > 0,
+      then: Yup.string().required(
+        "You must choose an entity for this snippet type"
+      ),
+    }),
+    name: Yup.string().required("Snippet name is required"),
+    value: Yup.string().required("DHCP snippet is required"),
+    type: Yup.string(),
+  })
+  .defined();
 
 type Props = {
   analyticsCategory: string;
@@ -92,7 +94,9 @@ export const DhcpForm = ({
       initialValues={{
         description: dhcpSnippet ? dhcpSnippet.description : "",
         enabled: dhcpSnippet ? dhcpSnippet.enabled : false,
-        entity: dhcpSnippet ? dhcpSnippet.node || dhcpSnippet.subnet || "" : "",
+        entity: dhcpSnippet
+          ? dhcpSnippet.node || `${dhcpSnippet.subnet}` || ""
+          : "",
         name: dhcpSnippet ? dhcpSnippet.name : "",
         type: (dhcpSnippet && targetType) || "",
         value: dhcpSnippet ? dhcpSnippet.value : "",

--- a/ui/src/app/base/components/DhcpForm/types.ts
+++ b/ui/src/app/base/components/DhcpForm/types.ts
@@ -6,5 +6,5 @@ export type DHCPFormValues = {
   entity: string;
   name: DHCPSnippet["name"];
   value: DHCPSnippet["value"];
-  type: "" | "subnet" | "controller" | "machine" | "device";
+  type: string;
 };

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import { Formik } from "formik";
-import type { FormikHelpers } from "formik";
+import type { FormikHelpers, FormikTouched } from "formik";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
 import { Redirect } from "react-router";
@@ -16,6 +16,7 @@ import { useSendAnalyticsWhen } from "app/base/hooks";
 
 export type Props<V, E = FormErrors> = {
   cleanup?: () => void;
+  initialTouched?: FormikTouched<V>;
   onSaveAnalytics?: {
     action?: string;
     category?: string;
@@ -40,6 +41,7 @@ const FormikForm = <V, E = FormErrors>({
   editable = true,
   errors,
   inline,
+  initialTouched,
   initialValues,
   loading,
   onCancel,
@@ -84,6 +86,7 @@ const FormikForm = <V, E = FormErrors>({
 
   return (
     <Formik
+      initialTouched={initialTouched}
       initialValues={initialValues}
       onSubmit={onSubmit}
       validateOnChange={validateOnChange}

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.test.tsx
@@ -431,6 +431,38 @@ describe("ComposeFormFields", () => {
     );
   });
 
+  it("shows an error if there are no cores available to pin", async () => {
+    const state = { ...initialState };
+    state.pod.items[0].resources = podResourcesFactory({
+      cores: podResourceFactory({ free: 0 }),
+    });
+    state.pod.items[0].cpu_over_commit_ratio = 1;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
+          <Route
+            exact
+            path="/kvm/:id"
+            component={() => <ComposeForm setSelectedAction={jest.fn()} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Switch to pinning cores
+    wrapper.find("input[id='pinning-cores']").simulate("change", {
+      target: {
+        name: "pinning-cores",
+        checked: true,
+      },
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("Input[name='pinnedCores']").prop("error")).toBe(
+      "There are no cores available to pin."
+    );
+  });
+
   it("shows an error if trying to pin more cores than are available", async () => {
     const state = { ...initialState };
     state.pod.items[0].resources = podResourcesFactory({

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeFormFields/ComposeFormFields.tsx
@@ -111,6 +111,7 @@ export const ComposeFormFields = ({
           label="Use any available core(s)"
           onChange={() => {
             setPinningCores(false);
+            setFieldValue("cores", defaults.cores);
             setFieldValue("pinnedCores", "");
           }}
           type="radio"
@@ -147,6 +148,7 @@ export const ComposeFormFields = ({
             onChange={() => {
               setPinningCores(true);
               setFieldValue("cores", "");
+              setFieldValue("pinnedCores", "");
             }}
             type="radio"
           />


### PR DESCRIPTION
## Done

- Validate cores + memory on mount for VM compose form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page for a KVM that has less than 1024 MiB memory and/or 0 cores available
- Check that an error shows for memory and/or cores
- Delete some VMs so that you have more than 1024MiB memory and/or at least 1 core
- Check that no errors show

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2407