### PR TITLE
fix(ui): don't overwrite events when fetching

### DIFF
--- a/ui/src/app/store/event/reducers.test.ts
+++ b/ui/src/app/store/event/reducers.test.ts
@@ -45,6 +45,40 @@ describe("eventRecord reducer", () => {
       });
     });
 
+    it("appends new items when reducing fetchSuccess", () => {
+      const items = [eventRecordFactory()];
+      const eventState = eventStateFactory({
+        items,
+        loading: true,
+      });
+      const eventRecords = [eventRecordFactory()];
+      expect(reducers(eventState, actions.fetchSuccess(eventRecords))).toEqual({
+        errors: null,
+        items: items.concat(eventRecords),
+        loading: false,
+        loaded: true,
+        saved: false,
+        saving: false,
+      });
+    });
+
+    it("deduplicates when reducing fetchSuccess", () => {
+      const items = [eventRecordFactory(), eventRecordFactory()];
+      const eventState = eventStateFactory({
+        items,
+        loading: true,
+      });
+      const eventRecords = [items[0], eventRecordFactory()];
+      expect(reducers(eventState, actions.fetchSuccess(eventRecords))).toEqual({
+        errors: null,
+        items: [...items, eventRecords[1]],
+        loading: false,
+        loaded: true,
+        saved: false,
+        saving: false,
+      });
+    });
+
     it("reduces fetchError", () => {
       const eventState = eventStateFactory();
       expect(

--- a/ui/src/app/store/event/slice.ts
+++ b/ui/src/app/store/event/slice.ts
@@ -57,6 +57,22 @@ const eventSlice = generateSlice<
         // No state changes need to be handled for this action.
       },
     },
+    fetchSuccess: (
+      state: EventState,
+      action: PayloadAction<EventState["items"]>
+    ) => {
+      state.loading = false;
+      state.loaded = true;
+      // Events are fetch by node ID and can be limited/paginated, so each time
+      // events are fetch they need to be appended to the current list of events
+      // instead of replacing the events.
+      action.payload.forEach((nodeEvent) => {
+        // Prevent duplicates:
+        if (!state.items.find(({ id }) => id === nodeEvent.id)) {
+          state.items.push(nodeEvent);
+        }
+      });
+    },
   },
 }) as EventSlice;
 


### PR DESCRIPTION
Backport: https://github.com/canonical-web-and-design/maas-ui/pull/2846.

## Done

- Append new events to the store instead of overwriting them when a new batch is fetched.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the logs tab for a machine.
- Change the number of events per page to 200.
- Click the arrow to the next page.
- The new events should get loaded and when they do you should be able to go back or forwards.

## Fixes

Fixes: #2824.