### PR TITLE
Zone polish

### DIFF
--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -191,7 +191,6 @@ export const Header = ({
     },
     {
       highlight: "/zone",
-      isLegacy: true,
       label: "AZs",
       url: "/zones",
     },

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
@@ -1,0 +1,82 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ZoneDetails from "./ZoneDetails";
+
+import type { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  zone as zoneFactory,
+  zoneState as zoneStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ZoneDetails", () => {
+  let initialState: RootState;
+
+  const testZones = zoneStateFactory({
+    errors: {},
+    loading: false,
+    loaded: true,
+    items: [
+      zoneFactory({
+        id: 1,
+        name: "zone-name",
+      }),
+    ],
+  });
+
+  beforeEach(() => {
+    initialState = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: true }),
+        }),
+      }),
+      zone: testZones,
+    });
+  });
+
+  it("shows Edit button if user is admin", () => {
+    const state = initialState;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
+        >
+          <Route exact path="/zone/:id" component={() => <ZoneDetails />} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="edit-zone"]').exists()).toBe(true);
+  });
+
+  it("hides Edit button if user is not admin", () => {
+    const state = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: false }),
+        }),
+      }),
+      zone: testZones,
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
+        >
+          <Route exact path="/zone/:id" component={() => <ZoneDetails />} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="edit-zone"]').exists()).toBe(false);
+  });
+});

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
@@ -35,7 +35,6 @@ const ZoneDetails = (): JSX.Element => {
   useWindowTitle(zone?.name ?? "Zone not found");
 
   if (zonesLoaded && zone) {
-    console.log(isAdmin);
     content = (
       <Row>
         <Col size="6">

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
@@ -9,6 +9,7 @@ import ZoneDetailsForm from "./ZoneDetailsForm";
 import ZoneDetailsHeader from "./ZoneDetailsHeader";
 
 import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
@@ -28,6 +29,8 @@ const ZoneDetails = (): JSX.Element => {
   const zoneID = Number(id);
 
   let content: JSX.Element | null = null;
+
+  useWindowTitle(zone?.name ?? "Zone not found");
 
   if (zonesLoaded && zone) {
     content = (

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetails.tsx
@@ -11,6 +11,7 @@ import ZoneDetailsHeader from "./ZoneDetailsHeader";
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
+import authSelectors from "app/store/auth/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
@@ -27,20 +28,26 @@ const ZoneDetails = (): JSX.Element => {
     dispatch(zoneActions.fetch());
   }, [dispatch]);
   const zoneID = Number(id);
+  const isAdmin = useSelector(authSelectors.isAdmin);
 
   let content: JSX.Element | null = null;
 
   useWindowTitle(zone?.name ?? "Zone not found");
 
   if (zonesLoaded && zone) {
+    console.log(isAdmin);
     content = (
       <Row>
         <Col size="6">
           <ZoneDetailsContent id={zoneID} />
         </Col>
-        <Col size="6" className="u-align--right">
-          <Button onClick={() => setShowForm(true)}>Edit</Button>
-        </Col>
+        {isAdmin && (
+          <Col size="6" className="u-align--right">
+            <Button data-test="edit-zone" onClick={() => setShowForm(true)}>
+              Edit
+            </Button>
+          </Col>
+        )}
       </Row>
     );
   }

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from "react";
 
-import { Row, Col } from "@canonical/react-components";
+import { Row, Col, Textarea } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
@@ -69,7 +69,11 @@ const ZoneForm = ({ id, closeForm }: Props): JSX.Element | null => {
               type="text"
               name="name"
             />
-            <FormikField label="Description" type="text" name="description" />
+            <FormikField
+              component={Textarea}
+              label="Description"
+              name="description"
+            />
           </Col>
         </Row>
       </FormikForm>

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
@@ -38,8 +38,10 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
   }, [dispatch, zonesSaved, history]);
 
   const deleteZone = () => {
-    dispatch(zoneActions.delete(id));
+    !isDefault && dispatch(zoneActions.delete(id));
   };
+
+  const isDefault = id === 1;
 
   const closeExpanded = () => setShowConfirm(false);
 
@@ -54,7 +56,7 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
     </Button>,
   ];
 
-  if (showConfirm) {
+  if (showConfirm || isDefault) {
     buttons = null;
   }
 
@@ -62,7 +64,7 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
 
   let confirmDelete = null;
 
-  if (showConfirm) {
+  if (showConfirm && !isDefault) {
     confirmDelete = (
       <>
         <hr />

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
@@ -7,6 +7,7 @@ import { useHistory } from "react-router-dom";
 import DeleteConfirm from "./DeleteConfirm";
 
 import SectionHeader from "app/base/components/SectionHeader";
+import authSelectors from "app/store/auth/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
@@ -37,11 +38,14 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
     }
   }, [dispatch, zonesSaved, history]);
 
-  const deleteZone = () => {
-    !isDefault && dispatch(zoneActions.delete(id));
-  };
+  const isAdmin = useSelector(authSelectors.isAdmin);
+  const isDefaultZone = id === 1;
 
-  const isDefault = id === 1;
+  const deleteZone = () => {
+    if (isAdmin && !isDefaultZone) {
+      dispatch(zoneActions.delete(id));
+    }
+  };
 
   const closeExpanded = () => setShowConfirm(false);
 
@@ -56,7 +60,7 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
     </Button>,
   ];
 
-  if (showConfirm || isDefault) {
+  if (showConfirm || isDefaultZone || !isAdmin) {
     buttons = null;
   }
 
@@ -64,7 +68,7 @@ const ZoneDetailsHeader = ({ id }: Props): JSX.Element => {
 
   let confirmDelete = null;
 
-  if (showConfirm && !isDefault) {
+  if (showConfirm && isAdmin && !isDefaultZone) {
     confirmDelete = (
       <>
         <hr />

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZonesDetailsHeader.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZonesDetailsHeader.test.tsx
@@ -7,9 +7,12 @@ import ZoneDetailsHeader from "./ZoneDetailsHeader";
 
 import type { RootState } from "app/store/root/types";
 import {
+  authState as authStateFactory,
   zone as zoneFactory,
   zoneState as zoneStateFactory,
   rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -17,23 +20,30 @@ const mockStore = configureStore();
 describe("ZoneDetailsHeader", () => {
   let initialState: RootState;
 
+  const testZones = zoneStateFactory({
+    errors: {},
+    loading: false,
+    loaded: true,
+    items: [
+      zoneFactory({
+        id: 1,
+        name: "zone-name",
+      }),
+      zoneFactory({
+        id: 2,
+        name: "zone2-name",
+      }),
+    ],
+  });
+
   beforeEach(() => {
     initialState = rootStateFactory({
-      zone: zoneStateFactory({
-        errors: {},
-        loading: false,
-        loaded: true,
-        items: [
-          zoneFactory({
-            id: 1,
-            name: "zone-name",
-          }),
-          zoneFactory({
-            id: 2,
-            name: "zone2-name",
-          }),
-        ],
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: true }),
+        }),
       }),
+      zone: testZones,
     });
   });
 
@@ -110,6 +120,32 @@ describe("ZoneDetailsHeader", () => {
             exact
             path="/zone/:id"
             component={() => <ZoneDetailsHeader id={1} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="delete-zone"]').exists()).toBe(false);
+  });
+
+  it("hides delete button for all zones when user isn't admin", () => {
+    const state = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: false }),
+        }),
+      }),
+      zone: testZones,
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/zone/2", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/zone/:id"
+            component={() => <ZoneDetailsHeader id={2} />}
           />
         </MemoryRouter>
       </Provider>

--- a/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZonesDetailsHeader.test.tsx
+++ b/ui/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZonesDetailsHeader.test.tsx
@@ -28,6 +28,10 @@ describe("ZoneDetailsHeader", () => {
             id: 1,
             name: "zone-name",
           }),
+          zoneFactory({
+            id: 2,
+            name: "zone2-name",
+          }),
         ],
       }),
     });
