### PR TITLE
fix(shared): fix error when closing menu

### DIFF
--- a/shared/src/components/Header/HardwareMenu/HardwareMenu.tsx
+++ b/shared/src/components/Header/HardwareMenu/HardwareMenu.tsx
@@ -26,12 +26,17 @@ export const HardwareMenu = ({
       );
     }
     handleClickOutsideRef.current = (event: React.MouseEvent<HTMLElement>) => {
+      // The target might be something like an SVG node which doesn't provide
+      // the class name as a string.
+      const isValidTarget =
+        typeof (event?.target as HTMLElement)?.className === "string";
       if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(event.target) &&
-        !(event.target as HTMLElement).className.includes(
-          "hardware-menu__toggle"
-        )
+        !isValidTarget ||
+        (wrapperRef.current &&
+          !wrapperRef.current.contains(event.target) &&
+          !(event.target as HTMLElement).className.includes(
+            "hardware-menu__toggle"
+          ))
       ) {
         toggleHardwareMenu(event);
       }


### PR DESCRIPTION
## Done

- Fix an error when clicking on the header logo when the hardware menu is open.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open a legacy page.
- Resize your window so that the hardware menu shows in the header.
- Open the hardware menu.
- Click on the MAAS logo in the header.
- The hardware menu should close and there shouldn't be an error in your console.

## Fixes

Fixes: #2599.