### PR TITLE
feat(ui): add image release/arch select form fields

### DIFF
--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
@@ -1,0 +1,76 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import ArchSelect from "./ArchSelect";
+
+import {
+  bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
+  bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory,
+} from "testing/factories";
+
+describe("ArchSelect", () => {
+  it("shows a message if no release is selected", () => {
+    const wrapper = mount(
+      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
+        <ArchSelect arches={[bootResourceUbuntuArchFactory()]} release={null} />
+      </Formik>
+    );
+
+    expect(wrapper.find("[data-test='no-release-selected']").text()).toBe(
+      "Please select a release to view the available architectures."
+    );
+  });
+
+  it("correctly shows when an arch checkbox is checked", () => {
+    const release = bootResourceUbuntuReleaseFactory({ name: "focal" });
+    const arches = [
+      bootResourceUbuntuArchFactory({ name: "amd64" }),
+      bootResourceUbuntuArchFactory({ name: "arm64" }),
+    ];
+    const wrapper = mount(
+      <Formik
+        initialValues={{
+          osystems: [
+            { arches: ["amd64"], osystem: "ubuntu", release: "focal" },
+          ],
+        }}
+        onSubmit={jest.fn()}
+      >
+        <ArchSelect arches={arches} release={release} />
+      </Formik>
+    );
+    const radioChecked = (id: string) =>
+      wrapper
+        .findWhere((n) => n.name() === "Input" && n.prop("id") === id)
+        .prop("checked");
+
+    expect(radioChecked("arch-amd64")).toBe(true);
+    expect(radioChecked("arch-arm64")).toBe(false);
+  });
+
+  it("disables a checkbox with tooltip if release does not support arch", () => {
+    const release = bootResourceUbuntuReleaseFactory({
+      name: "focal",
+      title: "20.04 LTS",
+      unsupported_arches: ["i386"],
+    });
+    const arches = [
+      bootResourceUbuntuArchFactory({ name: "amd64" }),
+      bootResourceUbuntuArchFactory({ name: "i386" }),
+    ];
+    const wrapper = mount(
+      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
+        <ArchSelect arches={arches} release={release} />
+      </Formik>
+    );
+
+    expect(
+      wrapper
+        .findWhere((n) => n.name() === "Input" && n.prop("id") === "arch-i386")
+        .prop("disabled")
+    ).toBe(true);
+    expect(
+      wrapper.find("[data-test='disabled-arch-tooltip']").prop("message")
+    ).toBe("i386 is not available on 20.04 LTS.");
+  });
+});

