### PR TITLE
feat(ui): fetch full machine details from machine cloning form

### DIFF
--- a/ui/src/app/base/components/LabelledList/_index.scss
+++ b/ui/src/app/base/components/LabelledList/_index.scss
@@ -5,7 +5,9 @@
     .p-list__item {
       @extend %vf-list-item;
       display: flex;
-      padding: $spv-inner--x-small--scaleable 0;
+      // Vanilla lists have a different padding inside forms, but since this is
+      // a custom component we need to make sure it doesn't change.
+      padding: $spv-inner--x-small--scaleable 0 !important;
       word-wrap: break-word;
     }
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -1,0 +1,68 @@
+import { mount } from "enzyme";
+import { Formik } from "formik";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CloneFormFields from "./CloneFormFields";
+
+import { actions as machineActions } from "app/store/machine";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { waitForComponentToPaint } from "testing/utils";
+
+const mockStore = configureStore();
+
+describe("CloneFormFields", () => {
+  it("dispatches action to fetch machines on load", () => {
+    const state = rootStateFactory();
+    const store = mockStore(state);
+    mount(
+      <Provider store={store}>
+        <Formik
+          initialValues={{ interfaces: false, source: "", storage: false }}
+          onSubmit={jest.fn()}
+        >
+          <CloneFormFields />
+        </Formik>
+      </Provider>
+    );
+
+    expect(
+      store.getActions().some((action) => action.type === "machine/fetch")
+    ).toBe(true);
+  });
+
+  it("dispatches action to get full machine details on machine click", async () => {
+    const machine = machineFactory({ system_id: "abc123" });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+        loaded: true,
+        selected: [],
+        active: null,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik
+          initialValues={{ interfaces: false, source: "", storage: false }}
+          onSubmit={jest.fn()}
+        >
+          <CloneFormFields />
+        </Formik>
+      </Provider>
+    );
+    wrapper.find("[data-test='source-machine-row']").at(0).simulate("click");
+    await waitForComponentToPaint(wrapper);
+
+    const expectedAction = machineActions.get(machine.system_id);
+    const actualActions = store.getActions();
+    expect(
+      actualActions.find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -1,25 +1,66 @@
+import { useEffect, useState } from "react";
+
 import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
+import { useDispatch, useSelector } from "react-redux";
 
 import type { CloneFormValues } from "../CloneForm";
 
 import SourceMachineSelect from "./SourceMachineSelect";
 
 import FormikField from "app/base/components/FormikField";
-import type { Machine } from "app/store/machine/types";
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
+import type { MachineDetails } from "app/store/machine/types";
+import { isMachineDetails } from "app/store/machine/utils";
+import type { RootState } from "app/store/root/types";
 
 export const CloneFormFields = (): JSX.Element => {
+  const [selectedMachine, setSelectedMachine] = useState<MachineDetails | null>(
+    null
+  );
   const { setFieldValue, values } = useFormikContext<CloneFormValues>();
+  const dispatch = useDispatch();
+  const machineInState = useSelector((state: RootState) =>
+    machineSelectors.getById(state, values.source)
+  );
+  const unselectedMachines = useSelector(machineSelectors.unselected);
+  const loadingMachines = !useSelector(machineSelectors.loaded);
+  const loadingDetails = !!values.source && !selectedMachine;
+
+  useEffect(() => {
+    dispatch(machineActions.fetch());
+  }, [dispatch]);
+
+  // The machine in state can change between types Machine and MachineDetails at
+  // any time if it's not the "active" machine, so we set the MachineDetails
+  // version in local state when it's available. This would not be necessary
+  // if it were possible to set more than one machine as "active" at a time.
+  // https://bugs.launchpad.net/maas/+bug/1939078
+  useEffect(() => {
+    if (!selectedMachine && isMachineDetails(machineInState)) {
+      setSelectedMachine(machineInState);
+    }
+  }, [machineInState, selectedMachine]);
 
   return (
     <Row>
       <Col size={4}>
         <p>1. Select the source machine</p>
         <SourceMachineSelect
-          source={values.source}
-          setSource={(id: Machine["system_id"] | null) =>
-            setFieldValue("source", id || "")
-          }
+          loadingDetails={loadingDetails}
+          loadingMachines={loadingMachines}
+          machines={unselectedMachines}
+          onMachineClick={(machine) => {
+            if (machine) {
+              setFieldValue("source", machine.system_id);
+              dispatch(machineActions.get(machine.system_id));
+            } else {
+              setFieldValue("source", "");
+              setSelectedMachine(null);
+            }
+          }}
+          selectedMachine={selectedMachine}
         />
       </Col>
       <Col size={8}>

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.test.tsx
@@ -1,0 +1,38 @@
+import { mount } from "enzyme";
+
+import SourceMachineDetails from "./SourceMachineDetails";
+
+import { NodeStatus } from "app/store/types/node";
+import { machineDetails as machineDetailsFactory } from "testing/factories";
+
+describe("SourceMachineDetails", () => {
+  it("renders a list of the source machine's details", () => {
+    const machine = machineDetailsFactory({
+      architecture: "",
+      cpu_count: 2,
+      cpu_speed: 2000,
+      domain: { id: 1, name: "domain" },
+      metadata: { cpu_model: "CPU model" },
+      memory: 8,
+      owner: "Owner",
+      physical_disk_count: 2,
+      pod: { id: 2, name: "pod" },
+      power_type: "manual",
+      status: NodeStatus.READY,
+      storage: 8,
+      zone: { id: 3, name: "zone" },
+    });
+    const wrapper = mount(<SourceMachineDetails machine={machine} />);
+    expect(
+      wrapper.find("[data-test='source-machine-details']")
+    ).toMatchSnapshot();
+  });
+
+  it("shows a placeholder list if machine not provided", () => {
+    const wrapper = mount(<SourceMachineDetails machine={null} />);
+    expect(wrapper.find("[data-test='placeholder-list']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='source-machine-details']").exists()).toBe(
+      false
+    );
+  });
+});

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.tsx
@@ -1,0 +1,98 @@
+import pluralize from "pluralize";
+
+import LabelledList from "app/base/components/LabelledList";
+import Placeholder from "app/base/components/Placeholder";
+import type { MachineDetails } from "app/store/machine/types";
+
+type Props = {
+  machine: MachineDetails | null;
+};
+
+export const SourceMachineDetails = ({ machine }: Props): JSX.Element => {
+  if (!machine) {
+    return (
+      <LabelledList
+        data-test="placeholder-list"
+        items={[
+          { label: "Status", value: <Placeholder>Deployed</Placeholder> },
+          {
+            label: "CPU",
+            value: (
+              <>
+                <Placeholder>X cores, X.X GHz</Placeholder>
+                <br />
+                <Placeholder>Vendor information</Placeholder>
+                <br />
+                <Placeholder>Architecture</Placeholder>
+              </>
+            ),
+          },
+          { label: "Memory", value: <Placeholder>X GiB</Placeholder> },
+          {
+            label: "Storage",
+            value: <Placeholder>X GB over X disks</Placeholder>,
+          },
+          { label: "Power type", value: <Placeholder>Power type</Placeholder> },
+          { label: "Owner", value: <Placeholder>Owner</Placeholder> },
+          { label: "Host", value: <Placeholder>Host name</Placeholder> },
+          { label: "Zone", value: <Placeholder>Zone name</Placeholder> },
+          { label: "Domain", value: <Placeholder>Domain</Placeholder> },
+        ]}
+      />
+    );
+  }
+  const {
+    architecture,
+    cpu_count,
+    cpu_speed,
+    domain,
+    metadata,
+    memory,
+    owner,
+    physical_disk_count,
+    pod,
+    power_type,
+    status,
+    storage,
+    zone,
+  } = machine;
+  return (
+    <LabelledList
+      data-test="source-machine-details"
+      items={[
+        { label: "Status", value: status },
+        {
+          label: "CPU",
+          value: (
+            <>
+              <span>
+                {pluralize("core", cpu_count, true)}, {cpu_speed / 1000} GHz
+              </span>
+              <br />
+              <span>{metadata.cpu_model || "Unknown model"}</span>
+              <br />
+              <span>{architecture}</span>
+            </>
+          ),
+        },
+        { label: "Memory", value: `${memory} GiB` },
+        {
+          label: "Storage",
+          value: (
+            <>
+              {storage} GB{" "}
+              <small>over {pluralize("disk", physical_disk_count, true)}</small>
+            </>
+          ),
+        },
+        { label: "Power type", value: power_type },
+        { label: "Owner", value: owner || "-" },
+        { label: "Host", value: pod?.name || "-" },
+        { label: "Zone", value: zone?.name || "-" },
+        { label: "Domain", value: domain?.name || "-" },
+      ]}
+    />
+  );
+};
+
+export default SourceMachineDetails;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/__snapshots__/SourceMachineDetails.test.tsx.snap
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/__snapshots__/SourceMachineDetails.test.tsx.snap
@@ -1,0 +1,366 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SourceMachineDetails renders a list of the source machine's details 1`] = `
+<LabelledList
+  data-test="source-machine-details"
+  items={
+    Array [
+      Object {
+        "label": "Status",
+        "value": "Ready",
+      },
+      Object {
+        "label": "CPU",
+        "value": <React.Fragment>
+          <span>
+            2 cores
+            , 
+            2
+             GHz
+          </span>
+          <br />
+          <span>
+            CPU model
+          </span>
+          <br />
+          <span>
+            
+          </span>
+        </React.Fragment>,
+      },
+      Object {
+        "label": "Memory",
+        "value": "8 GiB",
+      },
+      Object {
+        "label": "Storage",
+        "value": <React.Fragment>
+          8
+           GB
+           
+          <small>
+            over 
+            2 disks
+          </small>
+        </React.Fragment>,
+      },
+      Object {
+        "label": "Power type",
+        "value": "manual",
+      },
+      Object {
+        "label": "Owner",
+        "value": "Owner",
+      },
+      Object {
+        "label": "Host",
+        "value": "pod",
+      },
+      Object {
+        "label": "Zone",
+        "value": "zone",
+      },
+      Object {
+        "label": "Domain",
+        "value": "domain",
+      },
+    ]
+  }
+>
+  <List
+    className="p-list--labelled"
+    items={
+      Array [
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Status
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            Ready
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            CPU
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <React.Fragment>
+              <span>
+                2 cores
+                , 
+                2
+                 GHz
+              </span>
+              <br />
+              <span>
+                CPU model
+              </span>
+              <br />
+              <span>
+                
+              </span>
+            </React.Fragment>
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Memory
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            8 GiB
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Storage
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <React.Fragment>
+              8
+               GB
+               
+              <small>
+                over 
+                2 disks
+              </small>
+            </React.Fragment>
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Power type
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            manual
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Owner
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            Owner
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Host
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            pod
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Zone
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            zone
+          </div>
+        </React.Fragment>,
+        <React.Fragment>
+          <div
+            className="p-list__item-label"
+          >
+            Domain
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            domain
+          </div>
+        </React.Fragment>,
+      ]
+    }
+  >
+    <ul
+      className="p-list--labelled p-list"
+    >
+      <li
+        className="p-list__item"
+        key="0"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Status
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          Ready
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="1"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          CPU
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          <span>
+            2 cores
+            , 
+            2
+             GHz
+          </span>
+          <br />
+          <span>
+            CPU model
+          </span>
+          <br />
+          <span />
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="2"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Memory
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          8 GiB
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="3"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Storage
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          8
+           GB
+           
+          <small>
+            over 
+            2 disks
+          </small>
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="4"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Power type
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          manual
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="5"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Owner
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          Owner
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="6"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Host
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          pod
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="7"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Zone
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          zone
+        </div>
+      </li>
+      <li
+        className="p-list__item"
+        key="8"
+      >
+        <div
+          className="p-list__item-label"
+        >
+          Domain
+        </div>
+        <div
+          className="p-list__item-value"
+        >
+          domain
+        </div>
+      </li>
+    </ul>
+  </List>
+</LabelledList>
+`;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/index.ts
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SourceMachineDetails";

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
@@ -5,7 +5,7 @@
   }
 
   .source-machine-select__table {
-    max-height: 20rem;
+    max-height: 22rem;
     overflow: auto;
   }
 

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -38,7 +38,6 @@ const MachineHeader = ({
   const dispatch = useDispatch();
   const { pathname } = useLocation();
   const { id } = useParams<RouteParams>();
-  const loading = useSelector(machineSelectors.loading);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
@@ -83,7 +82,7 @@ const MachineHeader = ({
           />
         ) : null
       }
-      loading={loading}
+      loading={!machine}
       subtitle={
         editingName
           ? null


### PR DESCRIPTION
## Done

- Fetch full machine details when selecting a source machine in the cloning form
- Show a placeholder list while details are loading
- Moved Redux store interactions up from `SourceMachineSelect` to `CloneFormFields` because the selected machine details will need to be made available to all the form fields

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a machine and open the clone form
- Select a source machine and check that a placeholder list shows while details are loading
- Check that the details are correct once loaded

## Fixes

Fixes canonical-web-and-design/app-squad#193

## Launchpad issue

[lp#1939078: Allow setting multiple machines as "active" via the websocket](https://bugs.launchpad.net/maas/+bug/1939078)

## Screenshots
### Loading
![2021-08-06_11-22](https://user-images.githubusercontent.com/25733845/128441704-ee7b4ea5-97e1-4e3f-bae3-4fd7eabef3e0.png)


### Loaded
![2021-08-06_11-22_1](https://user-images.githubusercontent.com/25733845/128441713-64085446-d904-490f-bb80-f59f2a4a0eee.png)
