### PR TITLE
feat(ui): add selector for determining if user is an admin

### DIFF
--- a/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/ui/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -25,15 +25,14 @@ const NotificationGroupNotification = ({
   type,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
-  const authUser = useSelector(authSelectors.get);
+  const isAdmin = useSelector(authSelectors.isAdmin);
   const notification = useSelector((state: RootState) =>
     notificationSelectors.getById(state, id)
   );
   if (!notification) {
     return null;
   }
-  const showSettings =
-    isReleaseNotification(notification) && authUser?.is_superuser;
+  const showSettings = isReleaseNotification(notification) && isAdmin;
   const showDate = isUpgradeNotification(notification);
   return (
     <Notification

--- a/ui/src/app/settings/views/Settings.test.tsx
+++ b/ui/src/app/settings/views/Settings.test.tsx
@@ -1,42 +1,22 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
-import { routerState as routerStateFactory } from "testing/factories";
 import Settings from "./Settings";
+
+import {
+  authState as authStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("Settings", () => {
-  let state;
-
-  beforeEach(() => {
-    state = {
-      config: {
-        loading: false,
-        loaded: false,
-        items: [],
-      },
-      message: {
-        items: [],
-      },
-      notification: {
-        items: [],
-      },
-      router: routerStateFactory(),
-      status: {},
-      user: {
-        auth: {
-          user: {
-            is_superuser: true,
-          },
-        },
-      },
-    };
-  });
-
   it("dispatches action to fetch config on load", () => {
+    const state = rootStateFactory();
     const store = mockStore(state);
     mount(
       <Provider store={store}>
@@ -63,7 +43,11 @@ describe("Settings", () => {
   });
 
   it("displays a message if not an admin", () => {
-    state.user.auth.user.is_superuser = false;
+    const state = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({ user: userFactory({ is_superuser: false }) }),
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/settings/views/Settings.tsx
+++ b/ui/src/app/settings/views/Settings.tsx
@@ -1,21 +1,22 @@
 import { useEffect } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 
-import authSelectors from "app/store/auth/selectors";
-import { actions as configActions } from "app/store/config";
-import Routes from "app/settings/components/Routes";
 import Section from "app/base/components/Section";
 import SettingsNav from "app/settings/components/Nav";
+import Routes from "app/settings/components/Routes";
+import authSelectors from "app/store/auth/selectors";
+import { actions as configActions } from "app/store/config";
 
-const Settings = () => {
+const Settings = (): JSX.Element => {
   const dispatch = useDispatch();
-  const authUser = useSelector(authSelectors.get);
+  const isAdmin = useSelector(authSelectors.isAdmin);
 
   useEffect(() => {
     dispatch(configActions.fetch());
   }, [dispatch]);
 
-  if (!authUser || !authUser.is_superuser) {
+  if (!isAdmin) {
     return <Section header="You do not have permission to view this page." />;
   }
 

--- a/ui/src/app/store/auth/selectors.test.ts
+++ b/ui/src/app/store/auth/selectors.test.ts
@@ -75,4 +75,15 @@ describe("auth", () => {
       username: "Username already exists",
     });
   });
+
+  it("can get whether the auth user is an admin", () => {
+    const state = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: true }),
+        }),
+      }),
+    });
+    expect(auth.isAdmin(state)).toBe(true);
+  });
 });

--- a/ui/src/app/store/auth/selectors.ts
+++ b/ui/src/app/store/auth/selectors.ts
@@ -44,9 +44,13 @@ const saving = (state: RootState): boolean => state.user.auth.saving;
  */
 const saved = (state: RootState): boolean => state.user.auth.saved;
 
+const isAdmin = (state: RootState): boolean =>
+  state.user.auth.user?.is_superuser || false;
+
 const auth = {
   errors,
   get,
+  isAdmin,
   loaded,
   loading,
   saved,


### PR DESCRIPTION
## Done

- Added `authSelectors.isAdmin` selector for determining if the currently logged in user is an admin
- Converted `Settings.js` to TypeScript

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A, tests should pass

## Fixes

Fixes #2783 
