### PR TITLE
feat(legacy): display controller VLAN counts

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -917,6 +917,12 @@ function NodesListController(
     );
   };
 
+  // Get the number of VLANs for a controller.
+  $scope.getVlanCount = function (controller) {
+    const vlansHA = controller.vlans_ha || {};
+    return (vlansHA.false || 0) + (vlansHA.true || 0)
+  };
+
   // Switch to the specified tab, if specified.
   angular.forEach(["devices", "controllers"], function (node_type) {
     if ($location.path().indexOf("/" + node_type) !== -1) {

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -1578,4 +1578,43 @@ describe("NodesListController", function () {
       expect($scope.getHaVlans(controller)).toBe(null);
     });
   });
+
+  describe("getVlanCount", () => {
+    it("can get the total amount of vlans", () => {
+      makeController();
+      const controller = {
+        vlans_ha: {
+          false: 5,
+          true: 2,
+        },
+      };
+      expect($scope.getVlanCount(controller)).toBe(7);
+    });
+
+    it("can get the total amount of vlans when only non-HA", () => {
+      makeController();
+      const controller = {
+        vlans_ha: {
+          false: 5,
+        },
+      };
+      expect($scope.getVlanCount(controller)).toBe(5);
+    });
+
+    it("can get the total amount of vlans when only HA", () => {
+      makeController();
+      const controller = {
+        vlans_ha: {
+          true: 2,
+        },
+      };
+      expect($scope.getVlanCount(controller)).toBe(2);
+    });
+
+    it("can get the total amount of vlans when there are no VLANs", () => {
+      makeController();
+      const controller = {};
+      expect($scope.getVlanCount(controller)).toBe(0);
+    });
+  });
 });

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -1346,7 +1346,15 @@ sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ ta
             </td>
             <td class="p-double-row" aria-label="# of VLANs">
               <div class="p-double-row__rows-container">
-                <div class="p-double-row__main-row"></div>
+                <div class="p-double-row__main-row">
+                  <a
+                    data-ng-if="getVlanCount(controller) ||
+                  getVlanCount(controller) === 0"
+                    href="{$ legacyURLBase $}/{$ controller.link_type $}/{$ controller.system_id $}?area=vlans"
+                  >
+                    {$ getVlanCount(controller) $}
+                  </a>
+                </div>
                 <div class="p-double-row__muted-row u-truncate">
                   {$ getHaVlans(controller) $}
                 </div>


### PR DESCRIPTION
## Done

- Display the number of VLANs for each controller in the controller list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the list of controllers.
- In the VLAN column there should be a total VLAN count for each controller.
- Click on the count and it should take you to the VLANs tab in the controller details page.

## Fixes

Fixes: #2589.