### PR TITLE
feat(ui): add user intro skip

### DIFF
--- a/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
+++ b/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
@@ -11,12 +11,13 @@ import type { Props as ButtonProps } from "@canonical/react-components/dist/comp
 
 import { COL_SIZES } from "app/base/constants";
 import { useCycled } from "app/base/hooks";
+import type { APIError } from "app/base/types";
 import { formatErrors } from "app/utils";
 
 export type Props = {
   confirmAppearance?: ButtonProps["appearance"];
   confirmLabel: string;
-  errors?: string | Record<string, string[]>;
+  errors?: APIError;
   errorKey?: string;
   finished?: boolean;
   inProgress?: boolean;

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -13,7 +13,9 @@ import FormikForm from "app/base/components/FormikForm";
 import Section from "app/base/components/Section";
 import TableConfirm from "app/base/components/TableConfirm";
 import { useWindowTitle } from "app/base/hooks";
+import dashboardURLs from "app/dashboard/urls";
 import introURLs from "app/intro/urls";
+import machineURLs from "app/machines/urls";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
@@ -38,6 +40,7 @@ const MaasIntro = (): JSX.Element => {
   const dispatch = useDispatch();
   const history = useHistory();
   const authLoading = useSelector(authSelectors.loading);
+  const authUser = useSelector(authSelectors.get);
   const httpProxy = useSelector(configSelectors.httpProxy);
   const maasName = useSelector(configSelectors.maasName);
   const upstreamDns = useSelector(configSelectors.upstreamDns);
@@ -132,7 +135,11 @@ const MaasIntro = (): JSX.Element => {
           {showSkip && (
             <Card data-test="skip-setup" highlighted>
               <TableConfirm
-                confirmLabel="Skip to user intro"
+                confirmLabel={
+                  authUser?.completed_intro
+                    ? "Skip setup"
+                    : "Skip to user setup"
+                }
                 message={
                   <>
                     <Icon className="is-inline" name="warning" />
@@ -144,7 +151,15 @@ const MaasIntro = (): JSX.Element => {
                 onClose={() => setShowSkip(false)}
                 onConfirm={() => {
                   dispatch(configActions.update({ completed_intro: true }));
-                  history.push({ pathname: introURLs.user });
+                  if (!authUser?.completed_intro) {
+                    history.push({ pathname: introURLs.user });
+                  } else {
+                    history.push({
+                      pathname: authUser?.is_superuser
+                        ? dashboardURLs.index
+                        : machineURLs.machines.index,
+                    });
+                  }
                 }}
                 sidebar={false}
               />

--- a/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -258,4 +258,28 @@ describe("UserIntro", () => {
     );
     expect(wrapper.find("Redirect").exists()).toBe(true);
   });
+
+  it("can skip the user setup", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <UserIntro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("[data-test='skip-setup']").exists()).toBe(false);
+    // Open the skip confirmation.
+    wrapper.find("button[data-test='skip-button']").simulate("click");
+    expect(wrapper.find("[data-test='skip-setup']").exists()).toBe(true);
+    // Confirm skipping MAAS setup.
+    wrapper.find("button[data-test='action-confirm']").simulate("click");
+    const expectedAction = userActions.markIntroComplete();
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+    expect(actualAction).toStrictEqual(expectedAction);
+  });
 });

--- a/ui/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import {
   ActionButton,
+  Button,
   Card,
   Icon,
   Notification,
@@ -13,6 +14,7 @@ import { Redirect } from "react-router";
 import SSHKeyForm from "app/base/components/SSHKeyForm";
 import SSHKeyList from "app/base/components/SSHKeyList";
 import Section from "app/base/components/Section";
+import TableConfirm from "app/base/components/TableConfirm";
 import { useCycled, useWindowTitle } from "app/base/hooks";
 import dashboardURLs from "app/dashboard/urls";
 import machineURLs from "app/machines/urls";
@@ -25,6 +27,7 @@ import { formatErrors } from "app/utils";
 
 const UserIntro = (): JSX.Element => {
   const dispatch = useDispatch();
+  const [showSkip, setShowSkip] = useState(false);
   const authLoading = useSelector(authSelectors.loading);
   const authUser = useSelector(authSelectors.get);
   const sshkeys = useSelector(sshkeySelectors.all);
@@ -89,11 +92,20 @@ const UserIntro = (): JSX.Element => {
         />
       </Card>
       <div className="u-align--right">
+        <Button
+          appearance="neutral"
+          data-test="skip-button"
+          onClick={() => {
+            setShowSkip(true);
+          }}
+        >
+          Skip user setup
+        </Button>
         <ActionButton
           appearance="positive"
           data-test="continue-button"
           disabled={!hasSSHKeys}
-          loading={markingIntroComplete}
+          loading={markingIntroComplete && !showSkip}
           onClick={() => {
             dispatch(userActions.markIntroComplete());
           }}
@@ -102,6 +114,28 @@ const UserIntro = (): JSX.Element => {
           Finish setup
         </ActionButton>
       </div>
+      {showSkip && (
+        <Card data-test="skip-setup" highlighted>
+          <TableConfirm
+            confirmLabel="Skip user setup"
+            errors={errors}
+            finished={markedIntroComplete}
+            inProgress={markingIntroComplete && showSkip}
+            message={
+              <>
+                <Icon className="is-inline" name="warning" />
+                Are you sure you want to skip your user setup? You will still be
+                able to manage your SSH keys in your user preferences.
+              </>
+            }
+            onClose={() => setShowSkip(false)}
+            onConfirm={() => {
+              dispatch(userActions.markIntroComplete());
+            }}
+            sidebar={false}
+          />
+        </Card>
+      )}
     </Section>
   );
 };


### PR DESCRIPTION
## Done

- Add a skip button and confirmation to the user intro.
- Update the main intro to now show the user intro if it has already been completed.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a new user.
- Visit /MAAS/r/intro/user.
- Click "Skip user setup" and you should see a confirmation.
- Confirm and the intro should close.

## Fixes

Fixes: canonical-web-and-design/app-squad#167.