### PR TITLE
feat(ui): add basic user intro form

### DIFF
--- a/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -1,0 +1,146 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import UserIntro from "./UserIntro";
+
+import dashboardURLs from "app/dashboard/urls";
+import machineURLs from "app/machines/urls";
+import type { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  sshKey as sshKeyFactory,
+  sshKeyState as sshKeyStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("UserIntro", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      sshkey: sshKeyStateFactory({
+        items: [sshKeyFactory()],
+      }),
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ completed_intro: false, is_superuser: true }),
+        }),
+      }),
+    });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.sshkey.loading = true;
+    state.user.auth.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a green tick icon when there are ssh keys", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='sshkey-card'] Icon[name='success']").exists()
+    ).toBe(true);
+  });
+
+  it("displays a grey tick icon when there are no ssh keys", async () => {
+    state.sshkey.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper
+        .find("[data-test='sshkey-card'] Icon[name='success-grey']")
+        .exists()
+    ).toBe(true);
+  });
+
+  it("sets the continue button to the dashboard for admins", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ completed_intro: false, is_superuser: true }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Button[data-test='continue-button']").prop("to")).toBe(
+      dashboardURLs.index
+    );
+  });
+
+  it("sets the continue button to the machine list for non-admins", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ completed_intro: true, is_superuser: false }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Button[data-test='continue-button']").prop("to")).toBe(
+      machineURLs.machines.index
+    );
+  });
+
+  it("disables the continue button if there are no ssh keys", () => {
+    state.sshkey.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("Button[data-test='continue-button']").prop("disabled")
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -1,9 +1,68 @@
+import { useEffect } from "react";
+
+import { Button, Card, Icon, Row, Spinner } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
 import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
+import dashboardURLs from "app/dashboard/urls";
+import machineURLs from "app/machines/urls";
+import authSelectors from "app/store/auth/selectors";
+import { actions as sshkeyActions } from "app/store/sshkey";
+import sshkeySelectors from "app/store/sshkey/selectors";
 
 const UserIntro = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const authLoading = useSelector(authSelectors.loading);
+  const authUser = useSelector(authSelectors.get);
+  const sshkeys = useSelector(sshkeySelectors.all);
+  const sshkeyLoading = useSelector(sshkeySelectors.loading);
+
+  const hasSSHKeys = sshkeys.length > 0;
+
+  useWindowTitle("Welcome");
+
+  useEffect(() => {
+    dispatch(sshkeyActions.fetch());
+  }, [dispatch]);
+
+  if (authLoading || sshkeyLoading) {
+    return <Spinner />;
+  }
+
   return (
-    <Section header="User intro">
-      <div>User intro</div>
+    <Section>
+      <Card
+        data-test="sshkey-card"
+        highlighted
+        title={
+          <span className="p-heading--4">
+            <Icon name={hasSSHKeys ? "success" : "success-grey"} /> SSH keys for{" "}
+            {authUser?.username}
+          </span>
+        }
+      >
+        <p>
+          Add multiple keys from Launchpad and Github or enter them manually.
+        </p>
+        <h4>Keys</h4>
+      </Card>
+      <Row>
+        <Button
+          appearance="positive"
+          data-test="continue-button"
+          disabled={!hasSSHKeys}
+          element={Link}
+          to={
+            authUser?.is_superuser
+              ? dashboardURLs.index
+              : machineURLs.machines.index
+          }
+        >
+          Go to {authUser?.is_superuser ? "dashboard" : "machine list"}
+        </Button>
+      </Row>
     </Section>
   );
 };


### PR DESCRIPTION
## Done

- Set up the form for the user intro.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Log in as a non admin.
- Visit /MAAS/r/intro/user
- You should see a SSH key card and a continue button.
- Log in as an admin.
- You should see the SSH key and successfully set up card and the continue button.
- In another tab add some SSH keys in your profile.
- In the intro the continue button should now be enabled.
- Click the continue button and you should go to the dashboard.

## Fixes

Fixes: canonical-web-and-design/app-squad#92.