### PR TITLE
feat(ui): build generated images table

### DIFF
--- a/ui/src/app/images/views/ImageList/GeneratedImages/GeneratedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/GeneratedImages/GeneratedImages.test.tsx
@@ -1,0 +1,88 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import GeneratedImages from "./GeneratedImages";
+
+import { BootResourceType } from "app/store/bootresource/types";
+import {
+  bootResource as bootResourceFactory,
+  bootResourceState as bootResourceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("GeneratedImages", () => {
+  it("does not render if there are no generated resources", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [
+          bootResourceFactory({ rtype: BootResourceType.SYNCED }),
+          bootResourceFactory({ rtype: BootResourceType.UPLOADED }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <GeneratedImages />
+      </Provider>
+    );
+    expect(wrapper.find("ImagesTable").exists()).toBe(false);
+  });
+
+  it("correctly sets images values based on generated resources", () => {
+    const resources = [
+      bootResourceFactory({
+        arch: "amd64",
+        name: "esxi/7.0",
+        rtype: BootResourceType.UPLOADED,
+        title: "VMWare ESXi 7.0",
+      }),
+      bootResourceFactory({
+        arch: "arm64",
+        name: "windows/win2012hvr2",
+        rtype: BootResourceType.GENERATED,
+        title: "Windows 2012",
+      }),
+      bootResourceFactory({
+        arch: "i386",
+        name: "centos/centos70",
+        rtype: BootResourceType.GENERATED,
+        title: "CentOS 7",
+      }),
+      bootResourceFactory({
+        arch: "ppc64el",
+        name: "ubuntu/focal",
+        rtype: BootResourceType.SYNCED,
+        title: "20.04 LTS",
+      }),
+    ];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <GeneratedImages />
+      </Provider>
+    );
+    expect(wrapper.find("ImagesTable").prop("images")).toStrictEqual([
+      {
+        arch: "arm64",
+        os: "windows",
+        release: "win2012hvr2",
+        title: "Windows 2012",
+      },
+      {
+        arch: "i386",
+        os: "centos",
+        release: "centos70",
+        title: "CentOS 7",
+      },
+    ]);
+  });
+});

--- a/ui/src/app/images/views/ImageList/GeneratedImages/GeneratedImages.tsx
+++ b/ui/src/app/images/views/ImageList/GeneratedImages/GeneratedImages.tsx
@@ -1,0 +1,40 @@
+import { Strip } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import ImagesTable from "app/images/components/ImagesTable";
+import type { ImageValue } from "app/images/types";
+import bootResourceSelectors from "app/store/bootresource/selectors";
+import { splitResourceName } from "app/store/bootresource/utils";
+
+const GeneratedImages = (): JSX.Element | null => {
+  const generatedResources = useSelector(
+    bootResourceSelectors.generatedResources
+  );
+
+  if (generatedResources.length === 0) {
+    return null;
+  }
+
+  const images = generatedResources.reduce<ImageValue[]>((images, resource) => {
+    const { os, release } = splitResourceName(resource.name);
+    images.push({
+      arch: resource.arch,
+      os,
+      release,
+      title: resource.title,
+    });
+    return images;
+  }, []);
+
+  return (
+    <>
+      <hr />
+      <Strip shallow>
+        <h4>Generated images</h4>
+        <ImagesTable images={images} resources={generatedResources} />
+      </Strip>
+    </>
+  );
+};
+
+export default GeneratedImages;

--- a/ui/src/app/images/views/ImageList/GeneratedImages/index.ts
+++ b/ui/src/app/images/views/ImageList/GeneratedImages/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GeneratedImages";

--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -4,6 +4,7 @@ import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import CustomImages from "./CustomImages";
+import GeneratedImages from "./GeneratedImages";
 import ImageListHeader from "./ImageListHeader";
 import OtherImages from "./OtherImages";
 import UbuntuImages from "./UbuntuImages";
@@ -48,6 +49,7 @@ const ImagesList = (): JSX.Element => {
       )}
       <UbuntuImages />
       <OtherImages />
+      <GeneratedImages />
       <CustomImages />
     </Section>
   );


### PR DESCRIPTION
## Done

- Added Genereted images table to images page. Generated images were deprecated in MAAS 2.2 but they might still exist for some MAASes. In the legacy code they are handled identically to Custom images, so I've basically just copy+pasted those components and reused here with a different selector.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- We can "simulate" there being generated images by updating  `app/store/bootresource/selectors.ts`.
  - add `import { bootResource } from "testing/factories"`;
  - Replace the `generatedResources` selector on line 68 with:
  ``` typescript
  const generatedResources = (): BootResourceState["resources"] => [
    bootResource({ rtype: BootResourceType.GENERATED, title: "Generated 1" }),
    bootResource({ rtype: BootResourceType.GENERATED, title: "Generated 2" }),
  ];
  ```
- Go to /MAAS/r/images and check that there is a Generated images section

## Fixes

Fixes canonical-web-and-design/app-squad#85