### PR TITLE
fix(ui): explicitly poll server after image action success

### DIFF
--- a/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.tsx
+++ b/ui/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.tsx
@@ -44,6 +44,9 @@ const DeleteImageConfirm = ({
         dispatch(bootResourceActions.cleanup());
         dispatch(bootResourceActions.deleteImage({ id: resource.id }));
       }}
+      onSuccess={() => {
+        dispatch(bootResourceActions.poll({ continuous: false }));
+      }}
       sidebar={false}
     />
   );

--- a/ui/src/app/images/views/ImageList/ImageList.tsx
+++ b/ui/src/app/images/views/ImageList/ImageList.tsx
@@ -23,7 +23,7 @@ const ImagesList = (): JSX.Element => {
   useWindowTitle("Images");
 
   useEffect(() => {
-    dispatch(bootResourceActions.poll());
+    dispatch(bootResourceActions.poll({ continuous: true }));
     dispatch(configActions.fetch());
     return () => {
       dispatch(bootResourceActions.pollStop());

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.tsx
@@ -126,7 +126,10 @@ const FetchedImages = ({ closeForm, source }: Props): JSX.Element | null => {
           };
           dispatch(bootResourceActions.saveUbuntu(params));
         }}
-        onSuccess={closeForm}
+        onSuccess={() => {
+          dispatch(bootResourceActions.poll({ continuous: false }));
+          closeForm();
+        }}
         saved={saved}
         saving={saving}
         submitLabel="Update selection"

--- a/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.tsx
@@ -104,6 +104,9 @@ const OtherImages = (): JSX.Element | null => {
             };
             dispatch(bootResourceActions.saveOther(params));
           }}
+          onSuccess={() => {
+            dispatch(bootResourceActions.poll({ continuous: false }));
+          }}
           saved={saved}
           saving={saving || stoppingImport}
           savingLabel={stoppingImport ? "Stopping image import..." : null}

--- a/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.tsx
@@ -104,6 +104,9 @@ const UbuntuCoreImages = (): JSX.Element | null => {
             };
             dispatch(bootResourceActions.saveUbuntuCore(params));
           }}
+          onSuccess={() => {
+            dispatch(bootResourceActions.poll({ continuous: false }));
+          }}
           saved={saved}
           saving={saving || stoppingImport}
           savingLabel={stoppingImport ? "Stopping image import..." : null}

--- a/ui/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.tsx
@@ -137,6 +137,9 @@ const UbuntuImages = ({ sources }: Props): JSX.Element | null => {
                 };
             dispatch(bootResourceActions.saveUbuntu(params));
           }}
+          onSuccess={() => {
+            dispatch(bootResourceActions.poll({ continuous: false }));
+          }}
           saved={saved}
           saving={saving || stoppingImport}
           savingLabel={stoppingImport ? "Stopping image import..." : null}

--- a/ui/src/app/store/bootresource/actions.test.ts
+++ b/ui/src/app/store/bootresource/actions.test.ts
@@ -41,14 +41,27 @@ describe("bootresource actions", () => {
     });
   });
 
-  it("can create a poll action", () => {
-    expect(actions.poll()).toEqual({
+  it("can create a continuous poll action", () => {
+    expect(actions.poll({ continuous: true })).toEqual({
       type: "bootresource/poll",
       meta: {
         jsonResponse: true,
         model: "bootresource",
         method: "poll",
         poll: true,
+      },
+      payload: null,
+    });
+  });
+
+  it("can create a one-off poll action", () => {
+    expect(actions.poll({ continuous: false })).toEqual({
+      type: "bootresource/poll",
+      meta: {
+        jsonResponse: true,
+        model: "bootresource",
+        method: "poll",
+        poll: false,
       },
       payload: null,
     });

--- a/ui/src/app/store/bootresource/slice.ts
+++ b/ui/src/app/store/bootresource/slice.ts
@@ -110,13 +110,13 @@ const bootResourceSlice = createSlice({
       state.fetchedImages = action.payload;
     },
     poll: {
-      prepare: () => ({
+      prepare: ({ continuous = true }) => ({
         meta: {
           // The data returned by the API is JSON for this endpoint.
           jsonResponse: true,
           model: BootResourceMeta.MODEL,
           method: "poll",
-          poll: true,
+          poll: continuous,
         },
         payload: null,
       }),


### PR DESCRIPTION
## Done

- Updated bootresource `poll` action to be able to only poll once
- Dispatch on-off poll action after image action success (i.e. save synced images, delete image)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/images and open Redux devtools
- Perform an action like deleting an image or saving a sync selection
- Check that once the `actionSuccess` action is dispatched, a `poll` action is immediately dispatched after it with `action.meta.poll === false`
- The results of your action should show up relatively quickly

## Fixes

Fixes #2873 