### PR TITLE
feat(ui): build source machine select in cloning form

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -33,7 +33,6 @@ export const CloneForm = ({
   actionDisabled,
   clearSelectedAction,
 }: Props): JSX.Element => {
-  const machines = useSelector(machineSelectors.all);
   const selectedMachineIDs = useSelector(machineSelectors.selectedIDs);
 
   return (
@@ -60,7 +59,7 @@ export const CloneForm = ({
       submitDisabled
       validationSchema={CloneFormSchema}
     >
-      <CloneFormFields machines={machines} />
+      <CloneFormFields />
     </ActionForm>
   );
 };

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -1,33 +1,29 @@
-import { Col, Row, Select } from "@canonical/react-components";
+import { Col, Row } from "@canonical/react-components";
+import { useFormikContext } from "formik";
+
+import type { CloneFormValues } from "../CloneForm";
+
+import SourceMachineSelect from "./SourceMachineSelect";
 
 import FormikField from "app/base/components/FormikField";
 import type { Machine } from "app/store/machine/types";
 
-type Props = {
-  machines: Machine[];
-};
+export const CloneFormFields = (): JSX.Element => {
+  const { setFieldValue, values } = useFormikContext<CloneFormValues>();
 
-export const CloneFormFields = ({ machines }: Props): JSX.Element => {
   return (
     <Row>
-      <Col size={6}>
-        <FormikField
-          component={Select}
-          label="Source machine"
-          name="source"
-          options={[
-            {
-              label: "Select source machine",
-              value: "",
-              disabled: true,
-            },
-            ...machines.map((machine) => ({
-              key: machine.system_id,
-              label: machine.hostname,
-              value: machine.system_id,
-            })),
-          ]}
+      <Col size={4}>
+        <p>1. Select the source machine</p>
+        <SourceMachineSelect
+          source={values.source}
+          setSource={(id: Machine["system_id"] | null) =>
+            setFieldValue("source", id || "")
+          }
         />
+      </Col>
+      <Col size={8}>
+        <p>2. Select what to clone</p>
         <FormikField
           label="Clone network configuration"
           name="interfaces"

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -1,0 +1,173 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import SourceMachineSelect from "./SourceMachineSelect";
+
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("SourceMachineSelect", () => {
+  let state: RootState;
+  let firstMachine: Machine;
+  let secondMachine: Machine;
+
+  beforeEach(() => {
+    firstMachine = machineFactory({
+      system_id: "abc123",
+      hostname: "first",
+      owner: "admin",
+      tags: ["tag1"],
+    });
+    secondMachine = machineFactory({
+      system_id: "def456",
+      hostname: "second",
+      owner: "user",
+      tags: ["tag2"],
+    });
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [firstMachine, secondMachine],
+        loaded: true,
+        active: null,
+        selected: [],
+      }),
+    });
+  });
+
+  it("dispatches action to fetch machines on load", () => {
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <SourceMachineSelect source="" setSource={jest.fn()} />
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "machine/fetch")
+    ).toBe(true);
+  });
+
+  it("shows a spinner while machines are loading", () => {
+    state.machine.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SourceMachineSelect source="" setSource={jest.fn()} />
+      </Provider>
+    );
+
+    expect(wrapper.find("[data-test='loading-spinner']").exists()).toBe(true);
+  });
+
+  it("can filter machines by hostname, system_id and/or tags", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SourceMachineSelect source="" setSource={jest.fn()} />
+      </Provider>
+    );
+
+    // Filter by "first" which matches the hostname of the first machine
+    wrapper
+      .find("[data-test='source-machine-searchbox'] input")
+      .simulate("change", { target: { value: "first" } });
+    expect(wrapper.find("[data-test='source-machine-first']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("[data-test='source-machine-second']").exists()).toBe(
+      false
+    );
+
+    // Filter by "def" which matches the system_id of the second machine
+    wrapper
+      .find("[data-test='source-machine-searchbox'] input")
+      .simulate("change", { target: { value: "def" } });
+    expect(wrapper.find("[data-test='source-machine-first']").exists()).toBe(
+      false
+    );
+    expect(wrapper.find("[data-test='source-machine-second']").exists()).toBe(
+      true
+    );
+
+    // Filter by "tag" which matches the tags of the first and second machine
+    wrapper
+      .find("[data-test='source-machine-searchbox'] input")
+      .simulate("change", { target: { value: "tag" } });
+    expect(wrapper.find("[data-test='source-machine-first']").exists()).toBe(
+      true
+    );
+    expect(wrapper.find("[data-test='source-machine-second']").exists()).toBe(
+      true
+    );
+  });
+
+  it("highlights the substring that matches the search text", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SourceMachineSelect source="" setSource={jest.fn()} />
+      </Provider>
+    );
+
+    // Filter by "fir" which matches part of the hostname of the first machine
+    wrapper
+      .find("[data-test='source-machine-searchbox'] input")
+      .simulate("change", { target: { value: "fir" } });
+    expect(
+      wrapper
+        .find("[data-test='source-machine-first']")
+        .render()
+        .find("strong")
+        .text()
+    ).toBe("fir");
+  });
+
+  it("sets the source on row click", () => {
+    const setSource = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SourceMachineSelect source="" setSource={setSource} />
+      </Provider>
+    );
+
+    wrapper.find("[data-test='source-machine-row']").at(0).simulate("click");
+    expect(setSource).toHaveBeenCalledWith(firstMachine.system_id);
+  });
+
+  it("shows the machine's details when selected", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SourceMachineSelect source="abc123" setSource={jest.fn()} />
+      </Provider>
+    );
+
+    expect(
+      wrapper.find("[data-test='selected-machine-details']").exists()
+    ).toBe(true);
+  });
+
+  it("clears the source on search input change", () => {
+    const setSource = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <SourceMachineSelect source="abc123" setSource={setSource} />
+      </Provider>
+    );
+
+    wrapper
+      .find("[data-test='source-machine-searchbox'] input")
+      .simulate("change", { target: { value: "" } });
+    expect(setSource).toHaveBeenCalledWith(null);
+  });
+});

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+
+import { MainTable, SearchBox, Spinner } from "@canonical/react-components";
+import { highlightSubString } from "@canonical/react-components/dist/utils";
+import { useDispatch, useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import LabelledList from "app/base/components/LabelledList";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+
+type Props = {
+  source?: Machine["system_id"] | null;
+  setSource: (id: Machine["system_id"] | null) => void;
+};
+
+const generateRows = (
+  machines: Machine[],
+  searchText: string,
+  onRowClick: (machine: Machine) => void
+) => {
+  const highlightedText = (text: string) => (
+    <span
+      dangerouslySetInnerHTML={{
+        __html: highlightSubString(text, searchText).text,
+      }}
+      data-test={`source-machine-${text}`}
+    />
+  );
+
+  return machines.map((machine) => ({
+    className: "source-machine-select__row",
+    columns: [
+      {
+        content: (
+          <DoubleRow
+            primary={highlightedText(machine.hostname)}
+            secondary={highlightedText(machine.system_id)}
+          />
+        ),
+      },
+      {
+        content: (
+          <DoubleRow
+            primary={machine.owner || "-"}
+            secondary={
+              machine.tags.length
+                ? highlightedText(machine.tags.join(", "))
+                : "-"
+            }
+          />
+        ),
+      },
+    ],
+    "data-test": "source-machine-row",
+    onClick: () => onRowClick(machine),
+  }));
+};
+
+export const SourceMachineSelect = ({
+  source,
+  setSource,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const [searchText, setSearchText] = useState("");
+  const unselectedMachines = useSelector(machineSelectors.unselected);
+  const selectedMachine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, source)
+  );
+  const loaded = useSelector(machineSelectors.loaded);
+  // We filter by a subset of machine parameters rather than using the search
+  // selector, because the search selector will match parameters that aren't
+  // included in the clone source table.
+  const filteredMachines = unselectedMachines.filter(
+    (machine) =>
+      machine.system_id.includes(searchText) ||
+      machine.hostname.includes(searchText) ||
+      machine.tags.join(", ").includes(searchText)
+  );
+
+  useEffect(() => {
+    dispatch(machineActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <div className="source-machine-select">
+      <SearchBox
+        data-test="source-machine-searchbox"
+        externallyControlled
+        placeholder="Search by hostname, system ID or tags"
+        onChange={(searchText: string) => {
+          setSearchText(searchText);
+          // Unset the selected machine if the search input changes - assume
+          // the user wants to change it.
+          if (selectedMachine) {
+            setSource(null);
+          }
+        }}
+        value={searchText}
+      />
+      {selectedMachine ? (
+        <LabelledList
+          data-test="selected-machine-details"
+          items={[{ label: "Status", value: selectedMachine.status }]}
+        />
+      ) : (
+        <div className="source-machine-select__table">
+          <MainTable
+            emptyStateMsg={
+              loaded ? "No machines match the search criteria." : null
+            }
+            headers={[
+              {
+                content: (
+                  <>
+                    <div>Hostname</div>
+                    <div>system_id</div>
+                  </>
+                ),
+              },
+              {
+                content: (
+                  <>
+                    <div>Owner</div>
+                    <div>Tags</div>
+                  </>
+                ),
+              },
+            ]}
+            rows={
+              loaded
+                ? generateRows(filteredMachines, searchText, (machine) => {
+                    setSource(machine.system_id);
+                    setSearchText(machine.hostname);
+                  })
+                : []
+            }
+          />
+        </div>
+      )}
+      {!loaded && <Spinner data-test="loading-spinner" text="Loading..." />}
+    </div>
+  );
+};
+
+export default SourceMachineSelect;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
@@ -1,0 +1,19 @@
+@mixin SourceMachineSelect {
+  .source-machine-select {
+    @extend %vf-is-bordered;
+    padding: $spv-inner--medium $sph-inner 0 $sph-inner;
+  }
+
+  .source-machine-select__table {
+    max-height: 20rem;
+    overflow: auto;
+  }
+
+  .source-machine-select__row {
+    cursor: pointer;
+
+    &:hover {
+      background-color: $color-light;
+    }
+  }
+}

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/index.ts
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SourceMachineSelect";

--- a/ui/src/app/store/machine/selectors.test.ts
+++ b/ui/src/app/store/machine/selectors.test.ts
@@ -81,6 +81,22 @@ describe("machine selectors", () => {
     expect(machine.active(state)).toEqual(activeMachine);
   });
 
+  it("can get the unselected machines", () => {
+    const [selectedMachine, activeMachine, unselectedMachine] = [
+      machineFactory(),
+      machineFactory(),
+      machineFactory(),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        active: activeMachine.system_id,
+        items: [activeMachine, selectedMachine, unselectedMachine],
+        selected: [selectedMachine.system_id],
+      }),
+    });
+    expect(machine.unselected(state)).toEqual([unselectedMachine]);
+  });
+
   it("can get the errors state", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({

--- a/ui/src/app/store/machine/selectors.ts
+++ b/ui/src/app/store/machine/selectors.ts
@@ -179,6 +179,19 @@ const selected = createSelector(
 );
 
 /**
+ * Returns machines that are neither active nor selected.
+ * @param state - The redux state.
+ * @returns Unselected machines.
+ */
+const unselected = createSelector(
+  [defaultSelectors.all, selectedIDs, activeID],
+  (machines, selectedIDs, activeID) =>
+    machines.filter(
+      (machine) => ![...selectedIDs, activeID].includes(machine.system_id)
+    )
+);
+
+/**
  * Select the event errors for all machines.
  * @param state - The redux state.
  * @returns The event errors.
@@ -339,6 +352,7 @@ const selectors = {
   unlockingSelected: statusSelectors["unlockingSelected"],
   unlinkingSubnet: statusSelectors["unlinkingSubnet"],
   unlinkingSubnetSelected: statusSelectors["unlinkingSubnetSelected"],
+  unselected,
 };
 
 export default selectors;

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -167,20 +167,21 @@
 @include DiscoveriesList;
 
 // machines
+@import "~app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect";
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
 @import "~app/machines/components/TakeActionMenu";
-@import "~app/machines/views/MachineList";
 @import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
+@import "~app/machines/views/MachineDetails/MachineLogs/DownloadMenu";
 @import "~app/machines/views/MachineDetails/MachineLogs/EventLogs/EventLogsTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/DHCPTable";
 @import "~app/machines/views/MachineDetails/MachineNetwork/NetworkTable";
-@import "~app/machines/views/MachineDetails/MachineLogs/DownloadMenu";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NetworkCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineDetails/MachineSummary/OverviewCard";
 @import "~app/machines/views/MachineDetails/MachineTests/MachineTestsTable";
 @import "~app/machines/views/MachineDetails/NodeDevices";
+@import "~app/machines/views/MachineList";
 @include DownloadMenu;
 @include EventLogsTable;
 @include MachineDHCPTable;
@@ -194,6 +195,7 @@
 @include NodeDevices;
 @include NumaCard;
 @include OverviewCard;
+@include SourceMachineSelect;
 @include TakeActionMenu;
 
 // preferences


### PR DESCRIPTION
## Done

- Built dynamic source machine select in cloning form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- From the machine list select some machines and select "Clone from..." from the action menu
- Check that the source machine select matches [the design](https://app.zeplin.io/project/60e32f0e5c4c0f13e711d590/screen/6107cdc190beaf14f03906fd)
- Check that you can filter machines by hostname, system_id or tags and the matching text is bold
- Check that clicking on a row selects the machine and shows that machine's "details" (for now just the status)
- Check that clicking the X in the searchbox clears the selected machine
- Note there's a bug with the `SearchBox` component so clicking on the magnifying glass will "submit" the form and refresh the page. https://github.com/canonical-web-and-design/react-components/issues/566

## Fixes

Fixes canonical-web-and-design/app-squad#192

## Screenshot
### Default state
![Screenshot 2021-08-05 at 12-06-24 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/128279621-fa20478b-8f9e-449a-a391-98e5c90ecc24.png)


### Filtered
![Screenshot 2021-08-05 at 12-06-47 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/128279627-7428d9e2-5887-429b-9dbd-454332990f3c.png)


### Selected
![Screenshot 2021-08-05 at 12-07-03 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/128279641-9adc71b6-2ec3-4dc2-9f1a-9cb00ea1beb5.png)
