### PR TITLE
feat(ui): set up clone form table styling

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -65,4 +65,41 @@ describe("CloneFormFields", () => {
       actualActions.find((action) => action.type === expectedAction.type)
     ).toStrictEqual(expectedAction);
   });
+
+  it("applies different styling depending on clone selection state", async () => {
+    const machine = machineFactory({ system_id: "abc123" });
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [machine],
+        loaded: true,
+        selected: [],
+        active: null,
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <Formik
+          initialValues={{ interfaces: false, source: "", storage: false }}
+          onSubmit={jest.fn()}
+        >
+          <CloneFormFields />
+        </Formik>
+      </Provider>
+    );
+    const getTableClass = () =>
+      wrapper.find(".clone-table").at(0).prop("className");
+    // Table has unselected styling by default
+    expect(getTableClass()?.includes("not-selected")).toBe(true);
+
+    // Check the checkbox for the table.
+    wrapper
+      .find("input[name='interfaces']")
+      .at(0)
+      .simulate("change", { target: { name: "interfaces", value: true } });
+    await waitForComponentToPaint(wrapper);
+
+    // Table should not have unselected styling.
+    expect(getTableClass()?.includes("not-selected")).toBe(false);
+  });
 });

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { Col, Row } from "@canonical/react-components";
+import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -44,39 +44,99 @@ export const CloneFormFields = (): JSX.Element => {
   }, [machineInState, selectedMachine]);
 
   return (
-    <Row>
-      <Col size={4}>
-        <p>1. Select the source machine</p>
-        <SourceMachineSelect
-          loadingDetails={loadingDetails}
-          loadingMachines={loadingMachines}
-          machines={unselectedMachines}
-          onMachineClick={(machine) => {
-            if (machine) {
-              setFieldValue("source", machine.system_id);
-              dispatch(machineActions.get(machine.system_id));
-            } else {
-              setFieldValue("source", "");
-              setSelectedMachine(null);
-            }
-          }}
-          selectedMachine={selectedMachine}
-        />
-      </Col>
-      <Col size={8}>
-        <p>2. Select what to clone</p>
-        <FormikField
-          label="Clone network configuration"
-          name="interfaces"
-          type="checkbox"
-        />
-        <FormikField
-          label="Clone storage configuration"
-          name="storage"
-          type="checkbox"
-        />
-      </Col>
-    </Row>
+    <div className="clone-form-fields">
+      <p className="source-label">1. Select the source machine</p>
+      <SourceMachineSelect
+        className="source-select"
+        loadingDetails={loadingDetails}
+        loadingMachines={loadingMachines}
+        machines={unselectedMachines}
+        onMachineClick={(machine) => {
+          if (machine) {
+            setFieldValue("source", machine.system_id);
+            dispatch(machineActions.get(machine.system_id));
+          } else {
+            setFieldValue("source", "");
+            setSelectedMachine(null);
+          }
+        }}
+        selectedMachine={selectedMachine}
+      />
+      <p className="clone-label">2. Select what to clone</p>
+      <div className="clone-tables">
+        <div className="clone-table-card">
+          <FormikField
+            label="Clone network configuration"
+            name="interfaces"
+            type="checkbox"
+            wrapperClassName="u-sv2"
+          />
+          <div className="clone-table-container">
+            {/* TODO: Replace with real network table */}
+            <table
+              className={classNames("clone-table", {
+                "not-selected": !values.interfaces,
+              })}
+            >
+              <thead>
+                <tr>
+                  <th>
+                    Interface
+                    <br />
+                    Subnet
+                  </th>
+                  <th>
+                    Fabric
+                    <br />
+                    VLAN
+                  </th>
+                  <th>
+                    Type
+                    <br />
+                    NUMA node
+                  </th>
+                  <th>DHCP</th>
+                </tr>
+              </thead>
+            </table>
+          </div>
+        </div>
+        <div className="clone-table-card">
+          <FormikField
+            label="Clone storage configuration"
+            name="storage"
+            type="checkbox"
+            wrapperClassName="u-sv2"
+          />
+          <div className="clone-table-container">
+            {/* Replace with real storage table */}
+            <table
+              className={classNames("clone-table", {
+                "not-selected": !values.storage,
+              })}
+            >
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>
+                    Model
+                    <br />
+                    Firmware
+                  </th>
+                  <th>
+                    Type
+                    <br />
+                    NUMA node
+                  </th>
+                  <th>Size</th>
+                  <th>Available</th>
+                </tr>
+              </thead>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
@@ -7,6 +7,7 @@ import {
   Strip,
 } from "@canonical/react-components";
 import { highlightSubString } from "@canonical/react-components/dist/utils";
+import classNames from "classnames";
 
 import SourceMachineDetails from "./SourceMachineDetails";
 
@@ -14,6 +15,7 @@ import DoubleRow from "app/base/components/DoubleRow";
 import type { Machine, MachineDetails } from "app/store/machine/types";
 
 type Props = {
+  className?: string;
   loadingDetails?: boolean;
   loadingMachines?: boolean;
   machines: Machine[];
@@ -65,6 +67,7 @@ const generateRows = (
 };
 
 export const SourceMachineSelect = ({
+  className,
   loadingDetails = false,
   loadingMachines = false,
   machines,
@@ -83,7 +86,7 @@ export const SourceMachineSelect = ({
   );
 
   return (
-    <div className="source-machine-select">
+    <div className={classNames("source-machine-select", className)}>
       <SearchBox
         data-test="source-machine-searchbox"
         externallyControlled

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
@@ -1,6 +1,7 @@
 @mixin SourceMachineSelect {
   .source-machine-select {
     @extend %vf-is-bordered;
+    @extend %vf-has-round-corners;
     padding: $spv-inner--medium $sph-inner 0 $sph-inner;
   }
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
@@ -1,0 +1,90 @@
+@mixin CloneFormFields {
+  .clone-form-fields {
+    @extend %base-grid;
+    grid:
+      [row1-start] "source-label clone-label" min-content [row1-end]
+      [row2-start] "source-select clone-tables" min-content [row2-end]
+      / 1fr 2fr;
+    margin-bottom: $spv-outer--shallow-scaleable;
+
+    .source-label {
+      grid-area: source-label;
+    }
+
+    .source-select {
+      grid-area: source-select;
+    }
+
+    .clone-label {
+      grid-area: clone-label;
+    }
+
+    .clone-tables {
+      grid-area: clone-tables;
+    }
+
+    @media only screen and (max-width: $breakpoint-x-large) {
+      grid:
+        [row1-start] "source-label" min-content [row1-end]
+        [row2-start] "source-select" min-content [row2-end]
+        [row3-start] "clone-label" min-content [row3-end]
+        [row4-start] "clone-tables" min-content [row4-end]
+        / 100%;
+
+      .source-select {
+        margin-bottom: $spv-outer--shallow-scaleable;
+      }
+    }
+  }
+
+  .clone-tables {
+    @extend %vf-is-bordered;
+    @extend %vf-has-round-corners;
+    display: flex;
+
+    @media only screen and (max-width: $breakpoint-medium) {
+      flex-direction: column;
+    }
+  }
+
+  .clone-table-card {
+    padding: $spv-inner--medium $sph-inner 0 $sph-inner;
+
+    &:not(:last-of-type) {
+      border-right: $border;
+
+      @media only screen and (max-width: $breakpoint-medium) {
+        border-bottom: $border;
+        border-right: 0;
+      }
+    }
+  }
+
+  .clone-table-container {
+    max-height: 22rem;
+    min-height: 8rem;
+    overflow: auto;
+  }
+
+  .clone-table {
+    th,
+    td {
+      padding-left: $sph-inner--x-small;
+      padding-right: $sph-inner--x-small;
+    }
+
+    th:first-child,
+    td:first-child {
+      padding-left: 0;
+    }
+
+    th:last-child,
+    td:last-child {
+      padding-right: 0;
+    }
+
+    &.not-selected {
+      opacity: 0.5;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -167,6 +167,7 @@
 @include DiscoveriesList;
 
 // machines
+@import "~app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields";
 @import "~app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect";
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
 @import "~app/machines/components/TakeActionMenu";
@@ -182,6 +183,7 @@
 @import "~app/machines/views/MachineDetails/MachineTests/MachineTestsTable";
 @import "~app/machines/views/MachineDetails/NodeDevices";
 @import "~app/machines/views/MachineList";
+@include CloneFormFields;
 @include DownloadMenu;
 @include EventLogsTable;
 @include MachineDHCPTable;


### PR DESCRIPTION
## Done

- Added styling for the clone form tables/cards

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the clone form and check that it matches [the design when no source is selected](https://app.zeplin.io/project/60e32f0e5c4c0f13e711d590/screen/6107cdc217980210cde2b201)
- Check that checking a checkbox increases the opacity of the table

## Fixes

Fixes canonical-web-and-design/app-squad#202

## Screenshot
![Screenshot 2021-08-09 at 11-33-17 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/128652520-d8447a02-a84e-4434-a96c-0e2b259d0956.png)

