### PR TITLE
feat(ui): add help text to clone form

### DIFF
--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -104,6 +104,7 @@ export type Props<V> = FormikFormProps<V> & {
 const ActionForm = <V,>({
   actionDisabled,
   actionName,
+  buttonsBordered = false,
   children,
   clearSelectedAction,
   errors,
@@ -151,7 +152,7 @@ const ActionForm = <V,>({
     return (
       <FormikForm<V>
         buttonsAlign="right"
-        buttonsBordered={false}
+        buttonsBordered={buttonsBordered}
         errors={formattedErrors}
         onCancel={clearSelectedAction}
         onSubmit={(values?, formikHelpers?) => {

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -12,8 +12,7 @@ const FormikForm = <V,>({
   buttonsAlign,
   buttonsBordered,
   buttonsClassName,
-  buttonsHelpLabel,
-  buttonsHelpLink,
+  buttonsHelp,
   cancelDisabled,
   children,
   className,
@@ -48,8 +47,7 @@ const FormikForm = <V,>({
         buttonsAlign={buttonsAlign}
         buttonsBordered={buttonsBordered}
         buttonsClassName={buttonsClassName}
-        buttonsHelpLabel={buttonsHelpLabel}
-        buttonsHelpLink={buttonsHelpLink}
+        buttonsHelp={buttonsHelp}
         cancelDisabled={cancelDisabled}
         className={className}
         cleanup={cleanup}

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
@@ -71,7 +71,36 @@ describe("FormikFormButtons ", () => {
         <FormikFormButtons buttonsBordered submitLabel="Save" />
       </Formik>
     );
-    expect(wrapper.find("hr").exists()).toBe(true);
+    expect(
+      wrapper
+        .find("[data-test='buttons-wrapper']")
+        .prop("className")
+        ?.includes("is-bordered")
+    ).toBe(true);
+  });
+
+  it("displays inline if inline is true", () => {
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormButtons inline submitLabel="Save" />
+      </Formik>
+    );
+    expect(
+      wrapper
+        .find("[data-test='buttons-wrapper']")
+        .prop("className")
+        ?.includes("is-inline")
+    ).toBe(true);
+  });
+
+  it("displays help text if provided", () => {
+    const buttonsHelp = <p>Help!</p>;
+    const wrapper = mount(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormButtons buttonsHelp={buttonsHelp} submitLabel="Save" />
+      </Formik>
+    );
+    expect(wrapper.find("[data-test='buttons-help']").exists()).toBe(true);
   });
 
   it("can fire custom onCancel function", () => {

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
@@ -101,6 +101,7 @@ describe("FormikFormButtons ", () => {
       </Formik>
     );
     expect(wrapper.find("[data-test='buttons-help']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='buttons-help']").text()).toBe("Help!");
   });
 
   it("can fire custom onCancel function", () => {

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
@@ -100,7 +100,7 @@ export const FormikFormButtons = <V,>({
         })}
         data-test="buttons-wrapper"
       >
-        {(buttonsHelp || buttonsAlign === "right") && (
+        {buttonsHelp && (
           <div className="formik-form-buttons__help" data-test="buttons-help">
             {buttonsHelp}
           </div>

--- a/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
+++ b/ui/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
@@ -1,11 +1,6 @@
 import type { ReactNode } from "react";
 
-import {
-  ActionButton,
-  Button,
-  Link,
-  Tooltip,
-} from "@canonical/react-components";
+import { ActionButton, Button, Tooltip } from "@canonical/react-components";
 import type { ActionButtonProps } from "@canonical/react-components";
 import classNames from "classnames";
 import type { FormikContextType } from "formik";
@@ -20,8 +15,7 @@ export type Props<V> = {
   buttonsAlign?: "left" | "right";
   buttonsBordered?: boolean;
   buttonsClassName?: string;
-  buttonsHelpLabel?: string;
-  buttonsHelpLink?: string;
+  buttonsHelp?: ReactNode;
   cancelDisabled?: boolean;
   inline?: boolean;
   onCancel?: FormikContextFunc<V> | null;
@@ -41,8 +35,7 @@ export const FormikFormButtons = <V,>({
   buttonsAlign = "right",
   buttonsBordered = true,
   buttonsClassName,
-  buttonsHelpLabel,
-  buttonsHelpLink,
+  buttonsHelp,
   cancelDisabled,
   inline,
   onCancel,
@@ -60,7 +53,6 @@ export const FormikFormButtons = <V,>({
   const formikContext = useFormikContext<V>();
   const { values } = formikContext;
   const showSecondarySubmit = Boolean(secondarySubmit && secondarySubmitLabel);
-  const showHelpLink = Boolean(buttonsHelpLink && buttonsHelpLabel);
 
   let secondaryButton: ReactNode;
   if (showSecondarySubmit) {
@@ -71,7 +63,7 @@ export const FormikFormButtons = <V,>({
     const button = (
       <Button
         appearance="neutral"
-        className={classNames({ "u-no-margin--bottom": buttonsBordered })}
+        className="formik-form-buttons__button"
         data-test="secondary-submit"
         disabled={secondarySubmitDisabled || submitDisabled}
         onClick={
@@ -101,32 +93,27 @@ export const FormikFormButtons = <V,>({
 
   return (
     <>
-      {buttonsBordered && <hr />}
       <div
-        className={classNames(buttonsClassName, {
-          "u-flex--between":
-            !inline && (buttonsAlign === "right" || showHelpLink),
+        className={classNames("formik-form-buttons", buttonsClassName, {
+          "is-bordered": buttonsBordered,
+          "is-inline": inline,
         })}
+        data-test="buttons-wrapper"
       >
-        <p className="u-no-margin--bottom u-no-max-width">
-          {showHelpLink ? (
-            <Link
-              external
-              href={buttonsHelpLink}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              {buttonsHelpLabel}
-            </Link>
-          ) : null}
-        </p>
-        <div>
+        {(buttonsHelp || buttonsAlign === "right") && (
+          <div className="formik-form-buttons__help" data-test="buttons-help">
+            {buttonsHelp}
+          </div>
+        )}
+        <div
+          className={classNames("formik-form-buttons__container", {
+            "u-align--right": buttonsAlign === "right",
+          })}
+        >
           {onCancel && (
             <Button
               appearance="base"
-              className={classNames({
-                "u-no-margin--bottom": buttonsBordered || inline,
-              })}
+              className="formik-form-buttons__button"
               data-test="cancel-action"
               disabled={cancelDisabled}
               onClick={
@@ -140,9 +127,7 @@ export const FormikFormButtons = <V,>({
           {secondaryButton}
           <ActionButton
             appearance={submitAppearance}
-            className={classNames({
-              "u-no-margin--bottom": buttonsBordered || inline,
-            })}
+            className="formik-form-buttons__button"
             disabled={submitDisabled}
             loading={saving}
             success={saved}

--- a/ui/src/app/base/components/FormikFormButtons/_index.scss
+++ b/ui/src/app/base/components/FormikFormButtons/_index.scss
@@ -19,6 +19,11 @@
 
     .formik-form-buttons__container {
       flex-shrink: 0;
+
+      // If there is no help text, the buttons should take up the full width.
+      &:only-child {
+        width: 100%;
+      }
     }
 
     .formik-form-buttons__help {

--- a/ui/src/app/base/components/FormikFormButtons/_index.scss
+++ b/ui/src/app/base/components/FormikFormButtons/_index.scss
@@ -1,0 +1,42 @@
+@mixin FormikFormButtons {
+  .formik-form-buttons {
+    align-items: center;
+    display: flex;
+    padding: $spv-inner--small 0;
+
+    &.is-bordered {
+      border-top: $border;
+    }
+
+    &.is-inline {
+      display: block;
+      padding: 0;
+    }
+
+    .formik-form-buttons__button {
+      margin-bottom: 0;
+    }
+
+    .formik-form-buttons__container {
+      flex-shrink: 0;
+    }
+
+    .formik-form-buttons__help {
+      flex-grow: 1;
+      padding-right: $sph-inner;
+    }
+
+    @media only screen and (max-width: $breakpoint-medium) {
+      flex-direction: column;
+
+      .formik-form-buttons__container {
+        width: 100%;
+      }
+
+      .formik-form-buttons__help {
+        padding-right: unset;
+        width: 100%;
+      }
+    }
+  }
+}

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -44,6 +45,22 @@ export const CloneForm = ({
     <ActionForm<CloneFormValues>
       actionDisabled={actionDisabled}
       actionName={NodeActions.CLONE}
+      buttonsBordered
+      buttonsHelp={
+        <p>
+          The clone function allows you to apply storage or network interface
+          configuration from the source machine to selected destination
+          machines.{" "}
+          <Link
+            external
+            href="https://discourse.maas.io/t/cloning-ui/4855"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Find out more
+          </Link>
+        </p>
+      }
       cleanup={machineActions.cleanup}
       clearSelectedAction={clearSelectedAction}
       errors={errors}

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -48,9 +48,9 @@ export const CloneForm = ({
       buttonsBordered
       buttonsHelp={
         <p>
-          The clone function allows you to apply storage or network interface
-          configuration from the source machine to selected destination
-          machines.{" "}
+          The clone function allows you to apply storage and/or network
+          interface configuration from the source machine to selected
+          destination machines.{" "}
           <Link
             external
             href="https://discourse.maas.io/t/cloning-ui/4855"

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
@@ -95,10 +95,6 @@ exports[`FieldlessForm renders 1`] = `
                   data-test="buttons-wrapper"
                 >
                   <div
-                    className="formik-form-buttons__help"
-                    data-test="buttons-help"
-                  />
-                  <div
                     className="formik-form-buttons__container u-align--right"
                   >
                     <Button

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/__snapshots__/FieldlessForm.test.tsx.snap
@@ -91,22 +91,26 @@ exports[`FieldlessForm renders 1`] = `
                 submitLabel="Power on machine"
               >
                 <div
-                  className="u-flex--between"
+                  className="formik-form-buttons"
+                  data-test="buttons-wrapper"
                 >
-                  <p
-                    className="u-no-margin--bottom u-no-max-width"
+                  <div
+                    className="formik-form-buttons__help"
+                    data-test="buttons-help"
                   />
-                  <div>
+                  <div
+                    className="formik-form-buttons__container u-align--right"
+                  >
                     <Button
                       appearance="base"
-                      className=""
+                      className="formik-form-buttons__button"
                       data-test="cancel-action"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
                     >
                       <button
-                        className="p-button--base"
+                        className="p-button--base formik-form-buttons__button"
                         data-test="cancel-action"
                         disabled={false}
                         onClick={[Function]}
@@ -117,13 +121,13 @@ exports[`FieldlessForm renders 1`] = `
                     </Button>
                     <ActionButton
                       appearance="positive"
-                      className=""
+                      className="formik-form-buttons__button"
                       loading={false}
                       success={false}
                       type="submit"
                     >
                       <button
-                        className="p-action-button p-button--positive"
+                        className="formik-form-buttons__button p-action-button p-button--positive"
                         disabled={false}
                         type="submit"
                       >

--- a/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
+++ b/ui/src/app/machines/views/AddChassis/AddChassisForm/AddChassisForm.js
@@ -1,4 +1,4 @@
-import { Spinner } from "@canonical/react-components";
+import { Link, Spinner } from "@canonical/react-components";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
@@ -75,8 +75,18 @@ export const AddChassisForm = () => {
       ) : (
         <FormCard sidebar={false} title="Add chassis">
           <FormikForm
-            buttonsHelpLabel="Help with adding chassis"
-            buttonsHelpLink="https://maas.io/docs/add-machines#heading--add-nodes-via-a-chassis"
+            buttonsHelp={
+              <p>
+                <Link
+                  external
+                  href="https://maas.io/docs/add-machines#heading--add-nodes-via-a-chassis"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Help with adding chassis
+                </Link>
+              </p>
+            }
             cleanup={machineActions.cleanup}
             errors={machineErrors}
             initialValues={{

--- a/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
+++ b/ui/src/app/machines/views/AddMachine/AddMachineForm/AddMachineForm.js
@@ -1,4 +1,4 @@
-import { Spinner } from "@canonical/react-components";
+import { Link, Spinner } from "@canonical/react-components";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
@@ -122,8 +122,18 @@ export const AddMachineForm = () => {
       ) : (
         <FormCard sidebar={false} title="Add machine">
           <FormikForm
-            buttonsHelpLabel="Help with adding machines"
-            buttonsHelpLink="https://maas.io/docs/add-machines"
+            buttonsHelp={
+              <p>
+                <Link
+                  external
+                  href="https://maas.io/docs/add-machines"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Help with adding machines
+                </Link>
+              </p>
+            }
             cleanup={machineActions.cleanup}
             errors={machineErrors}
             initialValues={{

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
@@ -280,7 +280,7 @@ exports[`MachineName can display the form 1`] = `
               }
               takeFocus={true}
               type="text"
-              wrapperClassName="u-nudge-left--small"
+              wrapperClassName="u-nudge-left--small u-no-margin--right"
             >
               <Input
                 className="machine-name__hostname"
@@ -298,16 +298,16 @@ exports[`MachineName can display the form 1`] = `
                 takeFocus={true}
                 type="text"
                 value="test-machine-5"
-                wrapperClassName="u-nudge-left--small"
+                wrapperClassName="u-nudge-left--small u-no-margin--right"
               >
                 <Field
-                  className="u-nudge-left--small"
+                  className="u-nudge-left--small u-no-margin--right"
                   error={null}
                   labelFirst={true}
                   required={true}
                 >
                   <div
-                    className="p-form__group p-form-validation u-nudge-left--small"
+                    className="p-form__group p-form-validation u-nudge-left--small u-no-margin--right"
                   >
                     <div
                       className="p-form__control u-clearfix"
@@ -331,7 +331,9 @@ exports[`MachineName can display the form 1`] = `
                 </Field>
               </Input>
             </FormikField>
-            <span>
+            <span
+              className="u-nudge-left--small u-no-margin--right"
+            >
               .
             </span>
             <Spinner
@@ -357,22 +359,26 @@ exports[`MachineName can display the form 1`] = `
             submitDisabled={true}
           >
             <div
-              className=""
+              className="formik-form-buttons is-inline"
+              data-test="buttons-wrapper"
             >
-              <p
-                className="u-no-margin--bottom u-no-max-width"
+              <div
+                className="formik-form-buttons__help"
+                data-test="buttons-help"
               />
-              <div>
+              <div
+                className="formik-form-buttons__container u-align--right"
+              >
                 <Button
                   appearance="base"
-                  className="u-no-margin--bottom"
+                  className="formik-form-buttons__button"
                   data-test="cancel-action"
                   disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
                   <button
-                    className="p-button--base u-no-margin--bottom"
+                    className="p-button--base formik-form-buttons__button"
                     data-test="cancel-action"
                     disabled={false}
                     onClick={[Function]}
@@ -383,14 +389,14 @@ exports[`MachineName can display the form 1`] = `
                 </Button>
                 <ActionButton
                   appearance="positive"
-                  className="u-no-margin--bottom"
+                  className="formik-form-buttons__button"
                   disabled={true}
                   loading={false}
                   success={false}
                   type="submit"
                 >
                   <button
-                    className="u-no-margin--bottom p-action-button p-button--positive is-disabled"
+                    className="formik-form-buttons__button p-action-button p-button--positive is-disabled"
                     disabled={true}
                     type="submit"
                   >

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineName/__snapshots__/MachineName.test.tsx.snap
@@ -363,10 +363,6 @@ exports[`MachineName can display the form 1`] = `
               data-test="buttons-wrapper"
             >
               <div
-                className="formik-form-buttons__help"
-                data-test="buttons-help"
-              />
-              <div
                 className="formik-form-buttons__container u-align--right"
               >
                 <Button

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/MachineNameFields.tsx
@@ -26,9 +26,9 @@ export const MachineNameFields = ({ saving }: Props): JSX.Element => {
         required={true}
         style={{ width: `${values.hostname.length}ch` }}
         takeFocus
-        wrapperClassName="u-nudge-left--small"
+        wrapperClassName="u-nudge-left--small u-no-margin--right"
       />
-      <span>.</span>
+      <span className="u-nudge-left--small u-no-margin--right">.</span>
       {domainsLoaded ? (
         <FormikField
           className="u-no-margin--bottom"
@@ -40,7 +40,7 @@ export const MachineNameFields = ({ saving }: Props): JSX.Element => {
             value: domain.id,
           }))}
           required
-          wrapperClassName="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+          wrapperClassName="u-nudge-left u-no-margin--right"
         />
       ) : (
         <Spinner className="u-width--auto" />

--- a/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/__snapshots__/MachineNameFields.test.tsx.snap
+++ b/ui/src/app/machines/views/MachineDetails/MachineHeader/MachineNameFields/__snapshots__/MachineNameFields.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`MachineNameFields displays the fields 1`] = `
     }
     takeFocus={true}
     type="text"
-    wrapperClassName="u-nudge-left--small"
+    wrapperClassName="u-nudge-left--small u-no-margin--right"
   >
     <Input
       className="machine-name__hostname"
@@ -30,16 +30,16 @@ exports[`MachineNameFields displays the fields 1`] = `
       takeFocus={true}
       type="text"
       value=""
-      wrapperClassName="u-nudge-left--small"
+      wrapperClassName="u-nudge-left--small u-no-margin--right"
     >
       <Field
-        className="u-nudge-left--small"
+        className="u-nudge-left--small u-no-margin--right"
         error={null}
         labelFirst={true}
         required={true}
       >
         <div
-          className="p-form__group p-form-validation u-nudge-left--small"
+          className="p-form__group p-form-validation u-nudge-left--small u-no-margin--right"
         >
           <div
             className="p-form__control u-clearfix"
@@ -62,7 +62,9 @@ exports[`MachineNameFields displays the fields 1`] = `
       </Field>
     </Input>
   </FormikField>
-  <span>
+  <span
+    className="u-nudge-left--small u-no-margin--right"
+  >
     .
   </span>
   <FormikField
@@ -71,7 +73,7 @@ exports[`MachineNameFields displays the fields 1`] = `
     name="domain"
     options={Array []}
     required={true}
-    wrapperClassName="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+    wrapperClassName="u-nudge-left u-no-margin--right"
   >
     <Select
       className="u-no-margin--bottom"
@@ -82,16 +84,16 @@ exports[`MachineNameFields displays the fields 1`] = `
       options={Array []}
       required={true}
       value=""
-      wrapperClassName="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+      wrapperClassName="u-nudge-left u-no-margin--right"
     >
       <Field
-        className="u-no-margin--left u-nudge-right--small u-nudge-left--small"
+        className="u-nudge-left u-no-margin--right"
         error={null}
         isSelect={true}
         required={true}
       >
         <div
-          className="p-form__group p-form-validation u-no-margin--left u-nudge-right--small u-nudge-left--small"
+          className="p-form__group p-form-validation u-nudge-left u-no-margin--right"
         >
           <div
             className="p-form__control u-clearfix"

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -71,6 +71,7 @@
 @import "~app/base/components/DoughnutChart";
 @import "~app/base/components/FilterAccordion";
 @import "~app/base/components/FormCard";
+@import "~app/base/components/FormikFormButtons";
 @import "~app/base/components/LabelledList";
 @import "~app/base/components/Login";
 @import "~app/base/components/Meter";
@@ -85,6 +86,7 @@
 @include DoughnutChart;
 @include FilterAccordion;
 @include FormCard;
+@include FormikFormButtons;
 @include LabelledList;
 @include Login;
 @include Meter;


### PR DESCRIPTION
## Done

- Added help text to the clone form
- Updated `FormikFormButtons` to be able to put anything in the "help" area
- Updated `FormikFormButtons` to use custom classes - seemed like there was too much styling logic happening in the JS
- Fixed up some wonky styling on the machine edit name form thing - think a Vanilla update might have changed how inline forms work

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the clone form and check that there's help text next to the buttons with a link to a placeholder discourse post
- Check a few forms throughout the app (e.g. a settings form, action form, add machine form, machine name edit form) and make sure they look good

## Fixes

Fixes canonical-web-and-design/app-squad#209

## Screenshot
![Screenshot 2021-08-12 at 15-31-24 Machines bolla MAAS](https://user-images.githubusercontent.com/25733845/129143211-96bc0124-a13b-45bc-909b-ec81ce7a7140.png)