--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
@@ -1,0 +1,104 @@
+import { Col, Icon, Input, Tooltip } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type {
+  BootResourceUbuntuArch,
+  BootResourceUbuntuRelease,
+  OsystemParam,
+} from "app/store/bootresource/types";
+
+type Props = {
+  arches: BootResourceUbuntuArch[];
+  release: BootResourceUbuntuRelease | null;
+};
+
+const ArchSelect = ({ arches, release }: Props): JSX.Element => {
+  const { setFieldValue, values } =
+    useFormikContext<{ osystems: OsystemParam[] }>();
+  const { osystems } = values;
+
+  if (!release) {
+    return (
+      <Col className="p-divider__block" size="6">
+        <h4>Architectures</h4>
+        <p data-test="no-release-selected">
+          Please select a release to view the available architectures.
+        </p>
+      </Col>
+    );
+  }
+
+  const isChecked = (arch: BootResourceUbuntuArch) =>
+    osystems.some(
+      (os) =>
+        os.osystem === "ubuntu" &&
+        os.release === release.name &&
+        os.arches.includes(arch.name)
+    );
+
+  const isDisabled = (arch: BootResourceUbuntuArch) =>
+    release.unsupported_arches.includes(arch.name);
+
+  const handleChange = (arch: BootResourceUbuntuArch) => {
+    let newOsystems: OsystemParam[] = [];
+    const osystem = osystems.find((os) => os.release === release.name);
+
+    if (osystem) {
+      // If osystem already exists, either add to or remove arch from its arches
+      const rest = osystems.filter((os) => os !== osystem);
+      const hasArch = osystem.arches.includes(arch.name);
+      newOsystems = [
+        {
+          ...osystem,
+          arches: hasArch
+            ? osystem.arches.filter((a) => a !== arch.name)
+            : osystem.arches.concat(arch.name),
+        },
+        ...rest,
+      ];
+    } else {
+      // Otherwise add a new osystem object
+      newOsystems = osystems.concat({
+        arches: [arch.name],
+        osystem: "ubuntu",
+        release: release.name,
+      });
+    }
+    setFieldValue("osystems", newOsystems);
+  };
+
+  return (
+    <Col className="p-divider__block" size="6">
+      <h4>Architectures for {release.title}</h4>
+      <ul className="p-list">
+        {arches.map((arch) => (
+          <li className="p-list__item u-sv1" key={arch.name}>
+            <Input
+              checked={isChecked(arch)}
+              disabled={isDisabled(arch)}
+              id={`arch-${arch.name}`}
+              label={
+                <span>
+                  {arch.name}
+                  {isDisabled(arch) && (
+                    <Tooltip
+                      className="u-nudge-right--small"
+                      data-test="disabled-arch-tooltip"
+                      message={`${arch.name} is not available on ${release.title}.`}
+                    >
+                      <Icon name="help" />
+                    </Tooltip>
+                  )}
+                </span>
+              }
+              onChange={() => handleChange(arch)}
+              type="checkbox"
+            />
+          </li>
+        ))}
+      </ul>
+    </Col>
+  );
+};
+
+export default ArchSelect;

--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/index.ts
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ArchSelect";

--- a/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.test.tsx
@@ -1,0 +1,80 @@
+import { mount } from "enzyme";
+
+import ReleaseSelect from "./ReleaseSelect";
+
+import { bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory } from "testing/factories";
+
+describe("ReleaseSelect", () => {
+  it("separates ubuntu releases by LTS and non-LTS, sorted descending by title", () => {
+    const releases = [
+      bootResourceUbuntuReleaseFactory({
+        name: "hirsute",
+        title: "21.04",
+      }),
+      bootResourceUbuntuReleaseFactory({
+        name: "bionic",
+        title: "18.04 LTS",
+      }),
+      bootResourceUbuntuReleaseFactory({
+        name: "groovy",
+        title: "20.10",
+      }),
+      bootResourceUbuntuReleaseFactory({
+        name: "xenial",
+        title: "16.04 LTS",
+      }),
+      bootResourceUbuntuReleaseFactory({
+        name: "impish",
+        title: "21.10",
+      }),
+      bootResourceUbuntuReleaseFactory({
+        name: "focal",
+        title: "20.04 LTS",
+      }),
+    ];
+    const wrapper = mount(
+      <ReleaseSelect
+        releases={releases}
+        selectedRelease="focal"
+        setSelectedRelease={jest.fn()}
+      />
+    );
+
+    const getLabel = (dataTest: string, pos: number) =>
+      wrapper.find(`[data-test='${dataTest}'] Input`).at(pos).prop("label");
+
+    expect(getLabel("lts-releases", 0)).toBe("20.04 LTS");
+    expect(getLabel("lts-releases", 1)).toBe("18.04 LTS");
+    expect(getLabel("lts-releases", 2)).toBe("16.04 LTS");
+    expect(getLabel("non-lts-releases", 0)).toBe("21.10");
+    expect(getLabel("non-lts-releases", 1)).toBe("21.04");
+    expect(getLabel("non-lts-releases", 2)).toBe("20.10");
+  });
+
+  it("can set the selected release", () => {
+    const setSelectedRelease = jest.fn();
+    const releases = [
+      bootResourceUbuntuReleaseFactory({
+        name: "focal",
+        title: "20.04",
+      }),
+      bootResourceUbuntuReleaseFactory({
+        name: "bionic",
+        title: "18.04",
+      }),
+    ];
+    const wrapper = mount(
+      <ReleaseSelect
+        releases={releases}
+        selectedRelease="focal"
+        setSelectedRelease={setSelectedRelease}
+      />
+    );
+
+    wrapper
+      .find("input[id='release-bionic']")
+      .simulate("change", { target: { checked: true, id: "release-bionic" } });
+
+    expect(setSelectedRelease).toHaveBeenCalledWith("bionic");
+  });
+});

