### PR TITLE
feat(ui): set up routes for intro pages

### DIFF
--- a/ui/src/app/Routes.tsx
+++ b/ui/src/app/Routes.tsx
@@ -9,6 +9,8 @@ import domainsURLs from "app/domains/urls";
 import Domains from "app/domains/views/Domains";
 import imagesURLs from "app/images/urls";
 import Images from "app/images/views/Images";
+import introURLs from "app/intro/urls";
+import Intro from "app/intro/views/Intro";
 import kvmURLs from "app/kvm/urls";
 import KVM from "app/kvm/views/KVM";
 import machineURLs from "app/machines/urls";
@@ -27,6 +29,14 @@ const Routes = (): JSX.Element => (
     <Route exact path={baseURLs.index}>
       <Redirect to={machineURLs.machines.index} />
     </Route>
+    <Route
+      path={introURLs.index}
+      render={() => (
+        <ErrorBoundary>
+          <Intro />
+        </ErrorBoundary>
+      )}
+    />
     <Route
       path={prefsURLs.prefs}
       render={() => (

--- a/ui/src/app/intro/urls.ts
+++ b/ui/src/app/intro/urls.ts
@@ -1,0 +1,6 @@
+const urls = {
+  index: "/intro",
+  user: "/intro/user",
+};
+
+export default urls;

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -1,0 +1,25 @@
+import { Route, Switch } from "react-router-dom";
+
+import MaasIntro from "./MaasIntro";
+import UserIntro from "./UserIntro";
+
+import NotFound from "app/base/views/NotFound";
+import introURLs from "app/intro/urls";
+
+const Routes = (): JSX.Element => {
+  return (
+    <Switch>
+      <Route exact path={introURLs.index}>
+        <MaasIntro />
+      </Route>
+      <Route exact path={introURLs.user}>
+        <UserIntro />
+      </Route>
+      <Route path="*">
+        <NotFound />
+      </Route>
+    </Switch>
+  );
+};
+
+export default Routes;

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -1,0 +1,11 @@
+import Section from "app/base/components/Section";
+
+const MaasIntro = (): JSX.Element => {
+  return (
+    <Section header="Welcome to MAAS">
+      <div>MAAS Intro</div>
+    </Section>
+  );
+};
+
+export default MaasIntro;

--- a/ui/src/app/intro/views/MaasIntro/index.ts
+++ b/ui/src/app/intro/views/MaasIntro/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MaasIntro";

--- a/ui/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -1,0 +1,11 @@
+import Section from "app/base/components/Section";
+
+const UserIntro = (): JSX.Element => {
+  return (
+    <Section header="User intro">
+      <div>User intro</div>
+    </Section>
+  );
+};
+
+export default UserIntro;

--- a/ui/src/app/intro/views/UserIntro/index.ts
+++ b/ui/src/app/intro/views/UserIntro/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UserIntro";

--- a/ui/src/app/intro/views/index.ts
+++ b/ui/src/app/intro/views/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Intro";

--- a/yarn.lock
+++ b/yarn.lock
@@ -9508,7 +9508,7 @@ jest-watcher@^26.3.0, jest-watcher@^26.6.2:
     jest-util "^26.6.2"
     string-length "^4.0.1"
 
-jest-websocket-mock@^2.2.0:
+jest-websocket-mock@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jest-websocket-mock/-/jest-websocket-mock-2.2.0.tgz#0eed73eb3c14d48b15dd046c9e40e9571377d06e"
   integrity sha512-lc3wwXOEyNa4ZpcgJtUG3mmKMAq5FAsKYiZph0p/+PAJrAPuX4JCIfJMdJ/urRsLBG51fwm/wlVPNbR6s2nzNw==


### PR DESCRIPTION
## Done

- Added routes and placeholder components for the `/intro` and `/intro/user` pages

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/intro and check that the `MaasIntro` component renders
- Go to /MAAS/r/intro/user and check that the `UserIntro` component renders

## Fixes

Fixes canonical-web-and-design/app-squad#88
