### PR TITLE
Add domain summary form

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -150,6 +150,10 @@ exports[`stricter compilation`] = {
       [72, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [73, 8, 17, "Argument of type \'{ name: string; rrtype: RecordType; rrdata: string; ttl: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "542464171"]
     ],
+    "src/app/domains/views/DomainDetails/DomainSummary/DomainsSummary.test.tsx:2012573864": [
+      [157, 8, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [158, 10, 5, "Argument of type \'{ id: number; name: string; ttl: number; authoritative: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'id\' does not exist in type \'FormEvent<{}>\'.", "179086467"]
+    ],
     "src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx:641465078": [
       [39, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [40, 8, 19, "Argument of type \'{ name: string; authoritative: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "3577698145"]

--- a/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.tsx
@@ -1,6 +1,14 @@
-import { Button, Col, Row, Strip } from "@canonical/react-components";
-import { useSelector } from "react-redux";
+import { useState } from "react";
 
+import { Button, Col, Row, Strip } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+
+import type { CreateDomainValues } from "../../DomainsList/DomainListHeaderForm/DomainListHeaderForm";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import authSelectors from "app/store/auth/selectors";
+import { actions as domainActions } from "app/store/domain";
 import domainsSelectors from "app/store/domain/selectors";
 import type { Domain } from "app/store/domain/types";
 import type { RootState } from "app/store/root/types";
@@ -10,46 +18,118 @@ type Props = {
 };
 
 const DomainSummary = ({ id }: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+
   const domain = useSelector((state: RootState) =>
     domainsSelectors.getById(state, Number(id))
   );
+  const errors = useSelector(domainsSelectors.errors);
+  const saved = useSelector(domainsSelectors.saved);
+  const saving = useSelector(domainsSelectors.saving);
+
+  const isAdmin = useSelector(authSelectors.isAdmin);
+  const [isFormOpen, setFormOpen] = useState(false);
 
   if (!domain) {
     return null;
   }
 
-  return (
-    <Strip>
+  const form = (
+    <FormikForm<CreateDomainValues>
+      buttonsAlign="right"
+      buttonsBordered={false}
+      errors={errors}
+      initialValues={{
+        name: domain.name,
+        authoritative: domain.authoritative,
+        ttl: domain.ttl,
+      }}
+      onSuccess={() => setFormOpen(false)}
+      onSubmit={(values) => {
+        dispatch(
+          domainActions.update({
+            id: domain.id,
+            ttl: values.ttl,
+            name: values.name,
+            authoritative: values.authoritative,
+          })
+        );
+      }}
+      onCancel={() => setFormOpen(false)}
+      submitLabel="Save summary"
+      saved={saved}
+      saving={saving}
+      cleanup={() => dispatch(domainActions.cleanup())}
+    >
       <Row>
-        <Col size="8">
-          <h3 className="p-heading--4">Domain Summary</h3>
+        <Col size="6">
+          <FormikField
+            label="Name"
+            placeholder="Name"
+            type="text"
+            name="name"
+          />
         </Col>
-        <Col size="4" className="u-align--right">
-          <Button disabled>Edit</Button>
+        <Col size="6">
+          <FormikField
+            label="TTL"
+            placeholder="30 (default)"
+            type="text"
+            name="ttl"
+          />
         </Col>
       </Row>
       <Row>
+        <Col size="6">
+          <FormikField
+            label="Authoritative"
+            type="checkbox"
+            name="authoritative"
+          />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+
+  const details = (
+    <>
+      <Row>
         <Col size="2">
-          <p className="u-text--muted">Name</p>
+          <p className="u-text--muted">Name:</p>
         </Col>
         <Col size="4">
           <p>{domain.name}</p>
         </Col>
         <Col size="2">
-          <p className="u-text--muted">Authoritative</p>
-        </Col>
-        <Col size="4">
-          <p>{domain.authoritative ? "Yes" : "No"}</p>
-        </Col>
-      </Row>
-      <Row>
-        <Col size="2">
-          <p className="u-text--muted">TTL</p>
+          <p className="u-text--muted">TTL:</p>
         </Col>
         <Col size="4">
           <p>{domain.ttl}</p>
         </Col>
       </Row>
+      <Row>
+        <Col size="2">
+          <p className="u-text--muted">Authoritative:</p>
+        </Col>
+        <Col size="4">
+          <p>{domain.authoritative ? "Yes" : "No"}</p>
+        </Col>
+      </Row>
+    </>
+  );
+  return (
+    <Strip>
+      <Row>
+        <Col size="8">
+          <h3 className="p-heading--4">Domain summary</h3>
+        </Col>
+        {isAdmin && !isFormOpen && (
+          <Col size="4" className="u-align--right">
+            <Button onClick={() => setFormOpen(true)}>Edit</Button>
+          </Col>
+        )}
+      </Row>
+      {isFormOpen ? form : details}
     </Strip>
   );
 };

--- a/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.tsx
@@ -40,16 +40,16 @@ const DomainSummary = ({ id }: Props): JSX.Element | null => {
       buttonsBordered={false}
       errors={errors}
       initialValues={{
-        name: domain.name,
-        authoritative: domain.authoritative,
-        ttl: domain.ttl,
+        name: domain.name || "",
+        authoritative: !!domain.authoritative,
+        ttl: domain.ttl ?? "",
       }}
       onSuccess={() => setFormOpen(false)}
       onSubmit={(values) => {
         dispatch(
           domainActions.update({
             id: domain.id,
-            ttl: values.ttl,
+            ttl: Number(values.ttl),
             name: values.name,
             authoritative: values.authoritative,
           })
@@ -60,6 +60,7 @@ const DomainSummary = ({ id }: Props): JSX.Element | null => {
       saved={saved}
       saving={saving}
       cleanup={() => dispatch(domainActions.cleanup())}
+      data-test="domain-summary-form"
     >
       <Row>
         <Col size="6">
@@ -93,7 +94,7 @@ const DomainSummary = ({ id }: Props): JSX.Element | null => {
 
   const details = (
     <>
-      <Row>
+      <Row data-test="domain-summary">
         <Col size="2">
           <p className="u-text--muted">Name:</p>
         </Col>
@@ -125,7 +126,9 @@ const DomainSummary = ({ id }: Props): JSX.Element | null => {
         </Col>
         {isAdmin && !isFormOpen && (
           <Col size="4" className="u-align--right">
-            <Button onClick={() => setFormOpen(true)}>Edit</Button>
+            <Button onClick={() => setFormOpen(true)} data-test="edit-domain">
+              Edit
+            </Button>
           </Col>
         )}
       </Row>

--- a/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainsSummary.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainSummary/DomainsSummary.test.tsx
@@ -1,0 +1,185 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DomainSummary from "./DomainSummary";
+
+import type { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DomainSummary", () => {
+  it("render nothing if domain doesn't exist", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <DomainSummary id={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find("DomainSummary").children()).toHaveLength(0);
+  });
+
+  it("renders domain summary", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ id: 1, name: "test" })],
+      }),
+    });
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <DomainSummary id={1} />
+      </Provider>
+    );
+
+    expect(wrapper.find('[data-test="domain-summary"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="domain-summary-form"]').exists()).toBe(
+      false
+    );
+  });
+
+  it("doesn't render Edit button when user is not admin", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ id: 1, name: "test" })],
+      }),
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: false }),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DomainSummary id={1} />
+      </Provider>
+    );
+    expect(wrapper.find('button[data-test="edit-domain"]').exists()).toBe(
+      false
+    );
+  });
+
+  describe("when user is admin", () => {
+    let state: RootState;
+
+    beforeEach(() => {
+      state = rootStateFactory({
+        domain: domainStateFactory({
+          items: [
+            domainFactory({
+              id: 1,
+              name: "test",
+            }),
+          ],
+        }),
+        user: userStateFactory({
+          auth: authStateFactory({
+            user: userFactory({ is_superuser: true }),
+          }),
+        }),
+      });
+    });
+
+    it("renders the Edit button", () => {
+      const store = mockStore(state);
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <DomainSummary id={1} />
+        </Provider>
+      );
+
+      expect(wrapper.find('button[data-test="edit-domain"]').exists()).toBe(
+        true
+      );
+    });
+
+    it("renders the form when Edit button is clicked", () => {
+      const store = mockStore(state);
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <DomainSummary id={1} />
+        </Provider>
+      );
+
+      wrapper.find('button[data-test="edit-domain"]').simulate("click");
+
+      expect(wrapper.find('[data-test="domain-summary"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test="domain-summary-form"]').exists()).toBe(
+        true
+      );
+    });
+
+    it("closes the form when Cancel button is clicked", () => {
+      const store = mockStore(state);
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <DomainSummary id={1} />
+        </Provider>
+      );
+
+      wrapper.find('button[data-test="edit-domain"]').simulate("click");
+      wrapper.find("button[data-test='cancel-action']").simulate("click");
+
+      expect(wrapper.find('[data-test="domain-summary"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test="domain-summary-form"]').exists()).toBe(
+        false
+      );
+    });
+
+    it("calls actions.update on save click", () => {
+      const store = mockStore(state);
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <DomainSummary id={1} />
+        </Provider>
+      );
+
+      wrapper.find('button[data-test="edit-domain"]').simulate("click");
+
+      act(() =>
+        wrapper.find("Formik").props().onSubmit({
+          id: 1,
+          name: "test",
+          ttl: 42,
+          authoritative: false,
+        })
+      );
+
+      expect(
+        store.getActions().find((action) => action.type === "domain/update")
+      ).toStrictEqual({
+        type: "domain/update",
+        meta: {
+          method: "update",
+          model: "domain",
+        },
+        payload: {
+          params: {
+            id: 1,
+            name: "test",
+            ttl: 42,
+            authoritative: false,
+          },
+        },
+      });
+    });
+  });
+});

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -19,6 +19,7 @@ type Props = {
 export type CreateDomainValues = {
   name: Domain["name"];
   authoritative: Domain["authoritative"];
+  ttl?: Domain["ttl"];
 };
 
 const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {

--- a/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
+++ b/ui/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.tsx
@@ -19,7 +19,7 @@ type Props = {
 export type CreateDomainValues = {
   name: Domain["name"];
   authoritative: Domain["authoritative"];
-  ttl?: Domain["ttl"];
+  ttl?: Domain["ttl"] | ""; // allow empty string for Formik initial values
 };
 
 const DomainListHeaderForm = ({ closeForm }: Props): JSX.Element => {


### PR DESCRIPTION
## Done

- Added domain summary form to domain details page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- `yarn start`
- go to http://0.0.0.0:8400/MAAS/r/domains
- click on any domain
- on details page click on "Edit" button next to domain summary
- edit fields, click cancel or save
- form should work as expected

## Fixes

Fixes: canonical-web-and-design/app-squad#47

