### PR TITLE
feat(ui): add warning to clone form if no source machines available

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -40,6 +40,23 @@ describe("SourceMachineSelect", () => {
     expect(wrapper.find("[data-test='loading-spinner']").exists()).toBe(true);
   });
 
+  it("shows an error if no machines are available to select", () => {
+    const wrapper = mount(
+      <SourceMachineSelect
+        machines={[machineFactory()]}
+        onMachineClick={jest.fn()}
+      />
+    );
+    expect(wrapper.find("[data-test='no-source-machines']").exists()).toBe(
+      false
+    );
+
+    wrapper.setProps({ machines: [] });
+    expect(wrapper.find("[data-test='no-source-machines']").exists()).toBe(
+      true
+    );
+  });
+
   it("can filter machines by hostname, system_id and/or tags", () => {
     const wrapper = mount(
       <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
@@ -1,7 +1,9 @@
+import type { ReactNode } from "react";
 import { useState } from "react";
 
 import {
   MainTable,
+  Notification,
   SearchBox,
   Spinner,
   Strip,
@@ -85,6 +87,58 @@ export const SourceMachineSelect = ({
       machine.tags.join(", ").includes(searchText)
   );
 
+  let content: ReactNode;
+  if (loadingData) {
+    content = (
+      <Strip shallow>
+        <Spinner data-test="loading-spinner" text="Loading..." />
+      </Strip>
+    );
+  } else if (loadingMachineDetails || selectedMachine) {
+    content = <SourceMachineDetails machine={selectedMachine} />;
+  } else if (machines.length === 0) {
+    content = (
+      <Notification
+        borderless
+        data-test="no-source-machines"
+        severity="negative"
+        title="No source machine available"
+      >
+        All machines are selected as destination machines. Unselect at least one
+        machine from the list.
+      </Notification>
+    );
+  } else {
+    content = (
+      <div className="source-machine-select__table">
+        <MainTable
+          emptyStateMsg="No machines match the search criteria."
+          headers={[
+            {
+              content: (
+                <>
+                  <div>Hostname</div>
+                  <div>system_id</div>
+                </>
+              ),
+            },
+            {
+              content: (
+                <>
+                  <div>Owner</div>
+                  <div>Tags</div>
+                </>
+              ),
+            },
+          ]}
+          rows={generateRows(filteredMachines, searchText, (machine) => {
+            setSearchText(machine.hostname);
+            onMachineClick(machine);
+          })}
+        />
+      </div>
+    );
+  }
   return (
     <div className={classNames("source-machine-select", className)}>
       <SearchBox
@@ -101,48 +155,7 @@ export const SourceMachineSelect = ({
         }}
         value={searchText}
       />
-      {loadingMachineDetails || selectedMachine ? (
-        <SourceMachineDetails machine={selectedMachine} />
-      ) : (
-        <div className="source-machine-select__table">
-          <MainTable
-            emptyStateMsg={
-              loadingData ? null : "No machines match the search criteria."
-            }
-            headers={[
-              {
-                content: (
-                  <>
-                    <div>Hostname</div>
-                    <div>system_id</div>
-                  </>
-                ),
-              },
-              {
-                content: (
-                  <>
-                    <div>Owner</div>
-                    <div>Tags</div>
-                  </>
-                ),
-              },
-            ]}
-            rows={
-              loadingData
-                ? []
-                : generateRows(filteredMachines, searchText, (machine) => {
-                    setSearchText(machine.hostname);
-                    onMachineClick(machine);
-                  })
-            }
-          />
-        </div>
-      )}
-      {loadingData && (
-        <Strip className="u-no-padding--top" shallow>
-          <Spinner data-test="loading-spinner" text="Loading..." />
-        </Strip>
-      )}
+      {content}
     </div>
   );
 };


### PR DESCRIPTION
## Done

- Added an error notification to the clone form if all machines in the list have been selected

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select all machines in the machine list and open the clone form
- Check that an error shows in the source machine select as per [the design](https://app.zeplin.io/project/60e32f0e5c4c0f13e711d590/screen/610bedecd41b0366218330b3)
- Unselect a machine and check that the error disappears

## Fixes

Fixes canonical-web-and-design/app-squad#204

## Screenshot
![Screenshot 2021-08-12 at 14-17-31 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/129137608-74889d67-bbe3-4afb-bf16-baa5c70ec80d.png)
