### PR TITLE
feat(ui): add the images header

### DIFF
--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -2,6 +2,8 @@ import { useEffect } from "react";
 
 import { useDispatch } from "react-redux";
 
+import ImageListHeader from "./ImageListHeader";
+
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
 import { actions as bootResourceActions } from "app/store/bootresource";
@@ -15,7 +17,10 @@ const ImagesList = (): JSX.Element => {
   }, [dispatch]);
 
   return (
-    <Section header="Images" headerClassName="u-no-padding--bottom">
+    <Section
+      header={<ImageListHeader />}
+      headerClassName="u-no-padding--bottom"
+    >
       Images
     </Section>
   );

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
@@ -1,0 +1,37 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ImageListHeader from "./ImageListHeader";
+
+import {
+  bootResourceState as bootResourceStateFactory,
+  bootResourceStatuses as bootResourceStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ImageListHeader", () => {
+  it("sets the loading state when polling", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        statuses: bootResourceStatusesFactory({
+          poll: true,
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/images", key: "testKey" }]}
+        >
+          <ImageListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("SectionHeader").prop("loading")).toBe(true);
+  });
+});

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+
+import SectionHeader from "app/base/components/SectionHeader";
+import { actions as bootResourceActions } from "app/store/bootresource";
+import bootResourceSelectors from "app/store/bootresource/selectors";
+
+const ImageListHeader = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const polling = useSelector(bootResourceSelectors.polling);
+
+  useEffect(() => {
+    dispatch(bootResourceActions.poll());
+  }, [dispatch]);
+
+  return <SectionHeader loading={polling} title="Images" />;
+};
+
+export default ImageListHeader;

--- a/ui/src/app/images/views/ImageList/ImageListHeader/index.ts
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ImageListHeader";

--- a/ui/src/app/store/bootresource/selectors.test.ts
+++ b/ui/src/app/store/bootresource/selectors.test.ts
@@ -1,0 +1,32 @@
+import bootResourceSelectors from "./selectors";
+
+import {
+  bootResourceState as bootResourceStateFactory,
+  bootResourceStatuses as bootResourceStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+describe("bootresource selectors", () => {
+  it("can get all statuses", () => {
+    const statuses = bootResourceStatusesFactory({
+      poll: true,
+    });
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        statuses,
+      }),
+    });
+    expect(bootResourceSelectors.statuses(state)).toStrictEqual(statuses);
+  });
+
+  it("can get the polling status", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        statuses: bootResourceStatusesFactory({
+          poll: true,
+        }),
+      }),
+    });
+    expect(bootResourceSelectors.polling(state)).toBe(true);
+  });
+});

--- a/ui/src/app/store/bootresource/selectors.ts
+++ b/ui/src/app/store/bootresource/selectors.ts
@@ -1,0 +1,28 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import type { BootResourceStatuses } from "./types";
+import { BootResourceMeta } from "./types";
+
+import type { RootState } from "app/store/root/types";
+
+/**
+ * Get the collection of statuses.
+ * @param state - The redux state.
+ * @returns Boot resource statuses.
+ */
+const statuses = (state: RootState): BootResourceStatuses =>
+  state[BootResourceMeta.MODEL].statuses;
+
+/**
+ * Whether the poll event is in progress.
+ * @param state - The redux state.
+ * @returns Whether a poll is in progress.
+ */
+const polling = createSelector([statuses], (statuses) => statuses.poll);
+
+const selectors = {
+  polling,
+  statuses,
+};
+
+export default selectors;


### PR DESCRIPTION
## Done

- Add the basic images header component and polling selector.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the React images page.
- You should see the basic header and the loading state (while loading).

## Fixes

Fixes: canonical-web-and-design/app-squad#78.