### PR TITLE
feat(ui): improve responsiveness of clone form

### DIFF
--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/_index.scss
@@ -25,11 +25,26 @@
 
     @media only screen and (max-width: $breakpoint-x-large) {
       grid:
+        [row1-start] "source-label empty" min-content [row1-end]
+        [row2-start] "source-select empty" min-content [row2-end]
+        [row3-start] "clone-label clone-label" min-content [row3-end]
+        [row4-start] "clone-tables clone-tables" min-content [row4-end]
+        / 1fr 1fr;
+      column-gap: 0;
+
+      .source-select {
+        margin-bottom: $spv-outer--shallow-scaleable;
+      }
+    }
+
+    @media only screen and (max-width: $breakpoint-navigation-threshold) {
+      grid:
         [row1-start] "source-label" min-content [row1-end]
         [row2-start] "source-select" min-content [row2-end]
         [row3-start] "clone-label" min-content [row3-end]
         [row4-start] "clone-tables" min-content [row4-end]
         / 100%;
+      column-gap: 0;
 
       .source-select {
         margin-bottom: $spv-outer--shallow-scaleable;
@@ -42,7 +57,7 @@
     @extend %vf-has-round-corners;
     display: flex;
 
-    @media only screen and (max-width: $breakpoint-medium) {
+    @media only screen and (max-width: $breakpoint-navigation-threshold) {
       flex-direction: column;
     }
   }
@@ -53,7 +68,7 @@
     &:not(:last-of-type) {
       border-right: $border;
 
-      @media only screen and (max-width: $breakpoint-medium) {
+      @media only screen and (max-width: $breakpoint-navigation-threshold) {
         border-bottom: $border;
         border-right: 0;
       }

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 
-import { Button, Col, Notification, Row } from "@canonical/react-components";
+import {
+  Button,
+  Icon,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
@@ -75,34 +82,56 @@ export const CloneResults = ({
   }
 
   return (
-    <Row>
-      <Col size={3}>
-        <h2 className="p-heading--4">Cloning complete</h2>
-      </Col>
-      <Col size={6}>
-        <p data-test="results-string">
-          {getResultsString(destinationCount, error)}{" "}
-          <Link to={machineURLs.machine.index({ id: sourceMachine.system_id })}>
-            {sourceMachine.hostname}
-          </Link>
-          .
-        </p>
-        {error && (
-          <>
-            <p>The following errors occurred:</p>
-            <Notification data-test="errors-table" severity="negative">
-              Error
-            </Notification>
-          </>
-        )}
-      </Col>
+    <>
+      <div className="clone-results">
+        <h2 className="clone-results__title p-heading--4">Cloning complete</h2>
+        <div className="clone-results__info">
+          <p data-test="results-string">
+            {getResultsString(destinationCount, error)}{" "}
+            <Link
+              to={machineURLs.machine.index({ id: sourceMachine.system_id })}
+            >
+              {sourceMachine.hostname}
+            </Link>
+            .
+          </p>
+          {error && (
+            <>
+              <p>The following errors occurred:</p>
+              <Table className="clone-results__table" data-test="errors-table">
+                <thead>
+                  <TableRow>
+                    <TableHeader className="error-col">
+                      <span className="u-nudge-right--x-large">Error</span>
+                    </TableHeader>
+                    <TableHeader className="affected-col u-align--right">
+                      Affected machines
+                    </TableHeader>
+                  </TableRow>
+                </thead>
+                <tbody>
+                  <TableRow>
+                    <TableCell className="error-col">
+                      <Icon name="error" />
+                      <span className="u-nudge-right">Error</span>
+                    </TableCell>
+                    <TableCell className="affected-col u-align--right">
+                      Show
+                    </TableCell>
+                  </TableRow>
+                </tbody>
+              </Table>
+            </>
+          )}
+        </div>
+      </div>
       <hr />
       <div className="u-align--right">
         <Button appearance="base" onClick={closeForm}>
           Close
         </Button>
       </div>
-    </Row>
+    </>
   );
 };
 

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/_index.scss
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/_index.scss
@@ -1,0 +1,35 @@
+@mixin CloneResults {
+  .clone-results {
+    @extend %base-grid;
+    grid-template-areas: "title title title info info info info info info empty empty empty";
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    grid-template-rows: min-content;
+
+    .clone-results__title {
+      grid-area: title;
+    }
+
+    .clone-results__info {
+      grid-area: info;
+    }
+
+    .error-col {
+      width: 100%;
+    }
+
+    .affected-col {
+      width: 9rem;
+    }
+
+    @media only screen and (max-width: $breakpoint-x-large) {
+      grid-template-areas: "title title title info info info info info info info info info";
+    }
+
+    @media only screen and (max-width: $breakpoint-large) {
+      grid-template-areas:
+        "title"
+        "info";
+      grid-template-columns: 100%;
+    }
+  }
+}

--- a/ui/src/scss/index.scss
+++ b/ui/src/scss/index.scss
@@ -171,6 +171,7 @@
 // machines
 @import "~app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields";
 @import "~app/machines/components/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect";
+@import "~app/machines/components/ActionFormWrapper/CloneForm/CloneResults";
 @import "~app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
 @import "~app/machines/components/TakeActionMenu";
 @import "~app/machines/views/MachineDetails/MachineHeader/MachineName";
@@ -186,6 +187,7 @@
 @import "~app/machines/views/MachineDetails/NodeDevices";
 @import "~app/machines/views/MachineList";
 @include CloneFormFields;
+@include CloneResults;
 @include DownloadMenu;
 @include EventLogsTable;
 @include MachineDHCPTable;


### PR DESCRIPTION
## Done

- Improved responsiveness of the clone form
- Converted error notification into a table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select some machines and open the clone form
- Resize the viewport and check that it looks good on all screen sizes
- Submit the form with errors to get to the results page
- Again resize the viewport and check that it looks good on all screen sizes

## Fixes

Fixes canonical-web-and-design/app-squad#207