### PR TITLE
feat(ui): replace legacy pod websocket fields with 'resources' equivalents (backport 3.0)

### DIFF
--- a/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetails.test.tsx
@@ -9,7 +9,9 @@ import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
+  podVmCount as podVmCountFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -28,7 +30,9 @@ describe("KVMDetails", () => {
           podFactory({
             id: 1,
             name: "pod-1",
-            composed_machines_count: 10,
+            resources: podResourcesFactory({
+              vm_count: podVmCountFactory({ tracked: 10 }),
+            }),
           }),
         ],
       }),

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -9,7 +9,9 @@ import { PodType } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
+  podVmCount as podVmCountFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -28,7 +30,9 @@ describe("KVMDetailsHeader", () => {
           podFactory({
             id: 1,
             name: "pod-1",
-            composed_machines_count: 10,
+            resources: podResourcesFactory({
+              vm_count: podVmCountFactory({ tracked: 10 }),
+            }),
           }),
         ],
       }),
@@ -80,9 +84,16 @@ describe("KVMDetailsHeader", () => {
     );
   });
 
-  it("can display composed machines count", () => {
+  it("can display the tracked VMs count", () => {
     const state = { ...initialState };
-    state.pod.items = [podFactory({ id: 1, composed_machines_count: 5 })];
+    state.pod.items = [
+      podFactory({
+        id: 1,
+        resources: podResourcesFactory({
+          vm_count: podVmCountFactory({ tracked: 5 }),
+        }),
+      }),
+    ];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -34,6 +34,7 @@ const KVMDetailsHeader = ({
   );
   const pathname = location.pathname;
   const previousPathname = usePrevious(pathname);
+  const vmCount = pod?.resources?.vm_count?.tracked || 0;
 
   useEffect(() => {
     dispatch(podActions.fetch());
@@ -67,9 +68,7 @@ const KVMDetailsHeader = ({
         )) ||
         undefined
       }
-      subtitle={`${pod?.composed_machines_count || 0} VM${
-        pod?.composed_machines_count === 1 ? "" : "s"
-      } available`}
+      subtitle={`${vmCount} VM${vmCount === 1 ? "" : "s"} available`}
       tabLinks={[
         ...(pod?.type === PodType.LXD
           ? [

--- a/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/StorageResources/StorageResources.tsx
@@ -23,9 +23,10 @@ const StorageResources = ({ id }: Props): JSX.Element | null => {
     return null;
   }
 
-  const total = formatBytes(pod.total.local_storage, "B");
-  const free = formatBytes(
-    pod.total.local_storage - pod.used.local_storage,
+  const { allocated_other, allocated_tracked, free } = pod.resources.storage;
+  const freeStorage = formatBytes(free, "B");
+  const totalStorage = formatBytes(
+    allocated_other + allocated_tracked + free,
     "B"
   );
 
@@ -39,15 +40,15 @@ const StorageResources = ({ id }: Props): JSX.Element | null => {
           <div className="u-nudge-left">
             <div className="p-heading--small u-text--muted">Total</div>
             <div className="u-nudge-right u-sv1">
-              {total.value}
-              {total.unit}
+              {totalStorage.value}
+              {totalStorage.unit}
             </div>
           </div>
           <div className="u-nudge-left">
             <div className="p-heading--small u-text--muted">Free</div>
             <div className="u-nudge-right u-sv1">
-              {free.value}
-              {free.unit}
+              {freeStorage.value}
+              {freeStorage.unit}
             </div>
           </div>
         </div>

--- a/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
+++ b/ui/src/app/kvm/views/KVMList/LxdTable/LxdTable.tsx
@@ -27,11 +27,11 @@ type LxdTableRow = {
   key: Pod["id"];
 };
 
-type SortKey = keyof Pod | "cpu" | "pool" | "ram" | "storage";
+type SortKey = keyof Pod | "cpu" | "pool" | "ram" | "storage" | "vms";
 
 const getSortValue = (sortKey: SortKey, pod: Pod, pools: ResourcePool[]) => {
   const { resources } = pod;
-  const { cores, memory } = resources;
+  const { cores, memory, storage, vm_count } = resources;
   const pool = pools.find((pool) => pod.pool === pool.id);
 
   switch (sortKey) {
@@ -44,7 +44,9 @@ const getSortValue = (sortKey: SortKey, pod: Pod, pools: ResourcePool[]) => {
         memory.general.allocated_tracked + memory.hugepages.allocated_tracked
       );
     case "storage":
-      return pod.used.local_storage;
+      return storage.allocated_tracked;
+    case "vms":
+      return vm_count.tracked;
     default:
       return pod[sortKey];
   }
@@ -166,8 +168,8 @@ const LxdTable = (): JSX.Element => {
                   <TableHeader
                     currentSort={currentSort}
                     data-test="vms-header"
-                    onClick={() => updateSort("composed_machines_count")}
-                    sortKey="composed_machines_count"
+                    onClick={() => updateSort("vms")}
+                    sortKey="vms"
                   >
                     VM<span className="u-no-text-transform">s</span>
                   </TableHeader>

--- a/ui/src/app/kvm/views/KVMList/StorageColumn/StorageColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/StorageColumn/StorageColumn.test.tsx
@@ -6,7 +6,8 @@ import StorageColumn from "./StorageColumn";
 
 import {
   pod as podFactory,
-  podHint as podHintFactory,
+  podResource as podResourceFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
@@ -21,11 +22,12 @@ describe("StorageColumn", () => {
           podFactory({
             id: 1,
             name: "pod-1",
-            total: podHintFactory({
-              local_storage: 1000000000000,
-            }),
-            used: podHintFactory({
-              local_storage: 100000000000,
+            resources: podResourcesFactory({
+              storage: podResourceFactory({
+                allocated_other: 30000000000,
+                allocated_tracked: 70000000000,
+                free: 900000000000,
+              }),
             }),
           }),
         ],

--- a/ui/src/app/kvm/views/KVMList/StorageColumn/StorageColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/StorageColumn/StorageColumn.tsx
@@ -18,9 +18,12 @@ const StorageColumn = ({ id }: Props): JSX.Element | null => {
   );
 
   if (pod) {
-    const availableStorage = formatBytes(pod.total.local_storage, "B");
-    const allocatedStorage = formatBytes(pod.used.local_storage, "B", {
-      convertTo: availableStorage.unit,
+    const { allocated_other, allocated_tracked, free } = pod.resources.storage;
+    const totalInBytes = allocated_other + allocated_tracked + free;
+    const totalStorage = formatBytes(totalInBytes, "B", { decimals: 1 });
+    const allocatedStorage = formatBytes(allocated_tracked, "B", {
+      convertTo: totalStorage.unit,
+      decimals: 1,
     });
 
     return (
@@ -32,16 +35,16 @@ const StorageColumn = ({ id }: Props): JSX.Element | null => {
           className="u-no-margin--bottom"
           data={[
             {
-              value: pod.used.local_storage,
+              value: allocated_tracked,
             },
           ]}
           label={
             <small className="u-text--light">
-              {`${allocatedStorage.value} of ${availableStorage.value} ${availableStorage.unit} allocated`}
+              {`${allocatedStorage.value} of ${totalStorage.value} ${totalStorage.unit} allocated`}
             </small>
           }
           labelClassName="u-align--right"
-          max={pod.total.local_storage}
+          max={totalInBytes}
           small
         />
       </StoragePopover>

--- a/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.test.tsx
@@ -5,32 +5,30 @@ import configureStore from "redux-mock-store";
 import VMsColumn from "./VMsColumn";
 
 import { PodType } from "app/store/pod/types";
-import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
+  podResources as podResourcesFactory,
   podState as podStateFactory,
+  podVmCount as podVmCountFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("VMsColumn", () => {
-  let state: RootState;
-
-  beforeEach(() => {
-    state = rootStateFactory({
+  it("displays the pod's tracked VMs", () => {
+    const state = rootStateFactory({
       pod: podStateFactory({
         items: [
           podFactory({
-            composed_machines_count: 10,
-            owners_count: 5,
+            id: 1,
+            resources: podResourcesFactory({
+              vm_count: podVmCountFactory({ tracked: 10 }),
+            }),
           }),
         ],
       }),
     });
-  });
-
-  it("displays the pod's VM count", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -41,9 +39,12 @@ describe("VMsColumn", () => {
   });
 
   it("shows the pod version for LXD pods", () => {
-    state.pod.items = [
-      podFactory({ id: 1, type: PodType.LXD, version: "1.2.3" }),
-    ];
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ id: 1, type: PodType.LXD, version: "1.2.3" })],
+      }),
+    });
+
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.tsx
+++ b/ui/src/app/kvm/views/KVMList/VMsColumn/VMsColumn.tsx
@@ -18,7 +18,7 @@ const VMsColumn = ({ id }: Props): JSX.Element | null => {
       <DoubleRow
         primary={
           <span data-test="pod-machines-count">
-            {pod.composed_machines_count}
+            {pod.resources.vm_count.tracked}
           </span>
         }
         primaryClassName="u-align--right"

--- a/ui/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
+++ b/ui/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
@@ -66,8 +66,8 @@ describe("VirshTable", () => {
 
   it("can sort by parameters of the pods themselves", () => {
     const state = { ...initialState };
-    state.pod.items[0].composed_machines_count = 1;
-    state.pod.items[1].composed_machines_count = 2;
+    state.pod.items[0].resources.vm_count.tracked = 1;
+    state.pod.items[1].resources.vm_count.tracked = 2;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -93,7 +93,7 @@ describe("VirshTable", () => {
     expect(
       wrapper.find('[data-test="vms-header"]').prop("currentSort")
     ).toStrictEqual({
-      key: "composed_machines_count",
+      key: "vms",
       direction: "descending",
     });
     expect(getName(0)).toBe(firstPod.name);
@@ -103,7 +103,7 @@ describe("VirshTable", () => {
     expect(
       wrapper.find('[data-test="vms-header"]').prop("currentSort")
     ).toStrictEqual({
-      key: "composed_machines_count",
+      key: "vms",
       direction: "ascending",
     });
     expect(getName(0)).toBe(secondPod.name);

--- a/ui/src/app/kvm/views/KVMList/VirshTable/_index.scss
+++ b/ui/src/app/kvm/views/KVMList/VirshTable/_index.scss
@@ -5,7 +5,7 @@
     }
 
     .vms-col {
-      @include breakpoint-widths(0, 0, 0, 0, 3.5rem);
+      @include breakpoint-widths(0, 0, 0, 0, 4rem);
     }
 
     .tags-col {

--- a/ui/src/app/store/pod/types.ts
+++ b/ui/src/app/store/pod/types.ts
@@ -8,21 +8,6 @@ export enum PodType {
   VIRSH = "virsh",
 }
 
-export type PodHint = {
-  cores: number;
-  local_storage: number;
-  local_storage_gb: string;
-  memory: number;
-  memory_gb: string;
-};
-
-export type PodHintExtras = {
-  cpu_speed: number;
-  iscsi_storage: number;
-  iscsi_storage_gb: string;
-  local_disks: number;
-};
-
 export type PodStoragePool = {
   available: number;
   id: string;
@@ -80,11 +65,18 @@ export type PodNuma = {
   vms: PodVM["id"][];
 };
 
+export type PodVmCount = {
+  tracked: number;
+  other: number;
+};
+
 export type PodResources = {
   cores: PodResource;
   interfaces: PodNetworkInterface[];
   memory: PodMemoryResource;
   numa: PodNuma[];
+  storage: PodResource;
+  vm_count: PodVmCount;
   vms: PodVM[];
 };
 
@@ -98,15 +90,12 @@ export type LxdServerGroup = {
 // on the backend to reduce the amount of database queries on list pages.
 export type BasePod = Model & {
   architectures: string[];
-  available: PodHint;
   capabilities: string[];
-  composed_machines_count: number;
   cpu_over_commit_ratio: number;
   cpu_speed: number;
   created: string;
   default_macvlan_mode: string;
   default_storage_pool: string | null;
-  hints: PodHint & PodHintExtras;
   host: string | null;
   ip_address: number | string;
   memory_over_commit_ratio: number;
@@ -119,13 +108,10 @@ export type BasePod = Model & {
   // Only LXD pods have the project parameter.
   project?: string;
   resources: PodResources;
-  owners_count: number;
   storage_pools: PodStoragePool[];
   tags: string[];
-  total: PodHint;
   type: PodType;
   updated: string;
-  used: PodHint;
   version: string;
   zone: number;
 };

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -72,7 +72,6 @@ export {
   networkLink,
   pod,
   podDetails,
-  podHint,
   podMemoryResource,
   podNetworkInterface,
   podNuma,
@@ -85,6 +84,7 @@ export {
   podResources,
   podStoragePool,
   podVM,
+  podVmCount,
   testStatus,
 } from "./nodes";
 export { dhcpSnippet } from "./dhcpsnippet";

--- a/ui/src/testing/factories/nodes.ts
+++ b/ui/src/testing/factories/nodes.ts
@@ -29,8 +29,6 @@ import {
 import type {
   Pod,
   PodDetails,
-  PodHint,
-  PodHintExtras,
   PodMemoryResource,
   PodNetworkInterface,
   PodNuma,
@@ -42,6 +40,7 @@ import type {
   PodResources,
   PodStoragePool,
   PodVM,
+  PodVmCount,
 } from "app/store/pod/types";
 import { PodType } from "app/store/pod/types";
 import type { Model } from "app/store/types/model";
@@ -75,7 +74,6 @@ const storage_pools = () => [podStoragePool(), podStoragePool()];
 const storage_tags = () => [];
 const subnets = () => [];
 const tags = () => [];
-const hints = () => ({ ...podHint(), ...podHintExtras() });
 
 const simpleNode = extend<Model, SimpleNode>(model, {
   domain: modelRef,
@@ -330,21 +328,6 @@ export const controller = extend<BaseNode, Controller>(node, {
   versions: null,
 });
 
-export const podHint = define<PodHint>({
-  cores: 8,
-  local_storage: 10000000000,
-  local_storage_gb: "1000",
-  memory: 8000,
-  memory_gb: "8",
-});
-
-const podHintExtras = define<PodHintExtras>({
-  cpu_speed: 1000,
-  iscsi_storage: -1,
-  iscsi_storage_gb: "-0.0",
-  local_disks: -1,
-});
-
 export const podStoragePool = define<PodStoragePool>({
   available: 700000000000,
   id: () => `pool-id-${random()}`,
@@ -409,11 +392,18 @@ export const podNuma = define<PodNuma>({
   vms: () => [0, 1],
 });
 
+export const podVmCount = define<PodVmCount>({
+  tracked: 2,
+  other: 1,
+});
+
 export const podResources = define<PodResources>({
   cores: podResource,
   interfaces: () => [podNetworkInterface()],
   memory: podMemoryResource,
   numa: () => [podNuma()],
+  storage: podResource,
+  vm_count: podVmCount,
   vms: () => [podVM()],
 });
 
@@ -424,15 +414,12 @@ export const podProject = define<PodProject>({
 
 export const pod = extend<Model, Pod>(model, {
   architectures,
-  available: podHint,
   capabilities,
-  composed_machines_count: 1,
   cpu_over_commit_ratio: 10,
   cpu_speed: 1000,
   created: "Wed, 19 Feb. 2020 11:59:19",
   default_macvlan_mode: "",
   default_storage_pool: "b85e27c9-9d53-4821-ad64-153c53767ce9",
-  hints,
   host: "",
   ip_address: (i: number) => `192.168.1.${i}`,
   memory_over_commit_ratio: 8,
@@ -442,13 +429,10 @@ export const pod = extend<Model, Pod>(model, {
   power_address: "qemu+ssh://ubuntu@127.0.0.1/system",
   power_pass: "",
   resources: podResources,
-  owners_count: 1,
   storage_pools,
   tags,
-  total: podHint,
   type: PodType.VIRSH,
   updated: "Fri, 03 Jul. 2020 02:44:12",
-  used: podHint,
   version: "4.0.2",
   zone: 1,
 });


### PR DESCRIPTION
## Done

- Backport of #2664 