### PR TITLE
feat(ui): add a discovery row menu

### DIFF
--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -15,13 +15,11 @@ import {
 const mockStore = configureStore();
 
 describe("DiscoveriesList", () => {
-  let initialState: RootState;
+  let state: RootState;
 
   beforeEach(() => {
-    initialState = rootStateFactory({
+    state = rootStateFactory({
       discovery: discoveryStateFactory({
-        errors: {},
-        loading: false,
         loaded: true,
         items: [
           discoveryFactory({
@@ -36,7 +34,7 @@ describe("DiscoveriesList", () => {
   });
 
   it("displays the discoveries", () => {
-    const store = mockStore(initialState);
+    const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
@@ -49,5 +47,92 @@ describe("DiscoveriesList", () => {
 
     expect(wrapper.text().includes("my-discovery-test")).toBe(true);
     expect(wrapper.text().includes("another-test")).toBe(true);
+  });
+
+  it("displays a spinner when loading", () => {
+    state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        loading: true,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveriesList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(wrapper.find("MainTable").exists()).toBe(false);
+  });
+
+  it("displays a message when there are no discoveries", () => {
+    state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        loaded: true,
+        items: [],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveriesList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='no-discoveries']").exists()).toBe(true);
+    expect(wrapper.find("MainTable").exists()).toBe(false);
+  });
+
+  it("can display the add form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveriesList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='add-discovery']").exists()).toBe(false);
+    wrapper
+      .find("[data-test='row-menu'] button.p-contextual-menu__toggle")
+      .first()
+      .simulate("click");
+    wrapper
+      .find("button[data-test='add-discovery-link']")
+      .first()
+      .simulate("click");
+    expect(wrapper.find("[data-test='add-discovery']").exists()).toBe(true);
+  });
+
+  it("can display the delete form", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveriesList />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='delete-discovery']").exists()).toBe(false);
+    wrapper
+      .find("[data-test='row-menu'] button.p-contextual-menu__toggle")
+      .first()
+      .simulate("click");
+    wrapper
+      .find("button[data-test='delete-discovery-link']")
+      .first()
+      .simulate("click");
+    expect(wrapper.find("[data-test='delete-discovery']").exists()).toBe(true);
   });
 });


### PR DESCRIPTION
## Done

- Add an action menu to the discovery rows.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/dashboard.
- You should see a spinner while the discoveries are loading.
- There should be an action menu for each row which shows the actions.

## Fixes

Fixes: canonical-web-and-design/app-squad#129.