### PR TITLE
Add basic table to domains listing

### DIFF
--- a/ui/src/app/domains/views/DomainsList/DomainsList.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsList.test.tsx
@@ -1,0 +1,57 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DomainsList from "./DomainsList";
+
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DomainsList", () => {
+  it("correctly fetches the necessary data", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainsList />
+        </MemoryRouter>
+      </Provider>
+    );
+    const expectedActions = ["domain/fetch"];
+    const actualActions = store.getActions();
+    expect(
+      expectedActions.every((expectedAction) =>
+        actualActions.some((action) => action.type === expectedAction)
+      )
+    ).toBe(true);
+  });
+
+  it("shows a domains table if there are any domains", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ name: "test" })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainsList />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='domains-table']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/domains/views/DomainsList/DomainsList.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsList.tsx
@@ -1,12 +1,26 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
 import { Route, Switch } from "react-router-dom";
+
+import DomainsTable from "./DomainsTable";
 
 import Section from "app/base/components/Section";
 import SectionHeader from "app/base/components/SectionHeader";
 import { useWindowTitle } from "app/base/hooks";
 import domainsURLs from "app/domains/urls";
+import { actions } from "app/store/domain";
+import domainsSelectors from "app/store/domain/selectors";
 
 const DomainsList = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const domains = useSelector(domainsSelectors.all);
+
   useWindowTitle("DNS");
+
+  useEffect(() => {
+    dispatch(actions.fetch());
+  }, [dispatch]);
 
   return (
     <Section
@@ -15,7 +29,7 @@ const DomainsList = (): JSX.Element => {
     >
       <Switch>
         <Route exact path={domainsURLs.domains}>
-          <p>Work in progress...</p>
+          {domains.length > 0 && <DomainsTable />}
         </Route>
       </Switch>
     </Section>

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -1,0 +1,45 @@
+import { MainTable } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import domainSelectors from "app/store/domain/selectors";
+
+const DomainsTable = (): JSX.Element => {
+  const domains = useSelector(domainSelectors.all);
+
+  const headers = [
+    { content: "Domain" },
+    { content: "Authoriatative" },
+    { content: "Hosts", className: "u-align--right" },
+    { content: "Total records", className: "u-align--right" },
+    { content: "Actions", className: "u-align--right" },
+  ];
+  const rows = domains.map((domain) => {
+    return {
+      key: domain.id,
+      className: "p-table__row",
+      columns: [
+        {
+          content: domain.name,
+        },
+        {
+          content: domain.authoritative ? "Yes" : "No",
+        },
+        {
+          content: domain.hosts,
+          className: "u-align--right",
+        },
+        {
+          content: domain.resource_count,
+          className: "u-align--right",
+        },
+        {
+          content: "",
+          className: "u-align--right",
+        },
+      ],
+    };
+  });
+  return <MainTable headers={headers} paginate={50} rows={rows} />;
+};
+
+export default DomainsTable;

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -39,7 +39,15 @@ const DomainsTable = (): JSX.Element => {
       ],
     };
   });
-  return <MainTable headers={headers} paginate={50} rows={rows} />;
+
+  return (
+    <MainTable
+      headers={headers}
+      paginate={50}
+      rows={rows}
+      data-test="domains-table"
+    />
+  );
 };
 
 export default DomainsTable;

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/index.ts
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DomainsTable";


### PR DESCRIPTION
## Done

- Adds a basic domains table component and renders it on domains listing page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to http://0.0.0.0:8400/MAAS/r/domains
- basic table of the domains should be rendered

<img width="1441" alt="Screenshot 2021-06-07 at 17 40 03" src="https://user-images.githubusercontent.com/83575/121048800-6907e600-c7b7-11eb-8799-f6ffeb4f9e85.png">


## Fixes

Fixes: canonical-web-and-design/app-squad#35

