### PR TITLE
feat(ui): update FilterAccordion to work with any model

### DIFF
--- a/ui/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
+++ b/ui/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
@@ -3,14 +3,15 @@ import { mount } from "enzyme";
 import FilterAccordion from "./FilterAccordion";
 import type { Props as FilterAccordionProps } from "./FilterAccordion";
 
-import type { Machine } from "app/store/machine/types";
+import type { Machine, MachineMeta } from "app/store/machine/types";
+import { FilterMachines } from "app/store/machine/utils";
 import { machine as machineFactory } from "testing/factories";
 
 describe("FilterAccordion", () => {
   let items: Machine[];
-  let filterNames: FilterAccordionProps<Machine>["filterNames"];
+  let filterNames: FilterAccordionProps<Machine, MachineMeta.PK>["filterNames"];
   let filterOrder: string[];
-  let getValue: FilterAccordionProps<Machine>["getValue"];
+  let getValue: FilterAccordionProps<Machine, MachineMeta.PK>["getValue"];
   beforeEach(() => {
     items = [
       machineFactory({
@@ -52,6 +53,7 @@ describe("FilterAccordion", () => {
   it("can mark an item as active", () => {
     const wrapper = mount(
       <FilterAccordion
+        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
         filterString="pool:(=pool1)"
@@ -71,6 +73,7 @@ describe("FilterAccordion", () => {
     const onUpdateFilterString = jest.fn();
     const wrapper = mount(
       <FilterAccordion
+        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
         filterString=""
@@ -89,6 +92,7 @@ describe("FilterAccordion", () => {
     delete items[0].pxe_mac;
     const wrapper = mount(
       <FilterAccordion
+        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
         filterString=""
@@ -106,6 +110,7 @@ describe("FilterAccordion", () => {
     items[0].link_speeds = [];
     const wrapper = mount(
       <FilterAccordion
+        filterItems={FilterMachines}
         filterNames={filterNames}
         filterOrder={filterOrder}
         filterString=""

--- a/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 
 import FilterAccordion from "app/base/components/FilterAccordion";
 import machineSelectors from "app/store/machine/selectors";
-import { getMachineValue } from "app/store/machine/utils";
+import { FilterMachines, getMachineValue } from "app/store/machine/utils";
 import { formatSpeedUnits } from "app/utils";
 import type { FilterValue } from "app/utils/search/filter-handlers";
 
@@ -71,6 +71,7 @@ const MachinesFilterAccordion = ({
 
   return (
     <FilterAccordion
+      filterItems={FilterMachines}
       filterNames={filterNames}
       filterOrder={filterOrder}
       filterString={searchText}

--- a/ui/src/app/utils/search/filter-handlers.test.ts
+++ b/ui/src/app/utils/search/filter-handlers.test.ts
@@ -197,10 +197,24 @@ describe("FilterHandlers", () => {
       },
     },
     {
+      input: "koala-type",
+      filters: {
+        q: [],
+        "koala-type": [""],
+      },
+    },
+    {
       input: "koala-type:(qwerty)",
       filters: {
         q: [],
         "koala-type": ["qwerty"],
+      },
+    },
+    {
+      input: "koala-type:(=qwerty,!dvorak)",
+      filters: {
+        q: [],
+        "koala-type": ["=qwerty", "!dvorak"],
       },
     },
     {
@@ -348,7 +362,7 @@ describe("FilterHandlers", () => {
       });
     });
 
-    it("removes value to type in filters", () => {
+    it("removes value from type in filters", () => {
       const filters = {
         type: ["exists", "value"],
       };
@@ -368,7 +382,7 @@ describe("FilterHandlers", () => {
       );
     });
 
-    it("removes exact value to type in filters", () => {
+    it("removes exact value from type in filters", () => {
       const filters = {
         type: ["exists", "value", "=value"],
       };
@@ -379,7 +393,7 @@ describe("FilterHandlers", () => {
       );
     });
 
-    it("removes lowercase value to type in filters", () => {
+    it("removes lowercase value from type in filters", () => {
       const filters = {
         type: ["exists", "=Value"],
       };
@@ -421,6 +435,67 @@ describe("FilterHandlers", () => {
         TestHandlers.toggleFilter({}, "type", "value", false, true)
       ).toEqual({
         type: ["value"],
+      });
+    });
+
+    it("can add a prefixed filter that doesn't currently exist", () => {
+      expect(
+        TestHandlers.toggleFilter({}, "koala_filter", "koala-value")
+      ).toEqual({
+        "koala-value": [""],
+      });
+    });
+
+    it("can remove a prefixed filter that currently exists", () => {
+      const filters = {
+        "koala-value": [""],
+      };
+      expect(
+        TestHandlers.toggleFilter(filters, "koala_filter", "koala-value")
+      ).toEqual({});
+    });
+
+    it("can remove a prefixed filter that currently exists with a value", () => {
+      const filters = {
+        "koala-value": ["cuddly"],
+      };
+      expect(
+        TestHandlers.toggleFilter(filters, "koala_filter", "koala-value")
+      ).toEqual({});
+    });
+
+    it("handles an expected prefixed filter that currently exists", () => {
+      const filters = {
+        "koala-value": [""],
+      };
+      expect(
+        TestHandlers.toggleFilter(
+          filters,
+          "koala_filter",
+          "koala-value",
+          false,
+          true
+        )
+      ).toEqual({
+        "koala-value": [""],
+      });
+    });
+
+    it("handles a not expected prefixed filter that does not currently exist", () => {
+      expect(
+        TestHandlers.toggleFilter(
+          {},
+          "koala_filter",
+          "koala-value",
+          false,
+          false
+        )
+      ).toEqual({});
+    });
+
+    it("can toggle a prefixed filter that is provided without the prefix", () => {
+      expect(TestHandlers.toggleFilter({}, "koala_filter", "value")).toEqual({
+        "koala-value": [""],
       });
     });
   });

--- a/ui/src/app/utils/search/filter-items.ts
+++ b/ui/src/app/utils/search/filter-items.ts
@@ -1,18 +1,18 @@
 import FilterHandlers from "./filter-handlers";
 import type { Filters, FilterValue, PrefixedFilter } from "./filter-handlers";
 
-export type GetValue<N> = (
-  item: N,
+export type GetValue<I> = (
+  item: I,
   filter: string
 ) => FilterValue | FilterValue[] | null;
 
-export default class FilterItems<N, PK extends keyof N> extends FilterHandlers {
-  getValue: GetValue<N>;
+export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
+  getValue: GetValue<I>;
   primaryKey: PK;
 
   constructor(
     primaryKey: PK,
-    getValue: GetValue<N>,
+    getValue: GetValue<I>,
     prefixedFilters?: PrefixedFilter[]
   ) {
     super(prefixedFilters);
@@ -71,11 +71,11 @@ export default class FilterItems<N, PK extends keyof N> extends FilterHandlers {
   };
 
   filterByTerms = (
-    filteredItems: N[],
+    filteredItems: I[],
     attr: keyof Filters,
     terms: FilterValue[],
-    selectedIDs: N[PK][]
-  ): N[] =>
+    selectedIDs: I[PK][]
+  ): I[] =>
     filteredItems.filter((item) => {
       let matched = false;
       let exclude = false;
@@ -132,7 +132,7 @@ export default class FilterItems<N, PK extends keyof N> extends FilterHandlers {
       return matched && !exclude;
     });
 
-  filterItems = (nodes: N[], search: string, selectedIDs: N[PK][]): N[] => {
+  filterItems = (nodes: I[], search: string, selectedIDs: I[PK][]): I[] => {
     let filteredItems = nodes;
     if (
       typeof nodes === "undefined" ||


### PR DESCRIPTION
## Done

- Update the FilterAccordion component to work with models other than machines.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Connect your UI to Bolla.
- Open the machine list.
- Open the filter accordion and click on a workload.
- The list should get filtered (there should be one machine with workload annotations).

## Fixes

Fixes: canonical-web-and-design/app-squad#135.