### PR TITLE
fix(legacy): fix legacy edit DHCP snippets enabled value (3.0 backport #3006)

### DIFF
--- a/legacy/src/app/directives/dhcp_snippets_table.js
+++ b/legacy/src/app/directives/dhcp_snippets_table.js
@@ -110,7 +110,7 @@ function DHCPSnippetsTableController(
   $scope.snippetEnterEdit = (snippet) => {
     $scope.newSnippet = null;
     $scope.deleteSnippet = null;
-    $scope.editSnippet = snippet;
+    $scope.editSnippet = { ...snippet };
     $scope.editSnippet.type = $scope.getSnippetTypeText(snippet);
   };
 

--- a/legacy/src/app/directives/tests/test_dhcp_snippets_table.js
+++ b/legacy/src/app/directives/tests/test_dhcp_snippets_table.js
@@ -307,7 +307,7 @@ describe("maasDhcpSnippetsTable", () => {
       scope.newSnippet = {};
       scope.deleteSnippet = {};
       scope.snippetEnterEdit(snippet);
-      expect(scope.editSnippet).toBe(snippet);
+      expect(scope.editSnippet.id).toBe(snippet.id);
       expect(scope.editSnippet.type).toBe(scope.getSnippetTypeText(snippet));
       expect(scope.newSnippet).toBeNull();
       expect(scope.deleteSnippet).toBeNull();

--- a/legacy/src/app/partials/dhcp-snippets-table.html
+++ b/legacy/src/app/partials/dhcp-snippets-table.html
@@ -18,26 +18,26 @@
     </tr>
     <tr
       data-ng-repeat="snippet in snippets track by snippet.id"
-      data-ng-class="{ 'is-active': editSnippet === snippet || deleteSnippet === snippet }"
+      data-ng-class="{ 'is-active': editSnippet.id === snippet.id || deleteSnippet === snippet }"
       role="row"
     >
-      <td aria-label="Name" data-ng-if="editSnippet !== snippet">
+      <td aria-label="Name" data-ng-if="editSnippet.id !== snippet.id">
         {$ snippet.name $}
       </td>
-      <td aria-label="Type" data-ng-if="editSnippet !== snippet">
+      <td aria-label="Type" data-ng-if="editSnippet.id !== snippet.id">
         {$ getSnippetTypeText(snippet) $}
       </td>
-      <td aria-label="Applies to" data-ng-if="editSnippet !== snippet">
+      <td aria-label="Applies to" data-ng-if="editSnippet.id !== snippet.id">
         {$ getSnippetAppliesToText(snippet) $}
       </td>
-      <td aria-label="Enabled" data-ng-if="editSnippet !== snippet">
+      <td aria-label="Enabled" data-ng-if="editSnippet.id !== snippet.id">
         <div class="onoffswitch" data-ng-if="deleteSnippet !== snippet">
           <span data-ng-if="snippet.enabled">Yes</span>
           <span data-ng-if="!snippet.enabled">No</span>
         </div>
       </td>
-      <td data-ng-if="editSnippet !== snippet">{$ snippet.description $}</td>
-      <td data-ng-if="editSnippet !== snippet">
+      <td data-ng-if="editSnippet.id !== snippet.id">{$ snippet.description $}</td>
+      <td data-ng-if="editSnippet.id !== snippet.id">
         <div class="u-align--right">
           <button
             aria-label="Edit {$ snippet.name $}"
@@ -56,7 +56,7 @@
           </button>
         </div>
       </td>
-      <td class="p-table-expanding__panel" data-ng-if="editSnippet === snippet">
+      <td class="p-table-expanding__panel" data-ng-if="editSnippet.id === snippet.id">
         <maas-obj-form
           obj="editSnippet"
           manager="snippetsManager"
@@ -148,19 +148,14 @@
             <div class="row">
               <div class="p-strip is-shallow">
                 <div class="p-form__group dhcp-checkbox">
-                  <label for="newEnabled" class="p-form__label">Enabled</label>
                   <input
                     type="checkbox"
                     name="enabled"
                     class="onoffswitch-checkbox"
-                    id="newEnabled"
-                    data-ng-model="newSnippet.data.enabled"
-                    data-ng-disabled="newSnippet.saving"
-                    checked
+                    id="editEnabled"
+                    data-ng-model="editSnippet.enabled"
                   />
-                  <label for="newEnabled" class="dhcp-checkbox__label"
-                    ><!-- needed to achieve desired layout --></label
-                  >
+                  <label for="editEnabled" class="p-form__label">Enabled</label>
                 </div>
                 <maas-obj-field
                   type="textarea"


### PR DESCRIPTION
## Done

- Backport of https://github.com/canonical-web-and-design/maas-ui/pull/3006

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Run the full app with `yarn start`
- Go to /MAAS/r/settings/dhcp/add and add a DHCP snippet for a device, controller or subnet
- Go to the details page of the device/controller/subnet you added a DHCP snippet for
- Click the edit button for the DHCP snippet and check that the initial "Enabled" value matches what was in the table
- Change the "Enabled" value and click "Save snippet"
- Check that the table updates accordingly
