### PR TITLE
Add "set default" action to the domain table

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -108,7 +108,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/clement/Code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -149,6 +149,10 @@ exports[`stricter compilation`] = {
     "src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx:641465078": [
       [39, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [40, 8, 19, "Argument of type \'{ name: string; authoritative: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "3577698145"]
+    ],
+    "src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx:3622848552": [
+      [111, 6, 70, "Cannot invoke an object which is possibly \'undefined\'.", "228068178"],
+      [111, 77, 2, "Argument of type \'{}\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Type \'{}\' is missing the following properties from type \'FormEvent<{}>\': nativeEvent, currentTarget, target, bubbles, and 11 more.", "5861859"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:934008644": [
       [143, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -687,9 +691,6 @@ exports[`stricter compilation`] = {
     "src/app/store/notification/selectors.ts:3319386295": [
       [27, 39, 12, "Object is possibly \'undefined\'.", "964199671"]
     ],
-    "src/app/utils/getCookie.ts:940992619": [
-      [8, 2, 38, "Type \'string | undefined\' is not assignable to type \'string\'.\\n  Type \'undefined\' is not assignable to type \'string\'.", "923945500"]
-    ],
     "src/app/utils/someInArray.ts:1833644967": [
       [11, 4, 68, "Type \'number | boolean\' is not assignable to type \'boolean\'.\\n  Type \'number\' is not assignable to type \'boolean\'.", "3447795550"]
     ],
@@ -865,6 +866,6 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `204
+  value: `203
 `
 };

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactWrapper } from "enzyme";
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
@@ -15,7 +16,7 @@ import {
 
 const mockStore = configureStore();
 
-const getNameFromTable = (rowNumber: number, wrapper) =>
+const getNameFromTable = (rowNumber: number, wrapper: ReactWrapper) =>
   wrapper
     .find("tbody TableRow")
     .at(rowNumber)

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,10 +1,12 @@
 import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DomainsTable from "./DomainsTable";
 
+import type { RootState } from "app/store/root/types";
 import {
   domain as domainFactory,
   domainState as domainStateFactory,
@@ -13,24 +15,41 @@ import {
 
 const mockStore = configureStore();
 
+const getNameFromTable = (rowNumber: number, wrapper) =>
+  wrapper
+    .find("tbody TableRow")
+    .at(rowNumber)
+    .find("[data-test='domain-name']")
+    .at(0); // both TableCell and td have the same data-test value
+
 describe("DomainsTable", () => {
-  it("can update the sort order", () => {
-    const state = rootStateFactory({
+  let initialState: RootState;
+  beforeEach(() => {
+    initialState = rootStateFactory({
       domain: domainStateFactory({
         items: [
           domainFactory({
+            id: 1,
             name: "b",
+            is_default: true,
           }),
           domainFactory({
+            id: 2,
             name: "c",
+            is_default: false,
           }),
           domainFactory({
+            id: 3,
             name: "a",
+            is_default: false,
           }),
         ],
       }),
     });
-    const store = mockStore(state);
+  });
+
+  it("can update the sort order", () => {
+    const store = mockStore(initialState);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
@@ -40,28 +59,71 @@ describe("DomainsTable", () => {
         </MemoryRouter>
       </Provider>
     );
-    const getNameFromTable = (rowNumber: number) =>
-      wrapper
-        .find("tbody TableRow")
-        .at(rowNumber)
-        .find("[data-test='domain-name']")
-        .at(0); // both TableCell and td have the same data-test value
 
     // Sorted ascending by name by default
-    expect(getNameFromTable(0).text()).toBe("a");
-    expect(getNameFromTable(1).text()).toBe("b");
-    expect(getNameFromTable(2).text()).toBe("c");
+    expect(getNameFromTable(0, wrapper).text()).toBe("a");
+    expect(getNameFromTable(1, wrapper).text()).toBe("b (default)");
+    expect(getNameFromTable(2, wrapper).text()).toBe("c");
 
     // Change to sort descending by name
     wrapper.find("[data-test='domain-name-header']").at(0).simulate("click");
-    expect(getNameFromTable(0).text()).toBe("c");
-    expect(getNameFromTable(1).text()).toBe("b");
-    expect(getNameFromTable(2).text()).toBe("a");
+    expect(getNameFromTable(0, wrapper).text()).toBe("c");
+    expect(getNameFromTable(1, wrapper).text()).toBe("b (default)");
+    expect(getNameFromTable(2, wrapper).text()).toBe("a");
 
     // Change to no sort
     wrapper.find("[data-test='domain-name-header']").at(0).simulate("click");
-    expect(getNameFromTable(0).text()).toBe("b");
-    expect(getNameFromTable(1).text()).toBe("c");
-    expect(getNameFromTable(2).text()).toBe("a");
+    expect(getNameFromTable(0, wrapper).text()).toBe("b (default)");
+    expect(getNameFromTable(1, wrapper).text()).toBe("c");
+    expect(getNameFromTable(2, wrapper).text()).toBe("a");
+  });
+
+  it("has a (defaut) next to the default domain's title", () => {
+    const store = mockStore(initialState);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainsTable />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(getNameFromTable(1, wrapper).text()).toBe("b (default)");
+  });
+
+  it("calls the setDefault action if set default is clicked", () => {
+    const store = mockStore(initialState);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
+        >
+          <DomainsTable />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper.find("tbody TableRow").at(0).find("Formik").invoke("onSubmit")({})
+    );
+
+    expect(
+      store.getActions().find((action) => action.type === "domain/setDefault")
+    ).toStrictEqual({
+      type: "domain/setDefault",
+      meta: {
+        method: "set_default",
+        model: "domain",
+      },
+      payload: {
+        params: {
+          domain: 3,
+        },
+      },
+    });
   });
 });

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -1,4 +1,12 @@
-import { MainTable, ContextualMenu } from "@canonical/react-components";
+import { useState } from "react";
+
+import {
+  MainTable,
+  ContextualMenu,
+  Row,
+  Col,
+  Button,
+} from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
@@ -7,7 +15,7 @@ import domainSelectors from "app/store/domain/selectors";
 
 const DomainsTable = (): JSX.Element => {
   const domains = useSelector(domainSelectors.all);
-
+  const [expandedID, setExpandedID] = useState(-1);
   const headers = [
     {
       content: "Domain",
@@ -35,16 +43,17 @@ const DomainsTable = (): JSX.Element => {
   ];
 
   const rows = domains.map((domain) => {
+    const isActive = expandedID === domain.id;
     return {
       // making sure we don't pass id directly as a key because of
       // https://github.com/canonical-web-and-design/react-components/issues/476
       key: `domain-row-${domain.id}`,
-      className: "p-table__row",
+      className: `p-table__row ${isActive ? "is-active" : ""}`,
       columns: [
         {
           content: (
             <Link to={domainURLs.details({ id: domain.id })}>
-              {domain.name}
+              {domain.is_default ? `${domain.name} (default)` : domain.name}
             </Link>
           ),
           "data-test": "domain-name",
@@ -69,7 +78,7 @@ const DomainsTable = (): JSX.Element => {
                 {
                   children: "Set default...",
                   onClick: () => {
-                    console.log(domain.id);
+                    setExpandedID(domain.id);
                   },
                 },
               ]}
@@ -78,6 +87,10 @@ const DomainsTable = (): JSX.Element => {
           className: "u-align--right",
         },
       ],
+      expanded: isActive,
+      expandedContent: (
+        <ExpandedContent setExpandedID={setExpandedID} id={domain.id} />
+      ),
       sortData: {
         name: domain.name,
         authoritative: domain.authoritative,
@@ -96,7 +109,40 @@ const DomainsTable = (): JSX.Element => {
       sortable
       defaultSort="name"
       defaultSortDirection="ascending"
+      expanding={true}
     />
+  );
+};
+
+const ExpandedContent = ({ setExpandedID, id }): JSX.Element => {
+  return (
+    <Row>
+      <Col>
+        <hr />
+      </Col>
+      <Col size="9">
+        Setting this domain as the default will update all existing machines (in
+        Ready state) with the new default domain. Are you sure?
+      </Col>
+      <Col size="3" className="u-align--right">
+        <Button
+          appearance="base"
+          onClick={() => {
+            setExpandedID(-1);
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          appearance="positive"
+          onClick={() => {
+            console.log(id);
+          }}
+        >
+          Save
+        </Button>
+      </Col>
+    </Row>
   );
 };
 

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -5,11 +5,11 @@ import {
   ContextualMenu,
   Row,
   Col,
-  Button,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import FormikForm from "app/base/components/FormikForm";
 import domainURLs from "app/domains/urls";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
@@ -128,6 +128,15 @@ const ExpandedContent = ({
 }: ExpandedContentProps): JSX.Element => {
   const dispatch = useDispatch();
 
+  const errors = useSelector(domainSelectors.errors);
+  const saving = useSelector(domainSelectors.saving);
+  const saved = useSelector(domainSelectors.saved);
+
+  const closeForm = () => {
+    dispatch(domainActions.cleanup());
+    setExpandedID(-1);
+  };
+
   return (
     <Row>
       <Col size="12">
@@ -138,23 +147,20 @@ const ExpandedContent = ({
         Ready state) with the new default domain. Are you sure?
       </Col>
       <Col size="3" className="u-align--right">
-        <Button
-          appearance="base"
-          onClick={() => {
-            setExpandedID(-1);
-          }}
-        >
-          Cancel
-        </Button>
-        <Button
-          appearance="positive"
-          onClick={() => {
+        <FormikForm
+          initialValues={{}}
+          buttonsAlign="right"
+          buttonsBordered={false}
+          errors={errors}
+          onCancel={closeForm}
+          onSubmit={() => {
             dispatch(domainActions.setDefault(id));
-            console.log(id);
           }}
-        >
-          Save
-        </Button>
+          onSuccess={closeForm}
+          saved={saved}
+          saving={saving}
+          submitLabel={`Set default`}
+        ></FormikForm>
       </Col>
     </Row>
   );

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -7,10 +7,11 @@ import {
   Col,
   Button,
 } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import domainURLs from "app/domains/urls";
+import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 
 const DomainsTable = (): JSX.Element => {
@@ -125,9 +126,11 @@ const ExpandedContent = ({
   setExpandedID,
   id,
 }: ExpandedContentProps): JSX.Element => {
+  const dispatch = useDispatch();
+
   return (
     <Row>
-      <Col>
+      <Col size="12">
         <hr />
       </Col>
       <Col size="9">
@@ -146,6 +149,7 @@ const ExpandedContent = ({
         <Button
           appearance="positive"
           onClick={() => {
+            dispatch(domainActions.setDefault(id));
             console.log(id);
           }}
         >

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -114,7 +114,15 @@ const DomainsTable = (): JSX.Element => {
   );
 };
 
-const ExpandedContent = ({ setExpandedID, id }): JSX.Element => {
+type ExpandedContentProps = {
+  setExpandedID: (id: number) => void;
+  id: number;
+};
+
+const ExpandedContent = ({
+  setExpandedID,
+  id,
+}: ExpandedContentProps): JSX.Element => {
   return (
     <Row>
       <Col>

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -1,4 +1,4 @@
-import { MainTable } from "@canonical/react-components";
+import { MainTable, ContextualMenu } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
@@ -61,7 +61,20 @@ const DomainsTable = (): JSX.Element => {
           className: "u-align--right",
         },
         {
-          content: "",
+          content: (
+            <ContextualMenu
+              hasToggleIcon={true}
+              toggleAppearance="base"
+              links={[
+                {
+                  children: "Set default...",
+                  onClick: () => {
+                    console.log(domain.id);
+                  },
+                },
+              ]}
+            />
+          ),
           className: "u-align--right",
         },
       ],

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -73,7 +73,9 @@ const DomainsTable = (): JSX.Element => {
           content: (
             <ContextualMenu
               hasToggleIcon={true}
+              toggleDisabled={domain.is_default}
               toggleAppearance="base"
+              toggleClassName="u-no-margin--bottom"
               links={[
                 {
                   children: "Set default...",

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -15,6 +15,7 @@ import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 
 const DomainsTable = (): JSX.Element => {
+  const dispatch = useDispatch();
   const domains = useSelector(domainSelectors.all);
   const [expandedID, setExpandedID] = useState(-1);
   const headers = [
@@ -81,6 +82,7 @@ const DomainsTable = (): JSX.Element => {
                 {
                   children: "Set default...",
                   onClick: () => {
+                    dispatch(domainActions.cleanup());
                     setExpandedID(domain.id);
                   },
                 },
@@ -92,7 +94,13 @@ const DomainsTable = (): JSX.Element => {
       ],
       expanded: isActive,
       expandedContent: (
-        <ExpandedContent setExpandedID={setExpandedID} id={domain.id} />
+        <ExpandedContent
+          closeForm={() => {
+            dispatch(domainActions.cleanup());
+            setExpandedID(-1);
+          }}
+          id={domain.id}
+        />
       ),
       sortData: {
         name: domain.name,
@@ -118,12 +126,12 @@ const DomainsTable = (): JSX.Element => {
 };
 
 type ExpandedContentProps = {
-  setExpandedID: (id: number) => void;
+  closeForm: () => void;
   id: number;
 };
 
 const ExpandedContent = ({
-  setExpandedID,
+  closeForm,
   id,
 }: ExpandedContentProps): JSX.Element => {
   const dispatch = useDispatch();
@@ -132,21 +140,10 @@ const ExpandedContent = ({
   const saving = useSelector(domainSelectors.saving);
   const saved = useSelector(domainSelectors.saved);
 
-  const closeForm = () => {
-    dispatch(domainActions.cleanup());
-    setExpandedID(-1);
-  };
-
   return (
     <Row>
-      <Col size="12">
+      <Col size="12" className="u-align--right">
         <hr />
-      </Col>
-      <Col size="9">
-        Setting this domain as the default will update all existing machines (in
-        Ready state) with the new default domain. Are you sure?
-      </Col>
-      <Col size="3" className="u-align--right">
         <FormikForm
           initialValues={{}}
           buttonsAlign="right"
@@ -160,7 +157,12 @@ const ExpandedContent = ({
           saved={saved}
           saving={saving}
           submitLabel={`Set default`}
-        ></FormikForm>
+        >
+          <p className="u-no-max-width">
+            Setting this domain as the default will update all existing machines
+            (in Ready state) with the new default domain. Are you sure?
+          </p>
+        </FormikForm>
       </Col>
     </Row>
   );

--- a/ui/src/app/store/domain/actions.test.ts
+++ b/ui/src/app/store/domain/actions.test.ts
@@ -33,4 +33,19 @@ describe("domain actions", () => {
       payload: { params: { id: 1, name: "updated domain" } },
     });
   });
+
+  it("can create an action for setting a default domain", () => {
+    expect(actions.setDefault(1)).toEqual({
+      type: "domain/setDefault",
+      meta: {
+        model: "domain",
+        method: "set_default",
+      },
+      payload: {
+        params: {
+          domain: 1,
+        },
+      },
+    });
+  });
 });

--- a/ui/src/app/store/domain/reducers.test.ts
+++ b/ui/src/app/store/domain/reducers.test.ts
@@ -181,4 +181,53 @@ describe("domain reducer", () => {
       saving: false,
     });
   });
+
+  it("reduces setDefaultStart", () => {
+    const domainState = domainStateFactory({
+      saving: false,
+    });
+
+    expect(reducers(domainState, actions.setDefaultStart())).toEqual(
+      domainStateFactory({
+        saving: true,
+        saved: false,
+      })
+    );
+  });
+
+  it("reduces setDefaultError", () => {
+    const domainState = domainStateFactory({
+      errors: null,
+    });
+
+    expect(reducers(domainState, actions.setDefaultError())).toEqual(
+      domainStateFactory({
+        errors: "There was an error when setting default domain.",
+      })
+    );
+  });
+
+  it("reduces setDefaultSuccess", () => {
+    const domain1 = domainFactory({ id: 1, is_default: true });
+    const domain2 = domainFactory({ id: 2, is_default: false });
+    const domainState = domainStateFactory({
+      items: [domain1, domain2],
+      saving: true,
+      saved: false,
+    });
+
+    expect(
+      reducers(domainState, actions.setDefaultSuccess(domainFactory({ id: 2 })))
+    ).toEqual(
+      domainStateFactory({
+        items: [
+          { ...domain1, is_default: false },
+          { ...domain2, is_default: true },
+        ],
+        saving: false,
+        saved: true,
+        errors: null,
+      })
+    );
+  });
 });

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -36,19 +36,22 @@ const domainSlice = createSlice({
     },
     setDefaultStart: (state: DomainState) => {
       state.saving = true;
+      state.saved = false;
     },
     setDefaultError: (
       state: DomainState,
       action: PayloadAction<DomainState["errors"]>
     ) => {
-      state.saving = null;
+      state.saving = false;
       state.errors = action.payload;
     },
     setDefaultSuccess: (
       state: DomainState,
       action: PayloadAction<DomainState["errors"]>
     ) => {
-      state.saving = null;
+      state.saving = false;
+      state.saved = true;
+      state.errors = null;
 
       // update the default domain in the redux store
       state.items.forEach((domain) => {

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -44,8 +44,20 @@ const domainSlice = createSlice({
       state.saving = null;
       state.errors = action.payload;
     },
-    setDefaultSuccess: (state: DomainState) => {
+    setDefaultSuccess: (
+      state: DomainState,
+      action: PayloadAction<DomainState["errors"]>
+    ) => {
       state.saving = null;
+
+      // update the default domain in the redux store
+      state.items.forEach((domain) => {
+        if (domain.id === action.payload.id) {
+          domain.is_default = true;
+        } else {
+          domain.is_default = false;
+        }
+      });
     },
   },
 });

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -38,17 +38,12 @@ const domainSlice = createSlice({
       state.saving = true;
       state.saved = false;
     },
-    setDefaultError: (
-      state: DomainState,
-      action: PayloadAction<DomainState["errors"]>
-    ) => {
+    setDefaultError: (state: DomainState) => {
       state.saving = false;
-      state.errors = action.payload;
+      // API seems to return the domain id in payload.error not an error message
+      state.errors = "There was an error when setting default domain.";
     },
-    setDefaultSuccess: (
-      state: DomainState,
-      action: PayloadAction<DomainState["errors"]>
-    ) => {
+    setDefaultSuccess: (state: DomainState, action: PayloadAction<Domain>) => {
       state.saving = false;
       state.saved = true;
       state.errors = null;

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -1,7 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
 
 import { DomainMeta } from "./types";
-import type { CreateParams, DomainState, UpdateParams } from "./types";
+import type { CreateParams, DomainState, UpdateParams, Domain } from "./types";
 
 import {
   generateCommonReducers,
@@ -11,12 +12,42 @@ import {
 const domainSlice = createSlice({
   name: DomainMeta.MODEL,
   initialState: genericInitialState as DomainState,
-  reducers: generateCommonReducers<
-    DomainState,
-    DomainMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(DomainMeta.MODEL, DomainMeta.PK),
+  reducers: {
+    ...generateCommonReducers<
+      DomainState,
+      DomainMeta.PK,
+      CreateParams,
+      UpdateParams
+    >(DomainMeta.MODEL, DomainMeta.PK),
+    setDefault: {
+      prepare: (id: Domain[DomainMeta.PK] | null) => ({
+        meta: {
+          model: DomainMeta.MODEL,
+          method: "set_default",
+        },
+        payload: {
+          // Server unsets active pod if primary key (id) is not sent.
+          params: { domain: id },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    setDefaultStart: (state: DomainState) => {
+      state.saving = true;
+    },
+    setDefaultError: (
+      state: DomainState,
+      action: PayloadAction<DomainState["errors"]>
+    ) => {
+      state.saving = null;
+      state.errors = action.payload;
+    },
+    setDefaultSuccess: (state: DomainState) => {
+      state.saving = null;
+    },
+  },
 });
 
 export const { actions } = domainSlice;


### PR DESCRIPTION
## Done
![image](https://user-images.githubusercontent.com/11927929/121517934-3268e000-c9f0-11eb-9472-c2007babfcaa.png)

1 - added `(default)` to the default domain name
2 - added the set default confirmation in an expandable row
3 - added the contextual menu to expand the row 


## QA

go to the table http://0.0.0.0:8400/MAAS/r/domains and switch around the default domain

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-squad/issues/40

## Note

The background of the expanded row should be white (probably an artifact of yarn UI vs yarn start)
The alignment is a bit wonky there but we tried every "simple" solution and this was the best we could come up with without touching FormikForm component

## To do

- [x] Add tests for the table component


