### PR TITLE
Add sorting to domains table

### DIFF
--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,0 +1,62 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DomainsTable from "./DomainsTable";
+
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DomainsTable", () => {
+  it("can update the sort order", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [
+          domainFactory({
+            name: "b",
+          }),
+          domainFactory({
+            name: "c",
+          }),
+          domainFactory({
+            name: "a",
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DomainsTable />
+      </Provider>
+    );
+    const getNameFromTable = (rowNumber: number) =>
+      wrapper
+        .find("tbody TableRow")
+        .at(rowNumber)
+        .find("[data-test='domain-name']")
+        .at(0); // both TableCell and td have the same data-test value
+
+    // Sorted ascending by name by default
+    expect(getNameFromTable(0).text()).toBe("a");
+    expect(getNameFromTable(1).text()).toBe("b");
+    expect(getNameFromTable(2).text()).toBe("c");
+
+    // Change to sort descending by name
+    wrapper.find("[data-test='domain-name-header']").at(0).simulate("click");
+    expect(getNameFromTable(0).text()).toBe("c");
+    expect(getNameFromTable(1).text()).toBe("b");
+    expect(getNameFromTable(2).text()).toBe("a");
+
+    // Change to no sort
+    wrapper.find("[data-test='domain-name-header']").at(0).simulate("click");
+    expect(getNameFromTable(0).text()).toBe("b");
+    expect(getNameFromTable(1).text()).toBe("c");
+    expect(getNameFromTable(2).text()).toBe("a");
+  });
+});

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -7,19 +7,41 @@ const DomainsTable = (): JSX.Element => {
   const domains = useSelector(domainSelectors.all);
 
   const headers = [
-    { content: "Domain" },
-    { content: "Authoriatative" },
-    { content: "Hosts", className: "u-align--right" },
-    { content: "Total records", className: "u-align--right" },
-    { content: "Actions", className: "u-align--right" },
+    {
+      content: "Domain",
+      sortKey: "name",
+      "data-test": "domain-name-header",
+    },
+    {
+      content: "Authoriatative",
+      sortKey: "authoritative",
+    },
+    {
+      content: "Hosts",
+      sortKey: "hosts",
+      className: "u-align--right",
+    },
+    {
+      content: "Total records",
+      sortKey: "records",
+      className: "u-align--right",
+    },
+    {
+      content: "Actions",
+      className: "u-align--right",
+    },
   ];
+
   const rows = domains.map((domain) => {
     return {
-      key: domain.id,
+      // making sure we don't pass id directly as a key because of
+      // https://github.com/canonical-web-and-design/react-components/issues/476
+      key: `domain-row-${domain.id}`,
       className: "p-table__row",
       columns: [
         {
           content: domain.name,
+          "data-test": "domain-name",
         },
         {
           content: domain.authoritative ? "Yes" : "No",
@@ -37,15 +59,24 @@ const DomainsTable = (): JSX.Element => {
           className: "u-align--right",
         },
       ],
+      sortData: {
+        name: domain.name,
+        authoritative: domain.authoritative,
+        hosts: domain.hosts,
+        records: domain.resource_count,
+      },
     };
   });
 
   return (
     <MainTable
-      headers={headers}
-      paginate={50}
-      rows={rows}
       data-test="domains-table"
+      headers={headers}
+      rows={rows}
+      paginate={50}
+      sortable
+      defaultSort="name"
+      defaultSortDirection="ascending"
     />
   );
 };


### PR DESCRIPTION
## Done

- Add sorting to domains table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- run `yarn start`
- go to http://0.0.0.0:8400/MAAS/r/domains
- you should be able to sort the table

## Fixes

Fixes: canonical-web-and-design/app-squad#41

![sortable-domains](https://user-images.githubusercontent.com/83575/121214466-6ec8fe80-c87f-11eb-85cc-a88184a2c950.gif)
