### PR TITLE
feat(legacy): display the origin for debs

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -862,9 +862,10 @@ function NodesListController(
       cohortKey = chunks.map((chunk) => chunk.trim()).join(" \n");
     }
     return {
-      channel: versions.origin || null,
+      origin: versions.origin || null,
       cohortTooltip: cohortKey ? `Cohort key: \n${cohortKey}` : null,
       current: (versions.current && versions.current.version) || null,
+      isDeb: versions.install_type === "deb",
       update: (versions.update && versions.update.version) || null,
     };
   };

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -1409,9 +1409,10 @@ describe("NodesListController", function () {
         },
       };
       expect($scope.getVersions(controller)).toStrictEqual({
-        channel: "stable",
+        origin: "stable",
         cohortTooltip: `Cohort key: \nMSBzaFkyMllUWjNSaEpKRE9qME1mbVNoVE5aVEViM \nUppcSAxNjE3MTgyOTcxIGJhM2VlYzQ2NDc5ZDdmNT \nI3NzIzNTUyMmRlOTc1MGIzZmNhYTI0MDE1MTQ3ZjV \nhM2ViNzQwZGZmYzk5OWFiYWU=`,
         current: "1.2.3",
+        isDeb: false,
         update: "1.2.4",
       });
     });
@@ -1420,9 +1421,10 @@ describe("NodesListController", function () {
       makeController();
       const controller = {};
       expect($scope.getVersions(controller)).toStrictEqual({
-        channel: null,
+        origin: null,
         cohortTooltip: null,
         current: null,
+        isDeb: false,
         update: null,
       });
     });
@@ -1433,9 +1435,10 @@ describe("NodesListController", function () {
         versions: {},
       };
       expect($scope.getVersions(controller)).toStrictEqual({
-        channel: null,
+        origin: null,
         cohortTooltip: null,
         current: null,
+        isDeb: false,
         update: null,
       });
     });
@@ -1449,11 +1452,32 @@ describe("NodesListController", function () {
         },
       };
       expect($scope.getVersions(controller)).toStrictEqual({
-        channel: null,
+        origin: null,
         cohortTooltip: null,
         current: null,
+        isDeb: false,
         update: null,
       });
+    });
+
+    it("can identify deb installs", () => {
+      makeController();
+      const controller = {
+        versions: {
+          install_type: "deb",
+        },
+      };
+      expect($scope.getVersions(controller).isDeb).toBe(true);
+    });
+
+    it("handles snap installs", () => {
+      makeController();
+      const controller = {
+        versions: {
+          install_type: "snap",
+        },
+      };
+      expect($scope.getVersions(controller).isDeb).toBe(false);
     });
   });
 

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -1377,19 +1377,22 @@ sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ ta
                 </div>
                 <div class="p-double-row__muted-row">
                   <div
-                    data-ng-if="getVersions(controller).channel"
-                    title="{$ getVersions(controller).channel $}"
+                    data-ng-if="getVersions(controller).origin"
+                    title="{$ getVersions(controller).origin $}"
                   >
-                    {$ getVersions(controller).channel $}
+                    {$ getVersions(controller).isDeb ? "Deb" :
+                    getVersions(controller).origin $}
                   </div>
                   &nbsp;
                   <div
                     class="p-tooltip--top-left"
-                    data-ng-if="getVersions(controller).cohortTooltip"
+                    data-ng-if="getVersions(controller).cohortTooltip || getVersions(controller).isDeb"
                   >
                     <i class="p-icon--information"></i>
                     <span class="p-tooltip__message" role="tooltip"
-                      >{$ getVersions(controller).cohortTooltip $}</span
+                      >{$ getVersions(controller).isDeb ?
+                      getVersions(controller).origin :
+                      getVersions(controller).cohortTooltip $}</span
                     >
                   </div>
                 </div>


### PR DESCRIPTION
## Done

- Display the origin for deb installs in the controller list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- There is no easy way to QA this so the data will need to be faked for now.
- Open `legacy/src/app/controllers/nodes_list.js`.
- Go to line 855 and replace the function with:
```typescript
  $scope.getVersions = function (controller) {
    return {
      origin: "ppa:maas/3.0-next",
      cohortTooltip: null,
      current: "1.2.3",
      isDeb: true,
      update: null,
    };
  };
```
- Start the ui and go to the controllers list.
- In the version column you should see "Deb" and hovering the icon should show the PPA.

## Fixes

Fixes: #2603.