### PR TITLE
refactor(ui): migrate ErrorBoundary to TypeScript

### DIFF
--- a/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,30 +1,32 @@
-import { mount } from "enzyme";
-import configureStore from "redux-mock-store";
-import { Provider } from "react-redux";
 import * as Sentry from "@sentry/browser";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
 
-import ErrorBoundary from "app/base/components/ErrorBoundary";
+import ErrorBoundary from "./ErrorBoundary";
+
+import type { RootState } from "app/store/root/types";
+import {
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+  versionState as versionStateFactory,
+} from "testing/factories";
 
 const mockStore = configureStore();
 
 describe("ErrorBoundary", () => {
-  let state;
+  let state: RootState;
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
   beforeEach(() => {
-    state = {
-      config: {
-        items: [],
-      },
-      general: {
-        version: {
-          data: "2.7.0",
-        },
-      },
-    };
+    state = rootStateFactory({
+      general: generalStateFactory({
+        version: versionStateFactory({ data: "2.7.0" }),
+      }),
+    });
   });
 
   it("should display an ErrorMessage if wrapped component throws", () => {
@@ -49,7 +51,7 @@ describe("ErrorBoundary", () => {
 
   it("should not capture exceptions with Sentry when enable_analytics is disabled", () => {
     jest.spyOn(console, "error"); // suppress traceback in test
-    jest.spyOn(Sentry, "captureException").mockImplementation(() => {});
+    jest.spyOn(Sentry, "captureException").mockImplementation(() => "");
 
     state.config.items = [
       {
@@ -76,7 +78,7 @@ describe("ErrorBoundary", () => {
 
   it("should capture exceptions with Sentry when enable_analytics is enabled", () => {
     jest.spyOn(console, "error"); // suppress traceback in test
-    jest.spyOn(Sentry, "captureException").mockImplementation(() => {});
+    jest.spyOn(Sentry, "captureException").mockImplementation(() => "");
 
     state.config.items = [
       {

--- a/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/ui/src/app/base/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,12 +1,26 @@
 import { Component } from "react";
+import type { ReactNode, ErrorInfo } from "react";
+
 import * as Sentry from "@sentry/browser";
 import { connect } from "react-redux";
 
 import configSelectors from "app/store/config/selectors";
 import { version as versionSelectors } from "app/store/general/selectors";
+import type { RootState } from "app/store/root/types";
 
-class ErrorBoundary extends Component {
-  constructor(props) {
+type Props = {
+  analyticsEnabled?: boolean | null;
+  children?: ReactNode;
+  maasVersion?: string;
+};
+
+type State = {
+  eventId: string | null;
+  hasError: boolean;
+};
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
     super(props);
     this.state = { hasError: false, eventId: null };
   }
@@ -15,7 +29,7 @@ class ErrorBoundary extends Component {
     return { hasError: true };
   }
 
-  componentDidCatch(error, errorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     const { analyticsEnabled, maasVersion } = this.props;
 
     if (analyticsEnabled) {
@@ -42,7 +56,7 @@ class ErrorBoundary extends Component {
     return this.props.children;
   }
 }
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state: RootState) => ({
   analyticsEnabled: configSelectors.analyticsEnabled(state),
   maasVersion: versionSelectors.get(state),
 });


### PR DESCRIPTION
## Done

- migrate ErrorBoundary to TypeScript.

## QA

N/A