### PR TITLE
Add record updates

### DIFF
--- a/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetails.tsx
@@ -20,6 +20,7 @@ const DomainDetails = (): JSX.Element => {
   const domain = useSelector((state: RootState) =>
     domainsSelectors.getById(state, Number(id))
   );
+  const domainsLoaded = useSelector(domainsSelectors.loaded);
 
   const dispatch = useDispatch();
   useWindowTitle(domain?.name ?? "Loading...");
@@ -35,15 +36,16 @@ const DomainDetails = (): JSX.Element => {
     };
   }, [dispatch, id]);
 
-  let header = <DomainDetailsHeader />;
+  let header = <DomainDetailsHeader id={id} />;
   let content: JSX.Element | null = (
     <>
       <DomainSummary id={id} />
       <ResourceRecords id={id} />
     </>
   );
-  if (!domain) {
-    header = <DomainNotFoundHeader />;
+
+  if (domainsLoaded && !domain) {
+    header = <DomainNotFoundHeader id={id} />;
     content = null;
   }
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.test.tsx
@@ -62,9 +62,11 @@ describe("AddRecordDomainForm", () => {
     );
 
     expect(
-      store.getActions().find((action) => action.type === "domain/createRecord")
+      store
+        .getActions()
+        .find((action) => action.type === "domain/createDNSData")
     ).toStrictEqual({
-      type: "domain/createRecord",
+      type: "domain/createDNSData",
       meta: {
         method: "create_dnsdata",
         model: "domain",

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.test.tsx
@@ -1,7 +1,6 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddRecordDomainForm from "./AddRecordDomainForm";
@@ -26,15 +25,7 @@ describe("AddRecordDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <AddRecordDomainForm closeForm={closeForm} />}
-          />
-        </MemoryRouter>
+        <AddRecordDomainForm id={1} closeForm={closeForm} />
       </Provider>
     );
     wrapper.find("button[data-test='cancel-action']").simulate("click");
@@ -57,15 +48,7 @@ describe("AddRecordDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <AddRecordDomainForm closeForm={closeForm} />}
-          />
-        </MemoryRouter>
+        <AddRecordDomainForm id={1} closeForm={closeForm} />
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.tsx
@@ -1,39 +1,30 @@
 import { useCallback } from "react";
 
-import { Col, Row, Select } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router";
 import * as Yup from "yup";
 import type { SchemaOf } from "yup";
 
-import FormikField from "app/base/components/FormikField";
+import AddRecordFields from "./AddRecordFields";
+
 import FormikForm from "app/base/components/FormikForm";
-import type { RouteParams } from "app/base/types";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
-import type { DomainResource } from "app/store/domain/types/base";
+import type { Domain, DomainResource } from "app/store/domain/types/base";
 import { RecordType } from "app/store/domain/types/base";
-
-const SelectValues = Object.values(RecordType).map((value) => {
-  return {
-    value: value,
-    label: value,
-  };
-});
 
 type Props = {
   closeForm: () => void;
+  id: Domain["id"];
 };
 
 export type CreateRecordValues = {
   name: DomainResource["name"];
-  rrtype: DomainResource["rrtype"] | "";
+  rrtype: DomainResource["rrtype"];
   rrdata: DomainResource["rrdata"];
-  ttl: DomainResource["ttl"];
+  ttl: DomainResource["ttl"] | "";
 };
 
-const AddRecordDomainForm = ({ closeForm }: Props): JSX.Element => {
-  const { id } = useParams<RouteParams>();
+const AddRecordDomainForm = ({ closeForm, id }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const errors = useSelector(domainSelectors.errors);
   const saved = useSelector(domainSelectors.saved);
@@ -42,27 +33,15 @@ const AddRecordDomainForm = ({ closeForm }: Props): JSX.Element => {
 
   const CreateRecordSchema: SchemaOf<CreateRecordValues> = Yup.object()
     .shape({
-      name: Yup.string().required("This field is required name"),
-      rrtype: Yup.string().required("This field is required tuype"),
-      rrdata: Yup.string().required("This field is required data"),
-      ttl: Yup.number()
-        .nullable(true)
-        .min(0, "Ensure this value is greater than or equal to 0."),
+      name: Yup.string().required("Name is required."),
+      rrtype: Yup.string().required("Record type is required"),
+      rrdata: Yup.string().required("Record data is required"),
+      ttl: Yup.number().min(
+        0,
+        "Ensure this value is greater than or equal to 0."
+      ),
     })
     .defined();
-
-  const createRecord = (values: CreateRecordValues) => {
-    dispatch(cleanup());
-    dispatch(
-      domainActions.createRecord(
-        parseInt(id),
-        values.name,
-        values.rrtype,
-        values.rrdata,
-        values.ttl
-      )
-    );
-  };
 
   return (
     <FormikForm<CreateRecordValues>
@@ -71,13 +50,31 @@ const AddRecordDomainForm = ({ closeForm }: Props): JSX.Element => {
       errors={errors}
       initialValues={{
         name: "",
-        rrtype: "",
+        rrtype: RecordType.A,
         rrdata: "",
-        ttl: null,
+        ttl: "",
       }}
       onCancel={closeForm}
       onSubmit={(values) => {
-        createRecord(values);
+        dispatch(cleanup());
+        if ([RecordType.A, RecordType.AAAA].includes(values.rrtype)) {
+          const params = {
+            address_ttl: Number(values.ttl) || null,
+            domain: id,
+            ip_addresses: values.rrdata.split(/[ ,]+/),
+            name: values.name,
+          };
+          dispatch(domainActions.createAddressRecord(params));
+        } else {
+          const params = {
+            domain: id,
+            name: values.name,
+            rrdata: values.rrdata,
+            rrtype: values.rrtype,
+            ttl: Number(values.ttl) || null,
+          };
+          dispatch(domainActions.createDNSData(params));
+        }
       }}
       onSuccess={() => {
         closeForm();
@@ -85,46 +82,9 @@ const AddRecordDomainForm = ({ closeForm }: Props): JSX.Element => {
       saving={saving}
       saved={saved}
       submitLabel="Add record"
-      submitDisabled={false}
       validationSchema={CreateRecordSchema}
     >
-      <Row>
-        <Col size="6">
-          <FormikField
-            label="Name"
-            type="text"
-            name="name"
-            placeholder="Name"
-            required
-          />
-          <FormikField
-            component={Select}
-            name="rrtype"
-            label="Type"
-            options={[
-              { value: "", label: "Type", disabled: true },
-              ...SelectValues,
-            ]}
-            required
-          />
-        </Col>
-        <Col size="6">
-          <FormikField
-            label="Data"
-            type="text"
-            name="rrdata"
-            placeholder="Data"
-            required
-          />
-          <FormikField
-            label="TTL"
-            type="number"
-            min={0}
-            name="ttl"
-            placeholder="TTL in seconds (optional)"
-          />
-        </Col>
-      </Row>
+      <AddRecordFields />
     </FormikForm>
   );
 };

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordDomainForm.tsx
@@ -61,7 +61,7 @@ const AddRecordDomainForm = ({ closeForm, id }: Props): JSX.Element => {
           const params = {
             address_ttl: Number(values.ttl) || null,
             domain: id,
-            ip_addresses: values.rrdata.split(/[ ,]+/),
+            ip_addresses: (values.rrdata ?? "").split(/[ ,]+/),
             name: values.name,
           };
           dispatch(domainActions.createAddressRecord(params));

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordFields/AddRecordFields.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordFields/AddRecordFields.tsx
@@ -1,0 +1,101 @@
+import { Col, Row, Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { CreateRecordValues } from "../AddRecordDomainForm";
+
+import FormikField from "app/base/components/FormikField";
+import { RecordType } from "app/store/domain/types/base";
+
+const recordTypeOptions = [
+  { value: "", label: "Type", disabled: true },
+  ...Object.values(RecordType).map((value) => {
+    return {
+      value: value,
+      label: value,
+    };
+  }),
+];
+
+const getRecordDataHelp = (type: RecordType) => {
+  switch (type) {
+    case RecordType.A:
+      return "A records require an IPv4 address.";
+    case RecordType.AAAA:
+      return "AAAA records require an IPv6 address.";
+    case RecordType.CNAME:
+      return "CNAME records require a canonical domain name.";
+    case RecordType.MX:
+      return 'MX records require "<preference> <domain name>" of a mail server.';
+    case RecordType.NS:
+      return "NS records require the domain name of a name server.";
+    case RecordType.SRV:
+      return 'SRV records require "<priority> <weight> <port> <target>" of a server.';
+    case RecordType.SSHPF:
+      return 'SSHPF records require "<algorithm> <fptype> <fingerprint>".';
+    default:
+      return "";
+  }
+};
+
+const getRecordDataPlaceholder = (type: RecordType) => {
+  switch (type) {
+    case RecordType.A:
+      return "e.g. 192.168.1.1";
+    case RecordType.AAAA:
+      return "e.g. 001:db8::ff00:42:8329";
+    case RecordType.CNAME:
+      return "e.g. www.mydomain.com";
+    case RecordType.MX:
+      return "e.g. 0 mymailserver.example.com";
+    case RecordType.NS:
+      return "e.g. ns1.domain.com.";
+    case RecordType.SRV:
+      return "e.g. 0 5 5060 service.example.com";
+    case RecordType.SSHPF:
+      return "e.g. 2 1 123456789abcdef67890123456789abcdef67890";
+    default:
+      return "";
+  }
+};
+
+const AddRecordFields = (): JSX.Element => {
+  const { values } = useFormikContext<CreateRecordValues>();
+
+  return (
+    <Row>
+      <Col size="6">
+        <FormikField
+          label="Name"
+          type="text"
+          name="name"
+          placeholder="Name"
+          required
+        />
+        <FormikField
+          component={Select}
+          name="rrtype"
+          label="Record type"
+          options={recordTypeOptions}
+          required
+        />
+        <FormikField
+          help={getRecordDataHelp(values.rrtype)}
+          label="Data"
+          placeholder={getRecordDataPlaceholder(values.rrtype)}
+          type="text"
+          name="rrdata"
+          required
+        />
+        <FormikField
+          label="TTL"
+          type="number"
+          min={0}
+          name="ttl"
+          placeholder="TTL in seconds (optional)"
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default AddRecordFields;

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordFields/index.ts
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordDomainForm/AddRecordFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddRecordFields";

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeleteDomainForm from "./DeleteDomainForm";
@@ -24,15 +23,7 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DeleteDomainForm closeForm={closeForm} />}
-          />
-        </MemoryRouter>
+        component={() => <DeleteDomainForm id={1} closeForm={closeForm} />}
       </Provider>
     );
     wrapper.find("button[data-test='close-confirm-delete']").simulate("click");
@@ -55,15 +46,7 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DeleteDomainForm closeForm={closeForm} />}
-          />
-        </MemoryRouter>
+        component={() => <DeleteDomainForm id={1} closeForm={closeForm} />}
       </Provider>
     );
 
@@ -105,15 +88,7 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DeleteDomainForm closeForm={closeForm} />}
-          />
-        </MemoryRouter>
+        component={() => <DeleteDomainForm id={1} closeForm={closeForm} />}
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
@@ -23,7 +23,7 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DeleteDomainForm id={1} closeForm={closeForm} />}
+        <DeleteDomainForm id={1} closeForm={closeForm} />
       </Provider>
     );
     wrapper.find("button[data-test='close-confirm-delete']").simulate("click");
@@ -46,7 +46,7 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DeleteDomainForm id={1} closeForm={closeForm} />}
+        <DeleteDomainForm id={1} closeForm={closeForm} />
       </Provider>
     );
 
@@ -88,7 +88,7 @@ describe("DeleteDomainForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DeleteDomainForm id={1} closeForm={closeForm} />}
+        <DeleteDomainForm id={1} closeForm={closeForm} />
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.tsx
@@ -8,20 +8,20 @@ import {
   Icon,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router";
 import { useHistory } from "react-router-dom";
 
-import type { RouteParams } from "app/base/types";
 import domainsURLs from "app/domains/urls";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
+import type { Domain } from "app/store/domain/types";
 import type { RootState } from "app/store/root/types";
+
 type Props = {
   closeForm: () => void;
+  id: Domain["id"];
 };
 
-const DeleteDomainForm = ({ closeForm }: Props): JSX.Element => {
-  const { id } = useParams<RouteParams>();
+const DeleteDomainForm = ({ closeForm, id }: Props): JSX.Element => {
   const domain = useSelector((state: RootState) =>
     domainSelectors.getById(state, Number(id))
   );
@@ -39,7 +39,7 @@ const DeleteDomainForm = ({ closeForm }: Props): JSX.Element => {
   }, [dispatch, saved, history]);
 
   const deleteDomain = () => {
-    dispatch(domainActions.delete(parseInt(id)));
+    dispatch(domainActions.delete(id));
   };
 
   let message = "Are you sure you want to delete this domain?";

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
@@ -20,7 +20,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DomainDetailsHeader id={1} />}
+        <DomainDetailsHeader id={1} />
       </Provider>
     );
 
@@ -36,7 +36,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DomainDetailsHeader id={1} />}
+        <DomainDetailsHeader id={1} />
       </Provider>
     );
 
@@ -62,7 +62,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DomainDetailsHeader id={1} />}
+        <DomainDetailsHeader id={1} />
       </Provider>
     );
 
@@ -87,7 +87,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DomainDetailsHeader id={1} />}
+        <DomainDetailsHeader id={1} />
       </Provider>
     );
 
@@ -112,7 +112,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DomainDetailsHeader id={1} />}
+        <DomainDetailsHeader id={1} />
       </Provider>
     );
 
