### PR TITLE
feat(ui): add UI support for VMFS7 (3.0 backport)

### DIFF
--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -9,27 +9,40 @@ import FormikForm from "app/base/components/FormikForm";
 import { useMachineDetailsForm } from "app/machines/hooks";
 import { actions as machineActions } from "app/store/machine";
 import type { Machine } from "app/store/machine/types";
+import { StorageLayout } from "app/store/machine/types";
+import { isVMWareLayout } from "app/store/machine/utils";
 
 type StorageLayoutOption = {
   label: string;
   sentenceLabel: string;
-  value: string;
+  value: StorageLayout;
 };
 
 type Props = { systemId: Machine["system_id"] };
 
 const storageLayoutOptions: StorageLayoutOption[][] = [
   [
-    { label: "Flat", sentenceLabel: "flat", value: "flat" },
-    { label: "LVM", sentenceLabel: "LVM", value: "lvm" },
-    { label: "bcache", sentenceLabel: "bcache", value: "bcache" },
+    { label: "Flat", sentenceLabel: "flat", value: StorageLayout.FLAT },
+    { label: "LVM", sentenceLabel: "LVM", value: StorageLayout.LVM },
+    { label: "bcache", sentenceLabel: "bcache", value: StorageLayout.BCACHE },
   ],
-  [{ label: "VMFS6 (VMware ESXI)", sentenceLabel: "VMFS6", value: "vmfs6" }],
+  [
+    {
+      label: "VMFS6",
+      sentenceLabel: "VMFS6",
+      value: StorageLayout.VMFS6,
+    },
+    {
+      label: "VMFS7",
+      sentenceLabel: "VMFS7",
+      value: StorageLayout.VMFS7,
+    },
+  ],
   [
     {
       label: "No storage (blank) layout",
       sentenceLabel: "blank",
-      value: "blank",
+      value: StorageLayout.BLANK,
     },
   ],
 ];
