### PR TITLE
feat(ui): add ssh key form to user intro

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -82,11 +82,13 @@ exports[`stricter compilation`] = {
       [32, 4, 11, "Type \'number\' is not assignable to type \'null\'.", "1179509236"],
       [34, 4, 12, "Type \'number\' is not assignable to type \'null\'.", "304100367"]
     ],
-    "src/app/base/components/SSHKeyForm/SSHKeyForm.test.tsx:723394325": [
+    "src/app/base/components/SSHKeyForm/SSHKeyForm.test.tsx:3962155056": [
       [70, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
       [71, 8, 17, "Argument of type \'{ key: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'key\' does not exist in type \'FormEvent<{}>\'.", "1354989507"],
       [100, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "2019447570"],
-      [101, 8, 19, "Argument of type \'{ auth_id: string; protocol: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'auth_id\' does not exist in type \'FormEvent<{}>\'.", "3669199840"]
+      [101, 8, 19, "Argument of type \'{ auth_id: string; protocol: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'auth_id\' does not exist in type \'FormEvent<{}>\'.", "3669199840"],
+      [132, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [133, 6, 19, "Argument of type \'{ auth_id: string; protocol: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'auth_id\' does not exist in type \'FormEvent<{}>\'.", "3669199840"]
     ],
     "src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.test.tsx:447801057": [
       [61, 6, 25, "Cannot invoke an object which is possibly \'undefined\'.", "2260906107"],
@@ -94,13 +96,14 @@ exports[`stricter compilation`] = {
       [88, 6, 43, "Cannot invoke an object which is possibly \'undefined\'.", "4146450395"],
       [90, 30, 16, "Type \'{ name: string; value: string; }\' is not assignable to type \'EventTarget\'.\\n  Object literal may only specify known properties, and \'name\' does not exist in type \'EventTarget\'.", "1207371790"]
     ],
-    "src/app/base/components/SSHKeyList/SSHKeyList.test.tsx:817004380": [
+    "src/app/base/components/SSHKeyList/SSHKeyList.test.tsx:45164224": [
       [101, 11, 38, "Object is possibly \'undefined\'.", "1978148098"],
       [101, 50, 6, "Property \'length\' does not exist on type \'number\'.", "1433765721"],
       [162, 14, 38, "Object is possibly \'undefined\'.", "1978148098"],
       [162, 14, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
       [170, 10, 38, "Object is possibly \'undefined\'.", "1978148098"],
-      [170, 10, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"]
+      [170, 10, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"],
+      [268, 46, 11, "Argument of type \'\\"onConfirm\\"\' is not assignable to parameter of type \'\\"download\\" | \\"inlist\\" | \\"onCopy\\" | \\"onCopyCapture\\" | \\"onCut\\" | \\"onCutCapture\\" | \\"onPaste\\" | \\"onPasteCapture\\" | \\"onCompositionEnd\\" | \\"onCompositionEndCapture\\" | \\"onCompositionStart\\" | ... 150 more ... | \\"onTransitionEndCapture\\"\'.", "1296914934"]
     ],
     "src/app/base/components/ScriptStatus/ScriptStatus.tsx:4195111423": [
       [48, 14, 9, "Type \'string | null\' is not assignable to type \'string | undefined\'.\\n  Type \'null\' is not assignable to type \'string | undefined\'.", "2450009324"]
@@ -135,7 +138,7 @@ exports[`stricter compilation`] = {
       [213, 7, 11, "Property \'placeholder\' is missing in type \'{ disabledTags: { id: number; name: string; }[]; initialSelected: { id: number; name: string; }[]; tags: { id: number; name: string; }[]; }\' but required in type \'Props\'.", "3766634306"]
     ],
     "src/app/base/components/TagSelector/TagSelector.tsx:1747674011": [
-      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/caleb/Projects/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
+      [3, 18, 51, "Could not find a declaration file for module \'@canonical/react-components/dist/components/Field\'. \'/home/ubuntu/code/maas-ui/node_modules/@canonical/react-components/dist/components/Field/index.js\' implicitly has an \'any\' type.\\n  Try \`npm i --save-dev @types/canonical__react-components\` if it exists or add a new declaration (.d.ts) file containing \`declare module \'@canonical/react-components/dist/components/Field\';\`", "1535046059"],
       [38, 2, 12, "Binding element \'allowNewTags\' implicitly has an \'any\' type.", "3979358209"],
       [39, 2, 6, "Binding element \'filter\' implicitly has an \'any\' type.", "1355726373"],
       [40, 2, 12, "Binding element \'selectedTags\' implicitly has an \'any\' type.", "2698915821"],
@@ -789,9 +792,8 @@ exports[`stricter compilation`] = {
       [244, 10, 38, "Object is possibly \'undefined\'.", "1978148098"],
       [244, 10, 41, "Element implicitly has an \'any\' type because expression of type \'0\' can\'t be used to index type \'Number\'.\\n  Property \'0\' does not exist on type \'Number\'.", "2704435572"]
     ],
-    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx:535388423": [
-      [148, 4, 4, "Argument of type \'null\' is not assignable to parameter of type \'(() => void) | undefined\'.", "2087897566"],
-      [193, 8, 10, "Argument of type \'null\' is not assignable to parameter of type \'number\'.", "668428687"]
+    "src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx:1352214070": [
+      [150, 4, 4, "Argument of type \'null\' is not assignable to parameter of type \'(() => void) | undefined\'.", "2087897566"]
     ],
     "src/app/settings/views/Users/UserForm/UserForm.test.tsx:1181495248": [
       [87, 45, 6, "Property \'onSave\' does not exist on type \'HTMLAttributes\'.", "1685285285"],

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyForm.test.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyForm.test.tsx
@@ -123,13 +123,17 @@ describe("SSHKeyForm", () => {
   it("adds a message when a SSH key is added", () => {
     state.sshkey.saved = true;
     const store = mockStore(state);
-    mount(
+    const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
           <SSHKeyForm />
         </MemoryRouter>
       </Provider>
     );
+    wrapper.find("Formik").invoke("onSubmit")({
+      auth_id: "wallaroo",
+      protocol: "lp",
+    });
     const actions = store.getActions();
     expect(actions.some((action) => action.type === "sshkey/cleanup")).toBe(
       true

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyForm.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyForm.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -22,15 +24,23 @@ const SSHKeySchema = Yup.object().shape({
   }),
 });
 
-type Props = Partial<FormikFormProps<SSHKeyFormValues>>;
+type Props = {
+  cols?: number;
+} & Partial<FormikFormProps<SSHKeyFormValues>>;
 
-export const SSHKeyForm = (props: Props): JSX.Element => {
+export const SSHKeyForm = ({ cols, ...props }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const [adding, setAdding] = useState(false);
   const errors = useSelector(sshkeySelectors.errors);
   const saved = useSelector(sshkeySelectors.saved);
   const saving = useSelector(sshkeySelectors.saving);
 
-  useAddMessage(saved, sshkeyActions.cleanup, "SSH key successfully imported.");
+  useAddMessage(
+    adding && saved,
+    sshkeyActions.cleanup,
+    "SSH key successfully imported.",
+    () => setAdding(false)
+  );
 
   return (
     <FormikForm<SSHKeyFormValues>
@@ -38,6 +48,7 @@ export const SSHKeyForm = (props: Props): JSX.Element => {
       errors={errors}
       initialValues={{ auth_id: "", protocol: "", key: "" }}
       onSubmit={(values) => {
+        setAdding(true);
         if (values.key && values.key !== "") {
           dispatch(sshkeyActions.create(values));
         } else {
@@ -50,7 +61,7 @@ export const SSHKeyForm = (props: Props): JSX.Element => {
       validationSchema={SSHKeySchema}
       {...props}
     >
-      <SSHKeyFormFields />
+      <SSHKeyFormFields cols={cols} />
     </FormikForm>
   );
 };

--- a/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
+++ b/ui/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.tsx
@@ -11,16 +11,24 @@ import { useFormikContext } from "formik";
 import type { SSHKeyFormValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
+import { COL_SIZES } from "app/base/constants";
 
-export const SSHKeyFormFields = (): JSX.Element => {
+type Props = {
+  cols?: number;
+};
+
+export const SSHKeyFormFields = ({
+  cols = COL_SIZES.TOTAL,
+}: Props): JSX.Element => {
   const { values } = useFormikContext<SSHKeyFormValues>();
   const { protocol } = values;
   const uploadSelected = protocol === "upload";
+  const colSize = cols / 2;
 
   return (
     <>
       <Row>
-        <Col size="4">
+        <Col size={Math.ceil(colSize)}>
           <FormikField
             component={Select}
             name="protocol"
@@ -60,7 +68,7 @@ export const SSHKeyFormFields = (): JSX.Element => {
             />
           )}
         </Col>
-        <Col size="4">
+        <Col size={Math.floor(colSize)}>
           <p className="form-card__help">
             Before you can deploy a machine you must import at least one public
             SSH key into MAAS, so the deployed machine can be accessed.

--- a/ui/src/app/base/components/SSHKeyList/SSHKeyList.test.tsx
+++ b/ui/src/app/base/components/SSHKeyList/SSHKeyList.test.tsx
@@ -265,13 +265,8 @@ describe("SSHKeyList", () => {
       .at(0)
       .findWhere((n) => n.name() === "Button" && n.text() === "Delete")
       .simulate("click");
-    // Click on the delete confirm button
-    wrapper
-      .find("tbody TableRow")
-      .at(0)
-      .findWhere((n) => n.name() === "Button" && n.text() === "Delete")
-      .last()
-      .simulate("click");
+    // Simulate clicking on the delete confirm button.
+    wrapper.find("TableDeleteConfirm").invoke("onConfirm")();
     const actions = store.getActions();
     expect(actions.some((action) => action.type === "sshkey/cleanup")).toBe(
       true

--- a/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -143,4 +143,33 @@ describe("UserIntro", () => {
       wrapper.find("Button[data-test='continue-button']").prop("disabled")
     ).toBe(true);
   });
+
+  it("hides the SSH list if there are no ssh keys", () => {
+    state.sshkey.items = [];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("SSHKeyList").exists()).toBe(false);
+  });
+
+  it("shows the SSH list if there are ssh keys", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("SSHKeyList").exists()).toBe(true);
+  });
 });

--- a/ui/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -4,6 +4,8 @@ import { Button, Card, Icon, Row, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import SSHKeyForm from "app/base/components/SSHKeyForm";
+import SSHKeyList from "app/base/components/SSHKeyList";
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
 import dashboardURLs from "app/dashboard/urls";
@@ -21,7 +23,7 @@ const UserIntro = (): JSX.Element => {
 
   const hasSSHKeys = sshkeys.length > 0;
 
-  useWindowTitle("Welcome");
+  useWindowTitle("Welcome - User");
 
   useEffect(() => {
     dispatch(sshkeyActions.fetch());
@@ -47,6 +49,15 @@ const UserIntro = (): JSX.Element => {
           Add multiple keys from Launchpad and Github or enter them manually.
         </p>
         <h4>Keys</h4>
+        {hasSSHKeys ? <SSHKeyList sidebar={false} /> : null}
+        <SSHKeyForm
+          onSaveAnalytics={{
+            action: "Import",
+            category: "User intro",
+            label: "Import SSH key form",
+          }}
+          resetOnSave
+        />
       </Card>
       <Row>
         <Button

--- a/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.tsx
+++ b/ui/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.tsx
@@ -2,8 +2,11 @@ import { useHistory } from "react-router-dom";
 
 import FormCard from "app/base/components/FormCard";
 import SSHKeyForm from "app/base/components/SSHKeyForm";
+import { COL_SIZES } from "app/base/constants";
 import { useWindowTitle } from "app/base/hooks";
 import prefsURLs from "app/preferences/urls";
+
+const { CARD_TITLE, SIDEBAR, TOTAL } = COL_SIZES;
 
 export const AddSSHKey = (): JSX.Element => {
   const history = useHistory();
@@ -12,6 +15,7 @@ export const AddSSHKey = (): JSX.Element => {
   return (
     <FormCard title="Add SSH key">
       <SSHKeyForm
+        cols={TOTAL - SIDEBAR - CARD_TITLE}
         onCancel={() => history.push({ pathname: prefsURLs.sshKeys.index })}
         onSaveAnalytics={{
           action: "Saved",


### PR DESCRIPTION
## Done

- Add the ssh key form and table to the user intro.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/account/prefs/ssh-keys and remove any keys you have.
- Visit /MAAS/r/intro/user.
- You should see the SSH key form.
- Add an SSH key.
- The SSH key table should appear and the continue button should become enabled.
- You should be able to remove SSH keys from the SSH table.

## Fixes

Fixes: canonical-web-and-design/app-squad#93.