--- a/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.tsx
@@ -1,0 +1,74 @@
+import { Col, Input, Row } from "@canonical/react-components";
+
+import type { BootResourceUbuntuRelease } from "app/store/bootresource/types";
+import { simpleSortByKey } from "app/utils";
+
+type Props = {
+  releases: BootResourceUbuntuRelease[];
+  selectedRelease: BootResourceUbuntuRelease["name"];
+  setSelectedRelease: (release: BootResourceUbuntuRelease["name"]) => void;
+};
+
+const ReleaseSelect = ({
+  releases,
+  selectedRelease,
+  setSelectedRelease,
+}: Props): JSX.Element => {
+  const [ltsReleases, nonLtsReleases] = releases.reduce<
+    BootResourceUbuntuRelease[][]
+  >(
+    ([lts, nonLts], release, i) => {
+      if (release.title.includes("LTS")) {
+        lts.push(release);
+      } else {
+        nonLts.push(release);
+      }
+      if (i === releases.length - 1) {
+        lts.sort(simpleSortByKey("title", { reverse: true }));
+        nonLts.sort(simpleSortByKey("title", { reverse: true }));
+      }
+      return [lts, nonLts];
+    },
+    [[], []]
+  );
+
+  return (
+    <Col className="p-divider__block" size="6">
+      <h4>Releases</h4>
+      <Row>
+        <Col size="3">
+          <ul className="p-list" data-test="lts-releases">
+            {ltsReleases.map((release) => (
+              <li className="p-list__item u-sv1" key={release.name}>
+                <Input
+                  checked={selectedRelease === release.name}
+                  id={`release-${release.name}`}
+                  label={release.title}
+                  onChange={() => setSelectedRelease(release.name)}
+                  type="radio"
+                />
+              </li>
+            ))}
+          </ul>
+        </Col>
+        <Col size="3">
+          <ul className="p-list" data-test="non-lts-releases">
+            {nonLtsReleases.map((release) => (
+              <li className="p-list__item u-sv1" key={release.name}>
+                <Input
+                  checked={selectedRelease === release.name}
+                  id={`release-${release.name}`}
+                  label={release.title}
+                  onChange={() => setSelectedRelease(release.name)}
+                  type="radio"
+                />
+              </li>
+            ))}
+          </ul>
+        </Col>
+      </Row>
+    </Col>
+  );
+};
+
+export default ReleaseSelect;

