### PR TITLE
Add form to Domain header

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -18,7 +18,7 @@ exports[`stricter compilation`] = {
       [146, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [146, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/base/components/ActionForm/ActionForm.tsx:1889232348": [
+    "src/app/base/components/ActionForm/ActionForm.tsx:2551815612": [
       [16, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [20, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [23, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
@@ -108,7 +108,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/clement/Code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -145,6 +145,10 @@ exports[`stricter compilation`] = {
       [401, 39, 5, "Object is of type \'unknown\'.", "195909085"],
       [404, 31, 5, "Object is of type \'unknown\'.", "195909086"],
       [404, 39, 5, "Object is of type \'unknown\'.", "195909085"]
+    ],
+    "src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx:616205101": [
+      [41, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [42, 8, 19, "Argument of type \'{ name: string; authoritative: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "3577698145"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:934008644": [
       [143, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -695,12 +699,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:1367425813": [
       [12, 2, 5, "Type \'null\' is not assignable to type \'NotificationIdent | ArrayFactory<never> | AttributeFunction<NotificationIdent> | Factory<NotificationIdent> | DerivedFunction<...>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:4195749555": [
-      [258, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [373, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [374, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [376, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [381, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:3966424341": [
+      [271, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [386, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [387, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [389, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [394, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -711,7 +715,7 @@ exports[`no TSFixMe types`] = {
       [8, 13, 8, "RegExp match", "1152173309"],
       [24, 40, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/base/types.ts:672384522": [
+    "src/app/base/types.ts:2467381707": [
       [0, 11, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/auth/selectors.ts:3627802507": [

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -21,34 +21,36 @@ const DomainListHeader = (): JSX.Element => {
     dispatch(domainActions.fetch());
   }, [dispatch]);
 
+  let buttons = [
+    <Button
+      appearance="neutral"
+      data-test="add-domain"
+      key="add-domain"
+      onClick={() => setFormOpen(true)}
+    >
+      Add domains
+    </Button>,
+  ];
+
+  let formWrapper = null;
+
+  if (isFormOpen) {
+    buttons = null;
+    formWrapper = (
+      <DomainListHeaderForm
+        closeForm={() => {
+          setFormOpen(false);
+        }}
+      />
+    );
+  }
   return (
     <SectionHeader
-      buttons={
-        isFormOpen
-          ? null
-          : [
-              <Button
-                appearance="neutral"
-                data-test="add-domain"
-                key="add-domain"
-                onClick={() => setFormOpen(true)}
-              >
-                Add domains
-              </Button>,
-            ]
-      }
+      buttons={buttons}
       loading={!domainsLoaded}
       subtitle={`${pluralize("domain", domainCount, true)} available`}
       title="DNS"
-      formWrapper={
-        isFormOpen ? (
-          <DomainListHeaderForm
-            closeForm={() => {
-              setFormOpen(false);
-            }}
-          />
-        ) : null
-      }
+      formWrapper={formWrapper}
     />
   );
 };

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -1,8 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
+
+import DomainListHeaderForm from "../DomainListHeaderForm";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import { actions as domainActions } from "app/store/domain";
@@ -13,20 +15,40 @@ const DomainListHeader = (): JSX.Element => {
   const domainCount = useSelector(domainSelectors.count);
   const domainsLoaded = useSelector(domainSelectors.loaded);
 
+  const [isFormOpen, setFormOpen] = useState(false);
+
   useEffect(() => {
     dispatch(domainActions.fetch());
   }, [dispatch]);
 
   return (
     <SectionHeader
-      buttons={[
-        <Button appearance="neutral" data-test="add-domain" key="add-domain">
-          Add domains
-        </Button>,
-      ]}
+      buttons={
+        isFormOpen
+          ? null
+          : [
+              <Button
+                appearance="neutral"
+                data-test="add-domain"
+                key="add-domain"
+                onClick={() => setFormOpen(true)}
+              >
+                Add domains
+              </Button>,
+            ]
+      }
       loading={!domainsLoaded}
       subtitle={`${pluralize("domain", domainCount, true)} available`}
       title="DNS"
+      formWrapper={
+        isFormOpen && (
+          <DomainListHeaderForm
+            closeForm={() => {
+              setFormOpen(false);
+            }}
+          />
+        )
+      }
     />
   );
 };

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -41,13 +41,13 @@ const DomainListHeader = (): JSX.Element => {
       subtitle={`${pluralize("domain", domainCount, true)} available`}
       title="DNS"
       formWrapper={
-        isFormOpen && (
+        isFormOpen ? (
           <DomainListHeaderForm
             closeForm={() => {
               setFormOpen(false);
             }}
           />
-        )
+        ) : null
       }
     />
   );

--- a/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -21,7 +21,7 @@ const DomainListHeader = (): JSX.Element => {
     dispatch(domainActions.fetch());
   }, [dispatch]);
 
-  let buttons = [
+  let buttons: JSX.Element[] | null = [
     <Button
       appearance="neutral"
       data-test="add-domain"
@@ -32,7 +32,7 @@ const DomainListHeader = (): JSX.Element => {
     </Button>,
   ];
 
-  let formWrapper = null;
+  let formWrapper: JSX.Element | null = null;
 
   if (isFormOpen) {
     buttons = null;

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -22,6 +22,8 @@ describe("DomainListHeaderForm", () => {
         <DomainListHeader />
       </Provider>
     );
+    expect(wrapper.find("DomainListHeaderForm").exists()).toBe(false);
+
     wrapper.find("button[data-test='add-domain']").simulate("click");
 
     expect(wrapper.find("DomainListHeaderForm").exists()).toBe(true);

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -41,7 +41,7 @@ describe("DomainListHeaderForm", () => {
     act(() =>
       wrapper.find("Formik").invoke("onSubmit")({
         name: "some-domain",
-        isAuthoritative: true,
+        authoritative: true,
       })
     );
 

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -43,7 +43,6 @@ describe("DomainListHeaderForm", () => {
       })
     );
 
-    console.log(store.getActions());
     expect(
       store.getActions().find((action) => action.type === "domain/create")
     ).toStrictEqual({

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -1,0 +1,66 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DomainListHeaderForm from "./DomainListHeaderForm";
+
+import type { RootState } from "app/store/root/types";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DomainListHeaderForm", () => {
+  let initialState: RootState;
+
+  beforeEach(() => {
+    initialState = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+        items: [domainFactory(), domainFactory()],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("displays a loader if domains have not loaded", () => {
+    const state = { ...initialState };
+    state.domain.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainListHeaderForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a domain count if domains have loaded", () => {
+    const state = { ...initialState };
+    state.domain.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainListHeaderForm />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="section-header-subtitle"]').text()).toBe(
+      "2 domains available"
+    );
+  });
+});

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+
+import { Button, Col, Form, Input, Row } from "@canonical/react-components";
+
+type Props = {
+  closeForm: () => void;
+};
+
+const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
+  const [name, setName] = useState("");
+  const [isAuthoritative, setAuthoritative] = useState(true);
+
+  const onNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.currentTarget.value);
+  };
+  const onAuthoritativeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAuthoritative(e.currentTarget.checked);
+  };
+
+  const onSaveClick = () => {
+    console.log({ name: name, isAuthoritative: isAuthoritative });
+  };
+
+  const onSaveAndCloseClick = () => {
+    onSaveClick();
+    closeForm();
+  };
+
+  return (
+    <Row>
+      <Col size="6">
+        <Form inline={true} className="row">
+          <Input
+            id="name"
+            type="text"
+            wrapperClassName="col-3"
+            onChange={onNameChange}
+            label="Name"
+            placeholder="Domain name"
+          />
+          <Input
+            id="Authoritative"
+            wrapperClassName="col-3"
+            type="checkbox"
+            defaultChecked
+            onChange={onAuthoritativeChange}
+            label="Authoritative"
+          />
+        </Form>
+      </Col>
+      <Col size="6" className="u-align--right">
+        <Button appearance="base" onClick={closeForm}>
+          Cancel
+        </Button>
+        <Button
+          appearance="neutral"
+          onClick={onSaveClick}
+          disabled={name === ""}
+        >
+          Save and add another
+        </Button>
+        <Button
+          appearance="positive"
+          onClick={onSaveAndCloseClick}
+          disabled={name === ""}
+        >
+          Save domain
+        </Button>
+      </Col>
+    </Row>
+  );
+};
+
+export default DomainListHeaderForm;

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -1,4 +1,3 @@
-import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import type { SchemaOf } from "yup";
@@ -56,31 +55,31 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
             name: values.name,
           })
         );
+        closeForm();
       }}
       resetOnSave={true}
       saving={saving}
       saved={saved}
       submitLabel="Save domain"
       validationSchema={domainNameSchema}
+      secondarySubmit={(values) => {
+        dispatch(
+          domainActions.create({
+            authoritative: values.authoritative,
+            name: values.name,
+          })
+        );
+      }}
+      secondarySubmitLabel="Save and add another"
     >
-      <Row style={{ width: "50%", marginRight: "auto" }}>
-        <Col size="6">
-          <FormikField
-            label="Name"
-            type="text"
-            name="name"
-            placeHolder="Domain name"
-            required
-          />
-        </Col>
-        <Col size="6">
-          <FormikField
-            label="Authoritative"
-            type="checkbox"
-            name="authoritative"
-          />
-        </Col>
-      </Row>
+      <FormikField
+        label="Name"
+        type="text"
+        name="name"
+        placeHolder="Domain name"
+        required
+      />
+      <FormikField label="Authoritative" type="checkbox" name="authoritative" />
     </FormikForm>
   );
 };

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -1,4 +1,4 @@
-import { Col, Input, Row } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import type { SchemaOf } from "yup";
@@ -63,7 +63,6 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
       <Row style={{ width: "50%", marginRight: "auto" }}>
         <Col size="6">
           <FormikField
-            component={Input}
             label="Name"
             type="text"
             name="name"
@@ -73,7 +72,6 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
         </Col>
         <Col size="6">
           <FormikField
-            component={Input}
             label="Authoritative"
             type="checkbox"
             name="isAuthoritative"

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -7,14 +7,15 @@ import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
+import type { Domain } from "app/store/domain/types";
 
 type Props = {
   closeForm: () => void;
 };
 
 export type CreateDomain = {
-  name: string;
-  isAuthoritative: boolean;
+  name: Domain["name"];
+  authoritative: Domain["authoritative"];
 };
 
 const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
@@ -28,13 +29,15 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
   // which is wrong.
   const domainnamePattern = /^([a-z\d]|[a-z\d][a-z\d-.]*[a-z\d])*$/i;
 
-  const domainNameSchema: SchemaOf<CreateDomain> = Yup.object().shape({
-    name: Yup.string()
-      .required("Domain name cannot be empty")
-      .matches(domainnamePattern, "The domain name is incorrect")
-      .max(253, "Domain name is too long"),
-    isAuthoritative: Yup.bool(),
-  });
+  const domainNameSchema: SchemaOf<CreateDomain> = Yup.object()
+    .shape({
+      name: Yup.string()
+        .required("Domain name cannot be empty")
+        .matches(domainnamePattern, "The domain name is incorrect")
+        .max(253, "Domain name is too long"),
+      authoritative: Yup.bool(),
+    })
+    .defined();
 
   return (
     <FormikForm<CreateDomain>
@@ -42,14 +45,14 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
       errors={errors}
       initialValues={{
         name: "",
-        isAuthoritative: true,
+        authoritative: true,
       }}
       inline={true}
       onCancel={closeForm}
-      onSubmit={(values: CreateDomain) => {
+      onSubmit={(values) => {
         dispatch(
           domainActions.create({
-            authoritative: values.isAuthoritative,
+            authoritative: values.authoritative,
             name: values.name,
           })
         );
@@ -74,7 +77,7 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
           <FormikField
             label="Authoritative"
             type="checkbox"
-            name="isAuthoritative"
+            name="authoritative"
           />
         </Col>
       </Row>

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -67,6 +67,7 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
             label="Name"
             type="text"
             name="name"
+            placeHolder="Domain name"
             required
           />
         </Col>

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -1,3 +1,4 @@
+import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 import type { SchemaOf } from "yup";
@@ -46,7 +47,6 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
         name: "",
         authoritative: true,
       }}
-      inline={true}
       onCancel={closeForm}
       onSubmit={(values) => {
         dispatch(
@@ -72,14 +72,22 @@ const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {
       }}
       secondarySubmitLabel="Save and add another"
     >
-      <FormikField
-        label="Name"
-        type="text"
-        name="name"
-        placeHolder="Domain name"
-        required
-      />
-      <FormikField label="Authoritative" type="checkbox" name="authoritative" />
+      <Row>
+        <Col size="6">
+          <FormikField
+            label="Name"
+            type="text"
+            name="name"
+            placeHolder="Domain name"
+            required
+          />
+          <FormikField
+            label="Authoritative"
+            type="checkbox"
+            name="authoritative"
+          />
+        </Col>
+      </Row>
     </FormikForm>
   );
 };

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/index.ts
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DomainListHeaderForm";


### PR DESCRIPTION
## Done

- Add the collapsible form to the DNS header

## QA

- go to http://0.0.0.0:8400/MAAS/r/domains
- Add a domain and watch the number of domains go up :chart_with_upwards_trend: 

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-squad/issues/38

## Notes

We went for a simpler approach for the for layout 
![image](https://user-images.githubusercontent.com/11927929/121331755-7805aa00-c917-11eb-8866-12a593264c60.png)


![image](https://user-images.githubusercontent.com/11927929/121195540-f9a1fd00-c86f-11eb-82fd-67522c01452f.png)

@Caleb-Ellis said he would look at it as a part of his refactor and I'll update this component when it's done



Betterer is giving me a hard time :( 