### PR TITLE
feat(ui): show discovery count

### DIFF
--- a/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
@@ -1,0 +1,53 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DashboardHeader from "./DashboardHeader";
+
+import dashboardURLs from "app/dashboard/urls";
+import type { RootState } from "app/store/root/types";
+import {
+  discovery as discoveryFactory,
+  discoveryState as discoveryStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DashboardHeader", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        loaded: true,
+        items: [
+          discoveryFactory({
+            hostname: "my-discovery-test",
+          }),
+          discoveryFactory({
+            hostname: "another-test",
+          }),
+        ],
+      }),
+    });
+  });
+
+  it("displays the discovery count in the header", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DashboardHeader />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(wrapper.find(`[to='${dashboardURLs.index}']`).text()).toBe(
+      "2 discoveries"
+    );
+  });
+});

--- a/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
+++ b/ui/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
@@ -1,10 +1,22 @@
+import { useEffect } from "react";
+
+import pluralize from "pluralize";
+import { useSelector, useDispatch } from "react-redux";
 import { Link, useLocation } from "react-router-dom";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import dashboardURLs from "app/dashboard/urls";
+import { actions as discoveryActions } from "app/store/discovery";
+import discoverySelectors from "app/store/discovery/selectors";
 
 const DashboardHeader = (): JSX.Element => {
   const location = useLocation();
+  const dispatch = useDispatch();
+  const discoveries = useSelector(discoverySelectors.all);
+
+  useEffect(() => {
+    dispatch(discoveryActions.fetch());
+  }, [dispatch]);
 
   return (
     <SectionHeader
@@ -13,7 +25,7 @@ const DashboardHeader = (): JSX.Element => {
         {
           active: location.pathname === dashboardURLs.index,
           component: Link,
-          label: "Discoveries",
+          label: pluralize("discovery", discoveries.length, true),
           to: dashboardURLs.index,
         },
         {


### PR DESCRIPTION
## Done

- Add the discovery count to the dashboard tab.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/dashboard.
- Check that the number of discoveries is shown in the discovery tab in the dashboard header.

## Fixes

Fixes: canonical-web-and-design/app-squad#131.