### PR TITLE
Add domain details actions/reducers

### DIFF
--- a/ui/src/__snapshots__/root-reducer.test.js.snap
+++ b/ui/src/__snapshots__/root-reducer.test.js.snap
@@ -64,6 +64,7 @@ Object {
     "saving": false,
   },
   "domain": Object {
+    "active": null,
     "errors": null,
     "items": Array [],
     "loaded": false,

--- a/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
@@ -21,14 +21,13 @@ const DomainDetails = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(domainsActions.get(Number(id)));
-    // TODO:
     // Set domain as active to ensure all domain data is sent from the server.
-    // dispatch(domainsActions.setActive(Number(id)));
+    dispatch(domainsActions.setActive(Number(id)));
 
     // Unset active domain on cleanup.
-    // return () => {
-    //   dispatch(domainsActions.setActive(null));
-    // };
+    return () => {
+      dispatch(domainsActions.setActive(null));
+    };
   }, [dispatch, id]);
 
   return (

--- a/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
@@ -20,8 +20,16 @@ const DomainDetails = (): JSX.Element => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(domainsActions.fetch());
-  }, [dispatch]);
+    dispatch(domainsActions.get(Number(id)));
+    // TODO:
+    // Set domain as active to ensure all domain data is sent from the server.
+    // dispatch(domainsActions.setActive(Number(id)));
+
+    // Unset active domain on cleanup.
+    // return () => {
+    //   dispatch(domainsActions.setActive(null));
+    // };
+  }, [dispatch, id]);
 
   return (
     <Section

--- a/ui/src/app/store/domain/actions.test.ts
+++ b/ui/src/app/store/domain/actions.test.ts
@@ -34,6 +34,21 @@ describe("domain actions", () => {
     });
   });
 
