### PR TITLE
feat(ui): add connectivity card to MAAS intro form

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -115,7 +115,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -220,10 +220,11 @@ exports[`stricter compilation`] = {
       [104, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [105, 6, 256, "Argument of type \'{ images: { arch: string; os: string; release: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2870584855"]
     ],
-    "src/app/intro/views/MaasIntro/MaasIntro.test.tsx:2230107946": [
-      [56, 38, 11, "Argument of type \'\\"onSuccess\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "641512391"],
+    "src/app/intro/views/MaasIntro/MaasIntro.test.tsx:282976037": [
+      [73, 4, 45, "Cannot invoke an object which is possibly \'undefined\'.", "2890963284"],
+      [74, 6, 36, "Argument of type \'{ httpProxy: string; mainArchiveUrl: string; name: string; portsArchiveUrl: string; upstreamDns: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'httpProxy\' does not exist in type \'FormEvent<{}>\'.", "1476874575"],
       [105, 4, 45, "Cannot invoke an object which is possibly \'undefined\'.", "2890963284"],
-      [105, 52, 19, "Argument of type \'{ name: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'FormEvent<{}>\'.", "2759788366"]
+      [106, 6, 36, "Argument of type \'{ httpProxy: string; mainArchiveUrl: string; name: string; portsArchiveUrl: string; upstreamDns: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'httpProxy\' does not exist in type \'FormEvent<{}>\'.", "1476874575"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:934008644": [
       [143, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -541,9 +542,9 @@ exports[`stricter compilation`] = {
       [218, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [219, 8, 21, "Argument of type \'{ ip_address: string; mode: NetworkLinkMode; subnet: number; system_id: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'ip_address\' does not exist in type \'FormEvent<{}>\'.", "2616770373"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx:2006895429": [
-      [318, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
-      [322, 8, 18, "Argument of type \'{ bond_downdelay: number; bond_lacp_rate: string; bond_mode: BondMode; bond_miimon: number; bond_updelay: number; fabric: number; ip_address: string; linkMonitoring: LinkMonitoring; ... 5 more ...; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bond_downdelay\' does not exist in type \'FormEvent<{}>\'.", "796132353"]
+    "src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx:3842464814": [
+      [362, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
+      [366, 8, 18, "Argument of type \'{ bond_downdelay: number; bond_lacp_rate: string; bond_mode: BondMode; bond_miimon: number; bond_updelay: number; fabric: number; ip_address: string; linkMonitoring: LinkMonitoring; ... 5 more ...; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'bond_downdelay\' does not exist in type \'FormEvent<{}>\'.", "796132353"]
     ],
     "src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx:1857760705": [
       [129, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],

--- a/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
+++ b/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
@@ -1,0 +1,64 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+
+import { MaasIntroSchema } from "../MaasIntro";
+
+import ConnectivityCard from "./ConnectivityCard";
+
+import { waitForComponentToPaint } from "testing/utils";
+
+describe("ConnectivityCard", () => {
+  it("displays a tick when there are no errors", () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{
+          httpProxy: "http://www.website.com",
+          mainArchiveUrl: "http://www.mainarchive.com",
+          portsArchiveUrl: "http://www.portsarchive.com",
+          upstreamDns: "8.8.8.8",
+        }}
+        onSubmit={jest.fn()}
+        validationSchema={MaasIntroSchema}
+      >
+        <ConnectivityCard />
+      </Formik>
+    );
+    expect(
+      wrapper
+        .find("[data-test='maas-connectivity-form'] Icon[name='success']")
+        .exists()
+    ).toBe(true);
+  });
+
+  it("displays an error icon when there are errors", async () => {
+    const wrapper = mount(
+      <Formik
+        initialValues={{
+          httpProxy: "http://www.website.com",
+          mainArchiveUrl: "http://www.mainarchive.com",
+          portsArchiveUrl: "http://www.portsarchive.com",
+          upstreamDns: "8.8.8.8",
+        }}
+        onSubmit={jest.fn()}
+        validationSchema={MaasIntroSchema}
+      >
+        <ConnectivityCard />
+      </Formik>
+    );
+    wrapper
+      .find("[name='mainArchiveUrl']")
+      .last()
+      .simulate("change", {
+        target: {
+          name: "mainArchiveUrl",
+          value: "",
+        },
+      });
+    await waitForComponentToPaint(wrapper);
+    expect(
+      wrapper
+        .find("[data-test='maas-connectivity-form'] Icon[name='error']")
+        .exists()
+    ).toBe(true);
+  });
+});

--- a/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
+++ b/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
@@ -1,0 +1,63 @@
+import { Card, Col, Icon, Row } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { MaasIntroValues } from "../types";
+
+import FormikField from "app/base/components/FormikField";
+
+const ConnectivityCard = (): JSX.Element => {
+  const { errors } = useFormikContext<MaasIntroValues>();
+  const showErrorIcon =
+    errors.httpProxy ||
+    errors.mainArchiveUrl ||
+    errors.portsArchiveUrl ||
+    errors.upstreamDns;
+
+  return (
+    <Card
+      className="maas-intro__card"
+      data-test="maas-connectivity-form"
+      highlighted
+      title={
+        <>
+          <span className="p-heading--4 u-sv1">
+            <Icon name={showErrorIcon ? "error" : "success"} /> Connectivity
+          </span>
+          <hr />
+        </>
+      }
+    >
+      <Row>
+        <Col size="6">
+          <FormikField
+            help="A space-separated list of upstream DNS servers to which MAAS should forward requests for domains not managed by MAAS directly."
+            label="DNS forwarder"
+            name="upstreamDns"
+            placeholder="e.g: 8.8.8.8 8.8.4.4"
+            type="text"
+          />
+          <FormikField
+            help="The server where machines retrieve packages for Intel architectures."
+            label="Ubuntu archive"
+            name="mainArchiveUrl"
+            type="text"
+          />
+          <FormikField
+            help="Archive used by machines to retrieve packages for non-Intel architectures."
+            label="Ubuntu extra architectures"
+            name="portsArchiveUrl"
+            type="text"
+          />
+          <FormikField
+            help="This will be passed onto deployed machines to use as a proxy for APT and YUM traffic. MAAS also uses the proxy for downloading boot images. If no URL is provided, the built-in MAAS proxy will be used."
+            label="APT &amp; HTTP/HTTPS proxy server"
+            name="httpProxy"
+            type="text"
+          />
+        </Col>
+      </Row>
+    </Card>
+  );
+};
+
+export default ConnectivityCard;

--- a/ui/src/app/intro/views/MaasIntro/ConnectivityCard/index.ts
+++ b/ui/src/app/intro/views/MaasIntro/ConnectivityCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ConnectivityCard";

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -1,79 +1,123 @@
+import { useEffect } from "react";
+
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
-import MaasIntroFields from "./MaasIntroFields";
+import ConnectivityCard from "./ConnectivityCard";
+import NameCard from "./NameCard";
 import type { MaasIntroValues } from "./types";
 
 import FormikForm from "app/base/components/FormikForm";
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
-import baseURLs from "app/base/urls";
-import machineURLs from "app/machines/urls";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
+import { actions as repoActions } from "app/store/packagerepository";
+import repoSelectors from "app/store/packagerepository/selectors";
 
-export const IntroSchema = Yup.object()
+export const MaasIntroSchema = Yup.object()
   .shape({
+    httpProxy: Yup.string().url("Must be a valid URL."),
+    mainArchiveUrl: Yup.string()
+      .url("Must be a valid URL.")
+      .required("Ubuntu archive is required."),
     name: Yup.string().required("MAAS name is required"),
+    portsArchiveUrl: Yup.string()
+      .url("Must be a valid URL.")
+      .required("Ubuntu extra architectures is required."),
+    upstreamDns: Yup.string(),
   })
   .defined();
 
 const MaasIntro = (): JSX.Element => {
   const dispatch = useDispatch();
   const authLoading = useSelector(authSelectors.loading);
-  const authUser = useSelector(authSelectors.get);
-  const errors = useSelector(configSelectors.errors);
+  const httpProxy = useSelector(configSelectors.httpProxy);
   const maasName = useSelector(configSelectors.maasName);
+  const upstreamDns = useSelector(configSelectors.upstreamDns);
+  const configErrors = useSelector(configSelectors.errors);
   const configLoading = useSelector(configSelectors.loading);
-  const saved = useSelector(configSelectors.saved);
-  const saving = useSelector(configSelectors.saving);
+  const configSaved = useSelector(configSelectors.saved);
+  const configSaving = useSelector(configSelectors.saving);
+  const reposErrors = useSelector(repoSelectors.errors);
+  const reposLoading = useSelector(repoSelectors.loading);
+  const reposSaving = useSelector(repoSelectors.saving);
+  const mainArchive = useSelector(repoSelectors.mainArchive);
+  const portsArchive = useSelector(repoSelectors.portsArchive);
 
   useWindowTitle("Welcome");
 
-  if (authLoading || configLoading) {
-    return <Spinner />;
-  }
+  useEffect(() => {
+    dispatch(repoActions.fetch());
+  }, [dispatch]);
+
+  const errors = { ...configErrors, ...reposErrors };
+  const loading = authLoading || configLoading || reposLoading;
+  const saving = configSaving || reposSaving;
+  const saved = configSaved;
 
   return (
     <Section>
-      <FormikForm<MaasIntroValues>
-        buttonsBordered={false}
-        cleanup={configActions.cleanup}
-        errors={errors}
-        initialValues={{
-          name: maasName || "",
-        }}
-        onSaveAnalytics={{
-          action: "Saved",
-          category: "Intro",
-          label: "Intro form",
-        }}
-        onSuccess={() => {
-          dispatch(configActions.fetch());
-        }}
-        onSubmit={(values) => {
-          dispatch(configActions.cleanup());
-          dispatch(
-            configActions.update({
-              completed_intro: true,
-              maas_name: values.name,
-            })
-          );
-        }}
-        savedRedirect={
-          authUser?.completed_intro
-            ? machineURLs.machines.index
-            : baseURLs.intro.user
-        }
-        saving={saving}
-        saved={saved}
-        submitLabel="Continue"
-        validationSchema={IntroSchema}
-      >
-        <MaasIntroFields />
-      </FormikForm>
+      {loading ? (
+        <Spinner text="Loading..." />
+      ) : (
+        <FormikForm<MaasIntroValues>
+          allowUnchanged
+          buttonsBordered={false}
+          cleanup={configActions.cleanup}
+          errors={errors}
+          initialValues={{
+            httpProxy: httpProxy || "",
+            mainArchiveUrl: mainArchive?.url || "",
+            name: maasName || "",
+            portsArchiveUrl: portsArchive?.url || "",
+            upstreamDns: upstreamDns || "",
+          }}
+          onSaveAnalytics={{
+            action: "Saved",
+            category: "Intro",
+            label: "Intro form",
+          }}
+          onSubmit={(values) => {
+            dispatch(configActions.cleanup());
+            dispatch(repoActions.cleanup());
+            dispatch(
+              configActions.update({
+                http_proxy: values.httpProxy,
+                maas_name: values.name,
+                upstream_dns: values.upstreamDns,
+              })
+            );
+            if (mainArchive && mainArchive.url !== values.mainArchiveUrl) {
+              dispatch(
+                repoActions.update({
+                  id: mainArchive.id,
+                  name: mainArchive.name,
+                  url: values.mainArchiveUrl,
+                })
+              );
+            }
+            if (portsArchive && portsArchive.url !== values.portsArchiveUrl) {
+              dispatch(
+                repoActions.update({
+                  id: portsArchive.id,
+                  name: portsArchive.name,
+                  url: values.portsArchiveUrl,
+                })
+              );
+            }
+          }}
+          saving={saving}
+          saved={saved}
+          submitLabel="Save and continue"
+          validationSchema={MaasIntroSchema}
+        >
+          <NameCard />
+          <ConnectivityCard />
+        </FormikForm>
+      )}
     </Section>
   );
 };

--- a/ui/src/app/intro/views/MaasIntro/MaasIntroFields/index.ts
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntroFields/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./MaasIntroFields";

--- a/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
+++ b/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
@@ -3,9 +3,9 @@ import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
-import { IntroSchema } from "../MaasIntro";
+import { MaasIntroSchema } from "../MaasIntro";
 
-import MaasIntroFields from "./MaasIntroFields";
+import NameCard from "./NameCard";
 
 import type { RootState } from "app/store/root/types";
 import {
@@ -20,7 +20,7 @@ import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
-describe("MaasIntroFields", () => {
+describe("NameCard", () => {
   let state: RootState;
   beforeEach(() => {
     state = rootStateFactory({
@@ -41,7 +41,7 @@ describe("MaasIntroFields", () => {
     const wrapper = mount(
       <Provider store={store}>
         <Formik initialValues={{ name: "my new maas" }} onSubmit={jest.fn()}>
-          <MaasIntroFields />
+          <NameCard />
         </Formik>
       </Provider>
     );
@@ -57,9 +57,9 @@ describe("MaasIntroFields", () => {
         <Formik
           initialValues={{ name: "my new maas" }}
           onSubmit={jest.fn()}
-          validationSchema={IntroSchema}
+          validationSchema={MaasIntroSchema}
         >
-          <MaasIntroFields />
+          <NameCard />
         </Formik>
       </Provider>
     );

--- a/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
+++ b/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
@@ -1,11 +1,11 @@
-import { Card, Col, Icon, Row, Link } from "@canonical/react-components";
+import { Card, Col, Icon, Link, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { MaasIntroValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
 
-const MaasIntroFields = (): JSX.Element => {
+const NameCard = (): JSX.Element => {
   const { errors } = useFormikContext<MaasIntroValues>();
 
   return (
@@ -47,4 +47,4 @@ const MaasIntroFields = (): JSX.Element => {
   );
 };
 
-export default MaasIntroFields;
+export default NameCard;

--- a/ui/src/app/intro/views/MaasIntro/NameCard/index.ts
+++ b/ui/src/app/intro/views/MaasIntro/NameCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NameCard";

--- a/ui/src/app/intro/views/MaasIntro/types.ts
+++ b/ui/src/app/intro/views/MaasIntro/types.ts
@@ -1,3 +1,7 @@
 export type MaasIntroValues = {
+  httpProxy: string;
+  mainArchiveUrl: string;
   name: string;
+  portsArchiveUrl: string;
+  upstreamDns: string;
 };

--- a/ui/src/app/store/packagerepository/selectors.test.ts
+++ b/ui/src/app/store/packagerepository/selectors.test.ts
@@ -118,4 +118,30 @@ describe("packagerepository selectors", () => {
     });
     expect(packagerepository.search(state, "Ubuntu")).toEqual([items[0]]);
   });
+
+  it("can get the main archive", () => {
+    const [mainArchive, otherArchive] = [
+      packageRepositoryFactory({ name: "main_archive", default: true }),
+      packageRepositoryFactory({ name: "other_archive", default: true }),
+    ];
+    const state = rootStateFactory({
+      packagerepository: packageRepositoryStateFactory({
+        items: [mainArchive, otherArchive],
+      }),
+    });
+    expect(packagerepository.mainArchive(state)).toEqual(mainArchive);
+  });
+
+  it("can get the ports archive", () => {
+    const [portsArchive, otherArchive] = [
+      packageRepositoryFactory({ name: "ports_archive", default: true }),
+      packageRepositoryFactory({ name: "other_archive", default: true }),
+    ];
+    const state = rootStateFactory({
+      packagerepository: packageRepositoryStateFactory({
+        items: [portsArchive, otherArchive],
+      }),
+    });
+    expect(packagerepository.portsArchive(state)).toEqual(portsArchive);
+  });
 });

--- a/ui/src/app/store/packagerepository/selectors.ts
+++ b/ui/src/app/store/packagerepository/selectors.ts
@@ -5,6 +5,7 @@ import type {
   PackageRepository,
   PackageRepositoryState,
 } from "app/store/packagerepository/types";
+import type { RootState } from "app/store/root/types";
 import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (repo: PackageRepository, term: string) =>
@@ -12,10 +13,32 @@ const searchFunction = (repo: PackageRepository, term: string) =>
   repo.name.includes(term) ||
   repo.url.includes(term);
 
-const selectors = generateBaseSelectors<
+const defaultSelectors = generateBaseSelectors<
   PackageRepositoryState,
   PackageRepository,
   PackageRepositoryMeta.PK
 >(PackageRepositoryMeta.MODEL, PackageRepositoryMeta.PK, searchFunction);
+
+/**
+ * Returns the main archive package repository.
+ * @param state - The redux state.
+ * @returns The main archive package repository.
+ */
+const mainArchive = (state: RootState): PackageRepository | null =>
+  state.packagerepository.items.find(
+    (repo) => repo.default && repo.name === "main_archive"
+  ) || null;
+
+/**
+ * Returns the ports archive package repository.
+ * @param state - The redux state.
+ * @returns The ports archive package repository.
+ */
+const portsArchive = (state: RootState): PackageRepository | null =>
+  state.packagerepository.items.find(
+    (repo) => repo.default && repo.name === "ports_archive"
+  ) || null;
+
+const selectors = { ...defaultSelectors, portsArchive, mainArchive };
 
 export default selectors;


### PR DESCRIPTION
## Done

- Added the connectivity card to the MAAS intro form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/intro and check that there is a connectivity card
- Remove the Ubuntu archive URL and check that an error icon shows in the card title
- Reenter the URL and check that you can successfully submit the form

## Fixes

Fixes canonical-web-and-design/app-squad#90

## Screenshot

![Screenshot 2021-07-21 at 10-25-51 Welcome focal-maas MAAS](https://user-images.githubusercontent.com/25733845/126411532-b5e199f6-3407-4dc8-9133-877419f9bb3f.png)