@@ -73,5 +77,43 @@ describe("ZoneDetailsHeader", () => {
     expect(wrapper.find('[data-test="section-header-title"]').text()).toBe(
       "Availability zone not found"
     );
+  });
+
+  it("shows delete az button when zone id isn't 1", () => {
+    const state = initialState;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/zone/2", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/zone/:id"
+            component={() => <ZoneDetailsHeader id={2} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="delete-zone"]').exists()).toBe(true);
+  });
+
+  it("hides delete button when zone id is 1 (as this is the default)", () => {
+    const state = initialState;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/zone/1", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/zone/:id"
+            component={() => <ZoneDetailsHeader id={1} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find('[data-test="delete-zone"]').exists()).toBe(false);
   });
 });

--- a/ui/src/app/zones/views/ZonesList/ZonesList.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesList.tsx
@@ -6,12 +6,15 @@ import ZonesListHeader from "./ZonesListHeader";
 import ZonesListTable from "./ZonesListTable";
 
 import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
 import { actions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
 
 const ZonesList = (): JSX.Element => {
   const dispatch = useDispatch();
   const zonesCount = useSelector(zoneSelectors.count);
+
+  useWindowTitle("Zones");
 
   useEffect(() => {
     dispatch(actions.fetch());

--- a/ui/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.tsx
+++ b/ui/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { Row, Col } from "@canonical/react-components";
+import { Row, Col, Textarea } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
@@ -58,7 +58,11 @@ const ZonesListForm = ({ closeForm }: Props): JSX.Element => {
             name="name"
             required
           />
-          <FormikField label="Description" type="text" name="description" />
+          <FormikField
+            component={Textarea}
+            label="Description"
+            name="description"
+          />
         </Col>
       </Row>
     </FormikForm>


### PR DESCRIPTION
## Done

- Updated zones list and details pages with page titles
- Added check for default zone, to prevent it being deleted on details page
- Updated "AZs" link in top nav to point to react version, rather than legacy version
- Added `isAdmin` checks to the edit and delete zone actions on the details page 

## QA

- Check out this branch, visit http://0.0.0.0:8400/MAAS/r/zones
- Click "default" in the table, see that its details page doesn't show a "Delete AZ" button in the header
- Click "AZs" in the top nav, see that you are taken back to the table list at /r/zones, not /l/zones
- Click any of the other zones in the table, see that their details page _does_ have the "Delete AZ" button in the header
- For admin checks, see that the tests pass

![Screenshot from 2021-06-15 10-32-24](https://user-images.githubusercontent.com/2376968/122029725-05884480-cdc5-11eb-9609-efc4892483bd.png)

