### PR TITLE
feat(ui): add new table confirm component

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -108,7 +108,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/clement/Code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -150,9 +150,8 @@ exports[`stricter compilation`] = {
       [39, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [40, 8, 19, "Argument of type \'{ name: string; authoritative: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "3577698145"]
     ],
-    "src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx:3622848552": [
-      [111, 6, 70, "Cannot invoke an object which is possibly \'undefined\'.", "228068178"],
-      [111, 77, 2, "Argument of type \'{}\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Type \'{}\' is missing the following properties from type \'FormEvent<{}>\': nativeEvent, currentTarget, target, bubbles, and 11 more.", "5861859"]
+    "src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx:2262769286": [
+      [113, 14, 11, "Argument of type \'\\"onConfirm\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "1296914934"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:934008644": [
       [143, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -645,7 +644,7 @@ exports[`stricter compilation`] = {
     "src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx:3425686756": [
       [25, 10, 4, "Type \'{ osystems: [string, string][]; releases: [string, string][]; }\' is missing the following properties from type \'OSInfo\': kernels, default_osystem, default_release", "2087377941"]
     ],
-    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx:2015952668": [
+    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx:2093645883": [
       [95, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
       [95, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
       [97, 6, 38, "Object is possibly \'undefined\'.", "1978148098"],
@@ -704,12 +703,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:1367425813": [
       [12, 2, 5, "Type \'null\' is not assignable to type \'NotificationIdent | ArrayFactory<never> | AttributeFunction<NotificationIdent> | Factory<NotificationIdent> | DerivedFunction<...>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:3966424341": [
+    "src/testing/factories/state.ts:2306025433": [
       [271, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [386, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [387, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [389, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [394, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+      [387, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [388, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [390, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [395, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };

--- a/ui/src/app/base/components/TableConfirm/TableConfirm.test.tsx
+++ b/ui/src/app/base/components/TableConfirm/TableConfirm.test.tsx
@@ -1,0 +1,103 @@
+import { mount, shallow } from "enzyme";
+
+import TableConfirm from "./TableConfirm";
+
+describe("TableConfirm", () => {
+  it("renders", () => {
+    const wrapper = shallow(
+      <TableConfirm
+        confirmLabel="save"
+        finished={false}
+        inProgress={false}
+        message="Are you sure"
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("can confirm", () => {
+    const onConfirm = jest.fn();
+    const wrapper = shallow(
+      <TableConfirm
+        confirmLabel="save"
+        finished={false}
+        inProgress={false}
+        message="Are you sure"
+        onClose={jest.fn()}
+        onConfirm={onConfirm}
+      />
+    );
+    wrapper.find("ActionButton").simulate("click");
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("can cancel", () => {
+    const onClose = jest.fn();
+    const wrapper = shallow(
+      <TableConfirm
+        confirmLabel="save"
+        finished={false}
+        inProgress={false}
+        message="Are you sure"
+        onClose={onClose}
+        onConfirm={jest.fn()}
+      />
+    );
+    wrapper.find("Button").simulate("click");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes when it has finished", () => {
+    const onClose = jest.fn();
+    const wrapper = mount(
+      <TableConfirm
+        confirmLabel="save"
+        finished={false}
+        inProgress={false}
+        message="Are you sure"
+        onClose={onClose}
+        onConfirm={jest.fn()}
+      />
+    );
+    wrapper.find("ActionButton").simulate("click");
+    expect(onClose).not.toHaveBeenCalled();
+    wrapper.setProps({ finished: true });
+    wrapper.update();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("can display an error", () => {
+    const onClose = jest.fn();
+    const wrapper = mount(
+      <TableConfirm
+        confirmLabel="save"
+        errors="It didn't work"
+        finished={false}
+        inProgress={false}
+        message="Are you sure"
+        onClose={onClose}
+        onConfirm={jest.fn()}
+      />
+    );
+    expect(wrapper.find("Notification").text()).toBe("Error:It didn't work");
+  });
+
+  it("can display an error for a field", () => {
+    const onClose = jest.fn();
+    const wrapper = mount(
+      <TableConfirm
+        confirmLabel="save"
+        errors={{ delete: ["It didn't work"] }}
+        errorKey="delete"
+        finished={false}
+        inProgress={false}
+        message="Are you sure"
+        onClose={onClose}
+        onConfirm={jest.fn()}
+      />
+    );
+    expect(wrapper.find("Notification").text()).toBe("Error:It didn't work");
+  });
+});

--- a/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
+++ b/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react";
+
+import {
+  ActionButton,
+  Button,
+  Col,
+  Notification,
+  Row,
+} from "@canonical/react-components";
+import type { Props as ButtonProps } from "@canonical/react-components/dist/components/Button";
+
+import { COL_SIZES } from "app/base/constants";
+import { useCycled } from "app/base/hooks";
+
+export type Props = {
+  confirmAppearance?: ButtonProps["appearance"];
+  confirmLabel: string;
+  errors?: string | Record<string, string[]>;
+  errorKey?: string;
+  finished: boolean;
+  inProgress: boolean;
+  message: ReactNode;
+  onClose: () => void;
+  onConfirm: () => void;
+  sidebar?: boolean;
+};
+
+const TableConfirm = ({
+  confirmAppearance = "positive",
+  confirmLabel,
+  errors,
+  errorKey,
+  finished,
+  inProgress,
+  message,
+  onClose,
+  onConfirm,
+  sidebar = true,
+}: Props): JSX.Element => {
+  useCycled(finished, () => {
+    onClose();
+  });
+  let errorMessage: string | null = null;
+  if (errors) {
+    if (typeof errors === "string") {
+      errorMessage = errors;
+    } else if (errorKey && typeof errors === "object") {
+      errorMessage = errors[errorKey].join(" ");
+    }
+  }
+
+  const { TABLE_CONFIRM_BUTTONS, SIDEBAR, TOTAL } = COL_SIZES;
+  return (
+    <Row>
+      {errorMessage && (
+        <Notification type="negative" status="Error:">
+          {errorMessage}
+        </Notification>
+      )}
+      <Col
+        size={
+          sidebar
+            ? TOTAL - SIDEBAR - TABLE_CONFIRM_BUTTONS
+            : TOTAL - TABLE_CONFIRM_BUTTONS
+        }
+      >
+        <p className="u-no-margin--bottom u-no-max-width">{message}</p>
+      </Col>
+      <Col size={TABLE_CONFIRM_BUTTONS} className="u-align--right">
+        <Button className="u-no-margin--bottom" onClick={onClose}>
+          Cancel
+        </Button>
+        <ActionButton
+          appearance={confirmAppearance}
+          className="u-no-margin--bottom"
+          data-test="action-confirm"
+          loading={inProgress}
+          onClick={onConfirm}
+          success={finished}
+        >
+          {confirmLabel}
+        </ActionButton>
+      </Col>
+    </Row>
+  );
+};
+
+export default TableConfirm;

--- a/ui/src/app/base/components/TableConfirm/__snapshots__/TableConfirm.test.tsx.snap
+++ b/ui/src/app/base/components/TableConfirm/__snapshots__/TableConfirm.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableConfirm renders 1`] = `
+<Row>
+  <Col
+    size={5}
+  >
+    <p
+      className="u-no-margin--bottom u-no-max-width"
+    >
+      Are you sure
+    </p>
+  </Col>
+  <Col
+    className="u-align--right"
+    size={4}
+  >
+    <Button
+      className="u-no-margin--bottom"
+      onClick={[MockFunction]}
+    >
+      Cancel
+    </Button>
+    <ActionButton
+      appearance="positive"
+      className="u-no-margin--bottom"
+      data-test="action-confirm"
+      loading={false}
+      onClick={[MockFunction]}
+      success={false}
+    >
+      save
+    </ActionButton>
+  </Col>
+</Row>
+`;

--- a/ui/src/app/base/components/TableConfirm/index.ts
+++ b/ui/src/app/base/components/TableConfirm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TableConfirm";

--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.test.tsx
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.test.tsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from "enzyme";
+import { shallow } from "enzyme";
 
 import TableDeleteConfirm from "./TableDeleteConfirm";
 
@@ -15,56 +15,5 @@ describe("TableDeleteConfirm", () => {
       />
     );
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it("can confirm", () => {
-    const onConfirm = jest.fn();
-    const wrapper = shallow(
-      <TableDeleteConfirm
-        deleted={false}
-        deleting={false}
-        modelName="Cobba"
-        modelType="user"
-        onClose={jest.fn()}
-        onConfirm={onConfirm}
-      />
-    );
-    wrapper.find("ActionButton").simulate("click");
-    expect(onConfirm).toHaveBeenCalled();
-  });
-
-  it("can cancel", () => {
-    const onClose = jest.fn();
-    const wrapper = shallow(
-      <TableDeleteConfirm
-        deleted={false}
-        deleting={false}
-        modelName="Cobba"
-        modelType="user"
-        onClose={onClose}
-        onConfirm={jest.fn()}
-      />
-    );
-    wrapper.find("Button").simulate("click");
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it("closes when it has finished deleting", () => {
-    const onClose = jest.fn();
-    const wrapper = mount(
-      <TableDeleteConfirm
-        deleted={false}
-        deleting={false}
-        modelName="Cobba"
-        modelType="user"
-        onClose={onClose}
-        onConfirm={jest.fn()}
-      />
-    );
-    wrapper.find("ActionButton").simulate("click");
-    expect(onClose).not.toHaveBeenCalled();
-    wrapper.setProps({ deleted: true });
-    wrapper.update();
-    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.tsx
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.tsx
@@ -1,18 +1,16 @@
-import { ActionButton, Button, Col, Row } from "@canonical/react-components";
-
-import { COL_SIZES } from "app/base/constants";
-import { useCycled } from "app/base/hooks";
+import TableConfirm from "app/base/components/TableConfirm";
+import type { Props as TableConfirmProps } from "app/base/components/TableConfirm/TableConfirm";
 
 type Props = {
-  deleted: boolean;
-  deleting: boolean;
+  deleted: TableConfirmProps["finished"];
+  deleting: TableConfirmProps["inProgress"];
   message?: string;
   modelName?: string;
   modelType?: string;
-  onClose: () => void;
-  onConfirm: () => void;
-  sidebar?: boolean;
-};
+  onClose: TableConfirmProps["onClose"];
+  onConfirm: TableConfirmProps["onConfirm"];
+  sidebar?: TableConfirmProps["sidebar"];
+} & Pick<TableConfirmProps, "onClose" | "onConfirm" | "sidebar">;
 
 const TableDeleteConfirm = ({
   deleted,
@@ -20,47 +18,25 @@ const TableDeleteConfirm = ({
   message,
   modelName,
   modelType,
-  onClose,
-  onConfirm,
-  sidebar = true,
+  ...props
 }: Props): JSX.Element => {
-  useCycled(deleted, () => {
-    onClose();
-  });
-  const { DELETE_ROW_BUTTONS, SIDEBAR, TOTAL } = COL_SIZES;
   return (
-    <Row>
-      <Col
-        size={
-          sidebar
-            ? TOTAL - SIDEBAR - DELETE_ROW_BUTTONS
-            : TOTAL - DELETE_ROW_BUTTONS
-        }
-      >
-        <p className="u-no-margin--bottom u-no-max-width">
+    <TableConfirm
+      confirmAppearance="negative"
+      confirmLabel="Delete"
+      finished={deleted}
+      inProgress={deleting}
+      message={
+        <>
           {message ||
             `Are you sure you want to delete ${modelType} "${modelName}"?`}{" "}
           <span className="u-text--light">
             This action is permanent and can not be undone.
           </span>
-        </p>
-      </Col>
-      <Col size={DELETE_ROW_BUTTONS} className="u-align--right">
-        <Button className="u-no-margin--bottom" onClick={onClose}>
-          Cancel
-        </Button>
-        <ActionButton
-          appearance="negative"
-          className="u-no-margin--bottom"
-          data-test="delete-confirm"
-          loading={deleting}
-          onClick={onConfirm}
-          success={deleted}
-        >
-          Delete
-        </ActionButton>
-      </Col>
-    </Row>
+        </>
+      }
+      {...props}
+    />
   );
 };
 

--- a/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.tsx.snap
+++ b/ui/src/app/base/components/TableDeleteConfirm/__snapshots__/TableDeleteConfirm.test.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableDeleteConfirm renders 1`] = `
-<Row>
-  <Col
-    size={5}
-  >
-    <p
-      className="u-no-margin--bottom u-no-max-width"
-    >
+<TableConfirm
+  confirmAppearance="negative"
+  confirmLabel="Delete"
+  finished={false}
+  inProgress={false}
+  message={
+    <React.Fragment>
       Are you sure you want to delete user "Cobba"?
        
       <span
@@ -15,28 +15,9 @@ exports[`TableDeleteConfirm renders 1`] = `
       >
         This action is permanent and can not be undone.
       </span>
-    </p>
-  </Col>
-  <Col
-    className="u-align--right"
-    size={4}
-  >
-    <Button
-      className="u-no-margin--bottom"
-      onClick={[MockFunction]}
-    >
-      Cancel
-    </Button>
-    <ActionButton
-      appearance="negative"
-      className="u-no-margin--bottom"
-      data-test="delete-confirm"
-      loading={false}
-      onClick={[MockFunction]}
-      success={false}
-    >
-      Delete
-    </ActionButton>
-  </Col>
-</Row>
+    </React.Fragment>
+  }
+  onClose={[MockFunction]}
+  onConfirm={[MockFunction]}
+/>
 `;

--- a/ui/src/app/base/constants.ts
+++ b/ui/src/app/base/constants.ts
@@ -3,7 +3,7 @@
  */
 export const COL_SIZES = {
   CARD_TITLE: 2,
-  DELETE_ROW_BUTTONS: 4,
+  TABLE_CONFIRM_BUTTONS: 4,
   SIDEBAR: 3,
   TOTAL: 12,
 };

--- a/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,6 +1,5 @@
 import type { ReactWrapper } from "enzyme";
 import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -21,7 +20,7 @@ const getNameFromTable = (rowNumber: number, wrapper: ReactWrapper) =>
     .find("tbody TableRow")
     .at(rowNumber)
     .find("[data-test='domain-name']")
-    .at(0); // both TableCell and td have the same data-test value
+    .first(); // both TableCell and td have the same data-test value
 
 describe("DomainsTable", () => {
   let initialState: RootState;
@@ -67,13 +66,13 @@ describe("DomainsTable", () => {
     expect(getNameFromTable(2, wrapper).text()).toBe("c");
 
     // Change to sort descending by name
-    wrapper.find("[data-test='domain-name-header']").at(0).simulate("click");
+    wrapper.find("[data-test='domain-name-header']").first().simulate("click");
     expect(getNameFromTable(0, wrapper).text()).toBe("c");
     expect(getNameFromTable(1, wrapper).text()).toBe("b (default)");
     expect(getNameFromTable(2, wrapper).text()).toBe("a");
 
     // Change to no sort
-    wrapper.find("[data-test='domain-name-header']").at(0).simulate("click");
+    wrapper.find("[data-test='domain-name-header']").first().simulate("click");
     expect(getNameFromTable(0, wrapper).text()).toBe("b (default)");
     expect(getNameFromTable(1, wrapper).text()).toBe("c");
     expect(getNameFromTable(2, wrapper).text()).toBe("a");
@@ -108,9 +107,11 @@ describe("DomainsTable", () => {
       </Provider>
     );
 
-    act(() =>
-      wrapper.find("tbody TableRow").at(0).find("Formik").invoke("onSubmit")({})
-    );
+    wrapper
+      .find("tbody TableRow")
+      .first()
+      .find("TableConfirm")
+      .invoke("onConfirm")();
 
     expect(
       store.getActions().find((action) => action.type === "domain/setDefault")

--- a/ui/src/app/pools/views/Pools.js
+++ b/ui/src/app/pools/views/Pools.js
@@ -69,7 +69,7 @@ const generateRows = (
                   "Cannot delete a pool that contains machines.")
               }
               editDisabled={!row.permissions.includes("edit")}
-              editPath={poolsURLs.edit({ edit: row.id })}
+              editPath={poolsURLs.edit({ id: row.id })}
               onDelete={() => setExpandedId(row.id)}
             />
           ),

--- a/ui/src/app/pools/views/Pools.test.js
+++ b/ui/src/app/pools/views/Pools.test.js
@@ -127,7 +127,7 @@ describe("Pools", () => {
     wrapper
       .find("TableRow")
       .at(1)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .simulate("click");
 
     expect(store.getActions()[2]).toEqual({

--- a/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.js
+++ b/ui/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.js
@@ -191,7 +191,7 @@ describe("SSHKeyList", () => {
     wrapper
       .find("tbody TableRow")
       .at(0)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .last()
       .simulate("click");
     expect(
@@ -233,7 +233,7 @@ describe("SSHKeyList", () => {
     wrapper
       .find("tbody TableRow")
       .at(1)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .simulate("click");
     expect(
       store.getActions().filter((action) => action.type === "sshkey/delete")

--- a/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.js
+++ b/ui/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.js
@@ -145,7 +145,7 @@ describe("SSLKeyList", () => {
     wrapper
       .find("tbody TableRow")
       .at(0)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .simulate("click");
     expect(
       store.getActions().find((action) => action.type === "sslkey/delete")

--- a/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
+++ b/ui/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.js
@@ -89,7 +89,7 @@ describe("DhcpList", () => {
     wrapper
       .find("TableRow")
       .at(2)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .simulate("click");
     expect(
       store.getActions().find((action) => action.type === "dhcpsnippet/delete")
@@ -127,7 +127,7 @@ describe("DhcpList", () => {
     wrapper
       .find("TableRow")
       .at(2)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .last()
       .simulate("click");
     const actions = store.getActions();

--- a/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
+++ b/ui/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.js
@@ -132,7 +132,7 @@ describe("RepositoriesList", () => {
     wrapper
       .find("TableRow")
       .at(3)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .simulate("click");
 
     // 1. Fetch, 2. Cleanup, 3. Delete

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -190,7 +190,7 @@ describe("ScriptsList", () => {
     wrapper
       .find("TableRow")
       .at(1)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .simulate("click");
     expect(
       store.getActions().find((action) => action.type === "script/delete")

--- a/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
+++ b/ui/src/app/settings/views/Users/UsersList/UsersList.test.js
@@ -84,7 +84,7 @@ describe("UsersList", () => {
     wrapper
       .find("TableRow")
       .at(2)
-      .find("ActionButton[data-test='delete-confirm']")
+      .find("ActionButton[data-test='action-confirm']")
       .simulate("click");
     expect(store.getActions()[1]).toEqual({
       type: "user/delete",

--- a/ui/src/app/store/domain/reducers.test.ts
+++ b/ui/src/app/store/domain/reducers.test.ts
@@ -46,7 +46,7 @@ describe("domain reducer", () => {
       loading: true,
     });
     expect(reducers(domainState, actions.fetchSuccess(domains))).toEqual({
-      errors: {},
+      errors: null,
       loading: false,
       loaded: true,
       saved: false,
@@ -74,7 +74,7 @@ describe("domain reducer", () => {
     const domainState = domainStateFactory({ saved: true });
 
     expect(reducers(domainState, actions.createStart())).toEqual({
-      errors: {},
+      errors: null,
       items: [],
       loaded: false,
       loading: false,
@@ -109,7 +109,7 @@ describe("domain reducer", () => {
     });
 
     expect(reducers(domainState, actions.createNotify(newDomain))).toEqual({
-      errors: {},
+      errors: null,
       items: [...domains, newDomain],
       loaded: false,
       loading: false,
@@ -125,7 +125,7 @@ describe("domain reducer", () => {
     });
 
     expect(reducers(domainState, actions.deleteStart())).toEqual({
-      errors: {},
+      errors: null,
       items: domains,
       loaded: false,
       loading: false,
@@ -173,7 +173,7 @@ describe("domain reducer", () => {
     });
 
     expect(reducers(domainState, actions.deleteNotify(1))).toEqual({
-      errors: {},
+      errors: null,
       items: [domains[1]],
       loaded: false,
       loading: false,
@@ -198,11 +198,29 @@ describe("domain reducer", () => {
   it("reduces setDefaultError", () => {
     const domainState = domainStateFactory({
       errors: null,
+      saving: true,
     });
 
-    expect(reducers(domainState, actions.setDefaultError())).toEqual(
+    expect(
+      reducers(domainState, actions.setDefaultError("It didn't work"))
+    ).toEqual(
+      domainStateFactory({
+        errors: "It didn't work",
+        saving: false,
+      })
+    );
+  });
+
+  it("reduces setDefaultError when the error when a domain can't be found", () => {
+    const domainState = domainStateFactory({
+      errors: null,
+      saving: true,
+    });
+
+    expect(reducers(domainState, actions.setDefaultError(9))).toEqual(
       domainStateFactory({
         errors: "There was an error when setting default domain.",
+        saving: false,
       })
     );
   });

--- a/ui/src/app/store/domain/types/actions.ts
+++ b/ui/src/app/store/domain/types/actions.ts
@@ -10,3 +10,5 @@ export type CreateParams = {
 export type UpdateParams = CreateParams & {
   [DomainMeta.PK]: Domain[DomainMeta.PK];
 };
+
+export type SetDefaultErrors = string | number | { domain: string[] };

--- a/ui/src/app/store/domain/types/index.ts
+++ b/ui/src/app/store/domain/types/index.ts
@@ -1,4 +1,4 @@
-export type { CreateParams, UpdateParams } from "./actions";
+export type { CreateParams, UpdateParams, SetDefaultErrors } from "./actions";
 
 export type { Domain, DomainState } from "./base";
 

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -340,6 +340,7 @@ export const statusState = define<StatusState>({
 
 export const domainState = define<DomainState>({
   ...defaultState,
+  errors: null,
 });
 
 export const nodeDeviceState = define<NodeDeviceState>({


### PR DESCRIPTION
## Done

- Add a new table confirm component. 
- Update the domain table to use the new component. 
- Domain improvements from review.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/domains.
- Check that the domain confirmation has a white background.
- Check that you can change the default domain.

<img width="1251" alt="Screen Shot 2021-06-11 at 4 30 19 pm" src="https://user-images.githubusercontent.com/361637/121641307-5bfa3800-cad2-11eb-83a2-b3ea659fc56e.png">

