### PR TITLE
feat(ui): create reusable intro components

### DIFF
--- a/ui/src/app/base/components/Section/Section.tsx
+++ b/ui/src/app/base/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { HTMLProps, ReactNode } from "react";
 
 import { Col, Strip } from "@canonical/react-components";
 import classNames from "classnames";
@@ -6,22 +6,23 @@ import classNames from "classnames";
 import NotificationList from "app/base/components/NotificationList";
 import { COL_SIZES } from "app/base/constants";
 
-type Props = {
+export type Props = {
   children?: ReactNode;
   header?: ReactNode;
   headerClassName?: string;
   sidebar?: ReactNode;
-};
+} & HTMLProps<HTMLDivElement>;
 
 const Section = ({
   children,
   header,
   headerClassName,
   sidebar,
+  ...props
 }: Props): JSX.Element => {
   const { SIDEBAR, TOTAL } = COL_SIZES;
   return (
-    <div className="section">
+    <div className="section" {...props}>
       {header ? (
         <Strip
           className={classNames("section__header", headerClassName)}

--- a/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/ChangeSource/ChangeSource.tsx
@@ -9,23 +9,24 @@ import type { BootResourceUbuntuSource } from "app/store/bootresource/types";
 
 type Props = {
   closeForm: (() => void) | null;
+  inCard?: boolean;
 };
 
-const ChangeSource = ({ closeForm }: Props): JSX.Element => {
+const ChangeSource = ({ closeForm, inCard = true }: Props): JSX.Element => {
   const [source, setSource] = useState<BootResourceUbuntuSource | null>(null);
 
-  return (
-    <Card highlighted>
-      {source ? (
-        <FetchedImages
-          closeForm={closeForm ? () => closeForm() : () => setSource(null)}
-          source={source}
-        />
-      ) : (
-        <FetchImagesForm closeForm={closeForm} setSource={setSource} />
-      )}
-    </Card>
+  const content = source ? (
+    <FetchedImages
+      closeForm={closeForm ? () => closeForm() : () => setSource(null)}
+      source={source}
+    />
+  ) : (
+    <FetchImagesForm closeForm={closeForm} setSource={setSource} />
   );
+  if (inCard) {
+    return <Card highlighted>{content}</Card>;
+  }
+  return content;
 };
 
 export default ChangeSource;

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -16,7 +16,7 @@ import {
 const mockStore = configureStore();
 
 describe("SyncedImages", () => {
-  it("can render in a card", () => {
+  it("can render the form in a card", () => {
     const state = rootStateFactory({
       bootresource: bootResourceStateFactory({
         ubuntu: ubuntuFactory({
@@ -29,10 +29,11 @@ describe("SyncedImages", () => {
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
-        <SyncedImages inCard />
+        <SyncedImages formInCard />
       </Provider>
     );
-    expect(wrapper.find("[data-test='images-in-card']").exists()).toBe(true);
+    wrapper.find("button[data-test='change-source-button']").simulate("click");
+    expect(wrapper.find("ChangeSource").prop("inCard")).toBe(true);
   });
 
   it("renders the change source form and disables closing it if no sources are detected", () => {

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 
 import {
   Button,
-  Card,
   Col,
   Icon,
   Row,
@@ -32,10 +31,10 @@ const getImageSyncText = (sources: BootResourceUbuntuSource[]) => {
 };
 
 type Props = {
-  inCard?: boolean;
+  formInCard?: boolean;
 };
 
-const SyncedImages = ({ inCard = false }: Props): JSX.Element | null => {
+const SyncedImages = ({ formInCard = true }: Props): JSX.Element | null => {
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
   const resources = useSelector(bootResourceSelectors.resources);
   const sources = ubuntu?.sources || [];
@@ -47,52 +46,6 @@ const SyncedImages = ({ inCard = false }: Props): JSX.Element | null => {
   }
 
   const canChangeSource = resources.every((resource) => !resource.downloading);
-  let content = (
-    <>
-      <div className="u-flex--between">
-        <h4 data-test="image-sync-text">
-          Showing images synced from{" "}
-          <strong>{getImageSyncText(sources)}</strong>
-        </h4>
-        <Button
-          appearance="neutral"
-          data-test="change-source-button"
-          disabled={!canChangeSource}
-          onClick={() => setShowChangeSource(true)}
-        >
-          Change source
-          {!canChangeSource && (
-            <Tooltip
-              message="Cannot change source while images are downloading."
-              className="u-nudge-right--small"
-              position="top-right"
-            >
-              <Icon name="information" />
-            </Tooltip>
-          )}
-        </Button>
-      </div>
-      <p>
-        Select images to be imported and kept in sync daily. Images will be
-        available for deploying to machines managed by MAAS.
-      </p>
-      <UbuntuImages sources={sources} />
-      <UbuntuCoreImages />
-      <OtherImages />
-    </>
-  );
-  if (inCard) {
-    content = (
-      <Card
-        className="u-no-padding--bottom"
-        data-test="images-in-card"
-        highlighted
-      >
-        {content}
-      </Card>
-    );
-  }
-
   return (
     <Strip shallow>
       <Row>
@@ -100,9 +53,41 @@ const SyncedImages = ({ inCard = false }: Props): JSX.Element | null => {
           {showChangeSource ? (
             <ChangeSource
               closeForm={hasSources ? () => setShowChangeSource(false) : null}
+              inCard={formInCard}
             />
           ) : (
-            content
+            <>
+              <div className="u-flex--between">
+                <h4 data-test="image-sync-text">
+                  Showing images synced from{" "}
+                  <strong>{getImageSyncText(sources)}</strong>
+                </h4>
+                <Button
+                  appearance="neutral"
+                  data-test="change-source-button"
+                  disabled={!canChangeSource}
+                  onClick={() => setShowChangeSource(true)}
+                >
+                  Change source
+                  {!canChangeSource && (
+                    <Tooltip
+                      message="Cannot change source while images are downloading."
+                      className="u-nudge-right--small"
+                      position="top-right"
+                    >
+                      <Icon name="information" />
+                    </Tooltip>
+                  )}
+                </Button>
+              </div>
+              <p>
+                Select images to be imported and kept in sync daily. Images will
+                be available for deploying to machines managed by MAAS.
+              </p>
+              <UbuntuImages sources={sources} />
+              <UbuntuCoreImages />
+              <OtherImages />
+            </>
           )}
         </Col>
       </Row>

--- a/ui/src/app/intro/components/IntroCard/IntroCard.test.tsx
+++ b/ui/src/app/intro/components/IntroCard/IntroCard.test.tsx
@@ -3,15 +3,6 @@ import { mount } from "enzyme";
 import IntroCard from "./IntroCard";
 
 describe("IntroCard", () => {
-  it("displays a spinner when loading", () => {
-    const wrapper = mount(
-      <IntroCard loading title="Setup MAAS">
-        Card content
-      </IntroCard>
-    );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
-  });
-
   it("displays a title link if supplied", () => {
     const wrapper = mount(
       <IntroCard

--- a/ui/src/app/intro/components/IntroCard/IntroCard.test.tsx
+++ b/ui/src/app/intro/components/IntroCard/IntroCard.test.tsx
@@ -1,0 +1,57 @@
+import { mount } from "enzyme";
+
+import IntroCard from "./IntroCard";
+
+describe("IntroCard", () => {
+  it("displays a spinner when loading", () => {
+    const wrapper = mount(
+      <IntroCard loading title="Setup MAAS">
+        Card content
+      </IntroCard>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("displays a title link if supplied", () => {
+    const wrapper = mount(
+      <IntroCard
+        titleLink={
+          <a href="#help" data-test="help-link">
+            Help!
+          </a>
+        }
+        title="Setup MAAS"
+      >
+        Card content
+      </IntroCard>
+    );
+    expect(wrapper.find("[data-test='help-link']").exists()).toBe(true);
+  });
+
+  it("can display a green tick icon", () => {
+    const wrapper = mount(
+      <IntroCard title="Setup MAAS" complete>
+        Card content
+      </IntroCard>
+    );
+    expect(wrapper.find("Icon[name='success']").exists()).toBe(true);
+  });
+
+  it("can display an error icon", () => {
+    const wrapper = mount(
+      <IntroCard title="Setup MAAS" hasErrors>
+        Card content
+      </IntroCard>
+    );
+    expect(wrapper.find("Icon[name='error']").exists()).toBe(true);
+  });
+
+  it("can display a grey tick icon", () => {
+    const wrapper = mount(
+      <IntroCard complete={false} title="Setup MAAS">
+        Card content
+      </IntroCard>
+    );
+    expect(wrapper.find("Icon[name='success-grey']").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/intro/components/IntroCard/IntroCard.tsx
+++ b/ui/src/app/intro/components/IntroCard/IntroCard.tsx
@@ -1,0 +1,58 @@
+import type { HTMLProps, ReactNode } from "react";
+
+import { Card, Icon, Spinner } from "@canonical/react-components";
+
+type Props = {
+  children: ReactNode;
+  complete?: boolean;
+  hasErrors?: boolean;
+  loading?: boolean;
+  title: ReactNode;
+  titleLink?: ReactNode;
+} & Omit<HTMLProps<HTMLDivElement>, "title">;
+
+const IntroCard = ({
+  children,
+  complete,
+  hasErrors,
+  loading,
+  title,
+  titleLink,
+  ...props
+}: Props): JSX.Element => {
+  if (loading) {
+    return <Spinner />;
+  }
+  let icon = "success-grey";
+  if (hasErrors) {
+    icon = "error";
+  } else if (complete) {
+    icon = "success";
+  }
+  return (
+    <Card
+      highlighted
+      title={
+        <>
+          <span className="u-flex--between">
+            <span className="p-heading--4">
+              <Icon name={icon} />
+              &ensp;{title}
+            </span>
+            {titleLink ? (
+              <span className="p-text--default u-text--default-size">
+                {titleLink}
+              </span>
+            ) : null}
+          </span>
+          <hr />
+        </>
+      }
+      {...props}
+    >
+      {children}
+    </Card>
+  );
+};
+
+export default IntroCard;

--- a/ui/src/app/intro/components/IntroCard/IntroCard.tsx
+++ b/ui/src/app/intro/components/IntroCard/IntroCard.tsx
@@ -1,12 +1,11 @@
 import type { HTMLProps, ReactNode } from "react";
 
-import { Card, Icon, Spinner } from "@canonical/react-components";
+import { Card, Icon } from "@canonical/react-components";
 
 type Props = {
   children: ReactNode;
   complete?: boolean;
   hasErrors?: boolean;
-  loading?: boolean;
   title: ReactNode;
   titleLink?: ReactNode;
 } & Omit<HTMLProps<HTMLDivElement>, "title">;
@@ -15,14 +14,10 @@ const IntroCard = ({
   children,
   complete,
   hasErrors,
-  loading,
   title,
   titleLink,
   ...props
 }: Props): JSX.Element => {
-  if (loading) {
-    return <Spinner />;
-  }
   let icon = "success-grey";
   if (hasErrors) {
     icon = "error";
@@ -31,6 +26,7 @@ const IntroCard = ({
   }
   return (
     <Card
+      className="maas-intro__card"
       highlighted
       title={
         <>

--- a/ui/src/app/intro/components/IntroCard/index.ts
+++ b/ui/src/app/intro/components/IntroCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IntroCard";

--- a/ui/src/app/intro/components/IntroSection/IntroSection.test.tsx
+++ b/ui/src/app/intro/components/IntroSection/IntroSection.test.tsx
@@ -56,7 +56,7 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection closeIntro={true}>Intro content</IntroSection>
+          <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
         </MemoryRouter>
       </Provider>
     );
@@ -75,7 +75,7 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection closeIntro={true}>Intro content</IntroSection>
+          <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
         </MemoryRouter>
       </Provider>
     );
@@ -94,7 +94,7 @@ describe("IntroSection", () => {
         <MemoryRouter
           initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
         >
-          <IntroSection closeIntro={true}>Intro content</IntroSection>
+          <IntroSection shouldExitIntro={true}>Intro content</IntroSection>
         </MemoryRouter>
       </Provider>
     );

--- a/ui/src/app/intro/components/IntroSection/IntroSection.test.tsx
+++ b/ui/src/app/intro/components/IntroSection/IntroSection.test.tsx
@@ -1,0 +1,122 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import IntroSection from "./IntroSection";
+
+import dashboardURLs from "app/dashboard/urls";
+import machineURLs from "app/machines/urls";
+import type { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userEventError as userEventErrorFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("IntroSection", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ completed_intro: false, is_superuser: true }),
+        }),
+      }),
+    });
+  });
+
+  it("can display a loading spinner", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <IntroSection loading={true}>Intro content</IntroSection>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+  });
+
+  it("can redirect to close the intro", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ completed_intro: true }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <IntroSection closeIntro={true}>Intro content</IntroSection>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+  });
+
+  it("redirects to the dashboard for admins", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ completed_intro: true, is_superuser: true }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <IntroSection closeIntro={true}>Intro content</IntroSection>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").prop("to")).toBe(dashboardURLs.index);
+  });
+
+  it("redirects to the machine list for non-admins", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ completed_intro: true, is_superuser: false }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <IntroSection closeIntro={true}>Intro content</IntroSection>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").prop("to")).toBe(
+      machineURLs.machines.index
+    );
+  });
+
+  it("can show errors", () => {
+    state.user = userStateFactory({
+      eventErrors: [userEventErrorFactory()],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <IntroSection errors="Uh oh!">Intro content</IntroSection>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
+  });
+});

--- a/ui/src/app/intro/components/IntroSection/IntroSection.tsx
+++ b/ui/src/app/intro/components/IntroSection/IntroSection.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+import { Notification, Spinner } from "@canonical/react-components";
+import { Redirect } from "react-router";
+
+import Section from "app/base/components/Section";
+import type { Props as SectionProps } from "app/base/components/Section/Section";
+import { useWindowTitle } from "app/base/hooks";
+import type { APIError } from "app/base/types";
+import { useExitURL } from "app/intro/hooks";
+import { formatErrors } from "app/utils";
+
+type Props = {
+  children: ReactNode;
+  closeIntro?: boolean;
+  complete?: boolean;
+  errors?: APIError;
+  loading?: boolean;
+  titleLink?: ReactNode;
+  windowTitle?: string;
+} & SectionProps;
+
+const IntroSection = ({
+  children,
+  closeIntro,
+  complete,
+  errors,
+  loading,
+  titleLink,
+  windowTitle,
+  ...props
+}: Props): JSX.Element => {
+  const errorMessage = formatErrors(errors);
+  const exitURL = useExitURL();
+
+  useWindowTitle(windowTitle ? `Welcome ${windowTitle}` : "Welcome");
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (closeIntro) {
+    return <Redirect to={exitURL} />;
+  }
+
+  return (
+    <Section {...props}>
+      {errorMessage && (
+        <Notification type="negative" status="Error:">
+          {errorMessage}
+        </Notification>
+      )}
+      {children}
+    </Section>
+  );
+};
+
+export default IntroSection;

--- a/ui/src/app/intro/components/IntroSection/IntroSection.tsx
+++ b/ui/src/app/intro/components/IntroSection/IntroSection.tsx
@@ -12,20 +12,20 @@ import { formatErrors } from "app/utils";
 
 type Props = {
   children: ReactNode;
-  closeIntro?: boolean;
   complete?: boolean;
   errors?: APIError;
   loading?: boolean;
+  shouldExitIntro?: boolean;
   titleLink?: ReactNode;
   windowTitle?: string;
 } & SectionProps;
 
 const IntroSection = ({
   children,
-  closeIntro,
   complete,
   errors,
   loading,
+  shouldExitIntro,
   titleLink,
   windowTitle,
   ...props
@@ -33,13 +33,9 @@ const IntroSection = ({
   const errorMessage = formatErrors(errors);
   const exitURL = useExitURL();
 
-  useWindowTitle(windowTitle ? `Welcome ${windowTitle}` : "Welcome");
+  useWindowTitle(windowTitle ? `Welcome - ${windowTitle}` : "Welcome");
 
-  if (loading) {
-    return <Spinner />;
-  }
-
-  if (closeIntro) {
+  if (shouldExitIntro) {
     return <Redirect to={exitURL} />;
   }
 
@@ -50,7 +46,7 @@ const IntroSection = ({
           {errorMessage}
         </Notification>
       )}
-      {children}
+      {loading ? <Spinner text="Loading..." /> : children}
     </Section>
   );
 };

--- a/ui/src/app/intro/components/IntroSection/index.ts
+++ b/ui/src/app/intro/components/IntroSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IntroSection";

--- a/ui/src/app/intro/hooks.test.tsx
+++ b/ui/src/app/intro/hooks.test.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from "react";
+
+import { renderHook } from "@testing-library/react-hooks";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import type { MockStoreEnhanced } from "redux-mock-store";
+
+import { useExitURL } from "./hooks";
+
+import dashboardURLs from "app/dashboard/urls";
+import machineURLs from "app/machines/urls";
+import type { RootState } from "app/store/root/types";
+import {
+  authState as authStateFactory,
+  rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+const generateWrapper =
+  (store: MockStoreEnhanced<unknown>) =>
+  ({ children }: { children: ReactNode }) =>
+    <Provider store={store}>{children}</Provider>;
+
+describe("hooks", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory({
+      user: userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ completed_intro: false, is_superuser: true }),
+        }),
+      }),
+    });
+  });
+
+  describe("useExitURL", () => {
+    it("gets the exit URL for an admin", () => {
+      state.user = userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: true }),
+        }),
+      });
+      const store = mockStore(state);
+      const { result } = renderHook(() => useExitURL(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(dashboardURLs.index);
+    });
+
+    it("gets the exit URL for a non-admin", () => {
+      state.user = userStateFactory({
+        auth: authStateFactory({
+          user: userFactory({ is_superuser: false }),
+        }),
+      });
+      const store = mockStore(state);
+      const { result } = renderHook(() => useExitURL(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(machineURLs.machines.index);
+    });
+  });
+});

--- a/ui/src/app/intro/hooks.ts
+++ b/ui/src/app/intro/hooks.ts
@@ -1,0 +1,17 @@
+import { useSelector } from "react-redux";
+
+import dashboardURLs from "app/dashboard/urls";
+import machineURLs from "app/machines/urls";
+import authSelectors from "app/store/auth/selectors";
+
+/**
+ * Combines formik validation errors and errors returned from server
+ * for use in formik forms.
+ * @param errors - The errors object in redux state.
+ */
+export const useExitURL = (): string => {
+  const authUser = useSelector(authSelectors.get);
+  return authUser?.is_superuser
+    ? dashboardURLs.index
+    : machineURLs.machines.index;
+};

--- a/ui/src/app/intro/hooks.ts
+++ b/ui/src/app/intro/hooks.ts
@@ -5,9 +5,8 @@ import machineURLs from "app/machines/urls";
 import authSelectors from "app/store/auth/selectors";
 
 /**
- * Combines formik validation errors and errors returned from server
- * for use in formik forms.
- * @param errors - The errors object in redux state.
+ * Get the URL to redirect to when the intro closes.
+ * @returns The URL to redirect to.
  */
 export const useExitURL = (): string => {
   const authUser = useSelector(authSelectors.get);

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -1,18 +1,12 @@
 import { useEffect } from "react";
 
-import {
-  Button,
-  Icon,
-  Spinner,
-  Strip,
-  Tooltip,
-} from "@canonical/react-components";
+import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useHistory } from "react-router-dom";
 
-import Section from "app/base/components/Section";
-import { useWindowTitle } from "app/base/hooks";
 import SyncedImages from "app/images/views/ImageList/SyncedImages";
+import IntroCard from "app/intro/components/IntroCard";
+import IntroSection from "app/intro/components/IntroSection";
 import introURLs from "app/intro/urls";
 import { actions as bootResourceActions } from "app/store/bootresource";
 import bootResourceSelectors from "app/store/bootresource/selectors";
@@ -22,7 +16,6 @@ const ImagesIntro = (): JSX.Element => {
   const history = useHistory();
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
   const resources = useSelector(bootResourceSelectors.resources);
-  useWindowTitle("Welcome - Images");
 
   useEffect(() => {
     dispatch(bootResourceActions.poll({ continuous: true }));
@@ -33,43 +26,36 @@ const ImagesIntro = (): JSX.Element => {
   }, [dispatch]);
 
   const hasSources = (ubuntu?.sources || []).length > 0;
-  const continueDisabled = !hasSources || resources.length === 0;
+  const incomplete = !hasSources || resources.length === 0;
 
   return (
-    <Section>
-      <h4>Images</h4>
-      {!ubuntu ? (
-        <Strip shallow>
-          <Spinner text="Loading..." />
-        </Strip>
-      ) : (
-        <>
-          <SyncedImages inCard />
-          <div className="u-align--right">
-            <Button appearance="neutral" element={Link} to={introURLs.index}>
-              Back
-            </Button>
-            <Button
-              appearance="positive"
-              data-test="images-intro-continue"
-              disabled={continueDisabled}
-              hasIcon
-              onClick={() => history.push({ pathname: introURLs.success })}
+    <IntroSection loading={!ubuntu} windowTitle="Images">
+      <IntroCard complete={!incomplete} title="Images">
+        <SyncedImages formInCard={false} />
+      </IntroCard>
+      <div className="u-align--right">
+        <Button appearance="neutral" element={Link} to={introURLs.index}>
+          Back
+        </Button>
+        <Button
+          appearance="positive"
+          data-test="images-intro-continue"
+          disabled={incomplete}
+          hasIcon
+          onClick={() => history.push({ pathname: introURLs.success })}
+        >
+          Continue
+          {incomplete && (
+            <Tooltip
+              className="u-nudge-right"
+              message="At least one image and source must be configured to continue."
             >
-              Continue
-              {continueDisabled && (
-                <Tooltip
-                  className="u-nudge-right"
-                  message="At least one image and source must be configured to continue."
-                >
-                  <Icon className="is-light" name="information" />
-                </Tooltip>
-              )}
-            </Button>
-          </div>
-        </>
-      )}
-    </Section>
+              <Icon className="is-light" name="information" />
+            </Tooltip>
+          )}
+        </Button>
+      </div>
+    </IntroSection>
   );
 };
 

--- a/ui/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
+++ b/ui/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
@@ -1,10 +1,32 @@
 import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import IncompleteCard from "./IncompleteCard";
 
+import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
+
+const mockStore = configureStore();
+
 describe("IncompleteCard", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory();
+  });
+
   it("renders", () => {
-    const wrapper = mount(<IncompleteCard />);
-    expect(wrapper).toMatchSnapshot();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
+        >
+          <IncompleteCard />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("IncompleteCard")).toMatchSnapshot();
   });
 });

--- a/ui/src/app/intro/views/IncompleteCard/IncompleteCard.tsx
+++ b/ui/src/app/intro/views/IncompleteCard/IncompleteCard.tsx
@@ -1,37 +1,31 @@
-import { Card, Icon, Link } from "@canonical/react-components";
+import { Link } from "@canonical/react-components";
+
+import IntroCard from "app/intro/components/IntroCard";
+import IntroSection from "app/intro/components/IntroSection";
 
 const IncompleteCard = (): JSX.Element => {
   return (
-    <Card
-      className="maas-intro__card"
-      data-test="maas-name-form"
-      highlighted
-      title={
-        <>
-          <span className="u-flex--between">
-            <span className="p-heading--4">
-              <Icon name="error" />
-              &ensp;Welcome to MAAS
-            </span>
-            <span className="p-text--default u-text--default-size">
-              <Link
-                external
-                href="https://maas.io/docs/configuration-journey"
-                target="_blank"
-              >
-                Help with configuring MAAS
-              </Link>
-            </span>
-          </span>
-          <hr />
-        </>
-      }
-    >
-      <p>
-        This MAAS has not be configured. Ask an admin to log in and finish the
-        configuration.
-      </p>
-    </Card>
+    <IntroSection>
+      <IntroCard
+        hasErrors={true}
+        data-test="maas-name-form"
+        title="Welcome to MAAS"
+        titleLink={
+          <Link
+            external
+            href="https://maas.io/docs/configuration-journey"
+            target="_blank"
+          >
+            Help with configuring MAAS
+          </Link>
+        }
+      >
+        <p>
+          This MAAS has not be configured. Ask an admin to log in and finish the
+          configuration.
+        </p>
+      </IntroCard>
+    </IntroSection>
   );
 };
 

--- a/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
+++ b/ui/src/app/intro/views/IncompleteCard/__snapshots__/IncompleteCard.test.tsx.snap
@@ -2,89 +2,143 @@
 
 exports[`IncompleteCard renders 1`] = `
 <IncompleteCard>
-  <Card
-    className="maas-intro__card"
-    data-test="maas-name-form"
-    highlighted={true}
-    title={
-      <React.Fragment>
-        <span
-          className="u-flex--between"
-        >
-          <span
-            className="p-heading--4"
-          >
-            <Icon
-              name="error"
-            />
-             Welcome to MAAS
-          </span>
-          <span
-            className="p-text--default u-text--default-size"
-          >
-            <Link
-              external={true}
-              href="https://maas.io/docs/configuration-journey"
-              target="_blank"
-            >
-              Help with configuring MAAS
-            </Link>
-          </span>
-        </span>
-        <hr />
-      </React.Fragment>
-    }
-  >
-    <div
-      className="maas-intro__card p-card--highlighted"
-      data-test="maas-name-form"
-    >
-      <h3
-        className="p-card__title"
-      >
-        <span
-          className="u-flex--between"
-        >
-          <span
-            className="p-heading--4"
-          >
-            <Icon
-              name="error"
-            >
-              <i
-                className="p-icon--error"
-              />
-            </Icon>
-             Welcome to MAAS
-          </span>
-          <span
-            className="p-text--default u-text--default-size"
-          >
-            <Link
-              external={true}
-              href="https://maas.io/docs/configuration-journey"
-              target="_blank"
-            >
-              <a
-                className="p-link--external"
-                href="https://maas.io/docs/configuration-journey"
-                target="_blank"
-              >
-                Help with configuring MAAS
-              </a>
-            </Link>
-          </span>
-        </span>
-        <hr />
-      </h3>
+  <IntroSection>
+    <Section>
       <div
-        className="p-card__content"
+        className="section"
       >
-        <p>
-          This MAAS has not be configured. Ask an admin to log in and finish the configuration.
-        </p>
+        <Strip
+          element="main"
+          includeCol={false}
+          rowClassName="section__content-wrapper"
+          shallow={true}
+        >
+          <main
+            className="p-strip is-shallow"
+          >
+            <Row
+              className="section__content-wrapper"
+            >
+              <div
+                className="section__content-wrapper row"
+              >
+                <Col
+                  className="section__content"
+                  size={12}
+                >
+                  <div
+                    className="section__content col-12"
+                  >
+                    <NotificationList />
+                    <IntroCard
+                      data-test="maas-name-form"
+                      hasErrors={true}
+                      title="Welcome to MAAS"
+                      titleLink={
+                        <Link
+                          external={true}
+                          href="https://maas.io/docs/configuration-journey"
+                          target="_blank"
+                        >
+                          Help with configuring MAAS
+                        </Link>
+                      }
+                    >
+                      <Card
+                        className="maas-intro__card"
+                        data-test="maas-name-form"
+                        highlighted={true}
+                        title={
+                          <React.Fragment>
+                            <span
+                              className="u-flex--between"
+                            >
+                              <span
+                                className="p-heading--4"
+                              >
+                                <Icon
+                                  name="error"
+                                />
+                                 
+                                Welcome to MAAS
+                              </span>
+                              <span
+                                className="p-text--default u-text--default-size"
+                              >
+                                <Link
+                                  external={true}
+                                  href="https://maas.io/docs/configuration-journey"
+                                  target="_blank"
+                                >
+                                  Help with configuring MAAS
+                                </Link>
+                              </span>
+                            </span>
+                            <hr />
+                          </React.Fragment>
+                        }
+                      >
+                        <div
+                          className="maas-intro__card p-card--highlighted"
+                          data-test="maas-name-form"
+                        >
+                          <h3
+                            className="p-card__title"
+                          >
+                            <span
+                              className="u-flex--between"
+                            >
+                              <span
+                                className="p-heading--4"
+                              >
+                                <Icon
+                                  name="error"
+                                >
+                                  <i
+                                    className="p-icon--error"
+                                  />
+                                </Icon>
+                                 
+                                Welcome to MAAS
+                              </span>
+                              <span
+                                className="p-text--default u-text--default-size"
+                              >
+                                <Link
+                                  external={true}
+                                  href="https://maas.io/docs/configuration-journey"
+                                  target="_blank"
+                                >
+                                  <a
+                                    className="p-link--external"
+                                    href="https://maas.io/docs/configuration-journey"
+                                    target="_blank"
+                                  >
+                                    Help with configuring MAAS
+                                  </a>
+                                </Link>
+                              </span>
+                            </span>
+                            <hr />
+                          </h3>
+                          <div
+                            className="p-card__content"
+                          >
+                            <p>
+                              This MAAS has not be configured. Ask an admin to log in and finish the configuration.
+                            </p>
+                          </div>
+                        </div>
+                      </Card>
+                    </IntroCard>
+                  </div>
+                </Col>
+              </div>
+            </Row>
+          </main>
+        </Strip>
       </div>
-    </div>
-  </Card>
+    </Section>
+  </IntroSection>
 </IncompleteCard>
 `;

--- a/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
+++ b/ui/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
@@ -1,9 +1,10 @@
-import { Card, Col, Icon, Row } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { MaasIntroValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
+import IntroCard from "app/intro/components/IntroCard";
 
 const ConnectivityCard = (): JSX.Element => {
   const { errors } = useFormikContext<MaasIntroValues>();
@@ -14,19 +15,11 @@ const ConnectivityCard = (): JSX.Element => {
     errors.upstreamDns;
 
   return (
-    <Card
-      className="maas-intro__card"
+    <IntroCard
+      complete={!showErrorIcon}
       data-test="maas-connectivity-form"
-      highlighted
-      title={
-        <>
-          <span className="p-heading--4 u-sv1">
-            <Icon name={showErrorIcon ? "error" : "success"} />
-            &ensp;Connectivity
-          </span>
-          <hr />
-        </>
-      }
+      hasErrors={!!showErrorIcon}
+      title="Connectivity"
     >
       <Row>
         <Col size="6">
@@ -57,7 +50,7 @@ const ConnectivityCard = (): JSX.Element => {
           />
         </Col>
       </Row>
-    </Card>
+    </IntroCard>
   );
 };
 

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -13,9 +13,8 @@ import FormikForm from "app/base/components/FormikForm";
 import Section from "app/base/components/Section";
 import TableConfirm from "app/base/components/TableConfirm";
 import { useWindowTitle } from "app/base/hooks";
-import dashboardURLs from "app/dashboard/urls";
+import { useExitURL } from "app/intro/hooks";
 import introURLs from "app/intro/urls";
-import machineURLs from "app/machines/urls";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
@@ -54,6 +53,7 @@ const MaasIntro = (): JSX.Element => {
   const mainArchive = useSelector(repoSelectors.mainArchive);
   const portsArchive = useSelector(repoSelectors.portsArchive);
   const [showSkip, setShowSkip] = useState(false);
+  const exitURL = useExitURL();
 
   useWindowTitle("Welcome");
 
@@ -155,9 +155,7 @@ const MaasIntro = (): JSX.Element => {
                     history.push({ pathname: introURLs.user });
                   } else {
                     history.push({
-                      pathname: authUser?.is_superuser
-                        ? dashboardURLs.index
-                        : machineURLs.machines.index,
+                      pathname: exitURL,
                     });
                   }
                 }}

--- a/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
+++ b/ui/src/app/intro/views/MaasIntro/NameCard/NameCard.tsx
@@ -1,37 +1,28 @@
-import { Card, Col, Icon, Link, Row } from "@canonical/react-components";
+import { Col, Link, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { MaasIntroValues } from "../types";
 
 import FormikField from "app/base/components/FormikField";
+import IntroCard from "app/intro/components/IntroCard";
 
 const NameCard = (): JSX.Element => {
   const { errors } = useFormikContext<MaasIntroValues>();
 
   return (
-    <Card
-      className="maas-intro__card"
+    <IntroCard
+      complete={!errors.name}
       data-test="maas-name-form"
-      highlighted
-      title={
-        <>
-          <span className="u-flex--between">
-            <span className="p-heading--4">
-              <Icon name={errors.name ? "error" : "success"} />
-              &ensp;Welcome to MAAS
-            </span>
-            <span className="p-text--default u-text--default-size">
-              <Link
-                external
-                href="https://maas.io/docs/configuration-journey"
-                target="_blank"
-              >
-                Help with configuring MAAS
-              </Link>
-            </span>
-          </span>
-          <hr />
-        </>
+      hasErrors={!!errors.name}
+      title="Welcome to MAAS"
+      titleLink={
+        <Link
+          external
+          href="https://maas.io/docs/configuration-journey"
+          target="_blank"
+        >
+          Help with configuring MAAS
+        </Link>
       }
     >
       <Row>
@@ -44,7 +35,7 @@ const NameCard = (): JSX.Element => {
           />
         </Col>
       </Row>
-    </Card>
+    </IntroCard>
   );
 };
 

--- a/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
+++ b/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
@@ -4,26 +4,18 @@ import { Link } from "react-router-dom";
 
 import Section from "app/base/components/Section";
 import { useWindowTitle } from "app/base/hooks";
-import dashboardURLs from "app/dashboard/urls";
+import { useExitURL } from "app/intro/hooks";
 import introURLs from "app/intro/urls";
-import machineURLs from "app/machines/urls";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
 
 const MaasIntroSuccess = (): JSX.Element => {
   const dispatch = useDispatch();
   const authUser = useSelector(authSelectors.get);
+  const exitURL = useExitURL();
+  const continueLink = authUser?.completed_intro ? exitURL : introURLs.user;
+
   useWindowTitle("Welcome - Success");
-
-  let continueLink = introURLs.user;
-
-  if (authUser?.completed_intro) {
-    if (authUser?.is_superuser) {
-      continueLink = dashboardURLs.index;
-    } else {
-      continueLink = machineURLs.machines.index;
-    }
-  }
 
   return (
     <Section>

--- a/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
+++ b/ui/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
@@ -1,9 +1,9 @@
-import { Button, Card, Icon, List } from "@canonical/react-components";
+import { Button, List } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import Section from "app/base/components/Section";
-import { useWindowTitle } from "app/base/hooks";
+import IntroCard from "app/intro/components/IntroCard";
+import IntroSection from "app/intro/components/IntroSection";
 import { useExitURL } from "app/intro/hooks";
 import introURLs from "app/intro/urls";
 import authSelectors from "app/store/auth/selectors";
@@ -15,23 +15,12 @@ const MaasIntroSuccess = (): JSX.Element => {
   const exitURL = useExitURL();
   const continueLink = authUser?.completed_intro ? exitURL : introURLs.user;
 
-  useWindowTitle("Welcome - Success");
-
   return (
-    <Section>
-      <Card
-        className="maas-intro__card"
+    <IntroSection windowTitle="Success">
+      <IntroCard
+        complete={true}
         data-test="maas-connectivity-form"
-        highlighted
-        title={
-          <>
-            <span className="p-heading--4 u-sv1">
-              <Icon name="success" />
-              &ensp;MAAS has been successfully set up
-            </span>
-            <hr />
-          </>
-        }
+        title="MAAS has been successfully set up"
       >
         <List
           items={[
@@ -40,7 +29,7 @@ const MaasIntroSuccess = (): JSX.Element => {
             "The fabrics, VLANs and subnets in your network will be automatically added to MAAS in the Subnets tab.",
           ]}
         />
-      </Card>
+      </IntroCard>
       <div className="u-align--right">
         <Button appearance="neutral" element={Link} to={introURLs.images}>
           Back
@@ -57,7 +46,7 @@ const MaasIntroSuccess = (): JSX.Element => {
           Finish setup
         </Button>
       </div>
-    </Section>
+    </IntroSection>
   );
 };
 

--- a/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -6,8 +6,6 @@ import configureStore from "redux-mock-store";
 import UserIntro from "./UserIntro";
 
 import * as baseHooks from "app/base/hooks";
-import dashboardURLs from "app/dashboard/urls";
-import machineURLs from "app/machines/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as userActions } from "app/store/user";
 import {
@@ -49,22 +47,6 @@ describe("UserIntro", () => {
     });
   });
 
-  it("displays a spinner when loading", () => {
-    state.sshkey.loading = true;
-    state.user.auth.loading = true;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
-        >
-          <UserIntro />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
-  });
-
   it("displays a green tick icon when there are ssh keys", () => {
     const store = mockStore(state);
     const wrapper = mount(
@@ -76,9 +58,7 @@ describe("UserIntro", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(
-      wrapper.find("[data-test='sshkey-card'] Icon[name='success']").exists()
-    ).toBe(true);
+    expect(wrapper.find("IntroCard").prop("complete")).toBe(true);
   });
 
   it("displays a grey tick icon when there are no ssh keys", async () => {
@@ -93,11 +73,7 @@ describe("UserIntro", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(
-      wrapper
-        .find("[data-test='sshkey-card'] Icon[name='success-grey']")
-        .exists()
-    ).toBe(true);
+    expect(wrapper.find("IntroCard").prop("complete")).toBe(false);
   });
 
   it("redirects if the user has already completed the intro", () => {
@@ -117,46 +93,6 @@ describe("UserIntro", () => {
       </Provider>
     );
     expect(wrapper.find("Redirect").exists()).toBe(true);
-  });
-
-  it("redirects to the dashboard for admins", () => {
-    state.user = userStateFactory({
-      auth: authStateFactory({
-        user: userFactory({ completed_intro: true, is_superuser: true }),
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
-        >
-          <UserIntro />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Redirect").prop("to")).toBe(dashboardURLs.index);
-  });
-
-  it("redirects to the machine list for non-admins", () => {
-    state.user = userStateFactory({
-      auth: authStateFactory({
-        user: userFactory({ completed_intro: true, is_superuser: false }),
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/intro/user", key: "testKey" }]}
-        >
-          <UserIntro />
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Redirect").prop("to")).toBe(
-      machineURLs.machines.index
-    );
   });
 
   it("disables the continue button if there are no ssh keys", () => {

--- a/ui/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -1,23 +1,14 @@
 import { useEffect, useState } from "react";
 
-import {
-  ActionButton,
-  Button,
-  Card,
-  Icon,
-  Notification,
-  Spinner,
-} from "@canonical/react-components";
+import { ActionButton, Button, Card, Icon } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Redirect } from "react-router";
 
 import SSHKeyForm from "app/base/components/SSHKeyForm";
 import SSHKeyList from "app/base/components/SSHKeyList";
-import Section from "app/base/components/Section";
 import TableConfirm from "app/base/components/TableConfirm";
-import { useCycled, useWindowTitle } from "app/base/hooks";
-import dashboardURLs from "app/dashboard/urls";
-import machineURLs from "app/machines/urls";
+import { useCycled } from "app/base/hooks";
+import IntroCard from "app/intro/components/IntroCard";
+import IntroSection from "app/intro/components/IntroSection";
 import authSelectors from "app/store/auth/selectors";
 import { actions as sshkeyActions } from "app/store/sshkey";
 import sshkeySelectors from "app/store/sshkey/selectors";
@@ -38,44 +29,22 @@ const UserIntro = (): JSX.Element => {
   const hasSSHKeys = sshkeys.length > 0;
   const errorMessage = formatErrors(errors);
 
-  useWindowTitle("Welcome - User");
-
   useEffect(() => {
     dispatch(sshkeyActions.fetch());
   }, [dispatch]);
 
-  if (authLoading || sshkeyLoading) {
-    return <Spinner />;
-  }
-
-  if (authUser?.completed_intro || markedIntroComplete) {
-    return (
-      <Redirect
-        to={
-          authUser?.is_superuser
-            ? dashboardURLs.index
-            : machineURLs.machines.index
-        }
-      />
-    );
-  }
-
   return (
-    <Section>
-      {errorMessage && (
-        <Notification type="negative" status="Error:">
-          {errorMessage}
-        </Notification>
-      )}
-      <Card
+    <IntroSection
+      errors={errors}
+      closeIntro={authUser?.completed_intro || markedIntroComplete}
+      windowTitle="User"
+    >
+      <IntroCard
         data-test="sshkey-card"
-        highlighted
-        title={
-          <span className="p-heading--4">
-            <Icon name={hasSSHKeys ? "success" : "success-grey"} />
-            &ensp;SSH keys for {authUser?.username}
-          </span>
-        }
+        hasErrors={!!errorMessage}
+        complete={!!hasSSHKeys}
+        title={<>SSH keys for {authUser?.username}</>}
+        loading={authLoading || sshkeyLoading}
       >
         <p>
           Add multiple keys from Launchpad and Github or enter them manually.
@@ -90,7 +59,7 @@ const UserIntro = (): JSX.Element => {
           }}
           resetOnSave
         />
-      </Card>
+      </IntroCard>
       <div className="u-align--right">
         <Button
           appearance="neutral"
@@ -136,7 +105,7 @@ const UserIntro = (): JSX.Element => {
           />
         </Card>
       )}
-    </Section>
+    </IntroSection>
   );
 };
 

--- a/ui/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/ui/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -36,7 +36,8 @@ const UserIntro = (): JSX.Element => {
   return (
     <IntroSection
       errors={errors}
-      closeIntro={authUser?.completed_intro || markedIntroComplete}
+      loading={authLoading || sshkeyLoading}
+      shouldExitIntro={authUser?.completed_intro || markedIntroComplete}
       windowTitle="User"
     >
       <IntroCard
@@ -44,7 +45,6 @@ const UserIntro = (): JSX.Element => {
         hasErrors={!!errorMessage}
         complete={!!hasSSHKeys}
         title={<>SSH keys for {authUser?.username}</>}
-        loading={authLoading || sshkeyLoading}
       >
         <p>
           Add multiple keys from Launchpad and Github or enter them manually.


### PR DESCRIPTION
## Done

- Create components to capture shared display and behaviour of intro screens.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a new user and visit the user intro.
- The intro should appear unchanged.

## Fixes

Fixes: canonical-web-and-design/app-squad#165.