### PR TITLE
feat(ui): prevent removing last image of default commissioning release

### DIFF
--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
@@ -1,19 +1,49 @@
 import { mount } from "enzyme";
 import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
 import ArchSelect from "./ArchSelect";
 
+import type { RootState } from "app/store/root/types";
 import {
   bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
   bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory,
+  config as configFactory,
+  configState as configStateFactory,
+  rootState as rootStateFactory,
 } from "testing/factories";
 
+const mockStore = configureStore();
+
 describe("ArchSelect", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: "commissioning_distro_series",
+            value: "bionic",
+          }),
+        ],
+        loaded: true,
+        loading: false,
+      }),
+    });
+  });
+
   it("shows a message if no release is selected", () => {
+    const store = mockStore(state);
     const wrapper = mount(
-      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
-        <ArchSelect arches={[bootResourceUbuntuArchFactory()]} release={null} />
-      </Formik>
+      <Provider store={store}>
+        <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+          <ArchSelect
+            arches={[bootResourceUbuntuArchFactory()]}
+            release={null}
+          />
+        </Formik>
+      </Provider>
     );
 
     expect(wrapper.find("[data-test='no-release-selected']").text()).toBe(
@@ -27,22 +57,25 @@ describe("ArchSelect", () => {
       bootResourceUbuntuArchFactory({ name: "amd64" }),
       bootResourceUbuntuArchFactory({ name: "arm64" }),
     ];
+    const store = mockStore(state);
     const wrapper = mount(
-      <Formik
-        initialValues={{
-          images: [
-            {
-              arch: "amd64",
-              os: "ubuntu",
-              release: "focal",
-              title: "20.04 LTS",
-            },
-          ],
-        }}
-        onSubmit={jest.fn()}
-      >
-        <ArchSelect arches={arches} release={release} />
-      </Formik>
+      <Provider store={store}>
+        <Formik
+          initialValues={{
+            images: [
+              {
+                arch: "amd64",
+                os: "ubuntu",
+                release: "focal",
+                title: "20.04 LTS",
+              },
+            ],
+          }}
+          onSubmit={jest.fn()}
+        >
+          <ArchSelect arches={arches} release={release} />
+        </Formik>
+      </Provider>
     );
     const radioChecked = (id: string) =>
       wrapper
@@ -63,10 +96,13 @@ describe("ArchSelect", () => {
       bootResourceUbuntuArchFactory({ name: "amd64" }),
       bootResourceUbuntuArchFactory({ name: "i386" }),
     ];
+    const store = mockStore(state);
     const wrapper = mount(
-      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
-        <ArchSelect arches={arches} release={release} />
-      </Formik>
+      <Provider store={store}>
+        <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+          <ArchSelect arches={arches} release={release} />
+        </Formik>
+      </Provider>
     );
 
     expect(
@@ -77,5 +113,44 @@ describe("ArchSelect", () => {
     expect(
       wrapper.find("[data-test='disabled-arch-tooltip']").prop("message")
     ).toBe("i386 is not available on 20.04 LTS.");
+  });
+
+  it(`disables a checkbox if it's the last checked arch for the default
+    commissioning release`, () => {
+    state.config.items = [
+      configFactory({ name: "commissioning_distro_series", value: "focal" }),
+    ];
+    const release = bootResourceUbuntuReleaseFactory({
+      name: "focal",
+      title: "20.04 LTS",
+    });
+    const arches = [
+      bootResourceUbuntuArchFactory({ name: "amd64" }),
+      bootResourceUbuntuArchFactory({ name: "arm64" }),
+    ];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik
+          initialValues={{
+            images: [{ arch: "amd64", os: "ubuntu", release: "focal" }],
+          }}
+          onSubmit={jest.fn()}
+        >
+          <ArchSelect arches={arches} release={release} />
+        </Formik>
+      </Provider>
+    );
+    const archCheckbox = wrapper.findWhere(
+      (n) => n.name() === "Input" && n.prop("id") === "arch-amd64"
+    );
+
+    expect(archCheckbox.prop("checked")).toBe(true);
+    expect(archCheckbox.prop("disabled")).toBe(true);
+    expect(
+      archCheckbox.find("[data-test='disabled-arch-tooltip']").prop("message")
+    ).toBe(
+      "At least one architecture must be selected for the default commissioning release."
+    );
   });
 });

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
@@ -1,28 +1,55 @@
 import { mount } from "enzyme";
 import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
 import UbuntuImageSelect from "./UbuntuImageSelect";
 
+import type { RootState } from "app/store/root/types";
 import {
   bootResourceUbuntuArch as bootResourceUbuntuArchFactory,
   bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory,
+  config as configFactory,
+  configState as configStateFactory,
+  rootState as rootStateFactory,
 } from "testing/factories";
 
+const mockStore = configureStore();
+
 describe("UbuntuImageSelect", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: "commissioning_distro_series",
+            value: "bionic",
+          }),
+        ],
+        loaded: true,
+        loading: false,
+      }),
+    });
+  });
+
   it("does not show a radio button for a release deleted from the source", () => {
     const [available, deleted] = [
       bootResourceUbuntuReleaseFactory({ name: "available", deleted: false }),
       bootResourceUbuntuReleaseFactory({ name: "deleted", deleted: true }),
     ];
     const arches = [bootResourceUbuntuArchFactory()];
+    const store = mockStore(state);
     const wrapper = mount(
-      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
-        <UbuntuImageSelect
-          arches={arches}
-          releases={[available, deleted]}
-          resources={[]}
-        />
-      </Formik>
+      <Provider store={store}>
+        <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+          <UbuntuImageSelect
+            arches={arches}
+            releases={[available, deleted]}
+            resources={[]}
+          />
+        </Formik>
+      </Provider>
     );
     const radioExists = (id: string) =>
       wrapper
@@ -39,14 +66,17 @@ describe("UbuntuImageSelect", () => {
       bootResourceUbuntuArchFactory({ name: "available", deleted: false }),
       bootResourceUbuntuArchFactory({ name: "delete", deleted: true }),
     ];
+    const store = mockStore(state);
     const wrapper = mount(
-      <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
-        <UbuntuImageSelect
-          arches={[available, deleted]}
-          releases={releases}
-          resources={[]}
-        />
-      </Formik>
+      <Provider store={store}>
+        <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+          <UbuntuImageSelect
+            arches={[available, deleted]}
+            releases={releases}
+            resources={[]}
+          />
+        </Formik>
+      </Provider>
     );
     const checkboxExists = (id: string) =>
       wrapper


### PR DESCRIPTION
## Done

- Disabled the last checked checkbox if the selected release is the default commissioning release

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images and select the default commissioning release on the left
- Unselect checkboxes until there's one left
- Check that the last checkbox becomes disabled with a tooltip message
- Select a different release and check that all the checkboxes can be unchecked
- Change the default commissioning release at /MAAS/r/settings/configuration/commissioning and check that the same behaviour applies to the new default commissioning release

## Fixes

Fixes #2791 
