### PR TITLE
feat(ui): disable forms when network discovery is off

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -108,7 +108,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -146,9 +146,9 @@ exports[`stricter compilation`] = {
       [413, 31, 5, "Object is of type \'unknown\'.", "195909086"],
       [413, 39, 5, "Object is of type \'unknown\'.", "195909085"]
     ],
-    "src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx:3845870852": [
-      [100, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [107, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
+    "src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx:1871504739": [
+      [122, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [129, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
     ],
     "src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx:578155652": [
       [55, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
@@ -680,6 +680,10 @@ exports[`stricter compilation`] = {
     "src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx:3425686756": [
       [25, 10, 4, "Type \'{ osystems: [string, string][]; releases: [string, string][]; }\' is missing the following properties from type \'OSInfo\': kernels, default_osystem, default_release", "2087377941"]
     ],
+    "src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx:1105679732": [
+      [70, 4, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
+      [75, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
+    ],
     "src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx:2093645883": [
       [95, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
       [95, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
@@ -905,6 +909,6 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `199
+  value: `197
 `
 };

--- a/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
+++ b/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
@@ -4,8 +4,10 @@ import configureStore from "redux-mock-store";
 
 import DashboardConfigurationSubnetForm from "./DashboardConfigurationSubnetForm";
 
+import { NetworkDiscovery } from "app/store/config/types";
 import { actions as subnetActions } from "app/store/subnet";
 import {
+  configState as configStateFactory,
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
@@ -57,6 +59,26 @@ describe("DashboardConfigurationSubnetForm", () => {
     );
 
     expect(wrapper.find("FormikForm").exists()).toBe(true);
+  });
+
+  it("disables the form if discovery is disabled", () => {
+    const state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          { name: "network_discovery", value: NetworkDiscovery.DISABLED },
+        ],
+      }),
+      fabric: fabricStateFactory({ loaded: true }),
+      subnet: subnetStateFactory({ items: [subnetFactory()], loaded: true }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <DashboardConfigurationSubnetForm />
+      </Provider>
+    );
+    expect(wrapper.find("FormikForm").prop("submitDisabled")).toBe(true);
+    expect(wrapper.find("FormikField").first().prop("disabled")).toBe(true);
   });
 
   it("displays links for the subnet and its fabric", () => {

--- a/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.tsx
+++ b/ui/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.tsx
@@ -7,6 +7,8 @@ import FormikField from "app/base/components/FormikField";
 import FormikForm from "app/base/components/FormikForm";
 import LegacyLink from "app/base/components/LegacyLink";
 import baseURLs from "app/base/urls";
+import configSelectors from "app/store/config/selectors";
+import { NetworkDiscovery } from "app/store/config/types";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import { actions as subnetActions } from "app/store/subnet";
@@ -26,6 +28,8 @@ const DashboardConfigurationSubnetForm = (): JSX.Element => {
   const fabricsLoaded = useSelector(subnetSelectors.loaded);
   const saved = useSelector(subnetSelectors.saved);
   const saving = useSelector(subnetSelectors.saving);
+  const networkDiscovery = useSelector(configSelectors.networkDiscovery);
+  const discoveryDisabled = networkDiscovery === NetworkDiscovery.DISABLED;
 
   useEffect(() => {
     dispatch(subnetActions.fetch());
@@ -62,6 +66,7 @@ const DashboardConfigurationSubnetForm = (): JSX.Element => {
         }}
         saving={saving}
         saved={saved}
+        submitDisabled={discoveryDisabled}
       >
         <ul className="p-list is-split">
           {sortedSubnets.map((subnet) => {
@@ -71,6 +76,7 @@ const DashboardConfigurationSubnetForm = (): JSX.Element => {
             return (
               <li className="p-list__item" key={`subnet-${subnet.id}`}>
                 <FormikField
+                  disabled={discoveryDisabled}
                   label={
                     <>
                       <LegacyLink

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -3,6 +3,8 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import NetworkDiscoveryForm from "./NetworkDiscoveryForm";
+
+import type { RootState } from "app/store/root/types";
 import {
   configState as configStateFactory,
   rootState as rootStateFactory,
@@ -11,10 +13,10 @@ import {
 const mockStore = configureStore();
 
 describe("NetworkDiscoveryForm", () => {
-  let initialState;
+  let state: RootState;
 
   beforeEach(() => {
-    initialState = rootStateFactory({
+    state = rootStateFactory({
       config: configStateFactory({
         loaded: true,
         items: [
@@ -47,7 +49,6 @@ describe("NetworkDiscoveryForm", () => {
   });
 
   it("displays a spinner if config is loading", () => {
-    const state = { ...initialState };
     state.config.loading = true;
     const store = mockStore(state);
 
@@ -61,7 +62,6 @@ describe("NetworkDiscoveryForm", () => {
   });
 
   it("dispatches an action to update config on save button click", () => {
-    const state = { ...initialState };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -99,7 +99,6 @@ describe("NetworkDiscoveryForm", () => {
   });
 
   it("dispatches action to fetch config if not already loaded", () => {
-    const state = { ...initialState };
     state.config.loaded = false;
     const store = mockStore(state);
 

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
@@ -1,0 +1,85 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import NetworkDiscoveryFormFields from "./NetworkDiscoveryFormFields";
+
+import { NetworkDiscovery } from "app/store/config/types";
+import type { RootState } from "app/store/root/types";
+import {
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("NetworkDiscoveryFormFields", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        loaded: true,
+        items: [
+          {
+            name: "active_discovery_interval",
+            value: "0",
+            choices: [
+              [0, "Never (disabled)"],
+              [604800, "Every week"],
+              [86400, "Every day"],
+              [43200, "Every 12 hours"],
+              [21600, "Every 6 hours"],
+              [10800, "Every 3 hours"],
+              [3600, "Every hour"],
+              [1800, "Every 30 minutes"],
+              [600, "Every 10 minutes"],
+            ],
+          },
+          {
+            name: "network_discovery",
+            value: "enabled",
+            choices: [
+              ["enabled", "Enabled"],
+              ["disabled", "Disabled"],
+            ],
+          },
+        ],
+      }),
+    });
+  });
+
+  it("disables the interval field if discovery is disabled", async () => {
+    state.config.loading = true;
+    const store = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{}} onSubmit={jest.fn()}>
+          <NetworkDiscoveryFormFields />
+        </Formik>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("FormikField[name='active_discovery_interval']")
+        .prop("disabled")
+    ).toBe(false);
+    wrapper
+      .find("FormikField[name='network_discovery'] select")
+      .simulate("change", {
+        target: {
+          name: "network_discovery",
+          value: NetworkDiscovery.DISABLED,
+        },
+      });
+    await waitForComponentToPaint(wrapper);
+    expect(
+      wrapper
+        .find("FormikField[name='active_discovery_interval']")
+        .prop("disabled")
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.tsx
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.tsx
@@ -1,0 +1,40 @@
+import { Select } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+
+import type { NetworkDiscoveryValues } from "../types";
+
+import FormikField from "app/base/components/FormikField";
+import configSelectors from "app/store/config/selectors";
+import { NetworkDiscovery } from "app/store/config/types";
+
+const NetworkDiscoveryFormFields = (): JSX.Element => {
+  const { values } = useFormikContext<NetworkDiscoveryValues>();
+  const networkDiscoveryOptions = useSelector(
+    configSelectors.networkDiscoveryOptions
+  );
+  const discoveryIntervalOptions = useSelector(
+    configSelectors.discoveryIntervalOptions
+  );
+  return (
+    <>
+      <FormikField
+        component={Select}
+        options={networkDiscoveryOptions}
+        name="network_discovery"
+        label="Network discovery"
+        help="When enabled, MAAS will use passive techniques (such as listening to ARP requests and mDNS advertisements) to observe networks attached to rack controllers. Active subnet mapping will also be available to be enabled on the configured subnets."
+      />
+      <FormikField
+        component={Select}
+        disabled={values.network_discovery === NetworkDiscovery.DISABLED}
+        options={discoveryIntervalOptions}
+        name="active_discovery_interval"
+        label="Active subnet mapping interval"
+        help="When enabled, each rack will scan subnets enabled for active mapping. This helps ensure discovery information is accurate and complete."
+      />
+    </>
+  );
+};
+
+export default NetworkDiscoveryFormFields;

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/index.ts
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NetworkDiscoveryFormFields";

--- a/ui/src/app/settings/views/Network/NetworkDiscoveryForm/types.ts
+++ b/ui/src/app/settings/views/Network/NetworkDiscoveryForm/types.ts
@@ -1,0 +1,6 @@
+import type { NetworkDiscovery } from "app/store/config/types";
+
+export type NetworkDiscoveryValues = {
+  active_discovery_interval?: string;
+  network_discovery: NetworkDiscovery | "";
+};

--- a/ui/src/app/store/config/selectors.ts
+++ b/ui/src/app/store/config/selectors.ts
@@ -4,6 +4,7 @@ import type {
   AutoIpmiPrivilegeLevel,
   Config,
   ConfigValues,
+  NetworkDiscovery,
 } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
 
@@ -302,7 +303,7 @@ const remoteSyslog = createSelector([all], (configs) =>
  * @returns {Config["value"]} Enable network discovery.
  */
 const networkDiscovery = createSelector([all], (configs) =>
-  getValueFromName<string>(configs, "network_discovery")
+  getValueFromName<NetworkDiscovery>(configs, "network_discovery")
 );
 
 /**

--- a/ui/src/app/store/config/types/enum.ts
+++ b/ui/src/app/store/config/types/enum.ts
@@ -4,6 +4,11 @@ export enum AutoIpmiPrivilegeLevel {
   USER = "USER",
 }
 
+export enum NetworkDiscovery {
+  DISABLED = "disabled",
+  ENABLED = "enabled",
+}
+
 export enum ConfigMeta {
   MODEL = "config",
 }

--- a/ui/src/app/store/config/types/index.ts
+++ b/ui/src/app/store/config/types/index.ts
@@ -1,3 +1,3 @@
 export type { Config, ConfigChoice, ConfigState, ConfigValues } from "./base";
 
-export { AutoIpmiPrivilegeLevel, ConfigMeta } from "./enum";
+export { NetworkDiscovery, AutoIpmiPrivilegeLevel, ConfigMeta } from "./enum";


### PR DESCRIPTION
## Done

- Update the dashboard config forms to be disabled when network discovery is disabled.
- Added an enum for the network discovery states.
- Migrated the config form to typescript.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/dashboard and click on the config tab.
- Disable network discovery and save.
- The interval time and subnet form should be disabled.

## Fixes

Fixes: canonical-web-and-design/app-squad#130.