### PR TITLE
test(cypress): fix header test pointing to legacy zones url

### DIFF
--- a/integration/cypress/integration/base/header.spec.ts
+++ b/integration/cypress/integration/base/header.spec.ts
@@ -60,7 +60,7 @@ context("Header", () => {
 
   it("navigates to zones", () => {
     cy.get(".p-navigation__link a:contains(AZs)").click();
-    cy.location("pathname").should("eq", generateLegacyURL("/zones"));
+    cy.location("pathname").should("eq", generateNewURL("/zones"));
     cy.get(".p-navigation__link.is-selected a").contains("AZs");
   });
 


### PR DESCRIPTION
## Done

- Updated the Cypress header test to use the new zones url

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- N/A - Cypress tests should pass
