### PR TITLE
feat(ui) build fetched images table

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -197,13 +197,13 @@ exports[`stricter compilation`] = {
     "src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx:2262769286": [
       [113, 14, 11, "Argument of type \'\\"onConfirm\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "1296914934"]
     ],
-    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx:847758825": [
-      [43, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [44, 6, 20, "Argument of type \'{ keyring_data: string; keyring_filename: string; source_type: BootResourceSourceType; url: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'keyring_data\' does not exist in type \'FormEvent<{}>\'.", "1659605093"]
+    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx:2868343010": [
+      [42, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [43, 6, 20, "Argument of type \'{ keyring_data: string; keyring_filename: string; source_type: BootResourceSourceType; url: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'keyring_data\' does not exist in type \'FormEvent<{}>\'.", "1659605093"]
     ],
-    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx:2071988326": [
-      [82, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [83, 6, 256, "Argument of type \'{ images: { arch: string; os: string; release: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2870584855"]
+    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx:4236409862": [
+      [78, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [79, 6, 256, "Argument of type \'{ images: { arch: string; os: string; release: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2870584855"]
     ],
     "src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx:3963240424": [
       [91, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],

--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,8 +1,8 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
-    "src/app/App.tsx:1290662123": [
-      [190, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
+    "src/app/App.tsx:73777883": [
+      [191, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
     "src/app/base/components/ActionForm/ActionForm.test.tsx:1651560738": [
       [64, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -197,17 +197,21 @@ exports[`stricter compilation`] = {
     "src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx:2262769286": [
       [113, 14, 11, "Argument of type \'\\"onConfirm\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "1296914934"]
     ],
-    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx:379753697": [
-      [30, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [31, 6, 20, "Argument of type \'{ keyring_data: string; keyring_filename: string; source_type: BootResourceSourceType; url: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'keyring_data\' does not exist in type \'FormEvent<{}>\'.", "1659605093"]
+    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx:847758825": [
+      [43, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [44, 6, 20, "Argument of type \'{ keyring_data: string; keyring_filename: string; source_type: BootResourceSourceType; url: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'keyring_data\' does not exist in type \'FormEvent<{}>\'.", "1659605093"]
+    ],
+    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx:2071988326": [
+      [82, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [83, 6, 256, "Argument of type \'{ images: { arch: string; os: string; release: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2870584855"]
     ],
     "src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx:3963240424": [
       [91, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [92, 6, 148, "Argument of type \'{ images: { arch: string; os: string; release: string; subArch: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "623822400"]
     ],
-    "src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx:2597965359": [
-      [96, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [97, 6, 256, "Argument of type \'{ images: { arch: string; os: string; release: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2870584855"]
+    "src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx:1265148531": [
+      [104, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [105, 6, 256, "Argument of type \'{ images: { arch: string; os: string; release: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2870584855"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:934008644": [
       [143, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],

--- a/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 
 import type { ImageValue } from "app/images/types";
 import type {
+  BaseImageFields,
   BootResourceUbuntuArch,
   BootResourceUbuntuRelease,
 } from "app/store/bootresource/types";
@@ -11,7 +12,7 @@ import configSelectors from "app/store/config/selectors";
 
 type Props = {
   arches: BootResourceUbuntuArch[];
-  release: BootResourceUbuntuRelease | null;
+  release: BootResourceUbuntuRelease | BaseImageFields | null;
 };
 
 const ArchSelect = ({ arches, release }: Props): JSX.Element => {
@@ -45,6 +46,7 @@ const ArchSelect = ({ arches, release }: Props): JSX.Element => {
     );
 
   const archUnsupported = (arch: BootResourceUbuntuArch) =>
+    "unsupported_arches" in release &&
     release.unsupported_arches.includes(arch.name);
 
   const isLastCommissioningArch = (arch: BootResourceUbuntuArch) => {

--- a/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.tsx
@@ -1,10 +1,13 @@
 import { Col, Input, Row } from "@canonical/react-components";
 
-import type { BootResourceUbuntuRelease } from "app/store/bootresource/types";
+import type {
+  BaseImageFields,
+  BootResourceUbuntuRelease,
+} from "app/store/bootresource/types";
 import { simpleSortByKey } from "app/utils";
 
 type Props = {
-  releases: BootResourceUbuntuRelease[];
+  releases: (BootResourceUbuntuRelease | BaseImageFields)[];
   selectedRelease: BootResourceUbuntuRelease["name"];
   setSelectedRelease: (release: BootResourceUbuntuRelease["name"]) => void;
 };
@@ -14,9 +17,7 @@ const ReleaseSelect = ({
   selectedRelease,
   setSelectedRelease,
 }: Props): JSX.Element => {
-  const [ltsReleases, nonLtsReleases] = releases.reduce<
-    BootResourceUbuntuRelease[][]
-  >(
+  const [ltsReleases, nonLtsReleases] = releases.reduce<Props["releases"][]>(
     ([lts, nonLts], release, i) => {
       if (release.title.includes("LTS")) {
         lts.push(release);

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
@@ -24,7 +24,7 @@ describe("UbuntuImageSelect", () => {
         items: [
           configFactory({
             name: "commissioning_distro_series",
-            value: "bionic",
+            value: "focal",
           }),
         ],
         loaded: true,

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import { useSelector } from "react-redux";
 
 import ArchSelect from "./ArchSelect";
 import ReleaseSelect from "./ReleaseSelect";
@@ -9,14 +10,16 @@ import ReleaseSelect from "./ReleaseSelect";
 import ImagesTable from "app/images/components/ImagesTable";
 import type { ImageValue } from "app/images/types";
 import type {
+  BaseImageFields,
   BootResource,
   BootResourceUbuntuArch,
   BootResourceUbuntuRelease,
 } from "app/store/bootresource/types";
+import configSelectors from "app/store/config/selectors";
 
 type Props = {
   arches: BootResourceUbuntuArch[];
-  releases: BootResourceUbuntuRelease[];
+  releases: (BootResourceUbuntuRelease | BaseImageFields)[];
   resources: BootResource[];
 };
 
@@ -25,8 +28,12 @@ const UbuntuImageSelect = ({
   releases,
   resources,
 }: Props): JSX.Element => {
-  const [selectedRelease, setSelectedRelease] =
-    useState<BootResourceUbuntuRelease["name"]>("focal");
+  const commissioningReleaseName = useSelector(
+    configSelectors.commissioningDistroSeries
+  );
+  const [selectedRelease, setSelectedRelease] = useState<
+    BootResourceUbuntuRelease["name"]
+  >(commissioningReleaseName || "");
   const { values } = useFormikContext<{ images: ImageValue[] }>();
   const { images } = values;
   const availableArches = arches.filter((arch) => !arch.deleted);

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
@@ -19,6 +19,10 @@ import configSelectors from "app/store/config/selectors";
 
 type Props = {
   arches: BootResourceUbuntuArch[];
+  // The api returns a different release object depending on whether it was
+  // synced or fetched. Fetched releases don't include unsupported_arches so we
+  // need to handle both types.
+  // https://bugs.launchpad.net/maas/+bug/1934610
   releases: (BootResourceUbuntuRelease | BaseImageFields)[];
   resources: BootResource[];
 };

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import { Card } from "@canonical/react-components";
+
 import FetchImagesForm from "./FetchImagesForm";
 import FetchedImages from "./FetchedImages";
 
@@ -11,24 +13,15 @@ type Props = {
 
 const ChangeSource = ({ closeForm }: Props): JSX.Element => {
   const [source, setSource] = useState<BootResourceUbuntuSource | null>(null);
-  const [showTable, setShowTable] = useState(false);
 
-  if (source && showTable) {
-    return (
-      <FetchedImages
-        closeForm={closeForm}
-        closeTable={() => setShowTable(false)}
-        source={source}
-      />
-    );
-  }
   return (
-    <FetchImagesForm
-      closeForm={closeForm}
-      openTable={() => setShowTable(true)}
-      setSource={setSource}
-      source={source}
-    />
+    <Card highlighted>
+      {source ? (
+        <FetchedImages closeForm={closeForm} source={source} />
+      ) : (
+        <FetchImagesForm closeForm={closeForm} setSource={setSource} />
+      )}
+    </Card>
   );
 };
 

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
@@ -6,20 +6,26 @@ import FetchedImages from "./FetchedImages";
 import type { BootResourceUbuntuSource } from "app/store/bootresource/types";
 
 type Props = {
-  onCancel: (() => void) | null;
+  closeForm: () => void;
 };
 
-const ChangeSource = ({ onCancel }: Props): JSX.Element => {
+const ChangeSource = ({ closeForm }: Props): JSX.Element => {
   const [source, setSource] = useState<BootResourceUbuntuSource | null>(null);
   const [showTable, setShowTable] = useState(false);
 
   if (source && showTable) {
-    return <FetchedImages setShowTable={setShowTable} source={source} />;
+    return (
+      <FetchedImages
+        closeForm={closeForm}
+        closeTable={() => setShowTable(false)}
+        source={source}
+      />
+    );
   }
   return (
     <FetchImagesForm
-      onCancel={onCancel}
-      setShowTable={setShowTable}
+      closeForm={closeForm}
+      openTable={() => setShowTable(true)}
       setSource={setSource}
       source={source}
     />

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
@@ -33,12 +33,7 @@ describe("FetchImagesForm", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FetchImagesForm
-          closeForm={jest.fn()}
-          openTable={jest.fn()}
-          setSource={jest.fn()}
-          source={null}
-        />
+        <FetchImagesForm closeForm={jest.fn()} setSource={jest.fn()} />
       </Provider>
     );
     wrapper.find("Formik").invoke("onSubmit")({
@@ -62,13 +57,13 @@ describe("FetchImagesForm", () => {
     ).toStrictEqual(expectedAction);
   });
 
-  it("opens table if images successfuly fetched from source", () => {
+  it("sets source if images successfuly fetched", () => {
     // Mock the transition from "saving" to "saved"
     jest
       .spyOn(reactComponentHooks, "usePrevious")
       .mockReturnValueOnce(false)
       .mockReturnValue(true);
-    const openTable = jest.fn();
+    const setSource = jest.fn();
     const state = rootStateFactory({
       bootresource: bootResourceStateFactory({
         eventErrors: [],
@@ -78,18 +73,13 @@ describe("FetchImagesForm", () => {
     const store = mockStore(state);
     const Proxy = () => (
       <Provider store={store}>
-        <FetchImagesForm
-          closeForm={jest.fn()}
-          openTable={openTable}
-          setSource={jest.fn()}
-          source={null}
-        />
+        <FetchImagesForm closeForm={jest.fn()} setSource={setSource} />
       </Provider>
     );
     const wrapper = mount(<Proxy />);
     // Force the component to rerender to simulate the saved value changing.
     wrapper.setProps({});
 
-    expect(openTable).toHaveBeenCalled();
+    expect(setSource).toHaveBeenCalled();
   });
 });

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
@@ -20,14 +20,22 @@ jest.mock("@canonical/react-components/dist/hooks", () => ({
 }));
 
 describe("FetchImagesForm", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it("can dispatch an action to fetch images", () => {
     const state = rootStateFactory();
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
         <FetchImagesForm
-          onCancel={jest.fn()}
-          setShowTable={jest.fn()}
+          closeForm={jest.fn()}
+          openTable={jest.fn()}
           setSource={jest.fn()}
           source={null}
         />
@@ -54,13 +62,13 @@ describe("FetchImagesForm", () => {
     ).toStrictEqual(expectedAction);
   });
 
-  it("runs sets showTable to true if images successfuly fetched from source", () => {
+  it("opens table if images successfuly fetched from source", () => {
     // Mock the transition from "saving" to "saved"
     jest
       .spyOn(reactComponentHooks, "usePrevious")
       .mockReturnValueOnce(false)
       .mockReturnValue(true);
-    const setShowTable = jest.fn();
+    const openTable = jest.fn();
     const state = rootStateFactory({
       bootresource: bootResourceStateFactory({
         eventErrors: [],
@@ -71,8 +79,8 @@ describe("FetchImagesForm", () => {
     const Proxy = () => (
       <Provider store={store}>
         <FetchImagesForm
-          onCancel={jest.fn()}
-          setShowTable={setShowTable}
+          closeForm={jest.fn()}
+          openTable={openTable}
           setSource={jest.fn()}
           source={null}
         />
@@ -82,6 +90,6 @@ describe("FetchImagesForm", () => {
     // Force the component to rerender to simulate the saved value changing.
     wrapper.setProps({});
 
-    expect(setShowTable).toHaveBeenCalledWith(true);
+    expect(openTable).toHaveBeenCalled();
   });
 });

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.tsx
@@ -33,26 +33,28 @@ export type FetchImagesValues = {
 };
 
 type Props = {
-  onCancel: (() => void) | null;
-  setShowTable: (show: boolean) => void;
+  closeForm: () => void;
+  openTable: () => void;
   setSource: (source: BootResourceUbuntuSource) => void;
   source: BootResourceUbuntuSource | null;
 };
 
 const FetchImagesForm = ({
-  onCancel,
-  setShowTable,
+  closeForm,
+  openTable,
   setSource,
   source,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const errors = useSelector(bootResourceSelectors.fetchError);
   const saving = useSelector(bootResourceSelectors.fetching);
+  const ubuntu = useSelector(bootResourceSelectors.ubuntu);
   const previousSaving = usePrevious(saving);
   const cleanup = useCallback(() => bootResourceActions.cleanup(), []);
   // Consider the connection established if fetching was started, then stopped
   // without any errors.
   const saved = !saving && previousSaving && !errors;
+  const hasSources = ubuntu?.sources.length;
 
   return (
     <FormikForm<FetchImagesValues>
@@ -65,13 +67,13 @@ const FetchImagesForm = ({
         source_type: source?.source_type || BootResourceSourceType.MAAS_IO,
         url: source?.url || "",
       }}
-      onCancel={onCancel}
+      onCancel={hasSources ? closeForm : null}
       onSubmit={(values) => {
         setSource(values);
         dispatch(cleanup());
         dispatch(bootResourceActions.fetch(values));
       }}
-      onSuccess={() => setShowTable(true)}
+      onSuccess={openTable}
       saved={saved}
       saving={saving}
       submitLabel="Connect"

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.tsx
@@ -34,17 +34,10 @@ export type FetchImagesValues = {
 
 type Props = {
   closeForm: () => void;
-  openTable: () => void;
   setSource: (source: BootResourceUbuntuSource) => void;
-  source: BootResourceUbuntuSource | null;
 };
 
-const FetchImagesForm = ({
-  closeForm,
-  openTable,
-  setSource,
-  source,
-}: Props): JSX.Element => {
+const FetchImagesForm = ({ closeForm, setSource }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const errors = useSelector(bootResourceSelectors.fetchError);
   const saving = useSelector(bootResourceSelectors.fetching);
@@ -62,18 +55,19 @@ const FetchImagesForm = ({
       cleanup={cleanup}
       errors={errors as FormErrors}
       initialValues={{
-        keyring_data: source?.keyring_data || "",
-        keyring_filename: source?.keyring_filename || "",
-        source_type: source?.source_type || BootResourceSourceType.MAAS_IO,
-        url: source?.url || "",
+        keyring_data: "",
+        keyring_filename: "",
+        source_type: BootResourceSourceType.MAAS_IO,
+        url: "",
       }}
       onCancel={hasSources ? closeForm : null}
       onSubmit={(values) => {
-        setSource(values);
         dispatch(cleanup());
         dispatch(bootResourceActions.fetch(values));
       }}
-      onSuccess={openTable}
+      onSuccess={(values) => {
+        setSource(values);
+      }}
       saved={saved}
       saving={saving}
       submitLabel="Connect"

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -1,0 +1,145 @@
+import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import FetchedImages from "./FetchedImages";
+
+import { actions as bootResourceActions } from "app/store/bootresource";
+import { BootResourceSourceType } from "app/store/bootresource/types";
+import type { RootState } from "app/store/root/types";
+import {
+  bootResourceFetchedArch as fetchedArchFactory,
+  bootResourceFetchedImages as fetchedImagesFactory,
+  bootResourceFetchedRelease as fetchedReleaseFactory,
+  bootResourceState as bootResourceStateFactory,
+  bootResourceUbuntuSource as sourceFactory,
+  config as configFactory,
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+jest.mock("@canonical/react-components/dist/hooks", () => ({
+  usePrevious: jest.fn(),
+}));
+
+const mockStore = configureStore();
+
+describe("FetchedImages", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: "commissioning_distro_series",
+            value: "focal",
+          }),
+        ],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("can dispatch an action to save fetched ubuntu images", () => {
+    const source = sourceFactory({
+      keyring_data: "abcde",
+      keyring_filename: "/path/to/file",
+      source_type: BootResourceSourceType.CUSTOM,
+      url: "www.url.com",
+    });
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        fetchedImages: fetchedImagesFactory({
+          arches: [fetchedArchFactory()],
+          releases: [fetchedReleaseFactory()],
+        }),
+      }),
+    });
+    state.bootresource = bootResourceStateFactory({
+      fetchedImages: fetchedImagesFactory({
+        arches: [fetchedArchFactory()],
+        releases: [fetchedReleaseFactory()],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <FetchedImages
+          closeForm={jest.fn()}
+          closeTable={jest.fn()}
+          source={source}
+        />
+      </Provider>
+    );
+    wrapper.find("Formik").invoke("onSubmit")({
+      images: [
+        { arch: "amd64", os: "ubuntu", release: "xenial", title: "16.04 LTS" },
+        { arch: "amd64", os: "ubuntu", release: "bionic", title: "18.04 LTS" },
+        { arch: "i386", os: "ubuntu", release: "xenial", title: "16.04 LTS" },
+      ],
+    });
+
+    const expectedAction = bootResourceActions.saveUbuntu({
+      keyring_data: "abcde",
+      keyring_filename: "/path/to/file",
+      osystems: [
+        {
+          arches: ["amd64", "i386"],
+          osystem: "ubuntu",
+          release: "xenial",
+        },
+        {
+          arches: ["amd64"],
+          osystem: "ubuntu",
+          release: "bionic",
+        },
+      ],
+      source_type: BootResourceSourceType.CUSTOM,
+      url: "www.url.com",
+    });
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+
+  it("closes the fetched images form when successfully saved", () => {
+    // Mock the transition from "saving" to "saved"
+    jest
+      .spyOn(reactComponentHooks, "usePrevious")
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+    const source = sourceFactory();
+    const closeForm = jest.fn();
+    state.bootresource = bootResourceStateFactory({
+      fetchedImages: fetchedImagesFactory({
+        arches: [fetchedArchFactory()],
+        releases: [fetchedReleaseFactory()],
+      }),
+    });
+    const store = mockStore(state);
+    const Proxy = () => (
+      <Provider store={store}>
+        <FetchedImages
+          closeForm={closeForm}
+          closeTable={jest.fn()}
+          source={source}
+        />
+      </Provider>
+    );
+    const wrapper = mount(<Proxy />);
+    // Force the component to rerender to simulate the saved value changing.
+    wrapper.setProps({});
+
+    expect(closeForm).toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -73,11 +73,7 @@ describe("FetchedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <FetchedImages
-          closeForm={jest.fn()}
-          closeTable={jest.fn()}
-          source={source}
-        />
+        <FetchedImages closeForm={jest.fn()} source={source} />
       </Provider>
     );
     wrapper.find("Formik").invoke("onSubmit")({
@@ -129,11 +125,7 @@ describe("FetchedImages", () => {
     const store = mockStore(state);
     const Proxy = () => (
       <Provider store={store}>
-        <FetchedImages
-          closeForm={closeForm}
-          closeTable={jest.fn()}
-          source={source}
-        />
+        <FetchedImages closeForm={closeForm} source={source} />
       </Provider>
     );
     const wrapper = mount(<Proxy />);

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from "react";
 
-import { Strip } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
@@ -38,15 +37,10 @@ export type FetchedImagesValues = {
 
 type Props = {
   closeForm: () => void;
-  closeTable: () => void;
   source: BootResourceUbuntuSource;
 };
 
-const FetchedImages = ({
-  closeForm,
-  closeTable,
-  source,
-}: Props): JSX.Element | null => {
+const FetchedImages = ({ closeForm, source }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
   const commissioningReleaseName = useSelector(
     configSelectors.commissioningDistroSeries
@@ -73,7 +67,7 @@ const FetchedImages = ({
     !fetchedImages.arches.length ||
     !fetchedImages.releases.length
   ) {
-    closeTable();
+    closeForm();
     return null;
   }
 
@@ -89,64 +83,61 @@ const FetchedImages = ({
         Showing images fetched from <strong>{source.url || "maas.io"}</strong>
       </h4>
       <hr />
-      <Strip shallow>
-        <FormikForm<FetchedImagesValues>
-          allowUnchanged
-          buttonsBordered={false}
-          cleanup={cleanup}
-          enableReinitialize
-          errors={error}
-          initialValues={{
-            images: [
-              {
-                arch: defaultArch?.name || arches[0].name,
-                release: commissioningRelease?.name || releases[0].name,
-                os: "ubuntu",
-                title: commissioningRelease?.title || releases[0].title,
-              },
-            ],
-          }}
-          onCancel={closeTable}
-          onSubmit={(values) => {
-            dispatch(cleanup());
-            const osystems = values.images.reduce<OsystemParam[]>(
-              (osystems, image) => {
-                const existingOsystem = osystems.find(
-                  (os) =>
-                    os.osystem === image.os && os.release === image.release
-                );
-                if (existingOsystem) {
-                  existingOsystem.arches.push(image.arch);
-                } else {
-                  osystems.push({
-                    arches: [image.arch],
-                    osystem: image.os,
-                    release: image.release,
-                  });
-                }
-                return osystems;
-              },
-              []
-            );
-            const params = {
-              osystems,
-              ...source,
-            };
-            dispatch(bootResourceActions.saveUbuntu(params));
-          }}
-          onSuccess={closeForm}
-          saved={saved}
-          saving={saving}
-          submitLabel="Update selection"
-          validationSchema={FetchedImagesSchema}
-        >
-          <UbuntuImageSelect
-            arches={arches}
-            releases={releases}
-            resources={resources}
-          />
-        </FormikForm>
-      </Strip>
+      <FormikForm<FetchedImagesValues>
+        allowUnchanged
+        buttonsBordered={false}
+        cleanup={cleanup}
+        enableReinitialize
+        errors={error}
+        initialValues={{
+          images: [
+            {
+              arch: defaultArch?.name || arches[0].name,
+              release: commissioningRelease?.name || releases[0].name,
+              os: "ubuntu",
+              title: commissioningRelease?.title || releases[0].title,
+            },
+          ],
+        }}
+        onCancel={closeForm}
+        onSubmit={(values) => {
+          dispatch(cleanup());
+          const osystems = values.images.reduce<OsystemParam[]>(
+            (osystems, image) => {
+              const existingOsystem = osystems.find(
+                (os) => os.osystem === image.os && os.release === image.release
+              );
+              if (existingOsystem) {
+                existingOsystem.arches.push(image.arch);
+              } else {
+                osystems.push({
+                  arches: [image.arch],
+                  osystem: image.os,
+                  release: image.release,
+                });
+              }
+              return osystems;
+            },
+            []
+          );
+          const params = {
+            osystems,
+            ...source,
+          };
+          dispatch(bootResourceActions.saveUbuntu(params));
+        }}
+        onSuccess={closeForm}
+        saved={saved}
+        saving={saving}
+        submitLabel="Update selection"
+        validationSchema={FetchedImagesSchema}
+      >
+        <UbuntuImageSelect
+          arches={arches}
+          releases={releases}
+          resources={resources}
+        />
+      </FormikForm>
     </>
   );
 };

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -6,6 +6,7 @@ import SyncedImages from "./SyncedImages";
 
 import { BootResourceSourceType } from "app/store/bootresource/types";
 import {
+  bootResource as bootResourceFactory,
   bootResourceState as bootResourceStateFactory,
   bootResourceUbuntuSource as sourceFactory,
   bootResourceUbuntu as ubuntuFactory,
@@ -90,5 +91,26 @@ describe("SyncedImages", () => {
     expect(wrapper.find("[data-test='image-sync-text']").text()).toBe(
       "Showing images synced from sources"
     );
+  });
+
+  it("disables the button to change source if resources are downloading", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [bootResourceFactory({ downloading: true })],
+        ubuntu: ubuntuFactory({ sources: [sourceFactory()] }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SyncedImages />
+      </Provider>
+    );
+    expect(
+      wrapper.find("button[data-test='change-source-button']").prop("disabled")
+    ).toBe(true);
+    expect(
+      wrapper.find("[data-test='change-source-button'] Tooltip").prop("message")
+    ).toBe("Cannot change source while images are downloading.");
   });
 });

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 
-import { Button, Col, Row, Strip } from "@canonical/react-components";
+import {
+  Button,
+  Col,
+  Icon,
+  Row,
+  Strip,
+  Tooltip,
+} from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import ChangeSource from "./ChangeSource";
@@ -24,6 +31,7 @@ const getImageSyncText = (sources: BootResourceUbuntuSource[]) => {
 
 const SyncedImages = (): JSX.Element | null => {
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
+  const resources = useSelector(bootResourceSelectors.resources);
   const sources = ubuntu?.sources || [];
   const hasSources = sources.length !== 0;
   const [showChangeSource, setShowChangeSource] = useState(!hasSources);
@@ -32,14 +40,13 @@ const SyncedImages = (): JSX.Element | null => {
     return null;
   }
 
+  const canChangeSource = resources.every((resource) => !resource.downloading);
   return (
     <Strip shallow>
       <Row>
         <Col size="12">
           {showChangeSource ? (
-            <ChangeSource
-              onCancel={hasSources ? () => setShowChangeSource(false) : null}
-            />
+            <ChangeSource closeForm={() => setShowChangeSource(false)} />
           ) : (
             <>
               <div className="u-flex--between">
@@ -49,16 +56,27 @@ const SyncedImages = (): JSX.Element | null => {
                 </h4>
                 <Button
                   appearance="neutral"
+                  data-test="change-source-button"
+                  disabled={!canChangeSource}
                   onClick={() => setShowChangeSource(true)}
                 >
                   Change source
+                  {!canChangeSource && (
+                    <Tooltip
+                      message="Cannot change source while images are downloading."
+                      className="u-nudge-right--small"
+                      position="top-right"
+                    >
+                      <Icon name="information" />
+                    </Tooltip>
+                  )}
                 </Button>
               </div>
               <p>
                 Select images to be imported and kept in sync daily. Images will
                 be available for deploying to machines managed by MAAS.
               </p>
-              <UbuntuImages />
+              <UbuntuImages sources={sources} />
               <OtherImages />
             </>
           )}

--- a/ui/src/app/store/bootresource/types/actions.ts
+++ b/ui/src/app/store/bootresource/types/actions.ts
@@ -1,11 +1,16 @@
-import type { BootResource, BootResourceUbuntuSource } from "./base";
+import type { BootResource } from "./base";
 import type { BootResourceSourceType } from "./enum";
 
 export type DeleteImageParams = {
   id: BootResource["id"];
 };
 
-export type FetchParams = BootResourceUbuntuSource;
+export type FetchParams = {
+  keyring_data?: string;
+  keyring_filename?: string;
+  source_type: BootResourceSourceType;
+  url?: string;
+};
 
 export type OsystemParam = {
   osystem: string;
@@ -22,6 +27,9 @@ export type SaveUbuntuCoreParams = {
 };
 
 export type SaveUbuntuParams = {
+  keyring_data?: string;
+  keyring_filename?: string;
   osystems: OsystemParam[];
   source_type: BootResourceSourceType;
+  url?: string;
 };

--- a/ui/src/app/store/bootresource/types/index.ts
+++ b/ui/src/app/store/bootresource/types/index.ts
@@ -7,6 +7,7 @@ export type {
   SaveUbuntuParams,
 } from "./actions";
 export type {
+  BaseImageFields,
   BootResource,
   BootResourceEventError,
   BootResourceFetchedArch,


### PR DESCRIPTION
## Done

- Built FetchedImages table which is used to sync images with a different source

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images and click "Change source"
- Use a source type that's different to the current selection and click "Connect"
- Check that an image selection table shows
- Select an image and click "Update selection"
- It might take a while but eventually you should get taken back to the main image list, and the header should say "Syncing images from {the source URL you chose}"
- Wait until images start downloading and check that the "Change source" button becomes disabled
- Click "Stop import".
- It might take a while but eventually downloading will stop, then check that the "Change source" button becomes enabled again.

## Fixes

Fixes canonical-web-and-design/app-squad#141