@@ -137,7 +137,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        component={() => <DomainDetailsHeader id={1} />}
+        <DomainDetailsHeader id={1} />
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DomainDetailsHeader from "./DomainDetailsHeader";
@@ -21,15 +20,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DomainDetailsHeader />}
-          />
-        </MemoryRouter>
+        component={() => <DomainDetailsHeader id={1} />}
       </Provider>
     );
 
@@ -45,15 +36,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DomainDetailsHeader />}
-          />
-        </MemoryRouter>
+        component={() => <DomainDetailsHeader id={1} />}
       </Provider>
     );
 
@@ -79,15 +62,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DomainDetailsHeader />}
-          />
-        </MemoryRouter>
+        component={() => <DomainDetailsHeader id={1} />}
       </Provider>
     );
 
@@ -112,15 +87,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DomainDetailsHeader />}
-          />
-        </MemoryRouter>
+        component={() => <DomainDetailsHeader id={1} />}
       </Provider>
     );
 
@@ -145,15 +112,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DomainDetailsHeader />}
-          />
-        </MemoryRouter>
+        component={() => <DomainDetailsHeader id={1} />}
       </Provider>
     );
 
@@ -178,15 +137,7 @@ describe("DomainDetailsHeader", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/1", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DomainDetailsHeader />}
-          />
-        </MemoryRouter>
+        component={() => <DomainDetailsHeader id={1} />}
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -28,7 +28,7 @@ type Props = {
   id: Domain["id"];
 };
 
-const DomainDetailsHeader = ({ id }: Props): JSX.Element => {
+const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
   const domain = useSelector((state: RootState) =>
     domainSelectors.getById(state, id)
   );

--- a/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -3,15 +3,14 @@ import { useEffect, useState } from "react";
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router";
 
 import AddRecordDomainForm from "./AddRecordDomainForm";
 import DeleteDomainForm from "./DeleteDomainForm";
 
 import SectionHeader from "app/base/components/SectionHeader";
-import type { RouteParams } from "app/base/types";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
+import type { Domain } from "app/store/domain/types";
 import type { RootState } from "app/store/root/types";
 
 const pluralizeString = (
@@ -25,10 +24,13 @@ const pluralizeString = (
   return `${pluralize(prefix, count, true)}`;
 };
 
-const DomainDetailsHeader = (): JSX.Element => {
-  const { id } = useParams<RouteParams>();
+type Props = {
+  id: Domain["id"];
+};
+
+const DomainDetailsHeader = ({ id }: Props): JSX.Element => {
   const domain = useSelector((state: RootState) =>
-    domainSelectors.getById(state, Number(id))
+    domainSelectors.getById(state, id)
   );
   const dispatch = useDispatch();
   const domainsLoaded = useSelector(domainSelectors.loaded);
@@ -70,10 +72,10 @@ const DomainDetailsHeader = (): JSX.Element => {
 
   if (formOpen === "delete") {
     buttons = null;
-    formWrapper = <DeleteDomainForm closeForm={closeForm} />;
+    formWrapper = <DeleteDomainForm closeForm={closeForm} id={id} />;
   } else if (formOpen === "add-record") {
     buttons = null;
-    formWrapper = <AddRecordDomainForm closeForm={closeForm} />;
+    formWrapper = <AddRecordDomainForm closeForm={closeForm} id={id} />;
   }
   return (
     <SectionHeader

--- a/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.test.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DomainNotFound from "./DomainNotFoundHeader";
@@ -23,15 +22,7 @@ describe("DomainNotFound", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domain/12", key: "testKey" }]}
-        >
-          <Route
-            exact
-            path="/domain/:id"
-            component={() => <DomainNotFound />}
-          />
-        </MemoryRouter>
+        <DomainNotFound id={12} />
       </Provider>
     );
 

--- a/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.tsx
+++ b/ui/src/app/domains/views/DomainDetails/DomainNotFoundHeader/DomainNotFoundHeader.tsx
@@ -1,15 +1,19 @@
 import { Button } from "@canonical/react-components";
-import { useParams } from "react-router";
 import { useHistory } from "react-router-dom";
 
 import SectionHeader from "app/base/components/SectionHeader";
-import type { RouteParams } from "app/base/types";
 import domainsURLs from "app/domains/urls";
-const DomainDetailsHeader = (): JSX.Element => {
-  const { id } = useParams<RouteParams>();
+import type { Domain } from "app/store/domain/types";
+
+type Props = {
+  id: Domain["id"];
+};
+
+const DomainDetailsHeader = ({ id }: Props): JSX.Element => {
   const history = useHistory();
   const buttons = [
     <Button
+      key="reload-domains"
       onClick={() => {
         history.go(0);
       }}
@@ -17,6 +21,7 @@ const DomainDetailsHeader = (): JSX.Element => {
       Reload
     </Button>,
     <Button
+      key="back-to-domains-list"
       onClick={() => {
         history.push({ pathname: domainsURLs.domains });
       }}

--- a/ui/src/app/store/domain/actions.test.ts
+++ b/ui/src/app/store/domain/actions.test.ts
@@ -80,11 +80,17 @@ describe("domain actions", () => {
     });
   });
 
-  it("creates an action for creating a new record", () => {
+  it("creates an action for creating a new DNSData record", () => {
     expect(
-      actions.createRecord(1, "name", RecordType.TXT, "Some data", 42)
+      actions.createDNSData({
+        domain: 1,
+        name: "name",
+        rrtype: RecordType.TXT,
+        rrdata: "Some data",
+        ttl: 42,
+      })
     ).toEqual({
-      type: "domain/createRecord",
+      type: "domain/createDNSData",
       meta: {
         model: "domain",
         method: "create_dnsdata",
@@ -100,11 +106,17 @@ describe("domain actions", () => {
       },
     });
   });
-  it("calls the correct method for A and AAAA types", () => {
+
+  it("creates an action for creating a new address record", () => {
     expect(
-      actions.createRecord(1, "name", RecordType.A, "127.0.0.1", null)
+      actions.createAddressRecord({
+        domain: 1,
+        name: "name",
+        ip_addresses: ["127.0.0.1"],
+        address_ttl: null,
+      })
     ).toEqual({
-      type: "domain/createRecord",
+      type: "domain/createAddressRecord",
       meta: {
         model: "domain",
         method: "create_address_record",
@@ -114,22 +126,19 @@ describe("domain actions", () => {
           domain: 1,
           name: "name",
           ip_addresses: ["127.0.0.1"],
-          rrtype: RecordType.A,
-          rrdata: "127.0.0.1",
-          ttl: null,
+          address_ttl: null,
         },
       },
     });
     expect(
-      actions.createRecord(
-        1,
-        "name",
-        RecordType.AAAA,
-        "127.0.0.1 0.0.0.0 8.0.0.8",
-        42
-      )
+      actions.createAddressRecord({
+        domain: 1,
+        name: "name",
+        ip_addresses: ["127.0.0.1", "0.0.0.0", "8.0.0.8"],
+        address_ttl: 42,
+      })
     ).toEqual({
-      type: "domain/createRecord",
+      type: "domain/createAddressRecord",
       meta: {
         model: "domain",
         method: "create_address_record",
@@ -139,9 +148,7 @@ describe("domain actions", () => {
           domain: 1,
           name: "name",
           ip_addresses: ["127.0.0.1", "0.0.0.0", "8.0.0.8"],
-          rrtype: RecordType.AAAA,
-          rrdata: "127.0.0.1 0.0.0.0 8.0.0.8",
-          ttl: 42,
+          address_ttl: 42,
         },
       },
     });

--- a/ui/src/app/store/domain/types/actions.ts
+++ b/ui/src/app/store/domain/types/actions.ts
@@ -1,5 +1,20 @@
-import type { Domain } from "./base";
+import type { Domain, DomainResource } from "./base";
 import type { DomainMeta } from "./enum";
+
+export type CreateAddressRecordParams = {
+  address_ttl: DomainResource["ttl"] | null;
+  domain: Domain[DomainMeta.PK];
+  ip_addresses: string[];
+  name: DomainResource["name"];
+};
+
+export type CreateDNSDataParams = {
+  domain: Domain[DomainMeta.PK];
+  name: DomainResource["name"];
+  rrdata: DomainResource["rrdata"];
+  rrtype: DomainResource["rrtype"];
+  ttl: DomainResource["ttl"];
+};
 
 export type CreateParams = {
   authoritative?: Domain["authoritative"];
@@ -7,8 +22,8 @@ export type CreateParams = {
   ttl?: Domain["ttl"];
 };
 
+export type SetDefaultErrors = string | number | { domain: string[] };
+
 export type UpdateParams = CreateParams & {
   [DomainMeta.PK]: Domain[DomainMeta.PK];
 };
-
-export type SetDefaultErrors = string | number | { domain: string[] };

--- a/ui/src/app/store/domain/types/index.ts
+++ b/ui/src/app/store/domain/types/index.ts
@@ -1,4 +1,10 @@
-export type { CreateParams, UpdateParams, SetDefaultErrors } from "./actions";
+export type {
+  CreateAddressRecordParams,
+  CreateDNSDataParams,
+  CreateParams,
+  SetDefaultErrors,
+  UpdateParams,
+} from "./actions";
 
 export type { Domain, DomainState } from "./base";
 


### PR DESCRIPTION
## Done

- Updated Domain components to use an `id` prop instead of parsing it from the url in each component. This will make it easier if, for example, we want to render a component somewhere other than `/domain/{id}`.
- Separated `createRecord` action into two separate actions `createAddressRecord` and `createDNSData` (and typed params) to closer match the websocket api.
- Fixed a bug where TTL would not save for A and AAAA records.
- Added some help text for each record type.

## QA steps

- Go to /MAAS/r/domains and click "Add record"
- Check that you can successfully add each record type with TTL saved
- Check that you can still delete a domain that has no records

