### PR TITLE
feat(ui): add boot resources slice

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -3,6 +3,19 @@
 exports[`rootReducer should reset app to initial state on LOGOUT_SUCCESS, except status which
     resets to authenticating = false 1`] = `
 Object {
+  "bootresource": Object {
+    "connectionError": false,
+    "eventErrors": Array [],
+    "otherImages": Array [],
+    "rackImportRunning": false,
+    "regionImportRunning": false,
+    "resources": Array [],
+    "statuses": Object {
+      "poll": false,
+    },
+    "ubuntu": null,
+    "ubuntuCoreImages": Array [],
+  },
   "config": Object {
     "errors": null,
     "items": Array [],

--- a/ui/src/app/base/sagas/websockets.test.js
+++ b/ui/src/app/base/sagas/websockets.test.js
@@ -300,6 +300,26 @@ describe("websocket sagas", () => {
     );
   });
 
+  it("can handle a WebSocket JSON response message", () => {
+    const saga = handleMessage(socketChannel, socketClient);
+    expect(saga.next().value).toEqual(take(socketChannel));
+    expect(
+      saga.next({ request_id: 99, result: '{"this_is": "JSON"}' }).value
+    ).toEqual(call([socketClient, socketClient.getRequest], 99));
+    saga.next({
+      meta: { jsonResponse: true },
+      type: "test/action",
+      payload: { id: 808 },
+    });
+    expect(saga.next(false).value).toEqual(
+      put({
+        meta: { item: { id: 808 } },
+        type: "test/actionSuccess",
+        payload: { this_is: "JSON" },
+      })
+    );
+  });
+
   it("can handle a batch response", () => {
     const saga = handleMessage(socketChannel, socketClient);
     saga.next();

--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -1,8 +1,18 @@
+import { useEffect } from "react";
+
+import { useDispatch } from "react-redux";
+
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
+import { actions as bootResourceActions } from "app/store/bootresource";
 
 const ImagesList = (): JSX.Element => {
+  const dispatch = useDispatch();
   useWindowTitle("Images");
+
+  useEffect(() => {
+    dispatch(bootResourceActions.poll());
+  }, [dispatch]);
 
   return (
     <Section header="Images" headerClassName="u-no-padding--bottom">

--- a/ui/src/app/store/bootresource/actions.test.ts
+++ b/ui/src/app/store/bootresource/actions.test.ts
@@ -1,0 +1,15 @@
+import { actions } from "./slice";
+
+describe("bootresource actions", () => {
+  it("can create a poll action", () => {
+    expect(actions.poll()).toEqual({
+      type: "bootresource/poll",
+      meta: {
+        jsonResponse: true,
+        model: "bootresource",
+        method: "poll",
+      },
+      payload: null,
+    });
+  });
+});

--- a/ui/src/app/store/bootresource/index.ts
+++ b/ui/src/app/store/bootresource/index.ts
@@ -1,0 +1,1 @@
+export { default, actions } from "./slice";

--- a/ui/src/app/store/bootresource/reducers.test.ts
+++ b/ui/src/app/store/bootresource/reducers.test.ts
@@ -1,0 +1,113 @@
+import reducers, { actions } from "./slice";
+import { BootResourceAction } from "./types";
+
+import {
+  bootResource as bootResourceFactory,
+  bootResourceUbuntu as bootResourceUbuntuFactory,
+  bootResourceUbuntuCoreImage as bootResourceUbuntuCoreImageFactory,
+  bootResourceOtherImage as bootResourceOtherImageFactory,
+  bootResourceEventError as bootResourceEventErrorFactory,
+  bootResourceState as bootResourceStateFactory,
+  bootResourceStatuses as bootResourceStatusesFactory,
+} from "testing/factories";
+
+describe("bootresource reducers", () => {
+  it("returns the initial state", () => {
+    expect(reducers(undefined, { type: "" })).toEqual({
+      connectionError: false,
+      eventErrors: [],
+      otherImages: [],
+      rackImportRunning: false,
+      regionImportRunning: false,
+      resources: [],
+      statuses: {
+        poll: false,
+      },
+      ubuntu: null,
+      ubuntuCoreImages: [],
+    });
+  });
+
+  describe("poll", () => {
+    it("reduces pollStart", () => {
+      expect(
+        reducers(
+          bootResourceStateFactory({
+            statuses: bootResourceStatusesFactory({
+              poll: false,
+            }),
+          }),
+          actions.pollStart()
+        )
+      ).toEqual(
+        bootResourceStateFactory({
+          statuses: bootResourceStatusesFactory({
+            poll: true,
+          }),
+        })
+      );
+    });
+
+    it("reduces pollSuccess", () => {
+      const bootResourceState = bootResourceStateFactory({
+        statuses: bootResourceStatusesFactory({
+          poll: true,
+        }),
+      });
+      const resources = [bootResourceFactory()];
+      const ubuntu = bootResourceUbuntuFactory();
+      const ubuntuCoreImages = [bootResourceUbuntuCoreImageFactory()];
+      const otherImages = [bootResourceOtherImageFactory()];
+      expect(
+        reducers(
+          bootResourceState,
+          actions.pollSuccess({
+            connection_error: false,
+            other_images: otherImages,
+            rack_import_running: false,
+            region_import_running: false,
+            resources,
+            ubuntu_core_images: ubuntuCoreImages,
+            ubuntu,
+          })
+        )
+      ).toEqual(
+        bootResourceStateFactory({
+          connectionError: false,
+          otherImages,
+          rackImportRunning: false,
+          regionImportRunning: false,
+          resources,
+          ubuntuCoreImages,
+          ubuntu,
+          statuses: bootResourceStatusesFactory({
+            poll: false,
+          }),
+        })
+      );
+    });
+
+    it("reduces pollError", () => {
+      const bootResourceState = bootResourceStateFactory({
+        statuses: bootResourceStatusesFactory({
+          poll: true,
+        }),
+      });
+      expect(
+        reducers(bootResourceState, actions.pollError("Could not poll"))
+      ).toEqual(
+        bootResourceStateFactory({
+          eventErrors: [
+            bootResourceEventErrorFactory({
+              error: "Could not poll",
+              event: BootResourceAction.POLL,
+            }),
+          ],
+          statuses: bootResourceStatusesFactory({
+            poll: false,
+          }),
+        })
+      );
+    });
+  });
+});

--- a/ui/src/app/store/bootresource/slice.ts
+++ b/ui/src/app/store/bootresource/slice.ts
@@ -1,0 +1,77 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
+
+import type {
+  BootResourceState,
+  BootResourcePollResponse,
+  BootResourceEventError,
+} from "./types";
+import { BootResourceAction, BootResourceMeta } from "./types";
+
+const bootResourceSlice = createSlice({
+  name: BootResourceMeta.MODEL,
+  initialState: {
+    connectionError: false,
+    eventErrors: [],
+    otherImages: [],
+    rackImportRunning: false,
+    regionImportRunning: false,
+    resources: [],
+    statuses: {
+      poll: false,
+    },
+    ubuntu: null,
+    ubuntuCoreImages: [],
+  } as BootResourceState,
+  reducers: {
+    [BootResourceAction.POLL]: {
+      // poll: {
+      prepare: () => ({
+        meta: {
+          // The data returned by the API is JSON for this endpoint.
+          jsonResponse: true,
+          model: BootResourceMeta.MODEL,
+          method: "poll",
+        },
+        payload: null,
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    pollError: (
+      state: BootResourceState,
+      action: PayloadAction<BootResourceEventError["error"]>
+    ) => {
+      state.statuses[BootResourceAction.POLL] = false;
+      state.eventErrors.push({
+        error: action.payload,
+        event: BootResourceAction.POLL,
+      });
+    },
+    pollStart: (state: BootResourceState) => {
+      state.statuses[BootResourceAction.POLL] = true;
+    },
+    pollSuccess: (
+      state: BootResourceState,
+      action: PayloadAction<BootResourcePollResponse>
+    ) => {
+      const { payload } = action;
+      state.statuses[BootResourceAction.POLL] = false;
+      state.connectionError = payload.connection_error;
+      state.otherImages = payload.other_images;
+      state.rackImportRunning = payload.rack_import_running;
+      state.regionImportRunning = payload.region_import_running;
+      state.resources = payload.resources;
+      state.ubuntu = payload.ubuntu;
+      state.ubuntuCoreImages = payload.ubuntu_core_images;
+    },
+    cleanup(state: BootResourceState) {
+      state.eventErrors = [];
+    },
+  },
+});
+
+export const { actions } = bootResourceSlice;
+
+export default bootResourceSlice.reducer;

--- a/ui/src/app/store/bootresource/types/base.ts
+++ b/ui/src/app/store/bootresource/types/base.ts
@@ -1,0 +1,84 @@
+import type {
+  BootResourceAction,
+  BootResourceSourceType,
+  BootResourceType,
+} from "./enum";
+
+import type { Model } from "app/store/types/model";
+
+export type BootResourceStatuses = {
+  [BootResourceAction.POLL]: boolean;
+};
+
+export type BootResource = Model & {
+  arch: string;
+  complete: boolean;
+  downloading: boolean;
+  icon: "in-progress" | "queued" | "succeeded" | "waiting";
+  lastUpdate: string;
+  name: string;
+  numberOfNodes: number;
+  rtype: BootResourceType;
+  size: string;
+  status: string;
+  title: string;
+};
+
+export type BootResourceUbuntuSource = {
+  keyring_data: string;
+  keyring_filename: string;
+  source_type: BootResourceSourceType;
+  url: string;
+};
+
+export type BootResourceUbuntuRelease = {
+  checked: boolean;
+  deleted: boolean;
+  name: string;
+  title: string;
+  unsupported_arches: string[];
+};
+
+export type BootResourceUbuntuArch = {
+  checked: boolean;
+  deleted: boolean;
+  name: string;
+  title: string;
+};
+
+export type BootResourceUbuntu = {
+  arches: BootResourceUbuntuArch[];
+  commissioning_series: string;
+  releases: BootResourceUbuntuRelease[];
+  sources: BootResourceUbuntuSource[];
+};
+
+export type BootResourceOtherImage = {
+  checked: boolean;
+  deleted: boolean;
+  name: string;
+  title: string;
+};
+export type BootResourceUbuntuCoreImage = {
+  checked: boolean;
+  deleted: boolean;
+  name: string;
+  title: string;
+};
+
+export type BootResourceEventError = {
+  error: string;
+  event: string;
+};
+
+export type BootResourceState = {
+  connectionError: boolean;
+  eventErrors: BootResourceEventError[];
+  otherImages: BootResourceOtherImage[];
+  rackImportRunning: boolean;
+  regionImportRunning: boolean;
+  resources: BootResource[];
+  statuses: BootResourceStatuses;
+  ubuntu: BootResourceUbuntu | null;
+  ubuntuCoreImages: BootResourceUbuntuCoreImage[];
+};

--- a/ui/src/app/store/bootresource/types/enum.ts
+++ b/ui/src/app/store/bootresource/types/enum.ts
@@ -1,0 +1,21 @@
+export enum BootResourceAction {
+  POLL = "poll",
+}
+
+export enum BootResourceMeta {
+  MODEL = "bootresource",
+  PK = "id",
+}
+
+export enum BootResourceSourceType {
+  MAAS_IO = "maas.io",
+  CUSTOM = "custom",
+}
+
+export enum BootResourceType {
+  SYNCED = 0,
+
+  GENERATED = 1,
+
+  UPLOADED = 2,
+}

--- a/ui/src/app/store/bootresource/types/index.ts
+++ b/ui/src/app/store/bootresource/types/index.ts
@@ -1,0 +1,19 @@
+export type {
+  BootResource,
+  BootResourceEventError,
+  BootResourceOtherImage,
+  BootResourceState,
+  BootResourceStatuses,
+  BootResourceUbuntu,
+  BootResourceUbuntuArch,
+  BootResourceUbuntuCoreImage,
+  BootResourceUbuntuRelease,
+  BootResourceUbuntuSource,
+} from "./base";
+export type { BootResourcePollResponse } from "./responses";
+export {
+  BootResourceAction,
+  BootResourceMeta,
+  BootResourceSourceType,
+  BootResourceType,
+} from "./enum";

--- a/ui/src/app/store/bootresource/types/responses.ts
+++ b/ui/src/app/store/bootresource/types/responses.ts
@@ -1,0 +1,16 @@
+import type {
+  BootResource,
+  BootResourceUbuntu,
+  BootResourceOtherImage,
+  BootResourceUbuntuCoreImage,
+} from "./base";
+
+export type BootResourcePollResponse = {
+  connection_error: boolean;
+  other_images: BootResourceOtherImage[];
+  rack_import_running: boolean;
+  region_import_running: boolean;
+  resources: BootResource[];
+  ubuntu: BootResourceUbuntu;
+  ubuntu_core_images: BootResourceUbuntuCoreImage[];
+};

--- a/ui/src/app/store/root/types.ts
+++ b/ui/src/app/store/root/types.ts
@@ -1,5 +1,9 @@
 import type { RouterState } from "connected-react-router";
 
+import type {
+  BootResourceState,
+  BootResourceMeta,
+} from "app/store/bootresource/types";
 import type { ConfigState, ConfigMeta } from "app/store/config/types";
 import type {
   ControllerState,
@@ -60,6 +64,7 @@ import type { VLANState, VLANMeta } from "app/store/vlan/types";
 import type { ZoneState, ZoneMeta } from "app/store/zone/types";
 
 export type RootState = {
+  [BootResourceMeta.MODEL]: BootResourceState;
   [ConfigMeta.MODEL]: ConfigState;
   [ControllerMeta.MODEL]: ControllerState;
   [DeviceMeta.MODEL]: DeviceState;

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -5,6 +5,7 @@ import type {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
+import type { BootResourceMeta } from "app/store/bootresource/types";
 import type { ConfigMeta } from "app/store/config/types";
 import type { GeneralMeta } from "app/store/general/types";
 import type { MachineMeta, MachineStatus } from "app/store/machine/types";
@@ -19,6 +20,7 @@ export type GenericItemMeta<I> = {
 };
 
 // Get the models that follow the generic shape. The following models are excluded:
+// - 'bootresource' does not follow the standard shape.
 // - 'config' contains a collection of children without IDs.
 // - 'general' has a collection of sub-models that form a different shape.
 // - 'messages' not an API model.
@@ -28,6 +30,7 @@ export type GenericItemMeta<I> = {
 export type CommonStates = Omit<
   RootState,
   | "router"
+  | BootResourceMeta.MODEL
   | ConfigMeta.MODEL
   | GeneralMeta.MODEL
   | MessageMeta.MODEL

--- a/ui/src/root-reducer.js
+++ b/ui/src/root-reducer.js
@@ -4,6 +4,7 @@ import { connectRouter } from "connected-react-router";
 
 import { genericInitialState as userInitialState } from "./app/store/utils/slice";
 import auth from "app/store/auth";
+import bootresource from "app/store/bootresource";
 import config from "app/store/config";
 import controller from "app/store/controller";
 import device from "app/store/device";
@@ -38,6 +39,7 @@ import zone from "app/store/zone";
 
 const createAppReducer = (history) =>
   combineReducers({
+    bootresource,
     config,
     controller,
     device,

--- a/ui/src/testing/factories/bootresource.ts
+++ b/ui/src/testing/factories/bootresource.ts
@@ -1,0 +1,58 @@
+import { define, extend } from "cooky-cutter";
+
+import { model } from "./model";
+
+import type {
+  BootResource,
+  BootResourceEventError,
+  BootResourceOtherImage,
+  BootResourceStatuses,
+  BootResourceUbuntu,
+  BootResourceUbuntuCoreImage,
+} from "app/store/bootresource/types";
+import { BootResourceAction } from "app/store/bootresource/types";
+import type { Model } from "app/store/types/model";
+
+export const bootResource = extend<Model, BootResource>(model, {
+  rtype: 0,
+  name: "ubuntu/bionic",
+  title: "18.04 LTS",
+  arch: "amd64",
+  size: "650.4 MB",
+  complete: false,
+  status: "Waiting for rack controller(s) to sync",
+  icon: "waiting",
+  downloading: false,
+  numberOfNodes: 0,
+  lastUpdate: "Tue, 08 Jun. 2021 02:12:47",
+});
+
+export const bootResourceUbuntu = define<BootResourceUbuntu>({
+  arches: () => [],
+  commissioning_series: "focal",
+  releases: () => [],
+  sources: () => [],
+});
+
+export const bootResourceUbuntuCoreImage = define<BootResourceUbuntuCoreImage>({
+  checked: false,
+  deleted: false,
+  name: "ubuntu/core",
+  title: "Ubuntu Core",
+});
+
+export const bootResourceOtherImage = define<BootResourceOtherImage>({
+  checked: false,
+  deleted: false,
+  name: "centos/amd64/generic/8",
+  title: "CentOS 8",
+});
+
+export const bootResourceEventError = define<BootResourceEventError>({
+  error: "Poll failed",
+  event: BootResourceAction.POLL,
+});
+
+export const bootResourceStatuses = define<BootResourceStatuses>({
+  poll: false,
+});

--- a/ui/src/testing/factories/bootresource.ts
+++ b/ui/src/testing/factories/bootresource.ts
@@ -8,9 +8,15 @@ import type {
   BootResourceOtherImage,
   BootResourceStatuses,
   BootResourceUbuntu,
+  BootResourceUbuntuArch,
   BootResourceUbuntuCoreImage,
+  BootResourceUbuntuRelease,
+  BootResourceUbuntuSource,
 } from "app/store/bootresource/types";
-import { BootResourceAction } from "app/store/bootresource/types";
+import {
+  BootResourceSourceType,
+  BootResourceAction,
+} from "app/store/bootresource/types";
 import type { Model } from "app/store/types/model";
 
 export const bootResource = extend<Model, BootResource>(model, {
@@ -34,11 +40,33 @@ export const bootResourceUbuntu = define<BootResourceUbuntu>({
   sources: () => [],
 });
 
+export const bootResourceUbuntuArch = define<BootResourceUbuntuArch>({
+  name: "amd64",
+  title: "amd64",
+  checked: false,
+  deleted: false,
+});
+
 export const bootResourceUbuntuCoreImage = define<BootResourceUbuntuCoreImage>({
   checked: false,
   deleted: false,
   name: "ubuntu/core",
   title: "Ubuntu Core",
+});
+
+export const bootResourceUbuntuSource = define<BootResourceUbuntuSource>({
+  source_type: BootResourceSourceType.MAAS_IO,
+  url: "http://images.maas.io/ephemeral-v3/stable/",
+  keyring_filename: "/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg",
+  keyring_data: "aabbccdd",
+});
+
+export const bootResourceUbuntuRelease = define<BootResourceUbuntuRelease>({
+  name: "xenial",
+  title: "16.04 LTS",
+  unsupported_arches: () => [],
+  checked: false,
+  deleted: false,
 });
 
 export const bootResourceOtherImage = define<BootResourceOtherImage>({

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -57,8 +57,11 @@ export {
   bootResourceEventError,
   bootResourceStatuses,
   bootResourceUbuntu,
+  bootResourceUbuntuArch,
   bootResourceUbuntuCoreImage,
+  bootResourceUbuntuSource,
   bootResourceOtherImage,
+  bootResourceUbuntuRelease,
 } from "./bootresource";
 export { config } from "./config";
 export { discovery } from "./discovery";

--- a/ui/src/testing/factories/index.ts
+++ b/ui/src/testing/factories/index.ts
@@ -1,4 +1,5 @@
 export {
+  bootResourceState,
   architecturesState,
   authState,
   bondOptionsState,
@@ -51,6 +52,14 @@ export {
   vlanState,
   zoneState,
 } from "./state";
+export {
+  bootResource,
+  bootResourceEventError,
+  bootResourceStatuses,
+  bootResourceUbuntu,
+  bootResourceUbuntuCoreImage,
+  bootResourceOtherImage,
+} from "./bootresource";
 export { config } from "./config";
 export { discovery } from "./discovery";
 export { domain } from "./domain";

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -1,6 +1,7 @@
 import type { RouterLocation, RouterState } from "connected-react-router";
 import { define, random } from "cooky-cutter";
 
+import type { BootResourceState } from "app/store/bootresource/types";
 import type { ConfigState } from "app/store/config/types";
 import type { ControllerState } from "app/store/controller/types";
 import type { DeviceState } from "app/store/device/types";
@@ -76,6 +77,18 @@ export const authState = define<AuthState>({
   saved: false,
   saving: false,
   user: null,
+});
+
+export const bootResourceState = define<BootResourceState>({
+  connectionError: false,
+  eventErrors: () => [],
+  otherImages: () => [],
+  rackImportRunning: false,
+  regionImportRunning: false,
+  resources: () => [],
+  statuses: () => ({ poll: false }),
+  ubuntu: null,
+  ubuntuCoreImages: () => [],
 });
 
 export const configState = define<ConfigState>({
@@ -383,6 +396,7 @@ export const routerState = define<RouterState>({
 });
 
 export const rootState = define<RootState>({
+  bootresource: bootResourceState,
   config: configState,
   controller: controllerState,
   device: deviceState,


### PR DESCRIPTION
## Done

- Add the slice for the boot resource model.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the React images page.
- Open the redux state in the dev tools.
- You should see bootresources with loaded data. 

## Fixes

Fixes: canonical-web-and-design#issues/75.