### PR TITLE
feat(ui): add type aliases for any and empty objects

### DIFF
--- a/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/ui/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -5,6 +5,7 @@ import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
+import type { AnyObject } from "app/base/types";
 import { actions as generalActions } from "app/store/general";
 import { powerTypes as powerTypesSelectors } from "app/store/general/selectors";
 import type { PowerType } from "app/store/general/types";
@@ -65,7 +66,7 @@ const generateFields = (
       );
     });
 
-export const PowerTypeFields = <F extends Record<string, unknown>>({
+export const PowerTypeFields = <V extends AnyObject>({
   disableFields = false,
   disableSelect = false,
   forChassis = false,
@@ -86,7 +87,7 @@ export const PowerTypeFields = <F extends Record<string, unknown>>({
     setFieldValue,
     setTouched,
     values,
-  } = useFormikContext<F>();
+  } = useFormikContext<V>();
 
   // Only power types that can probe are suitable for use when adding a chassis.
   const powerTypes = forChassis ? chassisPowerTypes : allPowerTypes;

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -23,3 +23,7 @@ export type SelectedAction<A, E> = {
 export type SetSelectedAction<SA> = (action: SA | null) => void;
 
 export type ClearSelectedAction = () => void;
+
+export type AnyObject = Record<string, unknown>;
+
+export type EmptyObject = Record<string, never>;

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/RefreshForm/RefreshForm.tsx
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearSelectedAction, EmptyObject } from "app/base/types";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 
@@ -20,7 +20,7 @@ const RefreshForm = ({ clearSelectedAction }: Props): JSX.Element | null => {
 
   if (activePod) {
     return (
-      <ActionForm<Record<string, never>>
+      <ActionForm<EmptyObject>
         actionName="refresh"
         cleanup={cleanup}
         clearSelectedAction={clearSelectedAction}

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
 
 import ActionForm from "app/base/components/ActionForm";
-import type { ClearSelectedAction } from "app/base/types";
+import type { ClearSelectedAction, EmptyObject } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import machineURLs from "app/machines/urls";
 import type { MachineSelectedAction } from "app/machines/views/types";
@@ -58,7 +58,7 @@ export const FieldlessForm = ({
   }
 
   return (
-    <ActionForm<Record<string, never>>
+    <ActionForm<EmptyObject>
       actionDisabled={actionDisabled}
       actionName={selectedAction.name}
       allowUnchanged

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from "react-redux";
 
 import FormCard from "app/base/components/FormCard";
 import FormikForm from "app/base/components/FormikForm";
+import type { EmptyObject } from "app/base/types";
 import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import { StorageLayout } from "app/store/machine/types";
@@ -68,7 +69,7 @@ export const ChangeStorageLayout = ({ systemId }: Props): JSX.Element => {
     </div>
   ) : (
     <FormCard data-test="confirmation-form" sidebar={false}>
-      <FormikForm<Record<string, never>>
+      <FormikForm<EmptyObject>
         cleanup={machineActions.cleanup}
         errors={errors}
         initialValues={{}}


### PR DESCRIPTION
## Done

- Added `AnyObject` and `EmptyObject` type aliases, since `Record<string, unknown>` kind of makes no sense at all.

## QA steps

- N/A