### PR TITLE
feat(ui): delete discovery

### DIFF
--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -103,7 +103,7 @@ describe("DiscoveriesList", () => {
     );
     expect(wrapper.find("[data-test='add-discovery']").exists()).toBe(false);
     wrapper
-      .find("[data-test='row-menu'] button.p-contextual-menu__toggle")
+      .find("[data-test='row-menu'] .row-menu-toggle")
       .first()
       .simulate("click");
     wrapper
@@ -126,7 +126,7 @@ describe("DiscoveriesList", () => {
     );
     expect(wrapper.find("[data-test='delete-discovery']").exists()).toBe(false);
     wrapper
-      .find("[data-test='row-menu'] button.p-contextual-menu__toggle")
+      .find("[data-test='row-menu'] .row-menu-toggle")
       .first()
       .simulate("click");
     wrapper
@@ -134,5 +134,36 @@ describe("DiscoveriesList", () => {
       .first()
       .simulate("click");
     expect(wrapper.find("[data-test='delete-discovery']").exists()).toBe(true);
+  });
+
+  it("can delete a discovery", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveriesList />
+        </MemoryRouter>
+      </Provider>
+    );
+    // Open the action menu.
+    wrapper
+      .find("[data-test='row-menu'] .row-menu-toggle")
+      .first()
+      .simulate("click");
+    // Click on the delete link.
+    wrapper
+      .find("button[data-test='delete-discovery-link']")
+      .first()
+      .simulate("click");
+    // Click on the confirm button.
+    wrapper
+      .find("[data-test='delete-discovery'] [data-test='action-confirm']")
+      .last()
+      .simulate("click");
+    expect(
+      store.getActions().some((action) => action.type === "discovery/delete")
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Done

- Add the action to delete a discovery.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/dashboard.
- Open the action menu and click delete and then confirm.
- The discovery should get deleted.

## Fixes

Fixes: canonical-web-and-design/app-squad#70.