### PR TITLE
fix(legacy): fix subnets pages QA issues

### DIFF
--- a/legacy/src/app/controllers/vlan_details.js
+++ b/legacy/src/app/controllers/vlan_details.js
@@ -463,17 +463,19 @@ export function VLANDetailsController(
     });
 
     if (!vm.iprangesInVLAN.length) {
-      vm.selectedSubnet = vm.filteredRelatedSubnets[0];
-      var firstAvailableRange = vm.selectedSubnet.subnet.statistics.ranges[0];
+      vm.selectedSubnet = vm.filteredRelatedSubnets[0] || {};
+      var firstAvailableRange =
+        vm.selectedSubnet.subnet?.statistics?.ranges[0] || {};
       vm.suggestedRange = {
         type: "dynamic",
         comment: "Dynamic",
-        start_ip: firstAvailableRange.start,
-        end_ip: firstAvailableRange.end,
-        subnet: vm.selectedSubnet.subnet.id,
+        start_ip: firstAvailableRange?.start || "",
+        end_ip: firstAvailableRange?.end || "",
+        subnet: vm.selectedSubnet.subnet?.id,
         gateway_ip:
           vm.selectedSubnet.subnet.gateway_ip ||
-          vm.selectedSubnet.subnet.statistics.suggested_gateway,
+          vm.selectedSubnet.subnet.statistics.suggested_gateway ||
+          "",
       };
 
       if (vm.relayVLAN) {

--- a/legacy/src/app/partials/fabric-details.html
+++ b/legacy/src/app/partials/fabric-details.html
@@ -364,9 +364,15 @@
                 </td>
                 <td class="col-2" aria-label="Space">
                   <div class="u-text-overflow">
-                    <a href="{$ legacyURLBase $}/space/{$ row.space.id $}"
-                      >{$ row.space_name $}</a
+                    <a
+                      data-ng-if="row.space_name !== '(undefined)'"
+                      href="{$ legacyURLBase $}/space/{$ row.space.id $}"
                     >
+                      {$ row.space_name $}
+                    </a>
+                    <span data-ng-if="row.space_name === '(undefined)'">
+                      {$ row.space_name $}
+                    </span>
                   </div>
                 </td>
               </tr>

--- a/legacy/src/app/partials/networks-list.html
+++ b/legacy/src/app/partials/networks-list.html
@@ -333,13 +333,17 @@
           &emsp;
           <div class="p-tooltip--right u-vertically-center">
             <i class="p-icon--help u-hide u-show--large">Help:</i>
-            <span class="p-tooltip__message" role="tooltip"
-              >Fabric is a set of consistent interconnected VLANs that are
-              capable of mutual communication.&#xa;Space is a grouping of
-              networks (VLANs and their subnets) that are able to mutually
-              communicate with each other.&#xa;Subnets within a space do not
-              need to belong to the same fabric.</span
+            <span
+              class="p-tooltip__message u-wrap"
+              role="tooltip"
+              style="width: 19rem"
             >
+              Fabric is a set of consistent interconnected VLANs that are
+              capable of mutual communication. Space is a grouping of networks
+              (VLANs and their subnets) that are able to mutually communicate
+              with each other. Subnets within a space do not need to belong to
+              the same fabric.
+            </span>
           </div>
         </div>
       </form>
@@ -438,11 +442,11 @@
               <span class="p-tooltip--top-left" ng-if="$index === 0">
                 <span>(undefined)&nbsp;</span>
                 <i class="p-icon--warning">No space</i>
-                <span class="p-tooltip__message"
-                  >MAAS integrations require a space in order to determine the
-                  purpose of a network.&#xa;Define a space for each subnet by
-                  selecting the space on the VLAN details page.</span
-                >
+                <span class="p-tooltip__message u-wrap" style="width: 16rem">
+                  MAAS integrations require a space in order to determine the
+                  purpose of a network. Define a space for each subnet by
+                  selecting the space on the VLAN details page.
+                </span>
               </span>
             </td>
             <td

--- a/legacy/src/app/partials/space-details.html
+++ b/legacy/src/app/partials/space-details.html
@@ -13,7 +13,7 @@
           data-ng-show="isSuperUser() && !isDefaultSpace() && !loading"
         >
           <button
-            class="p-button--neutral u-no-margin--bottom"
+            class="p-button--negative u-no-margin--bottom"
             data-ng-click="deleteButton()"
             data-ng-hide="confirmingDelete"
           >

--- a/legacy/src/app/partials/subnet-details.html
+++ b/legacy/src/app/partials/subnet-details.html
@@ -373,11 +373,15 @@
                 (undefined)
                 <span class="p-tooltip--top-center">
                   <i class="p-icon--warning">Warning:</i>
-                  <span class="p-tooltip__message" role="tooltip"
-                    >This subnet does not belong to a space.&#xa;MAAS
-                    integrations require a space in order to determine the
-                    purpose of a network.</span
+                  <span
+                    class="p-tooltip__message u-wrap"
+                    role="tooltip"
+                    style="width: 16rem"
                   >
+                    This subnet does not belong to a space. MAAS integrations
+                    require a space in order to determine the purpose of a
+                    network.
+                  </span>
                 </span>
               </span>
             </p>
@@ -1019,7 +1023,7 @@
               <td aria-label="Node" data-ng-switch="ip.node_summary.node_type">
                 <span data-ng-switch-when="0"
                   ><a
-                    href="{$ legacyURLBase $}/machine/{$ ip.node_summary.system_id $}"
+                    href="{$ newURLBase $}/machine/{$ ip.node_summary.system_id $}"
                     >{$ ip.node_summary.hostname $}</a
                   ></span
                 >

--- a/legacy/src/app/partials/vlan-details.html
+++ b/legacy/src/app/partials/vlan-details.html
@@ -955,9 +955,15 @@
               {$ row.subnet.statistics.usage_string $}
             </td>
             <td class="col-4 u-text-overflow" aria-label="Space">
-              <a href="{$ legacyURLBase $}/space/{$ row.space.id $}"
-                >{$ row.space.name $}</a
+              <a 
+                data-ng-if="row.space.name !== '(undefined)'"
+                href="{$ legacyURLBase $}/space/{$ row.space.id $}"
               >
+                {$ row.space.name $}
+              </a>
+              <span data-ng-if="row.space.name === '(undefined)'">
+                {$ row.space.name $}
+              </span>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Done

- Fixed a few oddly formatted tooltips
- Fixed undefined spaces linking to a non-existent page
- Fixed console error when clicking "Enable DHCP" for a subnet with no available ranges
- Fixed links to old machine details page
- Changed "Delete space" button to red

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Point the UI to bolla and go to `/MAAS/l/networks?by=space`
- Hover over the "i" by the grouping select and check that the tooltip looks ok
- Hover over the warning icon next to (undefined) space and check that the tooltip looks ok
- Go to a fabric that has at least one VLAN not in a space (e.g. `/MAAS/l/fabric/12`) and check that (undefined) spaces are not links
- Go to a VLAN that is not in a space (e.g. `/MAAS/l/vlan/5015`) and check that the (undefined) spaces are not links
- Go to a VLAN that has a subnet with no available ranges (e.g. `/MAAS/l/vlan/5018`) and click "Enable DHCP". Check there is no console error.
- Go to a subnet that is not in a space (e.g. `/MAAS/l/subnet/18`) and check that the tooltip over space looks ok
- Go to a subnet that is used in a machine (e.g. `/MAAS/l/subnet/5`) and check that the links to machines in the "Used" table go to the react page
- Go to any space page and check that the "Delete space" button is red

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2411