--- a/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/index.ts
+++ b/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReleaseSelect";

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
@@ -1,0 +1,51 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import UbuntuImageSelect from "./UbuntuImageSelect";
+
+import {
+  bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
+  bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory,
+} from "testing/factories";
+
+describe("UbuntuImageSelect", () => {
+  it("does not show a radio button for a release deleted from the source", () => {
+    const [available, deleted] = [
+      bootResourceUbuntuReleaseFactory({ name: "available", deleted: false }),
+      bootResourceUbuntuReleaseFactory({ name: "deleted", deleted: true }),
+    ];
+    const arches = [bootResourceUbuntuArchFactory()];
+    const wrapper = mount(
+      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
+        <UbuntuImageSelect arches={arches} releases={[available, deleted]} />
+      </Formik>
+    );
+    const radioExists = (id: string) =>
+      wrapper
+        .findWhere((n) => n.name() === "Input" && n.prop("id") === id)
+        .exists();
+
+    expect(radioExists("release-available")).toBe(true);
+    expect(radioExists("release-deleted")).toBe(false);
+  });
+
+  it("does not show a checkbox for an architecture delete from the source", () => {
+    const releases = [bootResourceUbuntuReleaseFactory({ name: "focal" })];
+    const [available, deleted] = [
+      bootResourceUbuntuArchFactory({ name: "available", deleted: false }),
+      bootResourceUbuntuArchFactory({ name: "delete", deleted: true }),
+    ];
+    const wrapper = mount(
+      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
+        <UbuntuImageSelect arches={[available, deleted]} releases={releases} />
+      </Formik>
+    );
+    const checkboxExists = (id: string) =>
+      wrapper
+        .findWhere((n) => n.name() === "Input" && n.prop("id") === id)
+        .exists();
+
+    expect(checkboxExists("arch-available")).toBe(true);
+    expect(checkboxExists("arch-deleted")).toBe(false);
+  });
+});

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+import { Row } from "@canonical/react-components";
+
+import ArchSelect from "./ArchSelect";
+import ReleaseSelect from "./ReleaseSelect";
+
+import type {
+  BootResourceUbuntuArch,
+  BootResourceUbuntuRelease,
+} from "app/store/bootresource/types";
+
+type Props = {
+  arches: BootResourceUbuntuArch[];
+  releases: BootResourceUbuntuRelease[];
+};
+
+const UbuntuImageSelect = ({ arches, releases }: Props): JSX.Element => {
+  const [selectedRelease, setSelectedRelease] =
+    useState<BootResourceUbuntuRelease["name"]>("focal");
+  const availableArches = arches.filter((arch) => !arch.deleted);
+  const availableReleases = releases.filter((release) => !release.deleted);
+
+  return (
+    <Row className="p-divider">
+      <ReleaseSelect
+        releases={availableReleases}
+        selectedRelease={selectedRelease}
+        setSelectedRelease={setSelectedRelease}
+      />
+      <ArchSelect
+        arches={availableArches}
+        release={
+          releases.find((release) => release.name === selectedRelease) || null
+        }
+      />
+    </Row>
+  );
+};
+
+export default UbuntuImageSelect;

--- a/ui/src/app/images/components/UbuntuImageSelect/index.ts
+++ b/ui/src/app/images/components/UbuntuImageSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UbuntuImageSelect";

--- a/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/DefaultSource.test.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/DefaultSource.test.tsx
@@ -1,0 +1,87 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DefaultSource from "./DefaultSource";
+
+import {
+  bootResource as bootResourceFactory,
+  bootResourceState as bootResourceStateFactory,
+  bootResourceUbuntu as bootResourceUbuntuFactory,
+  bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
+  bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DefaultSource", () => {
+  it("shows a spinner if ubuntu image metadata has not been loaded yet", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({ ubuntu: null }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DefaultSource />
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(wrapper.find("UbuntuImageSelect").exists()).toBe(false);
+  });
+
+  it("shows the ubuntu image selection form if metadata has loaded", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        ubuntu: bootResourceUbuntuFactory(),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DefaultSource />
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(false);
+    expect(wrapper.find("UbuntuImageSelect").exists()).toBe(true);
+  });
+
+  it("correctly sets initial values based on resources", () => {
+    const ubuntu = bootResourceUbuntuFactory({
+      arches: [
+        bootResourceUbuntuArchFactory({ name: "amd64" }),
+        bootResourceUbuntuArchFactory({ name: "i386" }),
+      ],
+      releases: [
+        bootResourceUbuntuReleaseFactory({ name: "xenial" }),
+        bootResourceUbuntuReleaseFactory({ name: "bionic" }),
+      ],
+    });
+    const resources = [
+      bootResourceFactory({ name: "ubuntu/xenial", arch: "amd64" }),
+      bootResourceFactory({ name: "ubuntu/xenial", arch: "i386" }),
+      bootResourceFactory({ name: "ubuntu/xenial", arch: "s390x" }), // source does not know this arch
+      bootResourceFactory({ name: "ubuntu/bionic", arch: "amd64" }),
+      bootResourceFactory({ name: "ubuntu/focal", arch: "amd64" }), // source does not know this release
+      bootResourceFactory({ name: "centos/centos70", arch: "amd64" }), // only Ubuntu resources are relevant
+    ];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources,
+        ubuntu,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DefaultSource />
+      </Provider>
+    );
+    expect(wrapper.find("Formik").prop("initialValues")).toStrictEqual({
+      osystems: [
+        { arches: ["amd64", "i386"], osystem: "ubuntu", release: "xenial" },
+        { arches: ["amd64"], osystem: "ubuntu", release: "bionic" },
+      ],
+    });
+  });
+});

