### PR TITLE
Domain details view

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -36,7 +36,7 @@ const Routes = (): JSX.Element => (
       )}
     />
     <Route
-      path={domainsURLs.domains}
+      path={[domainsURLs.domains, domainsURLs.details(null, true)]}
       render={() => (
         <ErrorBoundary>
           <Domains />

--- a/ui/src/app/domains/urls.ts
+++ b/ui/src/app/domains/urls.ts
@@ -1,4 +1,8 @@
+import type { Domain } from "app/store/domain/types";
+import { argPath } from "app/utils";
+
 const urls = {
+  details: argPath<{ id: Domain["id"] }>("/domain/:id"),
   domains: "/domains",
 };
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+
+import Section from "app/base/components/Section";
+import SectionHeader from "app/base/components/SectionHeader";
+import type { RouteParams } from "app/base/types";
+import { actions as domainsActions } from "app/store/domain";
+import domainsSelectors from "app/store/domain/selectors";
+import type { RootState } from "app/store/root/types";
+
+const DomainDetails = (): JSX.Element => {
+  const { id } = useParams<RouteParams>();
+  const domain = useSelector((state: RootState) =>
+    domainsSelectors.getById(state, Number(id))
+  );
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(domainsActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <Section
+      header={
+        <SectionHeader
+          title={domain ? domain.name : <Spinner text="Loading..." />}
+        />
+      }
+      headerClassName="u-no-padding--bottom"
+    />
+  );
+};
+
+export default DomainDetails;

--- a/ui/src/app/domains/views/DomainDetails/index.ts
+++ b/ui/src/app/domains/views/DomainDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DomainDetails";

--- a/ui/src/app/domains/views/Domains.tsx
+++ b/ui/src/app/domains/views/Domains.tsx
@@ -1,5 +1,6 @@
 import { Route, Switch } from "react-router-dom";
 
+import DomainDetails from "./DomainDetails";
 import DomainsList from "./DomainsList";
 
 import NotFound from "app/base/views/NotFound";
@@ -8,8 +9,11 @@ import domainsURLs from "app/domains/urls";
 const Domains = (): JSX.Element => {
   return (
     <Switch>
-      <Route exact path={[domainsURLs.domains]}>
+      <Route exact path={domainsURLs.domains}>
         <DomainsList />
+      </Route>
+      <Route exact path={domainsURLs.details(null, true)}>
+        <DomainDetails />
       </Route>
       <Route path="*">
         <NotFound />

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DomainsTable from "./DomainsTable";
@@ -32,7 +33,11 @@ describe("DomainsTable", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <DomainsTable />
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainsTable />
+        </MemoryRouter>
       </Provider>
     );
     const getNameFromTable = (rowNumber: number) =>

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -1,5 +1,8 @@
 import { MainTable } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import domainURLs from "../../../urls";
 
 import domainSelectors from "app/store/domain/selectors";
 
@@ -40,7 +43,11 @@ const DomainsTable = (): JSX.Element => {
       className: "p-table__row",
       columns: [
         {
-          content: domain.name,
+          content: (
+            <Link to={domainURLs.details({ id: domain.id })}>
+              {domain.name}
+            </Link>
+          ),
           "data-test": "domain-name",
         },
         {


### PR DESCRIPTION

- Adds basic details view for domain
- Links from details table to domain details view

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- `yarn start`
- go to http://0.0.0.0:8400/MAAS/r/domain/0
  - name of 'maas' domain should be rendered in page header
- go to http://0.0.0.0:8400/MAAS/r/domains
  - all domains in the table should have linked names
  - clicking on names should open details page for given domain

<img width="996" alt="Screenshot 2021-06-09 at 17 52 21" src="https://user-images.githubusercontent.com/83575/121388091-7655d980-c94b-11eb-8124-c6500289ea2a.png">
## Done


## Fixes

Fixes: canonical-web-and-design/app-squad#36
