### PR TITLE
feat(ui): add discovery filtering

### DIFF
--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
@@ -1,0 +1,54 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import DiscoveriesFilterAccordion from "./DiscoveriesFilterAccordion";
+
+import type { RootState } from "app/store/root/types";
+import {
+  discoveryState as discoveryStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("DiscoveriesFilterAccordion", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      discovery: discoveryStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("displays a spinner when loading discoveries", () => {
+    state.discovery.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/discoveries", key: "testKey" }]}
+        >
+          <DiscoveriesFilterAccordion searchText="" setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a filter accordion", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/discoveries", key: "testKey" }]}
+        >
+          <DiscoveriesFilterAccordion searchText="" setSearchText={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("FilterAccordion").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.tsx
@@ -1,0 +1,49 @@
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import FilterAccordion from "app/base/components/FilterAccordion";
+import discoverySelectors from "app/store/discovery/selectors";
+import {
+  FilterDiscoveries,
+  getDiscoveryValue,
+} from "app/store/discovery/utils";
+
+type Props = {
+  searchText?: string;
+  setSearchText: (searchText: string) => void;
+};
+
+const filterOrder = ["fabric_name", "vlan", "observer_hostname", "subnet"];
+
+const filterNames = new Map([
+  ["fabric_name", "Fabric"],
+  ["observer_hostname", "Rack"],
+  ["subnet", "Subnet"],
+  ["vlan", "VLAN"],
+]);
+
+const DiscoveriesFilterAccordion = ({
+  searchText,
+  setSearchText,
+}: Props): JSX.Element => {
+  const discoveries = useSelector(discoverySelectors.all);
+  const loaded = useSelector(discoverySelectors.loaded);
+
+  if (!loaded) {
+    return <Spinner />;
+  }
+
+  return (
+    <FilterAccordion
+      filterItems={FilterDiscoveries}
+      filterNames={filterNames}
+      filterOrder={filterOrder}
+      filterString={searchText}
+      getValue={getDiscoveryValue}
+      items={discoveries}
+      onUpdateFilterString={setSearchText}
+    />
+  );
+};
+
+export default DiscoveriesFilterAccordion;

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/index.ts
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DiscoveriesFilterAccordion";

--- a/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/ui/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
 import {
+  Col,
   ContextualMenu,
   MainTable,
   Tooltip,
   Icon,
+  Row,
   SearchBox,
   Spinner,
 } from "@canonical/react-components";
@@ -14,6 +16,8 @@ import { useSelector, useDispatch } from "react-redux";
 import type { Dispatch } from "redux";
 
 import DiscoveryAddForm from "../DiscoveryAddForm";
+
+import DiscoveriesFilterAccordion from "./DiscoveriesFilterAccordion";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
@@ -187,7 +191,7 @@ const DiscoveriesList = (): JSX.Element => {
     return <Spinner />;
   }
 
-  if (loaded && discoveries.length === 0) {
+  if (loaded && !searchString && discoveries.length === 0) {
     return <div data-test="no-discoveries">No new discoveries.</div>;
   }
 
@@ -220,10 +224,22 @@ const DiscoveriesList = (): JSX.Element => {
 
   return (
     <>
-      <SearchBox
-        data-test="discoveries-search"
-        onChange={(value: string) => setSearchString(value.toLowerCase())}
-      />
+      <Row>
+        <Col size={3}>
+          <DiscoveriesFilterAccordion
+            searchText={searchString}
+            setSearchText={setSearchString}
+          />
+        </Col>
+        <Col size={9}>
+          <SearchBox
+            data-test="discoveries-search"
+            externallyControlled
+            onChange={setSearchString}
+            value={searchString}
+          />
+        </Col>
+      </Row>
       <MainTable
         className="p-table--network-discoveries p-table-expanding--light"
         data-test="discoveries-table"
@@ -240,6 +256,7 @@ const DiscoveriesList = (): JSX.Element => {
           dispatch
         )}
         sortable
+        emptyStateMsg="No discoveries match the search criteria."
       />
     </>
   );

--- a/ui/src/app/store/discovery/selectors.test.ts
+++ b/ui/src/app/store/discovery/selectors.test.ts
@@ -103,14 +103,10 @@ describe("discovery selectors", () => {
     expect(results[1].mac_organization).toEqual("Foodies Inc.");
     expect(results[2].observer_hostname).toEqual("foot");
 
-    results = selectors.search(state, "3");
+    results = selectors.search(state, "hostname:bar");
     expect(results.length).toEqual(2);
 
-    expect(results[0].mac_address).toEqual("00:16:3e:9c:bf:e9");
-    expect(results[1].ip).toEqual("3.3.3.3");
-
-    results = selectors.search(state, "sat");
-    expect(results.length).toEqual(1);
-    expect(results[0].last_seen).toEqual("Sat, 17 Oct. 2020 01:15:57");
+    expect(results[0].hostname).toEqual("bar");
+    expect(results[1].hostname).toEqual("foobar");
   });
 });

--- a/ui/src/app/store/discovery/selectors.ts
+++ b/ui/src/app/store/discovery/selectors.ts
@@ -1,19 +1,41 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 import { DiscoveryMeta } from "app/store/discovery/types";
 import type { Discovery, DiscoveryState } from "app/store/discovery/types";
+import { FilterDiscoveries } from "app/store/discovery/utils";
+import type { RootState } from "app/store/root/types";
 import { generateBaseSelectors } from "app/store/utils";
 
-const searchFunction = (discovery: Discovery, term: string) =>
-  discovery.hostname?.toLowerCase().includes(term) ||
-  discovery.mac_address?.toLowerCase().includes(term) ||
-  discovery.mac_organization?.toLowerCase().includes(term) ||
-  discovery.ip?.toLowerCase().includes(term) ||
-  discovery.observer_hostname?.toLowerCase().includes(term) ||
-  discovery.last_seen.toLowerCase().includes(term);
-
-const selectors = generateBaseSelectors<
+const defaultSelectors = generateBaseSelectors<
   DiscoveryState,
   Discovery,
   DiscoveryMeta.PK
->(DiscoveryMeta.MODEL, DiscoveryMeta.PK, searchFunction);
+>(DiscoveryMeta.MODEL, DiscoveryMeta.PK);
+
+/**
+ * Get discoveries using the MAAS search syntax.
+ * @param state - The redux state.
+ * @param filters - The filters to match against.
+ * @returns A filtered list of discoveries.
+ */
+const search = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, filters: string | null) => ({
+      filters,
+    }),
+  ],
+  (items: Discovery[], { filters }) => {
+    if (!filters) {
+      return items;
+    }
+    return FilterDiscoveries.filterItems(items, filters);
+  }
+);
+
+const selectors = {
+  ...defaultSelectors,
+  search,
+};
 
 export default selectors;

