### PR TITLE
feat(legacy): display snap upgrade errors

### DIFF
--- a/legacy/src/app/controllers/nodes_list.js
+++ b/legacy/src/app/controllers/nodes_list.js
@@ -895,12 +895,21 @@ function NodesListController(
       const chunks = versions.snap_cohort.match(/.{1,41}/g) || [];
       cohortKey = chunks.map((chunk) => chunk.trim()).join(" \n");
     }
+    // Map the issue id to the type of issue.
+    const issues = (versions.issues || []).map((issue) =>
+      issue.replace("different-", "")
+    );
     return {
       origin: versions.origin || null,
       cohortTooltip: cohortKey ? `Cohort key: \n${cohortKey}` : null,
       current: (versions.current && versions.current.version) || null,
       isDeb: versions.install_type === "deb",
-      update: (versions.update && versions.update.version) || null,
+      issue: issues.length
+        ? `Different ${issues.join(" and ")} detected.`
+        : null,
+      upgrade: versions.up_to_date
+        ? "Up-to-date"
+        : (versions.update && versions.update.version) || null,
     };
   };
 

--- a/legacy/src/app/controllers/tests/test_nodes_list.js
+++ b/legacy/src/app/controllers/tests/test_nodes_list.js
@@ -1459,7 +1459,8 @@ describe("NodesListController", function () {
         cohortTooltip: `Cohort key: \nMSBzaFkyMllUWjNSaEpKRE9qME1mbVNoVE5aVEViM \nUppcSAxNjE3MTgyOTcxIGJhM2VlYzQ2NDc5ZDdmNT \nI3NzIzNTUyMmRlOTc1MGIzZmNhYTI0MDE1MTQ3ZjV \nhM2ViNzQwZGZmYzk5OWFiYWU=`,
         current: "1.2.3",
         isDeb: false,
-        update: "1.2.4",
+        issue: null,
+        upgrade: "1.2.4",
       });
     });
 
@@ -1471,7 +1472,8 @@ describe("NodesListController", function () {
         cohortTooltip: null,
         current: null,
         isDeb: false,
-        update: null,
+        issue: null,
+        upgrade: null,
       });
     });
 
@@ -1485,7 +1487,8 @@ describe("NodesListController", function () {
         cohortTooltip: null,
         current: null,
         isDeb: false,
-        update: null,
+        issue: null,
+        upgrade: null,
       });
     });
 
@@ -1502,7 +1505,8 @@ describe("NodesListController", function () {
         cohortTooltip: null,
         current: null,
         isDeb: false,
-        update: null,
+        issue: null,
+        upgrade: null,
       });
     });
 
@@ -1524,6 +1528,62 @@ describe("NodesListController", function () {
         },
       };
       expect($scope.getVersions(controller).isDeb).toBe(false);
+    });
+
+    it("handles up to date controllers", () => {
+      makeController();
+      const controller = {
+        versions: {
+          up_to_date: true,
+        },
+      };
+      expect($scope.getVersions(controller).upgrade).toBe("Up-to-date");
+    });
+
+    it("handles no issues", () => {
+      makeController();
+      const controller = {
+        versions: {
+          issues: [],
+        },
+      };
+      expect($scope.getVersions(controller).issue).toBe(null);
+    });
+
+    it("handles the different cohort issue", () => {
+      makeController();
+      const controller = {
+        versions: {
+          issues: ["different-cohort"],
+        },
+      };
+      expect($scope.getVersions(controller).issue).toBe(
+        "Different cohort detected."
+      );
+    });
+
+    it("handles the different channel issue", () => {
+      makeController();
+      const controller = {
+        versions: {
+          issues: ["different-channel"],
+        },
+      };
+      expect($scope.getVersions(controller).issue).toBe(
+        "Different channel detected."
+      );
+    });
+
+    it("handles both the different channel and cohort issues", () => {
+      makeController();
+      const controller = {
+        versions: {
+          issues: ["different-channel", "different-cohort"],
+        },
+      };
+      expect($scope.getVersions(controller).issue).toBe(
+        "Different channel and cohort detected."
+      );
     });
   });
 

--- a/legacy/src/app/partials/nodes-list.html
+++ b/legacy/src/app/partials/nodes-list.html
@@ -1331,12 +1331,26 @@ sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ ta
                 >
               </a>
             </td>
-            <td
-              class="p-table__cell u-align--center"
-              data-maas-controller-status="controller"
-              data-maas-services="services"
-              aria-label="Status"
-            ></td>
+            <td class="p-table__cell u-align--center">
+              <span
+                data-maas-controller-status="controller"
+                data-maas-services="services"
+                data-ng-if="!getVersions(controller).issue"
+                aria-label="Status"
+              ></span>
+              <span data-ng-if="getVersions(controller).issue">
+                <i class="p-icon--error"></i
+                ><span class="p-tooltip--top-center status-icon--negative-space"
+                  ><i class="p-icon--information u-no-margin--right"></i
+                  ><span class="p-tooltip__message" role="tooltip"
+                    >{$ getVersions(controller).issue $}&#xa;<a
+                      href="https://discourse.maas.io/t/4555"
+                      >More info</a
+                    ></span
+                  >
+                </span>
+              </span>
+            </td>
             <td
               class="p-table__cell"
               aria-label="Type"
@@ -1409,10 +1423,10 @@ sudo maas init rack --maas-url {$ tabs.controllers.registerUrl $} --secret {$ ta
             </td>
             <td class="p-table__cell" aria-label="Available upgrade">
               <div
-                data-ng-if="getVersions(controller).update"
-                title="{$ getVersions(controller).update $}"
+                data-ng-if="getVersions(controller).upgrade"
+                title="{$ getVersions(controller).upgrade $}"
               >
-                {$ getVersions(controller).update $}
+                {$ getVersions(controller).upgrade $}
               </div>
             </td>
             <td

--- a/legacy/src/scss/tables/_patterns_table-controllers.scss
+++ b/legacy/src/scss/tables/_patterns_table-controllers.scss
@@ -31,6 +31,11 @@
         }
       }
     }
+
+    .status-icon--negative-space {
+      margin-left: $sph-inner--x-small;
+      margin-right: -($sph-inner + $sph-inner--x-small);
+    }
   }
 
   .p-table--controller-interfaces {

--- a/ui/src/app/store/controller/types.ts
+++ b/ui/src/app/store/controller/types.ts
@@ -8,6 +8,11 @@ export enum ControllerInstallType {
   DEB = "deb",
 }
 
+export enum ControllerVersionIssues {
+  DIFFERENT_CHANNEL = "different-channel",
+  DIFFERENT_COHORT = "different-cohort",
+}
+
 export type ControllerVersionInfo = {
   snap_revision?: string;
   version: string;
@@ -18,7 +23,9 @@ export type ControllerVersions = {
   install_type?: ControllerInstallType;
   origin: string;
   snap_cohort?: string;
+  up_to_date: boolean;
   update?: ControllerVersionInfo;
+  issues: ControllerVersionIssues[];
 };
 
 export type ControllerVlansHA = {


### PR DESCRIPTION
Backport: https://github.com/canonical-web-and-design/maas-ui/pull/2616

QA:
- Point your UI to Bolla.
- Visit the controllers page.
- In the status column there should be an (i) icon. Hovering it should show the error.
- In the upgrade column it should read "Up-to-date".