### PR TITLE
fix(ui): fix loading urls with querystrings

### DIFF
--- a/ui/src/single-spa-entry.js
+++ b/ui/src/single-spa-entry.js
@@ -4,6 +4,7 @@ import singleSpaReact from "single-spa-react";
 
 import packageJson from "../package.json";
 import rootComponent from "./index";
+import { BASENAME, REACT_BASENAME } from "@maas-ui/maas-ui-shared";
 
 const reactLifecycles = singleSpaReact({
   React,
@@ -26,10 +27,18 @@ const reactLifecycles = singleSpaReact({
 
 export const { bootstrap } = reactLifecycles;
 export const mount = (props) => {
+  // Get the full path, querystring and hash. The regex gets the first
+  // forward slash that is not a double forward slash and everything after it.
+  const matches = window.location.href.match(/(?<!\/)\/(?!\/).+/);
+  // The app should never reach this entrypoint witout the basename and react
+  // path set, but to prevent possible future problems this sets the path if
+  // there isn't one already.
+  let currentURL =
+    matches && matches.length ? matches[0] : `/${BASENAME}/${REACT_BASENAME}`;
   // When the app is mounted there needs to be a history change so that
-  // react-router updates with the new url. This is requried when navigating
+  // react-router updates with the new url. This is re-queried when navigating
   // between the new/legacy clients.
-  window.history.replaceState(null, null, window.location.pathname);
+  window.history.replaceState(null, null, currentURL);
   return reactLifecycles.mount(props);
 };
 export const { unmount } = reactLifecycles;


### PR DESCRIPTION
## Done

- Fix updating the url when the React app loads so that it doesn't remove the querystring.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click on AZs in the header.
- In the machines column click one of the numbers.
- You should get taken to the machine list and the zone should be filtered.

## Fixes

Fixes: #2614.