### PR TITLE
feat(ui): add storage table to cloning form

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -88,7 +88,7 @@ describe("CloneFormFields", () => {
       </Provider>
     );
     const getTableClass = () =>
-      wrapper.find(".clone-table").at(0).prop("className");
+      wrapper.find(".clone-table--network").prop("className");
     // Table has unselected styling by default
     expect(getTableClass()?.includes("not-selected")).toBe(true);
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import type { CloneFormValues } from "../CloneForm";
 
+import CloneStorageTable from "./CloneStorageTable";
 import SourceMachineSelect from "./SourceMachineSelect";
 
 import FormikField from "app/base/components/FormikField";
@@ -74,7 +75,7 @@ export const CloneFormFields = (): JSX.Element => {
           <div className="clone-table-container">
             {/* TODO: Replace with real network table */}
             <table
-              className={classNames("clone-table", {
+              className={classNames("clone-table--network", {
                 "not-selected": !values.interfaces,
               })}
             >
@@ -109,30 +110,11 @@ export const CloneFormFields = (): JSX.Element => {
             wrapperClassName="u-sv2"
           />
           <div className="clone-table-container">
-            {/* Replace with real storage table */}
-            <table
-              className={classNames("clone-table", {
-                "not-selected": !values.storage,
-              })}
-            >
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>
-                    Model
-                    <br />
-                    Firmware
-                  </th>
-                  <th>
-                    Type
-                    <br />
-                    NUMA node
-                  </th>
-                  <th>Size</th>
-                  <th>Available</th>
-                </tr>
-              </thead>
-            </table>
+            <CloneStorageTable
+              loadingDetails={loadingDetails}
+              machine={selectedMachine}
+              selected={values.storage}
+            />
           </div>
         </div>
       </div>

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
@@ -1,0 +1,94 @@
+import { mount } from "enzyme";
+
+import CloneStorageTable from "./CloneStorageTable";
+
+import {
+  machineDetails as machineDetailsFactory,
+  machineDisk as diskFactory,
+  machineFilesystem as fsFactory,
+  machinePartition as partitionFactory,
+} from "testing/factories";
+
+describe("CloneStorageTable", () => {
+  it("renders empty table if neither loading details nor machine provided", () => {
+    const wrapper = mount(
+      <CloneStorageTable machine={null} selected={false} />
+    );
+    expect(wrapper.find("MainTable").prop("rows")).toStrictEqual([]);
+    expect(wrapper.find("Placeholder").exists()).toBe(false);
+  });
+
+  it("renders placeholder content while details are loading", () => {
+    const wrapper = mount(
+      <CloneStorageTable loadingDetails machine={null} selected={false} />
+    );
+    expect(wrapper.find("Placeholder").exists()).toBe(true);
+  });
+
+  it("renders machine storage details if machine is provided", () => {
+    const machine = machineDetailsFactory({ disks: [diskFactory()] });
+    const wrapper = mount(
+      <CloneStorageTable machine={machine} selected={false} />
+    );
+    expect(wrapper.find("Placeholder").exists()).toBe(false);
+    expect(wrapper.find("MainTable").prop("rows")).not.toStrictEqual([]);
+  });
+
+  it("shows a tick for available disks", () => {
+    const machine = machineDetailsFactory({
+      disks: [diskFactory({ available_size: 1000000000, size: 1000000000 })],
+    });
+    const wrapper = mount(
+      <CloneStorageTable machine={machine} selected={false} />
+    );
+
+    expect(wrapper.find("Icon[data-test='disk-available']").prop("name")).toBe(
+      "tick"
+    );
+  });
+
+  it("shows a cross for unavailable disks", () => {
+    const machine = machineDetailsFactory({
+      disks: [diskFactory({ available_size: 0, size: 1000000000 })],
+    });
+    const wrapper = mount(
+      <CloneStorageTable machine={machine} selected={false} />
+    );
+
+    expect(wrapper.find("Icon[data-test='disk-available']").prop("name")).toBe(
+      "close"
+    );
+  });
+
+  it("shows a tick for available partitions", () => {
+    const machine = machineDetailsFactory({
+      disks: [
+        diskFactory({ partitions: [partitionFactory({ filesystem: null })] }),
+      ],
+    });
+    const wrapper = mount(
+      <CloneStorageTable machine={machine} selected={false} />
+    );
+
+    expect(
+      wrapper.find("Icon[data-test='partition-available']").prop("name")
+    ).toBe("tick");
+  });
+
+  it("shows a cross for unavailable partitions", () => {
+    const machine = machineDetailsFactory({
+      disks: [
+        diskFactory({
+          partitions: [partitionFactory({ filesystem: fsFactory() })],
+        }),
+      ],
+    });
+    const wrapper = mount(
+      <CloneStorageTable machine={machine} selected={false} />
+    );
+
+    expect(
+      wrapper.find("Icon[data-test='partition-available']").prop("name")
+    ).toBe("close");
+  });
+});

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.tsx
@@ -1,0 +1,157 @@
+import type { ReactNode } from "react";
+
+import { Icon, MainTable } from "@canonical/react-components";
+import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import classNames from "classnames";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import Placeholder from "app/base/components/Placeholder";
+import NumaNodes from "app/machines/views/MachineDetails/MachineStorage/NumaNodes";
+import type { MachineDetails } from "app/store/machine/types";
+import {
+  diskAvailable,
+  formatSize,
+  formatType,
+  partitionAvailable,
+} from "app/store/machine/utils";
+
+type Props = {
+  loadingDetails?: boolean;
+  machine: MachineDetails | null;
+  selected: boolean;
+};
+
+const normaliseColumns = ({
+  available,
+  model,
+  name,
+  size,
+  type,
+}: {
+  available: ReactNode;
+  model: ReactNode;
+  name: ReactNode;
+  size: ReactNode;
+  type: ReactNode;
+}) => [
+  { className: "name-col", content: name },
+  { className: "model-col", content: model },
+  { className: "type-col", content: type },
+  { className: "size-col", content: size },
+  { className: "available-col u-align--center", content: available },
+];
+
+export const CloneStorageTable = ({
+  loadingDetails = false,
+  machine,
+  selected,
+}: Props): JSX.Element => {
+  let rows: MainTableRow[] = [];
+
+  if (loadingDetails) {
+    rows = Array.from(Array(4)).map(() => ({
+      columns: normaliseColumns({
+        available: <Placeholder>Icon</Placeholder>,
+        model: (
+          <DoubleRow
+            primary={<Placeholder>Model</Placeholder>}
+            secondary={<Placeholder>1.0.0</Placeholder>}
+          />
+        ),
+        name: <Placeholder>Disk name</Placeholder>,
+        size: <Placeholder>1.23 GB</Placeholder>,
+        type: (
+          <DoubleRow
+            primary={<Placeholder>Disk type</Placeholder>}
+            secondary={<Placeholder>X, X</Placeholder>}
+          />
+        ),
+      }),
+    }));
+  } else if (machine) {
+    rows = [];
+    machine.disks.forEach((disk) => {
+      rows.push({
+        columns: normaliseColumns({
+          available: (
+            <Icon
+              data-test="disk-available"
+              name={diskAvailable(disk) ? "tick" : "close"}
+            />
+          ),
+          model: (
+            <DoubleRow
+              primary={disk.model || "—"}
+              primaryTitle={disk.model}
+              secondary={disk.firmware_version}
+              secondaryTitle={disk.firmware_version}
+            />
+          ),
+          name: <DoubleRow primary={disk.name} primaryTitle={disk.name} />,
+          size: formatSize(disk.size),
+          type: (
+            <DoubleRow
+              primary={formatType(disk)}
+              primaryTitle={formatType(disk)}
+              secondary={<NumaNodes disk={disk} />}
+            />
+          ),
+        }),
+      });
+
+      if (disk.partitions) {
+        disk.partitions.forEach((partition) => {
+          rows.push({
+            columns: normaliseColumns({
+              available: (
+                <Icon
+                  data-test="partition-available"
+                  name={partitionAvailable(partition) ? "tick" : "close"}
+                />
+              ),
+              model: "—",
+              name: partition.name,
+              size: formatSize(partition.size),
+              type: (
+                <DoubleRow
+                  primary={formatType(partition)}
+                  primaryTitle={formatType(partition)}
+                  secondary={<NumaNodes disk={disk} />}
+                />
+              ),
+            }),
+          });
+        });
+      }
+    });
+  }
+
+  return (
+    <MainTable
+      className={classNames("clone-table--storage", {
+        "not-selected": !selected,
+      })}
+      emptyStateMsg={machine ? "No storage information detected." : null}
+      headers={normaliseColumns({
+        available: "Available",
+        model: (
+          <>
+            <div>Model</div>
+            <div>Firmware</div>
+          </>
+        ),
+        name: "Name",
+        size: "Size",
+        type: (
+          <>
+            <div>Type</div>
+            <div>NUMA node</div>
+          </>
+        ),
+      })}
+      rows={rows}
+    />
+  );
+};
+
+export default CloneStorageTable;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/index.ts
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CloneStorageTable";

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
@@ -66,7 +66,7 @@
     overflow: auto;
   }
 
-  .clone-table {
+  %clone-table {
     th,
     td {
       padding-left: $sph-inner--x-small;
@@ -85,6 +85,34 @@
 
     &.not-selected {
       opacity: 0.5;
+    }
+  }
+
+  .clone-table--network {
+    @extend %clone-table;
+  }
+
+  .clone-table--storage {
+    @extend %clone-table;
+
+    .name-col {
+      width: 33%;
+    }
+
+    .model-col {
+      width: 34%;
+    }
+
+    .type-col {
+      width: 33%;
+    }
+
+    .size-col {
+      width: 5.5rem;
+    }
+
+    .available-col {
+      width: 4.5rem;
     }
   }
 }

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AvailableStorageTable.tsx
@@ -166,7 +166,6 @@ const normaliseRowData = (
         ),
       },
       {
-        className: "u-align--center",
         content: (
           <DoubleRow
             primary={
@@ -176,6 +175,7 @@ const normaliseRowData = (
                 "—"
               )
             }
+            primaryClassName="u-align--center"
           />
         ),
       },

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/NumaNodes/NumaNodes.tsx
@@ -24,7 +24,7 @@ const NumaNodes = ({ disk }: Props): JSX.Element => {
           <i className="p-icon--warning is-inline"></i>
         </Tooltip>
       )}
-      <span data-test="numa-nodes">{numaNodes.join(", ")}</span>
+      <span data-test="numa-nodes">{numaNodes.join(", ") || "—"}</span>
     </>
   );
 };


### PR DESCRIPTION
## Done

- Added machine storage table to cloning form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a couple of machines and open the clone form
- Select a source machine and check that placeholder content shows in the storage table while the machine details are loading
- Check that once the details are loaded the storage table looks like [the design](https://app.zeplin.io/project/60e32f0e5c4c0f13e711d590/screen/6107cdc207416a12bf9794f8)

## Fixes

Fixes canonical-web-and-design/app-squad#195

## Screenshots
### Loading
![2021-08-10_16-19](https://user-images.githubusercontent.com/25733845/128817799-8ae5839b-a07f-47d3-949c-cf2560b5b02b.png)

### Loaded
![2021-08-10_16-19_1](https://user-images.githubusercontent.com/25733845/128817810-f8a4433d-ae12-40b9-ac2b-c58a3416767f.png)