+  it("creates an action for getting a domain details", () => {
+    expect(actions.get(1)).toEqual({
+      type: "domain/get",
+      meta: {
+        model: "domain",
+        method: "get",
+      },
+      payload: {
+        params: {
+          id: 1,
+        },
+      },
+    });
+  });
+
   it("can create an action for setting a default domain", () => {
     expect(actions.setDefault(1)).toEqual({
       type: "domain/setDefault",

--- a/ui/src/app/store/domain/actions.test.ts
+++ b/ui/src/app/store/domain/actions.test.ts
@@ -49,7 +49,7 @@ describe("domain actions", () => {
     });
   });
 
-  it("can create an action for setting a default domain", () => {
+  it("creates an action for setting a default domain", () => {
     expect(actions.setDefault(1)).toEqual({
       type: "domain/setDefault",
       meta: {
@@ -59,6 +59,21 @@ describe("domain actions", () => {
       payload: {
         params: {
           domain: 1,
+        },
+      },
+    });
+  });
+
+  it("can create an action for setting an active domain", () => {
+    expect(actions.setActive(1)).toEqual({
+      type: "domain/setActive",
+      meta: {
+        model: "domain",
+        method: "set_active",
+      },
+      payload: {
+        params: {
+          id: 1,
         },
       },
     });

--- a/ui/src/app/store/domain/reducers.test.ts
+++ b/ui/src/app/store/domain/reducers.test.ts
@@ -195,6 +195,57 @@ describe("domain reducer", () => {
     );
   });
 
+  it("reduces getStart", () => {
+    const domainState = domainStateFactory({ items: [], loading: false });
+
+    expect(reducers(domainState, actions.getStart())).toEqual(
+      domainStateFactory({ loading: true })
+    );
+  });
+
+  it("reduces getSuccess", () => {
+    const newDomain = domainFactory();
+    const domainState = domainStateFactory({
+      items: [],
+      loading: true,
+    });
+
+    expect(reducers(domainState, actions.getSuccess(newDomain))).toEqual(
+      domainStateFactory({
+        items: [newDomain],
+        loading: false,
+      })
+    );
+  });
+
+  it("reduces getError", () => {
+    const domainState = domainStateFactory({ loading: true });
+
+    expect(
+      reducers(domainState, actions.getError("Could not get domain"))
+    ).toEqual(
+      domainStateFactory({
+        errors: "Could not get domain",
+        loading: false,
+      })
+    );
+  });
+
+  // Related to: https://bugs.launchpad.net/maas/+bug/1931654.
+  it("reduces getError when the error when a domain can't be found", () => {
+    const domainState = domainStateFactory({
+      errors: null,
+      saving: true,
+    });
+
+    expect(reducers(domainState, actions.getError("9"))).toEqual(
+      domainStateFactory({
+        errors: "There was an error getting the domain.",
+        saving: false,
+      })
+    );
+  });
+
   it("reduces setDefaultError", () => {
     const domainState = domainStateFactory({
       errors: null,
@@ -211,13 +262,14 @@ describe("domain reducer", () => {
     );
   });
 
+  // Related to: https://bugs.launchpad.net/maas/+bug/1931654.
   it("reduces setDefaultError when the error when a domain can't be found", () => {
     const domainState = domainStateFactory({
       errors: null,
       saving: true,
     });
 
-    expect(reducers(domainState, actions.setDefaultError(9))).toEqual(
+    expect(reducers(domainState, actions.setDefaultError("9"))).toEqual(
       domainStateFactory({
         errors: "There was an error when setting default domain.",
         saving: false,

--- a/ui/src/app/store/domain/reducers.test.ts
+++ b/ui/src/app/store/domain/reducers.test.ts
@@ -8,6 +8,7 @@ import {
 describe("domain reducer", () => {
   it("should return the initial state", () => {
     expect(reducers(undefined, { type: "" })).toEqual({
+      active: null,
       errors: null,
       items: [],
       loaded: false,
@@ -18,25 +19,15 @@ describe("domain reducer", () => {
   });
 
   it("reduces fetch", () => {
-    expect(reducers(undefined, actions.fetch())).toEqual({
-      errors: null,
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
-    });
+    expect(reducers(undefined, actions.fetch())).toEqual(domainStateFactory());
   });
 
   it("reduces fetchStart", () => {
-    expect(reducers(undefined, actions.fetchStart())).toEqual({
-      errors: null,
-      items: [],
-      loaded: false,
-      loading: true,
-      saved: false,
-      saving: false,
-    });
+    expect(reducers(undefined, actions.fetchStart())).toEqual(
+      domainStateFactory({
+        loading: true,
+      })
+    );
   });
 
   it("reduces fetchSuccess", () => {
@@ -45,14 +36,13 @@ describe("domain reducer", () => {
       items: [],
       loading: true,
     });
-    expect(reducers(domainState, actions.fetchSuccess(domains))).toEqual({
-      errors: null,
-      loading: false,
-      loaded: true,
-      saved: false,
-      saving: false,
-      items: domains,
-    });
+    expect(reducers(domainState, actions.fetchSuccess(domains))).toEqual(
+      domainStateFactory({
+        loading: false,
+        loaded: true,
+        items: domains,
+      })
+    );
   });
 
   it("reduces fetchError", () => {
@@ -60,27 +50,21 @@ describe("domain reducer", () => {
 
     expect(
       reducers(domainState, actions.fetchError("Could not fetch domains"))
-    ).toEqual({
-      errors: "Could not fetch domains",
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
-    });
+    ).toEqual(
+      domainStateFactory({
+        errors: "Could not fetch domains",
+      })
+    );
   });
 
   it("reduces createStart", () => {
     const domainState = domainStateFactory({ saved: true });
 
-    expect(reducers(domainState, actions.createStart())).toEqual({
-      errors: null,
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: true,
-    });
+    expect(reducers(domainState, actions.createStart())).toEqual(
+      domainStateFactory({
+        saving: true,
+      })
+    );
   });
 
   it("reduces createError", () => {
@@ -91,14 +75,11 @@ describe("domain reducer", () => {
         domainState,
         actions.createError({ name: "Domain name already exists" })
       )
-    ).toEqual({
-      errors: { name: "Domain name already exists" },
-      items: [],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
-    });
+    ).toEqual(
+      domainStateFactory({
+        errors: { name: "Domain name already exists" },
+      })
+    );
   });
 
   it("updates domains on createNotify", () => {
@@ -108,14 +89,11 @@ describe("domain reducer", () => {
       items: domains,
     });
 
-    expect(reducers(domainState, actions.createNotify(newDomain))).toEqual({
-      errors: null,
-      items: [...domains, newDomain],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
-    });
+    expect(reducers(domainState, actions.createNotify(newDomain))).toEqual(
+      domainStateFactory({
+        items: [...domains, newDomain],
+      })
+    );
   });
 
   it("reduces deleteStart", () => {
@@ -124,29 +102,27 @@ describe("domain reducer", () => {
       items: domains,
     });
 
-    expect(reducers(domainState, actions.deleteStart())).toEqual({
-      errors: null,
-      items: domains,
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: true,
-    });
+    expect(reducers(domainState, actions.deleteStart())).toEqual(
+      domainStateFactory({
+        items: domains,
+        saving: true,
+      })
+    );
   });
 
   it("reduces deleteSuccess", () => {
     const domains = [domainFactory({ id: 1 })];
     const domainState = domainStateFactory({
       items: domains,
+      saving: true,
     });
-    expect(reducers(domainState, actions.deleteSuccess())).toEqual({
-      errors: null,
-      items: domains,
-      loaded: false,
-      loading: false,
-      saved: true,
-      saving: false,
-    });
+    expect(reducers(domainState, actions.deleteSuccess())).toEqual(
+      domainStateFactory({
+        items: domains,
+        saved: true,
+        saving: false,
+      })
+    );
   });
 
   it("reduces deleteError", () => {
@@ -156,14 +132,12 @@ describe("domain reducer", () => {
     });
     expect(
       reducers(domainState, actions.deleteError("Domain cannot be deleted"))
-    ).toEqual({
-      errors: "Domain cannot be deleted",
-      items: domains,
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
-    });
+    ).toEqual(
+      domainStateFactory({
+        errors: "Domain cannot be deleted",
+        items: domains,
+      })
+    );
   });
 
   it("reduces deleteNotify", () => {
@@ -172,14 +146,11 @@ describe("domain reducer", () => {
       items: domains,
     });
 
-    expect(reducers(domainState, actions.deleteNotify(1))).toEqual({
-      errors: null,
-      items: [domains[1]],
-      loaded: false,
-      loading: false,
-      saved: false,
-      saving: false,
-    });
+    expect(reducers(domainState, actions.deleteNotify(1))).toEqual(
+      domainStateFactory({
+        items: [domains[1]],
+      })
+    );
   });
 
   it("reduces setDefaultStart", () => {
@@ -297,6 +268,53 @@ describe("domain reducer", () => {
         saving: false,
         saved: true,
         errors: null,
+      })
+    );
+  });
+
+  it("reduces setActiveError", () => {
+    const podState = domainStateFactory({
+      active: 1,
+      errors: null,
+    });
+
+    expect(
+      reducers(
+        podState,
+        actions.setActiveError("Domain with this id does not exist")
+      )
+    ).toEqual(
+      domainStateFactory({
+        active: null,
+        errors: "Domain with this id does not exist",
+      })
+    );
+  });
+
+  // Related to: https://bugs.launchpad.net/maas/+bug/1931654.
+  it("reduces setActiveError when the error when a domain can't be found", () => {
+    const domainState = domainStateFactory({
+      errors: null,
+    });
+
+    expect(reducers(domainState, actions.setActiveError("9"))).toEqual(
+      domainStateFactory({
+        errors: "There was an error when setting active domain.",
+        saving: false,
+      })
+    );
+  });
+
+  it("reduces setActiveSuccess", () => {
+    const podState = domainStateFactory({
+      active: null,
+    });
+
+    expect(
+      reducers(podState, actions.setActiveSuccess(domainFactory({ id: 101 })))
+    ).toEqual(
+      domainStateFactory({
+        active: 101,
       })
     );
   });

--- a/ui/src/app/store/domain/types/base.ts
+++ b/ui/src/app/store/domain/types/base.ts
@@ -14,4 +14,6 @@ export type Domain = Model & {
   is_default: boolean;
 };
 
-export type DomainState = GenericState<Domain, TSFixMe>;
+export type DomainState = {
+  active: number | null;
+} & GenericState<Domain, TSFixMe>;

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -349,6 +349,7 @@ export const statusState = define<StatusState>({
 
 export const domainState = define<DomainState>({
   ...defaultState,
+  active: null,
   errors: null,
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9508,7 +9508,7 @@ jest-watcher@^26.3.0, jest-watcher@^26.6.2:
     jest-util "^26.6.2"
     string-length "^4.0.1"
 
-jest-websocket-mock@^2.2.0:
+jest-websocket-mock@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jest-websocket-mock/-/jest-websocket-mock-2.2.0.tgz#0eed73eb3c14d48b15dd046c9e40e9571377d06e"
   integrity sha512-lc3wwXOEyNa4ZpcgJtUG3mmKMAq5FAsKYiZph0p/+PAJrAPuX4JCIfJMdJ/urRsLBG51fwm/wlVPNbR6s2nzNw==


### PR DESCRIPTION
## Done

- Add action/reducers to get domain details
- Add action/reducers to set domain as active
- Fix error handling reducers and test related to bug https://bugs.launchpad.net/maas/+bug/1931654
- Drive by: update yarn.lock

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- `yarn start`
- open redux developer tools
- go to http://localhost:8400/MAAS/r/domain/3
- make sure domain data loads
- review redux state, see if proper domain id is set to active and that all domain data is loaded


<img width="899" alt="Screenshot 2021-06-14 at 13 30 03" src="https://user-images.githubusercontent.com/83575/121885615-a66af700-cd14-11eb-97cf-98403d731be1.png">

## Fixes

Fixes: canonical-web-and-design/app-squad#32

