### PR TITLE
feat(ui): add websocket polling

### DIFF
--- a/ui/src/app/base/sagas/websockets.test.ts
+++ b/ui/src/app/base/sagas/websockets.test.ts
@@ -20,7 +20,9 @@ import {
   handleMessage,
   handleNextActions,
   handleNotifyMessage,
+  handlePolling,
   nextActions,
+  pollAction,
   sendMessage,
   storeFileContextActions,
   watchMessages,
@@ -627,5 +629,66 @@ describe("websocket sagas", () => {
         payload: null,
       })
     );
+  });
+
+  describe("polling", () => {
+    it("can start polling", () => {
+      const action = {
+        type: "testAction",
+        meta: {
+          model: "test",
+          method: "method",
+          poll: true,
+        },
+        payload: null,
+      };
+      return expectSaga(handlePolling, action)
+        .put({
+          type: "testActionPollingStarted",
+        })
+        .run();
+    });
+
+    it("can stop polling", () => {
+      const action = {
+        type: "testAction",
+        meta: {
+          model: "test",
+          method: "method",
+          poll: true,
+        },
+        payload: null,
+      };
+      return expectSaga(handlePolling, action)
+        .put({
+          type: "testActionPollingStopped",
+        })
+        .dispatch({
+          type: "testAction",
+          meta: {
+            model: "test",
+            method: "method",
+            pollStop: true,
+          },
+          payload: null,
+        })
+        .run();
+    });
+
+    it("sends the action after the interval", () => {
+      const action = {
+        type: "testAction",
+        meta: {
+          model: "test",
+          method: "method",
+          poll: true,
+        },
+        payload: null,
+      };
+      const saga = pollAction(action);
+      // Skip the delay:
+      saga.next();
+      expect(saga.next(action).value).toEqual(put(action));
+    });
   });
 });

--- a/ui/src/app/base/sagas/websockets.ts
+++ b/ui/src/app/base/sagas/websockets.ts
@@ -35,7 +35,7 @@ import type {
 
 import { fileContextStore } from "app/base/file-context";
 
-const DEFAULT_POLL_INTERVAL = 10;
+const DEFAULT_POLL_INTERVAL = 10000;
 
 type ActionCreator = (...args: unknown[]) => WebSocketAction;
 

--- a/ui/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from "enzyme";
+import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -33,6 +34,35 @@ describe("ImageList", () => {
     expect(wrapper.find("[data-test='placeholder-section']").exists()).toBe(
       true
     );
+  });
+
+  it("stops polling when unmounted", () => {
+    const state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({ name: "boot_images_auto_import", value: false }),
+        ],
+        loaded: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/images", key: "testKey" }]}
+        >
+          <ImageList />
+        </MemoryRouter>
+      </Provider>
+    );
+    act(() => {
+      wrapper.unmount();
+    });
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "bootresource/pollStop")
+    ).toBe(true);
   });
 
   it("shows a warning if automatic image sync is disabled", () => {

--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -21,6 +21,9 @@ const ImagesList = (): JSX.Element => {
   useEffect(() => {
     dispatch(bootResourceActions.poll());
     dispatch(configActions.fetch());
+    return () => {
+      dispatch(bootResourceActions.pollStop());
+    };
   }, [dispatch]);
 
   return configLoaded ? (

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from "react-redux";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import SwitchField from "app/base/components/SwitchField";
-import { actions as bootResourceActions } from "app/store/bootresource";
 import bootResourceSelectors from "app/store/bootresource/selectors";
 import type { BootResourceState } from "app/store/bootresource/types";
 import { actions as configActions } from "app/store/config";
@@ -47,7 +46,6 @@ const ImageListHeader = (): JSX.Element => {
   );
 
   useEffect(() => {
-    dispatch(bootResourceActions.poll());
     dispatch(configActions.fetch());
   }, [dispatch]);
 

--- a/ui/src/app/store/bootresource/actions.test.ts
+++ b/ui/src/app/store/bootresource/actions.test.ts
@@ -48,6 +48,19 @@ describe("bootresource actions", () => {
         jsonResponse: true,
         model: "bootresource",
         method: "poll",
+        poll: true,
+      },
+      payload: null,
+    });
+  });
+
+  it("can create a pollStop action", () => {
+    expect(actions.pollStop()).toEqual({
+      type: "bootresource/pollStop",
+      meta: {
+        model: "bootresource",
+        method: "poll",
+        pollStop: true,
       },
       payload: null,
     });

--- a/ui/src/app/store/bootresource/reducers.test.ts
+++ b/ui/src/app/store/bootresource/reducers.test.ts
@@ -503,4 +503,23 @@ describe("bootresource reducers", () => {
       })
     );
   });
