### PR TITLE
feat(ui): only show the polling state on the first load

### DIFF
--- a/ui/src/app/base/hooks.test.ts
+++ b/ui/src/app/base/hooks.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks";
 
-import { useScrollOnRender } from "./hooks";
+import { useCycled, useScrollOnRender } from "./hooks";
 
 describe("hooks", () => {
   describe("useScrollOnRender", () => {
@@ -63,6 +63,41 @@ describe("hooks", () => {
         left: 0,
         behavior: "smooth",
       });
+    });
+  });
+
+  describe("useCycled", () => {
+    it("can handle the initial state", () => {
+      const onCycled = jest.fn();
+      const { result } = renderHook(() => useCycled(false, onCycled));
+      expect(result.current).toBe(false);
+      expect(onCycled).not.toHaveBeenCalled();
+    });
+
+    it("can handle rerenders when the value has not cycled", () => {
+      const onCycled = jest.fn();
+      const { result, rerender } = renderHook(
+        ({ state }) => useCycled(state, onCycled),
+        {
+          initialProps: { state: false },
+        }
+      );
+      rerender({ state: false });
+      expect(result.current).toBe(false);
+      expect(onCycled).not.toHaveBeenCalled();
+    });
+
+    it("can handle rerenders when the value has cycled", () => {
+      const onCycled = jest.fn();
+      const { result, rerender } = renderHook(
+        ({ state }) => useCycled(state, onCycled),
+        {
+          initialProps: { state: false },
+        }
+      );
+      rerender({ state: true });
+      expect(result.current).toBe(true);
+      expect(onCycled).toHaveBeenCalled();
     });
   });
 });

--- a/ui/src/app/base/hooks.ts
+++ b/ui/src/app/base/hooks.ts
@@ -291,16 +291,19 @@ export const useTrackById = <T>(): {
  * @param value - The value to check.
  * @param onCycled - The function to call when the value changes from false to true.
  */
-export const useCycled = (value: boolean, onCycled: () => void): void => {
+export const useCycled = (value: boolean, onCycled?: () => void): boolean => {
   const previousValue = useRef(value);
+  const [hasCycled, setHasCycled] = useState(false);
   useEffect(() => {
     if (value && !previousValue.current) {
-      onCycled();
+      onCycled && onCycled();
+      setHasCycled(true);
     }
     if (previousValue.current !== value) {
       previousValue.current = value;
     }
   }, [value, onCycled]);
+  return hasCycled;
 };
 
 /**

--- a/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/ui/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import SwitchField from "app/base/components/SwitchField";
+import { useCycled } from "app/base/hooks";
 import bootResourceSelectors from "app/store/bootresource/selectors";
 import type { BootResourceState } from "app/store/bootresource/types";
 import { actions as configActions } from "app/store/config";
@@ -44,6 +45,7 @@ const ImageListHeader = (): JSX.Element => {
   const regionImportRunning = useSelector(
     bootResourceSelectors.regionImportRunning
   );
+  const hasPolled = useCycled(!polling);
 
   useEffect(() => {
     dispatch(configActions.fetch());
@@ -94,7 +96,7 @@ const ImageListHeader = (): JSX.Element => {
           />
         </div>,
       ]}
-      loading={polling}
+      loading={polling && !hasPolled}
       subtitle={generateImportStatus(rackImportRunning, regionImportRunning)}
       title="Images"
     />


### PR DESCRIPTION
## Done

- Only show the polling state in the images header on the first load.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/images.
- You should see the loading state in the header.
- Wait 10 seconds and the poll will happen again, but you should not see it in the header.