### PR TITLE
Add domain not found header

### DIFF
--- a/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 
 import DomainDetailsHeader from "./DomainDetailsHeader";
+import DomainNotFoundHeader from "./DomainNotFoundHeader";
 import DomainSummary from "./DomainSummary/DomainSummary";
 import ResourceRecords from "./ResourceRecords";
 
@@ -34,17 +35,21 @@ const DomainDetails = (): JSX.Element => {
     };
   }, [dispatch, id]);
 
+  let header = <DomainDetailsHeader />;
+  let content: JSX.Element | null = (
+    <>
+      <DomainSummary id={id} />
+      <ResourceRecords id={id} />
+    </>
+  );
+  if (!domain) {
+    header = <DomainNotFoundHeader />;
+    content = null;
+  }
+
   return (
-    <Section
-      header={<DomainDetailsHeader />}
-      headerClassName="u-no-padding--bottom"
-    >
-      {domain && (
-        <>
-          <DomainSummary id={id} />
-          <ResourceRecords id={id} />
-        </>
-      )}
+    <Section header={header} headerClassName="u-no-padding--bottom">
+      {content}
     </Section>
   );
 };

--- a/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.test.tsx
@@ -1,0 +1,42 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DomainNotFound from "./DomainNotFoundHeader";
+
+import {
+  domain as domainFactory,
+  domainState as domainStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DomainNotFound", () => {
+  it("shows the domain id if the domain is not found", () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        items: [domainFactory({ id: 1, name: "domain-in-the-membrane" })],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/domain/12", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/domain/:id"
+            component={() => <DomainNotFound />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='section-header-title']").text()).toBe(
+      "No item with pk: 12"
+    );
+  });
+});

--- a/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@canonical/react-components";
+import { useParams } from "react-router";
+import { useHistory } from "react-router-dom";
+
+import SectionHeader from "app/base/components/SectionHeader";
+import type { RouteParams } from "app/base/types";
+import domainsURLs from "app/domains/urls";
+const DomainDetailsHeader = (): JSX.Element => {
+  const { id } = useParams<RouteParams>();
+  const history = useHistory();
+  const buttons = [
+    <Button
+      onClick={() => {
+        history.go(0);
+      }}
+    >
+      Reload
+    </Button>,
+    <Button
+      onClick={() => {
+        history.push({ pathname: domainsURLs.domains });
+      }}
+    >
+      Go back
+    </Button>,
+  ];
+
+  return <SectionHeader buttons={buttons} title={`No item with pk: ${id}`} />;
+};
+
+export default DomainDetailsHeader;

--- a/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/index.ts
+++ b/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DomainNotFoundHeader";

--- a/ui/src/app/domains/views/DomainDetails/DomainsDetails.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainsDetails.test.tsx
@@ -16,7 +16,10 @@ const mockStore = configureStore();
 describe("DomainDetails", () => {
   it("shows a spinner if domain has not loaded yet", () => {
     const state = rootStateFactory({
-      domain: domainStateFactory({ items: [] }),
+      domain: domainStateFactory({
+        items: [domainFactory({ id: 1, name: "domain-in-the-membrane" })],
+        loading: true,
+      }),
     });
     const store = mockStore(state);
     const wrapper = mount(


### PR DESCRIPTION
## Done

- Add domain not found header to the domain detail page if the domain doesn't exist

## QA

go to http://0.0.0.0:8400/MAAS/r/domain/123456789
check that it's showing the correct header


Legacy : 
![image](https://user-images.githubusercontent.com/11927929/122355592-50839280-cf52-11eb-93c5-5c0b6b7a1691.png)

New and improved :sparkles: 
![image](https://user-images.githubusercontent.com/11927929/122355666-5f6a4500-cf52-11eb-9456-6316b65eec5a.png)
