### PR TITLE
feat(ui): don't call form onSuccess on first render

### DIFF
--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
@@ -33,6 +33,24 @@ describe("FormikFormButtons ", () => {
     expect(secondarySubmit).toHaveBeenCalled();
   });
 
+  it("can generate a secondary submit label via a function", () => {
+    const secondarySubmit = jest.fn();
+    const wrapper = mount(
+      <Formik initialValues={{ name: "Koala" }} onSubmit={jest.fn()}>
+        <FormikFormButtons
+          submitLabel="Save user"
+          secondarySubmit={secondarySubmit}
+          secondarySubmitLabel={({ name }) => `Kool ${name}`}
+        />
+      </Formik>
+    );
+    expect(wrapper.find("button[data-test='secondary-submit']").text()).toBe(
+      "Kool Koala"
+    );
+    wrapper.find("[data-test='secondary-submit'] button").simulate("click");
+    expect(secondarySubmit).toHaveBeenCalled();
+  });
+
   it("can display a tooltip for the secondary submit action", () => {
     const wrapper = mount(
       <Formik initialValues={{}} onSubmit={jest.fn()}>

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
@@ -11,10 +11,10 @@ import classNames from "classnames";
 import type { FormikContextType } from "formik";
 import { useFormikContext } from "formik";
 
-export type FormikContextFunc<V> = (
+export type FormikContextFunc<V, R = void> = (
   values: V,
   formikContext: FormikContextType<V>
-) => void;
+) => R;
 
 export type Props<V> = {
   buttonsAlign?: "left" | "right";
@@ -30,7 +30,7 @@ export type Props<V> = {
   savingLabel?: string | null;
   secondarySubmit?: FormikContextFunc<V>;
   secondarySubmitDisabled?: boolean;
-  secondarySubmitLabel?: string | null;
+  secondarySubmitLabel?: string | FormikContextFunc<V, string> | null;
   secondarySubmitTooltip?: string | null;
   submitAppearance?: ButtonProps["appearance"];
   submitDisabled?: boolean;
@@ -64,6 +64,10 @@ export const FormikFormButtons = <V,>({
 
   let secondaryButton: ReactNode;
   if (showSecondarySubmit) {
+    const secondaryLabel =
+      typeof secondarySubmitLabel === "function"
+        ? secondarySubmitLabel(values, formikContext)
+        : secondarySubmitLabel;
     const button = (
       <Button
         appearance="neutral"
@@ -77,7 +81,7 @@ export const FormikFormButtons = <V,>({
         }
         type="button"
       >
-        {secondarySubmitLabel}
+        {secondaryLabel}
       </Button>
     );
     if (secondarySubmitTooltip) {

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -290,8 +290,26 @@ describe("FormikFormContent", () => {
     expect(onSuccess).not.toHaveBeenCalled();
 
     wrapper.setProps({ saved: true });
-    waitForComponentToPaint(wrapper);
+    await waitForComponentToPaint(wrapper);
     expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it("does not run onSuccess on first render", async () => {
+    const onSuccess = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <FormikFormContent errors={null} onSuccess={onSuccess} saved={true}>
+              <Field name="val1" />
+            </FormikFormContent>
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    await waitForComponentToPaint(wrapper);
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 
   it("does not run onSuccess function if saved but there are errors", async () => {
@@ -318,7 +336,7 @@ describe("FormikFormContent", () => {
     expect(onSuccess).not.toHaveBeenCalled();
 
     wrapper.setProps({ errors: "Everything is ruined", saved: true });
-    waitForComponentToPaint(wrapper);
+    await waitForComponentToPaint(wrapper);
     expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -9,6 +9,7 @@ import { Redirect } from "react-router";
 import type { FormikFormButtonsProps } from "app/base/components/FormikFormButtons";
 import FormikFormButtons from "app/base/components/FormikFormButtons";
 import {
+  useCycled,
   useFormikErrors,
   useFormikFormDisabled,
   useSendAnalyticsWhen,
@@ -19,7 +20,8 @@ export type FormErrors =
   | {
       __all__?: string[];
       [x: string]: unknown;
-    };
+    }
+  | null;
 
 export type Props<V> = {
   allowAllEmpty?: boolean;
@@ -82,7 +84,7 @@ const FormikFormContent = <V,>({
   onSuccess = () => void 0,
   onValuesChanged,
   resetOnSave,
-  saved,
+  saved = false,
   savedRedirect,
   saving,
   submitDisabled,
@@ -95,6 +97,7 @@ const FormikFormContent = <V,>({
     allowAllEmpty,
     allowUnchanged,
   });
+  const hasSaved = useCycled(saved);
 
   // Run onValuesChanged function whenever formik values change.
   useEffect(() => {
@@ -110,10 +113,10 @@ const FormikFormContent = <V,>({
   }, [initialValues, resetForm, resetOnSave, saved]);
 
   useEffect(() => {
-    if (!errors && saved) {
+    if (!errors && hasSaved) {
       onSuccess();
     }
-  }, [onSuccess, errors, saved]);
+  }, [onSuccess, errors, hasSaved]);
 
   // Send an analytics event when form is saved.
   useSendAnalyticsWhen(

--- a/ui/src/app/images/views/ImageList/UbuntuImages/CustomSource/CustomSourceConnect/CustomSourceConnect.test.tsx
+++ b/ui/src/app/images/views/ImageList/UbuntuImages/CustomSource/CustomSourceConnect/CustomSourceConnect.test.tsx
@@ -57,7 +57,8 @@ describe("CustomSourceConnect", () => {
     // Mock the transition from "saving" to "saved"
     jest
       .spyOn(reactComponentHooks, "usePrevious")
-      .mockImplementation(() => true);
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
     const setConnected = jest.fn();
     const state = rootStateFactory({
       bootresource: bootResourceStateFactory({
@@ -66,7 +67,7 @@ describe("CustomSourceConnect", () => {
       }),
     });
     const store = mockStore(state);
-    mount(
+    const Proxy = () => (
       <Provider store={store}>
         <CustomSourceConnect
           setConnected={setConnected}
@@ -74,6 +75,9 @@ describe("CustomSourceConnect", () => {
         />
       </Provider>
     );
+    const wrapper = mount(<Proxy />);
+    // Force the component to rerende to simulate the saved value changing.
+    wrapper.setProps({});
 
     expect(setConnected).toHaveBeenCalledWith(true);
   });

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`FieldlessForm renders 1`] = `
                 buttonsBordered={false}
                 cancelDisabled={false}
                 onCancel={[MockFunction]}
+                saved={false}
                 saving={false}
                 savingLabel="Powering on machine..."
                 submitAppearance="positive"
@@ -116,6 +117,7 @@ exports[`FieldlessForm renders 1`] = `
                       appearance="positive"
                       className=""
                       loading={false}
+                      success={false}
                       type="submit"
                     >
                       <button


### PR DESCRIPTION
## Done

- Update the formik form to not call onSuccess on the first render.
- Allow submit label to be generated with a function.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /r/domains.
- Click on a domain.
- Add a record.
- When the record is created the form should close.

## Fixes

Fixes: canonical-web-and-design/app-squad/issues/138.