### PR TITLE
feat(ui): add validation to clone form

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneForm.tsx
@@ -28,6 +28,19 @@ const CloneFormSchema = Yup.object()
     source: Yup.string().required("Source machine must be selected."),
     storage: Yup.boolean(),
   })
+  .test(
+    "networkOrStorage",
+    "Neither network nor storage selected",
+    (values, context) => {
+      if (!(values.interfaces || values.storage)) {
+        return context.createError({
+          message: "Either networking or storage must be selected.",
+          path: "hidden", // we don't surface the error at a particular field
+        });
+      }
+      return true;
+    }
+  )
   .defined();
 
 export const CloneForm = ({

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -72,6 +72,8 @@ export const CloneFormFields = (): JSX.Element => {
             dispatch(machineActions.get(machine.system_id));
           } else {
             setFieldValue("source", "");
+            setFieldValue("interfaces", false);
+            setFieldValue("storage", false);
             setSelectedMachine(null);
           }
         }}
@@ -81,6 +83,7 @@ export const CloneFormFields = (): JSX.Element => {
       <div className="clone-tables">
         <div className="clone-table-card">
           <FormikField
+            disabled={!selectedMachine}
             label="Clone network configuration"
             name="interfaces"
             type="checkbox"
@@ -96,6 +99,7 @@ export const CloneFormFields = (): JSX.Element => {
         </div>
         <div className="clone-table-card">
           <FormikField
+            disabled={!selectedMachine}
             label="Clone storage configuration"
             name="storage"
             type="checkbox"


### PR DESCRIPTION
## Done

- Added validation to clone form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a machine and open the clone form
- Check that the network and storage checkboxes are disabled and the submit button is disabled
- Select a source machine and check that the network and storage checkboxes are enabled, but the submit button is still disabled
- Tick one of either network or storage and check that the submit button is enabled

## Fixes

Fixes canonical-web-and-design/app-squad#208