### PR TITLE
fix(ui): fix ordering of CSS in standalone React mode

### DIFF
--- a/ui/src/app/App.tsx
+++ b/ui/src/app/App.tsx
@@ -13,8 +13,6 @@ import * as Sentry from "@sentry/browser";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useHistory, useLocation } from "react-router-dom";
 
-import "../scss/index.scss";
-
 import Routes from "app/Routes";
 import Login from "app/base/components/Login";
 import Section from "app/base/components/Section";

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -58,6 +58,8 @@ if (process.env.REACT_APP_STANDALONE === "true") {
   ReactDOM.render(<Root />, document.getElementById("root"));
 }
 
+require("./scss/index.scss");
+
 export default Root;
 
 serviceWorker.unregister();


### PR DESCRIPTION
## Done

- Fixed ordered of CSS when using `yarn ui`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

__Check that the styles are correct in development__
- Load the app in standalone React mode (`yarn ui`)
- Open up a production deployment of the same MAAS (e.g. bolla)
- Check that the UI is exactly the same between the two versions

__Check that the styles are correct in production__
- In a local MAAS repo run the following from the root of the project:
```shell
  make
  make install-dependencies
  make syncdb
  git config --file=.gitmodules submodule.src/maasui/src.url https://github.com/Caleb-Ellis/maas-ui.git
  git config --file=.gitmodules submodule.src/maasui/src.branch fix-styling-order
  git submodule sync
  git submodule update --init --recursive --remote
  make snap-prime
  sudo snap try build/dev-snap/prime
  utilities/connect-snap-interfaces
  sudo maas init
  ```
- You might need to update the offline docs submodule as well - for some reason I couldn't get it to pull from the main repo so I changed it to my fork, e.g. https://git.launchpad.net/~caleb-ellis/maas-offline-docs which seemed to get `make snap-prime` to work
- Open the production version of MAAS (it should be served from the url given in `sudo maas init`) and check that the UI looks the same as the production version of MAAS running on master.

## Fixes

Fixes #2176