### PR TITLE
fix(ui): round free storage values down in machine details

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
@@ -46,11 +46,13 @@ const generateSchema = (availableSize: number) =>
         const { size, unit } = values;
         const sizeInBytes = formatBytes(size, unit, {
           convertTo: "B",
+          roundFunc: "floor",
         }).value;
 
         if (sizeInBytes < MIN_PARTITION_SIZE) {
           const min = formatBytes(MIN_PARTITION_SIZE, "B", {
             convertTo: unit,
+            roundFunc: "floor",
           }).value;
           return this.createError({
             message: `At least ${min}${unit} is required to add a logical volume`,
@@ -61,6 +63,7 @@ const generateSchema = (availableSize: number) =>
         if (sizeInBytes > availableSize) {
           const max = formatBytes(availableSize, "B", {
             convertTo: unit,
+            roundFunc: "floor",
           }).value;
           return this.createError({
             message: `Only ${max}${unit} available in this volume group`,
@@ -108,8 +111,10 @@ export const AddLogicalVolume = ({
           mountOptions: "",
           mountPoint: "",
           name: initialName,
-          size: formatBytes(disk.available_size, "B", { convertTo: "GB" })
-            .value,
+          size: formatBytes(disk.available_size, "B", {
+            convertTo: "GB",
+            roundFunc: "floor",
+          }).value,
           tags: [],
           unit: "GB",
         }}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -43,11 +43,13 @@ const generateSchema = (availableSize: number) =>
         const { partitionSize, unit } = values;
         const sizeInBytes = formatBytes(partitionSize, unit, {
           convertTo: "B",
+          roundFunc: "floor",
         }).value;
 
         if (sizeInBytes < MIN_PARTITION_SIZE) {
           const min = formatBytes(MIN_PARTITION_SIZE, "B", {
             convertTo: unit,
+            roundFunc: "floor",
           }).value;
           return this.createError({
             message: `At least ${min}${unit} is required to partition this disk`,
@@ -58,6 +60,7 @@ const generateSchema = (availableSize: number) =>
         if (sizeInBytes > availableSize) {
           const max = formatBytes(availableSize, "B", {
             convertTo: unit,
+            roundFunc: "floor",
           }).value;
           return this.createError({
             message: `Only ${max}${unit} available in this disk`,
@@ -104,6 +107,7 @@ export const AddPartition = ({
           mountPoint: "",
           partitionSize: formatBytes(disk.available_size, "B", {
             convertTo: "GB",
+            roundFunc: "floor",
           }).value,
           unit: "GB",
         }}

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -249,7 +249,7 @@ export const diskAvailable = (disk: Disk | null): boolean => {
  * @returns formatted size string.
  */
 export const formatSize = (size: number | null): string => {
-  const formatted = !!size && formatBytes(size, "B");
+  const formatted = !!size && formatBytes(size, "B", { roundFunc: "floor" });
   return formatted ? `${formatted.value} ${formatted.unit}` : "—";
 };
 

--- a/ui/src/app/utils/formatBytes.test.ts
+++ b/ui/src/app/utils/formatBytes.test.ts
@@ -11,31 +11,46 @@ describe("formatBytes", () => {
     expect(formatBytes(0.1, "MB")).toStrictEqual({ value: 100, unit: "KB" });
   });
 
-  it("returns the value to the correct precision", () => {
-    expect(formatBytes(1234, "B", { precision: 1 })).toStrictEqual({
+  it("rounds the value to 2 decimal places by default", () => {
+    expect(formatBytes(1234, "B")).toStrictEqual({
+      value: 1.23,
+      unit: "KB",
+    });
+    expect(formatBytes(1236, "B")).toStrictEqual({
+      value: 1.24,
+      unit: "KB",
+    });
+  });
+
+  it("can round to different decimal places", () => {
+    expect(formatBytes(1234, "B", { decimals: 0 })).toStrictEqual({
       value: 1,
       unit: "KB",
     });
-    expect(formatBytes(1234, "B", { precision: 2 })).toStrictEqual({
+    expect(formatBytes(1234, "B", { decimals: 1 })).toStrictEqual({
       value: 1.2,
       unit: "KB",
     });
-    expect(formatBytes(1234, "B", { precision: 4 })).toStrictEqual({
+    expect(formatBytes(1234, "B", { decimals: 2 })).toStrictEqual({
+      value: 1.23,
+      unit: "KB",
+    });
+    expect(formatBytes(1234, "B", { decimals: 3 })).toStrictEqual({
       value: 1.234,
       unit: "KB",
     });
-    expect(formatBytes(123, "B", { precision: 1 })).toStrictEqual({
-      value: 123,
-      unit: "B",
+  });
+
+  it("can be forced to round result down", () => {
+    expect(formatBytes(1236, "B", { roundFunc: "floor" })).toStrictEqual({
+      value: 1.23,
+      unit: "KB",
     });
-    expect(formatBytes(0.123, "KB", { precision: 1 })).toStrictEqual({
-      value: 123,
-      unit: "B",
-    });
-    expect(
-      formatBytes(1234000, "B", { convertTo: "KB", precision: 1 })
-    ).toStrictEqual({
-      value: 1234, // Precision is ignored if converting to higher value and is integer
+  });
+
+  it("can be forced to round result up", () => {
+    expect(formatBytes(1234, "B", { roundFunc: "ceil" })).toStrictEqual({
+      value: 1.24,
       unit: "KB",
     });
   });
@@ -45,9 +60,7 @@ describe("formatBytes", () => {
       value: 0,
       unit: "B",
     });
-    expect(
-      formatBytes(1023, "MiB", { binary: true, precision: 4 })
-    ).toStrictEqual({
+    expect(formatBytes(1023, "MiB", { binary: true })).toStrictEqual({
       value: 1023,
       unit: "MiB",
     });
@@ -66,7 +79,7 @@ describe("formatBytes", () => {
       value: -2,
       unit: "GB",
     });
-    expect(formatBytes(-1234, "GB", { precision: 4 })).toStrictEqual({
+    expect(formatBytes(-1234, "GB", { decimals: 3 })).toStrictEqual({
       value: -1.234,
       unit: "TB",
     });
@@ -89,11 +102,15 @@ describe("formatBytes", () => {
       value: 1,
       unit: "MB",
     });
-    expect(formatBytes(1000000, "B", { convertTo: "GB" })).toStrictEqual({
+    expect(
+      formatBytes(1000000, "B", { convertTo: "GB", decimals: 3 })
+    ).toStrictEqual({
       value: 0.001,
       unit: "GB",
     });
-    expect(formatBytes(1000000, "B", { convertTo: "TB" })).toStrictEqual({
+    expect(
+      formatBytes(1000000, "B", { convertTo: "TB", decimals: 6 })
+    ).toStrictEqual({
       value: 0.000001,
       unit: "TB",
     });


### PR DESCRIPTION
## Done

- Updated formatBytes to be able to change rounding direction. Removed toPrecision which was a bit
too unreliable and inconsistent.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a Ready or Allocated machine (e.g. /MAAS/r/machine/bx7taq/storage on bolla)
- Create a partition of size 1001MB
- Check that the free space correctly rounds down
- Open the add partition form again and check that it auto-fills with the rounded-down value
- Run the same tests but with logical volumes (create partition -> create volume group -> add logical volume)

## Fixes

Fixes #2396 
Fixes #2612 
