### PR TITLE
fix(ui): keep arch column and allow clearing selection in images table

### DIFF
--- a/ui/src/app/base/components/TableActions/TableActions.test.tsx
+++ b/ui/src/app/base/components/TableActions/TableActions.test.tsx
@@ -16,7 +16,7 @@ describe("TableActions ", () => {
   it("renders an edit button if edit on-click provided", () => {
     const onEdit = jest.fn();
     const wrapper = shallow(<TableActions onEdit={onEdit} />);
-    wrapper.find("Button").props().onClick();
+    wrapper.find("Button").simulate("click");
     expect(onEdit).toHaveBeenCalled();
     expect(wrapper.find("Button").prop("element")).toBe(undefined);
   });
@@ -38,8 +38,8 @@ describe("TableActions ", () => {
         onDelete={jest.fn()}
       />
     );
-    expect(wrapper.find("Tooltip").at(0).props().message).toBe("edit tooltip");
-    expect(wrapper.find("Tooltip").at(1).props().message).toBe(
+    expect(wrapper.find("Tooltip").at(0).prop("message")).toBe("edit tooltip");
+    expect(wrapper.find("Tooltip").at(1).prop("message")).toBe(
       "delete tooltip"
     );
   });

--- a/ui/src/app/base/components/TableActions/TableActions.tsx
+++ b/ui/src/app/base/components/TableActions/TableActions.tsx
@@ -1,19 +1,35 @@
 import { Button, Tooltip } from "@canonical/react-components";
 import { Link } from "react-router-dom";
-import PropTypes from "prop-types";
 
 import CopyButton from "app/base/components/CopyButton";
 
+type Props = {
+  clearDisabled?: boolean;
+  clearTooltip?: string | null;
+  copyValue?: string;
+  deleteDisabled?: boolean;
+  deleteTooltip?: string | null;
+  editDisabled?: boolean;
+  editPath?: string;
+  editTooltip?: string | null;
+  onClear?: () => void;
+  onDelete?: () => void;
+  onEdit?: () => void;
+};
+
 const TableActions = ({
+  clearDisabled,
+  clearTooltip,
   copyValue,
   deleteDisabled,
   deleteTooltip,
   editDisabled,
   editPath,
   editTooltip,
+  onClear,
   onDelete,
   onEdit,
-}) => (
+}: Props): JSX.Element => (
   <div>
     {copyValue && <CopyButton value={copyValue} />}
     {(editPath || onEdit) && (
@@ -25,8 +41,8 @@ const TableActions = ({
           disabled={editDisabled}
           element={editPath ? Link : undefined}
           hasIcon
-          onClick={onEdit ? () => onEdit() : null}
-          to={editPath}
+          onClick={() => (onEdit ? onEdit() : null)}
+          to={editPath || ""}
         >
           <i className="p-icon--edit">Edit</i>
         </Button>
@@ -47,18 +63,22 @@ const TableActions = ({
         </Button>
       </Tooltip>
     )}
+    {onClear && (
+      <Tooltip message={clearTooltip} position="left">
+        <Button
+          appearance="base"
+          className="is-dense u-table-cell-padding-overlap"
+          data-test="table-actions-clear"
+          disabled={clearDisabled}
+          hasIcon
+          onClick={() => onClear()}
+          type="button"
+        >
+          <i className="p-icon--close">Clear</i>
+        </Button>
+      </Tooltip>
+    )}
   </div>
 );
-
-TableActions.propTypes = {
-  copyValue: PropTypes.string,
-  deleteDisabled: PropTypes.bool,
-  deleteTooltip: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  editDisabled: PropTypes.bool,
-  editPath: PropTypes.string,
-  editTooltip: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  onDelete: PropTypes.func,
-  onEdit: PropTypes.func,
-};
 
 export default TableActions;

--- a/ui/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/ui/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -115,6 +115,29 @@ describe("ImagesTable", () => {
     );
   });
 
+  it("can clear an image that has been selected", () => {
+    const handleClear = jest.fn();
+    const image = {
+      arch: "arch",
+      os: "os",
+      release: "release",
+      title: "New release",
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <ImagesTable
+          handleClear={handleClear}
+          images={[image]}
+          resources={[]}
+        />
+      </Provider>
+    );
+    wrapper.find("button[data-test='table-actions-clear']").simulate("click");
+
+    expect(handleClear).toHaveBeenCalledWith(image);
+  });
+
   it(`can open the delete image confirmation if the image does not use the
     default commissioning release`, async () => {
     const resources = [

--- a/ui/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/ui/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -14,6 +14,7 @@ import { splitResourceName } from "app/store/bootresource/utils";
 import configSelectors from "app/store/config/selectors";
 
 type Props = {
+  handleClear?: (image: ImageValue) => void;
   images: ImageValue[];
   resources: BootResource[];
 };
@@ -37,10 +38,10 @@ const resourceMatchesImage = (
 /**
  * Generates a row based on a form image value.
  * @param image - the image value from which to generate the row.
- * @param releases - the list of releases known by the source.
+ * @param onClear - function to clear the selected image from selection.
  * @returns row generated from form image value.
  */
-const generateImageRow = (image: ImageValue) => {
+const generateImageRow = (image: ImageValue, onClear: (() => void) | null) => {
   return {
     columns: [
       {
@@ -60,7 +61,14 @@ const generateImageRow = (image: ImageValue) => {
         ),
         className: "status-col",
       },
-      { content: "", className: "actions-col u-align--right" },
+      {
+        content: onClear ? (
+          <TableActions data-test="image-clear" onClear={onClear} />
+        ) : (
+          ""
+        ),
+        className: "actions-col u-align--right",
+      },
     ],
     key: `${image.os}-${image.release}-${image.arch}`,
     sortData: {
@@ -149,7 +157,11 @@ const generateResourceRow = (
   };
 };
 
-const ImagesTable = ({ images, resources }: Props): JSX.Element => {
+const ImagesTable = ({
+  handleClear,
+  images,
+  resources,
+}: Props): JSX.Element => {
   const commissioningRelease = useSelector(
     configSelectors.commissioningDistroSeries
   );
@@ -173,7 +185,8 @@ const ImagesTable = ({ images, resources }: Props): JSX.Element => {
           false
         );
       } else {
-        return generateImageRow(image);
+        const onClear = handleClear ? () => handleClear(image) : null;
+        return generateImageRow(image, onClear);
       }
     })
     .concat(

--- a/ui/src/app/images/components/ImagesTable/_index.scss
+++ b/ui/src/app/images/components/ImagesTable/_index.scss
@@ -1,11 +1,11 @@
 @mixin ImagesTable {
   .images-table {
     .release-col {
-      @include breakpoint-widths(0.35, 0.25, 0.25, 0.25, 0.2, true);
+      @include breakpoint-widths(0.25, 0.25, 0.2, 0.2, 0.2, true);
     }
 
     .arch-col {
-      @include breakpoint-widths(0, 0, 0, 0, 0.1, true);
+      @include breakpoint-widths(0.25, 0.2, 0.15, 0.15, 0.1, true);
     }
 
     .size-col {
@@ -13,11 +13,11 @@
     }
 
     .status-col {
-      @include breakpoint-widths(0.5, 0.65, 0.65, 0.65, 0.5, true);
+      @include breakpoint-widths(0.25, 0.45, 0.55, 0.55, 0.5, true);
     }
 
     .actions-col {
-      @include breakpoint-widths(0.15, 0.1, 0.1, 0.1, 0.1, true)
+      @include breakpoint-widths(0.25, 0.1, 0.1, 0.1, 0.1, true)
     }
   }
 }

--- a/ui/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.tsx
+++ b/ui/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.tsx
@@ -53,6 +53,11 @@ const NonUbuntuImageSelect = ({
     setFieldValue("images", newImageValues);
   };
 
+  const handleClear = (image: ImageValue) => {
+    const filteredImages = values.images.filter((i) => i !== image);
+    setFieldValue("images", filteredImages);
+  };
+
   return (
     <>
       <Row>
@@ -72,7 +77,11 @@ const NonUbuntuImageSelect = ({
           </ul>
         </Col>
       </Row>
-      <ImagesTable images={values.images} resources={resources} />
+      <ImagesTable
+        handleClear={handleClear}
+        images={values.images}
+        resources={resources}
+      />
     </>
   );
 };

--- a/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
+++ b/ui/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.tsx
@@ -38,10 +38,15 @@ const UbuntuImageSelect = ({
   const [selectedRelease, setSelectedRelease] = useState<
     BootResourceUbuntuRelease["name"]
   >(commissioningReleaseName || "");
-  const { values } = useFormikContext<{ images: ImageValue[] }>();
+  const { setFieldValue, values } =
+    useFormikContext<{ images: ImageValue[] }>();
   const { images } = values;
   const availableArches = arches.filter((arch) => !arch.deleted);
   const availableReleases = releases.filter((release) => !release.deleted);
+  const handleClear = (image: ImageValue) => {
+    const filteredImages = values.images.filter((i) => i !== image);
+    setFieldValue("images", filteredImages);
+  };
 
   return (
     <>
@@ -59,7 +64,11 @@ const UbuntuImageSelect = ({
         />
       </Row>
       <div className="u-sv2"></div>
-      <ImagesTable images={images} resources={resources} />
+      <ImagesTable
+        handleClear={handleClear}
+        images={images}
+        resources={resources}
+      />
     </>
   );
 };

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -20,6 +20,7 @@ import {
 } from "testing/factories";
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
+  ...jest.requireActual("@canonical/react-components/dist/hooks"),
   usePrevious: jest.fn(),
 }));
 

--- a/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
+++ b/ui/src/app/kvm/components/KVMActionFormWrapper/ComposeForm/StorageTable/StorageTable.tsx
@@ -151,7 +151,9 @@ export const StorageTable = ({ defaultDisk }: Props): JSX.Element => {
                         disks.length === 1 || !!composingPods.length
                       }
                       deleteTooltip={
-                        disks.length === 1 && "At least one disk is required."
+                        disks.length === 1
+                          ? "At least one disk is required."
+                          : null
                       }
                       onDelete={() => removeDisk(disk.id)}
                     />

--- a/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -77,7 +77,7 @@ const generateRows = (
             <TableActions
               deleteDisabled={script.default}
               deleteTooltip={
-                script.default && "Default scripts cannot be deleted."
+                script.default ? "Default scripts cannot be deleted." : null
               }
               onDelete={() => {
                 setExpandedId(script.id);


### PR DESCRIPTION
## Done

- Added a "clear" button to the images table so you don't need to select the correct release
- Updated the css so that the architecture column never gets hidden
- Converted TableActions to TypeScript

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images and select some new Ubuntu images
- Check that you can clear those selections from the table
- Resize the screen and check that the architecture column does not get hidden

## Fixes

Fixes #2868 
