### PR TITLE
feat(ui): add network table to cloning form

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.test.tsx
@@ -1,0 +1,273 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+
+import CloneNetworkTable from "./CloneNetworkTable";
+
+import type { RootState } from "app/store/root/types";
+import { NetworkInterfaceTypes } from "app/store/types/enum";
+import {
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  machineDetails as machineDetailsFactory,
+  machineInterface as machineInterfaceFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  networkLink as networkLinkFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("CloneNetworkTable", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        loaded: true,
+      }),
+      machine: machineStateFactory({
+        items: [machineDetailsFactory({ system_id: "abc123" })],
+        loaded: true,
+        statuses: {
+          abc123: machineStatusFactory(),
+        },
+      }),
+      subnet: subnetStateFactory({
+        loaded: true,
+      }),
+      vlan: vlanStateFactory({
+        loaded: true,
+      }),
+    });
+  });
+
+  it("renders empty table if neither loading machine nor machine provided", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CloneNetworkTable machine={null} selected={false} />
+      </Provider>
+    );
+    expect(wrapper.find("MainTable").prop("rows")).toStrictEqual([]);
+    expect(wrapper.find("Placeholder").exists()).toBe(false);
+  });
+
+  it("renders placeholder content while details are loading", () => {
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CloneNetworkTable
+          loadingMachineDetails
+          machine={null}
+          selected={false}
+        />
+      </Provider>
+    );
+    expect(wrapper.find("Placeholder").exists()).toBe(true);
+  });
+
+  it("renders machine network details if machine is provided", () => {
+    const machine = machineDetailsFactory({
+      interfaces: [machineInterfaceFactory()],
+    });
+
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CloneNetworkTable machine={machine} selected={false} />
+      </Provider>
+    );
+    expect(wrapper.find("Placeholder").exists()).toBe(false);
+    expect(wrapper.find("MainTable").prop("rows")).not.toStrictEqual([]);
+  });
+
+  it("can display an interface that has no links", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnets = [
+      subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" }),
+      subnetFactory({ cidr: "subnet2-cidr", name: "subnet2-name" }),
+    ];
+    const machine = machineDetailsFactory({
+      interfaces: [
+        machineInterfaceFactory({
+          discovered: null,
+          links: [],
+          type: NetworkInterfaceTypes.BOND,
+          vlan_id: vlan.id,
+        }),
+      ],
+      system_id: "abc123",
+    });
+    state.fabric.items = [fabric];
+    state.machine.items = [machine];
+    state.subnet.items = subnets;
+    state.vlan.items = [vlan];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CloneNetworkTable machine={machine} selected />
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='name-subnet'] DoubleRow").prop("secondary")
+    ).toBe("Unconfigured");
+  });
+
+  it("can display an interface that has a link", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnet = subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" });
+    const machine = machineDetailsFactory({
+      interfaces: [
+        machineInterfaceFactory({
+          discovered: null,
+          links: [
+            networkLinkFactory({
+              subnet_id: subnet.id,
+              ip_address: "1.2.3.99",
+            }),
+          ],
+          type: NetworkInterfaceTypes.BOND,
+          vlan_id: vlan.id,
+        }),
+      ],
+      system_id: "abc123",
+    });
+    state.fabric.items = [fabric];
+    state.machine.items = [machine];
+    state.subnet.items = [subnet];
+    state.vlan.items = [vlan];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CloneNetworkTable machine={machine} selected />
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='name-subnet'] DoubleRow").prop("secondary")
+    ).toBe("subnet-cidr");
+  });
+
+  it("can display an interface that is an alias", () => {
+    const fabric = fabricFactory({ name: "fabric-name" });
+    const vlan = vlanFactory({ fabric: fabric.id, vid: 2, name: "vlan-name" });
+    const subnets = [
+      subnetFactory({ cidr: "subnet-cidr", name: "subnet-name" }),
+      subnetFactory({ cidr: "subnet2-cidr", name: "subnet2-name" }),
+    ];
+    const machine = machineDetailsFactory({
+      interfaces: [
+        machineInterfaceFactory({
+          discovered: null,
+          links: [
+            networkLinkFactory({
+              subnet_id: subnets[0].id,
+              ip_address: "1.2.3.99",
+            }),
+            networkLinkFactory({
+              subnet_id: subnets[1].id,
+              ip_address: "1.2.3.101",
+            }),
+          ],
+          name: "alias",
+          type: NetworkInterfaceTypes.ALIAS,
+          vlan_id: vlan.id,
+        }),
+      ],
+      system_id: "abc123",
+    });
+    state.fabric.items = [fabric];
+    state.machine.items = [machine];
+    state.subnet.items = subnets;
+    state.vlan.items = [vlan];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CloneNetworkTable machine={machine} selected />
+      </Provider>
+    );
+    expect(
+      wrapper.find("[data-test='name-subnet'] DoubleRow").at(1).prop("primary")
+    ).toBe("alias:1");
+    expect(
+      wrapper
+        .find("[data-test='name-subnet'] DoubleRow")
+        .at(1)
+        .prop("secondary")
+    ).toBe("subnet2-cidr");
+  });
+
+  it("groups bonds and bridges with their parent interfaces", () => {
+    const machine = machineDetailsFactory({
+      interfaces: [
+        machineInterfaceFactory({
+          id: 100,
+          name: "bond0",
+          parents: [101, 104],
+          type: NetworkInterfaceTypes.BOND,
+        }),
+        machineInterfaceFactory({
+          children: [100],
+          id: 101,
+          name: "eth0",
+          type: NetworkInterfaceTypes.PHYSICAL,
+        }),
+        machineInterfaceFactory({
+          id: 102,
+          links: [networkLinkFactory(), networkLinkFactory()],
+          name: "br0",
+          parents: [103],
+          type: NetworkInterfaceTypes.BRIDGE,
+        }),
+        machineInterfaceFactory({
+          children: [102],
+          id: 103,
+          name: "eth1",
+          type: NetworkInterfaceTypes.PHYSICAL,
+        }),
+        machineInterfaceFactory({
+          id: 99,
+          name: "eth2",
+          parents: [],
+          type: NetworkInterfaceTypes.PHYSICAL,
+        }),
+        machineInterfaceFactory({
+          children: [100],
+          id: 104,
+          name: "eth3",
+          type: NetworkInterfaceTypes.PHYSICAL,
+        }),
+      ],
+      system_id: "abc123",
+    });
+    state.machine.items = [machine];
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <CloneNetworkTable machine={machine} selected />
+      </Provider>
+    );
+    const names = wrapper
+      .find("[data-test='name-subnet'] DoubleRow")
+      .map((doubleRow) => doubleRow.prop("primary"));
+    expect(names).toStrictEqual([
+      // Bond group:
+      "bond0",
+      "eth0", // bond parent
+      "eth3", // bond parent
+      // Bridge group:
+      "br0",
+      "eth1", // bridge parent
+      // Alias:
+      "br0:1",
+      // Physical:
+      "eth2",
+    ]);
+  });
+});

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.tsx
@@ -1,0 +1,248 @@
+import { MainTable } from "@canonical/react-components";
+import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import classNames from "classnames";
+import { useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import Placeholder from "app/base/components/Placeholder";
+import fabricSelectors from "app/store/fabric/selectors";
+import type { MachineDetails } from "app/store/machine/types";
+import {
+  getBondOrBridgeParents,
+  getInterfaceFabric,
+  getInterfaceName,
+  getInterfaceNumaNodes,
+  getInterfaceSubnet,
+  getInterfaceTypeText,
+  getLinkInterface,
+  isBondOrBridgeParent,
+  useIsAllNetworkingDisabled,
+} from "app/store/machine/utils";
+import subnetSelectors from "app/store/subnet/selectors";
+import { getSubnetDisplay } from "app/store/subnet/utils";
+import type { NetworkInterface, NetworkLink } from "app/store/types/node";
+import vlanSelectors from "app/store/vlan/selectors";
+import { getDHCPStatus, getVLANDisplay } from "app/store/vlan/utils";
+
+type Props = {
+  loadingMachineDetails?: boolean;
+  machine: MachineDetails | null;
+  selected: boolean;
+};
+
+export const CloneNetworkTable = ({
+  loadingMachineDetails = false,
+  machine,
+  selected,
+}: Props): JSX.Element => {
+  const fabrics = useSelector(fabricSelectors.all);
+  const subnets = useSelector(subnetSelectors.all);
+  const vlans = useSelector(vlanSelectors.all);
+  const isAllNetworkingDisabled = useIsAllNetworkingDisabled(machine);
+  let rows: MainTableRow[] = [];
+
+  if (loadingMachineDetails) {
+    rows = Array.from(Array(4)).map(() => ({
+      columns: [
+        {
+          className: "name-col",
+          content: (
+            <DoubleRow
+              primary={<Placeholder>Name</Placeholder>}
+              secondary={<Placeholder>Subnet</Placeholder>}
+            />
+          ),
+        },
+        {
+          className: "fabric-col",
+          content: (
+            <DoubleRow
+              primary={<Placeholder>Fabric name</Placeholder>}
+              secondary={<Placeholder>VLAN</Placeholder>}
+            />
+          ),
+        },
+        {
+          className: "type-col",
+          content: (
+            <DoubleRow
+              primary={<Placeholder>Disk type</Placeholder>}
+              secondary={<Placeholder>X, X</Placeholder>}
+            />
+          ),
+        },
+        {
+          className: "dhcp-col",
+          content: <Placeholder>DHCP</Placeholder>,
+        },
+      ],
+    }));
+  } else if (machine) {
+    const generateRow = ({
+      isParent,
+      link,
+      nic,
+    }: {
+      isParent: boolean;
+      link: NetworkLink | null;
+      nic: NetworkInterface | null;
+    }) => {
+      if (link && !nic) {
+        [nic] = getLinkInterface(machine, link);
+      }
+      const fabric = getInterfaceFabric(machine, fabrics, vlans, nic, link);
+      const vlan = vlans.find(({ id }) => id === nic?.vlan_id);
+      const subnet = getInterfaceSubnet(
+        machine,
+        subnets,
+        fabrics,
+        vlans,
+        isAllNetworkingDisabled,
+        nic,
+        link
+      );
+      const nameDisplay = getInterfaceName(machine, nic, link);
+      const subnetDisplay = getSubnetDisplay(subnet, true);
+      const fabricDisplay = fabric?.name || "Unconfigured";
+      const vlanDisplay = getVLANDisplay(vlan);
+      const typeDisplay = getInterfaceTypeText(machine, nic, link, true);
+      const numaDisplay = (getInterfaceNumaNodes(machine, nic) || []).join(
+        ", "
+      );
+      const dhcpDisplay = getDHCPStatus(vlan, vlans, fabrics);
+
+      return {
+        columns: [
+          {
+            className: "name-col",
+            content: (
+              <DoubleRow
+                primary={nameDisplay}
+                primaryTitle={nameDisplay}
+                secondary={!isParent ? subnetDisplay : null}
+                secondaryTitle={subnetDisplay}
+              />
+            ),
+            "data-test": "name-subnet",
+          },
+          {
+            className: "fabric-col",
+            content: !isParent ? (
+              <DoubleRow
+                primary={fabricDisplay}
+                primaryTitle={fabricDisplay}
+                secondary={vlanDisplay}
+                secondaryTitle={vlanDisplay}
+              />
+            ) : null,
+            "data-test": "fabric-vlan",
+          },
+          {
+            className: "type-col",
+            content: (
+              <DoubleRow
+                primary={typeDisplay}
+                primaryTitle={typeDisplay}
+                secondary={numaDisplay}
+                secondaryTitle={numaDisplay}
+              />
+            ),
+            "data-test": "type-numa",
+          },
+          {
+            className: "dhcp-col",
+            content: !isParent ? dhcpDisplay : null,
+            "data-test": "dhcp",
+          },
+        ],
+      };
+    };
+    rows = [];
+    machine.interfaces.forEach((nic) => {
+      // Childless nics are always rendered normally. Next, if the nic has any
+      // parents they will be rendered right after, in order to show the
+      // parent-child hierarchy. Finally, any aliases are rendered after the
+      // parent-child grouping.
+      if (!isBondOrBridgeParent(machine, nic)) {
+        const firstLink = nic.links.length >= 1 ? nic.links[0] : null;
+        const row = generateRow({
+          isParent: false,
+          link: firstLink,
+          nic: firstLink ? null : nic,
+        });
+        rows.push(row);
+
+        const parents = getBondOrBridgeParents(machine, nic);
+        parents.forEach((parentNic) => {
+          const row = generateRow({
+            isParent: true,
+            link: null,
+            nic: parentNic,
+          });
+          rows.push(row);
+        });
+
+        // "links" refers to aliases, however the first link in the array is
+        // an analog of the interface itself, so we only render the links from
+        // the second link onward.
+        if (nic.links.length >= 2) {
+          nic.links.forEach((link, i) => {
+            if (i > 0) {
+              const row = generateRow({
+                isParent: false,
+                link,
+                nic: null,
+              });
+              rows.push(row);
+            }
+          });
+        }
+      }
+    });
+  }
+
+  return (
+    <MainTable
+      className={classNames("clone-table--network", {
+        "not-selected": !selected,
+      })}
+      emptyStateMsg={machine ? "No network information detected." : null}
+      headers={[
+        {
+          className: "name-col",
+          content: (
+            <>
+              <div>Interface</div>
+              <div>Subnet</div>
+            </>
+          ),
+        },
+        {
+          className: "fabric-col",
+          content: (
+            <>
+              <div>Fabric</div>
+              <div>VLAN</div>
+            </>
+          ),
+        },
+        {
+          className: "type-col",
+          content: (
+            <>
+              <div>Type</div>
+              <div>NUMA node</div>
+            </>
+          ),
+        },
+        {
+          className: "dhcp-col",
+          content: "DHCP",
+        },
+      ]}
+      rows={rows}
+    />
+  );
+};
+
+export default CloneNetworkTable;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/index.ts
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CloneNetworkTable";

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
@@ -18,9 +18,13 @@ describe("CloneStorageTable", () => {
     expect(wrapper.find("Placeholder").exists()).toBe(false);
   });
 
-  it("renders placeholder content while details are loading", () => {
+  it("renders placeholder content while machine details are loading", () => {
     const wrapper = mount(
-      <CloneStorageTable loadingDetails machine={null} selected={false} />
+      <CloneStorageTable
+        loadingMachineDetails
+        machine={null}
+        selected={false}
+      />
     );
     expect(wrapper.find("Placeholder").exists()).toBe(true);
   });

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.tsx
@@ -16,7 +16,7 @@ import {
 } from "app/store/machine/utils";
 
 type Props = {
-  loadingDetails?: boolean;
+  loadingMachineDetails?: boolean;
   machine: MachineDetails | null;
   selected: boolean;
 };
@@ -42,13 +42,13 @@ const normaliseColumns = ({
 ];
 
 export const CloneStorageTable = ({
-  loadingDetails = false,
+  loadingMachineDetails = false,
   machine,
   selected,
 }: Props): JSX.Element => {
   let rows: MainTableRow[] = [];
 
-  if (loadingDetails) {
+  if (loadingMachineDetails) {
     rows = Array.from(Array(4)).map(() => ({
       columns: normaliseColumns({
         available: <Placeholder>Icon</Placeholder>,

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -28,10 +28,10 @@ describe("SourceMachineSelect", () => {
     ];
   });
 
-  it("shows a spinner while machines are loading", () => {
+  it("shows a spinner while data is loading", () => {
     const wrapper = mount(
       <SourceMachineSelect
-        loadingMachines
+        loadingData
         machines={machines}
         onMachineClick={jest.fn()}
       />

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
@@ -16,8 +16,8 @@ import type { Machine, MachineDetails } from "app/store/machine/types";
 
 type Props = {
   className?: string;
-  loadingDetails?: boolean;
-  loadingMachines?: boolean;
+  loadingData?: boolean;
+  loadingMachineDetails?: boolean;
   machines: Machine[];
   onMachineClick: (machine: Machine | null) => void;
   selectedMachine?: MachineDetails | null;
@@ -68,8 +68,8 @@ const generateRows = (
 
 export const SourceMachineSelect = ({
   className,
-  loadingDetails = false,
-  loadingMachines = false,
+  loadingData = false,
+  loadingMachineDetails = false,
   machines,
   onMachineClick,
   selectedMachine = null,
@@ -101,13 +101,13 @@ export const SourceMachineSelect = ({
         }}
         value={searchText}
       />
-      {loadingDetails || selectedMachine ? (
+      {loadingMachineDetails || selectedMachine ? (
         <SourceMachineDetails machine={selectedMachine} />
       ) : (
         <div className="source-machine-select__table">
           <MainTable
             emptyStateMsg={
-              loadingMachines ? null : "No machines match the search criteria."
+              loadingData ? null : "No machines match the search criteria."
             }
             headers={[
               {
@@ -128,7 +128,7 @@ export const SourceMachineSelect = ({
               },
             ]}
             rows={
-              loadingMachines
+              loadingData
                 ? []
                 : generateRows(filteredMachines, searchText, (machine) => {
                     setSearchText(machine.hostname);
@@ -138,7 +138,7 @@ export const SourceMachineSelect = ({
           />
         </div>
       )}
-      {loadingMachines && (
+      {loadingData && (
         <Strip className="u-no-padding--top" shallow>
           <Spinner data-test="loading-spinner" text="Loading..." />
         </Strip>

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
@@ -90,6 +90,22 @@
 
   .clone-table--network {
     @extend %clone-table;
+
+    .name-col {
+      width: 27%;
+    }
+
+    .fabric-col {
+      width: 33%;
+    }
+
+    .type-col {
+      width: 40%;
+    }
+
+    .dhcp-col {
+      width: 4.5rem;
+    }
   }
 
   .clone-table--storage {


### PR DESCRIPTION
## Done

- Added machine network table to cloning form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a couple of machines and open the clone form
- Select a source machine and check that placeholder content shows in the network table while the machine details are loading
- Check that once the details are loaded the network table looks like [the design](https://app.zeplin.io/project/60e32f0e5c4c0f13e711d590/screen/6107cdc207416a12bf9794f8)
- Interfaces should be grouped the same as the machine details network table, except without the ability to sort

## Fixes

Fixes canonical-web-and-design/app-squad#194

## Screenshots
### Loading
![2021-08-11_15-58](https://user-images.githubusercontent.com/25733845/128977236-5e4cea45-ee3c-4a98-ab96-eb493822deea.png)


### Loaded
![2021-08-11_15-58_1](https://user-images.githubusercontent.com/25733845/128977246-94ceeb5c-4e90-4115-91f9-4e8930c39064.png)

