### PR TITLE
feat(ui): add delete action to images table

### DIFF
--- a/ui/src/app/base/components/TableActions/TableActions.js
+++ b/ui/src/app/base/components/TableActions/TableActions.js
@@ -21,6 +21,7 @@ const TableActions = ({
         <Button
           appearance="base"
           className="is-dense u-table-cell-padding-overlap"
+          data-test="table-actions-edit"
           disabled={editDisabled}
           element={editPath ? Link : undefined}
           hasIcon
@@ -36,6 +37,7 @@ const TableActions = ({
         <Button
           appearance="base"
           className="is-dense u-table-cell-padding-overlap"
+          data-test="table-actions-delete"
           disabled={deleteDisabled}
           hasIcon
           onClick={() => onDelete()}

--- a/ui/src/app/base/components/TableConfirm/TableConfirm.test.tsx
+++ b/ui/src/app/base/components/TableConfirm/TableConfirm.test.tsx
@@ -68,6 +68,26 @@ describe("TableConfirm", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("runs onSuccess function when it has finished", () => {
+    const onSuccess = jest.fn();
+    const wrapper = mount(
+      <TableConfirm
+        confirmLabel="save"
+        finished={false}
+        inProgress={false}
+        message="Are you sure"
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        onSuccess={onSuccess}
+      />
+    );
+    wrapper.find("ActionButton").simulate("click");
+    expect(onSuccess).not.toHaveBeenCalled();
+    wrapper.setProps({ finished: true });
+    wrapper.update();
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
   it("can display an error", () => {
     const onClose = jest.fn();
     const wrapper = mount(

--- a/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
+++ b/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
@@ -22,6 +22,7 @@ export type Props = {
   message: ReactNode;
   onClose: () => void;
   onConfirm: () => void;
+  onSuccess?: () => void;
   sidebar?: boolean;
 };
 
@@ -35,9 +36,11 @@ const TableConfirm = ({
   message,
   onClose,
   onConfirm,
+  onSuccess,
   sidebar = true,
 }: Props): JSX.Element => {
   useCycled(finished, () => {
+    onSuccess && onSuccess();
     onClose();
   });
   let errorMessage: string | null = null;
@@ -67,7 +70,11 @@ const TableConfirm = ({
         <p className="u-no-margin--bottom u-no-max-width">{message}</p>
       </Col>
       <Col size={TABLE_CONFIRM_BUTTONS} className="u-align--right">
-        <Button className="u-no-margin--bottom" onClick={onClose}>
+        <Button
+          className="u-no-margin--bottom"
+          data-test="action-cancel"
+          onClick={onClose}
+        >
           Cancel
         </Button>
         <ActionButton
@@ -77,6 +84,7 @@ const TableConfirm = ({
           loading={inProgress}
           onClick={onConfirm}
           success={finished}
+          type="button"
         >
           {confirmLabel}
         </ActionButton>

--- a/ui/src/app/base/components/TableConfirm/__snapshots__/TableConfirm.test.tsx.snap
+++ b/ui/src/app/base/components/TableConfirm/__snapshots__/TableConfirm.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`TableConfirm renders 1`] = `
   >
     <Button
       className="u-no-margin--bottom"
+      data-test="action-cancel"
       onClick={[MockFunction]}
     >
       Cancel
@@ -28,6 +29,7 @@ exports[`TableConfirm renders 1`] = `
       loading={false}
       onClick={[MockFunction]}
       success={false}
+      type="button"
     >
       save
     </ActionButton>

--- a/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.tsx
+++ b/ui/src/app/base/components/TableDeleteConfirm/TableDeleteConfirm.tsx
@@ -10,7 +10,10 @@ type Props = {
   onClose: TableConfirmProps["onClose"];
   onConfirm: TableConfirmProps["onConfirm"];
   sidebar?: TableConfirmProps["sidebar"];
-} & Pick<TableConfirmProps, "onClose" | "onConfirm" | "sidebar">;
+} & Pick<
+  TableConfirmProps,
+  "errors" | "onClose" | "onConfirm" | "onSuccess" | "sidebar"
+>;
 
 const TableDeleteConfirm = ({
   deleted,

--- a/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
+++ b/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
@@ -1,0 +1,88 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import DeleteImageConfirm from "./DeleteImageConfirm";
+
+import { actions as bootResourceActions } from "app/store/bootresource";
+import {
+  bootResource as bootResourceFactory,
+  bootResourceState as bootResourceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("DeleteImageConfirm", () => {
+  it("calls closeForm on cancel click", () => {
+    const closeForm = jest.fn();
+    const resource = bootResourceFactory();
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [resource],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+          <DeleteImageConfirm closeForm={closeForm} resource={resource} />
+        </Formik>
+      </Provider>
+    );
+    wrapper.find("button[data-test='action-cancel']").simulate("click");
+    expect(closeForm).toHaveBeenCalled();
+  });
+
+  it("runs cleanup function on unmount", async () => {
+    const resource = bootResourceFactory();
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [resource],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+          <DeleteImageConfirm closeForm={jest.fn()} resource={resource} />
+        </Formik>
+      </Provider>
+    );
+    wrapper.unmount();
+    await waitForComponentToPaint(wrapper);
+
+    const expectedAction = bootResourceActions.cleanup();
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === "bootresource/cleanup")
+    ).toStrictEqual(expectedAction);
+  });
+
+  it("dispatches an action to delete an image", async () => {
+    const resource = bootResourceFactory({ id: 1 });
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [resource],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
+          <DeleteImageConfirm closeForm={jest.fn()} resource={resource} />
+        </Formik>
+      </Provider>
+    );
+    wrapper.find("button[data-test='action-confirm']").simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    const expectedAction = bootResourceActions.deleteImage({ id: 1 });
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === "bootresource/deleteImage")
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.tsx
+++ b/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+
+import { usePrevious } from "@canonical/react-components/dist/hooks";
+import { useFormikContext } from "formik";
+import { useDispatch, useSelector } from "react-redux";
+
+import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
+import type { ImageValue } from "app/images/types";
+import { actions as bootResourceActions } from "app/store/bootresource";
+import bootResourceSelectors from "app/store/bootresource/selectors";
+import type { BootResource } from "app/store/bootresource/types";
+import { BootResourceAction } from "app/store/bootresource/types";
+import { splitResourceName } from "app/store/bootresource/utils";
+
+type Props = {
+  closeForm: () => void;
+  resource: BootResource;
+};
+
+const DeleteImageConfirm = ({
+  closeForm,
+  resource,
+}: Props): JSX.Element | null => {
+  const dispatch = useDispatch();
+  const saving = useSelector(bootResourceSelectors.deletingImage);
+  const previousSaving = usePrevious(saving);
+  const eventErrors = useSelector(bootResourceSelectors.eventErrors);
+  const { setFieldValue, values } =
+    useFormikContext<{ images: ImageValue[] }>();
+  const error = eventErrors.find(
+    (error) => error.event === BootResourceAction.DELETE_IMAGE
+  )?.error;
+  const saved = previousSaving && !saving && !error;
+
+  useEffect(() => {
+    return () => {
+      dispatch(bootResourceActions.cleanup());
+    };
+  }, [dispatch]);
+
+  return (
+    <TableDeleteConfirm
+      deleted={saved}
+      deleting={saving}
+      errors={error}
+      message="Are you sure you want to delete this image?"
+      onClose={closeForm}
+      onConfirm={() => {
+        dispatch(bootResourceActions.cleanup());
+        dispatch(bootResourceActions.deleteImage({ id: resource.id }));
+      }}
+      onSuccess={() => {
+        const { os, release } = splitResourceName(resource.name);
+        const newImages = values.images.filter(
+          (image) =>
+            !(
+              image.os === os &&
+              image.release === release &&
+              image.arch === resource.arch
+            )
+        );
+        setFieldValue("images", newImages);
+      }}
+      sidebar={false}
+    />
+  );
+};
+
+export default DeleteImageConfirm;

--- a/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/index.ts
+++ b/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteImageConfirm";

--- a/ui/src/app/images/components/ImagesTable/_index.scss
+++ b/ui/src/app/images/components/ImagesTable/_index.scss
@@ -1,23 +1,23 @@
 @mixin ImagesTable {
   .images-table {
     .release-col {
-      @include breakpoint-widths(50%, 40%, 35%);
+      @include breakpoint-widths(0.35, 0.25, 0.25, 0.25, 0.2, true);
     }
 
     .arch-col {
-      @include breakpoint-widths(0, 0, 9rem);
+      @include breakpoint-widths(0, 0, 0, 0, 0.1, true);
     }
 
     .size-col {
-      @include breakpoint-widths(0, 0, 9rem);
+      @include breakpoint-widths(0, 0, 0, 0, 0.1, true);
     }
 
     .status-col {
-      @include breakpoint-widths(50%, 60%, 65%);
+      @include breakpoint-widths(0.5, 0.65, 0.65, 0.65, 0.5, true);
     }
 
     .actions-col {
-      width: 4.5rem;
+      @include breakpoint-widths(0.15, 0.1, 0.1, 0.1, 0.1, true)
     }
   }
 }

--- a/ui/src/app/images/views/ImageList/OtherImages/OtherImagesSelect/OtherImagesSelect.test.tsx
+++ b/ui/src/app/images/views/ImageList/OtherImages/OtherImagesSelect/OtherImagesSelect.test.tsx
@@ -1,14 +1,42 @@
 import { mount } from "enzyme";
 import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
 import OtherImagesSelect from "./OtherImagesSelect";
 
+import type { RootState } from "app/store/root/types";
 import {
   bootResource as bootResourceFactory,
+  bootResourceState as bootResourceStateFactory,
   bootResourceOtherImage as otherImageFactory,
+  config as configFactory,
+  configState as configStateFactory,
+  rootState as rootStateFactory,
 } from "testing/factories";
 
+const mockStore = configureStore();
+
 describe("OtherImagesSelect", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        otherImages: [],
+        resources: [],
+      }),
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: "commissioning_distro_series",
+            value: "focal",
+          }),
+        ],
+      }),
+    });
+  });
+
   it("correctly shows when an image checkbox is checked", () => {
     const otherImages = [
       otherImageFactory({
@@ -18,23 +46,28 @@ describe("OtherImagesSelect", () => {
       otherImageFactory({ name: "centos/amd64/generic/8", title: "CentOS 8" }),
     ];
     const resources = [bootResourceFactory()];
+    state.bootresource.otherImages = otherImages;
+    state.bootresource.resources = resources;
+    const store = mockStore(state);
     const wrapper = mount(
-      <Formik
-        initialValues={{
-          images: [
-            {
-              arch: "amd64",
-              os: "centos",
-              release: "centos7",
-              subArch: "generic",
-              title: "CentOS 7",
-            },
-          ],
-        }}
-        onSubmit={jest.fn()}
-      >
-        <OtherImagesSelect otherImages={otherImages} resources={resources} />
-      </Formik>
+      <Provider store={store}>
+        <Formik
+          initialValues={{
+            images: [
+              {
+                arch: "amd64",
+                os: "centos",
+                release: "centos7",
+                subArch: "generic",
+                title: "CentOS 7",
+              },
+            ],
+          }}
+          onSubmit={jest.fn()}
+        >
+          <OtherImagesSelect otherImages={otherImages} resources={resources} />
+        </Formik>
+      </Provider>
     );
     const imageChecked = (id: string) =>
       wrapper

--- a/ui/src/app/images/views/ImageList/OtherImages/OtherImagesSelect/OtherImagesSelect.tsx
+++ b/ui/src/app/images/views/ImageList/OtherImages/OtherImagesSelect/OtherImagesSelect.tsx
@@ -63,8 +63,8 @@ const OtherImagesSelect = ({
       <Row>
         <Col size="12">
           <ul className="p-list">
-            {otherImages.map((image) => (
-              <li className="p-list__item u-sv1" key={image.name}>
+            {otherImages.map((image, i) => (
+              <li className="p-list__item u-sv1" key={`${image.name}-${i}`}>
                 <Input
                   checked={isChecked(image)}
                   id={`other-image-${image.name}`}


### PR DESCRIPTION
## Done

- Added delete action for images
- Updated bootresource action reducers to handle success responses (which are identical to the poll success response)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images
- Check that images that have already been downloaded or are in the process of being downloaded (i.e. they exist in `bootresource.resources`) have a bin button
- Check that you can delete an image if it does not use the default commissioning release, which will always be an Ubuntu release (so Other images should always be deletable). The resource will stay in the table until state updates when the server is polled again.
- Check that you can't delete an image that uses the default commissioning release.

## Fixes

Fixes canonical-web-and-design/app-squad#142
