### PR TITLE
feat(ui): add basic clone form

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -33,6 +33,8 @@ const getLabel = (
       return `${processing ? "Aborting" : "Abort"} actions for ${modelString}`;
     case NodeActions.ACQUIRE:
       return `${processing ? "Acquiring" : "Acquire"} ${modelString}`;
+    case NodeActions.CLONE:
+      return processing ? "Cloning in progress" : `Clone to ${modelString}`;
     case NodeActions.COMMISSION:
       return `${
         processing ? "Starting" : "Start"

--- a/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ActionFormWrapper.tsx
@@ -4,6 +4,7 @@ import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
+import CloneForm from "./CloneForm";
 import CommissionForm from "./CommissionForm";
 import DeployForm from "./DeployForm";
 import FieldlessForm from "./FieldlessForm";
@@ -17,6 +18,7 @@ import TestForm from "./TestForm";
 
 import { useScrollOnRender } from "app/base/hooks";
 import { useMachineActionForm } from "app/machines/hooks";
+import { canOpenActionForm } from "app/machines/utils";
 import type {
   MachineSelectedAction,
   MachineSetSelectedAction,
@@ -34,6 +36,8 @@ const getErrorSentence = (action: MachineSelectedAction, count: number) => {
       return `${machineString} cannot abort action`;
     case NodeActions.ACQUIRE:
       return `${machineString} cannot be acquired`;
+    case NodeActions.CLONE:
+      return `${machineString} cannot be cloned to`;
     case NodeActions.COMMISSION:
       return `${machineString} cannot be commissioned`;
     case NodeActions.DELETE:
@@ -91,7 +95,7 @@ export const ActionFormWrapper = ({
   const actionableMachineIDs = selectedAction
     ? machinesToAction.reduce<Machine[MachineMeta.PK][]>(
         (machineIDs, machine) => {
-          if (machine.actions.includes(selectedAction.name)) {
+          if (canOpenActionForm(machine, selectedAction?.name)) {
             machineIDs.push(machine.system_id);
           }
           return machineIDs;
@@ -121,6 +125,13 @@ export const ActionFormWrapper = ({
   const getFormComponent = () => {
     if (selectedAction && selectedAction.name) {
       switch (selectedAction.name) {
+        case NodeActions.CLONE:
+          return (
+            <CloneForm
+              actionDisabled={actionDisabled}
+              clearSelectedAction={clearSelectedAction}
+            />
+          );
         case NodeActions.COMMISSION:
           return (
             <CommissionForm

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -1,0 +1,68 @@
+import { useSelector } from "react-redux";
+import * as Yup from "yup";
+
+import CloneFormFields from "./CloneFormFields";
+
+import ActionForm from "app/base/components/ActionForm";
+import type { ClearSelectedAction } from "app/base/types";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import { NodeActions } from "app/store/types/node";
+
+type Props = {
+  actionDisabled?: boolean;
+  clearSelectedAction: ClearSelectedAction;
+};
+
+export type CloneFormValues = {
+  interfaces: boolean;
+  source: Machine["system_id"];
+  storage: boolean;
+};
+
+const CloneFormSchema = Yup.object()
+  .shape({
+    interfaces: Yup.boolean(),
+    source: Yup.string().required("Source machine must be selected."),
+    storage: Yup.boolean(),
+  })
+  .defined();
+
+export const CloneForm = ({
+  actionDisabled,
+  clearSelectedAction,
+}: Props): JSX.Element => {
+  const machines = useSelector(machineSelectors.all);
+  const selectedMachineIDs = useSelector(machineSelectors.selectedIDs);
+
+  return (
+    <ActionForm<CloneFormValues>
+      actionDisabled={actionDisabled}
+      actionName={NodeActions.CLONE}
+      cleanup={machineActions.cleanup}
+      clearSelectedAction={clearSelectedAction}
+      initialValues={{
+        interfaces: false,
+        source: "",
+        storage: false,
+      }}
+      modelName="machine"
+      onSaveAnalytics={{
+        action: "Submit",
+        category: `Machine ${
+          selectedMachineIDs.length ? "list" : "details"
+        } action form`,
+        label: "Clone",
+      }}
+      onSubmit={() => void null}
+      selectedCount={selectedMachineIDs.length || 1}
+      submitDisabled
+      validationSchema={CloneFormSchema}
+    >
+      <CloneFormFields machines={machines} />
+    </ActionForm>
+  );
+};
+
+export default CloneForm;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -1,0 +1,46 @@
+import { Col, Row, Select } from "@canonical/react-components";
+
+import FormikField from "app/base/components/FormikField";
+import type { Machine } from "app/store/machine/types";
+
+type Props = {
+  machines: Machine[];
+};
+
+export const CloneFormFields = ({ machines }: Props): JSX.Element => {
+  return (
+    <Row>
+      <Col size={6}>
+        <FormikField
+          component={Select}
+          label="Source machine"
+          name="source"
+          options={[
+            {
+              label: "Select source machine",
+              value: "",
+              disabled: true,
+            },
+            ...machines.map((machine) => ({
+              key: machine.system_id,
+              label: machine.hostname,
+              value: machine.system_id,
+            })),
+          ]}
+        />
+        <FormikField
+          label="Clone network configuration"
+          name="interfaces"
+          type="checkbox"
+        />
+        <FormikField
+          label="Clone storage configuration"
+          name="storage"
+          type="checkbox"
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default CloneFormFields;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/index.ts
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CloneFormFields";

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/index.ts
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CloneForm";

--- a/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
+++ b/ui/src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx
@@ -3,6 +3,7 @@ import type { ButtonProps } from "@canonical/react-components";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 
+import { canOpenActionForm } from "app/machines/utils";
 import type { MachineSetSelectedAction } from "app/machines/views/types";
 import type { MachineAction } from "app/store/general/types";
 import machineSelectors from "app/store/machine/selectors";
@@ -34,6 +35,7 @@ const actionGroups: ActionGroup[] = [
       { label: "Deploy...", name: NodeActions.DEPLOY },
       { label: "Release...", name: NodeActions.RELEASE },
       { label: "Abort...", name: NodeActions.ABORT },
+      { label: "Clone from...", name: NodeActions.CLONE },
     ],
   },
   {
@@ -88,7 +90,7 @@ const getTakeActionLinks = (
         }
         const count = machines.reduce(
           (sum, machine) =>
-            machine.actions.includes(action.name) ? sum + 1 : sum,
+            canOpenActionForm(machine, action.name) ? sum + 1 : sum,
           0
         );
         // Lifecycle actions get displayed regardless of whether the selected

--- a/ui/src/app/machines/utils.test.ts
+++ b/ui/src/app/machines/utils.test.ts
@@ -1,0 +1,25 @@
+import { canOpenActionForm } from "./utils";
+
+import { NodeActions } from "app/store/types/node";
+import { machine as machineFactory } from "testing/factories";
+
+describe("machines view utils", () => {
+  describe("canOpenActionForm", () => {
+    it("handles the null case", () => {
+      expect(canOpenActionForm(null, null)).toBe(false);
+      expect(canOpenActionForm(machineFactory(), null)).toBe(false);
+      expect(canOpenActionForm(null, NodeActions.TAG)).toBe(false);
+    });
+
+    it("handles whether a machine can open non-clone action forms", () => {
+      const machine = machineFactory({ actions: [NodeActions.TAG] });
+      expect(canOpenActionForm(machine, NodeActions.TAG)).toBe(true);
+      expect(canOpenActionForm(machine, NodeActions.TEST)).toBe(false);
+    });
+
+    it("handles whether a machine can open the clone action form", () => {
+      const machine = machineFactory({ actions: [] });
+      expect(canOpenActionForm(machine, NodeActions.CLONE)).toBe(true);
+    });
+  });
+});

--- a/ui/src/app/machines/utils.ts
+++ b/ui/src/app/machines/utils.ts
@@ -1,0 +1,24 @@
+import type { Machine, MachineActions } from "app/store/machine/types";
+import { NodeActions } from "app/store/types/node";
+
+/**
+ * Determine whether a machine can open an action form for a particular action.
+ * @param machine - The machine to check.
+ * @param actionName - The name of the action to check, e.g. "commission"
+ * @returns Whether the machine can open the action form.
+ */
+export const canOpenActionForm = (
+  machine: Machine | null,
+  actionName: MachineActions | null
+): boolean => {
+  if (!machine || !actionName) {
+    return false;
+  }
+  // Cloning in the UI works inverse to the rest of the machine actions - we
+  // select the destination machines first then when the form is open we select
+  // the machine to actually perform the clone action.
+  if (actionName === NodeActions.CLONE) {
+    return true; // TODO - add basic validation for what can be cloned to.
+  }
+  return machine.actions.includes(actionName);
+};

--- a/ui/src/app/store/machine/index.ts
+++ b/ui/src/app/store/machine/index.ts
@@ -1,1 +1,1 @@
-export { default, actions } from "./slice";
+export { default, actions, DEFAULT_STATUSES } from "./slice";

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -280,6 +280,8 @@ const selectors = {
   activeID,
   checkingPower: statusSelectors["checkingPower"],
   checkingPowerSelected: statusSelectors["checkingPowerSelected"],
+  cloning: statusSelectors["cloning"],
+  cloningSelected: statusSelectors["cloningSelected"],
   commissioning: statusSelectors["commissioning"],
   commissioningSelected: statusSelectors["commissioningSelected"],
   creatingPhysical: statusSelectors["creatingPhysical"],

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -94,6 +94,10 @@ export const ACTIONS: Action[] = [
     status: "checkingPower",
   },
   {
+    name: NodeActions.CLONE,
+    status: "cloning",
+  },
+  {
     name: NodeActions.COMMISSION,
     status: "commissioning",
   },
@@ -275,11 +279,12 @@ export const ACTIONS: Action[] = [
   },
 ];
 
-const DEFAULT_STATUSES = {
+export const DEFAULT_STATUSES = {
   aborting: false,
   acquiring: false,
   applyingStorageLayout: false,
   checkingPower: false,
+  cloning: false,
   creatingBcache: false,
   creatingBond: false,
   creatingBridge: false,

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -224,6 +224,7 @@ export type MachineStatus = {
   acquiring: boolean;
   applyingStorageLayout: boolean;
   checkingPower: boolean;
+  cloning: boolean;
   creatingBcache: boolean;
   creatingBond: boolean;
   creatingBridge: boolean;

--- a/ui/src/app/store/types/node.ts
+++ b/ui/src/app/store/types/node.ts
@@ -105,6 +105,7 @@ export enum NodeStatus {
 export enum NodeActions {
   ABORT = "abort",
   ACQUIRE = "acquire",
+  CLONE = "clone",
   COMMISSION = "commission",
   DELETE = "delete",
   DEPLOY = "deploy",

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -25,6 +25,7 @@ import type {
   VersionState,
 } from "app/store/general/types";
 import type { LicenseKeysState } from "app/store/licensekeys/types";
+import { DEFAULT_STATUSES } from "app/store/machine";
 import type {
   Machine,
   MachineState,
@@ -138,57 +139,7 @@ export const licenseKeysState = define<LicenseKeysState>({
   ...defaultState,
 });
 
-export const machineStatus = define<MachineStatus>({
-  aborting: false,
-  acquiring: false,
-  applyingStorageLayout: false,
-  checkingPower: false,
-  creatingBcache: false,
-  creatingBond: false,
-  creatingBridge: false,
-  creatingCacheSet: false,
-  creatingLogicalVolume: false,
-  creatingPartition: false,
-  creatingPhysical: false,
-  creatingRaid: false,
-  creatingVlan: false,
-  creatingVmfsDatastore: false,
-  creatingVolumeGroup: false,
-  commissioning: false,
-  deleting: false,
-  deletingCacheSet: false,
-  deletingDisk: false,
-  deletingFilesystem: false,
-  deletingInterface: false,
-  deletingPartition: false,
-  deletingVolumeGroup: false,
-  deploying: false,
-  enteringRescueMode: false,
-  exitingRescueMode: false,
-  gettingSummaryXml: false,
-  gettingSummaryYaml: false,
-  linkingSubnet: false,
-  locking: false,
-  markingBroken: false,
-  markingFixed: false,
-  mountingSpecial: false,
-  overridingFailedTesting: false,
-  releasing: false,
-  settingBootDisk: false,
-  settingPool: false,
-  settingZone: false,
-  tagging: false,
-  testing: false,
-  turningOff: false,
-  turningOn: false,
-  unlocking: false,
-  unlinkingSubnet: false,
-  unmountingSpecial: false,
-  updatingDisk: false,
-  updatingFilesystem: false,
-  updatingInterface: false,
-  updatingVmfsDatastore: false,
-});
+export const machineStatus = define<MachineStatus>(DEFAULT_STATUSES);
 
 export const machineStatuses = define<MachineStatuses>({
   testNode: machineStatus,


### PR DESCRIPTION
## Done

- Built basic clone form with regular, unfiltered select and no validation. Form is currently unsubmittable until the API is ready.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select some machines from the machine list and check that you can open the Clone form.
- Go to a machine details page and check that you can open the Clone form.

## Fixes

Fixes canonical-web-and-design/app-squad#191

## Screenshot

![Screenshot 2021-08-04 at 10-58-13 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/128105055-d45f3ab1-8b10-4f03-be01-5f616274c2bd.png)
