### PR TITLE
fix(ui): select correct VLAN when creating a bond

### DIFF
--- a/ui/src/app/base/components/DynamicSelect/DynamicSelect.test.tsx
+++ b/ui/src/app/base/components/DynamicSelect/DynamicSelect.test.tsx
@@ -169,4 +169,19 @@ describe("DynamicSelect", () => {
     await waitForComponentToPaint(wrapper);
     expect(wrapper.find("FormikField select").prop("value")).toBe("2");
   });
+
+  it("doesn't change the value on first render", async () => {
+    const wrapper = mount(
+      <Formik initialValues={{ fabric: "2" }} onSubmit={jest.fn()}>
+        <DynamicSelect
+          name="fabric"
+          options={[
+            { label: "one", value: "1" },
+            { label: "two", value: "2" },
+          ]}
+        />
+      </Formik>
+    );
+    expect(wrapper.find("FormikField select").prop("value")).toBe("2");
+  });
 });

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -58,6 +58,23 @@ describe("AddBondForm", () => {
   });
 
   it("displays a table", async () => {
+    state.machine.items = [
+      machineDetailsFactory({
+        interfaces: [
+          machineInterfaceFactory({
+            id: 9,
+            type: NetworkInterfaceTypes.PHYSICAL,
+            vlan_id: 1,
+          }),
+          machineInterfaceFactory({
+            id: 10,
+            type: NetworkInterfaceTypes.PHYSICAL,
+            vlan_id: 1,
+          }),
+        ],
+        system_id: "abc123",
+      }),
+    ];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -66,7 +83,7 @@ describe("AddBondForm", () => {
         >
           <AddBondForm
             close={jest.fn()}
-            selected={[]}
+            selected={[{ nicId: 9 }, { nicId: 10 }]}
             setSelected={jest.fn()}
             systemId="abc123"
           />
@@ -280,7 +297,34 @@ describe("AddBondForm", () => {
       </Provider>
     );
     await waitForComponentToPaint(wrapper);
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(wrapper.find("Spinner[data-test='data-loading']").exists()).toBe(
+      true
+    );
+  });
+
+  it("displays a spinner if the VLAN hasn't been set", async () => {
+    state.fabric.loaded = true;
+    state.subnet.loaded = true;
+    state.vlan.loaded = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <AddBondForm
+            close={jest.fn()}
+            selected={[]}
+            setSelected={jest.fn()}
+            systemId="abc123"
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find("Spinner[data-test='data-loading']").exists()).toBe(
+      true
+    );
   });
 
   it("can dispatch an action to add a bond", async () => {

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
@@ -127,7 +127,7 @@ const AddBondForm = ({
     // to be done so that if all interfaces become deselected then the VLAN
     // information is not lost.
     if (!bondVLAN && hasEnoughNics && firstNic) {
-      setBondVLAN(firstNic?.vlan_id);
+      setBondVLAN(firstNic.vlan_id);
     }
   }, [bondVLAN, firstNic, hasEnoughNics, setBondVLAN]);
 
@@ -135,9 +135,10 @@ const AddBondForm = ({
     !isMachineDetails(machine) ||
     !vlansLoaded ||
     !fabricsLoaded ||
-    !subnetsLoaded
+    !subnetsLoaded ||
+    !bondVLAN
   ) {
-    return <Spinner />;
+    return <Spinner data-test="data-loading" />;
   }
   const subnet = getInterfaceSubnet(
     machine,


### PR DESCRIPTION
## Done

- Fix selecting the correct VLAN when adding a bond.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the network tab for a machine (at the time of writing 'top owl' on Bolla is set up correctly)
- If not using 'top owl' then create two interfaces with the same VLAN, but make sure that the VLAN isn't the default (i.e. choose a fabric that has - multiple VLANs and choose a VLAN that is not the first option).
- Tick both interfaces and click 'Create bond'.
- See that the VLAN selected in the disabled field is the VLAN that was set above.

## Fixes

Fixes: #2881.

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
