### PR TITLE
feat(ui): admin only dashboard

### DIFF
--- a/ui/src/app/dashboard/views/Dashboard.tsx
+++ b/ui/src/app/dashboard/views/Dashboard.tsx
@@ -9,10 +9,17 @@ import DiscoveriesList from "./DiscoveriesList";
 import Section from "app/base/components/Section";
 import NotFound from "app/base/views/NotFound";
 import dashboardURLs from "app/dashboard/urls";
+import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
 
 const Dashboard = (): JSX.Element => {
   const networkDiscovery = useSelector(configSelectors.networkDiscovery);
+  const isAdmin = useSelector(authSelectors.isAdmin);
+
+  if (!isAdmin) {
+    return <Section header="You do not have permission to view this page." />;
+  }
+
   return (
     <Section
       header={<DashboardHeader />}


### PR DESCRIPTION
## Done

- Limit the dashboard to admins only.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit /r/dashboard as an admin. It should load as normal.
- Visit /r/dashboard as a non admin. It should show a message.

## Fixes

Fixes: canonical-web-and-design/app-squad#147.