### PR TITLE
fix(ui): disable filesystems action menu when not editable

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.test.tsx
@@ -436,4 +436,30 @@ describe("FilesystemsTable", () => {
       type: "machine/updateFilesystem",
     });
   });
+
+  it("disables the action menu when storage can't be edited", () => {
+    const filesystem = fsFactory({ mount_point: "/disk-fs/path" });
+    const partition = partitionFactory({ filesystem });
+    const disk = diskFactory({ filesystem: null, partitions: [partition] });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [
+          machineDetailsFactory({
+            disks: [disk],
+            system_id: "abc123",
+          }),
+        ],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <FilesystemsTable canEditStorage={false} systemId="abc123" />
+      </Provider>
+    );
+    expect(wrapper.find("TableActionsDropdown").prop("disabled")).toBe(true);
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/FilesystemsTable.tsx
@@ -50,7 +50,8 @@ const normaliseRowData = (
   fs: Filesystem,
   storageDevice: Disk | Partition | null,
   expanded: Expanded | null,
-  setExpanded: (expanded: Expanded | null) => void
+  setExpanded: (expanded: Expanded | null) => void,
+  canEditStorage: Props["canEditStorage"]
 ) => {
   const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
 
@@ -77,6 +78,7 @@ const normaliseRowData = (
                 type: FilesystemAction.DELETE,
               },
             ]}
+            disabled={!canEditStorage}
             onActionClick={(action: FilesystemAction) =>
               setExpanded({ content: action, id: rowId })
             }
@@ -110,7 +112,14 @@ const FilesystemsTable = ({
         const rowId = `${diskFs.fstype}-${diskFs.id}`;
 
         rows.push({
-          ...normaliseRowData(rowId, diskFs, disk, expanded, setExpanded),
+          ...normaliseRowData(
+            rowId,
+            diskFs,
+            disk,
+            expanded,
+            setExpanded,
+            canEditStorage
+          ),
           expandedContent: (
             <div className="u-flex--grow">
               {expanded?.content === FilesystemAction.DELETE && (
@@ -182,7 +191,8 @@ const FilesystemsTable = ({
                 partitionFs,
                 partition,
                 expanded,
-                setExpanded
+                setExpanded,
+                canEditStorage
               ),
               expandedContent: (
                 <div className="u-flex--grow">
@@ -250,7 +260,14 @@ const FilesystemsTable = ({
         const rowId = `${specialFs.fstype}-${specialFs.id}`;
 
         rows.push({
-          ...normaliseRowData(rowId, specialFs, null, expanded, setExpanded),
+          ...normaliseRowData(
+            rowId,
+            specialFs,
+            null,
+            expanded,
+            setExpanded,
+            canEditStorage
+          ),
           expandedContent: (
             <div className="u-flex--grow">
               {expanded?.content === FilesystemAction.DELETE && (


### PR DESCRIPTION
## Done

- Disable the action menus in the filesystems table when the machine is not ready or allocated.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Find (or set up) a machine that is not ready or allocated and has an entry in the 'Filesystems' table (in the storage tab of machine details).
- Check that the action menu is disabled for the filesystem row.

## Fixes

Fixes: #2630.