--- a/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/DefaultSource.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/DefaultSource.tsx
@@ -1,0 +1,102 @@
+import { useCallback } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import FormikForm from "app/base/components/FormikForm";
+import UbuntuImageSelect from "app/images/components/UbuntuImageSelect";
+import { actions as bootResourceActions } from "app/store/bootresource";
+import bootResourceSelectors from "app/store/bootresource/selectors";
+import type { OsystemParam } from "app/store/bootresource/types";
+import { BootResourceSourceType } from "app/store/bootresource/types";
+import { splitResourceName } from "app/store/bootresource/utils";
+
+const DefaultSourceSchema = Yup.object()
+  .shape({
+    osystems: Yup.array().of(
+      Yup.object().shape({
+        arches: Yup.array().of(Yup.string()),
+        release: Yup.string(),
+      })
+    ),
+  })
+  .defined();
+
+export type DefaultSourceValues = {
+  osystems: OsystemParam[];
+};
+
+const DefaultSource = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const ubuntu = useSelector(bootResourceSelectors.ubuntu);
+  const resources = useSelector(bootResourceSelectors.ubuntuResources);
+  const saving = useSelector(bootResourceSelectors.savingUbuntu);
+  const cleanup = useCallback(() => bootResourceActions.cleanup(), []);
+
+  if (!ubuntu) {
+    return <Spinner text="Fetching image data..." />;
+  }
+
+  const initialOsystems = resources.reduce<OsystemParam[]>(
+    (osystems, resource) => {
+      // Resources come in the form "<os-name>/<release>" e.g. "ubuntu/bionic".
+      const { release: resourceRelease } = splitResourceName(resource.name);
+      // We check that the release and arch of the resource are known by the
+      // source(s).
+      const releaseExists = ubuntu.releases.some(
+        (release) => release.name === resourceRelease
+      );
+      const archExists = ubuntu.arches.some(
+        (arch) => arch.name === resource.arch
+      );
+      // If resource details are known, we either add a new osystem object to
+      // the osystem list, or add a new arch to an existing osystem object.
+      if (releaseExists && archExists) {
+        const osystem = osystems.find((os) => os.release === resourceRelease);
+        if (osystem) {
+          const newArch = osystem.arches.every(
+            (arch) => arch !== resource.arch
+          );
+          if (newArch) {
+            osystem.arches.push(resource.arch);
+          }
+        } else {
+          osystems.push({
+            arches: [resource.arch],
+            osystem: "ubuntu",
+            release: resourceRelease,
+          });
+        }
+      }
+      return osystems;
+    },
+    []
+  );
+
+  return (
+    <FormikForm<DefaultSourceValues>
+      buttonsBordered={false}
+      cleanup={cleanup}
+      editable={false}
+      initialValues={{
+        osystems: initialOsystems,
+      }}
+      onSubmit={(values) => {
+        dispatch(cleanup());
+        const params = {
+          osystems: values.osystems,
+          source_type: BootResourceSourceType.MAAS_IO,
+        };
+        dispatch(bootResourceActions.saveUbuntu(params));
+      }}
+      saving={saving}
+      submitLabel="Update selection"
+      validationSchema={DefaultSourceSchema}
+    >
+      <UbuntuImageSelect arches={ubuntu.arches} releases={ubuntu.releases} />
+    </FormikForm>
+  );
+};
+
+export default DefaultSource;

