### PR TITLE
feat(ui): build Ubuntu images table

### DIFF
--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
@@ -11,7 +11,7 @@ import {
 describe("ArchSelect", () => {
   it("shows a message if no release is selected", () => {
     const wrapper = mount(
-      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
+      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
         <ArchSelect arches={[bootResourceUbuntuArchFactory()]} release={null} />
       </Formik>
     );
@@ -30,8 +30,13 @@ describe("ArchSelect", () => {
     const wrapper = mount(
       <Formik
         initialValues={{
-          osystems: [
-            { arches: ["amd64"], osystem: "ubuntu", release: "focal" },
+          images: [
+            {
+              arch: "amd64",
+              os: "ubuntu",
+              release: "focal",
+              title: "20.04 LTS",
+            },
           ],
         }}
         onSubmit={jest.fn()}
@@ -59,7 +64,7 @@ describe("ArchSelect", () => {
       bootResourceUbuntuArchFactory({ name: "i386" }),
     ];
     const wrapper = mount(
-      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
+      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
         <ArchSelect arches={arches} release={release} />
       </Formik>
     );

--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
@@ -1,10 +1,10 @@
 import { Col, Icon, Input, Tooltip } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
+import type { ImageValue } from "app/images/types";
 import type {
   BootResourceUbuntuArch,
   BootResourceUbuntuRelease,
-  OsystemParam,
 } from "app/store/bootresource/types";
 
 type Props = {
@@ -14,8 +14,8 @@ type Props = {
 
 const ArchSelect = ({ arches, release }: Props): JSX.Element => {
   const { setFieldValue, values } =
-    useFormikContext<{ osystems: OsystemParam[] }>();
-  const { osystems } = values;
+    useFormikContext<{ images: ImageValue[] }>();
+  const { images } = values;
 
   if (!release) {
     return (
@@ -29,42 +29,35 @@ const ArchSelect = ({ arches, release }: Props): JSX.Element => {
   }
 
   const isChecked = (arch: BootResourceUbuntuArch) =>
-    osystems.some(
-      (os) =>
-        os.osystem === "ubuntu" &&
-        os.release === release.name &&
-        os.arches.includes(arch.name)
+    images.some(
+      (image) =>
+        image.os === "ubuntu" &&
+        image.release === release.name &&
+        image.arch === arch.name
     );
 
   const isDisabled = (arch: BootResourceUbuntuArch) =>
     release.unsupported_arches.includes(arch.name);
 
   const handleChange = (arch: BootResourceUbuntuArch) => {
-    let newOsystems: OsystemParam[] = [];
-    const osystem = osystems.find((os) => os.release === release.name);
-
-    if (osystem) {
-      // If osystem already exists, either add to or remove arch from its arches
-      const rest = osystems.filter((os) => os !== osystem);
-      const hasArch = osystem.arches.includes(arch.name);
-      newOsystems = [
-        {
-          ...osystem,
-          arches: hasArch
-            ? osystem.arches.filter((a) => a !== arch.name)
-            : osystem.arches.concat(arch.name),
-        },
-        ...rest,
-      ];
+    let newImages: ImageValue[] = [];
+    if (isChecked(arch)) {
+      newImages = images.filter(
+        (image) =>
+          !(
+            image.os === "ubuntu" &&
+            image.release === release.name &&
+            image.arch === arch.name
+          )
+      );
     } else {
-      // Otherwise add a new osystem object
-      newOsystems = osystems.concat({
-        arches: [arch.name],
-        osystem: "ubuntu",
+      newImages = images.concat({
+        arch: arch.name,
         release: release.name,
+        os: "ubuntu",
       });
     }
-    setFieldValue("osystems", newOsystems);
+    setFieldValue("images", newImages);
   };
 
   return (

--- a/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/ImagesTable.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/ImagesTable.test.tsx
@@ -1,0 +1,82 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import ImagesTable from "./ImagesTable";
+
+import {
+  bootResource as resourceFactory,
+  bootResourceUbuntuRelease as releaseFactory,
+} from "testing/factories";
+
+describe("ImagesTable", () => {
+  it("renders the correct status for a downloaded image that is selected", () => {
+    const resource = resourceFactory({
+      arch: "amd64",
+      complete: true,
+      name: "ubuntu/focal",
+    });
+    const wrapper = mount(
+      <Formik
+        initialValues={{
+          images: [{ arch: resource.arch, os: "ubuntu", release: "focal" }],
+        }}
+        onSubmit={jest.fn()}
+      >
+        <ImagesTable releases={[]} resources={[resource]} />
+      </Formik>
+    );
+    expect(
+      wrapper.find("[data-test='resource-status'] Icon").prop("name")
+    ).toBe("success");
+    expect(wrapper.find("[data-test='resource-status']").text()).toBe(
+      resource.status
+    );
+  });
+
+  it("renders the correct status for a downloaded image that is not selected", () => {
+    const resource = resourceFactory({
+      arch: "amd64",
+      complete: true,
+      name: "ubuntu/focal",
+    });
+    const wrapper = mount(
+      <Formik
+        initialValues={{
+          images: [],
+        }}
+        onSubmit={jest.fn()}
+      >
+        <ImagesTable releases={[]} resources={[resource]} />
+      </Formik>
+    );
+    expect(
+      wrapper.find("[data-test='resource-status'] Icon").prop("name")
+    ).toBe("error");
+    expect(wrapper.find("[data-test='resource-status']").text()).toBe(
+      "Will be deleted"
+    );
+  });
+
+  it("renders the correct data for a new image", () => {
+    const release = releaseFactory({ name: "release", title: "New release" });
+    const wrapper = mount(
+      <Formik
+        initialValues={{
+          images: [{ arch: "arch", os: "os", release: "release" }],
+        }}
+        onSubmit={jest.fn()}
+      >
+        <ImagesTable releases={[release]} resources={[]} />
+      </Formik>
+    );
+    expect(wrapper.find("td[data-test='new-image-title']").text()).toBe(
+      "New release"
+    );
+    expect(
+      wrapper.find("[data-test='new-image-status'] Icon").prop("name")
+    ).toBe("pending");
+    expect(wrapper.find("[data-test='new-image-status']").text()).toBe(
+      "Selected for download"
+    );
+  });
+});

--- a/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/ImagesTable.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/ImagesTable.tsx
@@ -1,0 +1,163 @@
+import { Icon, MainTable, Spinner } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import type { ImageValue } from "app/images/types";
+import type {
+  BootResource,
+  BootResourceUbuntuRelease,
+} from "app/store/bootresource/types";
+import { splitResourceName } from "app/store/bootresource/utils";
+
+type Props = {
+  releases: BootResourceUbuntuRelease[];
+  resources: BootResource[];
+};
+
+/**
+ * Check whether a given resource matches a form image value.
+ * @param resource - the resource to check.
+ * @param image - the form image value to check against.
+ * @returns resource matches form image value.
+ */
+const resourceMatchesImage = (
+  resource: BootResource,
+  image: ImageValue
+): boolean => {
+  const { os, release } = splitResourceName(resource.name);
+  return (
+    image.os === os && image.release === release && image.arch === resource.arch
+  );
+};
+
+/**
+ * Generates a row based on a form image value.
+ * @param image - the image value from which to generate the row.
+ * @param releases - the list of releases known by the source.
+ * @returns row generated from form image value.
+ */
+const generateImageRow = (
+  image: ImageValue,
+  releases: BootResourceUbuntuRelease[]
+) => {
+  const title =
+    releases.find((release) => release.name === image.release)?.title ||
+    "Unknown";
+  return {
+    columns: [
+      {
+        content: title,
+        className: "release-col",
+        "data-test": "new-image-title",
+      },
+      { content: image.arch, className: "arch-col" },
+      { content: "—", className: "size-col" },
+      {
+        content: (
+          <DoubleRow
+            data-test="new-image-status"
+            icon={<Icon name="pending" />}
+            primary="Selected for download"
+          />
+        ),
+        className: "status-col",
+      },
+      { content: "", className: "actions-col u-align--right" },
+    ],
+    key: `${image.os}-${image.release}-${image.arch}`,
+    sortData: {
+      title: title,
+      arch: image.arch,
+    },
+  };
+};
+/**
+ * Generates a row based on a resource.
+ * @param resource - the resource from which to generate the row.
+ * @param toDelete - whether the resource is slated for deletion.
+ * @returns row generated from resource.
+ */
+const generateResourceRow = (resource: BootResource, toDelete = false) => {
+  let statusIcon = <Spinner />;
+  let statusText = resource.status;
+
+  if (toDelete) {
+    statusIcon = <Icon name="error" />;
+    statusText = "Will be deleted";
+  } else if (resource.complete) {
+    statusIcon = <Icon name="success" />;
+  }
+
+  return {
+    columns: [
+      { content: resource.title, className: "release-col" },
+      { content: resource.arch, className: "arch-col" },
+      { content: resource.size, className: "size-col" },
+      {
+        content: (
+          <DoubleRow
+            data-test="resource-status"
+            icon={statusIcon}
+            primary={statusText}
+          />
+        ),
+        className: "status-col",
+      },
+      { content: "", className: "actions-col u-align--right" },
+    ],
+    key: `resource-${resource.id}`,
+    sortData: {
+      title: resource.title,
+      arch: resource.arch,
+      size: resource.size,
+      status: resource.status,
+    },
+  };
+};
+
+const ImagesTable = ({ releases, resources }: Props): JSX.Element => {
+  const { values } = useFormikContext<{ images: ImageValue[] }>();
+  const headers = [
+    { content: "Release", className: "release-col", sortKey: "title" },
+    { content: "Architecture", className: "arch-col", sortKey: "arch" },
+    { content: "Size", className: "size-col", sortKey: "size" },
+    {
+      content: <span className="u-nudge-right--large">Status</span>,
+      className: "status-col",
+      sortKey: "status",
+    },
+    { content: "Actions", className: "actions-col u-align--right" },
+  ];
+  // Resources set for deletion are those that exist in the database, but do not
+  // exist in the form's images value, i.e. the checkbox was unchecked.
+  const resourcesToDelete = resources.filter((resource) =>
+    values.images.every((image) => !resourceMatchesImage(resource, image))
+  );
+  const rows = values.images
+    .map((image) => {
+      const resource = resources.find((resource) =>
+        resourceMatchesImage(resource, image)
+      );
+      if (resource) {
+        return generateResourceRow(resource);
+      } else {
+        return generateImageRow(image, releases);
+      }
+    })
+    .concat(
+      resourcesToDelete.map((resource) => generateResourceRow(resource, true))
+    );
+
+  return (
+    <MainTable
+      className="images-table"
+      defaultSort="title"
+      defaultSortDirection="descending"
+      headers={headers}
+      rows={rows}
+      sortable
+    />
+  );
+};
+
+export default ImagesTable;

--- a/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/_index.scss
+++ b/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/_index.scss
@@ -1,0 +1,23 @@
+@mixin ImagesTable {
+  .images-table {
+    .release-col {
+      @include breakpoint-widths(50%, 40%, 35%);
+    }
+
+    .arch-col {
+      @include breakpoint-widths(0, 0, 9rem);
+    }
+
+    .size-col {
+      @include breakpoint-widths(0, 0, 9rem);
+    }
+
+    .status-col {
+      @include breakpoint-widths(50%, 60%, 65%);
+    }
+
+    .actions-col {
+      width: 4.5rem;
+    }
+  }
+}

--- a/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/index.ts
+++ b/ui/src/app/images/components/UbuntuImageSelect/ImagesTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ImagesTable";

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
@@ -16,8 +16,12 @@ describe("UbuntuImageSelect", () => {
     ];
     const arches = [bootResourceUbuntuArchFactory()];
     const wrapper = mount(
-      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
-        <UbuntuImageSelect arches={arches} releases={[available, deleted]} />
+      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+        <UbuntuImageSelect
+          arches={arches}
+          releases={[available, deleted]}
+          resources={[]}
+        />
       </Formik>
     );
     const radioExists = (id: string) =>
@@ -36,8 +40,12 @@ describe("UbuntuImageSelect", () => {
       bootResourceUbuntuArchFactory({ name: "delete", deleted: true }),
     ];
     const wrapper = mount(
-      <Formik initialValues={{ osystems: [] }} onSubmit={jest.fn()}>
-        <UbuntuImageSelect arches={[available, deleted]} releases={releases} />
+      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+        <UbuntuImageSelect
+          arches={[available, deleted]}
+          releases={releases}
+          resources={[]}
+        />
       </Formik>
     );
     const checkboxExists = (id: string) =>

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
@@ -3,9 +3,11 @@ import { useState } from "react";
 import { Row } from "@canonical/react-components";
 
 import ArchSelect from "./ArchSelect";
+import ImagesTable from "./ImagesTable";
 import ReleaseSelect from "./ReleaseSelect";
 
 import type {
+  BootResource,
   BootResourceUbuntuArch,
   BootResourceUbuntuRelease,
 } from "app/store/bootresource/types";
@@ -13,28 +15,37 @@ import type {
 type Props = {
   arches: BootResourceUbuntuArch[];
   releases: BootResourceUbuntuRelease[];
+  resources: BootResource[];
 };
 
-const UbuntuImageSelect = ({ arches, releases }: Props): JSX.Element => {
+const UbuntuImageSelect = ({
+  arches,
+  releases,
+  resources,
+}: Props): JSX.Element => {
   const [selectedRelease, setSelectedRelease] =
     useState<BootResourceUbuntuRelease["name"]>("focal");
   const availableArches = arches.filter((arch) => !arch.deleted);
   const availableReleases = releases.filter((release) => !release.deleted);
 
   return (
-    <Row className="p-divider">
-      <ReleaseSelect
-        releases={availableReleases}
-        selectedRelease={selectedRelease}
-        setSelectedRelease={setSelectedRelease}
-      />
-      <ArchSelect
-        arches={availableArches}
-        release={
-          releases.find((release) => release.name === selectedRelease) || null
-        }
-      />
-    </Row>
+    <>
+      <Row className="p-divider">
+        <ReleaseSelect
+          releases={availableReleases}
+          selectedRelease={selectedRelease}
+          setSelectedRelease={setSelectedRelease}
+        />
+        <ArchSelect
+          arches={availableArches}
+          release={
+            releases.find((release) => release.name === selectedRelease) || null
+          }
+        />
+      </Row>
+      <div className="u-sv2"></div>
+      <ImagesTable releases={releases} resources={resources} />
+    </>
   );
 };
 

--- a/ui/src/app/images/types.ts
+++ b/ui/src/app/images/types.ts
@@ -1,0 +1,5 @@
+export type ImageValue = {
+  arch: string;
+  release: string;
+  os: string;
+};

--- a/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/DefaultSource.test.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/DefaultSource/DefaultSource.test.tsx
@@ -78,9 +78,10 @@ describe("DefaultSource", () => {
       </Provider>
     );
     expect(wrapper.find("Formik").prop("initialValues")).toStrictEqual({
-      osystems: [
-        { arches: ["amd64", "i386"], osystem: "ubuntu", release: "xenial" },
-        { arches: ["amd64"], osystem: "ubuntu", release: "bionic" },
+      images: [
+        { arch: "amd64", os: "ubuntu", release: "xenial" },
+        { arch: "i386", os: "ubuntu", release: "xenial" },
+        { arch: "amd64", os: "ubuntu", release: "bionic" },
       ],
     });
   });

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -90,6 +90,10 @@
 @include TableMenu;
 @include TagSelector;
 
+// images
+@import "~app/images/components/UbuntuImageSelect/ImagesTable";
+@include ImagesTable;
+
 // kvm
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable";
 @import "~app/kvm/components/KVMActionFormWrapper/ComposeForm/InterfacesTable/SubnetSelect";


### PR DESCRIPTION
## Done

- Built Ubuntu images table, that reflects the current selections in the release/arch form fields
- Changed the shape of the form data to be an array of shallow objects instead of following the shape that the `saveUbuntu` api expects. It's a million times easier to manage on the component side, and we can munge the data into the right shape at the end instead.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images and check that the initial table data matches the resource data found in `bootresource.resources`.
- Select/unselect some checkboxes and check that the table updates accordingly.

## Fixes

Fixes canonical-web-and-design/app-squad#81

## Screenshot
![2021-06-15_19-05](https://user-images.githubusercontent.com/25733845/122026343-73f0f500-ce0d-11eb-807b-01c331901606.png)
