### PR TITLE
feat(ui): update Placeholder to show real content when loaded

### DIFF
--- a/ui/src/app/base/components/Placeholder/Placeholder.test.tsx
+++ b/ui/src/app/base/components/Placeholder/Placeholder.test.tsx
@@ -15,4 +15,11 @@ describe("Placeholder", () => {
     const wrapper = shallow(<Placeholder>Placeholder text</Placeholder>);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("does not return placeholder styling if loading is false", () => {
+    const wrapper = shallow(
+      <Placeholder loading={false}>Placeholder text</Placeholder>
+    );
+    expect(wrapper.find("[data-test='placeholder']").exists()).toBe(false);
+  });
 });

--- a/ui/src/app/base/components/Placeholder/Placeholder.tsx
+++ b/ui/src/app/base/components/Placeholder/Placeholder.tsx
@@ -5,18 +5,27 @@ import classNames from "classnames";
 type Props = {
   children: ReactNode;
   className?: string;
+  loading?: boolean;
 };
 
-const Placeholder = ({ children, className }: Props): JSX.Element => {
+const Placeholder = ({
+  children,
+  className,
+  loading = true,
+}: Props): JSX.Element => {
   const delay = Math.floor(Math.random() * 750);
-  return (
-    <span
-      className={classNames("p-placeholder", className)}
-      style={{ animationDelay: `${delay}ms` }}
-    >
-      {children}
-    </span>
-  );
+  if (loading) {
+    return (
+      <span
+        className={classNames("p-placeholder", className)}
+        data-test="placeholder"
+        style={{ animationDelay: `${delay}ms` }}
+      >
+        {children}
+      </span>
+    );
+  }
+  return <>{children}</>;
 };
 
 export default Placeholder;

--- a/ui/src/app/base/components/Placeholder/__snapshots__/Placeholder.test.tsx.snap
+++ b/ui/src/app/base/components/Placeholder/__snapshots__/Placeholder.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Placeholder renders 1`] = `
 <span
   className="p-placeholder"
+  data-test="placeholder"
   style={
     Object {
       "animationDelay": "0ms",

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.test.tsx
@@ -27,12 +27,4 @@ describe("SourceMachineDetails", () => {
       wrapper.find("[data-test='source-machine-details']")
     ).toMatchSnapshot();
   });
-
-  it("shows a placeholder list if machine not provided", () => {
-    const wrapper = mount(<SourceMachineDetails machine={null} />);
-    expect(wrapper.find("[data-test='placeholder-list']").exists()).toBe(true);
-    expect(wrapper.find("[data-test='source-machine-details']").exists()).toBe(
-      false
-    );
-  });
 });

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.tsx
@@ -9,87 +9,104 @@ type Props = {
 };
 
 export const SourceMachineDetails = ({ machine }: Props): JSX.Element => {
-  if (!machine) {
-    return (
-      <LabelledList
-        data-test="placeholder-list"
-        items={[
-          { label: "Status", value: <Placeholder>Deployed</Placeholder> },
-          {
-            label: "CPU",
-            value: (
-              <>
-                <Placeholder>X cores, X.X GHz</Placeholder>
-                <br />
-                <Placeholder>Vendor information</Placeholder>
-                <br />
-                <Placeholder>Architecture</Placeholder>
-              </>
-            ),
-          },
-          { label: "Memory", value: <Placeholder>X GiB</Placeholder> },
-          {
-            label: "Storage",
-            value: <Placeholder>X GB over X disks</Placeholder>,
-          },
-          { label: "Power type", value: <Placeholder>Power type</Placeholder> },
-          { label: "Owner", value: <Placeholder>Owner</Placeholder> },
-          { label: "Host", value: <Placeholder>Host name</Placeholder> },
-          { label: "Zone", value: <Placeholder>Zone name</Placeholder> },
-          { label: "Domain", value: <Placeholder>Domain</Placeholder> },
-        ]}
-      />
-    );
+  // Placeholder content is displayed until the machine has loaded.
+  let content = {
+    architecture: "Architecture",
+    cores: "X cores, X.X GHz",
+    cpuModel: "Model information",
+    domain: "Domain",
+    host: "Host name",
+    memory: "X GiB",
+    owner: "Owner",
+    powerType: "Power type",
+    status: "Machine status",
+    storage: (
+      <>
+        X GB <small>over X disks</small>
+      </>
+    ),
+    zone: "Zone name",
+  };
+
+  if (machine) {
+    content = {
+      architecture: machine.architecture,
+      cores: `${pluralize("core", machine.cpu_count, true)}, ${
+        machine.cpu_speed / 1000
+      } GHz`,
+      cpuModel: machine.metadata?.cpu_model || "Unknown model",
+      domain: machine.domain?.name || "-",
+      host: machine.pod?.name || "-",
+      memory: `${machine.memory} GiB`,
+      owner: machine.owner || "-",
+      powerType: machine.power_type || "Unknown",
+      status: machine.status,
+      storage: (
+        <>
+          {machine.storage} GB{" "}
+          <small>
+            over {pluralize("disk", machine.physical_disk_count, true)}
+          </small>
+        </>
+      ),
+      zone: machine.zone?.name || "-",
+    };
   }
-  const {
-    architecture,
-    cpu_count,
-    cpu_speed,
-    domain,
-    metadata,
-    memory,
-    owner,
-    physical_disk_count,
-    pod,
-    power_type,
-    status,
-    storage,
-    zone,
-  } = machine;
+
   return (
     <LabelledList
       data-test="source-machine-details"
       items={[
-        { label: "Status", value: status },
+        {
+          label: "Status",
+          value: <Placeholder loading={!machine}>{content.status}</Placeholder>,
+        },
         {
           label: "CPU",
           value: (
             <>
-              <span>
-                {pluralize("core", cpu_count, true)}, {cpu_speed / 1000} GHz
-              </span>
+              <Placeholder loading={!machine}>{content.cores}</Placeholder>
               <br />
-              <span>{metadata.cpu_model || "Unknown model"}</span>
+              <Placeholder loading={!machine}>{content.cpuModel}</Placeholder>
               <br />
-              <span>{architecture}</span>
+              <Placeholder loading={!machine}>
+                {content.architecture}
+              </Placeholder>
             </>
           ),
         },
-        { label: "Memory", value: `${memory} GiB` },
+        {
+          label: "Memory",
+          value: <Placeholder loading={!machine}>{content.memory}</Placeholder>,
+        },
         {
           label: "Storage",
           value: (
-            <>
-              {storage} GB{" "}
-              <small>over {pluralize("disk", physical_disk_count, true)}</small>
-            </>
+            <Placeholder loading={!machine}>{content.storage}</Placeholder>
           ),
         },
-        { label: "Power type", value: power_type },
-        { label: "Owner", value: owner || "-" },
-        { label: "Host", value: pod?.name || "-" },
-        { label: "Zone", value: zone?.name || "-" },
-        { label: "Domain", value: domain?.name || "-" },
+        {
+          label: "Power type",
+          value: (
+            <Placeholder loading={!machine}>{content.powerType}</Placeholder>
+          ),
+        },
+        {
+          label: "Owner",
+          value: <Placeholder loading={!machine}>{content.owner}</Placeholder>,
+        },
+        {
+          label: "Host",
+          value: <Placeholder loading={!machine}>{content.host}</Placeholder>,
+        },
+        {
+          label: "Zone",
+          value: <Placeholder loading={!machine}>{content.zone}</Placeholder>,
+        },
+        {
+          label: "Domain",
+          value: <Placeholder loading={!machine}>{content.domain}</Placeholder>,
+        },
       ]}
     />
   );

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/__snapshots__/SourceMachineDetails.test.tsx.snap
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/__snapshots__/SourceMachineDetails.test.tsx.snap
@@ -7,62 +7,97 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
     Array [
       Object {
         "label": "Status",
-        "value": "Ready",
+        "value": <Placeholder
+          loading={false}
+        >
+          Ready
+        </Placeholder>,
       },
       Object {
         "label": "CPU",
         "value": <React.Fragment>
-          <span>
-            2 cores
-            , 
-            2
-             GHz
-          </span>
+          <Placeholder
+            loading={false}
+          >
+            2 cores, 2 GHz
+          </Placeholder>
           <br />
-          <span>
+          <Placeholder
+            loading={false}
+          >
             CPU model
-          </span>
+          </Placeholder>
           <br />
-          <span>
+          <Placeholder
+            loading={false}
+          >
             
-          </span>
+          </Placeholder>
         </React.Fragment>,
       },
       Object {
         "label": "Memory",
-        "value": "8 GiB",
+        "value": <Placeholder
+          loading={false}
+        >
+          8 GiB
+        </Placeholder>,
       },
       Object {
         "label": "Storage",
-        "value": <React.Fragment>
-          8
-           GB
-           
-          <small>
-            over 
-            2 disks
-          </small>
-        </React.Fragment>,
+        "value": <Placeholder
+          loading={false}
+        >
+          <React.Fragment>
+            8
+             GB
+             
+            <small>
+              over 
+              2 disks
+            </small>
+          </React.Fragment>
+        </Placeholder>,
       },
       Object {
         "label": "Power type",
-        "value": "manual",
+        "value": <Placeholder
+          loading={false}
+        >
+          manual
+        </Placeholder>,
       },
       Object {
         "label": "Owner",
-        "value": "Owner",
+        "value": <Placeholder
+          loading={false}
+        >
+          Owner
+        </Placeholder>,
       },
       Object {
         "label": "Host",
-        "value": "pod",
+        "value": <Placeholder
+          loading={false}
+        >
+          pod
+        </Placeholder>,
       },
       Object {
         "label": "Zone",
-        "value": "zone",
+        "value": <Placeholder
+          loading={false}
+        >
+          zone
+        </Placeholder>,
       },
       Object {
         "label": "Domain",
-        "value": "domain",
+        "value": <Placeholder
+          loading={false}
+        >
+          domain
+        </Placeholder>,
       },
     ]
   }
@@ -80,7 +115,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            Ready
+            <Placeholder
+              loading={false}
+            >
+              Ready
+            </Placeholder>
           </div>
         </React.Fragment>,
         <React.Fragment>
@@ -93,20 +132,23 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
             className="p-list__item-value"
           >
             <React.Fragment>
-              <span>
-                2 cores
-                , 
-                2
-                 GHz
-              </span>
+              <Placeholder
+                loading={false}
+              >
+                2 cores, 2 GHz
+              </Placeholder>
               <br />
-              <span>
+              <Placeholder
+                loading={false}
+              >
                 CPU model
-              </span>
+              </Placeholder>
               <br />
-              <span>
+              <Placeholder
+                loading={false}
+              >
                 
-              </span>
+              </Placeholder>
             </React.Fragment>
           </div>
         </React.Fragment>,
@@ -119,7 +161,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            8 GiB
+            <Placeholder
+              loading={false}
+            >
+              8 GiB
+            </Placeholder>
           </div>
         </React.Fragment>,
         <React.Fragment>
@@ -131,15 +177,19 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            <React.Fragment>
-              8
-               GB
-               
-              <small>
-                over 
-                2 disks
-              </small>
-            </React.Fragment>
+            <Placeholder
+              loading={false}
+            >
+              <React.Fragment>
+                8
+                 GB
+                 
+                <small>
+                  over 
+                  2 disks
+                </small>
+              </React.Fragment>
+            </Placeholder>
           </div>
         </React.Fragment>,
         <React.Fragment>
@@ -151,7 +201,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            manual
+            <Placeholder
+              loading={false}
+            >
+              manual
+            </Placeholder>
           </div>
         </React.Fragment>,
         <React.Fragment>
@@ -163,7 +217,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            Owner
+            <Placeholder
+              loading={false}
+            >
+              Owner
+            </Placeholder>
           </div>
         </React.Fragment>,
         <React.Fragment>
@@ -175,7 +233,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            pod
+            <Placeholder
+              loading={false}
+            >
+              pod
+            </Placeholder>
           </div>
         </React.Fragment>,
         <React.Fragment>
@@ -187,7 +249,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            zone
+            <Placeholder
+              loading={false}
+            >
+              zone
+            </Placeholder>
           </div>
         </React.Fragment>,
         <React.Fragment>
@@ -199,7 +265,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
           <div
             className="p-list__item-value"
           >
-            domain
+            <Placeholder
+              loading={false}
+            >
+              domain
+            </Placeholder>
           </div>
         </React.Fragment>,
       ]
