### PR TITLE
fix(legacy): QA fixes for subnet boot architectures form

### DIFF
--- a/legacy/src/app/controllers/subnet_details.js
+++ b/legacy/src/app/controllers/subnet_details.js
@@ -70,6 +70,7 @@ export function SubnetDetailsController(
     "known_boot_architectures"
   );
   $scope.newDisabledArches = [];
+  $scope.bootArchSort = "name";
 
   $scope.MAP_SUBNET_ACTION = {
     name: "map_subnet",
@@ -418,6 +419,32 @@ export function SubnetDetailsController(
       );
     }
   };
+
+  const isCurrentSort = (key) => {
+    const sortKey = $scope.bootArchSort.replace("-", "");
+    return key === sortKey;
+  }
+
+  $scope.getBootArchSort = (key) => {
+    if (isCurrentSort(key)) {
+      return $scope.bootArchSort.startsWith("-")
+        ? "descending"
+        : "ascending";
+    }
+    return "none";
+  };
+
+  $scope.setBootArchSort = (key) => {
+    if (isCurrentSort(key)) {
+      if ($scope.bootArchSort.startsWith("-")) {
+        $scope.bootArchSort = key;
+      } else {
+        $scope.bootArchSort = `-${key}`;
+      }
+    } else {
+      $scope.bootArchSort = key;
+    }
+  }
 
   // Called when the subnet has been loaded.
   function subnetLoaded(subnet) {

--- a/legacy/src/app/controllers/tests/test_subnet_details.js
+++ b/legacy/src/app/controllers/tests/test_subnet_details.js
@@ -876,4 +876,38 @@ describe("SubnetDetailsController", function () {
       expect($scope.newDisabledArches.includes("pxe")).toBe(false);
     });
   });
+
+  describe("getBootArchSort", () => {
+    it("returns whether the given key is sorted in a particular direction", () => {
+      makeController();
+      // Sort by name:ascending
+      $scope.bootArchSort = "name";
+      expect($scope.getBootArchSort("name")).toBe("ascending");
+      expect($scope.getBootArchSort("protocol")).toBe("none");
+      // Update to sort by name:descending
+      $scope.bootArchSort = "-name";
+      $scope.$digest();
+      expect($scope.getBootArchSort("name")).toBe("descending");
+    });
+  });
+
+  describe("setBootArchSort", () => {
+    it("sets the current boot arch sort", () => {
+      makeController();
+      // Sort by name:ascending
+      $scope.bootArchSort = "name";
+      // Update sorting to name:descending
+      $scope.setBootArchSort("name");
+      $scope.$digest();
+      expect($scope.bootArchSort).toBe("-name");
+      // Revert to sorting by name:ascending
+      $scope.setBootArchSort("name");
+      $scope.$digest();
+      expect($scope.bootArchSort).toBe("name");
+      // Change sort to protocol:descending
+      $scope.setBootArchSort("protocol");
+      $scope.$digest();
+      expect($scope.bootArchSort).toBe("protocol");
+    });
+  });
 });

--- a/legacy/src/app/partials/subnet-details.html
+++ b/legacy/src/app/partials/subnet-details.html
@@ -71,15 +71,54 @@
         <hr />
         <div class="row">
           <div class="col-12">
-            <h4>Boot architectures</h4>
+            <ul class="p-inline-list">
+              <li class="p-inline-list__item p-heading--four">
+                Boot architectures
+              </li>
+              <li class="p-inline-list__item">
+                <a
+                  class="p-link--external"
+                  href="https://discourse.maas.io/t/boot-architectures/4610"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  More info
+                </a>
+              </li>
+            </ul>
             <table>
               <thead>
                 <tr>
-                  <th>Name</th>
-                  <th>BIOS boot method</th>
-                  <th>Bootloader architecture</th>
-                  <th>Protocol</th>
-                  <th>Architecture octet</th>
+                  <th
+                    aria-sort="{$ getBootArchSort('name') $}"
+                    ng-click="setBootArchSort('name')"
+                  >
+                    Name
+                  </th>
+                  <th
+                    aria-sort="{$ getBootArchSort('bios_boot_method') $}"
+                    ng-click="setBootArchSort('bios_boot_method')"
+                  >
+                    BIOS boot method
+                  </th>
+                  <th
+                    aria-sort="{$ getBootArchSort('bootloader_arches') $}"
+                    ng-click="setBootArchSort('bootloader_arches')"
+                  >
+                    Bootloader architecture
+                  </th>
+                  <th
+                    aria-sort="{$ getBootArchSort('protocol') $}"
+                    ng-click="setBootArchSort('protocol')"
+                  >
+                    Protocol
+                  </th>
+                  <th
+                    aria-sort="{$ getBootArchSort('arch_octet') $}"
+                    ng-click="setBootArchSort('arch_octet')"
+                  >
+                    Architecture octet
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -88,7 +127,8 @@
                   ng-class="{
                     'is-active': bootArchitectureEnabled(architecture.name)
                   }"
-                  ng-repeat="architecture in knownBootArchitectures | orderBy:'name'"
+                  ng-click="toggleBootArchitecture(architecture.name)"
+                  ng-repeat="architecture in knownBootArchitectures | orderBy:bootArchSort"
                 >
                   <td>
                     <label
@@ -97,7 +137,6 @@
                       <input
                         class="p-checkbox__input"
                         ng-checked="bootArchitectureEnabled(architecture.name)"
-                        ng-click="toggleBootArchitecture(architecture.name)"
                         type="checkbox"
                       />
                       <span class="p-checkbox__label">

--- a/legacy/src/scss/tables/_base_tables.scss
+++ b/legacy/src/scss/tables/_base_tables.scss
@@ -173,6 +173,7 @@
 
     &:hover {
       background-color: $color-light;
+      cursor: pointer;
     }
 
     &.is-active:hover {


### PR DESCRIPTION
## Done

- In the subnet details edit boot architecture form:
  - Made entire arch row clickable.
  - Made boot arch table sortable.
  - Added link to boot arch discourse page.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to a subnet details page and click "Take action" > "Edit boot architectures"
- Check that there is a "More info" link that takes you to the boot architectures discourse page
- Check that clicking anywhere on a row will toggle the checkbox
- Check that you can sort the table by the table headers

## Fixes

Fixes canonical-web-and-design/MAAS-Squad#2420
