### PR TITLE
feat(ui): display a message when a machine has no DHCP snippets

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/DHCPTable/DHCPTable.tsx
@@ -109,6 +109,7 @@ const DHCPTable = ({ systemId }: Props): JSX.Element | null => {
         className="dhcp-snippets-table p-table-expanding--light"
         defaultSort="name"
         defaultSortDirection="descending"
+        emptyStateMsg="No DHCP snippets applied to this machine."
         expanding
         headers={[
           {


### PR DESCRIPTION
## Done

- Display a message in the machine DHCP table when no DHCP snippets are applied.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab in machine details.
- If there are no DHCP snippets applied to the machine there should be a message saying so under the table.

## Fixes

Fixes: #2619.