### PR TITLE
fix(ui): preselect first PXE network when defining composed VM interface

### DIFF
--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -104,7 +104,11 @@ describe("SubnetSelect", () => {
       subnetFactory({ space: spaces[0].id, vlan: 1 }),
       subnetFactory({ space: spaces[1].id, vlan: 1 }),
     ];
-    const pod = podDetailsFactory({ attached_vlans: [1], id: 1 });
+    const pod = podDetailsFactory({
+      attached_vlans: [1],
+      boot_vlans: [1],
+      id: 1,
+    });
     const state = { ...initialState };
     state.pod.items = [pod];
     state.space.items = spaces;
@@ -134,7 +138,11 @@ describe("SubnetSelect", () => {
       subnetFactory({ space: space.id, vlan: 1 }),
       subnetFactory({ space: null, vlan: 1 }),
     ];
-    const pod = podDetailsFactory({ attached_vlans: [1], id: 1 });
+    const pod = podDetailsFactory({
+      attached_vlans: [1],
+      boot_vlans: [1],
+      id: 1,
+    });
     const state = { ...initialState };
     state.pod.items = [pod];
     state.space.items = [space];

--- a/ui/src/app/store/subnet/selectors.test.ts
+++ b/ui/src/app/store/subnet/selectors.test.ts
@@ -60,4 +60,22 @@ describe("subnet selectors", () => {
     });
     expect(subnet.getByPod(state, pod)).toStrictEqual([subnets[0], subnets[1]]);
   });
+
+  it("can get PXE-enabled subnets that are available to a given pod", () => {
+    const subnets = [
+      subnetFactory({ vlan: 1 }),
+      subnetFactory({ vlan: 2 }),
+      subnetFactory({ vlan: 3 }),
+    ];
+    const pod = podDetailsFactory({ boot_vlans: [1, 2] });
+    const state = rootStateFactory({
+      subnet: subnetStateFactory({
+        items: subnets,
+      }),
+    });
+    expect(subnet.getPxeEnabledByPod(state, pod)).toStrictEqual([
+      subnets[0],
+      subnets[1],
+    ]);
+  });
 });

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -32,6 +32,22 @@ const getByPod = createSelector(
   }
 );
 
-const selectors = { ...defaultSelectors, getByPod };
+/**
+ * Get PXE-enabled subnets that are available to a given pod.
+ * @param {RootState} state - The redux state.
+ * @param {Pod} pod - The pod to query.
+ * @returns {Subnet[]} PXE-enabled subnets that are available to a given pod.
+ */
+const getPxeEnabledByPod = createSelector(
+  [defaultSelectors.all, (_state: RootState, pod: PodDetails) => pod],
+  (subnets, pod) => {
+    if (!pod) {
+      return [];
+    }
+    return subnets.filter((subnet) => pod.boot_vlans?.includes(subnet.vlan));
+  }
+);
+
+const selectors = { ...defaultSelectors, getByPod, getPxeEnabledByPod };
 
 export default selectors;


### PR DESCRIPTION
## Done

- Preselect first PXE network when defining composed VM interface

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a KVM details page and open the Compose VM form
- Click the button to define an interface
- Check that the first available PXE network (i.e. one with a green tick) is preselected

## Fixes

Fixes #2647 