--- a/ui/src/app/store/discovery/utils/index.ts
+++ b/ui/src/app/store/discovery/utils/index.ts
@@ -1,0 +1,1 @@
+export { FilterDiscoveries, getDiscoveryValue } from "./search";

--- a/ui/src/app/store/discovery/utils/search.test.ts
+++ b/ui/src/app/store/discovery/utils/search.test.ts
@@ -1,0 +1,12 @@
+import { getDiscoveryValue } from "./search";
+
+import { discovery as discoveryFactory } from "testing/factories";
+
+describe("search", () => {
+  describe("getDiscoveryValue", () => {
+    it("can get an attribute directly from the discovery", () => {
+      const discovery = discoveryFactory({ id: 808 });
+      expect(getDiscoveryValue(discovery, "id")).toBe(808);
+    });
+  });
+});

--- a/ui/src/app/store/discovery/utils/search.ts
+++ b/ui/src/app/store/discovery/utils/search.ts
@@ -1,0 +1,28 @@
+import { DiscoveryMeta } from "app/store/discovery/types";
+import type { Discovery } from "app/store/discovery/types";
+import type { FilterValue } from "app/utils/search/filter-handlers";
+import {
+  isFilterValue,
+  isFilterValueArray,
+} from "app/utils/search/filter-handlers";
+import FilterItems from "app/utils/search/filter-items";
+
+export const getDiscoveryValue = (
+  dicovery: Discovery,
+  filter: string
+): FilterValue | FilterValue[] | null => {
+  let value: FilterValue | FilterValue[] | null = null;
+  if (dicovery.hasOwnProperty(filter)) {
+    const dicoveryValue = dicovery[filter as keyof Discovery];
+    // Only return values that are valid for filters.
+    if (isFilterValue(dicoveryValue) || isFilterValueArray(dicoveryValue)) {
+      value = dicoveryValue;
+    }
+  }
+  return value;
+};
+
+export const FilterDiscoveries = new FilterItems<Discovery, DiscoveryMeta.PK>(
+  DiscoveryMeta.PK,
+  getDiscoveryValue
+);

--- a/ui/src/app/utils/search/filter-items.ts
+++ b/ui/src/app/utils/search/filter-items.ts
@@ -132,7 +132,11 @@ export default class FilterItems<I, PK extends keyof I> extends FilterHandlers {
       return matched && !exclude;
     });
 
-  filterItems = (nodes: I[], search: string, selectedIDs: I[PK][]): I[] => {
+  filterItems = (
+    nodes: I[],
+    search: string,
+    selectedIDs: I[PK][] = []
+  ): I[] => {
     let filteredItems = nodes;
     if (
       typeof nodes === "undefined" ||


### PR DESCRIPTION
## Done

- Add a dropdown to filter discoveries on the dashboard.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/dashboard.
- Use the filter dropdown to change some filters.
- You should see the filters appear in the search box and the list should update.

## Fixes

Fixes: canonical-web-and-design/app-squad#68.