### PR TITLE
feat(ui): convert PCI table product columns to a double row

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/NodeDevices.tsx
@@ -91,10 +91,19 @@ const generateGroup = (
           )}
         </td>
         <td className="vendor-col">
-          <DoubleRow primary={vendor_name} secondary={vendor_id} />
+          <DoubleRow
+            primary={vendor_name}
+            primaryTitle={vendor_name}
+            secondary={vendor_id}
+          />
         </td>
-        <td className="product-col">{product_name}</td>
-        <td className="product-id-col">{product_id}</td>
+        <td className="product-col">
+          <DoubleRow
+            primary={product_name || "—"}
+            primaryTitle={product_name}
+            secondary={product_id}
+          />
+        </td>
         <td className="driver-col">{commissioning_driver}</td>
         <td
           className="numa-node-col u-align--right"
@@ -192,8 +201,10 @@ const NodeDevices = ({
               <div>Vendor</div>
               <div>ID</div>
             </th>
-            <th className="product-col">Product</th>
-            <th className="product-id-col">Product ID</th>
+            <th className="product-col">
+              <div>Product</div>
+              <div>ID</div>
+            </th>
             <th className="driver-col">Driver</th>
             <th className="numa-node-col u-align--right">NUMA node</th>
             {bus === NodeDeviceBus.PCIE ? (
@@ -239,10 +250,12 @@ const NodeDevices = ({
                     />
                   </td>
                   <td className="product-col">
-                    <Placeholder>Example product description</Placeholder>
-                  </td>
-                  <td className="product-id-col">
-                    <Placeholder>0000</Placeholder>
+                    <DoubleRow
+                      primary={
+                        <Placeholder>Example product description</Placeholder>
+                      }
+                      secondary={<Placeholder>0000</Placeholder>}
+                    />
                   </td>
                   <td className="driver-col">
                     <Placeholder>Driver name</Placeholder>

--- a/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
+++ b/ui/src/app/machines/views/MachineDetails/NodeDevices/_index.scss
@@ -7,15 +7,11 @@
     }
 
     .vendor-col {
-      @include breakpoint-widths(50%, 40%);
+      @include breakpoint-widths(50%, 35%);
     }
 
     .product-col {
-      @include breakpoint-widths(50%, 40%);
-    }
-
-    .product-id-col {
-      @include breakpoint-widths(0, 6rem, 8rem);
+      @include breakpoint-widths(50%, 45%);
     }
 
     .driver-col {


### PR DESCRIPTION
## Done

- Moved "Product ID" into "Product" column in PCI/USB tables

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the PCI or USB tab of a machine's details page and check that there is a double row column for Product and Product ID

## Fixes

Fixes #2765 

## Screenshot
![2021-07-01_11-42](https://user-images.githubusercontent.com/25733845/124052279-797f4980-da61-11eb-9efe-628ef2343da2.png)
