### PR TITLE
feat(ui): rack and region import statuses

### DIFF
--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
@@ -69,4 +69,44 @@ describe("ImageListHeader", () => {
       )
     ).toStrictEqual(expectedAction);
   });
+
+  it("can show the rack import status", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        rackImportRunning: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/images", key: "testKey" }]}
+        >
+          <ImageListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='rack-importing']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='region-importing']").exists()).toBe(false);
+  });
+
+  it("can show the region import status", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        regionImportRunning: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/images", key: "testKey" }]}
+        >
+          <ImageListHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='region-importing']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='rack-importing']").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -1,21 +1,50 @@
 import { useEffect } from "react";
 
-import { Icon, Tooltip } from "@canonical/react-components";
+import { Icon, Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import SwitchField from "app/base/components/SwitchField";
 import { actions as bootResourceActions } from "app/store/bootresource";
 import bootResourceSelectors from "app/store/bootresource/selectors";
+import type { BootResourceState } from "app/store/bootresource/types";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
 import { breakLines, unindentString } from "app/utils";
+
+const generateImportStatus = (
+  rackImportRunning: BootResourceState["rackImportRunning"],
+  regionImportRunning: BootResourceState["regionImportRunning"]
+) => {
+  if (regionImportRunning) {
+    return (
+      <>
+        <Spinner data-test="region-importing" /> Step 1/2: Region controller
+        importing
+      </>
+    );
+  } else if (rackImportRunning) {
+    return (
+      <>
+        <Spinner data-test="rack-importing" /> Step 2/2: Rack controller(s)
+        importing
+      </>
+    );
+  }
+  return null;
+};
 
 const ImageListHeader = (): JSX.Element => {
   const dispatch = useDispatch();
   const polling = useSelector(bootResourceSelectors.polling);
   const autoImport = useSelector(configSelectors.bootImagesAutoImport);
   const configSaving = useSelector(configSelectors.saving);
+  const rackImportRunning = useSelector(
+    bootResourceSelectors.rackImportRunning
+  );
+  const regionImportRunning = useSelector(
+    bootResourceSelectors.regionImportRunning
+  );
 
   useEffect(() => {
     dispatch(bootResourceActions.poll());
@@ -68,6 +97,7 @@ const ImageListHeader = (): JSX.Element => {
         </div>,
       ]}
       loading={polling}
+      subtitle={generateImportStatus(rackImportRunning, regionImportRunning)}
       title="Images"
     />
   );

--- a/ui/src/app/store/bootresource/selectors.test.ts
+++ b/ui/src/app/store/bootresource/selectors.test.ts
@@ -170,4 +170,22 @@ describe("bootresource selectors", () => {
     });
     expect(bootResourceSelectors.stoppingImport(state)).toBe(true);
   });
+
+  it("can get the rackImportRunning state", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        rackImportRunning: true,
+      }),
+    });
+    expect(bootResourceSelectors.rackImportRunning(state)).toBe(true);
+  });
+
+  it("can get the regionImportRunning state", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        regionImportRunning: true,
+      }),
+    });
+    expect(bootResourceSelectors.regionImportRunning(state)).toBe(true);
+  });
 });

--- a/ui/src/app/store/bootresource/selectors.ts
+++ b/ui/src/app/store/bootresource/selectors.ts
@@ -11,6 +11,14 @@ import type { RootState } from "app/store/root/types";
  * @param state - The redux state.
  * @returns Boot resource statuses.
  */
+const bootResourceState = (state: RootState): BootResourceState =>
+  state[BootResourceMeta.MODEL];
+
+/**
+ * Get the collection of statuses.
+ * @param state - The redux state.
+ * @returns Boot resource statuses.
+ */
 const statuses = (state: RootState): BootResourceStatuses =>
   state[BootResourceMeta.MODEL].statuses;
 
@@ -127,12 +135,34 @@ const stoppingImport = createSelector(
   (statuses) => statuses.stoppingImport
 );
 
+/**
+ * Whether the rack import is running.
+ * @param state - The redux state.
+ * @returns Whether the rack import is running.
+ */
+const rackImportRunning = createSelector(
+  [bootResourceState],
+  (bootResource) => bootResource.rackImportRunning
+);
+
+/**
+ * Whether the region import is running.
+ * @param state - The redux state.
+ * @returns Whether the region import is running.
+ */
+const regionImportRunning = createSelector(
+  [bootResourceState],
+  (bootResource) => bootResource.regionImportRunning
+);
+
 const selectors = {
   deletingImage,
   eventErrors,
   fetchError,
   fetching,
   polling,
+  rackImportRunning,
+  regionImportRunning,
   resources,
   savingOther,
   savingUbuntu,


### PR DESCRIPTION
## Done

- Add the rack and region image import statuses to the images header.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- I'm not sure if you can reliably QA this. You need the rack and region to be importing. I tried updating the images list and on one try it did start importing, but I'm not sure if I fluked that.
- If you can get the images to be importing you should see the status in the header

## Fixes

Fixes: canonical-web-and-design/app-squad#109.

## Screenshots

![Uploading Screen Shot 2021-06-16 at 2.58.58 pm.png…]()
