### PR TITLE
Add domainList header component

### DIFF
--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
@@ -1,0 +1,65 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DomainListHeader from "./DomainListHeader";
+
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DomainListHeader", () => {
+  let initialState;
+
+  beforeEach(() => {
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+        items: [domainFactory(), domainFactory()],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("displays a loader if domains have not loaded", () => {
+    const state = { ...initialState };
+    state.domain.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a domain count if domains have loaded", () => {
+    const state = { ...initialState };
+    state.domain.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="section-header-subtitle"]').text()).toBe(
+      "2 domains available"
+    );
+  });
+});

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 
 import DomainListHeader from "./DomainListHeader";
 
+import type { RootState } from "app/store/root/types";
 import {
   domain as domainFactory,
   domainState as domainStateFactory,
@@ -14,7 +15,7 @@ import {
 const mockStore = configureStore();
 
 describe("DomainListHeader", () => {
-  let initialState;
+  let initialState: RootState;
 
   beforeEach(() => {
     initialState = rootStateFactory({

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -10,7 +10,7 @@ import domainSelectors from "app/store/domain/selectors";
 
 const DomainListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
-  const domains = useSelector(domainSelectors.count);
+  const domainCount = useSelector(domainSelectors.count);
   const domainsLoaded = useSelector(domainSelectors.loaded);
 
   useEffect(() => {
@@ -25,7 +25,7 @@ const DomainListHeader = (): JSX.Element => {
         </Button>,
       ]}
       loading={!domainsLoaded}
-      subtitle={`${pluralize("domain", domains, true)} available`}
+      subtitle={`${pluralize("domain", domainCount, true)} available`}
       title="DNS"
     />
   );

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+
+import { Button } from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch, useSelector } from "react-redux";
+
+import SectionHeader from "app/base/components/SectionHeader";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+
+const DomainListHeader = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const domains = useSelector(domainSelectors.count);
+  const domainsLoaded = useSelector(domainSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(domainActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <SectionHeader
+      buttons={[
+        <Button appearance="neutral" data-test="add-domain" key="add-domain">
+          Add domains
+        </Button>,
+      ]}
+      loading={!domainsLoaded}
+      subtitle={`${pluralize("domain", domains, true)} available`}
+      title="DNS"
+    />
+  );
+};
+
+export default DomainListHeader;

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/index.ts
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DomainListHeader";

--- a/ui/src/app/domains/views/DomainsList/DomainsList.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsList.tsx
@@ -1,7 +1,8 @@
 import { Route, Switch } from "react-router-dom";
 
+import DomainListHeader from "./DomainListHeader";
+
 import Section from "app/base/components/Section";
-import SectionHeader from "app/base/components/SectionHeader";
 import { useWindowTitle } from "app/base/hooks";
 import domainsURLs from "app/domains/urls";
 
@@ -10,7 +11,7 @@ const DomainsList = (): JSX.Element => {
 
   return (
     <Section
-      header={<SectionHeader title="DNS" subtitle="Work in progress..." />}
+      header={<DomainListHeader />}
       headerClassName="u-no-padding--bottom"
     >
       <Switch>


### PR DESCRIPTION
## Done

- Add the header to the DomainsList page
![image](https://user-images.githubusercontent.com/11927929/121013449-20d9cb00-c799-11eb-8782-a72efbdecb12.png)

## QA

go to http://0.0.0.0:8400/MAAS/r/domains and check that the header is present and displays the number of domains

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-squad/issues/37
