### PR TITLE
feat(ui): add discovery model to store

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -33,7 +33,7 @@ exports[`stricter compilation`] = {
       [122, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [123, 8, 17, "Argument of type \'{ name: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "2541047863"]
     ],
-    "src/app/base/components/DhcpForm/DhcpForm.tsx:2742344659": [
+    "src/app/base/components/DhcpForm/DhcpForm.tsx:2587147152": [
       [108, 6, 8, "Type \'(values: DHCPFormValues) => void\' is not assignable to type \'(values?: DHCPFormValues | undefined, formikHelpers?: FormikHelpers<DHCPFormValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'DHCPFormValues | undefined\' is not assignable to type \'DHCPFormValues\'.\\n      Type \'undefined\' is not assignable to type \'DHCPFormValues\'.", "1301647696"]
     ],
     "src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx:2368311428": [
@@ -118,7 +118,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -422,7 +422,7 @@ exports[`stricter compilation`] = {
     "src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx:2287846344": [
       [123, 10, 8, "Type \'(values: PowerFormValues) => void\' is not assignable to type \'(values?: PowerFormValues | undefined, formikHelpers?: FormikHelpers<PowerFormValues> | undefined) => void\'.\\n  Types of parameters \'values\' and \'values\' are incompatible.\\n    Type \'PowerFormValues | undefined\' is not assignable to type \'PowerFormValues\'.\\n      Type \'undefined\' is not assignable to type \'PowerFormValues\'.", "1301647696"]
     ],
-    "src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx:1248309454": [
+    "src/app/machines/views/MachineDetails/MachineHeader/MachineName/MachineName.tsx:2703212116": [
       [98, 6, 8, "Type \'({ hostname, domain }: { hostname: any; domain: any; }) => void\' is not assignable to type \'(values?: unknown, formikHelpers?: FormikHelpers<unknown> | undefined) => void\'.\\n  Types of parameters \'__0\' and \'values\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'{ hostname: any; domain: any; }\'.", "1301647696"],
       [98, 19, 8, "Binding element \'hostname\' implicitly has an \'any\' type.", "244618690"],
       [98, 29, 6, "Binding element \'domain\' implicitly has an \'any\' type.", "1127975365"]
@@ -756,11 +756,11 @@ exports[`stricter compilation`] = {
       [164, 7, 25, "Object is possibly \'undefined\'.", "3221305423"],
       [193, 10, 25, "Object is possibly \'undefined\'.", "3221305423"]
     ],
-    "src/app/store/nodescriptresult/slice.ts:1858780301": [
-      [19, 4, 332, "No overload matches this call.\\n  Overload 1 of 2, \'(actionCreator: ActionCreatorWithPayload<ScriptResult[], string>, reducer: CaseReducer<{ items: {}; }, { payload: ScriptResult[]; type: string; }>): ActionReducerMapBuilder<...>\', gave the following error.\\n    Argument of type \'(state: NodeScriptResultState, action: PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to parameter of type \'CaseReducer<{ items: {}; }, { payload: ScriptResult[]; type: string; }>\'.\\n      Types of parameters \'action\' and \'action\' are incompatible.\\n        Type \'{ payload: ScriptResult[]; type: string; }\' is not assignable to type \'PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>, never>\'.\\n          Property \'meta\' is missing in type \'{ payload: ScriptResult[]; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.\\n  Overload 2 of 2, \'(type: string, reducer: CaseReducer<{ items: {}; }, PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>, never>>): ActionReducerMapBuilder<...>\', gave the following error.\\n    Argument of type \'ActionCreatorWithPayload<ScriptResult[], string>\' is not assignable to parameter of type \'string\'.", "2515705961"]
+    "src/app/store/nodescriptresult/slice.ts:3047103722": [
+      [20, 4, 332, "No overload matches this call.\\n  Overload 1 of 2, \'(actionCreator: ActionCreatorWithPayload<ScriptResult[], string>, reducer: CaseReducer<{ items: {}; }, { payload: ScriptResult[]; type: string; }>): ActionReducerMapBuilder<...>\', gave the following error.\\n    Argument of type \'(state: NodeScriptResultState, action: PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>>) => void\' is not assignable to parameter of type \'CaseReducer<{ items: {}; }, { payload: ScriptResult[]; type: string; }>\'.\\n      Types of parameters \'action\' and \'action\' are incompatible.\\n        Type \'{ payload: ScriptResult[]; type: string; }\' is not assignable to type \'PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>, never>\'.\\n          Property \'meta\' is missing in type \'{ payload: ScriptResult[]; type: string; }\' but required in type \'{ meta: GenericItemMeta<ItemMeta>; }\'.\\n  Overload 2 of 2, \'(type: string, reducer: CaseReducer<{ items: {}; }, PayloadAction<ScriptResult[], string, GenericItemMeta<ItemMeta>, never>>): ActionReducerMapBuilder<...>\', gave the following error.\\n    Argument of type \'ActionCreatorWithPayload<ScriptResult[], string>\' is not assignable to parameter of type \'string\'.", "2515705961"]
     ],
-    "src/app/store/notification/selectors.ts:1769104797": [
-      [26, 39, 12, "Object is possibly \'undefined\'.", "964199671"]
+    "src/app/store/notification/selectors.ts:3319386295": [
+      [27, 39, 12, "Object is possibly \'undefined\'.", "964199671"]
     ],
     "src/app/utils/getCookie.ts:940992619": [
       [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
@@ -774,12 +774,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:1367425813": [
       [12, 2, 5, "Type \'null\' is not assignable to type \'NotificationIdent | ArrayFactory<never> | AttributeFunction<NotificationIdent> | Factory<NotificationIdent> | DerivedFunction<...>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:986537156": [
-      [252, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [367, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [368, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [370, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [375, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:4195749555": [
+      [258, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [373, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [374, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [376, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [381, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -797,141 +797,145 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [30, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/config/types.ts:3058322945": [
+    "src/app/store/config/types.ts:2910681107": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [11, 46, 8, "RegExp match", "1152173309"]
+      [15, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/controller/types.ts:1816760971": [
+    "src/app/store/controller/types.ts:2307163726": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [56, 54, 8, "RegExp match", "1152173309"]
+      [61, 54, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/device/types.ts:3735479393": [
+    "src/app/store/device/types.ts:2235721380": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [22, 46, 8, "RegExp match", "1152173309"]
+      [27, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/dhcpsnippet/types.ts:3390116686": [
+    "src/app/store/dhcpsnippet/types.ts:1309905777": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [24, 56, 8, "RegExp match", "1152173309"]
+      [29, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/domain/types.ts:3895070165": [
+    "src/app/store/discovery/types.ts:3912442520": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [16, 46, 8, "RegExp match", "1152173309"]
+      [33, 52, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/fabric/types.ts:4166410381": [
+    "src/app/store/domain/types.ts:739865610": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [14, 46, 8, "RegExp match", "1152173309"]
+      [21, 46, 8, "RegExp match", "1152173309"]
+    ],
+    "src/app/store/fabric/types.ts:2772537746": [
+      [0, 13, 8, "RegExp match", "1152173309"],
+      [19, 46, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/general/selectors/utils.ts:1977532362": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [5, 31, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/general/types.ts:3903256859": [
+    "src/app/store/general/types.ts:2285470601": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [6, 9, 8, "RegExp match", "1152173309"],
-      [65, 9, 8, "RegExp match", "1152173309"],
-      [74, 9, 8, "RegExp match", "1152173309"],
-      [83, 9, 8, "RegExp match", "1152173309"],
-      [92, 9, 8, "RegExp match", "1152173309"],
-      [107, 9, 8, "RegExp match", "1152173309"],
-      [121, 9, 8, "RegExp match", "1152173309"],
-      [149, 9, 8, "RegExp match", "1152173309"],
-      [158, 9, 8, "RegExp match", "1152173309"],
-      [210, 9, 8, "RegExp match", "1152173309"],
-      [219, 9, 8, "RegExp match", "1152173309"]
+      [10, 9, 8, "RegExp match", "1152173309"],
+      [69, 9, 8, "RegExp match", "1152173309"],
+      [78, 9, 8, "RegExp match", "1152173309"],
+      [87, 9, 8, "RegExp match", "1152173309"],
+      [96, 9, 8, "RegExp match", "1152173309"],
+      [111, 9, 8, "RegExp match", "1152173309"],
+      [125, 9, 8, "RegExp match", "1152173309"],
+      [153, 9, 8, "RegExp match", "1152173309"],
+      [162, 9, 8, "RegExp match", "1152173309"],
+      [214, 9, 8, "RegExp match", "1152173309"],
+      [223, 9, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/licensekeys/types.ts:1152996219": [
+    "src/app/store/licensekeys/types.ts:1040674116": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [11, 56, 8, "RegExp match", "1152173309"]
+      [16, 56, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/machine/types.ts:2197488442": [
+    "src/app/store/machine/types.ts:279455775": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [383, 34, 8, "RegExp match", "1152173309"],
-      [386, 25, 8, "RegExp match", "1152173309"]
+      [388, 34, 8, "RegExp match", "1152173309"],
+      [391, 25, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/nodedevice/types.ts:2713937479": [
+    "src/app/store/nodedevice/types.ts:299675448": [
       [1, 13, 8, "RegExp match", "1152173309"],
-      [35, 54, 8, "RegExp match", "1152173309"]
+      [40, 54, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/notification/types.ts:3492003526": [
+    "src/app/store/notification/types.ts:549856665": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [35, 58, 8, "RegExp match", "1152173309"]
+      [40, 58, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/packagerepository/types.ts:3365432595": [
+    "src/app/store/packagerepository/types.ts:1300792236": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [20, 68, 8, "RegExp match", "1152173309"]
+      [25, 68, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/pod/types.ts:1717504456": [
+    "src/app/store/pod/types.ts:849573463": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [150, 21, 8, "RegExp match", "1152173309"]
+      [155, 21, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/resourcepool/types.ts:1043464479": [
+    "src/app/store/resourcepool/types.ts:605537376": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [15, 58, 8, "RegExp match", "1152173309"]
+      [20, 58, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/script/types.ts:3350953848": [
+    "src/app/store/script/types.ts:1541750343": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [10, 14, 8, "RegExp match", "1152173309"],
       [15, 14, 8, "RegExp match", "1152173309"],
-      [46, 46, 8, "RegExp match", "1152173309"]
+      [20, 14, 8, "RegExp match", "1152173309"],
+      [51, 46, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/scriptresult/selectors.ts:1601152711": [
       [14, 13, 8, "RegExp match", "1152173309"],
       [72, 34, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/scriptresult/types.ts:1346024943": [
+    "src/app/store/scriptresult/types.ts:455951152": [
       [3, 13, 8, "RegExp match", "1152173309"],
-      [130, 58, 8, "RegExp match", "1152173309"]
+      [135, 58, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/service/types.ts:3965282464": [
+    "src/app/store/service/types.ts:3544174591": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [10, 48, 8, "RegExp match", "1152173309"]
+      [15, 48, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/space/types.ts:578851947": [
+    "src/app/store/space/types.ts:1972992980": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [13, 44, 8, "RegExp match", "1152173309"]
+      [18, 44, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/sshkey/types.ts:832292503": [
+    "src/app/store/sshkey/types.ts:2104750376": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [19, 46, 8, "RegExp match", "1152173309"]
+      [24, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/sslkey/types.ts:3189641576": [
+    "src/app/store/sslkey/types.ts:3137260067": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [13, 46, 8, "RegExp match", "1152173309"]
+      [18, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/status/types.ts:4123989684": [
+    "src/app/store/status/types.ts:3513387174": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [5, 22, 8, "RegExp match", "1152173309"],
-      [8, 8, 8, "RegExp match", "1152173309"]
+      [9, 22, 8, "RegExp match", "1152173309"],
+      [12, 8, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/subnet/types.ts:1274895606": [
+    "src/app/store/subnet/types.ts:318481865": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [47, 46, 8, "RegExp match", "1152173309"]
+      [52, 46, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/tag/types.ts:3275525000": [
+    "src/app/store/tag/types.ts:2256940087": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [13, 40, 8, "RegExp match", "1152173309"]
+      [18, 40, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/token/types.ts:1575725788": [
+    "src/app/store/token/types.ts:3255610243": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [15, 44, 8, "RegExp match", "1152173309"]
+      [20, 44, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/user/types.ts:1826823345": [
+    "src/app/store/user/types.ts:1540499982": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [18, 9, 8, "RegExp match", "1152173309"],
-      [28, 22, 8, "RegExp match", "1152173309"]
+      [23, 9, 8, "RegExp match", "1152173309"],
+      [33, 22, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/utils/slice.ts:2237331519": [
+    "src/app/store/utils/slice.ts:3347996124": [
       [7, 13, 8, "RegExp match", "1152173309"],
-      [318, 20, 8, "RegExp match", "1152173309"],
-      [320, 25, 8, "RegExp match", "1152173309"]
+      [331, 20, 8, "RegExp match", "1152173309"],
+      [333, 25, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/vlan/types.ts:3430900440": [
+    "src/app/store/vlan/types.ts:2268913459": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [26, 42, 8, "RegExp match", "1152173309"]
+      [31, 42, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/zone/types.ts:3660426969": [
+    "src/app/store/zone/types.ts:1581999814": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [14, 42, 8, "RegExp match", "1152173309"]
+      [19, 42, 8, "RegExp match", "1152173309"]
     ]
   }`
 };

--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -35,6 +35,14 @@ Object {
     "saved": false,
     "saving": false,
   },
+  "discovery": Object {
+    "errors": null,
+    "items": Array [],
+    "loaded": false,
+    "loading": false,
+    "saved": false,
+    "saving": false,
+  },
   "domain": Object {
     "errors": null,
     "items": Array [],

--- a/ui/src/app/store/discovery/actions.test.ts
+++ b/ui/src/app/store/discovery/actions.test.ts
@@ -1,0 +1,38 @@
+import { actions } from "./slice";
+
+describe("discovery actions", () => {
+  it("creates an action for fetching discoveries", () => {
+    expect(actions.fetch()).toEqual({
+      type: "discovery/fetch",
+      meta: {
+        model: "discovery",
+        method: "list",
+      },
+      payload: null,
+    });
+  });
+
+  it("creates an action for deleting a discovery", () => {
+    expect(
+      actions.delete({ ip: "192.168.1.1", mac: "00:00:00:00:00:00" })
+    ).toEqual({
+      type: "discovery/delete",
+      meta: {
+        model: "discovery",
+        method: "delete_by_mac_and_ip",
+      },
+      payload: { params: { ip: "192.168.1.1", mac: "00:00:00:00:00:00" } },
+    });
+  });
+
+  it("creates an action for clearing discoveries", () => {
+    expect(actions.clear()).toEqual({
+      type: "discovery/clear",
+      meta: {
+        model: "discovery",
+        method: "clear",
+      },
+      payload: null,
+    });
+  });
+});

--- a/ui/src/app/store/discovery/index.ts
+++ b/ui/src/app/store/discovery/index.ts
@@ -1,0 +1,1 @@
+export { default, actions } from "./slice";

--- a/ui/src/app/store/discovery/reducers.test.ts
+++ b/ui/src/app/store/discovery/reducers.test.ts
@@ -1,0 +1,166 @@
+import reducers, { actions } from "./slice";
+
+import {
+  discovery as discoveryFactory,
+  discoveryState as discoveryStateFactory,
+} from "testing/factories";
+
+describe("discovery reducers", () => {
+  it("should return the initial state", () => {
+    expect(reducers(undefined, { type: "" })).toEqual({
+      errors: null,
+      items: [],
+      loaded: false,
+      loading: false,
+      saved: false,
+      saving: false,
+    });
+  });
+
+  it("reduces fetchStart", () => {
+    const initialState = discoveryStateFactory({ loading: false });
+    expect(reducers(initialState, actions.fetchStart())).toEqual(
+      discoveryStateFactory({ loading: true })
+    );
+  });
+
+  it("reduces fetchSuccess", () => {
+    const discoveries = [discoveryFactory()];
+    const initialState = discoveryStateFactory({
+      items: [],
+      loading: true,
+    });
+    expect(reducers(initialState, actions.fetchSuccess(discoveries))).toEqual(
+      discoveryStateFactory({
+        loading: false,
+        loaded: true,
+        items: discoveries,
+      })
+    );
+  });
+
+  it("reduces fetchError", () => {
+    const initialState = discoveryStateFactory({ errors: null });
+    expect(
+      reducers(initialState, actions.fetchError("Could not fetch discoveries"))
+    ).toEqual(
+      discoveryStateFactory({
+        errors: "Could not fetch discoveries",
+      })
+    );
+  });
+
+  it("reduces deleteStart", () => {
+    const initialState = discoveryStateFactory({ saved: true, saving: false });
+    expect(reducers(initialState, actions.deleteStart())).toEqual(
+      discoveryStateFactory({
+        saved: false,
+        saving: true,
+      })
+    );
+  });
+
+  it("reduces deleteSuccess", () => {
+    const [deleteDiscovery, keepDiscovery] = [
+      discoveryFactory({
+        ip: "192.168.1.1",
+        mac_address: "00:00:00:00:00:00",
+      }),
+      discoveryFactory({
+        ip: "172.0.0.1",
+        mac_address: "12:34:56:78:90:12",
+      }),
+    ];
+    const initialState = discoveryStateFactory({
+      items: [deleteDiscovery, keepDiscovery],
+      saved: false,
+      saving: true,
+    });
+    expect(
+      reducers(
+        initialState,
+        actions.deleteSuccess({
+          ip: deleteDiscovery.ip,
+          mac: deleteDiscovery.mac_address,
+        })
+      )
+    ).toStrictEqual(
+      discoveryStateFactory({
+        items: [keepDiscovery],
+        saved: true,
+        saving: false,
+      })
+    );
+  });
+
+  it("reduces deleteError", () => {
+    const discoveries = [
+      discoveryFactory({
+        ip: "192.168.1.1",
+        mac_address: "00:00:00:00:00:00",
+      }),
+    ];
+    const initialState = discoveryStateFactory({
+      errors: null,
+      items: discoveries,
+      saved: false,
+      saving: true,
+    });
+    expect(
+      reducers(initialState, actions.deleteError("Could not delete discovery"))
+    ).toEqual(
+      discoveryStateFactory({
+        errors: "Could not delete discovery",
+        items: discoveries,
+        saved: false,
+        saving: false,
+      })
+    );
+  });
+
+  it("reduces clearStart", () => {
+    const initialState = discoveryStateFactory({ saved: true, saving: false });
+    expect(reducers(initialState, actions.clearStart())).toEqual(
+      discoveryStateFactory({
+        saved: false,
+        saving: true,
+      })
+    );
+  });
+
+  it("reduces clearSuccess", () => {
+    const discoveries = [discoveryFactory(), discoveryFactory()];
+    const initialState = discoveryStateFactory({
+      items: discoveries,
+      saved: false,
+      saving: true,
+    });
+    expect(reducers(initialState, actions.clearSuccess())).toEqual(
+      discoveryStateFactory({
+        items: [],
+        saved: true,
+        saving: false,
+      })
+    );
+  });
+
+  it("reduces clearError", () => {
+    const discoveries = [discoveryFactory(), discoveryFactory()];
+    const initialState = discoveryStateFactory({
+      errors: null,
+      items: discoveries,
+      saved: false,
+      saving: true,
+    });
+    expect(
+      reducers(initialState, actions.clearError("Could not clear discoveries"))
+    ).toEqual(
+      discoveryStateFactory({
+        errors: "Could not clear discoveries",
+        items: discoveries,
+        saved: false,
+        saving: false,
+      })
+    );
+  });
+});

--- a/ui/src/app/store/discovery/selectors.test.ts
+++ b/ui/src/app/store/discovery/selectors.test.ts
@@ -1,0 +1,58 @@
+import selectors from "./selectors";
+
+import {
+  discovery as discoveryFactory,
+  discoveryState as discoveryStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+describe("discovery selectors", () => {
+  it("can get all items", () => {
+    const items = [discoveryFactory()];
+    const state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        items,
+      }),
+    });
+    expect(selectors.all(state)).toEqual(items);
+  });
+
+  it("can get the loading state", () => {
+    const state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        loading: true,
+      }),
+    });
+    expect(selectors.loading(state)).toEqual(true);
+  });
+
+  it("can get the loaded state", () => {
+    const state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        loaded: true,
+      }),
+    });
+    expect(selectors.loaded(state)).toEqual(true);
+  });
+
+  it("can get the errors state", () => {
+    const errors = "Nothing to discover";
+    const state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        errors,
+      }),
+    });
+    expect(selectors.errors(state)).toEqual(errors);
+  });
+
+  it("can get a discovery by id", () => {
+    const discovery = discoveryFactory({ discovery_id: "123" });
+    const state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        items: [discovery],
+      }),
+    });
+    expect(selectors.getById(state, "123")).toEqual(discovery);
+    expect(selectors.getById(state, "456")).toEqual(null);
+  });
+});

--- a/ui/src/app/store/discovery/selectors.ts
+++ b/ui/src/app/store/discovery/selectors.ts
@@ -1,0 +1,17 @@
+import { DiscoveryMeta } from "app/store/discovery/types";
+import type { Discovery, DiscoveryState } from "app/store/discovery/types";
+import { generateBaseSelectors } from "app/store/utils";
+
+// TODO: Placeholder search function for now. This will need to be updated to
+// follow the same format as machine searching (i.e. filtering by more than just
+// one parameter).
+const searchFunction = (discovery: Discovery, term: string) =>
+  discovery.discovery_id.includes(term);
+
+const selectors = generateBaseSelectors<
+  DiscoveryState,
+  Discovery,
+  DiscoveryMeta.PK
+>(DiscoveryMeta.MODEL, DiscoveryMeta.PK, searchFunction);
+
+export default selectors;

--- a/ui/src/app/store/discovery/slice.ts
+++ b/ui/src/app/store/discovery/slice.ts
@@ -1,0 +1,137 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
+
+import type { Discovery, DiscoveryState } from "app/store/discovery/types";
+import { DiscoveryMeta } from "app/store/discovery/types";
+import type { GenericItemMeta } from "app/store/utils";
+import { genericInitialState } from "app/store/utils/slice";
+
+type DeleteParams = {
+  mac: Discovery["mac_address"];
+  ip: Discovery["ip"];
+};
+
+const discoverySlice = createSlice({
+  name: DiscoveryMeta.MODEL,
+  initialState: genericInitialState as DiscoveryState,
+  reducers: {
+    fetch: {
+      prepare: () => ({
+        meta: {
+          model: DiscoveryMeta.MODEL,
+          method: "list",
+        },
+        payload: null,
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    fetchStart: (state: DiscoveryState) => {
+      state.loading = true;
+    },
+    fetchError: (
+      state: DiscoveryState,
+      action: PayloadAction<DiscoveryState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.loading = false;
+    },
+    fetchSuccess: (
+      state: DiscoveryState,
+      action: PayloadAction<DiscoveryState["items"]>
+    ) => {
+      state.loading = false;
+      state.loaded = true;
+      state.items = action.payload;
+    },
+    delete: {
+      prepare: ({ ip, mac }: DeleteParams) => ({
+        meta: {
+          model: DiscoveryMeta.MODEL,
+          method: "delete_by_mac_and_ip",
+        },
+        payload: {
+          params: { ip, mac },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    deleteStart: (state: DiscoveryState) => {
+      state.saved = false;
+      state.saving = true;
+    },
+    deleteError: (
+      state: DiscoveryState,
+      action: PayloadAction<DiscoveryState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.saving = false;
+    },
+    deleteSuccess: {
+      prepare: ({ mac, ip }: DeleteParams) => ({
+        meta: {
+          item: { mac, ip },
+        },
+        payload: null,
+      }),
+      reducer: (
+        state: DiscoveryState,
+        action: PayloadAction<null, string, GenericItemMeta<DeleteParams>>
+      ) => {
+        const index = state.items.findIndex(
+          (item) =>
+            item.mac_address === action.meta.item.mac &&
+            item.ip === action.meta.item.ip
+        );
+        if (index !== -1) {
+          state.items.splice(index, 1);
+        }
+        state.saving = false;
+        state.saved = true;
+      },
+    },
+    clear: {
+      prepare: () => ({
+        meta: {
+          model: DiscoveryMeta.MODEL,
+          method: "clear",
+        },
+        payload: null,
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    clearStart: (state: DiscoveryState) => {
+      state.saved = false;
+      state.saving = true;
+    },
+    clearError: (
+      state: DiscoveryState,
+      action: PayloadAction<DiscoveryState["errors"]>
+    ) => {
+      state.errors = action.payload;
+      state.saved = false;
+      state.saving = false;
+    },
+    clearSuccess: (state: DiscoveryState) => {
+      state.items = [];
+      state.saved = true;
+      state.saving = false;
+    },
+    cleanup: (state: DiscoveryState) => {
+      state.errors = null;
+      state.loaded = false;
+      state.loading = false;
+      state.saved = false;
+      state.saving = false;
+    },
+  },
+});
+
+export const { actions } = discoverySlice;
+
+export default discoverySlice.reducer;

--- a/ui/src/app/store/discovery/types.ts
+++ b/ui/src/app/store/discovery/types.ts
@@ -1,0 +1,34 @@
+import type { TSFixMe } from "app/base/types";
+import type { Model } from "app/store/types/model";
+import type { GenericState } from "app/store/types/state";
+
+export enum DiscoveryMeta {
+  MODEL = "discovery",
+  PK = "discovery_id",
+}
+
+export type Discovery = Model & {
+  discovery_id: string;
+  fabric_name: string | null;
+  fabric: number;
+  first_seen: string;
+  hostname: string | null;
+  ip: string | null;
+  is_external_dhcp: boolean | null;
+  last_seen: string;
+  mac_address: string | null;
+  mac_organization: string;
+  mdns: number | null;
+  neighbour: number;
+  observer_hostname: string | null;
+  observer_interface_name: string | null;
+  observer_interface: number;
+  observer_system_id: string;
+  observer: number;
+  subnet_cidr: string | null;
+  subnet: number | null;
+  vid: number | null;
+  vlan: number;
+};
+
+export type DiscoveryState = GenericState<Discovery, TSFixMe>;

--- a/ui/src/app/store/root/types.ts
+++ b/ui/src/app/store/root/types.ts
@@ -10,6 +10,7 @@ import type {
   DHCPSnippetState,
   DHCPSnippetMeta,
 } from "app/store/dhcpsnippet/types";
+import type { DiscoveryState, DiscoveryMeta } from "app/store/discovery/types";
 import type { DomainState, DomainMeta } from "app/store/domain/types";
 import type { EventState, EventMeta } from "app/store/event/types";
 import type { FabricState, FabricMeta } from "app/store/fabric/types";
@@ -63,6 +64,7 @@ export type RootState = {
   [ControllerMeta.MODEL]: ControllerState;
   [DeviceMeta.MODEL]: DeviceState;
   [DHCPSnippetMeta.MODEL]: DHCPSnippetState;
+  [DiscoveryMeta.MODEL]: DiscoveryState;
   [DomainMeta.MODEL]: DomainState;
   [EventMeta.MODEL]: EventState;
   [FabricMeta.MODEL]: FabricState;

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -20,9 +20,9 @@ export type GenericItemMeta<I> = {
 };
 
 // Get the models that follow the generic shape. The following models are excluded:
-// - 'messages' not an API model.
-// - 'general' has a collection of sub-models that form a different shape.
 // - 'config' contains a collection of children without IDs.
+// - 'general' has a collection of sub-models that form a different shape.
+// - 'messages' not an API model.
 // - 'nodescriptresult' returns an object of data rather than an array.
 // - 'router' is the react-router state.
 // - 'status' not an API model.

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -8,6 +8,7 @@ import config from "app/store/config";
 import controller from "app/store/controller";
 import device from "app/store/device";
 import dhcpsnippet from "app/store/dhcpsnippet";
+import discovery from "app/store/discovery";
 import domain from "app/store/domain";
 import event from "app/store/event";
 import fabric from "app/store/fabric";
@@ -41,6 +42,7 @@ const createAppReducer = (history) =>
     controller,
     device,
     dhcpsnippet,
+    discovery,
     domain,
     event,
     fabric,

--- a/ui/src/testing/factories/discovery.ts
+++ b/ui/src/testing/factories/discovery.ts
@@ -1,0 +1,30 @@
+import { extend, random } from "cooky-cutter";
+
+import { model } from "./model";
+
+import type { Discovery } from "app/store/discovery/types";
+import type { Model } from "app/store/types/model";
+
+export const discovery = extend<Model, Discovery>(model, {
+  discovery_id: () => `discovery-${random()}`,
+  fabric_name: "fabric-1",
+  fabric: 1,
+  first_seen: "1502597995.5000",
+  hostname: "discovery-hostname",
+  ip: "192.168.1.1",
+  is_external_dhcp: false,
+  last_seen: "Wed, 08 Jul. 2020 05:35:4",
+  mac_address: "00:00:00:00:00:00",
+  mac_organization: "Business Corp, Inc.",
+  mdns: 2,
+  neighbour: 3,
+  observer_hostname: "observer-hostname",
+  observer_interface_name: "iface-name",
+  observer_interface: 4,
+  observer_system_id: "abc123",
+  observer: 5,
+  subnet_cidr: "192.168.1.1/24",
+  subnet: 6,
+  vid: 7,
+  vlan: 5001,
+});

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -8,6 +8,7 @@ export {
   defaultMinHweKernelState,
   deviceState,
   dhcpSnippetState,
+  discoveryState,
   domainState,
   eventState,
   fabricState,
@@ -51,6 +52,7 @@ export {
   zoneState,
 } from "./state";
 export { config } from "./config";
+export { discovery } from "./discovery";
 export { domain } from "./domain";
 export { eventRecord, eventType } from "./event";
 export {

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -5,6 +5,7 @@ import type { ConfigState } from "app/store/config/types";
 import type { ControllerState } from "app/store/controller/types";
 import type { DeviceState } from "app/store/device/types";
 import type { DHCPSnippetState } from "app/store/dhcpsnippet/types";
+import type { DiscoveryState } from "app/store/discovery/types";
 import type { DomainState } from "app/store/domain/types";
 import type { EventState } from "app/store/event/types";
 import type { FabricState } from "app/store/fabric/types";
@@ -92,6 +93,11 @@ export const deviceState = define<DeviceState>({
 });
 
 export const dhcpSnippetState = define<DHCPSnippetState>({
+  ...defaultState,
+  errors: null,
+});
+
+export const discoveryState = define<DiscoveryState>({
   ...defaultState,
   errors: null,
 });
@@ -380,6 +386,7 @@ export const rootState = define<RootState>({
   config: configState,
   controller: controllerState,
   device: deviceState,
+  discovery: discoveryState,
   event: eventState,
   dhcpsnippet: dhcpSnippetState,
   domain: domainState,


### PR DESCRIPTION
## Done

- Added discovery model to store (slice, selectors, types), including actions for deleting and clearing

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- This can't really be QA'd properly until the dashboard/network discovery page is being worked on for real. In the mean time you could just pick a component to add `import { actions as discoveryActions } from "app/store/discovery";` to, and test that the follow things work:
  - `discoveryActions.fetch()` loads all the discoveries into state
  - `discoveryActions.delete({ ip: <IP_OF_DISCOVERY>, mac: <MAC_OF_DISCOVERY> })` deletes a discovery from state
  - `discoveryActions.clear()` clears all discoveries from state (might want to do this on a custom MAAS instead of bolla) 

## Fixes

Fixes canonical-web-and-design/app-squad#73
Fixes canonical-web-and-design/app-squad#74