### PR TITLE
Add discoveries search bar

### DIFF
--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -1,0 +1,49 @@
+import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DiscoveriesList from "./DiscoveriesList";
+
+import type { RootState } from "app/store/root/types";
+import {
+  discovery as discoveryFactory,
+  discoveryState as discoveryStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ZoneDetailsForm", () => {
+  let initialState: RootState;
+
+  beforeEach(() => {
+    initialState = rootStateFactory({
+      discovery: discoveryStateFactory({
+        errors: {},
+        loading: false,
+        loaded: true,
+        items: [
+          discoveryFactory({
+            hostname: "my-discovery-test",
+          }),
+          discoveryFactory({
+            hostname: "another-test",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("runs closeForm function when the cancel button is clicked", () => {
+    const store = mockStore(initialState);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DiscoveriesList />
+      </Provider>
+    );
+
+    expect(wrapper.text().includes("my-discovery-test")).toBe(true);
+    expect(wrapper.text().includes("another-test")).toBe(true);
+  });
+});

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DiscoveriesList from "./DiscoveriesList";
@@ -38,7 +39,11 @@ describe("ZoneDetailsForm", () => {
     const store = mockStore(initialState);
     const wrapper = mount(
       <Provider store={store}>
-        <DiscoveriesList />
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveriesList />
+        </MemoryRouter>
       </Provider>
     );
 

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -1,5 +1,4 @@
 import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
@@ -1,6 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
-import { MainTable, Tooltip, Icon } from "@canonical/react-components";
+import {
+  MainTable,
+  Tooltip,
+  Icon,
+  SearchBox,
+} from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
 
 import DiscoveriesListHeader from "../DiscoveriesListHeader";
@@ -9,11 +14,15 @@ import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
 import { actions } from "app/store/discovery";
 import discoverySelectors from "app/store/discovery/selectors";
+import type { RootState } from "app/store/root/types";
 
 const DiscoveriesList = (): JSX.Element => {
+  const [searchString, setSearchString] = useState("");
   useWindowTitle("Dashboard");
 
-  const discoveries = useSelector(discoverySelectors.all);
+  const discoveries = useSelector((state: RootState) =>
+    discoverySelectors.search(state, searchString)
+  );
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -113,11 +122,19 @@ const DiscoveriesList = (): JSX.Element => {
     };
   });
 
+  const handlechange = (value: string) => {
+    setSearchString(value.toLowerCase());
+  };
+
   return (
     <Section
       header={<DiscoveriesListHeader />}
       headerClassName="u-no-padding--bottom"
     >
+      <SearchBox
+        data-test="discoveries-search"
+        onChange={(value: string) => handlechange(value)}
+      />
       <MainTable
         className="p-table--network-discoveries"
         data-test="discoveries-table"

--- a/ui/src/app/store/discovery/selectors.test.ts
+++ b/ui/src/app/store/discovery/selectors.test.ts
@@ -55,4 +55,62 @@ describe("discovery selectors", () => {
     expect(selectors.getById(state, "123")).toEqual(discovery);
     expect(selectors.getById(state, "456")).toEqual(null);
   });
+
+  it("can search items", () => {
+    const state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        items: [
+          discoveryFactory({
+            hostname: "foo",
+            mac_address: "00:16:3e:9c:bf:e9",
+            mac_organization: "Acme Inc.",
+            ip: "0.0.0.0",
+            observer_hostname: "alpha",
+            last_seen: "Mon, 19 Oct. 2020 01:15:57",
+          }),
+          discoveryFactory({
+            hostname: "bar",
+            mac_address: "00:16:4a:9c:bf:e9",
+            mac_organization: "Foodies Inc.",
+            ip: "1.1.1.1",
+            observer_hostname: "bravo",
+            last_seen: "Sat, 17 Oct. 2020 01:15:57",
+          }),
+          discoveryFactory({
+            hostname: "foobar",
+            mac_address: "00:16:5b:9c:bf:e9",
+            mac_organization: "Roxxon",
+            ip: "2.2.2.2",
+            observer_hostname: "foot",
+            last_seen: "Mon, 19 Oct. 2020 01:15:57",
+          }),
+          discoveryFactory({
+            hostname: "fizz",
+            mac_address: "00:17:3e:9c:bf:e9",
+            mac_organization: "Pacific Couriers",
+            ip: "3.3.3.3",
+            observer_hostname: "alpha",
+            last_seen: "Mon, 19 Oct. 2020 01:15:57",
+          }),
+        ],
+      }),
+    });
+
+    let results = selectors.search(state, "foo");
+    expect(results.length).toEqual(3);
+
+    expect(results[0].hostname).toEqual("foo");
+    expect(results[1].mac_organization).toEqual("Foodies Inc.");
+    expect(results[2].observer_hostname).toEqual("foot");
+
+    results = selectors.search(state, "3");
+    expect(results.length).toEqual(2);
+
+    expect(results[0].mac_address).toEqual("00:16:3e:9c:bf:e9");
+    expect(results[1].ip).toEqual("3.3.3.3");
+
+    results = selectors.search(state, "sat");
+    expect(results.length).toEqual(1);
+    expect(results[0].last_seen).toEqual("Sat, 17 Oct. 2020 01:15:57");
+  });
 });

--- a/ui/src/app/store/discovery/selectors.ts
+++ b/ui/src/app/store/discovery/selectors.ts
@@ -2,11 +2,13 @@ import { DiscoveryMeta } from "app/store/discovery/types";
 import type { Discovery, DiscoveryState } from "app/store/discovery/types";
 import { generateBaseSelectors } from "app/store/utils";
 
-// TODO: Placeholder search function for now. This will need to be updated to
-// follow the same format as machine searching (i.e. filtering by more than just
-// one parameter).
 const searchFunction = (discovery: Discovery, term: string) =>
-  discovery.discovery_id.includes(term);
+  discovery.hostname?.toLowerCase().includes(term) ||
+  discovery.mac_address.toLowerCase().includes(term) ||
+  discovery.mac_organization.toLowerCase().includes(term) ||
+  discovery.ip.toLowerCase().includes(term) ||
+  discovery.observer_hostname.toLowerCase().includes(term) ||
+  discovery.last_seen.toLowerCase().includes(term);
 
 const selectors = generateBaseSelectors<
   DiscoveryState,

--- a/ui/src/app/store/discovery/selectors.ts
+++ b/ui/src/app/store/discovery/selectors.ts
@@ -4,10 +4,10 @@ import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (discovery: Discovery, term: string) =>
   discovery.hostname?.toLowerCase().includes(term) ||
-  discovery.mac_address.toLowerCase().includes(term) ||
-  discovery.mac_organization.toLowerCase().includes(term) ||
-  discovery.ip.toLowerCase().includes(term) ||
-  discovery.observer_hostname.toLowerCase().includes(term) ||
+  discovery.mac_address?.toLowerCase().includes(term) ||
+  discovery.mac_organization?.toLowerCase().includes(term) ||
+  discovery.ip?.toLowerCase().includes(term) ||
+  discovery.observer_hostname?.toLowerCase().includes(term) ||
   discovery.last_seen.toLowerCase().includes(term);
 
 const selectors = generateBaseSelectors<


### PR DESCRIPTION
## Done

- Updated the discovery search function to search multiple values
- Added test for search function

## QA

- Visit http://192.168.0.3:8400/MAAS/r/dashboard
- Search "28", see that the table updates with 3 results, all last seen on the 28th of September
- Search other terms, see that you get relevant results

![Screenshot from 2021-06-17 16-05-50](https://user-images.githubusercontent.com/2376968/122423661-fd2b3780-cf85-11eb-8431-7a4ec36e7420.png)
