### PR TITLE
feat(ui): disabled discovery warning

### DIFF
--- a/ui/src/app/dashboard/views/Dashboard.test.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.test.tsx
@@ -1,0 +1,64 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import Dashboard from "./Dashboard";
+
+import type { RootState } from "app/store/root/types";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("Dashboard", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [{ name: "network_discovery", value: "enabled" }],
+      }),
+    });
+  });
+
+  it("displays a notification when discovery is disabled", () => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [{ name: "network_discovery", value: "disabled" }],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/dashboard" }]}>
+          <Dashboard />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='disabled-notification']").exists()).toBe(
+      true
+    );
+  });
+
+  it("does not display a notification when discovery is enabled", () => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [{ name: "network_discovery", value: "enabled" }],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/dashboard" }]}>
+          <Dashboard />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='disabled-notification']").exists()).toBe(
+      false
+    );
+  });
+});

--- a/ui/src/app/dashboard/views/Dashboard.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.tsx
@@ -1,3 +1,5 @@
+import { Notification } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 import { Route, Switch } from "react-router-dom";
 
 import DashboardConfigurationForm from "./DashboardConfigurationForm";
@@ -7,13 +9,20 @@ import DiscoveriesList from "./DiscoveriesList";
 import Section from "app/base/components/Section";
 import NotFound from "app/base/views/NotFound";
 import dashboardURLs from "app/dashboard/urls";
+import configSelectors from "app/store/config/selectors";
 
 const Dashboard = (): JSX.Element => {
+  const networkDiscovery = useSelector(configSelectors.networkDiscovery);
   return (
     <Section
       header={<DashboardHeader />}
       headerClassName="u-no-padding--bottom"
     >
+      {networkDiscovery === "disabled" && (
+        <Notification data-test="disabled-notification" type="caution">
+          List of devices will not update as discovery is turned off.
+        </Notification>
+      )}
       <Switch>
         <Route exact path={[dashboardURLs.index]}>
           <DiscoveriesList />


### PR DESCRIPTION
## Done

- Show a notification when discovery is disabled.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/dashboard.
- Go to the config tab and disable discovery and save.
- You should see a warning on both tabs.

## Fixes

Fixes: canonical-web-and-design/app-squad#128.