### PR TITLE
feat(ui): add intro redirects

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,8 +1,8 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
-    "src/app/App.tsx:73777883": [
-      [191, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
+    "src/app/App.tsx:3662487992": [
+      [203, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
     "src/app/base/components/ActionForm/ActionForm.test.tsx:1651560738": [
       [64, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -24,7 +24,6 @@ exports[`stricter compilation`] = {
       [23, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [23, 22, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [25, 13, 13, "Object is possibly \'undefined\'.", "3155939599"],
-      [118, 39, 6, "Argument of type \'FormErrors | undefined\' is not assignable to parameter of type \'string | object | string[]\'.\\n  Type \'undefined\' is not assignable to type \'string | object | string[]\'.", "1168132398"],
       [121, 4, 15, "Argument of type \'number | undefined\' is not assignable to parameter of type \'number\'.\\n  Type \'undefined\' is not assignable to type \'number\'.", "1847077069"]
     ],
     "src/app/base/components/DhcpForm/DhcpForm.test.tsx:538955982": [
@@ -243,11 +242,15 @@ exports[`stricter compilation`] = {
       [104, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
       [105, 6, 256, "Argument of type \'{ images: { arch: string; os: string; release: string; title: string; }[]; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'images\' does not exist in type \'FormEvent<{}>\'.", "2870584855"]
     ],
-    "src/app/intro/views/MaasIntro/MaasIntro.test.tsx:282976037": [
-      [73, 4, 45, "Cannot invoke an object which is possibly \'undefined\'.", "2890963284"],
-      [74, 6, 36, "Argument of type \'{ httpProxy: string; mainArchiveUrl: string; name: string; portsArchiveUrl: string; upstreamDns: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'httpProxy\' does not exist in type \'FormEvent<{}>\'.", "1476874575"],
-      [105, 4, 45, "Cannot invoke an object which is possibly \'undefined\'.", "2890963284"],
-      [106, 6, 36, "Argument of type \'{ httpProxy: string; mainArchiveUrl: string; name: string; portsArchiveUrl: string; upstreamDns: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'httpProxy\' does not exist in type \'FormEvent<{}>\'.", "1476874575"]
+    "src/app/intro/views/Intro.test.tsx:2469393591": [
+      [94, 11, 38, "Object is of type \'unknown\'.", "2927944967"],
+      [111, 11, 38, "Object is of type \'unknown\'.", "2927944967"]
+    ],
+    "src/app/intro/views/MaasIntro/MaasIntro.test.tsx:1742415818": [
+      [76, 4, 45, "Cannot invoke an object which is possibly \'undefined\'.", "2890963284"],
+      [77, 6, 36, "Argument of type \'{ httpProxy: string; mainArchiveUrl: string; name: string; portsArchiveUrl: string; upstreamDns: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'httpProxy\' does not exist in type \'FormEvent<{}>\'.", "1476874575"],
+      [108, 4, 45, "Cannot invoke an object which is possibly \'undefined\'.", "2890963284"],
+      [109, 6, 36, "Argument of type \'{ httpProxy: string; mainArchiveUrl: string; name: string; portsArchiveUrl: string; upstreamDns: string; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'httpProxy\' does not exist in type \'FormEvent<{}>\'.", "1476874575"]
     ],
     "src/app/kvm/components/KVMActionFormWrapper/ComposeForm/ComposeForm.tsx:934008644": [
       [143, 16, 4, "Object is possibly \'undefined\'.", "2087386672"],
@@ -834,12 +837,12 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:1367425813": [
       [12, 2, 5, "Type \'null\' is not assignable to type \'NotificationIdent | ArrayFactory<never> | AttributeFunction<NotificationIdent> | Factory<NotificationIdent> | DerivedFunction<...>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:214913689": [
-      [280, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [397, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [398, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [400, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [405, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:1939875524": [
+      [284, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [401, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [402, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [404, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [409, 2, 6, "Type \'null\' is not assignable to type \'ArrayFactory<never> | Action | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
@@ -850,7 +853,7 @@ exports[`no TSFixMe types`] = {
       [8, 13, 8, "RegExp match", "1152173309"],
       [30, 40, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/base/types.ts:2467381707": [
+    "src/app/base/types.ts:807018941": [
       [0, 11, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/auth/selectors.ts:3731791020": [
@@ -979,10 +982,10 @@ exports[`no TSFixMe types`] = {
       [0, 13, 8, "RegExp match", "1152173309"],
       [15, 44, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/user/types/base.ts:1826823345": [
+    "src/app/store/user/types/base.ts:643948283": [
       [0, 13, 8, "RegExp match", "1152173309"],
       [18, 9, 8, "RegExp match", "1152173309"],
-      [28, 22, 8, "RegExp match", "1152173309"]
+      [39, 22, 8, "RegExp match", "1152173309"]
     ],
     "src/app/store/vlan/types/base.ts:1341634383": [
       [2, 13, 8, "RegExp match", "1152173309"],
@@ -996,6 +999,6 @@ exports[`no TSFixMe types`] = {
 };
 
 exports[`migrate js files to ts`] = {
-  value: `156
+  value: `154
 `
 };

--- a/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.tsx
@@ -83,7 +83,7 @@ const OtherImages = (): JSX.Element | null => {
   return (
     <>
       <hr />
-      <Strip shallow>
+      <Strip shallow className="u-no-padding--bottom">
         <h4>Other images</h4>
         <FormikForm<OtherImagesValues>
           allowUnchanged

--- a/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/ui/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { HTMLProps } from "react";
 
 import {
   Button,
@@ -32,9 +33,12 @@ const getImageSyncText = (sources: BootResourceUbuntuSource[]) => {
 
 type Props = {
   formInCard?: boolean;
-};
+} & HTMLProps<HTMLElement>;
 
-const SyncedImages = ({ formInCard = true }: Props): JSX.Element | null => {
+const SyncedImages = ({
+  formInCard = true,
+  ...stripProps
+}: Props): JSX.Element | null => {
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
   const resources = useSelector(bootResourceSelectors.resources);
   const sources = ubuntu?.sources || [];
@@ -47,7 +51,7 @@ const SyncedImages = ({ formInCard = true }: Props): JSX.Element | null => {
 
   const canChangeSource = resources.every((resource) => !resource.downloading);
   return (
-    <Strip shallow>
+    <Strip shallow {...stripProps}>
       <Row>
         <Col size="12">
           {showChangeSource ? (

--- a/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/ui/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -31,7 +31,7 @@ const ImagesIntro = (): JSX.Element => {
   return (
     <IntroSection loading={!ubuntu} windowTitle="Images">
       <IntroCard complete={!incomplete} title="Images">
-        <SyncedImages formInCard={false} />
+        <SyncedImages className="u-no-padding--bottom" formInCard={false} />
       </IntroCard>
       <div className="u-align--right">
         <Button appearance="neutral" element={Link} to={introURLs.index}>

--- a/ui/src/app/intro/views/Intro.test.tsx
+++ b/ui/src/app/intro/views/Intro.test.tsx
@@ -5,9 +5,11 @@ import configureStore from "redux-mock-store";
 
 import Intro from "./Intro";
 
+import introURLs from "app/intro/urls";
 import type { RootState } from "app/store/root/types";
 import {
   authState as authStateFactory,
+  configState as configStateFactory,
   rootState as rootStateFactory,
   user as userFactory,
   userState as userStateFactory,
@@ -20,6 +22,9 @@ describe("Intro", () => {
 
   beforeEach(() => {
     state = rootStateFactory({
+      config: configStateFactory({
+        items: [{ name: "completed_intro", value: false }],
+      }),
       user: userStateFactory({
         auth: authStateFactory({
           user: userFactory({ completed_intro: false, is_superuser: true }),
@@ -56,6 +61,57 @@ describe("Intro", () => {
       </Provider>
     );
     expect(wrapper.find("IncompleteCard").exists()).toBe(true);
+  });
+
+  it("exits the intro if both intros have been completed", () => {
+    state.config = configStateFactory({
+      items: [{ name: "completed_intro", value: true }],
+    });
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ completed_intro: true, is_superuser: true }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: introURLs.index }]}>
+          <Intro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Redirect").exists()).toBe(true);
+  });
+
+  it("returns to the start when loading the user intro and the main intro is incomplete", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: introURLs.user }]}>
+          <Intro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Router").prop("history").location.pathname).toBe(
+      introURLs.index
+    );
+  });
+
+  it("skips to the user intro when loading the main intro when it is complete", () => {
+    state.config = configStateFactory({
+      items: [{ name: "completed_intro", value: true }],
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: introURLs.index }]}>
+          <Intro />
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Router").prop("history").location.pathname).toBe(
+      introURLs.user
+    );
   });
 
   it("can display the routes", () => {

--- a/ui/src/app/intro/views/Intro.tsx
+++ b/ui/src/app/intro/views/Intro.tsx
@@ -2,7 +2,9 @@ import type { ReactNode } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Route, Switch } from "react-router-dom";
+import { Redirect, Route, Switch, useLocation } from "react-router-dom";
+
+import { useExitURL } from "../hooks";
 
 import ImagesIntro from "./ImagesIntro";
 import IncompleteCard from "./IncompleteCard";
@@ -17,11 +19,14 @@ import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
 
 const Intro = (): JSX.Element => {
+  const location = useLocation();
   const authLoading = useSelector(authSelectors.loading);
   const configLoading = useSelector(configSelectors.loading);
   const authUser = useSelector(authSelectors.get);
   const completedIntro = useSelector(configSelectors.completedIntro);
+  const exitURL = useExitURL();
   const isAdmin = authUser?.is_superuser;
+  const viewingUserIntro = location.pathname.startsWith(introURLs.user);
   let content: ReactNode;
   if (authLoading || configLoading) {
     content = <Spinner text="Loading..." />;
@@ -29,6 +34,17 @@ const Intro = (): JSX.Element => {
     // Prevent the user from reaching any of the intro urls if they are not an
     // admin.
     content = <IncompleteCard />;
+  } else if (completedIntro && authUser?.completed_intro) {
+    // If both intros have been completed then exit the flow.
+    return <Redirect to={exitURL} />;
+  } else if (viewingUserIntro && !completedIntro) {
+    // If the user is viewing the user intro but hasn't yet completed the maas
+    // intro then send them back to the start.
+    return <Redirect to={introURLs.index} />;
+  } else if (!viewingUserIntro && completedIntro) {
+    // If the user is viewing the maas intro but has already completed it then
+    //send them to the user intro.
+    return <Redirect to={introURLs.user} />;
   }
   if (content) {
     return <Section>{content}</Section>;


### PR DESCRIPTION
## Done

- Add redirects to the correct part of the intro or exit.
- Fix spacing after images form.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Create a new admin user and rest the main intro: `maas $PROFILE maas set-config name=completed_intro value=false`.
- Visit /MAAS/r/intro/user and you should end up /MAAS/r/intro.
- Click the skip button and confirm.
- Visit /MAAS/r/intro again and you should end up at /MAAS/r/intro/user.
- Click skip on the user intro and then visit /MAAS/r/intro or /MAAS/r/intro/user and you should get redirected to the dashboard.

## Fixes

Fixes: canonical-web-and-design/app-squad#159.
Fixes: canonical-web-and-design/app-squad#166.