### PR TITLE
fix(legacy): fix infinite loop when unselecting controllers

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -149,10 +149,29 @@ function NodesListController(
   // this scope.
   $scope.addDeviceScope = null;
 
+  // Whether the search string includes the 'selected' filter.
+  function searchHasSelected(query) {
+    var search = query.toLowerCase();
+    return search.includes("in:(selected)") || search.includes("in:selected");
+  }
+
+  // Remove the 'selected' filter from the search string.
+  function removeSelected(search) {
+    return search
+      .split(" ")
+      .reduce((cleaned, part) => {
+        const partLower = part.toLowerCase();
+        if (partLower !== "in:(selected)" && partLower !== "in:selected") {
+          cleaned.push(part);
+        }
+        return cleaned;
+      }, [])
+      .join(" ");
+  }
+
   // Return true if the tab is in viewing selected mode.
   function isViewingSelected(tab) {
-    var search = $scope.tabs[tab].search.toLowerCase();
-    return search === "in:(selected)" || search === "in:selected";
+    return searchHasSelected($scope.tabs[tab].search);
   }
 
   // Sets the search bar to only show selected.
@@ -164,7 +183,10 @@ function NodesListController(
   // Clear search bar from viewing selected.
   function leaveViewSelected(tab) {
     if (isViewingSelected(tab)) {
-      $scope.tabs[tab].search = $scope.tabs[tab].previous_search;
+      // Clean the 'selected' filter from the previous search otherwise it'll
+      // cause an infinite loop trying to remove the selected string.
+      const previousSearch = removeSelected($scope.tabs[tab].previous_search);
+      $scope.tabs[tab].search = previousSearch;
       $scope.updateFilters(tab);
     }
   }

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -773,6 +773,22 @@ describe("NodesListController", function () {
           expect($scope.tabs[tab].search).toBe("other");
         });
 
+        it("restores the previous search", function () {
+          makeController();
+          $scope.tabs.controllers.previous_search = "a:filter";
+          $scope.tabs.controllers.search = "in:(Selected)";
+          $scope.actionCancel("controllers");
+          expect($scope.tabs.controllers.search).toBe("a:filter");
+        });
+
+        it("removes in:Selected from the previous search", function () {
+          makeController();
+          $scope.tabs.controllers.previous_search = "a:filter in:(Selected)";
+          $scope.tabs.controllers.search = "in:(Selected)";
+          $scope.actionCancel("controllers");
+          expect($scope.tabs.controllers.search).toBe("a:filter");
+        });
+
         it("sets actionOption to null", function () {
           makeController();
           $scope.tabs[tab].actionOption = {};


### PR DESCRIPTION
## Done

- Fix the controller list from entering an infinite loop when unselecting all controllers.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the controller list.
- Use the check-all checkbox to select all controllers.
- Open the set zone form.
- Select a zone and submit.
- Open the delete form and then cancel.
- Untick the check-all checkbox and there should not be any errors in your console.

## Fixes

Fixes: #2608.