### PR TITLE
refactor(ui): use the trancated border mixin for all tables

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx
@@ -141,7 +141,7 @@ const generateRow = (
     : null;
   return {
     className: classNames("p-table__row", {
-      "indented-border": isABondOrBridgeParent,
+      "truncated-border": isABondOrBridgeParent,
       "is-active": isExpanded,
     }),
     columns: [

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/_index.scss
@@ -1,5 +1,9 @@
 @mixin MachineNetworkTable {
   .machine-network-table {
+    @include truncated-border(
+      $width: #{2 * map-get($icon-sizes, default) + $sph-inner--small}
+    );
+
     th,
     td {
       &:nth-child(1) {

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
+import classNames from "classnames";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
@@ -76,9 +77,9 @@ const generateGroup = (
 
     return (
       <tr
-        className={`node-devices-table__row${
-          showGroupLabel ? "" : " truncated-border"
-        }`}
+        className={classNames("node-devices-table__row", {
+          "truncated-border": !showGroupLabel,
+        })}
         key={`node-device-${id}`}
       >
         <td className="group-col">

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
@@ -1,8 +1,7 @@
 @mixin NodeDevices {
-  $group-label-width: 10rem;
-  @include truncated-border();
-
   %node-devices-table {
+    $group-label-width: 10rem;
+    @include truncated-border();
     .group-col {
       @include breakpoint-widths(0, 0, $group-label-width);
     }

--- a/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
+++ b/ui/src/app/machines/views/MachineList/MachineListTable/MachineListTable.js
@@ -218,7 +218,7 @@ const generateRows = ({
 
     return {
       key: row.system_id,
-      className: classNames("machine-list__machine", {
+      className: classNames("machine-list__machine", "truncated-border", {
         "machine-list__machine--active": isActive,
       }),
       columns: filterColumns(columns, hiddenColumns, showActions),

--- a/ui/src/app/machines/views/MachineList/_index.scss
+++ b/ui/src/app/machines/views/MachineList/_index.scss
@@ -4,6 +4,7 @@
   $grouped-machines-indentation: $box-size + $sph-inner - $checkbox-offset; // Checkbox + label - offset
 
   .machine-list {
+    @include truncated-border($width: $grouped-machines-indentation);
     margin-bottom: 0;
 
     .fqdn-col {
@@ -52,19 +53,8 @@
   }
 
   .machine-list--grouped .machine-list__machine {
-    border: 0;
     position: relative;
     transform: scale(1);
-
-    &::after {
-      background-color: $color-mid-light;
-      content: "";
-      height: 1px;
-      left: $grouped-machines-indentation;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
 
     td:first-child {
       padding-left: $grouped-machines-indentation;

--- a/ui/src/scss/_patterns_tables.scss
+++ b/ui/src/scss/_patterns_tables.scss
@@ -42,21 +42,7 @@
     text-transform: uppercase;
   }
 
-  tr:not(:first-child).indented-border {
-    border-color: transparent;
-    position: relative;
-
-    &::after {
-      background-color: $colors--light-theme--border-low-contrast;
-      content: "";
-      height: 1px;
-      left: #{2 * map-get($icon-sizes, default) + $sph-inner--small};
-      position: absolute;
-      right: 0;
-    }
+  .p-table__row--muted {
+    background-color: $color-light;
   }
-
-.p-table__row--muted {
-  background-color: $color-light;
-}
 }

--- a/ui/src/scss/_truncated-border.scss
+++ b/ui/src/scss/_truncated-border.scss
@@ -1,4 +1,7 @@
 // Truncates the border above a table row, usually to signify table grouping.
+// $width sets the size of the indent from the left. If it's not supplied then
+// the indent is the size of the first td.
+// $bg-color should be set to the background colour of the table.
 @mixin truncated-border($width: 100%, $bg-color: $color-light) {
   .truncated-border td:first-child {
     overflow: visible;


### PR DESCRIPTION
## Done

- Update the machine and network lists to use the trucated border mixin.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- The borders for machines inside a group should be indented by the width of the parent checkbox.
- Click on a machine and go to the network tab.
- Create a bond (or find a machine with a bond).
- The borders for the bond interfaces should be indented by the width of the parent checkbox.

## Fixes

Fixes: #2113.