### PR TITLE
feat(ui): add automatic sync toggle to images page

### DIFF
--- a/ui/src/app/base/components/Switch/Switch.tsx
+++ b/ui/src/app/base/components/Switch/Switch.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import PropTypes from "prop-types";
 
-type Props = {
+export type Props = {
   className?: string;
-  label?: string;
+  label?: ReactNode;
   // TODO: Investigate why this won't work with React.HTMLProps<HTMLInputElement>.
 } & React.PropsWithoutRef<JSX.IntrinsicElements["input"]>;
 

--- a/ui/src/app/base/components/Switch/index.ts
+++ b/ui/src/app/base/components/Switch/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Switch";
+export type { Props as SwitchProps } from "./Switch";

--- a/ui/src/app/base/components/SwitchField/SwitchField.tsx
+++ b/ui/src/app/base/components/SwitchField/SwitchField.tsx
@@ -1,9 +1,10 @@
-import type { HTMLProps, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { Field } from "@canonical/react-components";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 
+import type { SwitchProps } from "../Switch";
 import Switch from "../Switch";
 
 export type Props = {
@@ -19,7 +20,7 @@ export type Props = {
   success?: string;
   type?: string;
   wrapperClassName?: string;
-} & HTMLProps<HTMLInputElement>;
+} & SwitchProps;
 
 const SwitchField = ({
   caution,

--- a/ui/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.test.tsx
@@ -5,13 +5,23 @@ import configureStore from "redux-mock-store";
 
 import ImageList from "./ImageList";
 
-import { rootState as rootStateFactory } from "testing/factories";
+import {
+  config as configFactory,
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("ImageList", () => {
-  it("renders", () => {
-    const state = rootStateFactory();
+  it("shows a warning if automatic image sync is disabled", () => {
+    const state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({ name: "boot_images_auto_import", value: false }),
+        ],
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -22,6 +32,8 @@ describe("ImageList", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Section").exists()).toBe(true);
+    expect(wrapper.find("[data-test='disabled-sync-warning']").exists()).toBe(
+      true
+    );
   });
 });

--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -1,19 +1,24 @@
 import { useEffect } from "react";
 
-import { useDispatch } from "react-redux";
+import { Notification } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
 
 import ImageListHeader from "./ImageListHeader";
 
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
 import { actions as bootResourceActions } from "app/store/bootresource";
+import { actions as configActions } from "app/store/config";
+import configSelectors from "app/store/config/selectors";
 
 const ImagesList = (): JSX.Element => {
   const dispatch = useDispatch();
+  const autoImport = useSelector(configSelectors.bootImagesAutoImport);
   useWindowTitle("Images");
 
   useEffect(() => {
     dispatch(bootResourceActions.poll());
+    dispatch(configActions.fetch());
   }, [dispatch]);
 
   return (
@@ -21,6 +26,13 @@ const ImagesList = (): JSX.Element => {
       header={<ImageListHeader />}
       headerClassName="u-no-padding--bottom"
     >
+      {!autoImport && (
+        <Notification data-test="disabled-sync-warning" type="caution">
+          Automatic image updates are disabled. This may mean that images won't
+          be automatically updated and receive the latest package versions and
+          security fixes.
+        </Notification>
+      )}
       Images
     </Section>
   );

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
@@ -5,9 +5,12 @@ import configureStore from "redux-mock-store";
 
 import ImageListHeader from "./ImageListHeader";
 
+import { actions as configActions } from "app/store/config";
 import {
   bootResourceState as bootResourceStateFactory,
   bootResourceStatuses as bootResourceStatusesFactory,
+  config as configFactory,
+  configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
@@ -33,5 +36,37 @@ describe("ImageListHeader", () => {
       </Provider>
     );
     expect(wrapper.find("SectionHeader").prop("loading")).toBe(true);
+  });
+
+  it("dispatches an action to update config when changing the auto sync switch", () => {
+    const state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({ name: "boot_images_auto_import", value: true }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/images", key: "testKey" }]}
+        >
+          <ImageListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("input[data-test='auto-sync-switch']").simulate("change", {
+      target: { checked: false, id: "auto-sync-switch" },
+    });
+    const actualActions = store.getActions();
+    const expectedAction = configActions.update({
+      boot_images_auto_import: false,
+    });
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
   });
 });

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -1,20 +1,77 @@
 import { useEffect } from "react";
 
+import { Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import SectionHeader from "app/base/components/SectionHeader";
+import SwitchField from "app/base/components/SwitchField";
 import { actions as bootResourceActions } from "app/store/bootresource";
 import bootResourceSelectors from "app/store/bootresource/selectors";
+import { actions as configActions } from "app/store/config";
+import configSelectors from "app/store/config/selectors";
+import { breakLines } from "app/utils";
 
 const ImageListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
   const polling = useSelector(bootResourceSelectors.polling);
+  const autoImport = useSelector(configSelectors.bootImagesAutoImport);
+  const configSaving = useSelector(configSelectors.saving);
 
   useEffect(() => {
     dispatch(bootResourceActions.poll());
+    dispatch(configActions.fetch());
   }, [dispatch]);
 
-  return <SectionHeader loading={polling} title="Images" />;
+  return (
+    <SectionHeader
+      buttons={[
+        <div className="u-flex--align-baseline">
+          {configSaving && (
+            <div className="u-nudge-left--small">
+              <Icon className="u-animation--spin" name="spinner" />
+            </div>
+          )}
+          <SwitchField
+            checked={autoImport || false}
+            className="u-nudge-right"
+            data-test="auto-sync-switch"
+            id="auto-sync-switch"
+            label={
+              <span>
+                <span>Automatically sync images</span>
+                <Tooltip
+                  className="u-nudge-right--small"
+                  message={breakLines(
+                    `Enables automatic image updates (sync). The region
+                    controller will check for new images every hour and
+                    automatically sync them, if available, from the stream
+                    configured below. Syncing at the rack controller level
+                    occurs every 5 minutes and cannot be disabled.`.replace(
+                      /\s+/g,
+                      " "
+                    )
+                  )}
+                >
+                  <Icon name="help"></Icon>
+                </Tooltip>
+              </span>
+            }
+            onChange={() => {
+              dispatch(configActions.cleanup());
+              dispatch(
+                configActions.update({
+                  boot_images_auto_import: !autoImport,
+                })
+              );
+            }}
+            wrapperClassName="u-flex"
+          />
+        </div>,
+      ]}
+      loading={polling}
+      title="Images"
+    />
+  );
 };
 
 export default ImageListHeader;

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -9,7 +9,7 @@ import { actions as bootResourceActions } from "app/store/bootresource";
 import bootResourceSelectors from "app/store/bootresource/selectors";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
-import { breakLines } from "app/utils";
+import { breakLines, unindentString } from "app/utils";
 
 const ImageListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -42,13 +42,12 @@ const ImageListHeader = (): JSX.Element => {
                 <Tooltip
                   className="u-nudge-right--small"
                   message={breakLines(
-                    `Enables automatic image updates (sync). The region
-                    controller will check for new images every hour and
-                    automatically sync them, if available, from the stream
-                    configured below. Syncing at the rack controller level
-                    occurs every 5 minutes and cannot be disabled.`.replace(
-                      /\s+/g,
-                      " "
+                    unindentString(
+                      `Enables automatic image updates (sync). The region
+                      controller will check for new images every hour and
+                      automatically sync them, if available, from the stream
+                      configured below. Syncing at the rack controller level
+                      occurs every 5 minutes and cannot be disabled.`
                     )
                   )}
                 >

--- a/ui/src/app/store/config/selectors.test.ts
+++ b/ui/src/app/store/config/selectors.test.ts
@@ -458,4 +458,17 @@ describe("config selectors", () => {
       expect(config.releaseNotifications(state)).toBe(true);
     });
   });
+
+  describe("bootImagesAutoImport", () => {
+    it("returns MAAS config for boot images auto import", () => {
+      const state = rootStateFactory({
+        config: configStateFactory({
+          items: [
+            configFactory({ name: "boot_images_auto_import", value: true }),
+          ],
+        }),
+      });
+      expect(config.bootImagesAutoImport(state)).toBe(true);
+    });
+  });
 });

--- a/ui/src/app/store/config/selectors.ts
+++ b/ui/src/app/store/config/selectors.ts
@@ -470,10 +470,20 @@ const releaseNotifications = createSelector([all], (configs) =>
   getValueFromName<boolean>(configs, "release_notifications")
 );
 
+/**
+ * Returns the MAAS config for whether to automatically sync images.
+ * @param state - The redux state.
+ * @returns Whether the release notifications are enabled.
+ */
+const bootImagesAutoImport = createSelector([all], (configs) =>
+  getValueFromName<boolean>(configs, "boot_images_auto_import")
+);
+
 const config = {
   activeDiscoveryInterval,
   all,
   analyticsEnabled,
+  bootImagesAutoImport,
   commissioningDistroSeries,
   completedIntro,
   defaultDistroSeries,

--- a/ui/src/app/utils/index.ts
+++ b/ui/src/app/utils/index.ts
@@ -22,3 +22,4 @@ export { simpleSortByKey } from "./simpleSortByKey";
 export { someInArray } from "./someInArray";
 export { someNotAll } from "./someNotAll";
 export { toFormikNumber } from "./toFormikNumber";
+export { unindentString } from "./unindentString";

--- a/ui/src/app/utils/unindentString.test.ts
+++ b/ui/src/app/utils/unindentString.test.ts
@@ -1,0 +1,29 @@
+import { unindentString } from "./unindentString";
+
+describe("unindentString", () => {
+  it("removes excess spaces", () => {
+    expect(unindentString(" so  much    space   ")).toBe("so much space");
+  });
+
+  it("removes newlines", () => {
+    expect(unindentString("first line\nsecond line")).toBe(
+      "first line second line"
+    );
+    expect(
+      unindentString(
+        `first line
+        second line`
+      )
+    ).toBe("first line second line");
+    expect(
+      unindentString(`
+        first line
+        second line
+      `)
+    ).toBe("first line second line");
+  });
+
+  it("handles an empty string", () => {
+    expect(unindentString("")).toBe("");
+  });
+});

--- a/ui/src/app/utils/unindentString.ts
+++ b/ui/src/app/utils/unindentString.ts
@@ -1,0 +1,5 @@
+/**
+ * Replaces extra spaces and newlines with a single space.
+ */
+export const unindentString = (str: string): string =>
+  str.replace(/\s+/g, " ").trim();

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -23,6 +23,11 @@
     display: flex;
   }
 
+  .u-flex--align-baseline {
+    align-items: baseline;
+    display: flex;
+  }
+
   .u-flex--grow {
     flex: 1;
   }


### PR DESCRIPTION
## Done

- Added automatic sync toggle to images page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images
- Check that you can change the value of the automatic images sync toggle
- Check that when the toggle is off, a warning shows below

## Fixes

Fixes canonical-web-and-design/app-squad#79

## Screenshot
![2021-06-11_12-12](https://user-images.githubusercontent.com/25733845/121620828-568af680-caae-11eb-8d5f-cf2afd41787c.png)

