### PR TITLE
refactor(ui): set all errors to the api error type

### DIFF
--- a/ui/.betterer.results
+++ b/ui/.betterer.results
@@ -4,7 +4,7 @@ exports[`stricter compilation`] = {
     "src/app/App.tsx:2748552162": [
       [192, 7, 7, "Variable \'content\' is used before being assigned.", "3716929964"]
     ],
-    "src/app/base/components/ActionForm/ActionForm.tsx:49640416": [
+    "src/app/base/components/ActionForm/ActionForm.tsx:2701524677": [
       [16, 21, 15, "Object is possibly \'undefined\'.", "1847077069"],
       [20, 20, 13, "Object is possibly \'undefined\'.", "3155939599"],
       [23, 6, 13, "Object is possibly \'undefined\'.", "3155939599"],
@@ -137,13 +137,13 @@ exports[`stricter compilation`] = {
     "src/app/base/hooks.test.tsx:919691319": [
       [39, 6, 4, "Type \'HTMLHtmlElement | null\' is not assignable to type \'HTMLElement\'.\\n  Type \'null\' is not assignable to type \'HTMLElement\'.", "2087820472"]
     ],
-    "src/app/base/hooks.ts:178735358": [
-      [419, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
-      [420, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
-      [425, 31, 5, "Object is of type \'unknown\'.", "195909086"],
-      [425, 39, 5, "Object is of type \'unknown\'.", "195909085"],
-      [428, 31, 5, "Object is of type \'unknown\'.", "195909086"],
-      [428, 39, 5, "Object is of type \'unknown\'.", "195909085"]
+    "src/app/base/hooks.ts:3262052596": [
+      [421, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
+      [422, 36, 3, "Argument of type \'K | null\' is not assignable to parameter of type \'K\'.\\n  \'K | null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.\\n    Type \'null\' is not assignable to type \'K\'.\\n      \'null\' is assignable to the constraint of type \'K\', but \'K\' could be instantiated with a different subtype of constraint \'string | null\'.", "193424690"],
+      [427, 31, 5, "Object is of type \'unknown\'.", "195909086"],
+      [427, 39, 5, "Object is of type \'unknown\'.", "195909085"],
+      [430, 31, 5, "Object is of type \'unknown\'.", "195909086"],
+      [430, 39, 5, "Object is of type \'unknown\'.", "195909085"]
     ],
     "src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx:2867026375": [
       [92, 6, 83, "Object is of type \'unknown\'.", "1940328833"],
@@ -241,9 +241,9 @@ exports[`stricter compilation`] = {
       [72, 6, 14, "Type \'([file]: [any]) => void\' is not assignable to type \'<T extends File>(files: T[], event: DropEvent) => void\'.\\n  Types of parameters \'__0\' and \'files\' are incompatible.\\n    Type \'T[]\' is not assignable to type \'[any]\'.\\n      Target requires 1 element(s) but source may have fewer.", "3837758380"],
       [105, 34, 5, "Type \'null\' is not assignable to type \'CSSProperties | undefined\'.", "195056594"]
     ],
-    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:2874159016": [
-      [83, 4, 11, "Type \'(FormattedScript | undefined)[]\' is not assignable to type \'FormattedScript[]\'.\\n  Type \'FormattedScript | undefined\' is not assignable to type \'FormattedScript\'.\\n    Type \'undefined\' is not assignable to type \'FormattedScript\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"],
-      [93, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"]
+    "src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx:2650366085": [
+      [84, 4, 11, "Type \'(FormattedScript | undefined)[]\' is not assignable to type \'FormattedScript[]\'.\\n  Type \'FormattedScript | undefined\' is not assignable to type \'FormattedScript\'.\\n    Type \'undefined\' is not assignable to type \'FormattedScript\'.\\n      Type \'undefined\' is not assignable to type \'Model\'.", "611253867"],
+      [94, 6, 25, "Element implicitly has an \'any\' type because expression of type \'string\' can\'t be used to index type \'{}\'.\\n  No index signature with a parameter of type \'string\' was found on type \'{}\'.", "311081487"]
     ],
     "src/app/machines/components/TakeActionMenu/TakeActionMenu.tsx:2937561306": [
       [168, 10, 16, "Argument of type \'(Machine | undefined)[]\' is not assignable to parameter of type \'Machine[]\'.", "2366246550"]
@@ -453,163 +453,25 @@ exports[`stricter compilation`] = {
     "src/testing/factories/notification.ts:1367425813": [
       [12, 2, 5, "Type \'null\' is not assignable to type \'NotificationIdent | ArrayFactory<never> | AttributeFunction<NotificationIdent> | Factory<NotificationIdent> | DerivedFunction<...>\'.", "179146135"]
     ],
-    "src/testing/factories/state.ts:3871148871": [
-      [235, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
-      [352, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
-      [353, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
-      [355, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
-      [360, 2, 6, "Type \'null\' is not assignable to type \'Action | ArrayFactory<never> | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
+    "src/testing/factories/state.ts:651512736": [
+      [237, 2, 4, "Type \'null\' is not assignable to type \'BondOptions | ArrayFactory<never> | AttributeFunction<BondOptions> | Factory<BondOptions> | DerivedFunction<...>\'.", "2087377941"],
+      [354, 2, 5, "Type \'null\' is not assignable to type \'Record<string, string> | ArrayFactory<never> | AttributeFunction<Record<string, string>> | Factory<Record<string, string>> | DerivedFunction<...>\'.", "188027887"],
+      [355, 2, 6, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2158674347"],
+      [357, 2, 4, "Type \'null\' is not assignable to type \'string | ArrayFactory<never> | AttributeFunction<string> | Factory<string> | DerivedFunction<RouterLocation<unknown>, string>\'.", "2087809207"],
+      [362, 2, 6, "Type \'null\' is not assignable to type \'Action | ArrayFactory<never> | AttributeFunction<Action> | Factory<Action> | DerivedFunction<RouterState<unknown>, Action>\'.", "1314712411"]
     ]
   }`
 };
 
 exports[`no TSFixMe types`] = {
   value: `{
-    "src/app/base/hooks.ts:178735358": [
-      [12, 19, 8, "RegExp match", "1152173309"],
-      [36, 40, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/base/types.ts:1834489472": [
+    "src/app/base/types.ts:3315569138": [
       [2, 11, 8, "RegExp match", "1152173309"]
     ],
-    "src/app/store/auth/selectors.ts:1184961194": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [32, 34, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/config/types/base.ts:4044053723": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [13, 60, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/controller/types/base.ts:4070635752": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [47, 54, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/device/types/base.ts:727873425": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [41, 46, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/dhcpsnippet/types/base.ts:3390116686": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [24, 56, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/discovery/types/base.ts:241213906": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [28, 52, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/domain/types/base.ts:2689165932": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [40, 24, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/fabric/types/base.ts:4166410381": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [14, 46, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/general/selectors/utils.ts:1977532362": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [5, 31, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/general/types/base.ts:614661764": [
-      [9, 13, 8, "RegExp match", "1152173309"],
-      [15, 9, 8, "RegExp match", "1152173309"],
-      [51, 9, 8, "RegExp match", "1152173309"],
-      [60, 9, 8, "RegExp match", "1152173309"],
-      [69, 9, 8, "RegExp match", "1152173309"],
-      [78, 9, 8, "RegExp match", "1152173309"],
-      [93, 9, 8, "RegExp match", "1152173309"],
-      [107, 9, 8, "RegExp match", "1152173309"],
-      [136, 9, 8, "RegExp match", "1152173309"],
-      [145, 9, 8, "RegExp match", "1152173309"],
-      [180, 9, 8, "RegExp match", "1152173309"],
-      [189, 9, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/licensekeys/types/base.ts:1152996219": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [11, 56, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/machine/types/base.ts:780370828": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [278, 34, 8, "RegExp match", "1152173309"],
-      [281, 25, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/nodedevice/types/base.ts:1011270636": [
-      [3, 13, 8, "RegExp match", "1152173309"],
-      [28, 54, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/notification/types/base.ts:30404862": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [19, 58, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/packagerepository/types/base.ts:3365432595": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [20, 68, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/pod/types/base.ts:3430719631": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [147, 21, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/resourcepool/types/base.ts:1043464479": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [15, 58, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/script/types/base.ts:1978759558": [
-      [2, 13, 8, "RegExp match", "1152173309"],
+    "src/app/store/script/types/base.ts:3573504882": [
+      [2, 23, 8, "RegExp match", "1152173309"],
       [12, 14, 8, "RegExp match", "1152173309"],
-      [17, 14, 8, "RegExp match", "1152173309"],
-      [43, 46, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/scriptresult/selectors.ts:1601152711": [
-      [14, 13, 8, "RegExp match", "1152173309"],
-      [72, 34, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/scriptresult/types/base.ts:921278125": [
-      [10, 13, 8, "RegExp match", "1152173309"],
-      [93, 58, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/service/types/base.ts:3965282464": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [10, 48, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/space/types/base.ts:578851947": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [13, 44, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/sshkey/types/base.ts:2073640783": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [19, 46, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/sslkey/types/base.ts:2090428060": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [13, 46, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/status/types/base.ts:4123989684": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [5, 22, 8, "RegExp match", "1152173309"],
-      [8, 8, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/subnet/types/base.ts:1274895606": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [47, 46, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/tag/types/base.ts:3275525000": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [13, 40, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/token/types/base.ts:1575725788": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [15, 44, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/user/types/base.ts:643948283": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [18, 9, 8, "RegExp match", "1152173309"],
-      [39, 22, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/vlan/types/base.ts:1341634383": [
-      [2, 13, 8, "RegExp match", "1152173309"],
-      [24, 42, 8, "RegExp match", "1152173309"]
-    ],
-    "src/app/store/zone/types/base.ts:3660426969": [
-      [0, 13, 8, "RegExp match", "1152173309"],
-      [14, 42, 8, "RegExp match", "1152173309"]
+      [17, 14, 8, "RegExp match", "1152173309"]
     ]
   }`
 };

--- a/ui/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/ui/src/app/base/components/ActionForm/ActionForm.tsx
@@ -90,7 +90,7 @@ const getLabel = (
   }
 };
 
-export type Props<V> = FormikFormProps<V> & {
+export type Props<V, E = null> = FormikFormProps<V, E> & {
   actionDisabled?: boolean;
   actionName?: string;
   clearSelectedAction?: (...args: unknown[]) => void;
@@ -101,7 +101,7 @@ export type Props<V> = FormikFormProps<V> & {
   selectedCount?: number;
 };
 
-const ActionForm = <V,>({
+const ActionForm = <V, E = null>({
   actionDisabled,
   actionName,
   buttonsBordered = false,
@@ -115,7 +115,7 @@ const ActionForm = <V,>({
   processingCount,
   selectedCount,
   ...formikFormProps
-}: Props<V>): JSX.Element | null => {
+}: Props<V, E>): JSX.Element | null => {
   const [processing, setProcessing] = useState(false);
   const [saved, setSaved] = useState(false);
   const [selectedOnSubmit, setSelectedOnSubmit] = useState(selectedCount);
@@ -150,7 +150,7 @@ const ActionForm = <V,>({
 
   if (loaded) {
     return (
-      <FormikForm<V>
+      <FormikForm<V, E>
         buttonsAlign="right"
         buttonsBordered={buttonsBordered}
         errors={formattedErrors}

--- a/ui/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/ui/src/app/base/components/FormikForm/FormikForm.tsx
@@ -4,9 +4,9 @@ import type { FormikConfig } from "formik";
 import FormikFormContent from "app/base/components/FormikFormContent";
 import type { Props as ContentProps } from "app/base/components/FormikFormContent/FormikFormContent";
 
-export type Props<V> = ContentProps<V> & FormikConfig<V>;
+export type Props<V, E = null> = ContentProps<V, E> & FormikConfig<V>;
 
-const FormikForm = <V,>({
+const FormikForm = <V, E = null>({
   allowAllEmpty,
   allowUnchanged,
   buttonsAlign,
@@ -38,10 +38,10 @@ const FormikForm = <V,>({
   submitDisabled,
   submitLabel,
   ...formikProps
-}: Props<V>): JSX.Element => {
+}: Props<V, E>): JSX.Element => {
   return (
     <Formik<V> {...formikProps}>
-      <FormikFormContent<V>
+      <FormikFormContent<V, E>
         allowAllEmpty={allowAllEmpty}
         allowUnchanged={allowUnchanged}
         buttonsAlign={buttonsAlign}

--- a/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/ui/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -16,14 +16,14 @@ import {
 } from "app/base/hooks";
 import type { APIError } from "app/base/types";
 
-export type Props<V> = {
+export type Props<V, E> = {
   allowAllEmpty?: boolean;
   allowUnchanged?: boolean;
   children?: ReactNode;
   className?: string;
   cleanup?: () => void;
   editable?: boolean;
-  errors?: APIError;
+  errors?: APIError<E>;
   inline?: boolean;
   loading?: boolean;
   onSaveAnalytics?: {
@@ -40,7 +40,10 @@ export type Props<V> = {
   submitDisabled?: boolean;
 } & FormikFormButtonsProps<V>;
 
-const generateNonFieldError = <V,>(values: V, errors?: APIError) => {
+const generateNonFieldError = <V, E = null>(
+  values: V,
+  errors?: APIError<E>
+) => {
   if (errors) {
     if (typeof errors === "string") {
       return errors;
@@ -63,7 +66,7 @@ const generateNonFieldError = <V,>(values: V, errors?: APIError) => {
   return null;
 };
 
-const FormikFormContent = <V,>({
+const FormikFormContent = <V, E = null>({
   allowAllEmpty,
   allowUnchanged,
   children,
@@ -82,7 +85,7 @@ const FormikFormContent = <V,>({
   saving,
   submitDisabled,
   ...buttonsProps
-}: Props<V>): JSX.Element => {
+}: Props<V, E>): JSX.Element => {
   const dispatch = useDispatch();
   const onSuccessCalled = useRef(false);
   const { handleSubmit, initialValues, resetForm, values } =
@@ -133,8 +136,8 @@ const FormikFormContent = <V,>({
 
   // We use both formik validation errors (i.e. those associated with a given
   // form field) and errors returned from the server.
-  useFormikErrors(errors);
-  const nonFieldError = generateNonFieldError<V>(values, errors);
+  useFormikErrors<V, E>(errors);
+  const nonFieldError = generateNonFieldError<V, E>(values, errors);
 
   // Run cleanup function on component unmount.
   useEffect(() => {

--- a/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
+++ b/ui/src/app/base/components/TableConfirm/TableConfirm.tsx
@@ -45,7 +45,7 @@ const TableConfirm = ({
     onSuccess && onSuccess();
     onClose();
   });
-  const errorMessage = formatErrors(errors, errorKey);
+  const errorMessage = formatErrors(errors, errorKey as keyof APIError);
 
   const { TABLE_CONFIRM_BUTTONS, SIDEBAR, TOTAL } = COL_SIZES;
   return (

--- a/ui/src/app/base/components/UserForm/UserForm.tsx
+++ b/ui/src/app/base/components/UserForm/UserForm.tsx
@@ -88,8 +88,8 @@ export const UserForm = ({
   let errors = userErrors;
   if (includeCurrentPassword) {
     errors = {
-      ...authErrors,
-      ...userErrors,
+      ...(authErrors && typeof authErrors === "object" ? authErrors : {}),
+      ...(userErrors && typeof userErrors === "object" ? userErrors : {}),
     };
   }
   const initialValues: UserValues = {

--- a/ui/src/app/base/hooks.ts
+++ b/ui/src/app/base/hooks.ts
@@ -10,7 +10,7 @@ import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
-import type { Sort, TSFixMe } from "app/base/types";
+import type { AnyObject, APIError, Sort } from "app/base/types";
 import { SortDirection } from "app/base/types";
 import { simpleObjectEquality } from "app/settings/utils";
 import authSelectors from "app/store/auth/selectors";
@@ -34,8 +34,10 @@ declare global {
  * for use in formik forms.
  * @param errors - The errors object in redux state.
  */
-export const useFormikErrors = (errors?: TSFixMe): void => {
-  const { setFieldError, setFieldTouched, values } = useFormikContext();
+export const useFormikErrors = <V = AnyObject, E = null>(
+  errors?: APIError<E>
+): void => {
+  const { setFieldError, setFieldTouched, values } = useFormikContext<V>();
   const previousErrors = usePrevious(errors);
   useEffect(() => {
     // Only run this effect if the errors have changed.
@@ -44,12 +46,12 @@ export const useFormikErrors = (errors?: TSFixMe): void => {
       typeof errors === "object" &&
       !simpleObjectEquality(errors, previousErrors)
     ) {
-      Object.keys(errors).forEach((field) => {
+      Object.entries(errors).forEach(([field, fieldErrors]) => {
         let errorString: string;
-        if (Array.isArray(errors[field])) {
-          errorString = errors[field].join(" ");
+        if (Array.isArray(fieldErrors)) {
+          errorString = fieldErrors.join(" ");
         } else {
-          errorString = errors[field];
+          errorString = fieldErrors;
         }
         setFieldError(field, errorString);
         setFieldTouched(field, true, false);

--- a/ui/src/app/base/types.ts
+++ b/ui/src/app/base/types.ts
@@ -36,8 +36,9 @@ export type AnyObject = Record<string, unknown>;
 
 export type EmptyObject = Record<string, never>;
 
-export type APIError =
+export type APIError<E = null> =
   | string
   | string[]
   | Record<"__all__" | string, string | string[]>
-  | null;
+  | null
+  | E;

--- a/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/ui/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -58,7 +58,10 @@ const MaasIntro = (): JSX.Element => {
     dispatch(repoActions.fetch());
   }, [dispatch]);
 
-  const errors = { ...configErrors, ...reposErrors };
+  const errors = {
+    ...(configErrors && typeof configErrors === "object" ? configErrors : {}),
+    ...(reposErrors && typeof reposErrors === "object" ? reposErrors : {}),
+  };
   const loading = authLoading || configLoading || reposLoading;
   const saving = configSaving || reposSaving;
   const saved = configSaved;

--- a/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
@@ -12,21 +12,19 @@ import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
+import type { APIError } from "app/base/types";
 import machineURLs from "app/machines/urls";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineDetails } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 
-type CloneError =
-  | null
-  | string
-  | {
-      destinations: {
-        code: string;
-        message: string;
-      }[];
-    };
+export type CloneError = {
+  destinations: {
+    code: string;
+    message: string;
+  }[];
+};
 
 type Props = {
   closeForm: () => void;
@@ -34,7 +32,7 @@ type Props = {
   sourceMachine: MachineDetails | null;
 };
 
-const getResultsString = (count: number, error: CloneError) => {
+const getResultsString = (count: number, error: APIError<CloneError>) => {
   let successCount: number;
   if (!error) {
     successCount = count;
@@ -67,7 +65,9 @@ export const CloneResults = ({
       NodeActions.CLONE
     )
   );
-  const error: CloneError = cloneErrors.length ? cloneErrors[0].error : null;
+  const error: APIError<CloneError> = cloneErrors.length
+    ? cloneErrors[0].error
+    : null;
 
   useEffect(() => {
     // We set destination count in local state otherwise the user could unselect

--- a/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -12,6 +12,7 @@ import type { ClearSelectedAction } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { actions as scriptActions } from "app/store/script";
 import scriptSelectors from "app/store/script/selectors";
 import type { Script } from "app/store/script/types";
@@ -95,7 +96,7 @@ export const CommissionForm = ({
   }, [dispatch]);
 
   return (
-    <ActionForm<CommissionFormValues>
+    <ActionForm<CommissionFormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.COMMISSION}
       allowUnchanged

--- a/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/DeployForm/DeployForm.tsx
@@ -17,6 +17,7 @@ import {
 } from "app/store/general/selectors";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { PodType } from "app/store/pod/types";
 import { NodeActions } from "app/store/types/node";
 
@@ -84,7 +85,7 @@ export const DeployForm = ({
   }
 
   return (
-    <ActionForm<DeployFormValues>
+    <ActionForm<DeployFormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.DEPLOY}
       allowUnchanged={osystems?.length !== 0 && releases?.length !== 0}

--- a/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/FieldlessForm/FieldlessForm.tsx
@@ -9,6 +9,7 @@ import machineURLs from "app/machines/urls";
 import type { MachineSelectedAction } from "app/machines/views/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { NodeActions } from "app/store/types/node";
 import { kebabToCamelCase } from "app/utils";
 
@@ -58,7 +59,7 @@ export const FieldlessForm = ({
   }
 
   return (
-    <ActionForm<EmptyObject>
+    <ActionForm<EmptyObject, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={selectedAction.name}
       allowUnchanged

--- a/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -11,6 +11,7 @@ import type { ClearSelectedAction } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { NodeActions } from "app/store/types/node";
 
 const MarkBrokenSchema = Yup.object().shape({
@@ -44,7 +45,7 @@ export const MarkBrokenForm = ({
   );
 
   return (
-    <ActionForm<MarkBrokenFormValues>
+    <ActionForm<MarkBrokenFormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.MARK_BROKEN}
       allowAllEmpty

--- a/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -15,6 +15,7 @@ import machineURLs from "app/machines/urls";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import type { RootState } from "app/store/root/types";
 import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultsSelectors from "app/store/scriptresult/selectors";
@@ -123,7 +124,7 @@ export const OverrideTestForm = ({
   }, [dispatch, scriptResultsLoading, machineIDs, requestedScriptResults]);
 
   return (
-    <ActionForm<OverrideTestFormValues>
+    <ActionForm<OverrideTestFormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.OVERRIDE_FAILED_TESTING}
       allowUnchanged

--- a/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/ReleaseForm/ReleaseForm.tsx
@@ -14,6 +14,7 @@ import { actions as configActions } from "app/store/config";
 import configSelectors from "app/store/config/selectors";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { NodeActions } from "app/store/types/node";
 
 export type ReleaseFormValues = {
@@ -55,7 +56,7 @@ export const ReleaseForm = ({
     };
   }, [dispatch]);
   return configLoaded ? (
-    <ActionForm<ReleaseFormValues>
+    <ActionForm<ReleaseFormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.RELEASE}
       allowAllEmpty

--- a/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetPoolForm/SetPoolForm.tsx
@@ -11,6 +11,7 @@ import type { ClearSelectedAction } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { NodeActions } from "app/store/types/node";
@@ -61,7 +62,7 @@ export const SetPoolForm = ({
   );
 
   return (
-    <ActionForm<SetPoolFormValues>
+    <ActionForm<SetPoolFormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.SET_POOL}
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/SetZoneForm/SetZoneForm.tsx
@@ -10,6 +10,7 @@ import type { ClearSelectedAction } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { NodeActions } from "app/store/types/node";
 import { actions as zoneActions } from "app/store/zone";
 import zoneSelectors from "app/store/zone/selectors";
@@ -45,7 +46,7 @@ export const SetZoneForm = ({
   }, [dispatch]);
 
   return (
-    <ActionForm<SetZoneFormValues>
+    <ActionForm<SetZoneFormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.SET_ZONE}
       cleanup={machineActions.cleanup}

--- a/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TagForm/TagForm.tsx
@@ -44,9 +44,12 @@ export const TagForm = ({
     NodeActions.TAG
   );
 
-  const formErrors = { ...errors };
-  if (formErrors && formErrors.name) {
-    formErrors.tags = formErrors.name;
+  let formErrors: Record<string, string | string[]> | null = null;
+  if (errors && typeof errors === "object" && "name" in errors) {
+    formErrors = {
+      ...errors,
+      tags: errors.name,
+    };
     delete formErrors.name;
   }
 

--- a/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
+++ b/ui/src/app/machines/components/ActionFormWrapper/TestForm/TestForm.tsx
@@ -11,6 +11,7 @@ import type { ClearSelectedAction } from "app/base/types";
 import { useMachineActionForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { actions as scriptActions } from "app/store/script";
 import scriptSelectors from "app/store/script/selectors";
 import type { Script } from "app/store/script/types";
@@ -105,7 +106,7 @@ export const TestForm = ({
   }, [dispatch, scriptsLoaded]);
 
   return (
-    <ActionForm<FormValues>
+    <ActionForm<FormValues, MachineEventErrors>
       actionDisabled={actionDisabled}
       actionName={NodeActions.TEST}
       allowUnchanged

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.tsx
@@ -22,6 +22,7 @@ import type {
   LinkSubnetParams,
   MachineDetails,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
@@ -78,7 +79,7 @@ const AddAliasOrVlan = ({
   }
   return (
     <div ref={onRenderRef}>
-      <FormikForm<AddAliasOrVlanValues>
+      <FormikForm<AddAliasOrVlanValues, MachineEventErrors>
         cleanup={cleanup}
         errors={errors}
         initialValues={{

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.tsx
@@ -34,6 +34,7 @@ import {
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { CreateBondParams, MachineDetails } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   getInterfaceSubnet,
   getLinkFromNic,
@@ -158,7 +159,7 @@ const AddBondForm = ({
   const macAddress = firstNic?.mac_address || "";
   return (
     <FormCard sidebar={false} stacked title="Create bond">
-      <FormikForm<BondFormValues>
+      <FormikForm<BondFormValues, MachineEventErrors>
         allowUnchanged
         cleanup={cleanup}
         errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.tsx
@@ -24,6 +24,7 @@ import type {
   CreateBridgeParams,
   MachineDetails,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { getNextNicName, isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { BridgeType, NetworkInterfaceTypes } from "app/store/types/enum";
@@ -91,7 +92,7 @@ const AddBridgeForm = ({
   return (
     <FormCard sidebar={false} stacked title="Create bridge">
       <InterfaceFormTable interfaces={selected} systemId={systemId} />
-      <FormikForm<BridgeFormValues>
+      <FormikForm<BridgeFormValues, MachineEventErrors>
         allowUnchanged
         cleanup={cleanup}
         errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.tsx
@@ -25,6 +25,7 @@ import type {
   CreatePhysicalParams,
   MachineDetails,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { getNextNicName, isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
@@ -72,7 +73,7 @@ const AddInterface = ({ close, systemId }: Props): JSX.Element | null => {
   return (
     <div ref={onRenderRef}>
       <FormCard sidebar={false}>
-        <FormikForm<AddInterfaceValues>
+        <FormikForm<AddInterfaceValues, MachineEventErrors>
           cleanup={cleanup}
           errors={errors}
           initialValues={{

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.tsx
@@ -20,6 +20,7 @@ import type {
   MachineDetails,
   UpdateInterfaceParams,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   getInterfaceIPAddress,
   getInterfaceSubnet,
@@ -104,7 +105,7 @@ const EditAliasOrVlanForm = ({
   const ipAddress = getInterfaceIPAddress(machine, fabrics, vlans, nic, link);
   const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
   return (
-    <FormikForm<EditAliasOrVlanValues>
+    <FormikForm<EditAliasOrVlanValues, MachineEventErrors>
       cleanup={cleanup}
       errors={errors}
       initialValues={{

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBondForm/EditBondForm.tsx
@@ -33,6 +33,7 @@ import type {
   MachineDetails,
   UpdateInterfaceParams,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   getInterfaceIPAddress,
   getInterfaceSubnet,
@@ -162,7 +163,7 @@ const EditBondForm = ({
   const membersHaveChanged = !arrayItemsEqual(selectedIds, nic.parents);
   const macAddress = nic.mac_address || "";
   return (
-    <FormikForm<BondFormValues>
+    <FormikForm<BondFormValues, MachineEventErrors>
       allowUnchanged={membersHaveChanged}
       cleanup={cleanup}
       errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.tsx
@@ -17,6 +17,7 @@ import type {
   MachineDetails,
   UpdateInterfaceParams,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { isMachineDetails } from "app/store/machine/utils";
 import { getInterfaceTypeText } from "app/store/machine/utils/networking";
 import type { RootState } from "app/store/root/types";
@@ -75,7 +76,7 @@ const EditBridgeForm = ({
   }
   const interfaceTypeDisplay = getInterfaceTypeText(machine, nic, link);
   return (
-    <FormikForm<BridgeFormValues>
+    <FormikForm<BridgeFormValues, MachineEventErrors>
       allowUnchanged
       cleanup={cleanup}
       errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
@@ -21,6 +21,7 @@ import type {
   MachineDetails,
   UpdateInterfaceParams,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   getInterfaceIPAddress,
   getInterfaceSubnet,
@@ -106,7 +107,7 @@ const EditPhysicalForm = ({
   const ipAddress = getInterfaceIPAddress(machine, fabrics, vlans, nic, link);
 
   return (
-    <FormikForm<EditPhysicalValues>
+    <FormikForm<EditPhysicalValues, MachineEventErrors>
       cleanup={cleanup}
       errors={errors}
       initialValues={{

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddLogicalVolume/AddLogicalVolume.tsx
@@ -9,6 +9,7 @@ import { actions as machineActions } from "app/store/machine";
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { formatBytes } from "app/utils";
@@ -101,7 +102,7 @@ export const AddLogicalVolume = ({
     const AddLogicalVolumeSchema = generateSchema(disk.available_size);
 
     return (
-      <FormikForm<AddLogicalVolumeValues>
+      <FormikForm<AddLogicalVolumeValues, MachineEventErrors>
         allowUnchanged
         cleanup={machineActions.cleanup}
         errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/AddPartition/AddPartition.tsx
@@ -9,6 +9,7 @@ import { actions as machineActions } from "app/store/machine";
 import { MIN_PARTITION_SIZE } from "app/store/machine/constants";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import { formatBytes } from "app/utils";
@@ -96,7 +97,7 @@ export const AddPartition = ({
     const AddPartitionSchema = generateSchema(disk.available_size);
 
     return (
-      <FormikForm<AddPartitionValues>
+      <FormikForm<AddPartitionValues, MachineEventErrors>
         allowUnchanged
         cleanup={machineActions.cleanup}
         errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateDatastore/CreateDatastore.tsx
@@ -17,6 +17,7 @@ import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   formatSize,
   formatType,
@@ -77,7 +78,7 @@ export const CreateDatastore = ({
   if (isMachineDetails(machine)) {
     return (
       <FormCard sidebar={false}>
-        <FormikForm<CreateDatastoreValues>
+        <FormikForm<CreateDatastoreValues, MachineEventErrors>
           allowUnchanged
           cleanup={machineActions.cleanup}
           errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateRaid/CreateRaid.tsx
@@ -10,6 +10,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
 import { DiskTypes } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   isMachineDetails,
   isRaid,
@@ -89,7 +90,7 @@ export const CreateRaid = ({
   if (isMachineDetails(machine)) {
     return (
       <FormCard sidebar={false}>
-        <FormikForm<CreateRaidValues>
+        <FormikForm<CreateRaidValues, MachineEventErrors>
           allowUnchanged
           cleanup={machineActions.cleanup}
           errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/CreateVolumeGroup/CreateVolumeGroup.tsx
@@ -18,6 +18,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { DiskTypes } from "app/store/machine/types";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   formatSize,
   formatType,
@@ -71,7 +72,7 @@ export const CreateVolumeGroup = ({
   if (isMachineDetails(machine)) {
     return (
       <FormCard sidebar={false}>
-        <FormikForm<CreateVolumeGroupValues>
+        <FormikForm<CreateVolumeGroupValues, MachineEventErrors>
           allowUnchanged
           cleanup={machineActions.cleanup}
           errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/BulkActions/UpdateDatastore/UpdateDatastore.tsx
@@ -9,6 +9,7 @@ import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   isDatastore,
   isMachineDetails,
@@ -60,7 +61,7 @@ export const UpdateDatastore = ({
 
     return (
       <FormCard sidebar={false}>
-        <FormikForm<UpdateDatastoreValues>
+        <FormikForm<UpdateDatastoreValues, MachineEventErrors>
           allowUnchanged
           cleanup={machineActions.cleanup}
           errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/CreateBcache/CreateBcache.tsx
@@ -9,6 +9,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
 import { BcacheModes } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import {
   isBcache,
   isCacheSet,
@@ -84,7 +85,7 @@ export const CreateBcache = ({
     }
 
     return (
-      <FormikForm<CreateBcacheValues>
+      <FormikForm<CreateBcacheValues, MachineEventErrors>
         allowUnchanged
         cleanup={machineActions.cleanup}
         errors={errors}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDisk.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditDisk/EditDisk.tsx
@@ -7,6 +7,7 @@ import FormikForm from "app/base/components/FormikForm";
 import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import type { Disk, Machine } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { formatType } from "app/store/machine/utils";
 
 export type EditDiskValues = {
@@ -46,7 +47,7 @@ export const EditDisk = ({
   );
 
   return (
-    <FormikForm<EditDiskValues>
+    <FormikForm<EditDiskValues, MachineEventErrors>
       cleanup={machineActions.cleanup}
       errors={errors}
       initialValues={{

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/AvailableStorageTable/EditPartition/EditPartition.tsx
@@ -8,6 +8,7 @@ import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Disk, Machine, Partition } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
@@ -54,7 +55,7 @@ export const EditPartition = ({
     const fs = partition.filesystem;
 
     return (
-      <FormikForm<EditPartitionValues>
+      <FormikForm<EditPartitionValues, MachineEventErrors>
         cleanup={machineActions.cleanup}
         errors={errors}
         initialValues={{

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -10,6 +10,7 @@ import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import { StorageLayout } from "app/store/machine/types";
 import type { Machine } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 
 type StorageLayoutOption = {
   label: string;
@@ -69,7 +70,7 @@ export const ChangeStorageLayout = ({ systemId }: Props): JSX.Element => {
     </div>
   ) : (
     <FormCard data-test="confirmation-form" sidebar={false}>
-      <FormikForm<EmptyObject>
+      <FormikForm<EmptyObject, MachineEventErrors>
         cleanup={machineActions.cleanup}
         errors={errors}
         initialValues={{}}

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.tsx
@@ -9,6 +9,7 @@ import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import { isMachineDetails, usesStorage } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
@@ -56,7 +57,7 @@ export const AddSpecialFilesystem = ({
 
     return (
       <FormCard data-test="confirmation-form" sidebar={false}>
-        <FormikForm<AddSpecialFilesystemValues>
+        <FormikForm<AddSpecialFilesystemValues, MachineEventErrors>
           cleanup={machineActions.cleanup}
           errors={errors}
           initialValues={{

--- a/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
+++ b/ui/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
@@ -39,11 +39,11 @@ const ScriptsUpload = ({ type }: Props): JSX.Element => {
   useWindowTitle(title);
 
   useEffect(() => {
-    if (hasErrors) {
-      Object.keys(errors).forEach((key) => {
+    if (hasErrors && errors && typeof errors === "object") {
+      Object.values(errors).forEach((error) => {
         dispatch(
           messageActions.add(
-            `Error uploading ${savedScript}: ${errors[key]}`,
+            `Error uploading ${savedScript}: ${error}`,
             NotificationSeverity.NEGATIVE
           )
         );

--- a/ui/src/app/store/auth/selectors.ts
+++ b/ui/src/app/store/auth/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { RootState } from "app/store/root/types";
 import type { User } from "app/store/user/types";
 
@@ -30,7 +30,7 @@ const loaded = (state: RootState): boolean => state.user.auth.loaded;
  * @param state - The redux state.
  * @returns Errors for a user.
  */
-const errors = (state: RootState): TSFixMe => state.user.auth.errors;
+const errors = (state: RootState): APIError => state.user.auth.errors;
 
 /**
  * Get the saving state for the authenticated user.

--- a/ui/src/app/store/config/types/base.ts
+++ b/ui/src/app/store/config/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { GenericState } from "app/store/types/state";
 
 export type ConfigChoice = [string | number, string];
@@ -11,4 +11,4 @@ export type Config<V> = {
   choices?: ConfigChoice[];
 };
 
-export type ConfigState = GenericState<Config<ConfigValues>, TSFixMe>;
+export type ConfigState = GenericState<Config<ConfigValues>, APIError>;

--- a/ui/src/app/store/controller/types/base.ts
+++ b/ui/src/app/store/controller/types/base.ts
@@ -1,6 +1,6 @@
 import type { ControllerInstallType, ControllerVersionIssues } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { NodeActions, BaseNode, NodeType } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
 
@@ -45,4 +45,4 @@ export type Controller = BaseNode & {
   vlans_ha?: ControllerVlansHA;
 };
 
-export type ControllerState = GenericState<Controller, TSFixMe>;
+export type ControllerState = GenericState<Controller, APIError>;

--- a/ui/src/app/store/device/types/base.ts
+++ b/ui/src/app/store/device/types/base.ts
@@ -1,6 +1,6 @@
 import type { DeviceIpAssignment } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { ModelRef } from "app/store/types/model";
 import type {
   NetworkInterface,
@@ -39,4 +39,4 @@ export type DeviceDetails = Device & {
   updated: string;
 };
 
-export type DeviceState = GenericState<Device, TSFixMe>;
+export type DeviceState = GenericState<Device, APIError>;

--- a/ui/src/app/store/dhcpsnippet/types/base.ts
+++ b/ui/src/app/store/dhcpsnippet/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Device } from "app/store/device/types";
 import type { Subnet } from "app/store/subnet/types";
 import type { Host } from "app/store/types/host";
@@ -22,4 +22,4 @@ export type DHCPSnippet = Model & {
   value: string;
 };
 
-export type DHCPSnippetState = GenericState<DHCPSnippet, TSFixMe>;
+export type DHCPSnippetState = GenericState<DHCPSnippet, APIError>;

--- a/ui/src/app/store/discovery/types/base.ts
+++ b/ui/src/app/store/discovery/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -26,4 +26,4 @@ export type Discovery = Model & {
   vlan: number;
 };
 
-export type DiscoveryState = GenericState<Discovery, TSFixMe>;
+export type DiscoveryState = GenericState<Discovery, APIError>;

--- a/ui/src/app/store/domain/slice.ts
+++ b/ui/src/app/store/domain/slice.ts
@@ -20,6 +20,7 @@ import type {
   UpdateRecordParams,
 } from "./types";
 
+import type { APIError } from "app/base/types";
 import {
   generateCommonReducers,
   genericInitialState,
@@ -190,7 +191,10 @@ const domainSlice = createSlice({
       state.saving = true;
       state.saved = false;
     },
-    createAddressRecordError: (state: DomainState, action: PayloadAction) => {
+    createAddressRecordError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.saving = false;
       state.errors = action.payload;
     },
@@ -217,7 +221,10 @@ const domainSlice = createSlice({
       state.saving = true;
       state.saved = false;
     },
-    createDNSDataError: (state: DomainState, action: PayloadAction) => {
+    createDNSDataError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.saving = false;
       state.errors = action.payload;
     },
@@ -246,7 +253,10 @@ const domainSlice = createSlice({
       state.saving = true;
       state.saved = false;
     },
-    deleteAddressRecordError: (state: DomainState, action: PayloadAction) => {
+    deleteAddressRecordError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.saving = false;
       state.errors = action.payload;
     },
@@ -275,7 +285,10 @@ const domainSlice = createSlice({
       state.saving = true;
       state.saved = false;
     },
-    deleteDNSDataError: (state: DomainState, action: PayloadAction) => {
+    deleteDNSDataError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.saving = false;
       state.errors = action.payload;
     },
@@ -300,7 +313,10 @@ const domainSlice = createSlice({
         // No state changes need to be handled for this action.
       },
     },
-    deleteDNSResourceError: (state: DomainState, action: PayloadAction) => {
+    deleteDNSResourceError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.errors = action.payload;
     },
     deleteDNSResourceSuccess: (state: DomainState) => {
@@ -336,7 +352,10 @@ const domainSlice = createSlice({
       state.saving = true;
       state.saved = false;
     },
-    updateAddressRecordError: (state: DomainState, action: PayloadAction) => {
+    updateAddressRecordError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.saving = false;
       state.errors = action.payload;
     },
@@ -365,7 +384,10 @@ const domainSlice = createSlice({
       state.saving = true;
       state.saved = false;
     },
-    updateDNSDataError: (state: DomainState, action: PayloadAction) => {
+    updateDNSDataError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.saving = false;
       state.errors = action.payload;
     },
@@ -390,7 +412,10 @@ const domainSlice = createSlice({
         // No state changes need to be handled for this action.
       },
     },
-    updateDNSResourceError: (state: DomainState, action: PayloadAction) => {
+    updateDNSResourceError: (
+      state: DomainState,
+      action: PayloadAction<APIError>
+    ) => {
       state.errors = action.payload;
     },
     updateDNSResourceSuccess: (state: DomainState) => {

--- a/ui/src/app/store/domain/types/actions.ts
+++ b/ui/src/app/store/domain/types/actions.ts
@@ -44,7 +44,7 @@ export type DeleteRecordParams = {
   rrset: DomainResource;
 };
 
-export type SetDefaultErrors = string | number | { domain: string[] };
+export type SetDefaultErrors = string | { domain: string[] };
 
 export type UpdateAddressRecordParams = {
   address_ttl: DomainResource["ttl"];

--- a/ui/src/app/store/domain/types/base.ts
+++ b/ui/src/app/store/domain/types/base.ts
@@ -1,6 +1,6 @@
 import type { RecordType } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { BaseNode, NodeType } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
@@ -38,4 +38,4 @@ export type Domain = BaseDomain | DomainDetails;
 
 export type DomainState = {
   active: number | null;
-} & GenericState<Domain, TSFixMe>;
+} & GenericState<Domain, APIError>;

--- a/ui/src/app/store/fabric/types/base.ts
+++ b/ui/src/app/store/fabric/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -12,4 +12,4 @@ export type Fabric = Model & {
   vlan_ids: number[];
 };
 
-export type FabricState = GenericState<Fabric, TSFixMe>;
+export type FabricState = GenericState<Fabric, APIError>;

--- a/ui/src/app/store/general/selectors/utils.ts
+++ b/ui/src/app/store/general/selectors/utils.ts
@@ -1,9 +1,9 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { GeneralState } from "app/store/general/types";
 import type { RootState } from "app/store/root/types";
 
 type GeneralSelector<T extends keyof GeneralState> = {
-  errors: (state: RootState) => TSFixMe;
+  errors: (state: RootState) => APIError;
   get: (state: RootState) => GeneralState[T]["data"];
   loaded: (state: RootState) => boolean;
   loading: (state: RootState) => boolean;

--- a/ui/src/app/store/general/types/base.ts
+++ b/ui/src/app/store/general/types/base.ts
@@ -7,13 +7,13 @@ import type {
   PowerFieldType,
 } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { MachineActions } from "app/store/machine/types";
 
 export type Architecture = string;
 
 export type ArchitecturesState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: Architecture[];
   loaded: boolean;
   loading: boolean;
@@ -49,7 +49,7 @@ export type BondOptions = {
 };
 
 export type BondOptionsState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: BondOptions;
   loaded: boolean;
   loading: boolean;
@@ -58,7 +58,7 @@ export type BondOptionsState = {
 export type ComponentToDisable = "restricted" | "universe" | "multiverse";
 
 export type ComponentsToDisableState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: ComponentToDisable[];
   loaded: boolean;
   loading: boolean;
@@ -67,7 +67,7 @@ export type ComponentsToDisableState = {
 export type DefaultMinHweKernel = string;
 
 export type DefaultMinHweKernelState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: DefaultMinHweKernel;
   loaded: boolean;
   loading: boolean;
@@ -76,7 +76,7 @@ export type DefaultMinHweKernelState = {
 export type HWEKernel = [string, string];
 
 export type HWEKernelsState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: HWEKernel[];
   loaded: boolean;
   loading: boolean;
@@ -91,7 +91,7 @@ export type KnownArchitecture =
   | "s390x";
 
 export type KnownArchitecturesState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: KnownArchitecture[];
   loaded: boolean;
   loading: boolean;
@@ -105,7 +105,7 @@ export type MachineAction = {
 };
 
 export type MachineActionsState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: MachineAction[];
   loaded: boolean;
   loading: boolean;
@@ -134,7 +134,7 @@ export type OSInfo = {
 };
 
 export type OSInfoState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: OSInfo | null;
   loaded: boolean;
   loading: boolean;
@@ -143,7 +143,7 @@ export type OSInfoState = {
 export type PocketToDisable = "updates" | "security" | "backports";
 
 export type PocketsToDisableState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: PocketToDisable[];
   loaded: boolean;
   loading: boolean;
@@ -178,7 +178,7 @@ export type PowerType = {
 };
 
 export type PowerTypesState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: PowerType[];
   loaded: boolean;
   loading: boolean;
@@ -187,7 +187,7 @@ export type PowerTypesState = {
 export type Version = string;
 
 export type VersionState = {
-  errors: TSFixMe;
+  errors: APIError;
   data: Version;
   loaded: boolean;
   loading: boolean;

--- a/ui/src/app/store/licensekeys/selectors.ts
+++ b/ui/src/app/store/licensekeys/selectors.ts
@@ -24,7 +24,7 @@ const defaultSelectors = generateBaseSelectors<
  */
 const hasErrors = createSelector(
   [defaultSelectors.errors],
-  (errors) => errors && Object.entries(errors).length > 0
+  (errors) => !!errors && Object.entries(errors).length > 0
 );
 
 /**

--- a/ui/src/app/store/licensekeys/types/base.ts
+++ b/ui/src/app/store/licensekeys/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -9,4 +9,4 @@ export type LicenseKeys = Model & {
   resource_uri: string;
 };
 
-export type LicenseKeysState = GenericState<LicenseKeys, TSFixMe>;
+export type LicenseKeysState = GenericState<LicenseKeys, APIError>;

--- a/ui/src/app/store/machine/slice.ts
+++ b/ui/src/app/store/machine/slice.ts
@@ -1345,7 +1345,7 @@ const machineSlice = createSlice({
     },
     setActiveError: (
       state: MachineState,
-      action: PayloadAction<MachineState["errors"][0]>
+      action: PayloadAction<MachineState["errors"]>
     ) => {
       state.active = null;
       state.errors = action.payload;

--- a/ui/src/app/store/machine/types/base.ts
+++ b/ui/src/app/store/machine/types/base.ts
@@ -1,6 +1,7 @@
 import type { DiskTypes, PowerState, StorageLayout } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
+import type { CloneError } from "app/machines/components/ActionFormWrapper/CloneForm/CloneResults/CloneResults";
 import type { Model, ModelRef } from "app/store/types/model";
 import type {
   BaseNode,
@@ -274,9 +275,11 @@ export type MachineStatus = {
 
 export type MachineStatuses = Record<string, MachineStatus>;
 
+export type MachineEventErrors = CloneError;
+
 export type MachineState = {
   active: string | null;
-  eventErrors: EventError<Machine, TSFixMe, "system_id">[];
+  eventErrors: EventError<Machine, APIError<MachineEventErrors>, "system_id">[];
   selected: Machine["system_id"][];
   statuses: MachineStatuses;
-} & GenericState<Machine, TSFixMe>;
+} & GenericState<Machine, APIError>;

--- a/ui/src/app/store/nodedevice/types/base.ts
+++ b/ui/src/app/store/nodedevice/types/base.ts
@@ -1,7 +1,7 @@
 import type { NodeDeviceBus } from "./enum";
 
 import type { HardwareType } from "app/base/enum";
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Disk, Machine, MachineNumaNode } from "app/store/machine/types";
 import type { Model } from "app/store/types/model";
 import type { NetworkInterface } from "app/store/types/node";
@@ -26,4 +26,4 @@ export type NodeDevice = Model & {
   vendor_name: string;
 };
 
-export type NodeDeviceState = GenericState<NodeDevice, TSFixMe>;
+export type NodeDeviceState = GenericState<NodeDevice, APIError>;

--- a/ui/src/app/store/notification/types/base.ts
+++ b/ui/src/app/store/notification/types/base.ts
@@ -1,6 +1,6 @@
 import type { NotificationCategory, NotificationIdent } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 import type { User } from "app/store/user/types";
@@ -17,4 +17,4 @@ export type Notification = Model & {
   dismissable: boolean;
 };
 
-export type NotificationState = GenericState<Notification, TSFixMe>;
+export type NotificationState = GenericState<Notification, APIError>;

--- a/ui/src/app/store/packagerepository/types/base.ts
+++ b/ui/src/app/store/packagerepository/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -18,4 +18,4 @@ export type PackageRepository = Model & {
   url: string;
 };
 
-export type PackageRepositoryState = GenericState<PackageRepository, TSFixMe>;
+export type PackageRepositoryState = GenericState<PackageRepository, APIError>;

--- a/ui/src/app/store/pod/types/base.ts
+++ b/ui/src/app/store/pod/types/base.ts
@@ -1,6 +1,6 @@
 import type { PodType } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { Node } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
@@ -145,4 +145,4 @@ export type PodState = {
   active: number | null;
   projects: PodProjects;
   statuses: PodStatuses;
-} & GenericState<Pod, TSFixMe>;
+} & GenericState<Pod, APIError>;

--- a/ui/src/app/store/resourcepool/types/base.ts
+++ b/ui/src/app/store/resourcepool/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -13,4 +13,4 @@ export type ResourcePool = Model & {
   updated: string;
 };
 
-export type ResourcePoolState = GenericState<ResourcePool, TSFixMe>;
+export type ResourcePoolState = GenericState<ResourcePool, APIError>;

--- a/ui/src/app/store/script/selectors.test.ts
+++ b/ui/src/app/store/script/selectors.test.ts
@@ -32,6 +32,35 @@ describe("script selectors", () => {
     });
   });
 
+  describe("hasErrors", () => {
+    it("can identify errors from a string", () => {
+      const state = rootStateFactory({
+        script: scriptStateFactory({
+          errors: "Uh oh!",
+        }),
+      });
+      expect(script.hasErrors(state)).toStrictEqual(true);
+    });
+
+    it("can identify errors from an object", () => {
+      const state = rootStateFactory({
+        script: scriptStateFactory({
+          errors: { name: "Name is required" },
+        }),
+      });
+      expect(script.hasErrors(state)).toStrictEqual(true);
+    });
+
+    it("does not identify errors from an empty object", () => {
+      const state = rootStateFactory({
+        script: scriptStateFactory({
+          errors: {},
+        }),
+      });
+      expect(script.hasErrors(state)).toStrictEqual(false);
+    });
+  });
+
   describe("loaded", () => {
     it("returns script loaded state", () => {
       const state = rootStateFactory({

--- a/ui/src/app/store/script/selectors.ts
+++ b/ui/src/app/store/script/selectors.ts
@@ -18,10 +18,10 @@ const defaultSelectors = generateBaseSelectors<
  * @param {RootState} state - Redux state
  * @returns {Boolean} have errors
  */
-const hasErrors = createSelector(
-  [defaultSelectors.errors],
-  (errors) =>
-    errors && typeof errors === "object" && Object.entries(errors).length > 0
+const hasErrors = createSelector([defaultSelectors.errors], (errors) =>
+  typeof errors === "object" && errors !== null
+    ? Object.entries(errors).length > 0
+    : !!errors
 );
 
 /**

--- a/ui/src/app/store/script/types/base.ts
+++ b/ui/src/app/store/script/types/base.ts
@@ -1,6 +1,6 @@
 import type { ScriptType } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError, TSFixMe } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -41,4 +41,4 @@ export type Script = Model & {
   updated: string;
 };
 
-export type ScriptState = GenericState<Script, TSFixMe>;
+export type ScriptState = GenericState<Script, APIError>;

--- a/ui/src/app/store/scriptresult/selectors.ts
+++ b/ui/src/app/store/scriptresult/selectors.ts
@@ -12,7 +12,7 @@ import { ScriptResultType } from "./types";
 import { scriptResultFailed } from "./utils";
 
 import { HardwareType } from "app/base/enum";
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { NodeScriptResultState } from "app/store/nodescriptresult/types";
 import type { RootState } from "app/store/root/types";
 
@@ -70,7 +70,7 @@ const saved = (state: RootState): boolean => state.scriptresult.saved;
  * @param {RootState} state - The redux state.
  * @returns {ScriptResultState["errors"]} Errors for a script result.
  */
-const errors = (state: RootState): TSFixMe => state.scriptresult.errors;
+const errors = (state: RootState): APIError => state.scriptresult.errors;
 
 /**
  * Get a script result by id.
@@ -93,9 +93,10 @@ const getById = createSelector(
  * @param {RootState} state - Redux state
  * @returns {Boolean} Script results have errors
  */
-const hasErrors = createSelector(
-  [errors],
-  (errors) => Object.entries(errors).length > 0
+const hasErrors = createSelector([errors], (errors) =>
+  errors && typeof errors === "object"
+    ? Object.entries(errors).length > 0
+    : !!errors
 );
 
 const getResult = (

--- a/ui/src/app/store/scriptresult/types/base.ts
+++ b/ui/src/app/store/scriptresult/types/base.ts
@@ -8,7 +8,7 @@ import type {
 } from "./enum";
 
 import type { HardwareType } from "app/base/enum";
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { NetworkInterface } from "app/store/types/node";
 import type { GenericState } from "app/store/types/state";
@@ -91,7 +91,7 @@ export type ScriptResultData = {
   result?: string;
 };
 
-export type ScriptResultState = GenericState<ScriptResult, TSFixMe> & {
+export type ScriptResultState = GenericState<ScriptResult, APIError> & {
   history: Record<ScriptResult[ScriptResultMeta.PK], PartialScriptResult[]>;
   logs: Record<ScriptResult[ScriptResultMeta.PK], ScriptResultData> | null;
 };

--- a/ui/src/app/store/service/types/base.ts
+++ b/ui/src/app/store/service/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -8,4 +8,4 @@ export type Service = Model & {
   status_info: string;
 };
 
-export type ServiceState = GenericState<Service, TSFixMe>;
+export type ServiceState = GenericState<Service, APIError>;

--- a/ui/src/app/store/space/types/base.ts
+++ b/ui/src/app/store/space/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -11,4 +11,4 @@ export type Space = Model & {
   vlan_ids: number[];
 };
 
-export type SpaceState = GenericState<Space, TSFixMe>;
+export type SpaceState = GenericState<Space, APIError>;

--- a/ui/src/app/store/sshkey/types/base.ts
+++ b/ui/src/app/store/sshkey/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 import type { User } from "app/store/user/types";
@@ -17,4 +17,4 @@ export type SSHKey = Model & {
   user: User["id"];
 };
 
-export type SSHKeyState = GenericState<SSHKey, TSFixMe>;
+export type SSHKeyState = GenericState<SSHKey, APIError>;

--- a/ui/src/app/store/sslkey/types/base.ts
+++ b/ui/src/app/store/sslkey/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 import type { User, UserMeta } from "app/store/user/types";
@@ -11,4 +11,4 @@ export type SSLKey = Model & {
   user: User[UserMeta.PK];
 };
 
-export type SSLKeyState = GenericState<SSLKey, TSFixMe>;
+export type SSLKeyState = GenericState<SSLKey, APIError>;

--- a/ui/src/app/store/status/selectors.test.ts
+++ b/ui/src/app/store/status/selectors.test.ts
@@ -18,10 +18,10 @@ describe("status", () => {
   it("can get the error status", () => {
     const state = rootStateFactory({
       status: statusStateFactory({
-        error: false,
+        error: "Timeout",
       }),
     });
-    expect(status.error(state)).toBe(false);
+    expect(status.error(state)).toBe("Timeout");
   });
 
   it("can get the authenticated status", () => {

--- a/ui/src/app/store/status/selectors.ts
+++ b/ui/src/app/store/status/selectors.ts
@@ -31,11 +31,11 @@ const connected = (state: RootState): boolean => state.status.connected;
 const connecting = (state: RootState): boolean => state.status.connecting;
 
 /**
- * Whether there is a websocket error.
+ * Status errors.
  * @param {RootState} state - The redux state.
  * @returns {StatusState["error"]} TheStatusState error status.
  */
-const error = (state: RootState): boolean => state.status.error;
+const error = (state: RootState): APIError => state.status.error;
 
 /**
  * An authentication error.

--- a/ui/src/app/store/status/types/base.ts
+++ b/ui/src/app/store/status/types/base.ts
@@ -1,12 +1,12 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 
 export type StatusState = {
   authenticated: boolean;
   authenticating: boolean;
-  authenticationError: TSFixMe;
+  authenticationError: APIError;
   connected: boolean;
   connecting: boolean;
-  error: TSFixMe;
+  error: APIError;
   externalAuthURL: string | null;
   externalLoginURL: string | null;
   noUsers: boolean;

--- a/ui/src/app/store/subnet/types/base.ts
+++ b/ui/src/app/store/subnet/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 import type { VLAN } from "app/store/vlan/types";
@@ -45,4 +45,4 @@ export type Subnet = Model & {
   vlan: VLAN["id"];
 };
 
-export type SubnetState = GenericState<Subnet, TSFixMe>;
+export type SubnetState = GenericState<Subnet, APIError>;

--- a/ui/src/app/store/tag/types/base.ts
+++ b/ui/src/app/store/tag/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -11,4 +11,4 @@ export type Tag = Model & {
   kernel_opts: string | null;
 };
 
-export type TagState = GenericState<Tag, TSFixMe>;
+export type TagState = GenericState<Tag, APIError>;

--- a/ui/src/app/store/token/types/base.ts
+++ b/ui/src/app/store/token/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -13,4 +13,4 @@ export type Token = Model & {
   secret: string;
 };
 
-export type TokenState = GenericState<Token, TSFixMe>;
+export type TokenState = GenericState<Token, APIError>;

--- a/ui/src/app/store/user/types/base.ts
+++ b/ui/src/app/store/user/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -16,7 +16,7 @@ export type User = Model & {
 };
 
 export type AuthState = {
-  errors: TSFixMe;
+  errors: APIError;
   loaded: boolean;
   loading: boolean;
   saved: boolean;
@@ -29,7 +29,7 @@ export type UserStatuses = {
 };
 
 export type UserEventError = {
-  error: string;
+  error: APIError;
   event: string;
 };
 
@@ -37,4 +37,4 @@ export type UserState = {
   auth: AuthState;
   statuses: UserStatuses;
   eventErrors: UserEventError[];
-} & GenericState<User, TSFixMe>;
+} & GenericState<User, APIError>;

--- a/ui/src/app/store/utils/slice.ts
+++ b/ui/src/app/store/utils/slice.ts
@@ -109,7 +109,7 @@ export const updateErrors = <
   );
   // Set the new error.
   newErrors.push({
-    error: action?.payload,
+    error: action?.payload ?? null,
     event,
     id: metaId,
   });
@@ -331,7 +331,10 @@ export type StatusHandlers<
   status: string;
   statusKey: keyof S["statuses"][keyof S["statuses"]];
   // The handler for when there is an error.
-  error?: CaseReducer<S, PayloadAction<I, string, GenericItemMeta<I>>>;
+  error?: CaseReducer<
+    S,
+    PayloadAction<S["errors"], string, GenericItemMeta<I>>
+  >;
   // The handler for when the action has started.
   start?: CaseReducer<S, PayloadAction<I, string, GenericItemMeta<I>>>;
   // The handler for when the action has successfully completed.
@@ -420,7 +423,7 @@ export const generateStatusHandlers = <
           }),
           reducer: (
             state: Draft<S>,
-            action: PayloadAction<I, string, GenericItemMeta<I>>
+            action: PayloadAction<S["errors"], string, GenericItemMeta<I>>
           ) => {
             // Call the reducer handler if supplied.
             status.error && status.error(state, action);

--- a/ui/src/app/store/vlan/types/base.ts
+++ b/ui/src/app/store/vlan/types/base.ts
@@ -1,6 +1,6 @@
 import type { VlanVid } from "./enum";
 
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Fabric, FabricMeta } from "app/store/fabric/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
@@ -22,4 +22,4 @@ export type VLAN = Model & {
   vid: VlanVid.UNTAGGED | number;
 };
 
-export type VLANState = GenericState<VLAN, TSFixMe>;
+export type VLANState = GenericState<VLAN, APIError>;

--- a/ui/src/app/store/zone/types/base.ts
+++ b/ui/src/app/store/zone/types/base.ts
@@ -1,4 +1,4 @@
-import type { TSFixMe } from "app/base/types";
+import type { APIError } from "app/base/types";
 import type { Model } from "app/store/types/model";
 import type { GenericState } from "app/store/types/state";
 
@@ -12,4 +12,4 @@ export type Zone = Model & {
   updated: string;
 };
 
-export type ZoneState = GenericState<Zone, TSFixMe>;
+export type ZoneState = GenericState<Zone, APIError>;

--- a/ui/src/app/utils/formatErrors.ts
+++ b/ui/src/app/utils/formatErrors.ts
@@ -1,10 +1,11 @@
-import type { APIError } from "app/base/types";
-
-const flattenErrors = (errors: string | string[]): string => {
+const flattenErrors = (errors: unknown): string | null => {
   if (Array.isArray(errors)) {
     return errors.join(" ");
   }
-  return errors;
+  if (typeof errors === "string") {
+    return errors;
+  }
+  return null;
 };
 
 /**
@@ -13,19 +14,19 @@ const flattenErrors = (errors: string | string[]): string => {
  * @param errors - the errors string/array/object
  * @returns error message
  */
-export const formatErrors = (
-  errors?: APIError,
-  errorKey?: string
+export const formatErrors = <E>(
+  errors?: E,
+  errorKey?: keyof E
 ): string | null => {
   let errorMessage: string | null = null;
   if (errors) {
     if (Array.isArray(errors)) {
-      errorMessage = errors?.join(" ");
-    } else if (typeof errors === "object" && errors !== null) {
-      if (errorKey) {
+      errorMessage = errors.join(" ");
+    } else if (typeof errors === "object") {
+      if (errorKey && errorKey in errors) {
         errorMessage = flattenErrors(errors[errorKey]);
       } else {
-        errorMessage = Object.entries<string | string[]>(errors)
+        errorMessage = Object.entries(errors)
           .map(([key, value]) => `${key}: ${flattenErrors(value)}`)
           .join(" ");
       }

--- a/ui/src/testing/factories/state.ts
+++ b/ui/src/testing/factories/state.ts
@@ -1,6 +1,7 @@
 import type { RouterLocation, RouterState } from "connected-react-router";
 import { define, random } from "cooky-cutter";
 
+import type { APIError } from "app/base/types";
 import type { BootResourceState } from "app/store/bootresource/types";
 import type { ConfigState } from "app/store/config/types";
 import type { ControllerState } from "app/store/controller/types";
@@ -32,6 +33,7 @@ import type {
   MachineStatus,
   MachineStatuses,
 } from "app/store/machine/types";
+import type { MachineEventErrors } from "app/store/machine/types/base";
 import type { MessageState } from "app/store/message/types";
 import type { NodeDeviceState } from "app/store/nodedevice/types";
 import type { NodeScriptResultState } from "app/store/nodescriptresult/types";
@@ -146,7 +148,7 @@ export const machineStatuses = define<MachineStatuses>({
 });
 
 export const machineEventError = define<
-  EventError<Machine, MachineState["errors"], "system_id">
+  EventError<Machine, APIError<MachineEventErrors>, "system_id">
 >({
   id: random().toString(),
   error: "Uh oh",


### PR DESCRIPTION
## Done

- Use the `APIErrors` type for all errors instead of `TSFixMe`.
- Update form components to handle event errors that have specific types.

## QA

N/A