### PR TITLE
feat(scripts): Mark LP bugs as Fix Committed when GH issue is closed

### DIFF
--- a/scripts/lp-bugs-to-gh-issues.py
+++ b/scripts/lp-bugs-to-gh-issues.py
@@ -46,3 +46,11 @@ for bug in generate_open_bugs():
     create_bug_task(issue, bug)
     count += 1
 print(f"Issues created: {count}")
+print("Closing fixed LP bugs")
+closed_count = 0
+for task in project.searchTasks(status=["New", "Confirmed", "Triaged"], tags=["ui"], status_upstream='resolved_upstream'):
+    task.status = 'Fix Committed'
+    task.lp_save()
+    closed_count += 1
+
+print(f"LP bugs closed: {closed_count}")


### PR DESCRIPTION
## Done

- Extended `scripts/lp-bugs-to-gh-issues.py` to close LP bugs when GH issue is closed.

## QA

- from `lp-shell`
```
In [2]: len(p.searchTasks(status=["New", "Confirmed", "Triaged"], tags=["ui"], status_upstream='resolved_upstream'))
Out[2]: 29   
In [3]: for task in p.searchTasks(status=["New", "Confirmed", "Triaged"], tags=["ui"], status_upstream='resolved_upstream'):                                  
    ...:     task.status = 'Fix Committed'                                     
    ...:     task.lp_save()
```