### PR TITLE
fix(ui): fix network table header checkbox

### DIFF
--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
@@ -62,4 +62,17 @@ describe("GroupCheckbox", () => {
     );
     expect(wrapper.prop("checked")).toBe(true);
   });
+
+  it("can check if it should display as mixed via a function", () => {
+    const wrapper = shallow(
+      <GroupCheckbox
+        checkAllSelected={() => false}
+        items={[1, 2, 3]}
+        selectedItems={[2]}
+        handleGroupCheckbox={jest.fn()}
+      />
+    );
+    expect(wrapper.prop("checked")).toBe(true);
+    expect(wrapper.hasClass("p-checkbox--mixed")).toBe(true);
+  });
 });

--- a/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
+++ b/ui/src/app/base/components/GroupCheckbox/GroupCheckbox.tsx
@@ -9,6 +9,7 @@ import { someInArray, someNotAll } from "app/utils";
 import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
 type Props<S> = {
+  checkAllSelected?: CheckboxHandlers<S>["checkAllSelected"] | null;
   checkSelected?: CheckboxHandlers<S>["checkSelected"] | null;
   disabled?: boolean;
   handleGroupCheckbox: CheckboxHandlers<S>["handleGroupCheckbox"];
@@ -21,6 +22,7 @@ type Props<S> = {
 } & HTMLProps<HTMLInputElement>;
 
 const GroupCheckbox = <S,>({
+  checkAllSelected,
   checkSelected,
   disabled,
   handleGroupCheckbox,
@@ -31,6 +33,9 @@ const GroupCheckbox = <S,>({
   ...props
 }: Props<S>): JSX.Element => {
   const id = useRef(nanoid());
+  const notAllSelected = checkAllSelected
+    ? !checkAllSelected(items, selectedItems)
+    : someNotAll(items, selectedItems);
   return (
     <Input
       checked={
@@ -39,7 +44,7 @@ const GroupCheckbox = <S,>({
           : someInArray(items, selectedItems)
       }
       className={classNames("has-inline-label", {
-        "p-checkbox--mixed": someNotAll(items, selectedItems),
+        "p-checkbox--mixed": selectedItems.length > 0 && notAllSelected,
       })}
       disabled={items.length === 0 || disabled}
       id={id.current}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -409,6 +409,7 @@ const NetworkTable = ({
     rowSort
   );
   const {
+    checkAllSelected,
     checkSelected,
     handleGroupCheckbox,
     handleRowCheckbox,
@@ -457,6 +458,7 @@ const NetworkTable = ({
           content: (
             <>
               <GroupCheckbox
+                checkAllSelected={checkAllSelected}
                 checkSelected={checkSelected}
                 disabled={isAllNetworkingDisabled}
                 items={selectableIDs}

--- a/ui/src/app/utils/generateCheckboxHandlers.test.ts
+++ b/ui/src/app/utils/generateCheckboxHandlers.test.ts
@@ -116,4 +116,23 @@ describe("generateCheckboxHandlers", () => {
       ).toBe(true);
     });
   });
+
+  describe("checkAllSelected", () => {
+    it("checks if all ids are selected", () => {
+      expect(handlers.checkAllSelected([2, 3], [3, 2])).toBe(true);
+    });
+
+    it("checks if some ids are not selected", () => {
+      expect(handlers.checkAllSelected([2, 4], [1, 2])).toBe(false);
+    });
+
+    it("checks if all ids are selected with generateUniqueId", () => {
+      expect(
+        uniqueIdHandlers.checkAllSelected(
+          [{ system_id: 2 }, { system_id: 3 }],
+          [{ system_id: 3 }, { system_id: 2 }]
+        )
+      ).toBe(true);
+    });
+  });
 });

--- a/ui/src/app/utils/generateCheckboxHandlers.ts
+++ b/ui/src/app/utils/generateCheckboxHandlers.ts
@@ -1,9 +1,11 @@
+import { arrayItemsEqual } from "./arrayItemsEqual";
 import { someInArray } from "./someInArray";
 
 export type CheckboxHandlers<ID> = {
+  checkAllSelected: (rowIDs: ID[], selectedIDs: ID[]) => boolean;
+  checkSelected: (rowIDs: ID | ID[], selectedIDs: ID[]) => boolean;
   handleGroupCheckbox: (ids: ID[], selectedIDs: ID[]) => void;
   handleRowCheckbox: (rowID: ID, selectedIDs: ID[]) => void;
-  checkSelected: (rowIDs: ID | ID[], selectedIDs: ID[]) => boolean;
 };
 
 /**
@@ -43,6 +45,16 @@ export const generateCheckboxHandlers = <ID>(
     const uniqueSelectedIds = selectedIDs.map((id: ID) => generateUniqueId(id));
     return someInArray(uniqueRowIDs, uniqueSelectedIds);
   };
+  // Handler for checking whether all rows are in the selected state.
+  const checkAllSelected: CheckboxHandlers<ID>["checkAllSelected"] = (
+    rowIDs,
+    selectedIDs
+  ) => {
+    // Generate unique ids.
+    const uniqueRowIDs = rowIDs.map((id: ID) => generateUniqueId(id));
+    const uniqueSelectedIds = selectedIDs.map((id: ID) => generateUniqueId(id));
+    return arrayItemsEqual(uniqueRowIDs, uniqueSelectedIds);
+  };
   // Handler to update a single checkbox.
   const handleRowCheckbox: CheckboxHandlers<ID>["handleRowCheckbox"] = (
     rowID,
@@ -57,8 +69,9 @@ export const generateCheckboxHandlers = <ID>(
     onChange(newSelectedIDs);
   };
   return {
-    handleGroupCheckbox,
+    checkAllSelected,
     checkSelected,
+    handleGroupCheckbox,
     handleRowCheckbox,
   };
 };


### PR DESCRIPTION
## Done

- Show the all-ticked states in the header checkbox in the machine network tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab for a machine.
- Check some of the interfaces. The table header checkbox should show the mixed state [-].
- Tick all the interfaces. The header checkbox should be ticked.

## Fixes

Fixes: #2618.