### PR TITLE
fix(legacy): fix error when no zone is selected

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -567,6 +567,18 @@ function NodesListController(
     }
   };
 
+  // Whether the action menu submit button should be disabled.
+  $scope.actionSubmitDisabled = function (tab) {
+    const actionOption = $scope.tabs[tab].actionOption;
+    if (!actionOption) {
+      return true;
+    }
+    return (
+      (actionOption.name === "tag" && $scope.tags.length <= 0) ||
+      (actionOption.name === "set-zone" && !$scope.tabs[tab].zoneSelection)
+    );
+  };
+
   // Return True if there is an action error.
   $scope.isActionError = function (tab) {
     return $scope.tabs[tab].actionErrorCount !== 0;

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -729,6 +729,36 @@ describe("NodesListController", function () {
         });
       });
 
+      describe("actionSubmitDisabled", function () {
+        it("is disabled when there are no selected tags", function () {
+          makeController();
+          $scope.tabs[tab].actionOption = { name: "tag" };
+          $scope.tags = [];
+          expect($scope.actionSubmitDisabled(tab)).toBe(true);
+        });
+
+        it("is not disabled when there are selected tags", function () {
+          makeController();
+          $scope.tabs[tab].actionOption = { name: "tag" };
+          $scope.tags = ["tag"];
+          expect($scope.actionSubmitDisabled(tab)).toBe(false);
+        });
+
+        it("is disabled when there are no selected zones", function () {
+          makeController();
+          $scope.tabs[tab].actionOption = { name: "set-zone" };
+          $scope.tabs[tab].zoneSelection = null;
+          expect($scope.actionSubmitDisabled(tab)).toBe(true);
+        });
+
+        it("is not disabled when there are selected zones", function () {
+          makeController();
+          $scope.tabs[tab].actionOption = { name: "set-zone" };
+          $scope.tabs[tab].zoneSelection = { id: 1 };
+          expect($scope.actionSubmitDisabled(tab)).toBe(false);
+        });
+      });
+
       describe("isActionError", function () {
         it("returns true if actionErrorCount > 0", function () {
           makeController();

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -336,7 +336,7 @@
                   data-ng-class="tabs[tab].actionOption.name === 'delete' ? 'p-button--negative' : 'p-button--positive'"
                   data-ng-click="actionGo(tab)"
                   data-ng-hide="hasActionsFailed(tab)"
-                  data-ng-disabled="tabs[tab].actionOption.name === 'tag' && tags.length <= 0"
+                  data-ng-disabled="actionSubmitDisabled(tab)"
                 >
                   <span data-ng-if="tabs[tab].actionOption.name === 'set-zone'"
                     >Set zone for {$ tabs[tab].selectedItems.length $} {$
@@ -779,6 +779,7 @@
             class="p-button--positive"
             data-ng-class="{ 'p-button--positive': tabs.controllers.actionOption.name !== 'delete', 'p-button--negative': tabs.controllers.actionOption.name === 'delete' }"
             data-ng-click="actionGo('controllers')"
+            data-ng-disabled="actionSubmitDisabled('controllers')"
           >
             <span data-ng-if="tabs.controllers.actionOption.name === 'set-zone'"
               >Set zone for {$ tabs.controllers.selectedItems.length $}


### PR DESCRIPTION
## Done

- Prevent the action form from being submitted when a zone hasn't been selected.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the controller list.
- Tick a controller and open the set zone form.
- The submit button should be disabled.
- Choose a zone and the button should become enabled.
- Do the same for the device list.

## Fixes

Fixes: #2607.