### PR TITLE
feat(ui): add success page to MAAS intro flow

### DIFF
--- a/ui/src/app/intro/urls.ts
+++ b/ui/src/app/intro/urls.ts
@@ -1,6 +1,7 @@
 const urls = {
   images: "/intro/images",
   index: "/intro",
+  success: "/intro/success",
   user: "/intro/user",
 };
 

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -8,7 +8,7 @@ import {
   Tooltip,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
@@ -46,12 +46,7 @@ const ImagesIntro = (): JSX.Element => {
         <>
           <SyncedImages inCard />
           <div className="u-align--right">
-            <Button
-              appearance="neutral"
-              onClick={() => {
-                history.push({ pathname: introURLs.index });
-              }}
-            >
+            <Button appearance="neutral" element={Link} to={introURLs.index}>
               Back
             </Button>
             <Button
@@ -59,7 +54,7 @@ const ImagesIntro = (): JSX.Element => {
               data-test="images-intro-continue"
               disabled={continueDisabled}
               hasIcon
-              onClick={() => history.push({ pathname: introURLs.user })}
+              onClick={() => history.push({ pathname: introURLs.success })}
             >
               Continue
               {continueDisabled && (

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -2,12 +2,13 @@ import { Route, Switch } from "react-router-dom";
 
 import ImagesIntro from "./ImagesIntro";
 import MaasIntro from "./MaasIntro";
+import MaasIntroSuccess from "./MaasIntroSuccess";
 import UserIntro from "./UserIntro";
 
 import NotFound from "app/base/views/NotFound";
 import introURLs from "app/intro/urls";
 
-const Routes = (): JSX.Element => {
+const Intro = (): JSX.Element => {
   return (
     <Switch>
       <Route exact path={introURLs.index}>
@@ -15,6 +16,9 @@ const Routes = (): JSX.Element => {
       </Route>
       <Route exact path={introURLs.images}>
         <ImagesIntro />
+      </Route>
+      <Route exact path={introURLs.success}>
+        <MaasIntroSuccess />
       </Route>
       <Route exact path={introURLs.user}>
         <UserIntro />
@@ -26,4 +30,4 @@ const Routes = (): JSX.Element => {
   );
 };
 
-export default Routes;
+export default Intro;

--- a/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
+++ b/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
@@ -21,7 +21,8 @@ const ConnectivityCard = (): JSX.Element => {
       title={
         <>
           <span className="p-heading--4 u-sv1">
-            <Icon name={showErrorIcon ? "error" : "success"} /> Connectivity
+            <Icon name={showErrorIcon ? "error" : "success"} />
+            &ensp;Connectivity
           </span>
           <hr />
         </>

--- a/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
+++ b/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
@@ -17,7 +17,8 @@ const NameCard = (): JSX.Element => {
         <>
           <span className="u-flex--between">
             <span className="p-heading--4">
-              <Icon name={errors.name ? "error" : "success"} /> Welcome to MAAS
+              <Icon name={errors.name ? "error" : "success"} />
+              &ensp;Welcome to MAAS
             </span>
             <span className="p-text--default u-text--default-size">
               <Link

--- a/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -1,0 +1,115 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import MaasIntroSuccess from "./MaasIntroSuccess";
+
+import dashboardURLs from "app/dashboard/urls";
+import introURLs from "app/intro/urls";
+import machineURLs from "app/machines/urls";
+import { actions as configActions } from "app/store/config";
+import type { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  config as configFactory,
+  configState as configStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("MaasIntroSuccess", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      config: configStateFactory({
+        items: [configFactory({ name: "completed_intro", value: false })],
+      }),
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ completed_intro: false, is_superuser: false }),
+        }),
+      }),
+    });
+  });
+
+  it("links to the user intro if not yet completed", () => {
+    state.user.auth = authStateFactory({
+      user: userFactory({ completed_intro: false }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
+        >
+          <MaasIntroSuccess />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Link[data-test='continue-button']").prop("to")).toBe(
+      introURLs.user
+    );
+  });
+
+  it("links to the dashboard if an admin that has completed the user intro", () => {
+    state.user.auth = authStateFactory({
+      user: userFactory({ completed_intro: true, is_superuser: true }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
+        >
+          <MaasIntroSuccess />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Link[data-test='continue-button']").prop("to")).toBe(
+      dashboardURLs.index
+    );
+  });
+
+  it("links to the machine list if a non-admin that has completed the user intro", () => {
+    state.user.auth = authStateFactory({
+      user: userFactory({ completed_intro: true, is_superuser: false }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
+        >
+          <MaasIntroSuccess />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Link[data-test='continue-button']").prop("to")).toBe(
+      machineURLs.machines.index
+    );
+  });
+
+  it("dispatches an action to update completed intro config", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/success", key: "testKey" }]}
+        >
+          <MaasIntroSuccess />
+        </MemoryRouter>
+      </Provider>
+    );
+    wrapper.find("Link[data-test='continue-button']").simulate("click");
+
+    const expectedAction = configActions.update({ completed_intro: true });
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
+++ b/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
@@ -1,0 +1,72 @@
+import { Button, Card, Icon, List } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
+
+import Section from "app/base/components/Section";
+import { useWindowTitle } from "app/base/hooks";
+import dashboardURLs from "app/dashboard/urls";
+import introURLs from "app/intro/urls";
+import machineURLs from "app/machines/urls";
+import authSelectors from "app/store/auth/selectors";
+import { actions as configActions } from "app/store/config";
+
+const MaasIntroSuccess = (): JSX.Element => {
+  const dispatch = useDispatch();
+  const authUser = useSelector(authSelectors.get);
+  useWindowTitle("Welcome - Success");
+
+  let continueLink = introURLs.user;
+
+  if (authUser?.completed_intro) {
+    if (authUser?.is_superuser) {
+      continueLink = dashboardURLs.index;
+    } else {
+      continueLink = machineURLs.machines.index;
+    }
+  }
+
+  return (
+    <Section>
+      <Card
+        className="maas-intro__card"
+        data-test="maas-connectivity-form"
+        highlighted
+        title={
+          <>
+            <span className="p-heading--4 u-sv1">
+              <Icon name="success" />
+              &ensp;MAAS has been successfully set up
+            </span>
+            <hr />
+          </>
+        }
+      >
+        <List
+          items={[
+            "Once DHCP is enabled, set your machines to PXE boot and they will be automatically enlisted in the Machines tab.",
+            "Discovered MAC/IP pairs in your network will be listed on your dashboard and can be added to MAAS.",
+            "The fabrics, VLANs and subnets in your network will be automatically added to MAAS in the Subnets tab.",
+          ]}
+        />
+      </Card>
+      <div className="u-align--right">
+        <Button appearance="neutral" element={Link} to={introURLs.images}>
+          Back
+        </Button>
+        <Button
+          appearance="positive"
+          data-test="continue-button"
+          element={Link}
+          onClick={() => {
+            dispatch(configActions.update({ completed_intro: true }));
+          }}
+          to={continueLink}
+        >
+          Finish setup
+        </Button>
+      </div>
+    </Section>
+  );
+};
+
+export default MaasIntroSuccess;

--- a/ui/src/app/intro/views/MaasIntroSuccess/index.ts
+++ b/ui/src/app/intro/views/MaasIntroSuccess/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MaasIntroSuccess";

--- a/ui/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -38,8 +38,8 @@ const UserIntro = (): JSX.Element => {
         highlighted
         title={
           <span className="p-heading--4">
-            <Icon name={hasSSHKeys ? "success" : "success-grey"} /> SSH keys for{" "}
-            {authUser?.username}
+            <Icon name={hasSSHKeys ? "success" : "success-grey"} />
+            &ensp;SSH keys for {authUser?.username}
           </span>
         }
       >


### PR DESCRIPTION
## Done

- Added a success page to the MAAS intro flow, which redirects to either the user intro, dashboard or machine list depending on the auth user status

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/intro/success and check that a successful set up card shows up
- Check that you can navigate back to the images page and from the images page navigate to the success page
- Check that when you click the green button an action is dispatched to update config

## Fixes

Fixes canonical-web-and-design/app-squad#164

## Screenshot
![Screenshot 2021-07-21 at 15-42-22 Welcome - Success focal-maas MAAS](https://user-images.githubusercontent.com/25733845/126437581-00e5fddd-947d-4572-bd5a-2399d81dbb25.png)
