### PR TITLE
feat(ui): add images section to intro flow

### DIFF
--- a/ui/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/ui/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -138,6 +138,30 @@ describe("ImagesTable", () => {
     expect(handleClear).toHaveBeenCalledWith(image);
   });
 
+  it(`can not clear a selected image if it is the last image that uses the
+    default commissioning release`, () => {
+    const handleClear = jest.fn();
+    const image = {
+      arch: "amd64",
+      os: "ubuntu",
+      release: "focal",
+      title: "Ubuntu 20.04 LTS",
+    };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <ImagesTable
+          handleClear={handleClear}
+          images={[image]}
+          resources={[]}
+        />
+      </Provider>
+    );
+    expect(
+      wrapper.find("button[data-test='table-actions-clear']").prop("disabled")
+    ).toBe(true);
+  });
+
   it(`can open the delete image confirmation if the image does not use the
     default commissioning release`, async () => {
     const resources = [

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
@@ -8,7 +8,7 @@ import FetchedImages from "./FetchedImages";
 import type { BootResourceUbuntuSource } from "app/store/bootresource/types";
 
 type Props = {
-  closeForm: () => void;
+  closeForm: (() => void) | null;
 };
 
 const ChangeSource = ({ closeForm }: Props): JSX.Element => {
@@ -17,7 +17,10 @@ const ChangeSource = ({ closeForm }: Props): JSX.Element => {
   return (
     <Card highlighted>
       {source ? (
-        <FetchedImages closeForm={closeForm} source={source} />
+        <FetchedImages
+          closeForm={closeForm ? () => closeForm() : () => setSource(null)}
+          source={source}
+        />
       ) : (
         <FetchImagesForm closeForm={closeForm} setSource={setSource} />
       )}

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.tsx
@@ -33,7 +33,7 @@ export type FetchImagesValues = {
 };
 
 type Props = {
-  closeForm: () => void;
+  closeForm: (() => void) | null;
   setSource: (source: BootResourceUbuntuSource) => void;
 };
 
@@ -41,13 +41,11 @@ const FetchImagesForm = ({ closeForm, setSource }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const errors = useSelector(bootResourceSelectors.fetchError);
   const saving = useSelector(bootResourceSelectors.fetching);
-  const ubuntu = useSelector(bootResourceSelectors.ubuntu);
   const previousSaving = usePrevious(saving);
   const cleanup = useCallback(() => bootResourceActions.cleanup(), []);
   // Consider the connection established if fetching was started, then stopped
   // without any errors.
   const saved = !saving && previousSaving && !errors;
-  const hasSources = ubuntu?.sources.length;
 
   return (
     <FormikForm<FetchImagesValues>
@@ -60,7 +58,7 @@ const FetchImagesForm = ({ closeForm, setSource }: Props): JSX.Element => {
         source_type: BootResourceSourceType.MAAS_IO,
         url: "",
       }}
-      onCancel={hasSources ? closeForm : null}
+      onCancel={closeForm}
       onSubmit={(values) => {
         dispatch(cleanup());
         dispatch(bootResourceActions.fetch(values));

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -16,6 +16,25 @@ import {
 const mockStore = configureStore();
 
 describe("SyncedImages", () => {
+  it("can render in a card", () => {
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        ubuntu: ubuntuFactory({
+          sources: [
+            sourceFactory({ source_type: BootResourceSourceType.MAAS_IO }),
+          ],
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SyncedImages inCard />
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='images-in-card']").exists()).toBe(true);
+  });
+
   it("renders the change source form and disables closing it if no sources are detected", () => {
     const state = rootStateFactory({
       bootresource: bootResourceStateFactory({

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -16,7 +16,7 @@ import {
 const mockStore = configureStore();
 
 describe("SyncedImages", () => {
-  it("renders the change source form if no sources are detected", () => {
+  it("renders the change source form and disables closing it if no sources are detected", () => {
     const state = rootStateFactory({
       bootresource: bootResourceStateFactory({
         ubuntu: ubuntuFactory({ sources: [] }),
@@ -29,6 +29,7 @@ describe("SyncedImages", () => {
       </Provider>
     );
     expect(wrapper.find("ChangeSource").exists()).toBe(true);
+    expect(wrapper.find("ChangeSource").prop("closeForm")).toBe(null);
   });
 
   it("renders the correct text for a single default source", () => {

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import {
   Button,
+  Card,
   Col,
   Icon,
   Row,
@@ -30,7 +31,11 @@ const getImageSyncText = (sources: BootResourceUbuntuSource[]) => {
   return "sources";
 };
 
-const SyncedImages = (): JSX.Element | null => {
+type Props = {
+  inCard?: boolean;
+};
+
+const SyncedImages = ({ inCard = false }: Props): JSX.Element | null => {
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
   const resources = useSelector(bootResourceSelectors.resources);
   const sources = ubuntu?.sources || [];
@@ -42,6 +47,52 @@ const SyncedImages = (): JSX.Element | null => {
   }
 
   const canChangeSource = resources.every((resource) => !resource.downloading);
+  let content = (
+    <>
+      <div className="u-flex--between">
+        <h4 data-test="image-sync-text">
+          Showing images synced from{" "}
+          <strong>{getImageSyncText(sources)}</strong>
+        </h4>
+        <Button
+          appearance="neutral"
+          data-test="change-source-button"
+          disabled={!canChangeSource}
+          onClick={() => setShowChangeSource(true)}
+        >
+          Change source
+          {!canChangeSource && (
+            <Tooltip
+              message="Cannot change source while images are downloading."
+              className="u-nudge-right--small"
+              position="top-right"
+            >
+              <Icon name="information" />
+            </Tooltip>
+          )}
+        </Button>
+      </div>
+      <p>
+        Select images to be imported and kept in sync daily. Images will be
+        available for deploying to machines managed by MAAS.
+      </p>
+      <UbuntuImages sources={sources} />
+      <UbuntuCoreImages />
+      <OtherImages />
+    </>
+  );
+  if (inCard) {
+    content = (
+      <Card
+        className="u-no-padding--bottom"
+        data-test="images-in-card"
+        highlighted
+      >
+        {content}
+      </Card>
+    );
+  }
+
   return (
     <Strip shallow>
       <Row>
@@ -51,38 +102,7 @@ const SyncedImages = (): JSX.Element | null => {
               closeForm={hasSources ? () => setShowChangeSource(false) : null}
             />
           ) : (
-            <>
-              <div className="u-flex--between">
-                <h4 data-test="image-sync-text">
-                  Showing images synced from{" "}
-                  <strong>{getImageSyncText(sources)}</strong>
-                </h4>
-                <Button
-                  appearance="neutral"
-                  data-test="change-source-button"
-                  disabled={!canChangeSource}
-                  onClick={() => setShowChangeSource(true)}
-                >
-                  Change source
-                  {!canChangeSource && (
-                    <Tooltip
-                      message="Cannot change source while images are downloading."
-                      className="u-nudge-right--small"
-                      position="top-right"
-                    >
-                      <Icon name="information" />
-                    </Tooltip>
-                  )}
-                </Button>
-              </div>
-              <p>
-                Select images to be imported and kept in sync daily. Images will
-                be available for deploying to machines managed by MAAS.
-              </p>
-              <UbuntuImages sources={sources} />
-              <UbuntuCoreImages />
-              <OtherImages />
-            </>
+            content
           )}
         </Col>
       </Row>

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -47,7 +47,9 @@ const SyncedImages = (): JSX.Element | null => {
       <Row>
         <Col size="12">
           {showChangeSource ? (
-            <ChangeSource closeForm={() => setShowChangeSource(false)} />
+            <ChangeSource
+              closeForm={hasSources ? () => setShowChangeSource(false) : null}
+            />
           ) : (
             <>
               <div className="u-flex--between">

--- a/ui/src/app/intro/urls.ts
+++ b/ui/src/app/intro/urls.ts
@@ -1,4 +1,5 @@
 const urls = {
+  images: "/intro/images",
   index: "/intro",
   user: "/intro/user",
 };

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
@@ -13,6 +13,7 @@ import {
   bootResourceUbuntuSource as bootResourceUbuntuSourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -33,13 +34,33 @@ describe("ImagesIntro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+          initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
         >
           <ImagesIntro />
         </MemoryRouter>
       </Provider>
     );
     expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("stops polling when unmounted", async () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
+        >
+          <ImagesIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.unmount();
+    await waitForComponentToPaint(wrapper);
+    expect(
+      store
+        .getActions()
+        .some((action) => action.type === "bootresource/pollStop")
+    ).toBe(true);
   });
 
   it("disables the continue button if no image and source has been configured", () => {
@@ -49,7 +70,7 @@ describe("ImagesIntro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+          initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
         >
           <ImagesIntro />
         </MemoryRouter>
@@ -74,7 +95,7 @@ describe("ImagesIntro", () => {
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter
-          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+          initialEntries={[{ pathname: "/intro/images", key: "testKey" }]}
         >
           <ImagesIntro />
         </MemoryRouter>

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
@@ -1,0 +1,87 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import ImagesIntro from "./ImagesIntro";
+
+import type { RootState } from "app/store/root/types";
+import {
+  bootResource as bootResourceFactory,
+  bootResourceState as bootResourceStateFactory,
+  bootResourceUbuntu as bootResourceUbuntuFactory,
+  bootResourceUbuntuSource as bootResourceUbuntuSourceFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("ImagesIntro", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: [bootResourceFactory()],
+        ubuntu: bootResourceUbuntuFactory(),
+      }),
+    });
+  });
+
+  it("displays a spinner if server has not been polled yet", () => {
+    state.bootresource.ubuntu = null;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <ImagesIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("disables the continue button if no image and source has been configured", () => {
+    state.bootresource.ubuntu = bootResourceUbuntuFactory({ sources: [] });
+    state.bootresource.resources = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <ImagesIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("button[data-test='images-intro-continue']").prop("disabled")
+    ).toBe(true);
+    expect(
+      wrapper
+        .find("[data-test='images-intro-continue'] Tooltip")
+        .prop("message")
+    ).toBe("At least one image and source must be configured to continue.");
+  });
+
+  it("enables the continue button if an image and source has been configured", () => {
+    state.bootresource.ubuntu = bootResourceUbuntuFactory({
+      sources: [bootResourceUbuntuSourceFactory()],
+    });
+    state.bootresource.resources = [bootResourceFactory()];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <ImagesIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      wrapper.find("button[data-test='images-intro-continue']").prop("disabled")
+    ).toBe(false);
+  });
+});

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from "react";
+
+import {
+  Button,
+  Icon,
+  Spinner,
+  Strip,
+  Tooltip,
+} from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+
+import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
+import SyncedImages from "app/images/views/ImageList/SyncedImages";
+import introURLs from "app/intro/urls";
+import { actions as bootResourceActions } from "app/store/bootresource";
+import bootResourceSelectors from "app/store/bootresource/selectors";
+
+const ImagesIntro = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const ubuntu = useSelector(bootResourceSelectors.ubuntu);
+  const resources = useSelector(bootResourceSelectors.resources);
+  useWindowTitle("Welcome - Images");
+
+  useEffect(() => {
+    dispatch(bootResourceActions.poll({ continuous: true }));
+  }, [dispatch]);
+
+  const hasSources = (ubuntu?.sources || []).length > 0;
+  const continueDisabled = !hasSources || resources.length === 0;
+
+  return (
+    <Section>
+      <h4>Images</h4>
+      {!ubuntu ? (
+        <Strip shallow>
+          <Spinner text="Loading..." />
+        </Strip>
+      ) : (
+        <>
+          <SyncedImages />
+          <div className="u-align--right">
+            <Button
+              appearance="neutral"
+              onClick={() => {
+                history.push({ pathname: introURLs.index });
+              }}
+            >
+              Back
+            </Button>
+            <Button
+              appearance="positive"
+              data-test="images-intro-continue"
+              disabled={continueDisabled}
+              hasIcon
+              onClick={() => history.push({ pathname: introURLs.user })}
+            >
+              Continue
+              {continueDisabled && (
+                <Tooltip
+                  className="u-nudge-right"
+                  message="At least one image and source must be configured to continue."
+                >
+                  <Icon className="is-light" name="information" />
+                </Tooltip>
+              )}
+            </Button>
+          </div>
+        </>
+      )}
+    </Section>
+  );
+};
+
+export default ImagesIntro;

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -26,6 +26,10 @@ const ImagesIntro = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(bootResourceActions.poll({ continuous: true }));
+
+    return () => {
+      dispatch(bootResourceActions.pollStop());
+    };
   }, [dispatch]);
 
   const hasSources = (ubuntu?.sources || []).length > 0;

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -40,7 +40,7 @@ const ImagesIntro = (): JSX.Element => {
         </Strip>
       ) : (
         <>
-          <SyncedImages />
+          <SyncedImages inCard />
           <div className="u-align--right">
             <Button
               appearance="neutral"

--- a/ui/src/app/intro/views/ImagesIntro/index.ts
+++ b/ui/src/app/intro/views/ImagesIntro/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ImagesIntro";

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -1,5 +1,6 @@
 import { Route, Switch } from "react-router-dom";
 
+import ImagesIntro from "./ImagesIntro";
 import MaasIntro from "./MaasIntro";
 import UserIntro from "./UserIntro";
 
@@ -11,6 +12,9 @@ const Routes = (): JSX.Element => {
     <Switch>
       <Route exact path={introURLs.index}>
         <MaasIntro />
+      </Route>
+      <Route exact path={introURLs.images}>
+        <ImagesIntro />
       </Route>
       <Route exact path={introURLs.user}>
         <UserIntro />

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -11,6 +11,7 @@ import type { MaasIntroValues } from "./types";
 import FormikForm from "app/base/components/FormikForm";
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
+import introURLs from "app/intro/urls";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
@@ -111,6 +112,7 @@ const MaasIntro = (): JSX.Element => {
           }}
           saving={saving}
           saved={saved}
+          savedRedirect={introURLs.images}
           submitLabel="Save and continue"
           validationSchema={MaasIntroSchema}
         >


### PR DESCRIPTION
## Done

- Added images section to intro flow
- Driveby fix to prevent clear the last commissioning image in the table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Start a new `make start` MAAS or `make clean+db` an existing one to get the DB free of image data
- Go to /MAAS/r/intro/images and check that the continue button is disabled
- Fetch images from a source and check that one commissioning image is selected by default
- Check that you can't clear the last commissioning image from the table
- Start downloading an image and check that the continue button is enabled once downloading is queued

## Fixes

Fixes canonical-web-and-design/app-squad#91

## Screenshot
![2021-07-21_11-47](https://user-images.githubusercontent.com/25733845/126417680-6966709f-c568-4e0c-a10f-32830d1bba4f.png)
