### PR TITLE
fix(ui): fix the alignment of previous tests

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineTests/MachineTestsTable/index.scss
@@ -28,7 +28,7 @@
       flex: 0 0 4.5rem;
     }
 
-    .p-table-expanding__panel {
+    .p-table__expanding-panel {
       margin-left: 0;
       margin-right: 0;
       padding-left: 0;


### PR DESCRIPTION
## Done

- Fix the padding around the previous tests table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the tests tab for a machine that has run tests multiple times.
- Use the row action menu for a test result to open the previous tests.
- The table of previous tests should line up with the parent results.

## Fixes

Fixes: #2625.