### PR TITLE
fix(ui): fix spacing between settings buttons

### DIFF
--- a/ui/src/scss/_patterns_table-actions.scss
+++ b/ui/src/scss/_patterns_table-actions.scss
@@ -11,12 +11,12 @@
       margin: 0;
     }
 
-    .p-table-actions [class*="p-button"] {
-      margin: 0;
-
-      &:first-of-type {
-        margin-left: $sph-inner;
-      }
+    // But default Vanilla adds a space between forms and the top of the first
+    // button. Because this form is displayed horizontally the space needs to be
+    // to the left of the first button.
+    .p-table-actions [class*="p-button"]:first-of-type {
+      margin-left: $sph-inner;
+      margin-top: 0;
     }
   }
 }


### PR DESCRIPTION
## Done

- Correctly space buttons in the settings list pages.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to 'Page repos' in Settings.
- There should be space between the search box and the two 'Add ...' buttons.
- Click on some other list pages in settings and the search box/add button spaces should look OK.

## Fixes

Fixes: #2586.