### PR TITLE
fix(ui): correctly parse script creation date in settings

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -62,7 +62,7 @@
     "serve": "yarn run start",
     "build": "REACT_APP_STANDALONE=false react-app-rewired build && rm -rf dist && mv build dist",
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
-    "test": "react-scripts test",
+    "test": "TZ=UTC react-scripts test",
     "eject": "react-scripts eject",
     "betterer": "betterer",
     "lint": "yarn lint-package-json && yarn lint-js",

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -245,4 +245,54 @@ describe("ScriptsList", () => {
       true
     );
   });
+
+  it("correctly formats script creation date", () => {
+    const state = rootStateFactory({
+      script: scriptStateFactory({
+        loaded: true,
+        items: [
+          scriptFactory({
+            created: "Thu, 31 Dec. 2020 22:59:00",
+            script_type: ScriptType.TESTING,
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <ScriptsList type="testing" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='upload-date']").text()).toBe(
+      "2020-12-31 22:59"
+    );
+  });
+
+  it("formats script creation date as 'Never' if date cannot be parsed", () => {
+    const state = rootStateFactory({
+      script: scriptStateFactory({
+        loaded: true,
+        items: [
+          scriptFactory({
+            created: "",
+            script_type: ScriptType.TESTING,
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+          <ScriptsList type="testing" />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='upload-date']").text()).toBe("Never");
+  });
 });

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -38,7 +38,11 @@ const generateRows = (
     let uploadedOn: string;
     try {
       uploadedOn = format(
-        parse(script.created, "EEE, dd LLL yyyy HH:mm:ss xxxx", new Date()),
+        parse(
+          `${script.created} +00`, // let parse fn know it's UTC
+          "E, dd LLL. yyyy HH:mm:ss x",
+          new Date()
+        ),
         "yyyy-LL-dd H:mm"
       );
     } catch (error) {
@@ -65,7 +69,7 @@ const generateRows = (
         {
           content: script.description,
         },
-        { content: uploadedOn },
+        { content: <span data-test="upload-date">{uploadedOn}</span> },
         {
           content: (
             <TableActions


### PR DESCRIPTION
## Done

- Correctly parse script creation date in settings

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Settings > Testing scripts and check that the scripts have an uploaded date (i.e. they're not all "Never")
- Upload a script and check that the uploaded date is displayed as the current time in your timezone.

## Fixes

Fixes #2642 
