### PR TITLE
feat(ui): add custom source form to images page

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -108,7 +108,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -152,6 +152,10 @@ exports[`stricter compilation`] = {
     ],
     "src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx:2262769286": [
       [113, 14, 11, "Argument of type \'\\"onConfirm\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "1296914934"]
+    ],
+    "src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceForm.test.tsx:201997244": [
+      [21, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [22, 6, 20, "Argument of type \'{ keyring_data: string; keyring_filename: string; url: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'keyring_data\' does not exist in type \'FormEvent<{}>\'.", "1659605093"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:934008644": [
       [143, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -703,12 +707,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:1367425813": [
       [12, 2, 5, "Type \'null\' is not assignable to type \'NotificationIdent | ArrayFactory<never> | AttributeFunction<NotificationIdent> | Factory<NotificationIdent> | DerivedFunction<...>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:2306025433": [
-      [271, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [387, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [388, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [390, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [395, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:2809825342": [
+      [280, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [395, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [396, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [398, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [403, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };

--- a/ui/src/app/base/components/FormikFormContent/index.ts
+++ b/ui/src/app/base/components/FormikFormContent/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./FormikFormContent";
+export type { FormErrors } from "./FormikFormContent";

--- a/ui/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.test.tsx
@@ -14,12 +14,34 @@ import {
 const mockStore = configureStore();
 
 describe("ImageList", () => {
+  it("shows a placeholder section while config is loading", () => {
+    const state = rootStateFactory({
+      config: configStateFactory({
+        loaded: false,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/images", key: "testKey" }]}
+        >
+          <ImageList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='placeholder-section']").exists()).toBe(
+      true
+    );
+  });
+
   it("shows a warning if automatic image sync is disabled", () => {
     const state = rootStateFactory({
       config: configStateFactory({
         items: [
           configFactory({ name: "boot_images_auto_import", value: false }),
         ],
+        loaded: true,
       }),
     });
     const store = mockStore(state);

--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -4,6 +4,7 @@ import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import ImageListHeader from "./ImageListHeader";
+import UbuntuImages from "./UbuntuImages";
 
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
@@ -14,6 +15,7 @@ import configSelectors from "app/store/config/selectors";
 const ImagesList = (): JSX.Element => {
   const dispatch = useDispatch();
   const autoImport = useSelector(configSelectors.bootImagesAutoImport);
+  const configLoaded = useSelector(configSelectors.loaded);
   useWindowTitle("Images");
 
   useEffect(() => {
@@ -21,7 +23,7 @@ const ImagesList = (): JSX.Element => {
     dispatch(configActions.fetch());
   }, [dispatch]);
 
-  return (
+  return configLoaded ? (
     <Section
       header={<ImageListHeader />}
       headerClassName="u-no-padding--bottom"
@@ -33,8 +35,12 @@ const ImagesList = (): JSX.Element => {
           security fixes.
         </Notification>
       )}
-      Images
+      <UbuntuImages />
     </Section>
+  ) : (
+    // Dummy section is displayed while config is loading to prevent content
+    // jumping around.
+    <Section data-test="placeholder-section" header="Images" />
   );
 };
 

--- a/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceForm.test.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceForm.test.tsx
@@ -1,0 +1,41 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CustomSourceForm from "./CustomSourceForm";
+
+import { actions as bootResourceActions } from "app/store/bootresource";
+import { BootResourceSourceType } from "app/store/bootresource/types";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("CustomSourceForm", () => {
+  it("dispatches an action to fetch images from a custom source", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CustomSourceForm />
+      </Provider>
+    );
+    wrapper.find("Formik").invoke("onSubmit")({
+      keyring_data: "data",
+      keyring_filename: "/path/to/file",
+      url: "http://www.example.com/",
+    });
+
+    const actualActions = store.getActions();
+    const expectedAction = bootResourceActions.fetch({
+      keyring_data: "data",
+      keyring_filename: "/path/to/file",
+      source_type: BootResourceSourceType.CUSTOM,
+      url: "http://www.example.com/",
+    });
+    expect(
+      actualActions.find(
+        (actualAction) => actualAction.type === expectedAction.type
+      )
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceForm.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceForm.tsx
@@ -1,0 +1,67 @@
+import { useCallback } from "react";
+
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import CustomSourceFormFields from "./CustomSourceFormFields";
+
+import FormikForm from "app/base/components/FormikForm";
+import type { FormErrors } from "app/base/components/FormikFormContent";
+import { actions as bootResourceActions } from "app/store/bootresource";
+import bootResourceSelectors from "app/store/bootresource/selectors";
+import { BootResourceSourceType } from "app/store/bootresource/types";
+import type { FetchParams } from "app/store/bootresource/types";
+import { preparePayload } from "app/utils";
+
+const CustomSourceSchema = Yup.object()
+  .shape({
+    keyring_data: Yup.string(),
+    keyring_filename: Yup.string(),
+    url: Yup.string().required("URL is required"),
+  })
+  .defined();
+
+export type CustomSourceValues = {
+  keyring_data: string;
+  keyring_filename: string;
+  url: string;
+};
+
+const CustomSourceForm = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const errors = useSelector(bootResourceSelectors.fetchError);
+  const saving = useSelector(bootResourceSelectors.fetching);
+  const cleanup = useCallback(() => bootResourceActions.cleanup(), []);
+
+  return (
+    <>
+      <h4>Mirror URL</h4>
+      <p>Add the URL you want to use to select your images from.</p>
+      <FormikForm<CustomSourceValues>
+        buttonsBordered={false}
+        cleanup={cleanup}
+        errors={errors as FormErrors}
+        initialValues={{
+          keyring_data: "",
+          keyring_filename: "",
+          url: "",
+        }}
+        onSubmit={(values) => {
+          dispatch(cleanup());
+          const params = preparePayload({
+            ...values,
+            source_type: BootResourceSourceType.CUSTOM,
+          }) as FetchParams;
+          dispatch(bootResourceActions.fetch(params));
+        }}
+        saving={saving}
+        submitLabel="Connect"
+        validationSchema={CustomSourceSchema}
+      >
+        <CustomSourceFormFields />
+      </FormikForm>
+    </>
+  );
+};
+
+export default CustomSourceForm;

--- a/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceFormFields/CustomSourceFormFields.test.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceFormFields/CustomSourceFormFields.test.tsx
@@ -1,0 +1,71 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import CustomSourceFormFields from "./CustomSourceFormFields";
+
+import { waitForComponentToPaint } from "testing/utils";
+
+describe("CustomSourceFormFields", () => {
+  it("shows advanced fields when the Show advanced button is clicked", async () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{ keyring_data: "", keyring_filename: "", url: "" }}
+        onSubmit={jest.fn()}
+      >
+        <CustomSourceFormFields />
+      </Formik>
+    );
+    expect(wrapper.find("input[name='keyring_filename']").exists()).toBe(false);
+    expect(wrapper.find("input[name='keyring_data']").exists()).toBe(false);
+
+    // Click the "Show advanced" button
+    wrapper.find("button[data-test='show-advanced']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("input[name='keyring_filename']").exists()).toBe(true);
+    expect(wrapper.find("textarea[name='keyring_data']").exists()).toBe(true);
+  });
+
+  it("resets advanced field values when the Hide advanced button is clicked", async () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{
+          keyring_data: "data",
+          keyring_filename: "/path/to/file",
+          url: "http://www.example.com",
+        }}
+        onSubmit={jest.fn()}
+      >
+        <CustomSourceFormFields />
+      </Formik>
+    );
+    // Click the "Show advanced" button
+    wrapper.find("button[data-test='show-advanced']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("input[name='url']").prop("value")).toBe(
+      "http://www.example.com"
+    );
+    expect(wrapper.find("input[name='keyring_filename']").prop("value")).toBe(
+      "/path/to/file"
+    );
+    expect(wrapper.find("textarea[name='keyring_data']").prop("value")).toBe(
+      "data"
+    );
+
+    // Click the "Hide advanced" button
+    wrapper.find("button[data-test='hide-advanced']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    // Click the "Show advanced" button - advanced fields should've been cleared
+    wrapper.find("button[data-test='show-advanced']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("input[name='url']").prop("value")).toBe(
+      "http://www.example.com"
+    );
+    expect(wrapper.find("input[name='keyring_filename']").prop("value")).toBe(
+      ""
+    );
+    expect(wrapper.find("textarea[name='keyring_data']").prop("value")).toBe(
+      ""
+    );
+  });
+});

--- a/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceFormFields/CustomSourceFormFields.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceFormFields/CustomSourceFormFields.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+import { Button, Col, Row, Textarea } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { CustomSourceValues } from "../CustomSourceForm";
+
+import FormikField from "app/base/components/FormikField";
+
+const CustomSourceFormFields = (): JSX.Element => {
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
+  const { setFieldValue } = useFormikContext<CustomSourceValues>();
+
+  return (
+    <Row>
+      <Col size="6">
+        <FormikField
+          label="URL"
+          name="url"
+          placeholder="e.g. http:// or https://"
+          required
+          type="text"
+        />
+        {showAdvanced ? (
+          <>
+            <FormikField
+              help="Path to the keyring to validate the mirror path."
+              label="Keyring filename"
+              name="keyring_filename"
+              placeholder="e.g. /usr/share/keyrings/ubuntu-clooudimage-keyring.gpg"
+              type="text"
+            />
+            <FormikField
+              component={Textarea}
+              help="Contents on the keyring to validate the mirror path."
+              label="Keyring data"
+              name="keyring_data"
+              placeholder="Contents of GPG key"
+            />
+            <Button
+              appearance="link"
+              data-test="hide-advanced"
+              onClick={() => {
+                setShowAdvanced(false);
+                setFieldValue("keyring_data", "");
+                setFieldValue("keyring_filename", "");
+              }}
+            >
+              Hide advanced...
+            </Button>
+          </>
+        ) : (
+          <Button
+            appearance="link"
+            data-test="show-advanced"
+            onClick={() => setShowAdvanced(true)}
+          >
+            Show advanced...
+          </Button>
+        )}
+      </Col>
+    </Row>
+  );
+};
+
+export default CustomSourceFormFields;

--- a/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceFormFields/index.ts
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/CustomSourceFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CustomSourceFormFields";

--- a/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/index.ts
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/CustomSourceForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CustomSourceForm";

--- a/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.test.tsx
@@ -1,0 +1,28 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import UbuntuImages from "./UbuntuImages";
+
+import { BootResourceSourceType } from "app/store/bootresource/types";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("UbuntuImages", () => {
+  it("shows the custom source form if custom is selected", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UbuntuImages />
+      </Provider>
+    );
+    expect(wrapper.find("CustomSourceForm").exists()).toBe(false);
+
+    wrapper.find("input[id='custom-source']").simulate("change", {
+      target: { name: "source-type", value: BootResourceSourceType.CUSTOM },
+    });
+    expect(wrapper.find("CustomSourceForm").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+
+import { Col, Input, Row, Strip } from "@canonical/react-components";
+
+import CustomSourceForm from "./CustomSourceForm";
+
+import { BootResourceSourceType } from "app/store/bootresource/types";
+
+const UbuntuImages = (): JSX.Element => {
+  const [sourceType, setSourceType] = useState<BootResourceSourceType>(
+    BootResourceSourceType.MAAS_IO
+  );
+
+  return (
+    <Strip shallow>
+      <Row>
+        <Col size="12">
+          <h4>Ubuntu</h4>
+          <hr />
+          <p>
+            Select images to be imported and kept in sync daily. Images will be
+            available for deploying to machines managed by MAAS.
+          </p>
+          <h4>Choose source</h4>
+          <ul className="p-inline-list">
+            <li className="p-inline-list__item u-display-inline-block">
+              <Input
+                checked={sourceType === BootResourceSourceType.MAAS_IO}
+                id="maas-source"
+                label="maas.io"
+                onChange={() => setSourceType(BootResourceSourceType.MAAS_IO)}
+                type="radio"
+              />
+            </li>
+            <li className="p-inline-list__item u-display-inline-block u-nudge-right">
+              <Input
+                checked={sourceType === BootResourceSourceType.CUSTOM}
+                id="custom-source"
+                label="Custom"
+                onChange={() => setSourceType(BootResourceSourceType.CUSTOM)}
+                type="radio"
+              />
+            </li>
+          </ul>
+        </Col>
+      </Row>
+      {sourceType === BootResourceSourceType.CUSTOM && <CustomSourceForm />}
+    </Strip>
+  );
+};
+
+export default UbuntuImages;

--- a/ui/src/app/images/views/ImageList/UbuntuImages/index.ts
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UbuntuImages";

--- a/ui/src/app/store/bootresource/actions.test.ts
+++ b/ui/src/app/store/bootresource/actions.test.ts
@@ -10,7 +10,7 @@ describe("bootresource actions", () => {
         method: "delete_image",
       },
       payload: {
-        id: 1,
+        params: { id: 1 },
       },
     });
   });
@@ -31,10 +31,12 @@ describe("bootresource actions", () => {
         method: "fetch",
       },
       payload: {
-        keyring_data: "text",
-        keyring_filename: "text",
-        source_type: BootResourceSourceType.CUSTOM,
-        url: "www.website.com",
+        params: {
+          keyring_data: "text",
+          keyring_filename: "text",
+          source_type: BootResourceSourceType.CUSTOM,
+          url: "www.website.com",
+        },
       },
     });
   });
@@ -59,7 +61,9 @@ describe("bootresource actions", () => {
         method: "save_other",
       },
       payload: {
-        images: ["this/image/is/fake"],
+        params: {
+          images: ["this/image/is/fake"],
+        },
       },
     });
   });
@@ -83,14 +87,16 @@ describe("bootresource actions", () => {
         method: "save_ubuntu",
       },
       payload: {
-        osystems: [
-          {
-            osystem: "ubuntu",
-            release: "focal",
-            arches: ["amd64"],
-          },
-        ],
-        source_type: BootResourceSourceType.MAAS_IO,
+        params: {
+          osystems: [
+            {
+              osystem: "ubuntu",
+              release: "focal",
+              arches: ["amd64"],
+            },
+          ],
+          source_type: BootResourceSourceType.MAAS_IO,
+        },
       },
     });
   });
@@ -103,7 +109,9 @@ describe("bootresource actions", () => {
         method: "save_ubuntu_core",
       },
       payload: {
-        images: ["this/image/is/fake"],
+        params: {
+          images: ["this/image/is/fake"],
+        },
       },
     });
   });

--- a/ui/src/app/store/bootresource/selectors.test.ts
+++ b/ui/src/app/store/bootresource/selectors.test.ts
@@ -1,6 +1,8 @@
 import bootResourceSelectors from "./selectors";
+import { BootResourceAction } from "./types";
 
 import {
+  bootResourceEventError as eventErrorFactory,
   bootResourceState as bootResourceStateFactory,
   bootResourceStatuses as bootResourceStatusesFactory,
   rootState as rootStateFactory,
@@ -17,6 +19,37 @@ describe("bootresource selectors", () => {
       }),
     });
     expect(bootResourceSelectors.statuses(state)).toStrictEqual(statuses);
+  });
+
+  it("can get all event errors", () => {
+    const eventErrors = [eventErrorFactory()];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        eventErrors,
+      }),
+    });
+    expect(bootResourceSelectors.eventErrors(state)).toStrictEqual(eventErrors);
+  });
+
+  it("can get a fetch error, if it exists", () => {
+    const eventErrors = [
+      eventErrorFactory({
+        event: BootResourceAction.FETCH,
+        error: "NO FETCH",
+      }),
+    ];
+    const errorState = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        eventErrors,
+      }),
+    });
+    const nonErrorState = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        eventErrors: [],
+      }),
+    });
+    expect(bootResourceSelectors.fetchError(errorState)).toBe("NO FETCH");
+    expect(bootResourceSelectors.fetchError(nonErrorState)).toBe(null);
   });
 
   it("can get the deletingImage status", () => {

--- a/ui/src/app/store/bootresource/selectors.ts
+++ b/ui/src/app/store/bootresource/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import type { BootResourceStatuses } from "./types";
-import { BootResourceMeta } from "./types";
+import type { BootResourceState, BootResourceStatuses } from "./types";
+import { BootResourceAction, BootResourceMeta } from "./types";
 
 import type { RootState } from "app/store/root/types";
 
@@ -12,6 +12,14 @@ import type { RootState } from "app/store/root/types";
  */
 const statuses = (state: RootState): BootResourceStatuses =>
   state[BootResourceMeta.MODEL].statuses;
+
+/**
+ * Get the list of eventErrors.
+ * @param state - The redux state.
+ * @returns Boot resource errors.
+ */
+const eventErrors = (state: RootState): BootResourceState["eventErrors"] =>
+  state[BootResourceMeta.MODEL].eventErrors;
 
 /**
  * Whether the delete image action is in progress.
@@ -29,6 +37,19 @@ const deletingImage = createSelector(
  * @returns Whether a fetch action is in progress.
  */
 const fetching = createSelector([statuses], (statuses) => statuses.fetching);
+
+/**
+ * Returns the latest fetch error's error message.
+ * @param state - The redux state.
+ * @returns Fetch error message.
+ */
+const fetchError = createSelector(
+  [eventErrors],
+  (eventErrors) =>
+    eventErrors.find(
+      (eventError) => eventError.event === BootResourceAction.FETCH
+    )?.error || null
+);
 
 /**
  * Whether the poll event is in progress.
@@ -79,6 +100,8 @@ const stoppingImport = createSelector(
 
 const selectors = {
   deletingImage,
+  eventErrors,
+  fetchError,
   fetching,
   polling,
   savingOther,

--- a/ui/src/app/store/bootresource/slice.ts
+++ b/ui/src/app/store/bootresource/slice.ts
@@ -46,7 +46,9 @@ const bootResourceSlice = createSlice({
           model: BootResourceMeta.MODEL,
           method: "delete_image",
         },
-        payload: params,
+        payload: {
+          params,
+        },
       }),
       reducer: () => {
         // No state changes need to be handled for this action.
@@ -76,7 +78,9 @@ const bootResourceSlice = createSlice({
           model: BootResourceMeta.MODEL,
           method: "fetch",
         },
-        payload: params,
+        payload: {
+          params,
+        },
       }),
       reducer: () => {
         // No state changes need to be handled for this action.
@@ -149,7 +153,9 @@ const bootResourceSlice = createSlice({
           model: BootResourceMeta.MODEL,
           method: "save_other",
         },
-        payload: params,
+        payload: {
+          params,
+        },
       }),
       reducer: () => {
         // No state changes need to be handled for this action.
@@ -178,7 +184,9 @@ const bootResourceSlice = createSlice({
           model: BootResourceMeta.MODEL,
           method: "save_ubuntu",
         },
-        payload: params,
+        payload: {
+          params,
+        },
       }),
       reducer: () => {
         // No state changes need to be handled for this action.
@@ -206,7 +214,9 @@ const bootResourceSlice = createSlice({
           model: BootResourceMeta.MODEL,
           method: "save_ubuntu_core",
         },
-        payload: params,
+        payload: {
+          params,
+        },
       }),
       reducer: () => {
         // No state changes need to be handled for this action.

--- a/ui/src/app/store/bootresource/types/actions.ts
+++ b/ui/src/app/store/bootresource/types/actions.ts
@@ -1,16 +1,11 @@
-import type { BootResource } from "./base";
+import type { BootResource, BootResourceUbuntuSource } from "./base";
 import type { BootResourceSourceType } from "./enum";
 
 export type DeleteImageParams = {
   id: BootResource["id"];
 };
 
-export type FetchParams = {
-  keyring_data?: string;
-  keyring_filename?: string;
-  source_type: BootResourceSourceType;
-  url: string;
-};
+export type FetchParams = BootResourceUbuntuSource;
 
 export type SaveOtherParams = {
   images: string[];


### PR DESCRIPTION
## Done

- Added custom source form to images page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images and check that changing the source type radio to "Custom" shows the custom source form
- Enter a random url and submit the form - check that an error shows above the form
- Click "Show advanced" and enter some values, then click "Hide advanced" then "Show advanced" again. Check that the advanced values were cleared.
- Enter a valid URL (e.g. https://images.maas.io/ephemeral-v3/stable/) and check that images are successfully fetched and show up in `fetchedImages` in state

## Fixes

Fixes canonical-web-and-design/app-squad#86

## Screenshot
![Screenshot 2021-06-11 at 16-47-47 Images bolla MAAS](https://user-images.githubusercontent.com/25733845/121644515-6f0f0700-cad6-11eb-9a00-679aa087e42f.png)
