### PR TITLE
feat(legacy): allow disabling boot architectures in subnet details

### DIFF
--- a/legacy/src/app/controllers/subnet_details.js
+++ b/legacy/src/app/controllers/subnet_details.js
@@ -66,10 +66,18 @@ export function SubnetDetailsController(
   $scope.editStaticRoute = null;
   $scope.deleteStaticRoute = null;
   $scope.snippets = DHCPSnippetsManager.getItems();
+  $scope.knownBootArchitectures = GeneralManager.getData(
+    "known_boot_architectures"
+  );
+  $scope.newDisabledArches = [];
 
   $scope.MAP_SUBNET_ACTION = {
     name: "map_subnet",
     title: "Map subnet",
+  };
+  $scope.EDIT_BOOT_ARCHITECTURES_ACTION = {
+    name: "edit_boot_architectures",
+    title: "Edit boot architectures",
   };
   $scope.DELETE_ACTION = {
     name: "delete",
@@ -242,12 +250,32 @@ export function SubnetDetailsController(
           $scope.actionError = ManagerHelperService.parseValidationError(error);
         }
       );
+    } else if ($scope.actionOption.name === "edit_boot_architectures") {
+      const newSubnet = {
+        id: $scope.subnet.id,
+        disabled_boot_architectures: $scope.newDisabledArches.join(","),
+      };
+      SubnetsManager.update(newSubnet).then(
+        () => {
+          $scope.actionOption = null;
+          $scope.actionError = null;
+        },
+        (error) => {
+          $scope.actionError = ManagerHelperService.parseValidationError(error);
+        }
+      );
     }
   };
 
   // Called when a action is selected.
   $scope.actionChanged = function () {
     $scope.actionError = null;
+    if (
+      $scope.actionOption &&
+      $scope.actionOption.name === "edit_boot_architectures"
+    ) {
+      $scope.newDisabledArches = $scope.subnet.disabled_boot_architectures;
+    }
   };
 
   // Called when the "Cancel" button is pressed.
