### PR TITLE
feat(ui): add clone action to machine slice

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -162,7 +162,7 @@ exports[`stricter compilation`] = {
     "src/app/base/components/VLANSelect/VLANSelect.tsx:1063738059": [
       [59, 44, 7, "Type \'{ label: string | null; value: string; }[]\' is not assignable to type \'Option[]\'.\\n  Type \'{ label: string | null; value: string; }\' is not assignable to type \'Option\'.\\n    Types of property \'label\' are incompatible.\\n      Type \'string | null\' is not assignable to type \'string | undefined\'.\\n        Type \'null\' is not assignable to type \'string | undefined\'.", "717644789"]
     ],
-    "src/app/base/hooks.test.tsx:195133244": [
+    "src/app/base/hooks.test.tsx:919691319": [
       [39, 6, 4, "Type \'HTMLHtmlElement | null\' is not assignable to type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "2087820472"]
     ],
     "src/app/base/hooks.ts:3607810581": [
@@ -349,6 +349,12 @@ exports[`stricter compilation`] = {
     ],
     "src/app/kvm/views/KVMList/VirshTable/VirshTable.tsx:1938186400": [
       [84, 4, 12, "Argument of type \'(sortKey: SortKey, kvm: Pod, pools: ResourcePool[]) => string | number | string[] | PodResources | PodStoragePool[] | null | undefined\' is not assignable to parameter of type \'SortValueGetter<Pod, SortKey>\'.\\n  Types of parameters \'pools\' and \'args\' are incompatible.\\n    Type \'unknown\' is not assignable to type \'ResourcePool[]\'.", "3312061634"]
+    ],
+    "src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.test.tsx:3592403732": [
+      [50, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [51, 6, 16, "Argument of type \'{ interfaces: boolean; source: string; storage: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'interfaces\' does not exist in type \'FormEvent<{}>\'.", "4223787167"],
+      [101, 4, 41, "Cannot invoke an object which is possibly \'undefined\'.", "271797410"],
+      [102, 6, 16, "Argument of type \'{ interfaces: boolean; source: string; storage: boolean; }\' is not assignable to parameter of type \'FormEvent<{}>\'.\\n  Object literal may only specify known properties, and \'interfaces\' does not exist in type \'FormEvent<{}>\'.", "4223787167"]
     ],
     "src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.test.tsx:2249833249": [
       [109, 6, 66, "Cannot invoke an object which is possibly \'undefined\'.", "4166470712"],

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -1,0 +1,117 @@
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route } from "react-router-dom";
+import configureStore from "redux-mock-store";
+
+import CloneForm from "./CloneForm";
+
+import { actions as machineActions } from "app/store/machine";
+import {
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+describe("CloneForm", () => {
+  it("can dispatch an action to clone to selected machines in the machine list", () => {
+    const machines = [
+      machineFactory({ system_id: "abc123" }),
+      machineFactory({ system_id: "def456" }),
+      machineFactory({ system_id: "ghi789" }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        active: null,
+        items: machines,
+        loaded: true,
+        selected: ["abc123", "def456"],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+          def456: machineStatusFactory(),
+          ghi789: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CloneForm clearSelectedAction={jest.fn()} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find("Formik").invoke("onSubmit")({
+      interfaces: true,
+      source: "ghi789",
+      storage: false,
+    });
+
+    const expectedAction = machineActions.clone({
+      destinations: ["abc123", "def456"],
+      interfaces: true,
+      storage: false,
+      system_id: "ghi789",
+    });
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+    expect(expectedAction).toStrictEqual(actualAction);
+  });
+
+  it("can dispatch an action to clone to the active machine", () => {
+    const machines = [
+      machineFactory({ system_id: "abc123" }),
+      machineFactory({ system_id: "def456" }),
+    ];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        active: machines[0].system_id,
+        items: machines,
+        loaded: true,
+        selected: [],
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+          def456: machineStatusFactory(),
+        }),
+      }),
+    });
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
+        >
+          <Route
+            exact
+            path="/machine/:id"
+            component={() => <CloneForm clearSelectedAction={jest.fn()} />}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    wrapper.find("Formik").invoke("onSubmit")({
+      interfaces: true,
+      source: "def456",
+      storage: false,
+    });
+
+    const expectedAction = machineActions.clone({
+      destinations: ["abc123"],
+      interfaces: true,
+      storage: false,
+      system_id: "def456",
+    });
+    const actualAction = store
+      .getActions()
+      .find((action) => action.type === expectedAction.type);
+    expect(expectedAction).toStrictEqual(actualAction);
+  });
+});

--- a/ui/src/app/store/machine/actions.test.ts
+++ b/ui/src/app/store/machine/actions.test.ts
@@ -575,6 +575,34 @@ describe("machine actions", () => {
     );
   });
 
+  it("can handle cloning a machine", () => {
+    expect(
+      actions.clone({
+        destinations: ["def456", "ghi789"],
+        interfaces: true,
+        storage: false,
+        system_id: "abc123",
+      })
+    ).toEqual({
+      type: "machine/clone",
+      meta: {
+        model: "machine",
+        method: "action",
+      },
+      payload: {
+        params: {
+          action: NodeActions.CLONE,
+          extra: {
+            destinations: ["def456", "ghi789"],
+            interfaces: true,
+            storage: false,
+          },
+          system_id: "abc123",
+        },
+      },
+    });
+  });
+
   it("can handle applying a machine's storage layout", () => {
     expect(
       actions.applyStorageLayout({

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -5,6 +5,7 @@ import { MachineMeta } from "./types";
 import type {
   Action,
   ApplyStorageLayoutParams,
+  CloneParams,
   CommissionParams,
   CreateBcacheParams,
   CreateBondParams,
@@ -489,6 +490,31 @@ const machineSlice = createSlice({
     checkPowerError: statusHandlers.checkPower.error,
     checkPowerStart: statusHandlers.checkPower.start,
     checkPowerSuccess: statusHandlers.checkPower.success,
+    [NodeActions.CLONE]: {
+      prepare: (params: CloneParams) => ({
+        meta: {
+          model: MachineMeta.MODEL,
+          method: "action",
+        },
+        payload: {
+          params: {
+            action: NodeActions.CLONE,
+            extra: {
+              destinations: params.destinations,
+              interfaces: params.interfaces,
+              storage: params.storage,
+            },
+            system_id: params.system_id,
+          },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    cloneError: statusHandlers.clone.error,
+    cloneStart: statusHandlers.clone.start,
+    cloneSuccess: statusHandlers.clone.success,
     [NodeActions.COMMISSION]: {
       prepare: (params: CommissionParams) => {
         let formattedCommissioningScripts: (string | Script["id"])[] = [];

--- a/ui/src/app/store/machine/types/actions.ts
+++ b/ui/src/app/store/machine/types/actions.ts
@@ -23,6 +23,13 @@ export type ApplyStorageLayoutParams = {
   storageLayout: StorageLayout;
 };
 
+export type CloneParams = {
+  destinations: Machine[MachineMeta.PK][];
+  interfaces: boolean;
+  storage: boolean;
+  system_id: Machine[MachineMeta.PK];
+};
+
 export type CommissionParams = {
   systemId: Machine[MachineMeta.PK];
   enableSSH: boolean;

--- a/ui/src/app/store/machine/types/index.ts
+++ b/ui/src/app/store/machine/types/index.ts
@@ -1,6 +1,7 @@
 export type {
   Action,
   ApplyStorageLayoutParams,
+  CloneParams,
   CommissionParams,
   CreateBcacheParams,
   CreateBondParams,


### PR DESCRIPTION
## Done

- Added clone action to machine slice

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the clone form from the machine list and submit the form
- Check that Redux actions are dispatched and a response from the API is recorded (either `cloneSuccess` or `cloneError`). Ignore the unformatted errors for now as they'll be handled in follow-ups.
- Do the same from a machine details page.

## Fixes

Fixes canonical-web-and-design/app-squad#198