### PR TITLE
Decouple machine take action menu from API

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -1,8 +1,8 @@
 // BETTERER RESULTS V2.
 exports[`stricter compilation`] = {
   value: `{
-    "src/app/App.tsx:2306368039": [
-      [203, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
+    "src/app/App.tsx:3306177470": [
+      [187, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
     "src/app/base/components/ActionForm/ActionForm.test.tsx:1651560738": [
       [64, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
@@ -18,7 +18,7 @@ exports[`stricter compilation`] = {
       [146, 6, 39, "Cannot invoke an object which is possibly \'undefined\'.", "1015219919"],
       [146, 6, 41, "Expected 1 arguments, but got 0.", "1767895374"]
     ],
-    "src/app/base/components/ActionForm/ActionForm.tsx:2551815612": [
+    "src/app/base/components/ActionForm/ActionForm.tsx:3451789822": [
       [16, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [20, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [23, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
@@ -477,19 +477,8 @@ exports[`stricter compilation`] = {
       [83, 4, 11, "Type \'(FormattedScript | undefined)[]\' is not assignable to type \'FormattedScript[]\'.\\n  Type \'FormattedScript | undefined\' is not assignable to type \'FormattedScript\'.\\n    Type \'undefined\' is not assignable to type \'FormattedScript\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"],
       [93, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"]
     ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.test.tsx:1140491738": [
-      [370, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [371, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [372, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [373, 11, 5, "Object is of type \'unknown\'.", "173192470"],
-      [374, 11, 5, "Object is of type \'unknown\'.", "173192470"]
-    ],
-    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:1678643711": [
-      [48, 6, 5, "Object is possibly \'undefined\'.", "172404922"],
-      [49, 8, 8, "Type \'Element\' is not assignable to type \'never\'.", "1925793782"],
-      [64, 8, 8, "Type \'boolean\' is not assignable to type \'never\'.", "2577352917"],
-      [65, 8, 7, "Type \'() => void\' is not assignable to type \'never\'.", "4055953994"],
-      [119, 10, 16, "Argument of type \'(Machine | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "2366246550"]
+    "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:1590803250": [
+      [163, 10, 16, "Argument of type \'(Machine | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "2366246550"]
     ],
     "src/app/machines/hooks.tsx:2442063654": [
       [55, 4, 76, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 68 more ...; saving: (state: RootState) => boolean; }\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{ aborting: Selector<RootState, Machine[]>; abortingSelected: Selector<RootState, Machine[]>; acquiring: Selector<RootState, Machine[]>; ... 68 more ...; saving: (state: RootState) => boolean; }\'.", "1657451879"],
@@ -615,7 +604,7 @@ exports[`stricter compilation`] = {
       [108, 4, 60, "Cannot invoke an object which is possibly \'undefined\'.", "610087480"],
       [112, 8, 9, "Argument of type \'{ fabric: number; interface_speed: number; ip_address: string; link_speed: number; mac_address: string; mode: NetworkLinkMode; name: string; subnet: number; tags: string[]; vlan: number; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'fabric\' does not exist in type \'FormEvent<{}>\'.", "3240912851"]
     ],
-    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:4273220811": [
+    "src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTable.tsx:781352368": [
       [331, 4, 3, "Argument of type \'keyof NetworkRowSortData | null\' is not assignable to parameter of type \'keyof NetworkRowSortData\'.\\n  Type \'null\' is not assignable to type \'keyof NetworkRowSortData\'.", "193424690"],
       [335, 4, 3, "Argument of type \'keyof NetworkRowSortData | null\' is not assignable to parameter of type \'keyof NetworkRowSortData\'.", "193424690"],
       [360, 35, 9, "Object is possibly \'null\'.", "1794230341"],

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -16,7 +16,7 @@ const getLabel = (
 ) => {
   const processing = processingCount >= 0;
 
-  // e.g. "machine""
+  // e.g. "machine"
   let modelString = modelName;
   if (processing && selectedCount > 1) {
     // e.g.  "1 of 2 machines"

--- a/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
+++ b/ui/src/app/kvm/views/KVMDetails/LxdProject/ProjectVMs/VMsActionBar/VMsActionBar.tsx
@@ -53,8 +53,9 @@ const VMsActionBar = ({
           <span>Compose VM</span>
         </Button>
         <VmActionMenu
-          data-test="vm-actions"
           appearance="vmTable"
+          data-test="vm-actions"
+          excludeActions={[NodeActions.DELETE]}
           setSelectedAction={setSelectedAction}
         />
         <span className="u-nudge-right">

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -30,22 +30,46 @@ const getErrorSentence = (action: MachineSelectedAction, count: number) => {
   const machineString = pluralize("machine", count, true);
 
   switch (action.name) {
+    case NodeActions.ABORT:
+      return `${machineString} cannot abort action`;
+    case NodeActions.ACQUIRE:
+      return `${machineString} cannot be acquired`;
+    case NodeActions.COMMISSION:
+      return `${machineString} cannot be commissioned`;
+    case NodeActions.DELETE:
+      return `${machineString} cannot be deleted`;
+    case NodeActions.DEPLOY:
+      return `${machineString} cannot be deployed`;
     case NodeActions.EXIT_RESCUE_MODE:
       return `${machineString} cannot exit rescue mode`;
     case NodeActions.LOCK:
       return `${machineString} cannot be locked`;
+    case NodeActions.MARK_BROKEN:
+      return `${machineString} cannot be marked broken`;
+    case NodeActions.MARK_FIXED:
+      return `${machineString} cannot be marked fixed`;
+    case NodeActions.OFF:
+      return `${machineString} cannot be powered off`;
+    case NodeActions.ON:
+      return `${machineString} cannot be powered on`;
     case NodeActions.OVERRIDE_FAILED_TESTING:
       return `Cannot override failed tests on ${machineString}`;
+    case NodeActions.RELEASE:
+      return `${machineString} cannot be released`;
     case NodeActions.RESCUE_MODE:
       return `${machineString} cannot be put in rescue mode`;
     case NodeActions.SET_POOL:
       return `Cannot set pool of ${machineString}`;
     case NodeActions.SET_ZONE:
       return `Cannot set zone of ${machineString}`;
+    case NodeActions.TAG:
+      return `${machineString} cannot be tagged`;
+    case NodeActions.TEST:
+      return `${machineString} cannot be tested`;
     case NodeActions.UNLOCK:
       return `${machineString} cannot be unlocked`;
     default:
-      return `${machineString} cannot be ${action.extras?.sentence}`;
+      return `${machineString} cannot perform action`;
   }
 };
 

--- a/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/ui/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -203,7 +203,7 @@ describe("MachineListHeader", () => {
 
   it("disables the add hardware menu when machines are selected", () => {
     const state = { ...initialState };
-    state.machine.selected = ["foo"];
+    state.machine.selected = ["abc123"];
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/ui/src/app/machines/views/types.ts
+++ b/ui/src/app/machines/views/types.ts
@@ -6,9 +6,8 @@ import type { Script } from "app/store/script/types";
 export type MachineSelectedAction = SelectedAction<
   MachineAction["name"],
   {
-    sentence?: MachineAction["sentence"];
-    hardwareType?: HardwareType;
     applyConfiguredNetworking?: Script["apply_configured_networking"];
+    hardwareType?: HardwareType;
   }
 >;
 


### PR DESCRIPTION
## Done

- Rewrote `TakeActionMenu` to not rely on the API for the display, which will be required for the clone form that works inverse to the api

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the take action menu still works as before:
  - Action links are grouped and ordered the same
  - Counts are correct
  - Trying to perform an action that not all selected machines can perform shows an error message

## Fixes

Fixes canonical-web-and-design/app-squad#190
Fixes #2730 
