### PR TITLE
feat(ui): add ability to skip initial MAAS setup

### DIFF
--- a/shared/src/components/Header/Header.test.tsx
+++ b/shared/src/components/Header/Header.test.tsx
@@ -100,6 +100,7 @@ describe("Header", () => {
           } as Location
         }
         logout={jest.fn()}
+        onSkip={jest.fn()}
       />
     );
     expect(

--- a/shared/src/components/Header/Header.tsx
+++ b/shared/src/components/Header/Header.tsx
@@ -275,7 +275,7 @@ export const Header = ({
           )}
         </ul>
         <ul className="p-navigation__links" role="menu">
-          {!completedIntro && (
+          {!completedIntro && onSkip && (
             <li className="p-navigation__link" role="menuitem">
               {/* eslint-disable-next-line */}
               <a
@@ -289,17 +289,22 @@ export const Header = ({
               </a>
             </li>
           )}
-          <li
-            className={classNames("p-navigation__link", {
-              "is-selected": location.pathname.startsWith(
-                generateURL("/account/prefs", false, appendNewBase)
-              ),
-            })}
-            role="menuitem"
-          >
-            {authUser &&
-              generateLink({ url: "/account/prefs", label: authUser.username })}
-          </li>
+          {completedIntro && (
+            <li
+              className={classNames("p-navigation__link", {
+                "is-selected": location.pathname.startsWith(
+                  generateURL("/account/prefs", false, appendNewBase)
+                ),
+              })}
+              role="menuitem"
+            >
+              {authUser &&
+                generateLink({
+                  label: authUser.username,
+                  url: "/account/prefs",
+                })}
+            </li>
+          )}
           <li className="p-navigation__link" role="menuitem">
             {/* eslint-disable-next-line */}
             <a

--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -20,7 +20,7 @@ import Login from "app/base/components/Login";
 import Section from "app/base/components/Section";
 import StatusBar from "app/base/components/StatusBar";
 import FileContext, { fileContextStore } from "app/base/file-context";
-import baseURLs from "app/base/urls";
+import introURLs from "app/intro/urls";
 import { actions as authActions } from "app/store/auth";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
@@ -93,17 +93,29 @@ export const App = (): JSX.Element => {
     }
   }, [dispatch, connected]);
 
+  // Redirect to the MAAS or user intro if not completed and not already on
+  // an intro page.
   useEffect(() => {
-    if (!skipIntro && configLoaded) {
-      // Explicitly check that completedIntro is false so that it doesn't redirect
-      // if the config isn't defined yet.
+    if (
+      !skipIntro &&
+      configLoaded &&
+      !location.pathname.startsWith(introURLs.index)
+    ) {
       if (configLoaded && !completedIntro && !skipSetupIntro) {
-        navigateToLegacy(baseURLs.intro.index);
+        history.push({ pathname: introURLs.index });
       } else if (authUser && !authUser.completed_intro) {
-        navigateToLegacy(baseURLs.intro.user);
+        history.push({ pathname: introURLs.user });
       }
     }
-  }, [authUser, completedIntro, configLoaded, skipIntro, skipSetupIntro]);
+  }, [
+    authUser,
+    completedIntro,
+    configLoaded,
+    history,
+    location,
+    skipIntro,
+    skipSetupIntro,
+  ]);
 
   let content: JSX.Element;
   if (authLoading || connecting || authenticating) {

--- a/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
+++ b/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
@@ -17,8 +17,8 @@ export type Props = {
   confirmLabel: string;
   errors?: string | Record<string, string[]>;
   errorKey?: string;
-  finished: boolean;
-  inProgress: boolean;
+  finished?: boolean;
+  inProgress?: boolean;
   message: ReactNode;
   onClose: () => void;
   onConfirm: () => void;
@@ -31,8 +31,8 @@ const TableConfirm = ({
   confirmLabel,
   errors,
   errorKey,
-  finished,
-  inProgress,
+  finished = false,
+  inProgress = false,
   message,
   onClose,
   onConfirm,

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MaasIntro from "./MaasIntro";
@@ -127,5 +128,32 @@ describe("MaasIntro", () => {
     expect(updateRepoActions.length).toBe(2);
     expect(updateRepoActions[0]).toStrictEqual(updateMainArchiveAction);
     expect(updateRepoActions[1]).toStrictEqual(updatePortsArchiveAction);
+  });
+
+  it("can skip the initial MAAS setup", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/intro", key: "testKey" }]}>
+          <MaasIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='skip-setup']").exists()).toBe(false);
+
+    // Open the skip confirmation.
+    wrapper.find("button[data-test='secondary-submit']").simulate("click");
+    expect(wrapper.find("[data-test='skip-setup']").exists()).toBe(true);
+
+    // Confirm skipping MAAS setup.
+    wrapper.find("button[data-test='action-confirm']").simulate("click");
+    const expectedAction = configActions.update({
+      completed_intro: true,
+    });
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+
+    expect(actualAction).toStrictEqual(expectedAction);
   });
 });

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "@canonical/react-components";
+import { Card, Icon, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
 import * as Yup from "yup";
 
 import ConnectivityCard from "./ConnectivityCard";
@@ -10,6 +11,7 @@ import type { MaasIntroValues } from "./types";
 
 import FormikForm from "app/base/components/FormikForm";
 import Section from "app/base/components/Section";
+import TableConfirm from "app/base/components/TableConfirm";
 import { useWindowTitle } from "app/base/hooks";
 import introURLs from "app/intro/urls";
 import authSelectors from "app/store/auth/selectors";
@@ -34,6 +36,7 @@ export const MaasIntroSchema = Yup.object()
 
 const MaasIntro = (): JSX.Element => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const authLoading = useSelector(authSelectors.loading);
   const httpProxy = useSelector(configSelectors.httpProxy);
   const maasName = useSelector(configSelectors.maasName);
@@ -47,6 +50,7 @@ const MaasIntro = (): JSX.Element => {
   const reposSaving = useSelector(repoSelectors.saving);
   const mainArchive = useSelector(repoSelectors.mainArchive);
   const portsArchive = useSelector(repoSelectors.portsArchive);
+  const [showSkip, setShowSkip] = useState(false);
 
   useWindowTitle("Welcome");
 
@@ -64,61 +68,89 @@ const MaasIntro = (): JSX.Element => {
       {loading ? (
         <Spinner text="Loading..." />
       ) : (
-        <FormikForm<MaasIntroValues>
-          allowUnchanged
-          buttonsBordered={false}
-          cleanup={configActions.cleanup}
-          errors={errors}
-          initialValues={{
-            httpProxy: httpProxy || "",
-            mainArchiveUrl: mainArchive?.url || "",
-            name: maasName || "",
-            portsArchiveUrl: portsArchive?.url || "",
-            upstreamDns: upstreamDns || "",
-          }}
-          onSaveAnalytics={{
-            action: "Saved",
-            category: "Intro",
-            label: "Intro form",
-          }}
-          onSubmit={(values) => {
-            dispatch(configActions.cleanup());
-            dispatch(repoActions.cleanup());
-            dispatch(
-              configActions.update({
-                http_proxy: values.httpProxy,
-                maas_name: values.name,
-                upstream_dns: values.upstreamDns,
-              })
-            );
-            if (mainArchive && mainArchive.url !== values.mainArchiveUrl) {
+        <>
+          <FormikForm<MaasIntroValues>
+            allowUnchanged
+            buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            editable={!showSkip}
+            errors={errors}
+            initialValues={{
+              httpProxy: httpProxy || "",
+              mainArchiveUrl: mainArchive?.url || "",
+              name: maasName || "",
+              portsArchiveUrl: portsArchive?.url || "",
+              upstreamDns: upstreamDns || "",
+            }}
+            onSaveAnalytics={{
+              action: "Saved",
+              category: "Intro",
+              label: "Intro form",
+            }}
+            onSubmit={(values) => {
+              dispatch(configActions.cleanup());
+              dispatch(repoActions.cleanup());
               dispatch(
-                repoActions.update({
-                  id: mainArchive.id,
-                  name: mainArchive.name,
-                  url: values.mainArchiveUrl,
+                configActions.update({
+                  http_proxy: values.httpProxy,
+                  maas_name: values.name,
+                  upstream_dns: values.upstreamDns,
                 })
               );
-            }
-            if (portsArchive && portsArchive.url !== values.portsArchiveUrl) {
-              dispatch(
-                repoActions.update({
-                  id: portsArchive.id,
-                  name: portsArchive.name,
-                  url: values.portsArchiveUrl,
-                })
-              );
-            }
-          }}
-          saving={saving}
-          saved={saved}
-          savedRedirect={introURLs.images}
-          submitLabel="Save and continue"
-          validationSchema={MaasIntroSchema}
-        >
-          <NameCard />
-          <ConnectivityCard />
-        </FormikForm>
+              if (mainArchive && mainArchive.url !== values.mainArchiveUrl) {
+                dispatch(
+                  repoActions.update({
+                    id: mainArchive.id,
+                    name: mainArchive.name,
+                    url: values.mainArchiveUrl,
+                  })
+                );
+              }
+              if (portsArchive && portsArchive.url !== values.portsArchiveUrl) {
+                dispatch(
+                  repoActions.update({
+                    id: portsArchive.id,
+                    name: portsArchive.name,
+                    url: values.portsArchiveUrl,
+                  })
+                );
+              }
+            }}
+            saving={saving}
+            saved={saved}
+            savedRedirect={introURLs.images}
+            secondarySubmit={() => {
+              setShowSkip(true);
+            }}
+            secondarySubmitLabel="Skip setup"
+            submitLabel="Save and continue"
+            validationSchema={MaasIntroSchema}
+          >
+            <NameCard />
+            <ConnectivityCard />
+          </FormikForm>
+          {showSkip && (
+            <Card data-test="skip-setup" highlighted>
+              <TableConfirm
+                confirmLabel="Skip to user intro"
+                message={
+                  <>
+                    <Icon className="is-inline" name="warning" />
+                    Are you sure you want to skip the initial MAAS setup? You
+                    will still be able to find all configuration options in the
+                    Settings and Images tabs.
+                  </>
+                }
+                onClose={() => setShowSkip(false)}
+                onConfirm={() => {
+                  dispatch(configActions.update({ completed_intro: true }));
+                  history.push({ pathname: introURLs.user });
+                }}
+                sidebar={false}
+              />
+            </Card>
+          )}
+        </>
       )}
     </Section>
   );


### PR DESCRIPTION
## Done

- Added a skip button + confirmation to the initial MAAS intro page
- Removed skip and user preferences links from header in react app

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /MAAS/r/intro and check that you can skip straight to the user intro

## Fixes

Fixes canonical-web-and-design/app-squad#120