@@ -260,7 +288,11 @@ export function SubnetDetailsController(
   // is allowed to perform.
   $scope.updateActions = function () {
     if (UsersManager.isSuperUser()) {
-      $scope.actionOptions = [$scope.MAP_SUBNET_ACTION, $scope.DELETE_ACTION];
+      $scope.actionOptions = [
+        $scope.MAP_SUBNET_ACTION,
+        $scope.EDIT_BOOT_ARCHITECTURES_ACTION,
+        $scope.DELETE_ACTION,
+      ];
     } else {
       $scope.actionOptions = [];
     }
@@ -373,6 +405,20 @@ export function SubnetDetailsController(
     return IPAddresses.length ? true : false;
   };
 
+  $scope.bootArchitectureEnabled = (archName) => {
+    return !$scope.newDisabledArches.includes(archName);
+  };
+
+  $scope.toggleBootArchitecture = (archName) => {
+    if ($scope.bootArchitectureEnabled(archName)) {
+      $scope.newDisabledArches = [...$scope.newDisabledArches, archName];
+    } else {
+      $scope.newDisabledArches = $scope.newDisabledArches.filter(
+        (arch) => arch !== archName
+      );
+    }
+  };
+
   // Called when the subnet has been loaded.
   function subnetLoaded(subnet) {
     $scope.subnet = subnet;
@@ -439,6 +485,9 @@ export function SubnetDetailsController(
     StaticRoutesManager,
     DHCPSnippetsManager,
   ]).then(function () {
+    if (!GeneralManager.isDataLoaded("known_boot_architectures")) {
+      GeneralManager.loadItems(["known_boot_architectures"]);
+    }
     $scope.updateActions();
     $scope.active_discovery_data = ConfigsManager.getItemFromList(
       "active_discovery_interval"

--- a/legacy/src/app/factories/general.js
+++ b/legacy/src/app/factories/general.js
@@ -74,6 +74,14 @@ function GeneralManager($q, $timeout, RegionConnection, ErrorService) {
         polling: [],
         nextPromise: null,
       },
+      known_boot_architectures: {
+        method: "general.known_boot_architectures",
+        data: [],
+        requested: false,
+        loaded: false,
+        polling: [],
+        nextPromise: null,
+      },
       pockets_to_disable: {
         method: "general.pockets_to_disable",
         data: [],

--- a/legacy/src/app/factories/subnets.js
+++ b/legacy/src/app/factories/subnets.js
@@ -82,6 +82,11 @@ function SubnetsManager(RegionConnection, Manager) {
     });
   };
 
+  // Update the subnet.
+  SubnetsManager.prototype.update = function (subnet) {
+    return RegionConnection.callMethod("subnet.update", subnet);
+  };
+
   // Perform a neighbour discovery scan on the subnet.
   SubnetsManager.prototype.scanSubnet = function (subnet) {
     return RegionConnection.callMethod("subnet.scan", {

--- a/legacy/src/app/factories/tests/test_general.js
+++ b/legacy/src/app/factories/tests/test_general.js
@@ -56,6 +56,7 @@ describe("GeneralManager", function () {
       "region_and_rack_controller_actions",
       "architectures",
       "known_architectures",
+      "known_boot_architectures",
       "pockets_to_disable",
       "components_to_disable",
       "hwe_kernels",
@@ -339,6 +340,7 @@ describe("GeneralManager", function () {
       GeneralManager._data.region_and_rack_controller_actions.loaded = true;
       GeneralManager._data.architectures.loaded = true;
       GeneralManager._data.known_architectures.loaded = true;
+      GeneralManager._data.known_boot_architectures.loaded = true;
       GeneralManager._data.pockets_to_disable.loaded = true;
       GeneralManager._data.components_to_disable.loaded = true;
       GeneralManager._data.hwe_kernels.loaded = true;

--- a/legacy/src/app/factories/tests/test_subnets.js
+++ b/legacy/src/app/factories/tests/test_subnets.js
@@ -84,6 +84,19 @@ describe("SubnetsManager", function () {
     });
   });
 
+  describe("update", () => {
+    it("calls the region with expected parameters", function () {
+      var obj = { id: 1, param: "value" };
+      var result = {};
+      spyOn(RegionConnection, "callMethod").and.returnValue(result);
+      expect(SubnetsManager.update(obj)).toBe(result);
+      expect(RegionConnection.callMethod).toHaveBeenCalledWith(
+        "subnet.update",
+        { id: 1, param: "value" }
+      );
+    });
+  });
+
   describe("scan", function () {
     it("calls the region with expected parameters", function () {
       var obj = { id: "expected", not_the_id: "unexpected" };

--- a/legacy/src/app/partials/subnet-details.html
+++ b/legacy/src/app/partials/subnet-details.html
@@ -21,7 +21,7 @@
         <!-- "Take action" dropdown -->
         <div
           class="page-header__controls u-float--right ng-hide"
-          data-ng-show="isSuperUser() && !isDefaultSubnet() && !loading && actionOptions.length"
+          data-ng-show="isSuperUser() && !isDefaultSubnet() && !loading && actionOptions.length && !actionOption.name"
         >
           <div
             data-maas-cta="actionOptions"
@@ -60,6 +60,77 @@
               </button>
               <button class="p-button--positive" data-ng-click="actionGo()">
                 Map subnet
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section
+        ng-if="!actionError && actionOption.name === 'edit_boot_architectures'"
+      >
+        <hr />
+        <div class="row">
+          <div class="col-12">
+            <h4>Boot architectures</h4>
+            <table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>BIOS boot method</th>
+                  <th>Bootloader architecture</th>
+                  <th>Protocol</th>
+                  <th>Architecture octet</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  class="p-table__row--interactive"
+                  ng-class="{
+                    'is-active': bootArchitectureEnabled(architecture.name)
+                  }"
+                  ng-repeat="architecture in knownBootArchitectures | orderBy:'name'"
+                >
+                  <td>
+                    <label
+                      class="p-checkbox u-no-margin--bottom u-no-padding--top"
+                    >
+                      <input
+                        class="p-checkbox__input"
+                        ng-checked="bootArchitectureEnabled(architecture.name)"
+                        ng-click="toggleBootArchitecture(architecture.name)"
+                        type="checkbox"
+                      />
+                      <span class="p-checkbox__label">
+                        {$ architecture.name $}
+                      </span>
+                    </label>
+                  </td>
+                  <td>{$ architecture.bios_boot_method || "—" $}</td>
+                  <td>{$ architecture.bootloader_arches || "—" $}</td>
+                  <td>{$ architecture.protocol || "—" $}</td>
+                  <td>{$ architecture.arch_octet || "—" $}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-12 u-align--right">
+            <hr />
+            <div>
+              <button
+                class="p-button--base"
+                ng-click="cancelAction()"
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                class="p-button--positive"
+                ng-click="actionGo()"
+                ng-disabled="subnet.disabled_boot_architectures === newDisabledArches"
+              >
+                Save
               </button>
             </div>
           </div>

--- a/legacy/src/scss/tables/_base_tables.scss
+++ b/legacy/src/scss/tables/_base_tables.scss
@@ -167,4 +167,16 @@
         map-get($line-heights, small) - map-get($nudges, nudge--small);
     }
   }
+
+  .p-table__row--interactive {
+    background-color: $color-x-light;
+
+    &:hover {
+      background-color: $color-light;
+    }
+
+    &.is-active:hover {
+      background-color: transparentize($color-link, 0.85);
+    }
+  }
 }


### PR DESCRIPTION
## Done

- Added ability to disable boot architectures per subnet (default is all enabled).
- Added `p-table__row--interactive` class modifier for the different hover/selected states.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet details page
- Open the action menu and choose "Edit boot architectures"
- Check that you can change which of the boot architectures are enabled on the subnet, and that the data is persisted after a refresh

## Fixes

Fixes canonical-web-and-design/MAAS-squad#2400

## Screenshot
![Screenshot_2021-05-19 1 1 1 1 32 (1 1 1 1) bolla MAAS(1)](https://user-images.githubusercontent.com/25733845/118757723-fb038980-b8b0-11eb-8a12-9e65a6651c92.png)


