### PR TITLE
feat(ui): add Images view and route components

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -7,6 +7,8 @@ import dashboardURLs from "app/dashboard/urls";
 import Dashboard from "app/dashboard/views/Dashboard";
 import domainsURLs from "app/domains/urls";
 import Domains from "app/domains/views/Domains";
+import imagesURLs from "app/images/urls";
+import Images from "app/images/views/Images";
 import kvmURLs from "app/kvm/urls";
 import KVM from "app/kvm/views/KVM";
 import machineURLs from "app/machines/urls";
@@ -38,6 +40,14 @@ const Routes = (): JSX.Element => (
       render={() => (
         <ErrorBoundary>
           <Domains />
+        </ErrorBoundary>
+      )}
+    />
+    <Route
+      path={imagesURLs.index}
+      render={() => (
+        <ErrorBoundary>
+          <Images />
         </ErrorBoundary>
       )}
     />

--- a/ui/src/app/images/urls.ts
+++ b/ui/src/app/images/urls.ts
@@ -1,0 +1,5 @@
+const urls = {
+  index: "/images",
+};
+
+export default urls;

--- a/ui/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.test.tsx
@@ -1,0 +1,27 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ImageList from "./ImageList";
+
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ImageList", () => {
+  it("renders", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/images", key: "testKey" }]}
+        >
+          <ImageList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Section").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -1,0 +1,14 @@
+import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
+
+const ImagesList = (): JSX.Element => {
+  useWindowTitle("Images");
+
+  return (
+    <Section header="Images" headerClassName="u-no-padding--bottom">
+      Images
+    </Section>
+  );
+};
+
+export default ImagesList;

--- a/ui/src/app/images/views/ImageList/index.ts
+++ b/ui/src/app/images/views/ImageList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ImageList";

--- a/ui/src/app/images/views/Images.tsx
+++ b/ui/src/app/images/views/Images.tsx
@@ -1,0 +1,20 @@
+import { Route, Switch } from "react-router-dom";
+
+import NotFound from "app/base/views/NotFound";
+import imagesURLs from "app/images/urls";
+import ImageList from "app/images/views/ImageList";
+
+const Images = (): JSX.Element => {
+  return (
+    <Switch>
+      <Route exact path={[imagesURLs.index]}>
+        <ImageList />
+      </Route>
+      <Route path="*">
+        <NotFound />
+      </Route>
+    </Switch>
+  );
+};
+
+export default Images;


### PR DESCRIPTION
## Done

- Add the components for the Images view and routes.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images.
- You should see the basic images component.

## Fixes

Fixes: canonical-web-and-design/app-squad#77.