@@ -101,14 +114,14 @@ export const ChangeStorageLayout = ({ systemId }: Props): JSX.Element => {
               <br />
               Any changes done already will be lost.
               <br />
-              {selectedLayout.value === "blank" && (
+              {selectedLayout.value === StorageLayout.BLANK && (
                 <>
                   Used disks will be returned to available, and any volume
                   groups, raid sets, caches, and filesystems removed.
                   <br />
                 </>
               )}
-              {selectedLayout.value === "vmfs6" && (
+              {isVMWareLayout(selectedLayout.value) && (
                 <>
                   This layout allows only for the deployment of{" "}
                   <strong>VMware ESXi</strong> images.

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/DatastoresTable/DatastoresTable.tsx
@@ -41,7 +41,7 @@ const DatastoresTable = ({
 
   if (machine && "disks" in machine) {
     const rows = machine.disks.reduce<TSFixMe[]>((rows, disk) => {
-      if (isDatastore(disk.filesystem)) {
+      if (disk.filesystem && isDatastore(disk.filesystem)) {
         const fs = disk.filesystem;
         const rowId = `${fs.fstype}-${fs.id}`;
         const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
@@ -49,7 +49,7 @@ const DatastoresTable = ({
           className: isExpanded ? "p-table__row is-active" : null,
           columns: [
             { content: disk.name },
-            { content: "VMFS6" },
+            { content: fs.fstype },
             { content: formatSize(disk.size) },
             { content: fs.mount_point },
             {

--- a/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/ui/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -13,8 +13,11 @@ import UsedStorageTable from "./UsedStorageTable";
 import { useSendAnalytics, useWindowTitle } from "app/base/hooks";
 import type { RouteParams } from "app/base/types";
 import machineSelectors from "app/store/machine/selectors";
-import { StorageLayout } from "app/store/machine/types";
-import { isCacheSet, useCanEditStorage } from "app/store/machine/utils";
+import {
+  isCacheSet,
+  isVMWareLayout,
+  useCanEditStorage,
+} from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 
 const MachineStorage = (): JSX.Element => {
@@ -29,8 +32,7 @@ const MachineStorage = (): JSX.Element => {
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} storage`);
 
   if (machine && "disks" in machine && "special_filesystems" in machine) {
-    const showDatastores =
-      machine.detected_storage_layout === StorageLayout.VMFS6;
+    const showDatastores = isVMWareLayout(machine.detected_storage_layout);
     const showCacheSets = machine.disks.some((disk) => isCacheSet(disk));
 
     return (

--- a/ui/src/app/settings/views/Storage/StorageFormFields/StorageFormFields.js
+++ b/ui/src/app/settings/views/Storage/StorageFormFields/StorageFormFields.js
@@ -4,12 +4,12 @@ import { useSelector } from "react-redux";
 
 import configSelectors from "app/store/config/selectors";
 import FormikField from "app/base/components/FormikField";
+import { isVMWareLayout } from "app/store/machine/utils";
 
 const StorageFormFields = () => {
   const { values } = useFormikContext();
-  const storageLayoutOptions = useSelector(
-    configSelectors.storageLayoutOptions
-  );
+  const storageLayoutOptions =
+    useSelector(configSelectors.storageLayoutOptions) || [];
 
   return (
     <>
@@ -23,17 +23,17 @@ const StorageFormFields = () => {
       {values.default_storage_layout === "blank" && (
         <p className="p-form-validation__message">
           <i className="p-icon--warning" />
-          <strong className="p-icon__text">Caution:</strong> You will not be
-          able to deploy machines with this storage layout. Manual configuration
-          is required.
+          <strong className="u-nudge-right--x-small">Caution:</strong> You will
+          not be able to deploy machines with this storage layout. Manual
+          configuration is required.
         </p>
       )}
-      {values.default_storage_layout === "vmfs6" && (
+      {isVMWareLayout(values.default_storage_layout) && (
         <p className="p-form-validation__message">
           <i className="p-icon--warning" />
-          <strong className="p-icon__text">Caution:</strong> The VMFS6 storage
-          layout only allows for the deployment of{" "}
-          <strong>VMware (ESXi)</strong>.
+          <strong className="u-nudge-right--x-small">Caution:</strong> This
+          storage layout only allows for the deployment of{" "}
+          <strong>VMware (ESXi)</strong> images.
         </p>
       )}
       <FormikField

--- a/ui/src/app/settings/views/Storage/StorageFormFields/StorageFormFields.test.js
+++ b/ui/src/app/settings/views/Storage/StorageFormFields/StorageFormFields.test.js
@@ -56,7 +56,7 @@ describe("StorageFormFields", () => {
     );
   });
 
-  it("displays a warning if vmfs6 storage layout chosen", async () => {
+  it("displays a warning if VMWare storage layout chosen", async () => {
     const state = { ...initialState };
     const store = mockStore(state);
 
@@ -73,7 +73,7 @@ describe("StorageFormFields", () => {
     });
     wrapper.update();
     expect(wrapper.find(".p-form-validation__message").text()).toBe(
-      "Caution: The VMFS6 storage layout only allows for the deployment of VMware (ESXi)."
+      "Caution: This storage layout only allows for the deployment of VMware (ESXi) images."
     );
   });
 });

--- a/ui/src/app/store/machine/types.ts
+++ b/ui/src/app/store/machine/types.ts
@@ -97,6 +97,7 @@ export enum StorageLayout {
   LVM = "lvm",
   UNKNOWN = "unknown",
   VMFS6 = "vmfs6",
+  VMFS7 = "vmfs7",
 }
 
 export type Filesystem = Model & {
@@ -137,6 +138,7 @@ export enum DiskTypes {
   RAID_10 = "raid-10",
   VIRTUAL = "virtual",
   VMFS6 = "vmfs6",
+  VMFS7 = "vmfs7",
   VOLUME_GROUP = "lvm-vg",
 }
 

--- a/ui/src/app/store/machine/utils/index.ts
+++ b/ui/src/app/store/machine/utils/index.ts
@@ -69,6 +69,7 @@ export {
   isPhysical,
   isRaid,
   isVirtual,
+  isVMWareLayout,
   isVolumeGroup,
   partitionAvailable,
   splitDiskPartitionIds,

--- a/ui/src/app/store/machine/utils/storage.test.ts
+++ b/ui/src/app/store/machine/utils/storage.test.ts
@@ -28,6 +28,7 @@ import {
   isPhysical,
   isRaid,
   isVirtual,
+  isVMWareLayout,
   isVolumeGroup,
   partitionAvailable,
   splitDiskPartitionIds,
@@ -812,6 +813,14 @@ describe("machine storage utils", () => {
       expect(isVirtual(null)).toBe(false);
       expect(isVirtual(notVirtual)).toBe(false);
       expect(isVirtual(virtual)).toBe(true);
+    });
+  });
+
+  describe("isVMWareLayout", () => {
+    it("returns whether a storage layout is used for VMWare ESXi", () => {
+      expect(isVMWareLayout(StorageLayout.VMFS6)).toBe(true);
+      expect(isVMWareLayout(StorageLayout.VMFS7)).toBe(true);
+      expect(isVMWareLayout(StorageLayout.BLANK)).toBe(false);
     });
   });
 

--- a/ui/src/app/store/machine/utils/storage.ts
+++ b/ui/src/app/store/machine/utils/storage.ts
@@ -296,6 +296,8 @@ export const formatType = (
       return sentenceForm ? "virtual disk" : "Virtual";
     case DiskTypes.VMFS6:
       return "VMFS6";
+    case DiskTypes.VMFS7:
+      return "VMFS7";
     default:
       return typeToFormat;
   }
@@ -355,12 +357,12 @@ export const isCacheSet = (disk: Disk | null): boolean =>
   disk?.type === DiskTypes.CACHE_SET;
 
 /**
- * Returns whether a filesystem is a VMFS6 datastore.
+ * Returns whether a filesystem is a VMFS datastore.
  * @param fs - the filesystem to check.
- * @returns whether the filesystem is a VMFS6 datastore
+ * @returns whether the filesystem is a VMFS datastore
  */
 export const isDatastore = (fs: Filesystem | null): boolean =>
-  fs?.fstype === "vmfs6";
+  fs?.fstype === "vmfs6" || fs?.fstype === "vmfs7";
 
 /**
  * Returns whether a storage device is a disk.
@@ -448,6 +450,14 @@ export const isRaid = (disk: Disk | null): boolean =>
  */
 export const isVirtual = (disk: Disk | null): boolean =>
   disk?.type === DiskTypes.VIRTUAL && "parent" in disk;
+
+/**
+ * Returns whether a storage layout is used for VMWare ESXi.
+ * @param layout - the storage layout to check.
+ * @returns whether the storage layout is used for VMWare ESXi.
+ */
+export const isVMWareLayout = (layout: string): boolean =>
+  layout === StorageLayout.VMFS6 || layout === StorageLayout.VMFS7;
 
 /**
  * Returns whether a disk is a volume group.


### PR DESCRIPTION
## Done

- Added UI support for VMFS7 storage

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the storage tab of a machine with a boot disk smaller than 32GB
- Click "Change storage layout" and choose "VMFS7"
- Check that an error notification displays
- Go to the storage tab of a machine with a boot disk larger than 32GB and again choose "VMFS7"
- The machine should successfully change layout and the the datastores/available/used storage tables should show the correct data.
- Go to /MAAS/r/settings/storage and change the storage layout to "VMFS7"
- Check that a warning shows up below