### PR TITLE
Rename root dashboard route to index

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -100,7 +100,7 @@ const Routes = (): JSX.Element => (
       )}
     />
     <Route
-      path={dashboardURLs.dashboard}
+      path={dashboardURLs.index}
       render={() => (
         <ErrorBoundary>
           <Dashboard />

--- a/ui/src/app/dashboard/urls.ts
+++ b/ui/src/app/dashboard/urls.ts
@@ -1,5 +1,5 @@
 const urls = {
-  dashboard: "/dashboard",
+  index: "/dashboard",
 };
 
 export default urls;

--- a/ui/src/app/dashboard/views/Dashboard.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.tsx
@@ -8,7 +8,7 @@ import dashboardURLs from "app/dashboard/urls";
 const Dashboard = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={[dashboardURLs.dashboard]}>
+      <Route exact path={[dashboardURLs.index]}>
         <DiscoveriesList />
       </Route>
       <Route path="*">


### PR DESCRIPTION
## Done

Changed the root dashboard route to `index` as it makes more sense

## QA

- Go to 
- Check that the page loads

## Issue
Fixes https://github.com/canonical-web-and-design/app-squad/issues/110