### PR TITLE
feat(ui): add discovery form

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -150,10 +150,22 @@ exports[`stricter compilation`] = {
       [122, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [129, 6, 24, "Expected 1 arguments, but got 2.", "3437019925"]
     ],
-    "src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx:66478643": [
+    "src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx:3577670537": [
       [85, 4, 45, "Cannot invoke an object which is possibly \'undefined\'.", "2890963284"],
       [85, 4, 47, "Expected 1 arguments, but got 0.", "47989589"],
       [102, 38, 11, "Argument of type \'\\"onSuccess\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "641512391"]
+    ],
+    "src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx:2214229574": [
+      [122, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [123, 6, 19, "Argument of type \'{ system_id: string; domain: string; hostname: string; ip_assignment: DeviceIpAssignment; parent: string; type: DeviceType; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'[DeviceMeta.PK]\' does not exist in type \'FormEvent<{}>\'.", "754079017"],
+      [163, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [164, 6, 25, "Argument of type \'{ system_id: string; domain: string; hostname: string; ip_assignment: DeviceIpAssignment; parent: string; type: DeviceType; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'[DeviceMeta.PK]\' does not exist in type \'FormEvent<{}>\'.", "3561107705"]
+    ],
+    "src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx:2867026375": [
+      [92, 6, 83, "Object is of type \'unknown\'.", "1940328833"],
+      [95, 17, 5, "Binding element \'value\' implicitly has an \'any\' type.", "189936718"],
+      [114, 6, 83, "Object is of type \'unknown\'.", "1940328833"],
+      [117, 17, 5, "Binding element \'value\' implicitly has an \'any\' type.", "189936718"]
     ],
     "src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx:578155652": [
       [55, 6, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
@@ -13,6 +13,8 @@ import classNames from "classnames";
 import { useSelector, useDispatch } from "react-redux";
 import type { Dispatch } from "redux";
 
+import DiscoveryAddForm from "../DiscoveryAddForm";
+
 import DoubleRow from "app/base/components/DoubleRow";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import { useWindowTitle } from "app/base/hooks";
@@ -27,7 +29,10 @@ enum ExpandedType {
   DELETE = "delete",
 }
 
-type ExpandedRow = { id: Discovery[DiscoveryMeta.PK]; type: ExpandedType };
+type ExpandedRow = {
+  id: Discovery[DiscoveryMeta.PK];
+  type: ExpandedType;
+};
 
 const generateRows = (
   discoveries: Discovery[],
@@ -42,7 +47,15 @@ const generateRows = (
     const name = discovery.hostname || "Unknown";
     let expandedContent: ReactNode = null;
     if (isExpanded && expandedRow?.type === ExpandedType.ADD) {
-      expandedContent = <div data-test="add-discovery">add</div>;
+      expandedContent = (
+        <DiscoveryAddForm
+          data-test="add-discovery"
+          discovery={discovery}
+          onClose={() => {
+            setExpandedRow(null);
+          }}
+        />
+      );
     } else if (isExpanded && expandedRow?.type === ExpandedType.DELETE) {
       expandedContent = (
         <TableDeleteConfirm
@@ -132,8 +145,9 @@ const generateRows = (
                   },
                 },
               ]}
-              toggleClassName="row-menu-toggle u-no-margin--bottom"
               toggleAppearance="base"
+              toggleClassName="row-menu-toggle u-no-margin--bottom"
+              toggleDisabled={isExpanded}
             />
           ),
           className: "u-align--right",
@@ -174,7 +188,7 @@ const DiscoveriesList = (): JSX.Element => {
   }
 
   if (loaded && discoveries.length === 0) {
-    return <div data-test="no-discoveries">No discoveries.</div>;
+    return <div data-test="no-discoveries">No new discoveries.</div>;
   }
 
   const headers = [

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -1,0 +1,188 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DiscoveryAddForm from "./DiscoveryAddForm";
+import { DeviceType } from "./types";
+
+import { actions as deviceActions } from "app/store/device";
+import { DeviceIpAssignment, DeviceMeta } from "app/store/device/types";
+import type { Discovery } from "app/store/discovery/types";
+import type { RootState } from "app/store/root/types";
+import {
+  discovery as discoveryFactory,
+  discoveryState as discoveryStateFactory,
+  deviceState as deviceStateFactory,
+  domainState as domainStateFactory,
+  machineState as machineStateFactory,
+  subnetState as subnetStateFactory,
+  vlanState as vlanStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DiscoveryAddForm", () => {
+  let state: RootState;
+  let discovery: Discovery;
+
+  beforeEach(() => {
+    discovery = discoveryFactory({
+      ip: "1.2.3.4",
+      mac_address: "aa:bb:cc",
+      subnet: 9,
+      vlan: 8,
+    });
+    state = rootStateFactory({
+      device: deviceStateFactory({ loaded: true }),
+      discovery: discoveryStateFactory({
+        loaded: true,
+        items: [discovery],
+      }),
+      domain: domainStateFactory({ loaded: true }),
+      machine: machineStateFactory({ loaded: true }),
+      subnet: subnetStateFactory({ loaded: true }),
+      vlan: vlanStateFactory({ loaded: true }),
+    });
+  });
+
+  it("fetches the necessary data on load", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    const expectedActions = [
+      "device/fetch",
+      "domain/fetch",
+      "machine/fetch",
+      "subnet/fetch",
+      "vlan/fetch",
+    ];
+    expectedActions.forEach((expectedAction) => {
+      expect(
+        store.getActions().some((action) => action.type === expectedAction)
+      );
+    });
+  });
+
+  it("displays a spinner when data is loading", () => {
+    state.device.loaded = false;
+    state.domain.loaded = false;
+    state.machine.loaded = false;
+    state.subnet.loaded = false;
+    state.vlan.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("maps name errors to hostname", () => {
+    state.device.errors = { name: "Name is invalid" };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FormikForm").prop("errors")).toStrictEqual({
+      hostname: "Name is invalid",
+    });
+  });
+
+  it("can dispatch to create a device", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find("Formik").invoke("onSubmit")({
+      [DeviceMeta.PK]: "",
+      domain: "local",
+      hostname: "koala",
+      ip_assignment: DeviceIpAssignment.DYNAMIC,
+      parent: "abc123",
+      type: DeviceType.DEVICE,
+    });
+    expect(
+      store.getActions().find((action) => action.type === "device/create")
+    ).toStrictEqual(
+      deviceActions.create({
+        domain: { name: "local" },
+        extra_macs: [],
+        hostname: "koala",
+        interfaces: [
+          {
+            ip_address: "1.2.3.4",
+            ip_assignment: DeviceIpAssignment.DYNAMIC,
+            mac: "aa:bb:cc",
+            subnet: 9,
+          },
+        ],
+        parent: "abc123",
+        primary_mac: "aa:bb:cc",
+      })
+    );
+  });
+
+  it("can dispatch to create a device interface", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find("Formik").invoke("onSubmit")({
+      [DeviceMeta.PK]: "abc123",
+      domain: "",
+      hostname: "koala",
+      ip_assignment: DeviceIpAssignment.DYNAMIC,
+      parent: "",
+      type: DeviceType.INTERFACE,
+    });
+    expect(
+      store
+        .getActions()
+        .find((action) => action.type === "device/createInterface")
+    ).toStrictEqual(
+      deviceActions.createInterface({
+        [DeviceMeta.PK]: "abc123",
+        ip_address: "1.2.3.4",
+        ip_assignment: DeviceIpAssignment.DYNAMIC,
+        mac_address: "aa:bb:cc",
+        name: "koala",
+        subnet: 9,
+        vlan: 8,
+      })
+    );
+  });
+});

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useState } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { navigateToLegacy } from "@maas-ui/maas-ui-shared";
+import { useDispatch, useSelector } from "react-redux";
+import type { Dispatch } from "redux";
+import * as Yup from "yup";
+
+import DiscoveryAddFormFields from "./DiscoveryAddFormFields";
+import { DeviceType } from "./types";
+import type { DiscoveryAddValues } from "./types";
+
+import FormikForm from "app/base/components/FormikForm";
+import baseURLs from "app/base/urls";
+import { actions as deviceActions } from "app/store/device";
+import deviceSelectors from "app/store/device/selectors";
+import type { CreateInterfaceParams } from "app/store/device/types";
+import { DeviceIpAssignment, DeviceMeta } from "app/store/device/types";
+import { actions as discoveryActions } from "app/store/discovery";
+import type { Discovery } from "app/store/discovery/types";
+import { actions as domainActions } from "app/store/domain";
+import domainSelectors from "app/store/domain/selectors";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { RootState } from "app/store/root/types";
+import { actions as subnetActions } from "app/store/subnet";
+import subnetSelectors from "app/store/subnet/selectors";
+import { actions as vlanActions } from "app/store/vlan";
+import vlanSelectors from "app/store/vlan/selectors";
+import { preparePayload } from "app/utils";
+
+type Props = {
+  discovery: Discovery;
+  onClose: () => void;
+};
+
+const formSubmit = (
+  dispatch: Dispatch,
+  discovery: Discovery,
+  values: DiscoveryAddValues
+) => {
+  // Clear the errors from the previous submission.
+  dispatch(discoveryActions.cleanup());
+  if (values.type === DeviceType.DEVICE) {
+    if (!discovery.ip || !discovery.mac_address || !discovery.subnet) {
+      return;
+    }
+    dispatch(
+      deviceActions.create({
+        domain: { name: values.domain },
+        extra_macs: [],
+        hostname: values.hostname,
+        interfaces: [
+          {
+            ip_address: discovery.ip,
+            ip_assignment: values.ip_assignment,
+            mac: discovery.mac_address,
+            subnet: discovery.subnet,
+          },
+        ],
+        parent: values.parent || "",
+        primary_mac: discovery.mac_address,
+      })
+    );
+  } else {
+    dispatch(
+      deviceActions.createInterface(
+        preparePayload(
+          {
+            [DeviceMeta.PK]: values.system_id,
+            ip_address: discovery.ip,
+            ip_assignment: values.ip_assignment,
+            mac_address: discovery.mac_address,
+            name: values.hostname,
+            subnet: discovery.subnet,
+            vlan: discovery.vlan,
+          },
+          [],
+          [],
+          true
+        ) as CreateInterfaceParams
+      )
+    );
+  }
+};
+
+const setRedirectURL = (
+  values: DiscoveryAddValues,
+  setRedirect: (redirect: string | null) => void
+) => {
+  setRedirect(
+    values.parent ? baseURLs.device({ id: values.parent }) : baseURLs.devices
+  );
+};
+
+const DiscoveryAddSchema = Yup.object().shape({
+  [DeviceMeta.PK]: Yup.string().when("type", {
+    is: DeviceType.INTERFACE,
+    then: Yup.string().required(
+      "A device is required when adding an interface."
+    ),
+  }),
+  domain: Yup.string(),
+  hostname: Yup.string(),
+  ip_assignment: Yup.string(),
+  parent: Yup.string(),
+  type: Yup.string(),
+});
+
+const DiscoveryAddForm = ({ discovery, onClose }: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const [redirect, setRedirect] = useState<string | null>(null);
+  const devicesLoaded = useSelector(deviceSelectors.loaded);
+  const defaultDomain = useSelector(domainSelectors.getDefault);
+  let hostname = discovery.hostname;
+  let domainName: string | null = null;
+  if (hostname?.includes(".")) {
+    [hostname, domainName] = hostname.split(".");
+  }
+  const domainByName = useSelector((state: RootState) =>
+    domainSelectors.getByName(state, domainName)
+  );
+  const domainsLoaded = useSelector(domainSelectors.loaded);
+  let errors = useSelector(deviceSelectors.errors);
+  const machinesLoaded = useSelector(machineSelectors.loaded);
+  const saved = useSelector(deviceSelectors.saved);
+  const saving = useSelector(deviceSelectors.saving);
+  const subnetsLoaded = useSelector(subnetSelectors.loaded);
+  const vlansLoaded = useSelector(vlanSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(deviceActions.fetch());
+    dispatch(domainActions.fetch());
+    dispatch(machineActions.fetch());
+    dispatch(subnetActions.fetch());
+    dispatch(vlanActions.fetch());
+  }, [dispatch]);
+
+  if (
+    !devicesLoaded ||
+    !domainsLoaded ||
+    !machinesLoaded ||
+    !subnetsLoaded ||
+    !vlansLoaded
+  ) {
+    return <Spinner />;
+  }
+
+  // When creating an interface the error will get returned for "name" but this
+  // form uses "hostname" for the field name.
+  if (errors && typeof errors === "object" && "name" in errors) {
+    errors = { ...errors, hostname: errors["name"] };
+    delete errors["name"];
+  }
+
+  return (
+    <FormikForm<DiscoveryAddValues>
+      initialValues={{
+        [DeviceMeta.PK]: "",
+        domain: (domainByName || defaultDomain)?.name || "",
+        hostname: hostname || "",
+        ip_assignment: DeviceIpAssignment.DYNAMIC,
+        parent: "",
+        type: DeviceType.DEVICE,
+      }}
+      allowUnchanged
+      className="u-width--full"
+      cleanup={discoveryActions.cleanup}
+      errors={errors}
+      onSaveAnalytics={{
+        action: "Add discovery",
+        category: "Dashboard",
+        label: "Add discovery form",
+      }}
+      onCancel={onClose}
+      onSubmit={(values) => {
+        // The normal submit button should not redirect anywhere.
+        setRedirect(null);
+        formSubmit(dispatch, discovery, values);
+      }}
+      onSuccess={() => {
+        // Refetch the discoveries so that this discovery will get removed
+        // from the list.
+        dispatch(discoveryActions.fetch());
+        if (redirect) {
+          navigateToLegacy(redirect);
+        } else {
+          onClose();
+        }
+      }}
+      saved={saved}
+      saving={saving}
+      secondarySubmit={(values) => {
+        // The secondary submit should redirect to the device/devices.
+        setRedirectURL(values, setRedirect);
+        formSubmit(dispatch, discovery, values);
+      }}
+      secondarySubmitLabel={(values) =>
+        values.parent
+          ? "Save and go to machine details"
+          : "Save and go to device listing"
+      }
+      submitLabel="Save"
+      validationSchema={DiscoveryAddSchema}
+    >
+      <DiscoveryAddFormFields discovery={discovery} />
+    </FormikForm>
+  );
+};
+
+export default DiscoveryAddForm;

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
@@ -1,0 +1,121 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import { DeviceType } from "../types";
+
+import DiscoveryAddFormFields from "./DiscoveryAddFormFields";
+
+import { DeviceIpAssignment } from "app/store/device/types";
+import type { Discovery } from "app/store/discovery/types";
+import type { RootState } from "app/store/root/types";
+import {
+  discovery as discoveryFactory,
+  discoveryState as discoveryStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DiscoveryAddFormFields", () => {
+  let state: RootState;
+  let discovery: Discovery;
+
+  beforeEach(() => {
+    discovery = discoveryFactory();
+    state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        loaded: true,
+        items: [discovery],
+      }),
+    });
+  });
+
+  it("shows fields for a device", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ type: DeviceType.DEVICE }}
+            onSubmit={jest.fn()}
+          >
+            <DiscoveryAddFormFields discovery={discovery} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[name='domain']").exists()).toBe(true);
+    expect(wrapper.find("[name='parent']").exists()).toBe(true);
+    expect(wrapper.find("[name='system_id']").exists()).toBe(false);
+  });
+
+  it("shows fields for an interface", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <Formik
+            initialValues={{ type: DeviceType.INTERFACE }}
+            onSubmit={jest.fn()}
+          >
+            <DiscoveryAddFormFields discovery={discovery} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[name='system_id']").exists()).toBe(true);
+    expect(wrapper.find("[name='domain']").exists()).toBe(false);
+    expect(wrapper.find("[name='parent']").exists()).toBe(false);
+  });
+
+  it("includes static ip if there is a subnet", () => {
+    discovery.subnet = 0;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <DiscoveryAddFormFields discovery={discovery} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("FormikField[name='ip_assignment']")
+        .prop("options")
+        .some(({ value }) => value === DeviceIpAssignment.STATIC)
+    ).toBe(true);
+  });
+
+  it("does not includes static ip if there is no subnet", () => {
+    discovery.subnet = null;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/dashboard", key: "testKey" }]}
+        >
+          <Formik initialValues={{}} onSubmit={jest.fn()}>
+            <DiscoveryAddFormFields discovery={discovery} />
+          </Formik>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("FormikField[name='ip_assignment']")
+        .prop("options")
+        .some(({ value }) => value === DeviceIpAssignment.STATIC)
+    ).toBe(false);
+  });
+});

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -1,0 +1,170 @@
+import { Col, Icon, Row, Select, Tooltip } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
+
+import type { DiscoveryAddValues } from "../types";
+import { DeviceType } from "../types";
+
+import FormikField from "app/base/components/FormikField";
+import LegacyLink from "app/base/components/LegacyLink";
+import baseURLs from "app/base/urls";
+import deviceSelectors from "app/store/device/selectors";
+import { DeviceIpAssignment, DeviceMeta } from "app/store/device/types";
+import type { Discovery } from "app/store/discovery/types";
+import domainSelectors from "app/store/domain/selectors";
+import machineSelectors from "app/store/machine/selectors";
+import type { RootState } from "app/store/root/types";
+import subnetSelectors from "app/store/subnet/selectors";
+import { getSubnetDisplay } from "app/store/subnet/utils";
+import { NodeStatusCode } from "app/store/types/node";
+import vlanSelectors from "app/store/vlan/selectors";
+import { getVLANDisplay } from "app/store/vlan/utils";
+
+type Props = {
+  discovery: Discovery;
+};
+
+const DiscoveryAddFormFields = ({ discovery }: Props): JSX.Element | null => {
+  const devices = useSelector(deviceSelectors.all);
+  const domains = useSelector(domainSelectors.all);
+  const machines = useSelector((state: RootState) =>
+    machineSelectors.getByStatusCode(state, NodeStatusCode.DEPLOYED)
+  );
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getByCIDR(state, discovery.subnet_cidr)
+  );
+  const vlan = useSelector((state: RootState) =>
+    vlanSelectors.getById(state, discovery.vlan)
+  );
+  const { values } = useFormikContext<DiscoveryAddValues>();
+  const isDevice = values.type === DeviceType.DEVICE;
+  const isInterface = values.type === DeviceType.INTERFACE;
+  // Only include static when the discovery has a subnet.
+  const includeStatic = discovery.subnet || discovery.subnet === 0;
+
+  return (
+    <>
+      <Row>
+        <Col size="6">
+          <FormikField
+            component={Select}
+            label="Type"
+            name="type"
+            options={[
+              { label: "Choose type", value: "", disabled: true },
+              { label: "Device", value: DeviceType.DEVICE },
+              { label: "Interface", value: DeviceType.INTERFACE },
+            ]}
+            required
+          />
+          <FormikField
+            label={`${isDevice ? "Hostname" : "Interface name"} (optional)`}
+            name="hostname"
+            type="text"
+          />
+          {isDevice ? (
+            <FormikField
+              component={Select}
+              label="Domain"
+              name="domain"
+              options={[
+                { label: "Choose domain", value: "", disabled: true },
+                ...domains.map((domain) => ({
+                  label: domain.name,
+                  value: domain.name,
+                })),
+              ]}
+              required
+            />
+          ) : null}
+          {isInterface ? (
+            <FormikField
+              component={Select}
+              label={
+                <>
+                  Device name{" "}
+                  <Tooltip message="Create as an interface on the selected device.">
+                    <Icon name="information" />
+                  </Tooltip>
+                </>
+              }
+              name={DeviceMeta.PK}
+              options={[
+                { label: "Select device name", value: "", disabled: true },
+                ...devices.map((device) => ({
+                  label: device.fqdn,
+                  value: device[DeviceMeta.PK],
+                })),
+              ]}
+              required
+            />
+          ) : (
+            <FormikField
+              component={Select}
+              label={
+                <>
+                  Parent{" "}
+                  <Tooltip message="Assign this device as a child of the parent machine.">
+                    <Icon name="information" />
+                  </Tooltip>
+                </>
+              }
+              name="parent"
+              options={[
+                { label: "Select parent (optional)", value: "" },
+                ...machines.map((machine) => ({
+                  label: machine.fqdn,
+                  value: machine.system_id,
+                })),
+              ]}
+            />
+          )}
+        </Col>
+        <Col size="6">
+          <FormikField
+            component={Select}
+            label="IP assignment"
+            name="ip_assignment"
+            options={[
+              { label: "Select IP assignment", value: "", disabled: true },
+              { label: "Dynamic", value: DeviceIpAssignment.DYNAMIC },
+              ...(includeStatic
+                ? [{ label: "Static", value: DeviceIpAssignment.STATIC }]
+                : []),
+              { label: "External", value: DeviceIpAssignment.EXTERNAL },
+            ]}
+            required
+          />
+          <div className="">
+            <p>Fabric</p>
+            <p>
+              <LegacyLink route={baseURLs.fabric({ id: discovery.fabric })}>
+                {discovery.fabric_name}
+              </LegacyLink>
+            </p>
+          </div>
+          <div className="u-nudge-down--small">
+            <p>VLAN</p>
+            <p>
+              <LegacyLink route={baseURLs.vlan({ id: discovery.vlan })}>
+                {getVLANDisplay(vlan)}
+              </LegacyLink>
+            </p>
+          </div>
+          <div className="u-nudge-down--small">
+            <p>Subnet</p>
+            {discovery.subnet ? (
+              <p>
+                <LegacyLink route={baseURLs.subnet({ id: discovery.subnet })}>
+                  {getSubnetDisplay(subnet)}
+                </LegacyLink>
+              </p>
+            ) : null}
+          </div>
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default DiscoveryAddFormFields;

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/index.ts
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DiscoveryAddFormFields";

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/index.ts
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DiscoveryAddForm";

--- a/ui/src/app/dashboard/views/DiscoveryAddForm/types.ts
+++ b/ui/src/app/dashboard/views/DiscoveryAddForm/types.ts
@@ -1,0 +1,16 @@
+import type { Device, DeviceMeta } from "app/store/device/types";
+import type { Domain } from "app/store/domain/types";
+
+export enum DeviceType {
+  DEVICE = "device",
+  INTERFACE = "interface",
+}
+
+export type DiscoveryAddValues = {
+  [DeviceMeta.PK]: Device[DeviceMeta.PK] | "";
+  domain: Domain["name"] | "";
+  hostname: Device["hostname"] | "";
+  ip_assignment: Device["ip_assignment"];
+  parent: Device["parent"] | "";
+  type: DeviceType | "";
+};

--- a/ui/src/app/store/subnet/selectors.ts
+++ b/ui/src/app/store/subnet/selectors.ts
@@ -22,7 +22,10 @@ const defaultSelectors = generateBaseSelectors<
  * @returns Subnets for a cidr.
  */
 const getByCIDR = createSelector(
-  [defaultSelectors.all, (_state: RootState, cidr: Subnet["cidr"]) => cidr],
+  [
+    defaultSelectors.all,
+    (_state: RootState, cidr: Subnet["cidr"] | null) => cidr,
+  ],
   (subnets, cidr) => {
     if (!cidr) {
       return null;

--- a/ui/src/app/utils/preparePayload.ts
+++ b/ui/src/app/utils/preparePayload.ts
@@ -9,7 +9,8 @@
 export const preparePayload = <P, K extends keyof P>(
   payload: P,
   validEmpty: K[] = [],
-  removeAdditional: K[] = []
+  removeAdditional: K[] = [],
+  removeNull = false
 ): P => {
   Object.entries(payload).forEach(([key, value]) => {
     if (
@@ -17,6 +18,7 @@ export const preparePayload = <P, K extends keyof P>(
       // Remove empty fields or entries that should always be removed.
       (value === "" ||
         value === undefined ||
+        (removeNull && value === null) ||
         removeAdditional.includes(key as K))
     ) {
       delete payload[key as K];

--- a/ui/src/scss/_utilities.scss
+++ b/ui/src/scss/_utilities.scss
@@ -139,4 +139,8 @@
   .u-width--auto {
     width: auto;
   }
+
+  .u-width--full {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Done

- Add discovery form for creating devices/interfaces.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/dashboard.
- Open the action menu for a discovery and click "Add discovery".
- Try adding a device (don't choose a parent, this doesn't currently work: https://bugs.launchpad.net/maas/+bug/1933408).
- Repeat the process, but this time create an interface.

## Fixes

Fixes: canonical-web-and-design/app-squad#71.