@@ -220,7 +290,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          Ready
+          <Placeholder
+            loading={false}
+          >
+            Ready
+          </Placeholder>
         </div>
       </li>
       <li
@@ -235,18 +309,21 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          <span>
-            2 cores
-            , 
-            2
-             GHz
-          </span>
+          <Placeholder
+            loading={false}
+          >
+            2 cores, 2 GHz
+          </Placeholder>
           <br />
-          <span>
+          <Placeholder
+            loading={false}
+          >
             CPU model
-          </span>
+          </Placeholder>
           <br />
-          <span />
+          <Placeholder
+            loading={false}
+          />
         </div>
       </li>
       <li
@@ -261,7 +338,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          8 GiB
+          <Placeholder
+            loading={false}
+          >
+            8 GiB
+          </Placeholder>
         </div>
       </li>
       <li
@@ -276,13 +357,17 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          8
-           GB
-           
-          <small>
-            over 
-            2 disks
-          </small>
+          <Placeholder
+            loading={false}
+          >
+            8
+             GB
+             
+            <small>
+              over 
+              2 disks
+            </small>
+          </Placeholder>
         </div>
       </li>
       <li
@@ -297,7 +382,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          manual
+          <Placeholder
+            loading={false}
+          >
+            manual
+          </Placeholder>
         </div>
       </li>
       <li
@@ -312,7 +401,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          Owner
+          <Placeholder
+            loading={false}
+          >
+            Owner
+          </Placeholder>
         </div>
       </li>
       <li
@@ -327,7 +420,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          pod
+          <Placeholder
+            loading={false}
+          >
+            pod
+          </Placeholder>
         </div>
       </li>
       <li
@@ -342,7 +439,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          zone
+          <Placeholder
+            loading={false}
+          >
+            zone
+          </Placeholder>
         </div>
       </li>
       <li
@@ -357,7 +458,11 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         <div
           className="p-list__item-value"
         >
-          domain
+          <Placeholder
+            loading={false}
+          >
+            domain
+          </Placeholder>
         </div>
       </li>
     </ul>


### PR DESCRIPTION
## Done

- Updated `Placeholder` component to show real content when loaded

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the clone form and select a source machine
- Check that the placeholder content shows while the machine details are loading
- Go to a PCI devices tab of a machine has them
- Check that the placeholder content shows while the PCI devices are loading

## Fixes

Fixes #2933 