--- a/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/index.ts
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DefaultSource";

--- a/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.test.tsx
@@ -10,6 +10,22 @@ import { rootState as rootStateFactory } from "testing/factories";
 const mockStore = configureStore();
 
 describe("UbuntuImages", () => {
+  it("shows the default source images by default", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UbuntuImages />
+      </Provider>
+    );
+    expect(wrapper.find("DefaultSource").exists()).toBe(true);
+
+    wrapper.find("input[id='custom-source']").simulate("change", {
+      target: { name: "source-type", value: BootResourceSourceType.CUSTOM },
+    });
+    expect(wrapper.find("DefaultSource").exists()).toBe(false);
+  });
+
   it("shows the custom source form if custom is selected", () => {
     const state = rootStateFactory();
     const store = mockStore(state);

--- a/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/UbuntuImages.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Col, Input, Row, Strip } from "@canonical/react-components";
 
 import CustomSource from "./CustomSource";
+import DefaultSource from "./DefaultSource";
 
 import { BootResourceSourceType } from "app/store/bootresource/types";
 
@@ -44,6 +45,7 @@ const UbuntuImages = (): JSX.Element => {
           </ul>
         </Col>
       </Row>
+      {sourceType === BootResourceSourceType.MAAS_IO && <DefaultSource />}
       {sourceType === BootResourceSourceType.CUSTOM && <CustomSource />}
     </Strip>
   );

--- a/ui/src/app/store/bootresource/selectors.test.ts
+++ b/ui/src/app/store/bootresource/selectors.test.ts
@@ -2,13 +2,55 @@ import bootResourceSelectors from "./selectors";
 import { BootResourceAction } from "./types";
 
 import {
+  bootResource as bootResourceFactory,
   bootResourceEventError as eventErrorFactory,
   bootResourceState as bootResourceStateFactory,
   bootResourceStatuses as bootResourceStatusesFactory,
+  bootResourceUbuntu as bootResourceUbuntuFactory,
+  bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
+  bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 
 describe("bootresource selectors", () => {
+  it("can get all boot resources", () => {
+    const resources = [bootResourceFactory()];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources,
+      }),
+    });
+    expect(bootResourceSelectors.resources(state)).toStrictEqual(resources);
+  });
+
+  it("can get all ubuntu boot resources", () => {
+    const [ubuntuResource, nonUbuntuResource] = [
+      bootResourceFactory({ name: "ubuntu/focal" }),
+      bootResourceFactory({ name: "centos/centos70" }),
+    ];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [ubuntuResource, nonUbuntuResource],
+      }),
+    });
+    expect(bootResourceSelectors.ubuntuResources(state)).toStrictEqual([
+      ubuntuResource,
+    ]);
+  });
+
+  it("can get ubuntu boot resource metadata", () => {
+    const ubuntu = bootResourceUbuntuFactory({
+      arches: [bootResourceUbuntuArchFactory()],
+      releases: [bootResourceUbuntuReleaseFactory()],
+    });
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        ubuntu,
+      }),
+    });
+    expect(bootResourceSelectors.ubuntu(state)).toStrictEqual(ubuntu);
+  });
+
   it("can get all statuses", () => {
     const statuses = bootResourceStatusesFactory({
       polling: true,

--- a/ui/src/app/store/bootresource/selectors.ts
+++ b/ui/src/app/store/bootresource/selectors.ts
@@ -2,6 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import type { BootResourceState, BootResourceStatuses } from "./types";
 import { BootResourceAction, BootResourceMeta } from "./types";
+import { splitResourceName } from "./utils";
 
 import type { RootState } from "app/store/root/types";
 
@@ -20,6 +21,34 @@ const statuses = (state: RootState): BootResourceStatuses =>
  */
 const eventErrors = (state: RootState): BootResourceState["eventErrors"] =>
   state[BootResourceMeta.MODEL].eventErrors;
+
+/**
+ * Get the list of downloaded/downloading boot resources.
+ * @param state - The redux state.
+ * @returns Downloaded/downloading boot resources.
+ */
+const resources = (state: RootState): BootResourceState["resources"] =>
+  state[BootResourceMeta.MODEL].resources;
+
+/**
+ * Get the list of downloaded/downloading Ubuntu boot resources.
+ * @param state - The redux state.
+ * @returns Downloaded/downloading Ubuntu boot resources.
+ */
+const ubuntuResources = createSelector([resources], (resources) =>
+  resources.filter(
+    (resource) => splitResourceName(resource.name).os === "ubuntu"
+  )
+);
+
+/**
+ * Get Ubuntu boot resource metadata, i.e. the list of available Ubuntu
+ * releases and architectures from the default source.
+ * @param state - The redux state.
+ * @returns Ubuntu boot resource metadata.
+ */
+const ubuntu = (state: RootState): BootResourceState["ubuntu"] =>
+  state[BootResourceMeta.MODEL].ubuntu;
 
 /**
  * Whether the delete image action is in progress.
@@ -104,11 +133,14 @@ const selectors = {
   fetchError,
   fetching,
   polling,
+  resources,
   savingOther,
   savingUbuntu,
   savingUbuntuCore,
   statuses,
   stoppingImport,
+  ubuntu,
+  ubuntuResources,
 };
 
 export default selectors;

--- a/ui/src/app/store/bootresource/types/actions.ts
+++ b/ui/src/app/store/bootresource/types/actions.ts
@@ -7,6 +7,12 @@ export type DeleteImageParams = {
 
 export type FetchParams = BootResourceUbuntuSource;
 
+export type OsystemParam = {
+  osystem: string;
+  release: string;
+  arches: string[];
+};
+
 export type SaveOtherParams = {
   images: string[];
 };
@@ -16,12 +22,6 @@ export type SaveUbuntuCoreParams = {
 };
 
 export type SaveUbuntuParams = {
-  osystems: UbuntuOsystem[];
+  osystems: OsystemParam[];
   source_type: BootResourceSourceType;
-};
-
-export type UbuntuOsystem = {
-  osystem: string;
-  release: string;
-  arches: string[];
 };

--- a/ui/src/app/store/bootresource/types/index.ts
+++ b/ui/src/app/store/bootresource/types/index.ts
@@ -1,10 +1,10 @@
 export type {
   DeleteImageParams,
   FetchParams,
+  OsystemParam,
   SaveOtherParams,
   SaveUbuntuCoreParams,
   SaveUbuntuParams,
-  UbuntuOsystem,
 } from "./actions";
 export type {
   BootResource,

--- a/ui/src/app/store/bootresource/utils.test.ts
+++ b/ui/src/app/store/bootresource/utils.test.ts
@@ -1,0 +1,25 @@
+import { splitResourceName } from "./utils";
+
+describe("bootresource utils", () => {
+  describe("splitResourceName", () => {
+    it("correctly splits a resource name into os and release", () => {
+      expect(splitResourceName("ubuntu/focal")).toStrictEqual({
+        os: "ubuntu",
+        release: "focal",
+      });
+      expect(splitResourceName("centos/centos70")).toStrictEqual({
+        os: "centos",
+        release: "centos70",
+      });
+      expect(splitResourceName("ubuntu")).toStrictEqual({
+        os: "",
+        release: "",
+      });
+      expect(splitResourceName("ubuntu/focal/amd64/generic")).toStrictEqual({
+        os: "",
+        release: "",
+      });
+      expect(splitResourceName("")).toStrictEqual({ os: "", release: "" });
+    });
+  });
+});

--- a/ui/src/app/store/bootresource/utils.ts
+++ b/ui/src/app/store/bootresource/utils.ts
@@ -1,0 +1,10 @@
+import type { BootResource } from "./types";
+
+export const splitResourceName = (
+  name: BootResource["name"]
+): { os: string; release: string } => {
+  const split = name.split("/");
+  return split.length === 2
+    ? { os: split[0], release: split[1] }
+    : { os: "", release: "" };
+};

--- a/ui/src/app/utils/simpleSortByKey.test.ts
+++ b/ui/src/app/utils/simpleSortByKey.test.ts
@@ -1,13 +1,13 @@
 import { simpleSortByKey } from "./simpleSortByKey";
 
 describe("simpleSortByKey", () => {
-  it("correctly sorts objects by key", () => {
-    const arr = [
-      { name: "Bob", age: 30 },
-      { name: "Chris", age: 20 },
-      { name: "Alice", age: 25 },
-    ];
+  const arr = [
+    { name: "Bob", age: 30 },
+    { name: "Chris", age: 20 },
+    { name: "Alice", age: 25 },
+  ];
 
+  it("correctly sorts objects by key", () => {
     expect(arr.sort(simpleSortByKey("name"))).toEqual([
       { name: "Alice", age: 25 },
       { name: "Bob", age: 30 },
@@ -17,6 +17,19 @@ describe("simpleSortByKey", () => {
       { name: "Chris", age: 20 },
       { name: "Alice", age: 25 },
       { name: "Bob", age: 30 },
+    ]);
+  });
+
+  it("can reverse sort", () => {
+    expect(arr.sort(simpleSortByKey("name", { reverse: true }))).toEqual([
+      { name: "Chris", age: 20 },
+      { name: "Bob", age: 30 },
+      { name: "Alice", age: 25 },
+    ]);
+    expect(arr.sort(simpleSortByKey("age", { reverse: true }))).toEqual([
+      { name: "Bob", age: 30 },
+      { name: "Alice", age: 25 },
+      { name: "Chris", age: 20 },
     ]);
   });
 });

--- a/ui/src/app/utils/simpleSortByKey.ts
+++ b/ui/src/app/utils/simpleSortByKey.ts
@@ -2,12 +2,17 @@
  * Simple sort objects by key value.
  *
  * @param key - the key of the objects to sort by
+ * @param config - config object
+ * @param config.reverse - whether to reverse the results
  * @returns sort function
  */
 export const simpleSortByKey =
-  <O, K extends keyof O>(attr: K): ((a: O, b: O) => number) =>
+  <O, K extends keyof O>(
+    key: K,
+    { reverse } = { reverse: false }
+  ): ((a: O, b: O) => number) =>
   (a: O, b: O) => {
-    if (a[attr] > b[attr]) return 1;
-    if (a[attr] < b[attr]) return -1;
+    if (a[key] > b[key]) return reverse ? -1 : 1;
+    if (a[key] < b[key]) return reverse ? 1 : -1;
     return 0;
   };


### PR DESCRIPTION
## Done

- Added image release/arch select form fields, though the form is not yet submittable.
- Created `UbuntuImageSelect` component which can hopefully be reused for the custom source images as well

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images and check that a spinner shows while images are being fetched.
- Once fetched, check that the initial radio/arch combinations match the ubuntu resources found in `bootresource.resources`.

## Fixes

Fixes canonical-web-and-design/app-squad#80

## Screenshot
![2021-06-14_16-21](https://user-images.githubusercontent.com/25733845/121848589-990e3680-cd2d-11eb-9601-91465ad91334.png)
