### PR TITLE
feat(ui): scroll to action forms when they open

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -16,6 +16,7 @@ import SetZoneForm from "./SetZoneForm";
 import TagForm from "./TagForm";
 import TestForm from "./TestForm";
 
+import { useScrollOnRender } from "app/base/hooks";
 import { useMachineActionForm } from "app/machines/hooks";
 import type {
   SelectedAction,
@@ -58,6 +59,7 @@ export const ActionFormWrapper = ({
   setSelectedAction,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const activeMachineId = useSelector(machineSelectors.activeID);
   const { machinesToAction, processingCount } = useMachineActionForm(
     selectedAction.name
@@ -166,7 +168,7 @@ export const ActionFormWrapper = ({
   };
 
   return (
-    <>
+    <div ref={onRenderRef}>
       {actionDisabled ? (
         <p data-test="machine-action-warning">
           <i className="p-icon--warning" />
@@ -194,7 +196,7 @@ export const ActionFormWrapper = ({
       saves. This is to prevent race conditions from disabling the form and stopping the 
       save effect from running. */}
       {getFormComponent()}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Done

- When a machine action form opens then scroll to the top.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open machine details for a machine that hasn't yet had tests run (e.g. a new machine).
- Scroll down and click "Test network...".
- You should get scrolled to the open form at the top.

## Fixes

Fixes: #2622.