### PR TITLE
Add "Add record" form to details header

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -108,7 +108,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/clement/Code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -146,9 +146,9 @@ exports[`stricter compilation`] = {
       [410, 31, 5, "Object is of type \'unknown\'.", "195909086"],
       [410, 39, 5, "Object is of type \'unknown\'.", "195909085"]
     ],
-    "src/app/base/sagas/websockets.ts:2281209045": [
-      [8, 35, 24, "Cannot find module \'typed-redux-saga/macro\' or its corresponding type declarations.", "1093974958"],
-      [17, 7, 24, "Cannot find module \'typed-redux-saga/macro\' or its corresponding type declarations.", "1093974958"]
+    "src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.test.tsx:3405367153": [
+      [72, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [73, 8, 17, "Argument of type \'{ name: string; rrtype: RecordType; rrdata: string; ttl: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "542464171"]
     ],
     "src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx:641465078": [
       [39, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
@@ -762,9 +762,9 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [28, 52, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/domain/types/base.ts:3275777832": [
+    "src/app/store/domain/types/base.ts:1674353399": [
       [0, 13, 8, "RegExp match", "1152173309"],
-      [31, 24, 8, "RegExp match", "1152173309"]
+      [44, 24, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/fabric/types/base.ts:4166410381": [
       [0, 13, 8, "RegExp match", "1152173309"],

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.test.tsx
@@ -1,0 +1,100 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import AddRecordDomainForm from "./AddRecordDomainForm";
+
+import { RecordType } from "app/store/domain/types/base";
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("AddRecordDomainForm", () => {
+  it("calls closeForm on cancel click", () => {
+    const closeForm = jest.fn();
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ id: 1, name: "domain-in-the-brain" })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/domain/:id"
+            component={() => <AddRecordDomainForm closeForm={closeForm} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("button[data-test='cancel-action']").simulate("click");
+    expect(closeForm).toHaveBeenCalled();
+  });
+
+  it("Dispatches the correct action on submit", () => {
+    const closeForm = jest.fn();
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [
+          domainFactory({
+            id: 1,
+            name: "domain-in-the-brain",
+            resource_count: 0,
+          }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/domain/:id"
+            component={() => <AddRecordDomainForm closeForm={closeForm} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    act(() =>
+      wrapper.find("Formik").invoke("onSubmit")({
+        name: "Some name",
+        rrtype: RecordType.CNAME,
+        rrdata: "Some data",
+        ttl: 12,
+      })
+    );
+
+    expect(
+      store.getActions().find((action) => action.type === "domain/createRecord")
+    ).toStrictEqual({
+      type: "domain/createRecord",
+      meta: {
+        method: "create_dnsdata",
+        model: "domain",
+      },
+      payload: {
+        params: {
+          domain: 1,
+          name: "Some name",
+          rrtype: RecordType.CNAME,
+          rrdata: "Some data",
+          ttl: 12,
+        },
+      },
+    });
+  });
+});

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.tsx
@@ -1,0 +1,132 @@
+import { useCallback } from "react";
+
+import { Col, Row, Select } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import * as Yup from "yup";
+import type { SchemaOf } from "yup";
+
+import FormikField from "app/base/components/FormikField";
+import FormikForm from "app/base/components/FormikForm";
+import type { RouteParams } from "app/base/types";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+import type { DomainResource } from "app/store/domain/types/base";
+import { RecordType } from "app/store/domain/types/base";
+
+const SelectValues = Object.values(RecordType).map((value) => {
+  return {
+    value: value,
+    label: value,
+  };
+});
+
+type Props = {
+  closeForm: () => void;
+};
+
+export type CreateRecordValues = {
+  name: DomainResource["name"];
+  rrtype: DomainResource["rrtype"] | "";
+  rrdata: DomainResource["rrdata"];
+  ttl: DomainResource["ttl"];
+};
+
+const AddRecordDomainForm = ({ closeForm }: Props): JSX.Element => {
+  const { id } = useParams<RouteParams>();
+  const dispatch = useDispatch();
+  const errors = useSelector(domainSelectors.errors);
+  const saved = useSelector(domainSelectors.saved);
+  const saving = useSelector(domainSelectors.saving);
+  const cleanup = useCallback(() => domainActions.cleanup(), []);
+
+  const CreateRecordSchema: SchemaOf<CreateRecordValues> = Yup.object()
+    .shape({
+      name: Yup.string().required("This field is required name"),
+      rrtype: Yup.string().required("This field is required tuype"),
+      rrdata: Yup.string().required("This field is required data"),
+      ttl: Yup.number()
+        .nullable(true)
+        .min(0, "Ensure this value is greater than or equal to 0."),
+    })
+    .defined();
+
+  const createRecord = (values: CreateRecordValues) => {
+    dispatch(cleanup());
+    dispatch(
+      domainActions.createRecord(
+        parseInt(id),
+        values.name,
+        values.rrtype,
+        values.rrdata,
+        values.ttl
+      )
+    );
+  };
+
+  return (
+    <FormikForm<CreateRecordValues>
+      buttonsBordered={false}
+      cleanup={cleanup}
+      errors={errors}
+      initialValues={{
+        name: "",
+        rrtype: "",
+        rrdata: "",
+        ttl: null,
+      }}
+      onCancel={closeForm}
+      onSubmit={(values) => {
+        createRecord(values);
+      }}
+      onSuccess={() => {
+        closeForm();
+      }}
+      saving={saving}
+      saved={saved}
+      submitLabel="Add record"
+      submitDisabled={false}
+      validationSchema={CreateRecordSchema}
+    >
+      <Row>
+        <Col size="6">
+          <FormikField
+            label="Name"
+            type="text"
+            name="name"
+            placeholder="Name"
+            required
+          />
+          <FormikField
+            component={Select}
+            name="rrtype"
+            label="Type"
+            options={[
+              { value: "", label: "Type", disabled: true },
+              ...SelectValues,
+            ]}
+            required
+          />
+        </Col>
+        <Col size="6">
+          <FormikField
+            label="Data"
+            type="text"
+            name="rrdata"
+            placeholder="Data"
+            required
+          />
+          <FormikField
+            label="TTL"
+            type="number"
+            min={0}
+            name="ttl"
+            placeholder="TTL in seconds (optional)"
+          />
+        </Col>
+      </Row>
+    </FormikForm>
+  );
+};
+
+export default AddRecordDomainForm;

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/index.ts
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddRecordDomainForm";

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -5,6 +5,7 @@ import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
+import AddRecordDomainForm from "./AddRecordDomainForm";
 import DeleteDomainForm from "./DeleteDomainForm";
 
 import SectionHeader from "app/base/components/SectionHeader";
@@ -72,7 +73,7 @@ const DomainDetailsHeader = (): JSX.Element => {
     formWrapper = <DeleteDomainForm closeForm={closeForm} />;
   } else if (formOpen === "add-record") {
     buttons = null;
-    formWrapper = <h1>Add record form goes here</h1>;
+    formWrapper = <AddRecordDomainForm closeForm={closeForm} />;
   }
   return (
     <SectionHeader

--- a/ui/src/app/store/domain/actions.test.ts
+++ b/ui/src/app/store/domain/actions.test.ts
@@ -1,4 +1,5 @@
 import { actions } from "./slice";
+import { RecordType } from "./types/base";
 
 describe("domain actions", () => {
   it("creates an action for fetching domains", () => {
@@ -74,6 +75,73 @@ describe("domain actions", () => {
       payload: {
         params: {
           id: 1,
+        },
+      },
+    });
+  });
+
+  it("creates an action for creating a new record", () => {
+    expect(
+      actions.createRecord(1, "name", RecordType.TXT, "Some data", 42)
+    ).toEqual({
+      type: "domain/createRecord",
+      meta: {
+        model: "domain",
+        method: "create_dnsdata",
+      },
+      payload: {
+        params: {
+          domain: 1,
+          name: "name",
+          rrtype: RecordType.TXT,
+          rrdata: "Some data",
+          ttl: 42,
+        },
+      },
+    });
+  });
+  it("calls the correct method for A and AAAA types", () => {
+    expect(
+      actions.createRecord(1, "name", RecordType.A, "127.0.0.1", null)
+    ).toEqual({
+      type: "domain/createRecord",
+      meta: {
+        model: "domain",
+        method: "create_address_record",
+      },
+      payload: {
+        params: {
+          domain: 1,
+          name: "name",
+          ip_addresses: ["127.0.0.1"],
+          rrtype: RecordType.A,
+          rrdata: "127.0.0.1",
+          ttl: null,
+        },
+      },
+    });
+    expect(
+      actions.createRecord(
+        1,
+        "name",
+        RecordType.AAAA,
+        "127.0.0.1 0.0.0.0 8.0.0.8",
+        42
+      )
+    ).toEqual({
+      type: "domain/createRecord",
+      meta: {
+        model: "domain",
+        method: "create_address_record",
+      },
+      payload: {
+        params: {
+          domain: 1,
+          name: "name",
+          ip_addresses: ["127.0.0.1", "0.0.0.0", "8.0.0.8"],
+          rrtype: RecordType.AAAA,
+          rrdata: "127.0.0.1 0.0.0.0 8.0.0.8",
+          ttl: 42,
         },
       },
     });

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -183,7 +183,7 @@ const domainSlice = createSlice({
                 domain: id,
                 name: name,
                 rrdata: rrdata,
-                ip_addresses: rrdata.split(/[ ,]+/),
+                ip_addresses: (rrdata ?? "").split(/[ ,]+/),
                 rrtype: rrtype,
                 ttl: ttl,
               },


### PR DESCRIPTION
## Done

- Added the form allowing you to add records to your domains in the domain header

## QA
Go to http://0.0.0.0:8400/MAAS/r/domain/36 and add some records! 
Go wild, see if you can add a SRV one (I couldn't figure out the rules)

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-squad/issues/44


![image](https://user-images.githubusercontent.com/11927929/122244267-0a342200-cec5-11eb-8c10-51c1601ede08.png)
