### PR TITLE
fix(ui): fix tab background overlapping preceding hr

### DIFF
--- a/ui/src/scss/_vanilla-overrides.scss
+++ b/ui/src/scss/_vanilla-overrides.scss
@@ -60,3 +60,9 @@ input[type="radio"] {
 .p-notification__response {
   margin-bottom: $spv-outer--medium - $spv-nudge !important;
 }
+
+// 02-08-2021 Caleb: Tab background overlaps hr when focused.
+// https://github.com/canonical-web-and-design/vanilla-framework/issues/3878
+hr.u-no-margin--bottom {
+  z-index: 2 !important;
+}


### PR DESCRIPTION
## Done

- Fixed the tab background overlapping a preceding `hr.u-no-margin--bottom` when focused.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list
- Click on one of the tabs at the top ("X Machines" or "X Pools") and check that the border above it does not disappear.

## Fixes

Fixes #2925 
