### PR TITLE
refactor(ui): removed unnecessary getters and setters

### DIFF
--- a/ui/src/app/base/sagas/websockets.test.ts
+++ b/ui/src/app/base/sagas/websockets.test.ts
@@ -13,16 +13,15 @@ import WebSocketClient, {
 } from "../../../websocket-client";
 
 import {
+  batchRequests,
   createConnection,
-  getBatchRequest,
-  getNextActions,
   handleBatch,
   handleFileContextRequest,
   handleMessage,
   handleNextActions,
   handleNotifyMessage,
+  nextActions,
   sendMessage,
-  setNextActions,
   storeFileContextActions,
   watchMessages,
   watchWebSockets,
@@ -149,7 +148,7 @@ describe("websocket sagas", () => {
     const nextActionCreators = [jest.fn()];
     return expectSaga(sendMessage, socketClient, action, nextActionCreators)
       .provide([[matchers.call.fn(socketClient.send), 808]])
-      .call(setNextActions, 808, nextActionCreators)
+      .call(nextActions.set, 808, nextActionCreators)
       .run();
   });
 
@@ -372,7 +371,7 @@ describe("websocket sagas", () => {
     return expectSaga(handleBatch, response)
       .provide([
         [
-          call(getBatchRequest, 99),
+          call(batchRequests.get, 99),
           {
             type: "test/fetch",
             meta: {
@@ -406,7 +405,7 @@ describe("websocket sagas", () => {
     return expectSaga(handleBatch, response)
       .provide([
         [
-          call(getBatchRequest, 99),
+          call(batchRequests.get, 99),
           {
             type: "test/fetch",
             meta: {
@@ -441,7 +440,7 @@ describe("websocket sagas", () => {
     return expectSaga(handleBatch, response)
       .provide([
         [
-          call(getBatchRequest, 99),
+          call(batchRequests.get, 99),
           {
             type: "test/fetch",
             meta: {
@@ -469,7 +468,10 @@ describe("websocket sagas", () => {
     const action = { type: "NEXT_ACTION" };
     const actionCreator = jest.fn(() => action);
     return expectSaga(handleNextActions, response)
-      .provide([[call(getNextActions, 99), [actionCreator]]])
+      .provide([
+        [call(nextActions.get, 99), [actionCreator]],
+        [call(nextActions.delete, 99), null],
+      ])
       .call(actionCreator, response.result)
       .put(action)
       .run();

--- a/ui/src/app/base/sagas/websockets.test.ts
+++ b/ui/src/app/base/sagas/websockets.test.ts
@@ -148,7 +148,7 @@ describe("websocket sagas", () => {
     const nextActionCreators = [jest.fn()];
     return expectSaga(sendMessage, socketClient, action, nextActionCreators)
       .provide([[matchers.call.fn(socketClient.send), 808]])
-      .call(nextActions.set, 808, nextActionCreators)
+      .call([nextActions, nextActions.set], 808, nextActionCreators)
       .run();
   });
 
@@ -371,7 +371,7 @@ describe("websocket sagas", () => {
     return expectSaga(handleBatch, response)
       .provide([
         [
-          call(batchRequests.get, 99),
+          call([batchRequests, batchRequests.get], 99),
           {
             type: "test/fetch",
             meta: {
@@ -405,7 +405,7 @@ describe("websocket sagas", () => {
     return expectSaga(handleBatch, response)
       .provide([
         [
-          call(batchRequests.get, 99),
+          call([batchRequests, batchRequests.get], 99),
           {
             type: "test/fetch",
             meta: {
@@ -440,7 +440,7 @@ describe("websocket sagas", () => {
     return expectSaga(handleBatch, response)
       .provide([
         [
-          call(batchRequests.get, 99),
+          call([batchRequests, batchRequests.get], 99),
           {
             type: "test/fetch",
             meta: {
@@ -469,8 +469,8 @@ describe("websocket sagas", () => {
     const actionCreator = jest.fn(() => action);
     return expectSaga(handleNextActions, response)
       .provide([
-        [call(nextActions.get, 99), [actionCreator]],
-        [call(nextActions.delete, 99), null],
+        [call([nextActions, nextActions.get], 99), [actionCreator]],
+        [call([nextActions, nextActions.delete], 99), null],
       ])
       .call(actionCreator, response.result)
       .put(action)

--- a/ui/src/app/base/sagas/websockets.ts
+++ b/ui/src/app/base/sagas/websockets.ts
@@ -213,7 +213,10 @@ export function* handleBatch({
   request_id,
   result,
 }: WebSocketResponseResult): SagaGenerator<void> {
-  const batchRequest = yield* call(batchRequests.get, request_id);
+  const batchRequest = yield* call(
+    [batchRequests, batchRequests.get],
+    request_id
+  );
   if (batchRequest && Array.isArray(result)) {
     if (!batchRequest.payload.params) {
       batchRequest.payload.params = {};
@@ -264,7 +267,7 @@ function* storeNextActions(
 ) {
   if (nextActionCreators) {
     for (const id of requestIDs) {
-      yield call(nextActions.set, id, nextActionCreators);
+      yield call([nextActions, nextActions.set], id, nextActionCreators);
     }
   }
 }
@@ -278,7 +281,10 @@ export function* handleNextActions({
   request_id,
   result,
 }: WebSocketResponseResult): SagaGenerator<void> {
-  const actionCreators = yield* call(nextActions.get, request_id);
+  const actionCreators = yield* call(
+    [nextActions, nextActions.get],
+    request_id
+  );
   if (actionCreators && actionCreators.length) {
     for (const actionCreator of actionCreators) {
       // Generate the action object using the result from the response.
@@ -287,7 +293,7 @@ export function* handleNextActions({
       yield* put(action);
     }
     // Clean up the stored action creators.
-    yield* call(nextActions.delete, request_id);
+    yield* call([nextActions, nextActions.delete], request_id);
   }
 }
 
@@ -318,7 +324,10 @@ export function* handleFileContextRequest({
   request_id,
   result,
 }: WebSocketResponseResult<string>): SagaGenerator<boolean> {
-  const fileContextRequest = yield* call(fileContextRequests.get, request_id);
+  const fileContextRequest = yield* call(
+    [fileContextRequests, fileContextRequests.get],
+    request_id
+  );
   if (fileContextRequest?.meta.fileContextKey) {
     // Store the file in the context.
     fileContextStore.add(fileContextRequest.meta.fileContextKey, result);


### PR DESCRIPTION
## Done

- Removed unnecessary getters and setters for websocket maps.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Load the ui and make sure the machine list data can be loaded.