### PR TITLE
feat(ui): build ubuntu core images table

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -197,9 +197,9 @@ exports[`stricter compilation`] = {
     "src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx:2262769286": [
       [113, 14, 11, "Argument of type \'\\"onConfirm\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "1296914934"]
     ],
-    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx:2868343010": [
-      [42, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
-      [43, 6, 20, "Argument of type \'{ keyring_data: string; keyring_filename: string; source_type: BootResourceSourceType; url: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'keyring_data\' does not exist in type \'FormEvent<{}>\'.", "1659605093"]
+    "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx:4202811810": [
+      [38, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [39, 6, 20, "Argument of type \'{ keyring_data: string; keyring_filename: string; source_type: BootResourceSourceType; url: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'keyring_data\' does not exist in type \'FormEvent<{}>\'.", "1659605093"]
     ],
     "src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx:4236409862": [
       [78, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
@@ -208,6 +208,10 @@ exports[`stricter compilation`] = {
     "src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx:3963240424": [
       [91, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [92, 6, 148, "Argument of type \'{ images: { arch: string; os: string; release: string; subArch: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "623822400"]
+    ],
+    "src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx:1653668288": [
+      [91, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [92, 6, 182, "Argument of type \'{ images: { arch: string; os: string; release: string; subArch: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2784236342"]
     ],
     "src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx:1265148531": [
       [104, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],

--- a/ui/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/ui/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -193,6 +193,7 @@ const ImagesTable = ({ images, resources }: Props): JSX.Element => {
       className="images-table p-table-expanding--light"
       defaultSort="title"
       defaultSortDirection="descending"
+      emptyStateMsg="No images have been selected."
       expanding
       headers={[
         { content: "Release", className: "release-col", sortKey: "title" },

--- a/ui/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.test.tsx
+++ b/ui/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.test.tsx
@@ -3,7 +3,7 @@ import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import OtherImagesSelect from "./OtherImagesSelect";
+import NonUbuntuImageSelect from "./NonUbuntuImageSelect";
 
 import type { RootState } from "app/store/root/types";
 import {
@@ -17,7 +17,7 @@ import {
 
 const mockStore = configureStore();
 
-describe("OtherImagesSelect", () => {
+describe("NonUbuntuImageSelect", () => {
   let state: RootState;
 
   beforeEach(() => {
@@ -65,7 +65,7 @@ describe("OtherImagesSelect", () => {
           }}
           onSubmit={jest.fn()}
         >
-          <OtherImagesSelect otherImages={otherImages} resources={resources} />
+          <NonUbuntuImageSelect images={otherImages} resources={resources} />
         </Formik>
       </Provider>
     );
@@ -74,7 +74,7 @@ describe("OtherImagesSelect", () => {
         .findWhere((n) => n.name() === "Input" && n.prop("id") === id)
         .prop("checked");
 
-    expect(imageChecked("other-image-centos/amd64/generic/centos7")).toBe(true);
-    expect(imageChecked("other-image-centos/amd64/generic/8")).toBe(false);
+    expect(imageChecked("image-centos/amd64/generic/centos7")).toBe(true);
+    expect(imageChecked("image-centos/amd64/generic/8")).toBe(false);
   });
 });

--- a/ui/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.tsx
+++ b/ui/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.tsx
@@ -1,26 +1,21 @@
 import { Col, Input, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
-import type { OtherImagesValues } from "../OtherImages";
-
 import ImagesTable from "app/images/components/ImagesTable";
 import type { ImageValue } from "app/images/types";
 import type {
+  BaseImageFields,
   BootResource,
-  BootResourceOtherImage,
 } from "app/store/bootresource/types";
 import { splitImageName } from "app/store/bootresource/utils";
 
 type Props = {
-  otherImages: BootResourceOtherImage[];
+  images: BaseImageFields[];
   resources: BootResource[];
 };
 
-const otherImageMatchesImageValue = (
-  otherImage: BootResourceOtherImage,
-  imageValue: ImageValue
-) => {
-  const { arch, os, release, subArch } = splitImageName(otherImage.name);
+const imageMatchesValue = (image: BaseImageFields, imageValue: ImageValue) => {
+  const { arch, os, release, subArch } = splitImageName(image.name);
   return (
     imageValue.arch === arch &&
     imageValue.os === os &&
@@ -29,32 +24,30 @@ const otherImageMatchesImageValue = (
   );
 };
 
-const OtherImagesSelect = ({
-  otherImages,
+const NonUbuntuImageSelect = ({
+  images,
   resources,
 }: Props): JSX.Element | null => {
-  const { setFieldValue, values } = useFormikContext<OtherImagesValues>();
-  const { images } = values;
+  const { setFieldValue, values } =
+    useFormikContext<{ images: ImageValue[] }>();
 
-  const isChecked = (otherImage: BootResourceOtherImage) =>
-    images.some((imageValue) =>
-      otherImageMatchesImageValue(otherImage, imageValue)
-    );
+  const isChecked = (image: BaseImageFields) =>
+    values.images.some((imageValue) => imageMatchesValue(image, imageValue));
 
-  const handleChange = (otherImage: BootResourceOtherImage) => {
+  const handleChange = (image: BaseImageFields) => {
     let newImageValues: ImageValue[] = [];
-    if (isChecked(otherImage)) {
-      newImageValues = images.filter(
-        (imageValue) => !otherImageMatchesImageValue(otherImage, imageValue)
+    if (isChecked(image)) {
+      newImageValues = values.images.filter(
+        (imageValue) => !imageMatchesValue(image, imageValue)
       );
     } else {
-      const { arch, os, release, subArch } = splitImageName(otherImage.name);
-      newImageValues = images.concat({
+      const { arch, os, release, subArch } = splitImageName(image.name);
+      newImageValues = values.images.concat({
         arch,
         os,
         release,
         subArch,
-        title: otherImage.title,
+        title: image.title,
       });
     }
     setFieldValue("images", newImageValues);
@@ -65,11 +58,11 @@ const OtherImagesSelect = ({
       <Row>
         <Col size="12">
           <ul className="p-list">
-            {otherImages.map((image, i) => (
+            {images.map((image, i) => (
               <li className="p-list__item u-sv1" key={`${image.name}-${i}`}>
                 <Input
                   checked={isChecked(image)}
-                  id={`other-image-${image.name}`}
+                  id={`image-${image.name}`}
                   label={image.title}
                   onChange={() => handleChange(image)}
                   type="checkbox"
@@ -79,9 +72,9 @@ const OtherImagesSelect = ({
           </ul>
         </Col>
       </Row>
-      <ImagesTable images={images} resources={resources} />
+      <ImagesTable images={values.images} resources={resources} />
     </>
   );
 };
 
-export default OtherImagesSelect;
+export default NonUbuntuImageSelect;

--- a/ui/src/app/images/components/NonUbuntuImageSelect/index.ts
+++ b/ui/src/app/images/components/NonUbuntuImageSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NonUbuntuImageSelect";

--- a/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImagesSelect/index.ts
+++ b/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImagesSelect/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./OtherImagesSelect";

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -12,6 +12,7 @@ import { useSelector } from "react-redux";
 
 import ChangeSource from "./ChangeSource";
 import OtherImages from "./OtherImages";
+import UbuntuCoreImages from "./UbuntuCoreImages";
 import UbuntuImages from "./UbuntuImages";
 
 import bootResourceSelectors from "app/store/bootresource/selectors";
@@ -77,6 +78,7 @@ const SyncedImages = (): JSX.Element | null => {
                 be available for deploying to machines managed by MAAS.
               </p>
               <UbuntuImages sources={sources} />
+              <UbuntuCoreImages />
               <OtherImages />
             </>
           )}

--- a/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
@@ -1,0 +1,160 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import UbuntuCoreImages from "./UbuntuCoreImages";
+
+import { actions as bootResourceActions } from "app/store/bootresource";
+import {
+  bootResource as bootResourceFactory,
+  bootResourceUbuntuCoreImage as ubuntuCoreImageFactory,
+  bootResourceState as bootResourceStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("UbuntuCoreImages", () => {
+  it("does not render if there is no Ubuntu core image data", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({ ubuntuCoreImages: [] }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UbuntuCoreImages />
+      </Provider>
+    );
+    expect(wrapper.find("ImagesTable").exists()).toBe(false);
+  });
+
+  it("correctly sets initial values based on resources", () => {
+    const ubuntuCoreImages = [
+      ubuntuCoreImageFactory({
+        name: "ubuntu-core/amd64/generic/20",
+        title: "Ubuntu Core 20",
+      }),
+    ];
+    const resources = [
+      bootResourceFactory({
+        name: "ubuntu-core/20",
+        arch: "amd64",
+        title: "Ubuntu Core 20",
+      }), // only this resource is an "Ubuntu core image"
+      bootResourceFactory({
+        name: "ubuntu/focal",
+        arch: "amd64",
+        title: "20.04 LTS",
+      }),
+      bootResourceFactory({
+        name: "centos/centos70",
+        arch: "amd64",
+        title: "CentOS 7",
+      }),
+    ];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources,
+        ubuntuCoreImages,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UbuntuCoreImages />
+      </Provider>
+    );
+    expect(wrapper.find("Formik").prop("initialValues")).toStrictEqual({
+      images: [
+        {
+          arch: "amd64",
+          os: "ubuntu-core",
+          release: "20",
+          subArch: "generic",
+          title: "Ubuntu Core 20",
+        },
+      ],
+    });
+  });
+
+  it("can dispatch an action to save Ubuntu core images", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        ubuntuCoreImages: [ubuntuCoreImageFactory()],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UbuntuCoreImages />
+      </Provider>
+    );
+    wrapper.find("Formik").invoke("onSubmit")({
+      images: [
+        {
+          arch: "amd64",
+          os: "ubuntu-core",
+          release: "20",
+          subArch: "generic",
+          title: "Ubuntu Core 20",
+        },
+      ],
+    });
+
+    const expectedAction = bootResourceActions.saveUbuntuCore({
+      images: ["ubuntu-core/amd64/generic/20"],
+    });
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+
+  it(`does not show a button to stop importing Ubuntu core images if none are
+    downloading`, () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [
+          bootResourceFactory({ downloading: true, name: "ubuntu/focal" }),
+          bootResourceFactory({ downloading: false, name: "ubuntu-core/20" }),
+        ],
+        ubuntuCoreImages: [ubuntuCoreImageFactory()],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UbuntuCoreImages />
+      </Provider>
+    );
+
+    expect(wrapper.find("button[data-test='secondary-submit']").exists()).toBe(
+      false
+    );
+  });
+
+  it(`can dispatch an action to stop importing Ubuntu core images if at least
+    one is downloading`, () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [
+          bootResourceFactory({ downloading: true, name: "ubuntu-core/20" }),
+        ],
+        ubuntuCoreImages: [ubuntuCoreImageFactory()],
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <UbuntuCoreImages />
+      </Provider>
+    );
+    wrapper.find("button[data-test='secondary-submit']").simulate("click");
+
+    const expectedAction = bootResourceActions.stopImport();
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.tsx
@@ -16,7 +16,7 @@ import {
   splitResourceName,
 } from "app/store/bootresource/utils";
 
-const OtherImagesSchema = Yup.object()
+const UbuntuCoreImagesSchema = Yup.object()
   .shape({
     images: Yup.array().of(
       Yup.object().shape({
@@ -30,37 +30,37 @@ const OtherImagesSchema = Yup.object()
   })
   .defined();
 
-export type OtherImagesValues = {
+export type UbuntuCoreImagesValues = {
   images: ImageValue[];
 };
 
-const OtherImages = (): JSX.Element | null => {
+const UbuntuCoreImages = (): JSX.Element | null => {
   const dispatch = useDispatch();
-  const otherImages = useSelector(bootResourceSelectors.otherImages);
-  const resources = useSelector(bootResourceSelectors.otherResources);
-  const saving = useSelector(bootResourceSelectors.savingOther);
+  const ubuntuCoreImages = useSelector(bootResourceSelectors.ubuntuCoreImages);
+  const resources = useSelector(bootResourceSelectors.ubuntuCoreResources);
+  const saving = useSelector(bootResourceSelectors.savingUbuntuCore);
   const previousSaving = usePrevious(saving);
   const eventErrors = useSelector(bootResourceSelectors.eventErrors);
   const error = eventErrors.find(
     (error) =>
-      error.event === BootResourceAction.SAVE_OTHER ||
+      error.event === BootResourceAction.SAVE_UBUNTU_CORE ||
       error.event === BootResourceAction.STOP_IMPORT
   )?.error;
   const stoppingImport = useSelector(bootResourceSelectors.stoppingImport);
   const cleanup = useCallback(() => bootResourceActions.cleanup(), []);
   const saved = previousSaving && !saving && !error;
 
-  if (otherImages.length === 0) {
+  if (ubuntuCoreImages.length === 0) {
     return null;
   }
 
   const initialImages = resources.reduce<ImageValue[]>((images, resource) => {
-    // Resources come in the form "<os-name>/<release>" e.g. "centos/centos70".
+    // Resources come in the form "<os-name>/<release>" e.g. "ubuntu-core/20".
     const { os: resourceOs, release: resourceRelease } = splitResourceName(
       resource.name
     );
-    // We check that the "other image" is known by the source(s).
-    const image = otherImages.find((image) => {
+    // We check that the ubuntu core image is known by the source(s).
+    const image = ubuntuCoreImages.find((image) => {
       const { os: imageOs, release: imageRelease } = splitImageName(image.name);
       return imageOs === resourceOs && imageRelease === resourceRelease;
     });
@@ -84,8 +84,8 @@ const OtherImages = (): JSX.Element | null => {
     <>
       <hr />
       <Strip shallow>
-        <h4>Other images</h4>
-        <FormikForm<OtherImagesValues>
+        <h4>Ubuntu Core images</h4>
+        <FormikForm<UbuntuCoreImagesValues>
           allowUnchanged
           buttonsBordered={false}
           cleanup={cleanup}
@@ -102,7 +102,7 @@ const OtherImages = (): JSX.Element | null => {
                   `${os}/${arch}/${subArch}/${release}`
               ),
             };
-            dispatch(bootResourceActions.saveOther(params));
+            dispatch(bootResourceActions.saveUbuntuCore(params));
           }}
           saved={saved}
           saving={saving || stoppingImport}
@@ -113,13 +113,16 @@ const OtherImages = (): JSX.Element | null => {
           }}
           secondarySubmitLabel={canStopImport ? "Stop import" : null}
           submitLabel="Update selection"
-          validationSchema={OtherImagesSchema}
+          validationSchema={UbuntuCoreImagesSchema}
         >
-          <NonUbuntuImageSelect images={otherImages} resources={resources} />
+          <NonUbuntuImageSelect
+            images={ubuntuCoreImages}
+            resources={resources}
+          />
         </FormikForm>
       </Strip>
     </>
   );
 };
 
-export default OtherImages;
+export default UbuntuCoreImages;

--- a/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/index.ts
+++ b/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UbuntuCoreImages";


### PR DESCRIPTION
## Done

- Made `OtherImagesSelect` work with both Other images and Ubuntu Core images
- Built UbuntuCoreImages component

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- We need to fake Ubuntu Core images being available from the configured source. Open `app/store/bootresource/selectors.ts` and make the following edits:
  - On line 12:
  ``` typescript
  import { bootResourceUbuntuCoreImage as imageFactory } from "testing/factories";
  ```
  - On line 228:
  ``` typescript
  const ubuntuCoreImages = (): BootResourceState["ubuntuCoreImages"] => [
    imageFactory({
      name: "ubuntu-core/amd64/generic/20",
      title: "Ubuntu Core 20",
    }),
  ];
  ```
- Go to /MAAS/r/images and check that there is an "Ubuntu Core images" section.
- Check that you can check and uncheck the checkbox and the table updates accordingly
- You can test that the correct action is dispatched when clicking "Update selection" but it will always fail since the image doesn't actually exist at the source

## Fixes

Fixes canonical-web-and-design/app-squad#84

## Screenshot
![2021-07-05_15-39](https://user-images.githubusercontent.com/25733845/124422782-3dbcea80-dda7-11eb-898f-d4dbe15e3d68.png)
