### PR TITLE
refactor(ui): create util for generating next names

### DIFF
--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -59,6 +59,7 @@ export {
   formatSize,
   formatType,
   getDiskById,
+  getNextStorageName,
   getPartitionById,
   isBcache,
   isCacheSet,

--- a/ui/src/app/store/machine/utils/networking.ts
+++ b/ui/src/app/store/machine/utils/networking.ts
@@ -13,6 +13,7 @@ import {
 import { isMachineDetails } from "app/store/machine/utils";
 import type { Subnet } from "app/store/subnet/types";
 import type { VLAN } from "app/store/vlan/types";
+import { getNextName } from "app/utils";
 
 export const INTERFACE_TYPE_DISPLAY = {
   [NetworkInterfaceTypes.PHYSICAL]: "Physical",
@@ -711,7 +712,6 @@ export const getNextNicName = (
       return `${nic.name}.${vid}`;
     }
   }
-  let idx = 0;
   let prefix = "";
   switch (interfaceType) {
     case NetworkInterfaceTypes.BOND:
@@ -724,15 +724,11 @@ export const getNextNicName = (
       prefix = "eth";
       break;
   }
-  machine.interfaces.forEach(({ name }) => {
-    if (name.startsWith(prefix)) {
-      const counter = Number(name.replace(prefix, ""));
-      if (!isNaN(counter) && counter >= idx) {
-        idx = counter + 1;
-      }
-    }
-  });
-  return prefix ? `${prefix}${idx}` : null;
+  if (!prefix) {
+    return null;
+  }
+  const names = machine.interfaces.map(({ name }) => name);
+  return getNextName(names, prefix);
 };
 
 /**

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -523,7 +523,7 @@ export const getNextStorageName = (
   const diskNames = disks.reduce<string[]>((names, disk) => {
     if (
       // Filter volume groups.
-      (prefix === "vg" && disk.type === DiskTypes.VOLUME_GROUP) ||
+      (prefix === "vg" && isVolumeGroup(disk)) ||
       // Filter raids.
       (prefix === "md" && isRaid(disk)) ||
       // Filter bcaches.

--- a/ui/src/app/utils/getNextName.test.ts
+++ b/ui/src/app/utils/getNextName.test.ts
@@ -1,0 +1,37 @@
+import { getNextName } from "./getNextName";
+
+describe("getNextName", () => {
+  it("can get the next name", () => {
+    const names = ["vg0"];
+    expect(getNextName(names, "vg")).toStrictEqual("vg1");
+  });
+
+  it("ignores names with a different prefix", () => {
+    const names = ["vg0", "bcache1"];
+    expect(getNextName(names, "vg")).toStrictEqual("vg1");
+  });
+
+  it("can get the next name when there are no existing items", () => {
+    expect(getNextName([], "vg")).toStrictEqual("vg0");
+  });
+
+  it("can get the next name when the names are out of order", () => {
+    const names = ["vg1", "vg2", "vg0"];
+    expect(getNextName(names, "vg")).toStrictEqual("vg3");
+  });
+
+  it("can get the name when there are non sequential names", () => {
+    const names = ["vg0", "vg2"];
+    expect(getNextName(names, "vg")).toStrictEqual("vg3");
+  });
+
+  it("can get the next name when there are partial names", () => {
+    const names = ["vg0", "vg"];
+    expect(getNextName(names, "vg")).toStrictEqual("vg1");
+  });
+
+  it("can get the next name when there are partial similar names", () => {
+    const names = ["vg0", "vg2vg1"];
+    expect(getNextName(names, "vg")).toStrictEqual("vg1");
+  });
+});

--- a/ui/src/app/utils/getNextName.ts
+++ b/ui/src/app/utils/getNextName.ts
@@ -1,0 +1,27 @@
+/**
+ * Get the next valid name in the sequence.
+ * @param names - A list of existing names.
+ * @param prefix - The name prefix e.g. "eth"
+ * @param startIndex - The number to start the sequence on.
+ * @returns The new name.
+ */
+export const getNextName = (
+  names: string[],
+  prefix: string,
+  startIndex = 0
+): string => {
+  let idx = startIndex;
+  names.forEach((name) => {
+    // Check that the string starts with the prefix to prevent false positives
+    // if the prefix exists somewhere else in the string.
+    if (name.startsWith(prefix)) {
+      // Remove the prefix and try and turn the remaining string into a number.
+      const counter = Number(name.replace(prefix, ""));
+      // If this counter is a valid number and is higher than the stored id then store a new one.
+      if (!isNaN(counter) && counter >= idx) {
+        idx = counter + 1;
+      }
+    }
+  });
+  return `${prefix}${idx}`;
+};

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -11,6 +11,7 @@ export { formatSpeedUnits } from "./formatSpeedUnits";
 export { generateCheckboxHandlers } from "./generateCheckboxHandlers";
 export { getCookie } from "./getCookie";
 export { getMachineValue } from "./search";
+export { getNextName } from "./getNextName";
 export { getRanges } from "./getRanges";
 export { getStatusText } from "./getStatusText";
 export { groupAsMap } from "./groupAsMap";


### PR DESCRIPTION
## Done

- Refactor storage and network utils to find the next name in the sequence.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the network tab in machine details.
- Create some interfaces and they should get named appropriately.
- Go to the storage tab.
- Create some interfaces and they should get named appropriately.

## Fixes

Fixes: #2188.