### PR TITLE
refactor(ui): update Formik secondarySubmit to not also run onSubmit

### DIFF
--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -16,6 +16,7 @@ const FormikForm = <V,>({
   buttonsHelpLink,
   cancelDisabled,
   children,
+  className,
   cleanup,
   editable,
   errors,
@@ -49,6 +50,7 @@ const FormikForm = <V,>({
         buttonsHelpLabel={buttonsHelpLabel}
         buttonsHelpLink={buttonsHelpLink}
         cancelDisabled={cancelDisabled}
+        className={className}
         cleanup={cleanup}
         editable={editable}
         errors={errors}

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
@@ -11,6 +11,11 @@ import classNames from "classnames";
 import type { FormikContextType } from "formik";
 import { useFormikContext } from "formik";
 
+export type FormikContextFunc<V> = (
+  values: V,
+  formikContext: FormikContextType<V>
+) => void;
+
 export type Props<V> = {
   buttonsAlign?: "left" | "right";
   buttonsBordered?: boolean;
@@ -19,11 +24,11 @@ export type Props<V> = {
   buttonsHelpLink?: string;
   cancelDisabled?: boolean;
   inline?: boolean;
-  onCancel?: (formikContext: FormikContextType<V>) => void;
+  onCancel?: FormikContextFunc<V>;
   saved?: boolean;
   saving?: boolean;
   savingLabel?: string;
-  secondarySubmit?: () => void;
+  secondarySubmit?: FormikContextFunc<V>;
   secondarySubmitDisabled?: boolean;
   secondarySubmitLabel?: string;
   secondarySubmitTooltip?: string | null;
@@ -53,6 +58,7 @@ export const FormikFormButtons = <V,>({
   submitLabel = "Save",
 }: Props<V>): JSX.Element => {
   const formikContext = useFormikContext<V>();
+  const { values } = formikContext;
   const showSecondarySubmit = Boolean(secondarySubmit && secondarySubmitLabel);
   const showHelpLink = Boolean(buttonsHelpLink && buttonsHelpLabel);
 
@@ -64,7 +70,11 @@ export const FormikFormButtons = <V,>({
         className={classNames({ "u-no-margin--bottom": buttonsBordered })}
         data-test="secondary-submit"
         disabled={secondarySubmitDisabled || submitDisabled}
-        onClick={secondarySubmit}
+        onClick={
+          secondarySubmit
+            ? () => secondarySubmit(values, formikContext)
+            : undefined
+        }
         type="button"
       >
         {secondarySubmitLabel}
@@ -115,7 +125,9 @@ export const FormikFormButtons = <V,>({
               })}
               data-test="cancel-action"
               disabled={cancelDisabled}
-              onClick={onCancel ? () => onCancel(formikContext) : undefined}
+              onClick={
+                onCancel ? () => onCancel(values, formikContext) : undefined
+              }
               type="button"
             >
               Cancel

--- a/ui/src/app/base/components/FormikFormButtons/index.ts
+++ b/ui/src/app/base/components/FormikFormButtons/index.ts
@@ -1,2 +1,5 @@
 export { default } from "./FormikFormButtons";
-export type { Props as FormikFormButtonsProps } from "./FormikFormButtons";
+export type {
+  Props as FormikFormButtonsProps,
+  FormikContextFunc,
+} from "./FormikFormButtons";

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -25,6 +25,7 @@ export type Props<V> = {
   allowAllEmpty?: boolean;
   allowUnchanged?: boolean;
   children?: ReactNode;
+  className?: string;
   cleanup?: () => void;
   editable?: boolean;
   errors?: FormErrors;
@@ -40,7 +41,6 @@ export type Props<V> = {
   saved?: boolean;
   savedRedirect?: string;
   saving?: boolean;
-  secondarySubmit?: () => void;
   submitDisabled?: boolean;
 } & FormikFormButtonsProps<V>;
 
@@ -71,6 +71,7 @@ const FormikFormContent = <V,>({
   allowAllEmpty,
   allowUnchanged,
   children,
+  className,
   cleanup,
   editable = true,
   errors,
@@ -82,12 +83,11 @@ const FormikFormContent = <V,>({
   saved,
   savedRedirect,
   saving,
-  secondarySubmit,
   submitDisabled,
   ...buttonsProps
 }: Props<V>): JSX.Element => {
   const dispatch = useDispatch();
-  const { handleSubmit, initialValues, resetForm, submitForm, values } =
+  const { handleSubmit, initialValues, resetForm, values } =
     useFormikContext<V>();
   const formDisabled = useFormikFormDisabled<V>({
     allowAllEmpty,
@@ -132,7 +132,7 @@ const FormikFormContent = <V,>({
   }
 
   return (
-    <Form inline={inline} onSubmit={handleSubmit}>
+    <Form className={className} inline={inline} onSubmit={handleSubmit}>
       {!!nonFieldError && (
         <Notification type="negative" status="Error:">
           {nonFieldError}
@@ -146,14 +146,6 @@ const FormikFormContent = <V,>({
           inline={inline}
           saved={saved}
           saving={saving}
-          secondarySubmit={
-            secondarySubmit
-              ? () => {
-                  secondarySubmit();
-                  submitForm();
-                }
-              : undefined
-          }
           submitDisabled={loading || saving || formDisabled || submitDisabled}
         />
       )}

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
@@ -116,7 +116,10 @@ export const AddChassisForm = () => {
             saving={machineSaving}
             saved={machineSaved}
             savedRedirect={resetOnSave ? undefined : machineURLs.machines.index}
-            secondarySubmit={() => setResetOnSave(true)}
+            secondarySubmit={(_, { submitForm }) => {
+              setResetOnSave(true);
+              submitForm();
+            }}
             secondarySubmitLabel="Save and add another"
             submitLabel="Save chassis"
             validationSchema={AddChassisSchema}

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -175,7 +175,10 @@ export const AddMachineForm = () => {
             saving={machineSaving}
             saved={machineSaved}
             savedRedirect={resetOnSave ? undefined : machineURLs.machines.index}
-            secondarySubmit={() => setResetOnSave(true)}
+            secondarySubmit={(_, { submitForm }) => {
+              setResetOnSave(true);
+              submitForm();
+            }}
             secondarySubmitLabel="Save and add another"
             submitLabel="Save machine"
             validationSchema={AddMachineSchema}

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
@@ -100,8 +100,7 @@ const MachineForm = ({ systemId }: Props): JSX.Element | null => {
             category: "Machine details",
             label: "Save changes",
           }}
-          onCancel={(formikContext) => {
-            const { initialValues, resetForm } = formikContext;
+          onCancel={(_, { initialValues, resetForm }) => {
             resetForm({ values: initialValues });
             setEditing(false);
             dispatch(machineActions.cleanup());

--- a/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.tsx
@@ -111,8 +111,7 @@ const PowerForm = ({ systemId }: Props): JSX.Element | null => {
             category: "Machine details",
             label: "Save changes",
           }}
-          onCancel={(formikContext) => {
-            const { initialValues, resetForm } = formikContext;
+          onCancel={(_, { initialValues, resetForm }) => {
             setPowerTypeFromName(machine.power_type);
             resetForm({ values: initialValues });
             setEditing(false);

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
@@ -117,9 +117,10 @@ const AddAliasOrVlan = ({
         resetOnSave
         saved={saved}
         saving={saving}
-        secondarySubmit={() => {
+        secondarySubmit={(_, { submitForm }) => {
           // Flag that the form was submitted by the secondary action.
           setSecondarySubmit(true);
+          submitForm();
         }}
         secondarySubmitDisabled={!canAddAnother}
         secondarySubmitLabel="Save and add another"


### PR DESCRIPTION
## Done

- Updated `FormikForm`'s `secondarySubmit` prop to not always run `onSubmit`. It also includes formik context so you can use all of Formik's functions in `secondarySubmit` (including `submitForm`).
- Updated the `onCancel` prop to follow the same format, so now all the button functions have the shape `(values, formikContext) => {}`
- Driveby - added `className` prop to `FormikFormContent`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/machines/add and check that the "Save and add another" button still works as before

## Fixes

Fixes #2742
