### PR TITLE
feat(ui): clean up and make discovery table responsive

### DIFF
--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -14,7 +14,7 @@ import {
 
 const mockStore = configureStore();
 
-describe("ZoneDetailsForm", () => {
+describe("DiscoveriesList", () => {
   let initialState: RootState;
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe("ZoneDetailsForm", () => {
     });
   });
 
-  it("runs closeForm function when the cancel button is clicked", () => {
+  it("displays the discoveries", () => {
     const store = mockStore(initialState);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/dashboard/views/DiscoveriesList/_index.scss
+++ b/ui/src/app/dashboard/views/DiscoveriesList/_index.scss
@@ -1,0 +1,30 @@
+@mixin DiscoveriesList {
+  .p-table--network-discoveries {
+    th,
+    td {
+      &:nth-child(1) {
+        @include breakpoint-widths(0.3, 0.2, 0.15, 0.15, 0.15, true);
+      }
+
+      &:nth-child(2) {
+        @include breakpoint-widths(0.55, 0.35, 0.2, 0.2, 0.2, true);
+      }
+
+      &:nth-child(3) {
+        @include breakpoint-widths(0, 0.35, 0.25, 0.25, 0.25, true);
+      }
+
+      &:nth-child(4) {
+        @include breakpoint-widths(0, 0, 0.15, 0.15, 0.15, true);
+      }
+
+      &:nth-child(5) {
+        @include breakpoint-widths(0, 0, 0.2, 0.25, 0.25, true);
+      }
+
+      &:nth-child(6) {
+        @include breakpoint-widths(0.15, 0.1, 0.1, 0.05, 0.05, true);
+      }
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -152,6 +152,10 @@
 @include VMsActionBar;
 @include VMsTable;
 
+// Dashboard
+@import "~app/dashboard/views/DiscoveriesList";
+@include DiscoveriesList;
+
 // machines
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
 @import "~app/machines/components/TakeActionMenu";


### PR DESCRIPTION
## Done

- Add CSS to make the discovery table responsive.
- Cleanup discovery table and test.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- View the dashboard.
- Resize your window, check that the columns look OK at each size.

## Fixes

Fixes: canonical-web-and-design/app-squad#127.