### PR TITLE
fix(ui): remove old pod.numa_pinning utils + types

### DIFF
--- a/legacy/src/app/controllers/node_details.js
+++ b/legacy/src/app/controllers/node_details.js
@@ -44,23 +44,6 @@ export const getRanges = (array) => {
   return ranges;
 };
 
-export const getPodNumaID = (node, pod) => {
-  if (pod.numa_pinning) {
-    // If there is only one NUMA node on the VM host, then the VM must be
-    // aligned on that node even if it isn't specifically pinned.
-    if (pod.numa_pinning.length === 1) {
-      return pod.numa_pinning[0].node_id;
-    }
-    const podNuma = pod.numa_pinning.find((numa) =>
-      numa.vms.some((vm) => vm.system_id === node.system_id)
-    );
-    if (podNuma) {
-      return podNuma.node_id;
-    }
-  }
-  return null;
-};
-
 /* @ngInject */
 function NodeDetailsController(
   $scope,
@@ -130,7 +113,6 @@ function NodeDetailsController(
   $scope.failedUpdateError = "";
   $scope.disableTestButton = false;
   $scope.isVM = false;
-  $scope.podNumaID = null;
   $scope.sendAnalyticsEvent = $filter("sendAnalyticsEvent");
 
   // Node header section.
@@ -546,7 +528,6 @@ function NodeDetailsController(
       PodsManager.getItem(node.pod.id).then((pod) => {
         $scope.isVM = MachinesManager.isVM(node, pod);
         $scope.loaded = true;
-        $scope.podNumaID = getPodNumaID(node, pod);
       });
     } else {
       $scope.isVM = MachinesManager.isVM(node);

--- a/legacy/src/app/controllers/tests/test_node_details.js
+++ b/legacy/src/app/controllers/tests/test_node_details.js
@@ -7,7 +7,7 @@ import angular from "angular";
 
 import { makeInteger, makeName } from "testing/utils";
 import MockWebSocket from "testing/websocket";
-import { formatNumaMemory, getPodNumaID, getRanges } from "../node_details";
+import { formatNumaMemory, getRanges } from "../node_details";
 
 describe("NodeDetailsController", function () {
   // Load the MAAS module.
@@ -2432,37 +2432,5 @@ describe("NodeDetailsController", function () {
     it("can handle different types", () => {
       expect(getRanges([3, "1", 2, "0"])).toEqual(["0-3"]);
     });
-  });
-
-  describe("getPodNumaID", () => {
-    it("correctly returns the NUMA id of the pod that hosts the node, if it exists", () => {
-      const node1 = { pod: { id: 1, name: "pod1" }, system_id: "abc123" };
-      const node2 = { pod: { id: 1, name: "pod1" }, system_id: "def456" };
-      const node3 = { pod: { id: 1, name: "pod1" }, system_id: "ghi789" };
-      const pod = {
-        id: 1,
-        name: "pod1",
-        numa_pinning: [
-          { node_id: 0, vms: [{ system_id: "abc123" }] },
-          { node_id: 2, vms: [{ system_id: "def456" }] },
-        ],
-      };
-      expect(getPodNumaID(node1, pod)).toEqual(0);
-      expect(getPodNumaID(node2, pod)).toEqual(2);
-      expect(getPodNumaID(node3, pod)).toEqual(null);
-    });
-  });
-
-  it(`returns the id of the only NUMA node of a pod, even if it has not
-    specifically pinned the VM`, () => {
-    const node = { pod: { id: 1, name: "pod1" }, system_id: "abc123" };
-    const pod = {
-      id: 1,
-      name: "pod1",
-      numa_pinning: [
-        { node_id: 1, vms: [] }, // VM is not pinned here
-      ],
-    };
-    expect(getPodNumaID(node, pod)).toEqual(1);
   });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -12,7 +12,6 @@ import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   pod as podFactory,
-  podNumaNode as podNumaNodeFactory,
   powerType as powerTypeFactory,
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
@@ -72,13 +71,12 @@ describe("DetailsCard", () => {
     expect(wrapper.find("[data-test='domain']").text()).toEqual("maas");
   });
 
-  it("renders host details for NUMA aligned machines", () => {
+  it("renders host details for machines", () => {
     const machine = machineDetailsFactory({ pod: { id: 1, name: "pod-1" } });
     const pod = podFactory({
       id: 1,
       name: "pod-1",
       type: PodType.LXD,
-      numa_pinning: [podNumaNodeFactory({ node_id: 10 })],
     });
 
     state.machine.items = [machine];
@@ -95,37 +93,7 @@ describe("DetailsCard", () => {
       </Provider>
     );
 
-    expect(wrapper.find("[data-test='host']").text()).toEqual(
-      "On NUMA node 10 of pod-1 ›"
-    );
-  });
-
-  it("renders host details for non-NUMA aligned machines", () => {
-    const machine = machineDetailsFactory({ pod: { id: 1, name: "pod-1" } });
-    const pod = podFactory({
-      id: 1,
-      name: "pod-1",
-      type: PodType.LXD,
-      numa_pinning: [],
-    });
-
-    state.machine.items = [machine];
-    state.pod.items = [pod];
-
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-        >
-          <DetailsCard machine={machine} />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(wrapper.find("[data-test='host']").text()).toEqual(
-      "Not NUMA-aligned on pod-1 ›"
-    );
+    expect(wrapper.find("[data-test='host']").text()).toEqual("pod-1 ›");
   });
 
   it("renders a link to zone configuration with edit permissions", () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineSummary/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -9,10 +9,6 @@ import { actions as generalActions } from "app/store/general";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
 import type { MachineDetails } from "app/store/machine/types";
 import { useCanEdit } from "app/store/machine/utils";
-import { actions as podActions } from "app/store/pod";
-import podSelectors from "app/store/pod/selectors";
-import { getPodNumaID } from "app/store/pod/utils";
-import type { RootState } from "app/store/root/types";
 
 type Props = {
   machine: MachineDetails;
@@ -22,14 +18,9 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const sendAnalytics = useSendAnalytics();
   const canEdit = useCanEdit(machine, true);
-
-  const pod = useSelector((state: RootState) =>
-    podSelectors.getById(state, machine?.pod?.id)
-  );
   const powerTypes = useSelector(powerTypesSelectors.get);
 
   const configTabUrl = `/machine/${machine.system_id}/configuration`;
-  const podNumaID = pod ? getPodNumaID(machine, pod) : null;
 
   const powerTypeDescription = powerTypes.find(
     (powerType) => powerType.name === machine.power_type
@@ -41,7 +32,6 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
 
   useEffect(() => {
     dispatch(generalActions.fetchPowerTypes());
-    dispatch(podActions.fetch());
   }, [dispatch]);
 
   return (
@@ -62,11 +52,6 @@ const DetailsCard = ({ machine }: Props): JSX.Element => {
         <div>
           <div className="u-text--muted">Host</div>
           <span data-test="host">
-            {podNumaID !== null ? (
-              <>On NUMA node {podNumaID} of </>
-            ) : (
-              <>Not NUMA-aligned on </>
-            )}
             <Link to={`/kvm/${machine.pod.id}`}>{machine.pod.name} ›</Link>
           </span>
         </div>

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -33,41 +33,6 @@ export type PodStoragePool = {
   used: number;
 };
 
-// TODO: Remove when resources key fully implemented
-export type NumaResource<T> = {
-  allocated: T;
-  free: T;
-};
-
-// TODO: Remove when resources key fully implemented
-export type NumaInterface = {
-  id: number;
-  name: string;
-  virtual_functions?: NumaResource<number>;
-};
-
-// TODO: Remove when resources key fully implemented
-export type NumaVM = {
-  networks: {
-    guest_nic_id: number;
-    host_nic_id: number;
-  };
-  pinned_cores: number[];
-  system_id: string;
-};
-
-// TODO: Remove when resources key fully implemented
-export type PodNumaNode = {
-  cores: NumaResource<number[]>;
-  interfaces: NumaInterface[];
-  memory: {
-    hugepages: (NumaResource<number> & { page_size: number })[];
-    general: NumaResource<number>;
-  };
-  node_id: number;
-  vms: NumaVM[];
-};
-
 export type PodResource = {
   allocated_other: number;
   allocated_tracked: number;
@@ -146,8 +111,6 @@ export type BasePod = Model & {
   ip_address: number | string;
   memory_over_commit_ratio: number;
   name: string;
-  // TODO: Remove when resources key fully implemented
-  numa_pinning?: PodNumaNode[];
   password?: string;
   permissions: string[];
   pool: number;

--- a/ui/src/app/store/pod/utils.ts
+++ b/ui/src/app/store/pod/utils.ts
@@ -1,4 +1,3 @@
-import type { Machine } from "app/store/machine/types";
 import type { Pod, PodNuma, PodResource } from "app/store/pod/types";
 import { PodType } from "app/store/pod/types";
 
@@ -11,23 +10,6 @@ export const formatHostType = (type: PodType): string => {
     default:
       return type;
   }
-};
-
-export const getPodNumaID = (machine: Machine, pod: Pod): number | null => {
-  if (pod?.numa_pinning) {
-    // If there is only one NUMA node on the VM host, then the VM must be
-    // aligned on that node even if it isn't specifically pinned.
-    if (pod.numa_pinning.length === 1) {
-      return pod.numa_pinning[0].node_id;
-    }
-    const podNuma = pod.numa_pinning.find((numa) =>
-      numa.vms.some((vm) => vm.system_id === machine.system_id)
-    );
-    if (podNuma) {
-      return podNuma.node_id;
-    }
-  }
-  return null;
 };
 
 /**

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -80,7 +80,6 @@ export {
   podNumaGeneralMemory,
   podNumaHugepageMemory,
   podNumaMemory,
-  podNumaNode,
   podProject,
   podResource,
   podResources,

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -36,7 +36,6 @@ import type {
   PodNuma,
   PodNumaHugepageMemory,
   PodNumaMemory,
-  PodNumaNode,
   PodNumaResource,
   PodProject,
   PodResource,
@@ -356,24 +355,6 @@ export const podStoragePool = define<PodStoragePool>({
   used: 300000000000,
 });
 
-// TODO: Remove when resources key fully implemented
-export const podNumaNode = define<PodNumaNode>({
-  cores: () => ({
-    allocated: [0, 2, 4, 6],
-    free: [1, 3],
-  }),
-  interfaces: () => [],
-  memory: () => ({
-    general: {
-      allocated: 10240,
-      free: 4068,
-    },
-    hugepages: [],
-  }),
-  node_id: () => random(),
-  vms: () => [],
-});
-
 export const podResource = define<PodResource>({
   allocated_other: 2,
   allocated_tracked: 1,
@@ -456,7 +437,6 @@ export const pod = extend<Model, Pod>(model, {
   ip_address: (i: number) => `192.168.1.${i}`,
   memory_over_commit_ratio: 8,
   name: (i: number) => `pod${i}`,
-  numa_pinning: () => [podNumaNode()],
   permissions,
   pool: 1,
   power_address: "qemu+ssh://ubuntu@127.0.0.1/system",


### PR DESCRIPTION
## Done

- Removed all instances of `pod.numa_pinning` from the codebase
- Removed `getPodNumaID` util which only works when the `pod` is active with the new `resources` structure. I think this is okay, because the NUMA-alignment message was added before we even had the KVM NUMA node view. Now it's much easier to see NUMA resource usage.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page of a machine that is in a pod and check that under "Host" it just displays the name of the pod a link to it.

## Fixes

Fixes #2626 
