### PR TITLE
feat(ui): display non-admin intro message

### DIFF
--- a/ui/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
+++ b/ui/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
@@ -1,0 +1,10 @@
+import { mount } from "enzyme";
+
+import IncompleteCard from "./IncompleteCard";
+
+describe("IncompleteCard", () => {
+  it("renders", () => {
+    const wrapper = mount(<IncompleteCard />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui/src/app/intro/views/IncompleteCard/IncompleteCard.tsx
+++ b/ui/src/app/intro/views/IncompleteCard/IncompleteCard.tsx
@@ -1,0 +1,38 @@
+import { Card, Icon, Link } from "@canonical/react-components";
+
+const IncompleteCard = (): JSX.Element => {
+  return (
+    <Card
+      className="maas-intro__card"
+      data-test="maas-name-form"
+      highlighted
+      title={
+        <>
+          <span className="u-flex--between">
+            <span className="p-heading--4">
+              <Icon name="error" />
+              &ensp;Welcome to MAAS
+            </span>
+            <span className="p-text--default u-text--default-size">
+              <Link
+                external
+                href="https://maas.io/docs/configuration-journey"
+                target="_blank"
+              >
+                Help with configuring MAAS
+              </Link>
+            </span>
+          </span>
+          <hr />
+        </>
+      }
+    >
+      <p>
+        This MAAS has not be configured. Ask an admin to log in and finish the
+        configuration.
+      </p>
+    </Card>
+  );
+};
+
+export default IncompleteCard;

--- a/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
+++ b/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IncompleteCard renders 1`] = `
+<IncompleteCard>
+  <Card
+    className="maas-intro__card"
+    data-test="maas-name-form"
+    highlighted={true}
+    title={
+      <React.Fragment>
+        <span
+          className="u-flex--between"
+        >
+          <span
+            className="p-heading--4"
+          >
+            <Icon
+              name="error"
+            />
+             Welcome to MAAS
+          </span>
+          <span
+            className="p-text--default u-text--default-size"
+          >
+            <Link
+              external={true}
+              href="https://maas.io/docs/configuration-journey"
+              target="_blank"
+            >
+              Help with configuring MAAS
+            </Link>
+          </span>
+        </span>
+        <hr />
+      </React.Fragment>
+    }
+  >
+    <div
+      className="maas-intro__card p-card--highlighted"
+      data-test="maas-name-form"
+    >
+      <h3
+        className="p-card__title"
+      >
+        <span
+          className="u-flex--between"
+        >
+          <span
+            className="p-heading--4"
+          >
+            <Icon
+              name="error"
+            >
+              <i
+                className="p-icon--error"
+              />
+            </Icon>
+             Welcome to MAAS
+          </span>
+          <span
+            className="p-text--default u-text--default-size"
+          >
+            <Link
+              external={true}
+              href="https://maas.io/docs/configuration-journey"
+              target="_blank"
+            >
+              <a
+                className="p-link--external"
+                href="https://maas.io/docs/configuration-journey"
+                target="_blank"
+              >
+                Help with configuring MAAS
+              </a>
+            </Link>
+          </span>
+        </span>
+        <hr />
+      </h3>
+      <div
+        className="p-card__content"
+      >
+        <p>
+          This MAAS has not be configured. Ask an admin to log in and finish the configuration.
+        </p>
+      </div>
+    </div>
+  </Card>
+</IncompleteCard>
+`;

--- a/ui/src/app/intro/views/IncompleteCard/index.ts
+++ b/ui/src/app/intro/views/IncompleteCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IncompleteCard";

--- a/ui/src/app/intro/views/Intro.test.tsx
+++ b/ui/src/app/intro/views/Intro.test.tsx
@@ -1,0 +1,72 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import Intro from "./Intro";
+
+import type { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("Intro", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ completed_intro: false, is_superuser: true }),
+        }),
+      }),
+    });
+  });
+
+  it("displays a spinner when loading", () => {
+    state.user.auth.loading = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/intro" }]}>
+          <Intro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a message if the user is not an admin", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ completed_intro: false, is_superuser: false }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/intro" }]}>
+          <Intro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("IncompleteCard").exists()).toBe(true);
+  });
+
+  it("can display the routes", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/intro" }]}>
+          <Intro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Switch").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -1,14 +1,35 @@
+import type { ReactNode } from "react";
+
+import { Spinner } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 import { Route, Switch } from "react-router-dom";
 
 import ImagesIntro from "./ImagesIntro";
+import IncompleteCard from "./IncompleteCard";
 import MaasIntro from "./MaasIntro";
 import MaasIntroSuccess from "./MaasIntroSuccess";
 import UserIntro from "./UserIntro";
 
+import Section from "app/base/components/Section";
 import NotFound from "app/base/views/NotFound";
 import introURLs from "app/intro/urls";
+import authSelectors from "app/store/auth/selectors";
 
 const Intro = (): JSX.Element => {
+  const loading = useSelector(authSelectors.loading);
+  const authUser = useSelector(authSelectors.get);
+  let content: ReactNode;
+  if (loading) {
+    content = <Spinner text="Loading..." />;
+  } else if (authUser && !authUser.is_superuser) {
+    // Prevent the user from reaching any of the intro urls if they are not an
+    // admin.
+    content = <IncompleteCard />;
+  }
+  if (content) {
+    return <Section>{content}</Section>;
+  }
+
   return (
     <Switch>
       <Route exact path={introURLs.index}>

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -14,14 +14,18 @@ import Section from "app/base/components/Section";
 import NotFound from "app/base/views/NotFound";
 import introURLs from "app/intro/urls";
 import authSelectors from "app/store/auth/selectors";
+import configSelectors from "app/store/config/selectors";
 
 const Intro = (): JSX.Element => {
-  const loading = useSelector(authSelectors.loading);
+  const authLoading = useSelector(authSelectors.loading);
+  const configLoading = useSelector(configSelectors.loading);
   const authUser = useSelector(authSelectors.get);
+  const completedIntro = useSelector(configSelectors.completedIntro);
+  const isAdmin = authUser?.is_superuser;
   let content: ReactNode;
-  if (loading) {
+  if (authLoading || configLoading) {
     content = <Spinner text="Loading..." />;
-  } else if (authUser && !authUser.is_superuser) {
+  } else if (!completedIntro && !isAdmin) {
     // Prevent the user from reaching any of the intro urls if they are not an
     // admin.
     content = <IncompleteCard />;
@@ -29,7 +33,6 @@ const Intro = (): JSX.Element => {
   if (content) {
     return <Section>{content}</Section>;
   }
-
   return (
     <Switch>
       <Route exact path={introURLs.index}>

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -48,7 +48,9 @@ describe("MaasIntro", () => {
         items: [mainArchive, portsArchive],
       }),
       user: userStateFactory({
-        auth: authStateFactory({ user: userFactory({ is_superuser: true }) }),
+        auth: authStateFactory({
+          user: userFactory({ completed_intro: false, is_superuser: true }),
+        }),
       }),
     });
   });


### PR DESCRIPTION
## Done

- Display a message if the user logs in before the intro is complete.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a non-admin and log in.
- Visit /MAAS/r/intro
- You should see a message instead of the intro.
- Log in as an admin and visit /MAAS/r/intro
- You should see the intro as normal.

## Fixes

Fixes: canonical-web-and-design/app-squad#158.