+
+  it("reduces pollStop", () => {
+    expect(
+      reducers(
+        bootResourceStateFactory({
+          statuses: bootResourceStatusesFactory({
+            polling: true,
+          }),
+        }),
+        actions.pollStop()
+      )
+    ).toEqual(
+      bootResourceStateFactory({
+        statuses: bootResourceStatusesFactory({
+          polling: false,
+        }),
+      })
+    );
+  });
 });

--- a/ui/src/app/store/bootresource/slice.ts
+++ b/ui/src/app/store/bootresource/slice.ts
@@ -113,6 +113,7 @@ const bootResourceSlice = createSlice({
           jsonResponse: true,
           model: BootResourceMeta.MODEL,
           method: "poll",
+          poll: true,
         },
         payload: null,
       }),
@@ -132,6 +133,19 @@ const bootResourceSlice = createSlice({
     },
     pollStart: (state: BootResourceState) => {
       state.statuses.polling = true;
+    },
+    pollStop: {
+      prepare: () => ({
+        meta: {
+          method: "poll",
+          model: BootResourceMeta.MODEL,
+          pollStop: true,
+        },
+        payload: null,
+      }),
+      reducer: (state: BootResourceState) => {
+        state.statuses.polling = false;
+      },
     },
     pollSuccess: (
       state: BootResourceState,

--- a/ui/src/websocket-client.ts
+++ b/ui/src/websocket-client.ts
@@ -54,10 +54,14 @@ export type WebSocketResponseNotify = {
   type: WebSocketMessageType.NOTIFY;
 };
 
+export type WebSocketActionParams =
+  | Record<string, unknown>
+  | Record<string, unknown>[];
+
 export type WebSocketAction = PayloadAction<
   {
-    params?: Record<string, unknown> | Record<string, unknown>[];
-  },
+    params?: WebSocketActionParams;
+  } | null,
   string,
   {
     // Whether the request should be fetched in batches.
@@ -74,6 +78,12 @@ export type WebSocketAction = PayloadAction<
     model: string;
     // Whether the request should be fetched every time.
     nocache?: boolean;
+    // Whether the request should be polled.
+    poll?: boolean;
+    // The amount of time in seconds between requests.
+    pollInterval?: number;
+    // Whether polling should be stopped for the request.
+    pollStop?: boolean;
     // Batch requests may set a limit for all requests after the first (i.e. the
     // first action may set a limit of 5 and then use subsequentLimit to set all
     // following requests to 10).

--- a/ui/src/websocket-client.ts
+++ b/ui/src/websocket-client.ts
@@ -2,6 +2,7 @@ import { BASENAME } from "@maas-ui/maas-ui-shared";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import ReconnectingWebSocket from "reconnecting-websocket";
 
+import type { AnyObject } from "app/base/types";
 import { getCookie } from "app/utils";
 
 // A model and method (e.g. 'users.list')
@@ -54,9 +55,7 @@ export type WebSocketResponseNotify = {
   type: WebSocketMessageType.NOTIFY;
 };
 
-export type WebSocketActionParams =
-  | Record<string, unknown>
-  | Record<string, unknown>[];
+export type WebSocketActionParams = AnyObject | AnyObject[];
 
 export type WebSocketAction = PayloadAction<
   {
@@ -80,7 +79,7 @@ export type WebSocketAction = PayloadAction<
     nocache?: boolean;
     // Whether the request should be polled.
     poll?: boolean;
-    // The amount of time in seconds between requests.
+    // The amount of time in milliseconds between requests.
     pollInterval?: number;
     // Whether polling should be stopped for the request.
     pollStop?: boolean;


### PR DESCRIPTION
## Done

- Add the ability to poll an action using the websocket.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/images and open the redux tools to see the dispatches.
- You should see some start polling actions.
- Wait 10 seconds and you should see the next poll happen.
- Click on Settings in the header and you should see the stop polling actions.
- Wait 10 seconds and you should not see any more poll events.

## Fixes

Fixes: canonical-web-and-design/app-squad#87.